### PR TITLE
Add comprehensive repository documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,52 @@
+# Claudin2
+
+Claudin2 is a Claude Code workflow automation framework that orchestrates multi-agent design, code review, and implementation through collaborative AI-driven processes.
+
+## Features
+
+- **Multi-agent design planning** — 5 agents independently propose architectural approaches before a full implementation plan is written, preventing anchoring bias
+- **Voting-based review resolution** — A 3-agent voting panel (YES/NO/EXONERATE) adjudicates review findings for both plan review and code review
+- **Reviewer competition scoring** — Reviewers earn points based on finding quality, with a scoreboard tracking accepted, neutral, exonerated, and rejected findings
+- **End-to-end automation** — From feature design through PR creation, CI monitoring, merge, and Slack announcement in a single command
+- **External reviewer integration** — Codex and Cursor participate alongside Claude subagents as both reviewers and voters
+- **Systematic codebase review** — Partition an entire repository into slices, review each with specialized subagents, and implement improvements automatically
+
+## Skills
+
+Slash commands available in Claude Code sessions. They automate multi-step workflows by orchestrating git, GitHub, Slack, and other tools.
+
+| Command | Arguments | Description |
+|---|---|---|
+| [`/design`](.claude/skills/design/SKILL.md) | `[--auto] <feature description>` | Design an implementation plan with collaborative multi-reviewer review. 5 agents (3 Claude + Cursor + Codex) independently propose architectural approaches, then 6 reviewers (4 Claude + Cursor + Codex) validate the plan. `--auto` suppresses all interactive question checkpoints. [(Diagram).](.claude/skills/design/diagram.svg) |
+| [`/implement`](.claude/skills/implement/SKILL.md) | `[--quick] [--auto] <feature description>` | Implement a feature from design through PR creation, CI monitoring, and Slack announcement, with code review and version bump. `--quick` skips `/design` and uses simplified code review (4 Claude subagents, 1 round). `--auto` suppresses all interactive question checkpoints. Does not merge — use `/shazam` for the full end-to-end workflow including merge. [(Diagram).](.claude/skills/implement/diagram.svg) |
+| [`/research`](.claude/skills/research/SKILL.md) | `<research question or topic>` | Collaborative read-only research using 5 research agents (3 Claude + Cursor + Codex) then 6 validation reviewers (4 Claude + Cursor + Codex). Produces a structured report with findings, risk assessment, difficulty estimates, and feasibility verdict. Does not modify the repo. [(Diagram).](.claude/skills/research/diagram.svg) |
+| [`/review`](.claude/skills/review/SKILL.md) | *(none)* | Code review current branch changes with specialized subagents (4 Claude + Codex + Cursor, if available), implementing accepted suggestions in a recursive loop (up to 5 rounds). Reviews the diff between main and HEAD. [(Diagram).](.claude/skills/review/diagram.svg) |
+| [`/shazam`](.claude/skills/shazam/SKILL.md) | `[--quick] [--auto] [--no-merge] <feature description>` | Full end-to-end feature workflow — design, implement, PR, Slack announce, CI+rebase+merge, and cleanup. `--quick` skips `/design` and uses simplified code review (4 Claude subagents, 1 round). `--auto` suppresses all interactive question checkpoints. `--no-merge` skips CI monitoring, merge, :merged: emoji, and local branch cleanup (final report and temp cleanup still run). [(Diagram).](.claude/skills/shazam/diagram.svg) |
+| [`/loop-review`](.claude/skills/loop-review/SKILL.md) | `[partition criteria]` | Systematic code review of entire repository by partitioning into slices, reviewing each with specialized subagents (4 Claude + Codex + Cursor, if available), implementing improvements via `/shazam`, and logging deferred suggestions. The optional argument specifies how to partition the codebase (e.g., by directory, by file type). [(Diagram).](.claude/skills/loop-review/diagram.svg) |
+| [`/skill-creator`](.claude/skills/skill-creator/SKILL.md) | *(conversational)* | Create new skills, modify and improve existing skills, and measure skill performance via eval-based testing. No specific arguments — works conversationally based on your request. [(Diagram).](.claude/skills/skill-creator/diagram.svg) |
+| [`/relevant-checks`](.claude/skills/relevant-checks/SKILL.md) | *(none)* | Run repo-specific validation checks based on modified files. Invoked automatically by `/implement` and `/review` after code changes. |
+
+## Review Agents
+
+Internal agent definitions used by skills like `/design`, `/review`, and `/loop-review`. They are not invoked directly — the skills launch them as specialized subagents during plan and code review.
+
+| Agent | Description |
+|---|---|
+| [`generic-reviewer`](.claude/agents/generic-reviewer.md) | General-purpose code reviewer for bugs, logic, quality, tests, backward compatibility, and style consistency. |
+| [`correctness-reviewer`](.claude/agents/correctness-reviewer.md) | Correctness-focused code reviewer specializing in logic errors, off-by-one bugs, nil handling, type mismatches, race conditions, and error path analysis. |
+| [`risk-reviewer`](.claude/agents/risk-reviewer.md) | Risk and integration reviewer specializing in breaking changes, side effects, thread safety, deployment risks, regressions, and CI impact analysis. |
+| [`architect-reviewer`](.claude/agents/architect-reviewer.md) | Senior systems architect reviewer focused on separation of concerns, contract boundaries, invariants, and semantic boundary violations. |
+
+## Environment Variables
+
+*Coming soon.*
+
+## Detailed Documentation
+
+- [Workflow Lifecycle](docs/workflow-lifecycle.md) — How skills compose to form the end-to-end development workflow
+- [Voting Process](docs/voting-process.md) — The 3-agent voting panel that adjudicates review findings
+- [Point Competition](docs/point-competition.md) — Reviewer scoring system and competition mechanics
+- [Collaborative Sketches](docs/collaborative-sketches.md) — The diverge-then-converge design phase
+- [External Reviewers](docs/external-reviewers.md) — Codex and Cursor integration procedures
+- [Review Agents](docs/review-agents.md) — The 4 specialized Claude reviewer archetypes
+- [Agent System](docs/agents.md) — How skills orchestrate parallel subagents

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,0 +1,88 @@
+# Agent System
+
+How Claudin2 skills orchestrate parallel subagents to achieve collaborative multi-perspective workflows.
+
+## What Are Agents?
+
+In the Claude Code context, an **agent** is a subprocess spawned via the Agent tool that runs autonomously with its own context window. Each agent receives a prompt, has access to a defined set of tools, and returns a result when complete. Agents are isolated from each other — they cannot see each other's outputs or share state.
+
+## How Skills Use Agents
+
+Skills launch agents to parallelize work that benefits from multiple independent perspectives. The key patterns:
+
+### Parallel Fan-Out
+
+Multiple agents are launched simultaneously, each examining the same material from a different angle. Results are collected and synthesized after all agents return.
+
+```mermaid
+flowchart TD
+    SKILL[Skill orchestrator] --> A1[Agent 1]
+    SKILL --> A2[Agent 2]
+    SKILL --> A3[Agent 3]
+    SKILL --> A4[Agent 4]
+    A1 --> COLLECT[Collect results]
+    A2 --> COLLECT
+    A3 --> COLLECT
+    A4 --> COLLECT
+    COLLECT --> SYNTHESIZE[Synthesize / deduplicate]
+```
+
+This pattern is used for:
+
+- **[Collaborative sketches](collaborative-sketches.md)** — 5 agents propose architectural approaches in parallel
+- **Plan review** — 6 reviewers examine the implementation plan simultaneously
+- **Code review** — 6 reviewers examine the diff simultaneously
+- **[Voting](voting-process.md)** — 3 voters evaluate findings in parallel
+
+### Sequential Composition
+
+Skills invoke other skills in sequence, each building on the previous result. For example, `/implement` invokes `/design` first, then implements the resulting plan, then invokes `/review` on the implementation.
+
+## Agent Types
+
+Claudin2 uses several categories of agents:
+
+### Review Agents
+
+The 4 persistent [reviewer archetypes](review-agents.md) (Generic, Correctness, Risk/Integration, Architect) launched during plan and code review. These are defined in `.claude/agents/*.md` with specific model assignments and tool access.
+
+### Sketch Agents
+
+The 5 agents in the [collaborative sketch phase](collaborative-sketches.md) (General, Architecture/Standards, Pragmatism/Safety, plus Cursor/Codex or Claude replacements). These are ephemeral — launched with inline prompts, not persistent agent definitions.
+
+### Voting Panel Agents
+
+The 3 voters in the [voting process](voting-process.md) (one Claude subagent + Codex + Cursor). These are ephemeral agents launched with the ballot and voting instructions.
+
+### Research Agents
+
+The 5 research agents in `/research` (3 Claude subagents + Codex + Cursor) that investigate a question from different angles, followed by 6 validation reviewers. All are ephemeral.
+
+## Context Isolation
+
+Each agent runs in its own context window:
+
+- Agents **cannot** see each other's outputs during execution
+- Agents **cannot** communicate with each other
+- The orchestrating skill collects all results and performs synthesis
+- This isolation is by design — it ensures independent perspectives and prevents groupthink
+
+## Tool Access
+
+Agents have restricted tool access depending on their role:
+
+- **Review agents** — Read, Grep, Glob only (cannot modify files)
+- **Sketch agents** — Read, Grep, Glob only (research phase)
+- **Voting agents** — Read, Grep, Glob only (evaluation phase)
+- **Implementation agents** — Full tool access when implementing fixes
+
+External tools (Codex, Cursor) have their own tool access controlled by their respective platforms. See [External Reviewers](external-reviewers.md) for integration details.
+
+## Performance Optimization
+
+Skills optimize agent usage through:
+
+1. **Launch order** — Slowest agents (Cursor) launched first, fastest (Claude) launched last
+2. **Background execution** — External tools run in background while Claude agents execute
+3. **Early processing** — Claude subagent results are processed immediately while waiting for slower external reviewers
+4. **Sentinel-based coordination** — `.done` files signal completion without polling the output

--- a/docs/collaborative-sketches.md
+++ b/docs/collaborative-sketches.md
@@ -1,0 +1,91 @@
+# Collaborative Sketches
+
+The collaborative sketch phase is a diverge-then-converge process in `/design` where 5 agents independently propose architectural approaches before the full implementation plan is written. This prevents anchoring bias — where a single perspective locks in the direction before alternatives are considered.
+
+## Why Sketches Exist
+
+Without the sketch phase, the first idea considered tends to dominate the plan. By having 5 agents independently explore the design space, the system surfaces different perspectives early — when they can still influence the architectural direction — rather than waiting for review when the plan is already anchored.
+
+## The 5 Sketch Agents
+
+The sketch phase always uses exactly 5 agents. Three are Claude subagents with fixed roles, and two are external tools (or Claude replacements when unavailable):
+
+| Agent | Role | Focus |
+|---|---|---|
+| **Claude (General)** | The orchestrating agent's own sketch | Key decisions, files to modify, tradeoffs |
+| **Claude (Architecture/Standards)** | Maintainability architect | Clean design, proper layering, reuse of existing libraries |
+| **Claude (Pragmatism/Safety)** | Minimal-change advocate | Smallest change set, avoid regressions, protect existing features |
+| **Cursor** (or Claude replacement) | External perspective | Explores the codebase independently |
+| **Codex** (or Claude replacement) | External perspective | Explores the codebase independently |
+
+### Important Distinction
+
+The 5 sketch agents are **completely separate** from the 6 plan-review agents that evaluate the plan later in `/design` Step 3. The sketch agents explore the design space; the plan reviewers validate the resulting plan. They have different roles, different prompts, and serve different purposes.
+
+## Claude Replacement Roles
+
+When Cursor or Codex are unavailable, they are replaced by Claude subagents with specialized roles. The replacement names differ by skill:
+
+| Unavailable Tool | `/design` Replacement | `/research` Replacement |
+|---|---|---|
+| Cursor | Claude (Innovation/Exploration) — questions assumptions, suggests creative alternatives | Claude (Alternative Perspectives) |
+| Codex | Claude (Edge-cases/Failure-modes) — focuses on what can go wrong, boundary conditions | Claude (Edge-cases/Gaps) |
+
+This ensures the always-5-agents invariant holds regardless of external tool availability.
+
+## Fallback Behavior by Phase
+
+The handling of unavailable external tools differs across workflow phases:
+
+| Phase | Unavailable Tool Handling |
+|---|---|
+| **Sketch phase** (`/design`, `/research`) | Claude replacement agents are used — always 5 agents |
+| **Plan review** (`/design`) | Proceeds with fewer reviewers; voting adjusts thresholds |
+| **Code review** (`/review`) | Proceeds with fewer reviewers; voting adjusts thresholds |
+| **Voting** | Panel reduces to available voters; requires 2+ for quorum |
+
+## How It Works
+
+```mermaid
+flowchart TD
+    START([Feature description]) --> LAUNCH
+
+    subgraph LAUNCH["Launch in parallel (slowest first)"]
+        direction LR
+        CURSOR[Cursor / Replacement] ~~~ CODEX[Codex / Replacement]
+        CODEX ~~~ ARCH_STD[Architecture/Standards]
+        ARCH_STD ~~~ PRAG[Pragmatism/Safety]
+    end
+
+    LAUNCH --> GENERAL[Claude General sketch]
+    GENERAL --> WAIT[Wait for all 5 sketches]
+    WAIT --> SYNTHESIS[Synthesis]
+
+    subgraph SYNTHESIS["Approach Synthesis"]
+        AGREE[Where agents agree] ~~~ DIVERGE[Where agents diverge]
+        DIVERGE ~~~ DECISION[Reasoned decisions on contested points]
+    end
+
+    SYNTHESIS --> PLAN[Full implementation plan]
+
+    style CURSOR fill:#1a4a6e,color:#fff
+    style CODEX fill:#1a4a6e,color:#fff
+    style ARCH_STD fill:#4a3a6e,color:#fff
+    style PRAG fill:#4a3a6e,color:#fff
+    style GENERAL fill:#2d5a27,color:#fff
+```
+
+1. **Parallel launch** — All external and Claude subagent sketches are launched simultaneously. Cursor is launched first (slowest), then Codex, then Claude subagents. The orchestrating agent writes its own sketch last, before reading any others, to preserve independence.
+
+2. **Each agent produces** a 2-3 paragraph sketch covering:
+   - Key architectural decisions and approach
+   - Which files/modules to modify and why
+   - Main tradeoffs to consider
+
+3. **Synthesis** — After all 5 sketches return, the orchestrating agent produces a synthesis that:
+   - Identifies where approaches agree (likely the majority)
+   - Identifies divergence points and makes reasoned calls with justification
+   - Notes which ideas from each sketch are incorporated
+   - Highlights Architecture/Standards concerns and Pragmatism/Safety warnings
+
+4. **Full plan** — The synthesis informs the complete implementation plan, which is then submitted to 6 reviewers for validation.

--- a/docs/external-reviewers.md
+++ b/docs/external-reviewers.md
@@ -1,0 +1,70 @@
+# External Reviewers
+
+Codex and Cursor participate alongside Claude subagents as both reviewers and voters in the Claudin2 workflow. This document covers the shared integration procedures.
+
+## Availability Checks
+
+At the start of each skill, a binary check determines which external tools are installed:
+
+- If **Codex** is not found, a warning is printed and the skill proceeds without it
+- If **Cursor** is not found, a warning is printed and the skill proceeds without it
+
+Skills gracefully degrade when external tools are unavailable. During [sketch and research phases](collaborative-sketches.md), Claude replacement agents are used to maintain the 5-agent invariant. During review and voting phases, the skill simply operates with fewer participants and adjusts voting thresholds accordingly.
+
+## Launching External Reviewers
+
+External reviewers are launched via the `run-external-reviewer.sh` wrapper script, which provides:
+
+- **Timeout enforcement** — Kills the process after a configurable timeout
+- **Sentinel file creation** — Writes a `.done` file containing the exit code when the process completes
+- **Output capture** — Captures stdout to a specified output file
+- **Elapsed time tracking** — Reports how long the review took
+
+Reviewers are always launched with `run_in_background: true` so they run concurrently with other work.
+
+## Launch Order
+
+External reviewers are always launched in a specific order to maximize parallelism — **slowest first**:
+
+1. **Cursor** (slowest) — launched first
+2. **Codex** — launched second
+3. **Claude subagents** (fastest) — launched last
+
+All launches happen in a single message to ensure true parallel execution.
+
+## Sentinel File Monitoring
+
+The wrapper script writes a `.done` sentinel file when the process completes. This is the only reliable way to detect completion:
+
+- **Do not read output files until the sentinel exists** — Cursor buffers all stdout until exit, so its output file is empty until the process finishes
+- **Poll for sentinels** using the `wait-for-reviewers.sh` script, which checks every 5 seconds and prints compact progress dots
+- Sentinel files contain the exit code (e.g., `0` for success)
+
+## Output Validation
+
+After the sentinel file exists, the output is validated:
+
+1. Read the output file
+2. Check that it is non-empty and contains substantive content (numbered findings or `NO_ISSUES_FOUND`)
+3. If empty despite exit code 0, **retry once** with a fresh invocation (output file gets a `-retry` suffix)
+4. If still empty after retry, or if the exit code is non-zero, print a warning and proceed without that reviewer's findings
+
+## Timeout Handling
+
+External reviewers have configurable timeouts (typically 600-900 seconds). If a reviewer exceeds its timeout:
+
+- The process is killed by the wrapper script
+- The sentinel file records a non-zero exit code
+- A warning is printed and the skill proceeds without that reviewer
+
+## Roles Across the Workflow
+
+External reviewers participate in multiple phases:
+
+| Phase | Role | Skills |
+|---|---|---|
+| [Collaborative sketches](collaborative-sketches.md) | Propose architectural approaches | `/design`, `/research` |
+| Plan review | Review implementation plans | `/design` |
+| Code review | Review code changes | `/review` |
+| [Voting](voting-process.md) | Vote on findings | `/design`, `/review` |
+| Negotiation | Multi-round dispute resolution | `/research`, `/loop-review` |

--- a/docs/external-reviewers.md
+++ b/docs/external-reviewers.md
@@ -20,7 +20,7 @@ External reviewers are launched via the `run-external-reviewer.sh` wrapper scrip
 - **Output capture** — Captures stdout to a specified output file
 - **Elapsed time tracking** — Reports how long the review took
 
-Reviewers are always launched with `run_in_background: true` so they run concurrently with other work.
+During review and voting phases, reviewers are launched with `run_in_background: true` so they run concurrently with other work. (Negotiation rounds in `/research` and `/loop-review` run synchronously.)
 
 ## Launch Order
 

--- a/docs/point-competition.md
+++ b/docs/point-competition.md
@@ -1,0 +1,63 @@
+# Point Competition
+
+Reviewers earn points based on how their findings perform in the [voting process](voting-process.md). The competition incentivizes high-quality, actionable findings and discourages noise.
+
+## Scoring Rules
+
+Each finding's vote outcome determines the points awarded to the reviewer(s) who proposed it:
+
+| Vote Result | Points | Description |
+|---|---|---|
+| **Accepted** (2+ YES) | +1 | The finding was validated by the voting panel |
+| **Neutral** (exactly 1 YES) | 0 | Insufficient support, but not dismissed |
+| **Exonerated** (0 YES, 1+ EXONERATE) | 0 | Legitimate concern, but not actionable in this PR |
+| **Rejected** (0 YES, 0 EXONERATE) | -1 | Finding was unanimously dismissed by the panel |
+
+If a deduplicated finding was proposed by multiple reviewers (merged during deduplication), all contributing reviewers receive the same points for that finding.
+
+## Out-of-Scope Scoring
+
+Out-of-scope (OOS) observations use a **per-item scoring floor of 0**. This asymmetry is a deliberate design decision: reviewers should feel free to surface pre-existing issues and observations beyond the PR's scope without risking penalty.
+
+| OOS Vote Result | Points | Description |
+|---|---|---|
+| **OOS Promoted** (2+ YES) | +1 | Reviewer surfaced an issue worth fixing in this PR |
+| **OOS Not Promoted** | 0 | Useful observation, no penalty regardless of vote outcome |
+
+The key invariant: **OOS items can never score below 0.** This encourages reviewers to report pre-existing code issues, technical debt, and architectural concerns freely.
+
+## OOS Promotion Mechanics
+
+Out-of-scope items go on the same voting ballot as in-scope findings, labeled with `[OUT_OF_SCOPE]`:
+
+```text
+OOS_1: [OUT_OF_SCOPE] Generic — <description>
+```
+
+Voters can promote an OOS item to in-scope by voting YES:
+
+- **2+ YES** → Promoted to in-scope, implemented in this PR, reviewer earns +1
+- **Fewer than 2 YES** → Remains an observation, reported in the PR body, reviewer earns 0
+
+## Scoreboard
+
+After voting completes, a scoreboard is printed showing each reviewer's performance:
+
+| Reviewer | Findings | Accepted | Neutral (1 YES) | Exonerated (0 YES, 1+ EXON.) | Rejected (0 YES, 0 EXON.) | OOS Proposed | OOS Promoted | Score |
+|----------|----------|----------|-----------------|-------------------------------|---------------------------|--------------|--------------|-------|
+| Generic | 3 | 2 | 1 | 0 | 0 | 1 | 0 | +2 |
+| Architect | 2 | 1 | 0 | 1 | 0 | 0 | 0 | +1 |
+| Codex | 1 | 0 | 0 | 0 | 1 | 0 | 0 | -1 |
+
+## Future Plans
+
+In future iterations, token allocation will be weighted proportionally to reviewer scores — higher-scoring reviewers will receive more tokens, allowing them to conduct deeper analysis.
+
+## Where Scoring Applies
+
+The competition scoring system is active in skills that use the [voting protocol](voting-process.md):
+
+- **`/design`** — Plan review findings are scored after the voting panel adjudicates
+- **`/review`** — Code review findings (round 1) are scored after voting
+
+Skills that use the negotiation protocol (`/research`, `/loop-review`) do not use competition scoring.

--- a/docs/review-agents.md
+++ b/docs/review-agents.md
@@ -1,0 +1,94 @@
+# Review Agents
+
+Claudin2 uses 4 specialized Claude reviewer archetypes that provide different perspectives during plan review and code review. Each archetype has a distinct focus area, ensuring comprehensive coverage across quality dimensions.
+
+## The 4 Archetypes
+
+### Generic Reviewer
+
+**Focus**: Broad code quality coverage — bugs, logic, duplication, test coverage, backward compatibility, and style consistency.
+
+**Checklist**:
+
+- Logical flaws, incorrect conditions, wrong variable usage, broken control flow
+- Code duplication — searches the codebase for existing implementations that overlap
+- Missing or insufficient test coverage
+- Breaking changes to existing callers, CLI commands, API contracts
+- Style consistency with existing patterns and naming conventions
+
+**Model**: Sonnet
+
+### Correctness Reviewer
+
+**Focus**: Deep correctness analysis — everything that could cause the code to produce wrong results.
+
+**Specialized checks**:
+
+- Logic errors (incorrect booleans, inverted checks, wrong operators)
+- Off-by-one errors (loop bounds, slice indices, pagination limits)
+- Null/nil/None handling (missing nil checks, zero-value assumptions)
+- Type mismatches (wrong assertions, implicit conversions)
+- Incorrect return values (swapped returns, missing early returns)
+- Race conditions (shared state without synchronization, goroutine leaks)
+- Exception/error paths (swallowed errors, panic recovery gaps)
+- Math errors (integer overflow, division by zero, floating-point comparison)
+
+**Model**: Sonnet
+
+### Risk/Integration Reviewer
+
+**Focus**: Breaking changes, side effects, and deployment risks — everything that could go wrong in production.
+
+**Specialized checks**:
+
+- Breaking changes to callers, API contracts, downstream consumers
+- Cache invalidation issues
+- Import side effects (init functions, global state, circular dependencies)
+- Thread safety (concurrent map access, channel misuse)
+- Deployment risks (schema migrations, config changes, incompatible wire formats)
+- Regression risk to existing tests
+- Module interaction (tracing callers of modified functions)
+- CI constraints (test globs, workflow YAML syntax)
+
+**Model**: Sonnet
+
+### Architect Reviewer
+
+**Focus**: Structural integrity — separation of concerns, contract boundaries, invariants, and semantic boundaries.
+
+**Specialized checks**:
+
+- **Separation of Concerns**: Single responsibility per module, business logic not mixed with I/O
+- **Contract Boundaries**: Explicit cross-repo contracts, consistent types across layers, peer field consistency
+- **Invariants**: Edge case validation at boundaries, loud failures over silent defaults, proper ordering of operations
+- **Semantic Boundaries**: Domain logic in the right layer, correct import direction, explicit data shapes at system boundaries
+
+**Model**: Opus
+
+## Persistent Agents vs. Inline Templates
+
+There are two related but distinct mechanisms for invoking these archetypes:
+
+**Persistent agent definitions** (`.claude/agents/*.md`) — Standalone agent files with frontmatter specifying name, description, model, and allowed tools. These can be referenced by the Agent tool by name.
+
+**Inline reviewer templates** (`.claude/skills/shared/reviewer-templates.md`) — Parameterized prompt templates that skills fill in with context-specific variables. Skills use these templates to spawn fresh Agent tool invocations with the full review prompt.
+
+The persistent agents and inline templates are derived from the same source and kept in sync.
+
+## Output Format
+
+All 4 reviewer archetypes produce **dual-list output**:
+
+1. **In-Scope Findings** — Issues that should be fixed in this PR, with specific file/line references and suggested fixes
+2. **Out-of-Scope Observations** — Pre-existing issues or concerns beyond the PR's scope, surfaced for future attention
+
+External reviewers (Codex, Cursor) produce single-list output — their entire output is treated as in-scope findings.
+
+## Usage Across Skills
+
+| Skill | Phase | Reviewers Used |
+|---|---|---|
+| `/design` | Plan review | All 4 Claude archetypes + Codex + Cursor (6 total) |
+| `/review` | Code review | All 4 Claude archetypes + Codex + Cursor (6 total) |
+| `/loop-review` | Slice review | All 4 Claude archetypes + Codex + Cursor (6 total) |
+| `/implement` (quick mode) | Simplified review | All 4 Claude archetypes only (no external reviewers) |

--- a/docs/voting-process.md
+++ b/docs/voting-process.md
@@ -25,7 +25,7 @@ The number of YES votes required depends on how many voters are available:
 
 ## Voter Panel Composition
 
-The panel always consists of 3 voters, but the **Claude voter role differs by skill**:
+When all tools are available, the panel has 3 voters. The **Claude voter role differs by skill**:
 
 | Skill | Voter 1 (Claude) | Voter 2 | Voter 3 |
 |---|---|---|---|

--- a/docs/voting-process.md
+++ b/docs/voting-process.md
@@ -1,0 +1,108 @@
+# Voting Process
+
+The voting protocol is used by `/design` (plan review) and `/review` (code review) to adjudicate review findings. It replaces the older Negotiation Protocol for these skills. (`/research` and `/loop-review` continue using the Negotiation Protocol.)
+
+## Overview
+
+After reviewers submit findings and findings are deduplicated, a **3-agent voting panel** votes on each finding. Each voter casts one of three votes:
+
+| Vote | Meaning |
+|---|---|
+| **YES** | The finding is correct, important, and worth implementing. |
+| **NO** | The finding is incorrect, trivial, or would cause more harm than good. |
+| **EXONERATE** | The finding raises a legitimate concern, but is not worth implementing in this PR. Spares the proposing reviewer from losing a point. |
+
+## Threshold Rules
+
+The number of YES votes required depends on how many voters are available:
+
+| Eligible Voters | YES Votes Required | Notes |
+|---|---|---|
+| 3 | 2+ | Standard majority |
+| 2 | 2 (unanimous) | When one voter is unavailable or timed out |
+| 1 | Skip voting | All findings accepted automatically |
+| 0 | Skip voting | All findings accepted automatically |
+
+## Voter Panel Composition
+
+The panel always consists of 3 voters, but the **Claude voter role differs by skill**:
+
+| Skill | Voter 1 (Claude) | Voter 2 | Voter 3 |
+|---|---|---|---|
+| `/design` (plan review) | Architect subagent | Codex | Cursor |
+| `/review` (code review) | Generic code reviewer subagent | Codex | Cursor |
+
+All voters vote on all findings — there is no self-voting exclusion. Voters evaluate each finding on its merits regardless of who proposed it.
+
+## Ballot Format
+
+Before voting, each deduplicated finding receives a stable sequential ID. The ballot is formatted as:
+
+```text
+FINDING_1: <reviewer attribution> — <finding description>
+FINDING_2: <reviewer attribution> — <finding description>
+```
+
+Out-of-scope observations are included on the same ballot with an `[OUT_OF_SCOPE]` prefix:
+
+```text
+OOS_1: [OUT_OF_SCOPE] Generic — <description of pre-existing issue>
+```
+
+## Voter Output Format
+
+Each voter outputs one line per finding:
+
+```text
+FINDING_1: YES — <one-line rationale>
+FINDING_2: NO — <one-line rationale>
+FINDING_3: EXONERATE — <one-line rationale>
+```
+
+## Voting Flow
+
+```mermaid
+flowchart TD
+    REVIEW[6 reviewers submit findings] --> DEDUP[Deduplicate findings]
+    DEDUP --> BALLOT[Format ballot with IDs]
+    BALLOT --> LAUNCH[Launch 3 voters in parallel]
+    LAUNCH --> COLLECT[Collect votes]
+    COLLECT --> TALLY{Tally per finding}
+
+    TALLY -->|2+ YES| ACCEPT[Finding accepted]
+    TALLY -->|1 YES| NEUTRAL[Finding neutral]
+    TALLY -->|0 YES, 1+ EXON| EXON[Finding exonerated]
+    TALLY -->|0 YES, 0 EXON| REJECT[Finding rejected]
+
+    ACCEPT --> IMPLEMENT[Implement accepted findings]
+    NEUTRAL --> SCORE[Score reviewers]
+    EXON --> SCORE
+    REJECT --> SCORE
+    IMPLEMENT --> SCORE
+
+    style ACCEPT fill:#2d5a27,color:#fff
+    style REJECT fill:#8b1a1a,color:#fff
+    style EXON fill:#4a3a6e,color:#fff
+    style NEUTRAL fill:#555,color:#fff
+```
+
+## Out-of-Scope Observations
+
+Reviewers may surface **out-of-scope (OOS) observations** — pre-existing issues or concerns beyond the PR's scope. These are handled alongside in-scope findings but with different semantics:
+
+- OOS items are included on the ballot with the `[OUT_OF_SCOPE]` prefix
+- **YES** on an OOS item means "promote to in-scope — implement in this PR"
+- **NO** means "keep as observation"
+- **EXONERATE** means "legitimate observation worth documenting"
+- If an OOS item receives 2+ YES votes, it is **promoted** to in-scope and implemented
+- Non-promoted OOS items are collected and reported in the PR body for future attention
+
+Only Claude subagent reviewers produce OOS observations (via their dual-list output format). External reviewers (Codex, Cursor) produce single-list output treated entirely as in-scope.
+
+## Connection to Other Protocols
+
+- **Voting Protocol** is used by `/design` and `/review` — see this document
+- **Negotiation Protocol** is used by `/research` and `/loop-review` — up to N rounds of back-and-forth with external reviewers, where Claude makes the final call
+- The key difference: voting uses a democratic panel with threshold rules; negotiation uses bilateral dialogue with Claude as arbiter
+
+See [Point Competition](point-competition.md) for how voting outcomes translate to reviewer scores.

--- a/docs/workflow-lifecycle.md
+++ b/docs/workflow-lifecycle.md
@@ -80,8 +80,8 @@ flowchart TD
 Not every task requires the full `/shazam` pipeline. Skills can be used independently:
 
 - **`/design <feature>`** — Plan a feature without implementing it. Creates a branch, runs collaborative sketches, writes and reviews the plan.
-- **`/implement <feature>`** — Implement and create a PR without merging. If a design plan exists on the current branch, it skips `/design`.
-- **`/review`** — Review the current branch's changes without any other workflow steps.
+- **`/implement <feature>`** — Implement and create a PR without merging. If a reviewed design plan is visible in the current session context, it skips `/design`.
+- **`/review`** — Review the current branch's changes. Launches reviewers, runs voting on findings, implements accepted fixes, and re-runs validation checks in a recursive loop.
 - **`/research <topic>`** — Read-only investigation. Does not create branches, modify files, or make commits. Uses a restricted tool set (no Edit, Write, or Skill tools).
 
 ## Flags

--- a/docs/workflow-lifecycle.md
+++ b/docs/workflow-lifecycle.md
@@ -1,0 +1,114 @@
+# Workflow Lifecycle
+
+How skills compose to form the end-to-end development workflow in Claudin2.
+
+## Skill Orchestration Hierarchy
+
+Skills are not invoked in a flat sequence. They form a hierarchical call graph where higher-level skills orchestrate lower-level ones:
+
+```mermaid
+graph TD
+    SHAZAM["/shazam"] -->|invokes| IMPLEMENT["/implement"]
+    IMPLEMENT -->|invokes| DESIGN["/design"]
+    IMPLEMENT -->|invokes| REVIEW["/review"]
+    IMPLEMENT -->|invokes| CHECKS["/relevant-checks"]
+    LOOP["/loop-review"] -->|invokes| SHAZAM
+
+    style SHAZAM fill:#2d5a27,color:#fff
+    style LOOP fill:#2d5a27,color:#fff
+    style IMPLEMENT fill:#1a4a6e,color:#fff
+    style DESIGN fill:#4a3a6e,color:#fff
+    style REVIEW fill:#4a3a6e,color:#fff
+    style CHECKS fill:#555,color:#fff
+```
+
+- **`/shazam`** is the top-level orchestrator. It invokes `/implement` for the full workflow (design, code, review, PR, CI, Slack), then handles CI monitoring, rebasing, merging, and cleanup.
+- **`/implement`** invokes `/design` for planning, `/review` for code review, and `/relevant-checks` for validation. It creates the PR and monitors CI, but does not merge.
+- **`/loop-review`** partitions the codebase into slices, reviews each, and invokes `/shazam` to implement accepted improvements — accumulating up to 3 slices per `/shazam` invocation before flushing.
+
+## End-to-End Flow
+
+The full lifecycle when running `/shazam <feature description>`:
+
+```mermaid
+flowchart TD
+    START([Start]) --> DESIGN_PHASE
+
+    subgraph DESIGN_PHASE["Design Phase (/design)"]
+        BRANCH[Create branch] --> QUESTIONS[Clarifying questions]
+        QUESTIONS --> SKETCHES[5-agent collaborative sketches]
+        SKETCHES --> SYNTHESIS[Approach synthesis]
+        SYNTHESIS --> PLAN[Write implementation plan]
+        PLAN --> PLAN_REVIEW[Plan review: 6 reviewers]
+        PLAN_REVIEW --> VOTE1[Voting panel adjudicates findings]
+        VOTE1 --> REVISE[Revise plan if needed]
+    end
+
+    DESIGN_PHASE --> IMPL_PHASE
+
+    subgraph IMPL_PHASE["Implementation Phase (/implement)"]
+        CODE[Implement feature] --> VALIDATE1[Validation checks]
+        VALIDATE1 --> COMMIT1[First commit]
+        COMMIT1 --> CODE_REVIEW[Code review: 6 reviewers]
+        CODE_REVIEW --> VOTE2[Voting panel adjudicates findings]
+        VOTE2 --> FIX[Implement accepted fixes]
+        FIX --> VALIDATE2[Validation checks]
+        VALIDATE2 --> COMMIT2[Second commit]
+        COMMIT2 --> VERSION[Version bump]
+        VERSION --> PR[Create PR]
+        PR --> CI_MONITOR[Monitor CI + fix failures]
+        CI_MONITOR --> SLACK[Slack announcement]
+    end
+
+    IMPL_PHASE --> MERGE_PHASE
+
+    subgraph MERGE_PHASE["Merge Phase (/shazam)"]
+        CI_WAIT[Wait for CI to pass] --> REBASE{Main advanced?}
+        REBASE -->|Yes| DO_REBASE[Rebase + push]
+        DO_REBASE --> CI_WAIT
+        REBASE -->|No| MERGE[Merge PR]
+        MERGE --> EMOJI[Add :merged: emoji to Slack]
+        EMOJI --> CLEANUP[Local cleanup]
+        CLEANUP --> VERIFY[Verify main]
+    end
+
+    MERGE_PHASE --> DONE([Complete])
+```
+
+## Standalone Usage
+
+Not every task requires the full `/shazam` pipeline. Skills can be used independently:
+
+- **`/design <feature>`** — Plan a feature without implementing it. Creates a branch, runs collaborative sketches, writes and reviews the plan.
+- **`/implement <feature>`** — Implement and create a PR without merging. If a design plan exists on the current branch, it skips `/design`.
+- **`/review`** — Review the current branch's changes without any other workflow steps.
+- **`/research <topic>`** — Read-only investigation. Does not create branches, modify files, or make commits. Uses a restricted tool set (no Edit, Write, or Skill tools).
+
+## Flags
+
+Flags modify behavior across the skill hierarchy:
+
+| Flag | Available on | Effect |
+|---|---|---|
+| `--quick` | `/shazam`, `/implement` | Skips `/design` (produces inline plan instead). Simplifies code review to 1 round with 4 Claude subagents only (no external reviewers, no voting panel). |
+| `--auto` | `/shazam`, `/implement`, `/design` | Suppresses all interactive question checkpoints. Skills run fully autonomously without user interaction. |
+| `--no-merge` | `/shazam` | Creates PR but skips CI monitoring, merge, :merged: emoji, and local branch cleanup. |
+
+## Conditional Steps
+
+Certain steps in the workflow depend on configuration prerequisites and are skipped when unavailable:
+
+- **Slack announcements** — Require Slack configuration. When unavailable, the announcement step is skipped with a warning but the workflow continues.
+- **CI monitoring** — Requires repository identification. When unavailable, CI monitoring is skipped.
+- **Version bump** — Requires a `/bump-version` skill defined in the repo. When absent, the version bump step is skipped with a warning.
+
+## Resolution Protocols
+
+Different skills use different protocols for resolving review findings:
+
+| Protocol | Used by | Mechanism |
+|---|---|---|
+| [Voting](voting-process.md) | `/design`, `/review` | 3-agent panel votes YES/NO/EXONERATE. 2+ YES required to accept. |
+| Negotiation | `/research`, `/loop-review` | Up to N rounds of back-and-forth with external reviewers. Claude makes the final call. |
+
+See [Voting Process](voting-process.md) for full details on the voting protocol.


### PR DESCRIPTION
## Summary

- Added comprehensive documentation suite: README.md (hub) with skills table, review agents table, and links to 7 detailed docs in `docs/`
- Created detailed documentation covering workflow lifecycle, voting process, point competition, collaborative sketches, external reviewers, review agents, and agent system
- Included mermaid diagrams for skill orchestration hierarchy, workflow flow, voting process, sketch fan-out, and agent patterns

<details><summary>Architecture Diagram</summary>

```mermaid
graph TD
    subgraph "Skills Layer"
        SHAZAM["/shazam<br/>End-to-end orchestrator"]
        IMPLEMENT["/implement<br/>PR creation + CI"]
        DESIGN["/design<br/>Planning + plan review"]
        REVIEW["/review<br/>Code review"]
        LOOP["/loop-review<br/>Systematic codebase review"]
        RESEARCH["/research<br/>Read-only research"]
        CHECKS["/relevant-checks<br/>Validation"]
        CREATOR["/skill-creator<br/>Skill management"]
    end

    subgraph "Shared Protocols"
        VOTING["Voting Protocol<br/>(3-agent panel)"]
        NEGOTIATION["Negotiation Protocol<br/>(back-and-forth)"]
        EXTREV["External Reviewer<br/>Procedures"]
        TEMPLATES["Reviewer Templates<br/>(4 archetypes)"]
    end

    subgraph "Agent Definitions"
        GENERIC["Generic Reviewer<br/>(sonnet)"]
        CORRECT["Correctness Reviewer<br/>(sonnet)"]
        RISK["Risk Reviewer<br/>(sonnet)"]
        ARCH["Architect Reviewer<br/>(opus)"]
    end

    subgraph "External Tools"
        CODEX["Codex"]
        CURSOR["Cursor"]
    end

    SHAZAM -->|"invokes"| IMPLEMENT
    IMPLEMENT -->|"invokes"| DESIGN
    IMPLEMENT -->|"invokes"| REVIEW
    IMPLEMENT -->|"invokes"| CHECKS
    LOOP -->|"invokes"| SHAZAM

    DESIGN -->|"uses"| VOTING
    DESIGN -->|"uses"| EXTREV
    DESIGN -->|"uses"| TEMPLATES
    REVIEW -->|"uses"| VOTING
    REVIEW -->|"uses"| EXTREV
    REVIEW -->|"uses"| TEMPLATES
    RESEARCH -->|"uses"| NEGOTIATION
    RESEARCH -->|"uses"| EXTREV
    LOOP -->|"uses"| NEGOTIATION
    LOOP -->|"uses"| EXTREV

    TEMPLATES -->|"defines"| GENERIC
    TEMPLATES -->|"defines"| CORRECT
    TEMPLATES -->|"defines"| RISK
    TEMPLATES -->|"defines"| ARCH

    EXTREV -->|"integrates"| CODEX
    EXTREV -->|"integrates"| CURSOR
```

</details>

<details><summary>Code Flow Diagram</summary>

```mermaid
sequenceDiagram
    participant User
    participant Shazam as /shazam
    participant Impl as /implement
    participant Design as /design
    participant Review as /review
    participant Checks as /relevant-checks
    participant CI as GitHub CI
    participant Slack

    User->>Shazam: /shazam <feature>
    Shazam->>Impl: Invoke /implement

    Note over Design: Design Phase
    Impl->>Design: Invoke /design
    Design->>Design: Create branch
    Design->>Design: 5-agent collaborative sketches
    Design->>Design: Synthesis → Implementation plan
    Design->>Design: 6-reviewer plan review + voting
    Design-->>Impl: Plan ready

    Note over Impl: Implementation Phase
    Impl->>Impl: Implement feature
    Impl->>Checks: Validate
    Impl->>Impl: Commit #1

    Note over Review: Code Review Phase
    Impl->>Review: Invoke /review
    Review->>Review: 6 reviewers in parallel
    Review->>Review: Voting panel adjudicates
    Review->>Review: Implement accepted fixes
    Review-->>Impl: Review complete

    Impl->>Checks: Validate again
    Impl->>Impl: Commit #2
    Impl->>Impl: Version bump + commit
    Impl->>CI: Create PR
    Impl->>CI: Monitor CI, fix failures
    Impl->>Slack: Post announcement
    Impl-->>Shazam: PR ready

    Note over Shazam: Merge Phase
    loop CI + Rebase Loop
        Shazam->>CI: Wait for CI pass
        Shazam->>Shazam: Rebase if main advanced
    end
    Shazam->>CI: Merge PR
    Shazam->>Slack: Add :merged: emoji
    Shazam->>Shazam: Local cleanup
    Shazam-->>User: Complete
```

</details>

<details><summary>Goal</summary>

- Write comprehensive documentation for the claudin2 repository
  - Create `README.md` at root level as the documentation hub
    - One-sentence summary of the repo's purpose
    - Bullet list of main features
    - Skills table (modeled on ~/dev-tools format) for all 8 skills
    - Review Agents table linking to agent definitions
    - Empty Environment Variables section (placeholder for future)
    - Links to detailed documentation in `docs/`
  - Create `docs/` subdirectory with 7 detailed markdown documents
    - Workflow lifecycle: skill orchestration hierarchy, end-to-end flow, flags, conditional steps
    - Voting process: panel composition, threshold rules, ballot format, OOS handling
    - Point competition: scoring rules, OOS scoring floor, scoreboard format
    - Collaborative sketches: 5-agent diverge-then-converge phase, replacements, fallbacks
    - External reviewers: Codex/Cursor integration, sentinel monitoring, output validation
    - Review agents: 4 archetypes with focus areas, persistent vs. inline templates
    - Agent system: orchestration patterns, context isolation, performance optimization
  - Include mermaid diagrams for complex flows
  - Leave out mentions of repo-config.json and env vars (being changed in parallel PR)

</details>

<details><summary>Test plan</summary>

- [x] All `.md` files pass `markdownlint` with project's `.markdownlint.json` config
- [x] All relative links to `.claude/skills/*/SKILL.md` files resolve correctly
- [x] All relative links to `.claude/skills/*/diagram.svg` files resolve correctly
- [x] All relative links to `.claude/agents/*.md` files resolve correctly
- [x] Cross-links between `docs/*.md` files use relative sibling paths
- [x] Links from `README.md` use `docs/filename.md` format
- [x] No mentions of `repo-config.json` or environment variables beyond the empty placeholder

</details>

<details><summary>Final Design</summary>

### Files to Create

1. **README.md** (root) — Hub document with one-sentence summary, feature bullets, skills table (8 skills), review agents table, empty ENV section, links to docs/
2. **docs/workflow-lifecycle.md** — Skill orchestration hierarchy (/shazam wraps /implement wraps /design+/review), end-to-end flow diagram, flags, conditional steps, /loop-review batching
3. **docs/voting-process.md** — Per-skill panel composition, YES/NO/EXONERATE semantics, threshold rules, ballot format, OOS handling, voting vs. negotiation distinction
4. **docs/point-competition.md** — All 4 scoring rows, OOS promotion mechanics, OOS scoring floor invariant, scoreboard format
5. **docs/collaborative-sketches.md** — 5 sketch agents (distinct from 6 plan-review agents), Claude replacement roles per skill, fallback behavior by phase
6. **docs/external-reviewers.md** — Binary checks, sentinel monitoring, output validation, timeout handling, roles across workflow
7. **docs/review-agents.md** — 4 archetypes with focus areas, model assignments, persistent agents vs. inline templates, dual-list output
8. **docs/agents.md** — Agent orchestration patterns, agent types, context isolation, tool access, performance optimization

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

### [Plan Review] Generic, Correctness, Architect
**Finding**: FINDING_2 — Voting vs. negotiation needs finer-grained detail (max_rounds=1 for /loop-review, negotiation scope in /research).
**Reason**: Neutral (1 YES, 2 EXONERATE). High-level distinction is captured; fine-grained operational details are in SKILL.md files.

### [Plan Review] Generic, Risk, Codex
**Finding**: FINDING_4 — Merge docs/agents.md and docs/review-agents.md into one document.
**Reason**: Rejected (0 YES, 3 NO). The agent system concept is broader than the 4 reviewer archetypes. Keeping them separate maintains cleaner separation of concerns.

### [Plan Review] Architect
**Finding**: FINDING_12 — Add source attribution headers to each doc file.
**Reason**: Exonerated (0 YES, 3 EXONERATE). Legitimate maintenance aid but stylistic polish, not a necessary plan revision.

</details>

<details><summary>Implementation Deviations</summary>

No deviations from the plan.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

### [Code Review] Generic, Correctness, Architect
**Finding**: FINDING_2 — docs/collaborative-sketches.md uses "voting adjusts thresholds" and "quorum" wording that misrepresents the fallback behavior.
**Reason not implemented**: Neutral (1 YES, 1 EXONERATE, 1 NO). The fallback table is a summary; voting-process.md provides authoritative behavior.

### [Code Review] Generic, Architect
**Finding**: FINDING_3 — docs/agents.md says "without polling the output" but wait-for-reviewers.sh polls every 5 seconds.
**Reason not implemented**: Neutral (1 YES, 2 NO). "Without polling the output" is technically accurate — system polls sentinel files, not output files.

### [Code Review] Correctness, Risk
**Finding**: FINDING_4 — docs/agents.md line 55 describes voting panel generically without noting role differs by skill.
**Reason not implemented**: Neutral (1 YES, 2 NO). agents.md is a high-level overview; per-skill distinction is in voting-process.md.

### [Code Review] Correctness
**Finding**: FINDING_5 — "launched simultaneously" contradicts ordered launch description.
**Reason not implemented**: Neutral (1 YES, 1 EXONERATE, 1 NO). Intent is understandable from context and diagram.

### [Code Review] Generic
**Finding**: FINDING_6 — /implement quick mode row omits "no voting panel."
**Reason not implemented**: Neutral (1 YES, 1 NO, 1 EXONERATE). Table is about reviewer participation, not resolution mechanism.

### [Code Review] Correctness
**Finding**: FINDING_7 — /loop-review flush description omits file-count trigger (>10 files).
**Reason not implemented**: Neutral (1 YES, 2 EXONERATE). Lifecycle doc is a summary; detailed conditions are in SKILL.md.

### [Code Review] Cursor
**Finding**: FINDING_10 — "Three are Claude subagents" is actually 2 subagents + 1 inline orchestrator.
**Reason not implemented**: Neutral (1 YES, 2 EXONERATE). Page clarifies the five participants; behavioral distinction is minor.

### [Code Review] Risk
**Finding**: FINDING_12 — "submitted to 6 reviewers" stated unconditionally.
**Reason not implemented**: Neutral (1 YES, 2 EXONERATE). Same document explains fallback behavior with fewer reviewers.

</details>

<details><summary>Plan Review Voting Tally</summary>

| Finding | Architect | Cursor | Codex | Result |
|---------|-----------|--------|-------|--------|
| FINDING_1 | YES | YES | YES | **ACCEPTED** (3/3 YES) |
| FINDING_2 | EXONERATE | EXONERATE | YES | Neutral (1/3 YES) |
| FINDING_3 | YES | YES | YES | **ACCEPTED** (3/3 YES) |
| FINDING_4 | NO | NO | NO | Rejected (0/3 YES) |
| FINDING_5 | YES | YES | YES | **ACCEPTED** (3/3 YES) |
| FINDING_6 | YES | YES | YES | **ACCEPTED** (3/3 YES) |
| FINDING_7 | YES | YES | EXONERATE | **ACCEPTED** (2/3 YES) |
| FINDING_8 | EXONERATE | YES | YES | **ACCEPTED** (2/3 YES) |
| FINDING_9 | YES | EXONERATE | YES | **ACCEPTED** (2/3 YES) |
| FINDING_10 | YES | EXONERATE | YES | **ACCEPTED** (2/3 YES) |
| FINDING_11 | YES | NO | YES | **ACCEPTED** (2/3 YES) |
| FINDING_12 | EXONERATE | EXONERATE | EXONERATE | Exonerated (0 YES, 3 EXON) |
| OOS_1 | YES | EXONERATE | EXONERATE | Not promoted (1/3 YES) |
| OOS_2 | YES | EXONERATE | EXONERATE | Not promoted (1/3 YES) |
| OOS_3 | YES | EXONERATE | EXONERATE | Not promoted (1/3 YES) |
| OOS_4 | EXONERATE | EXONERATE | NO | Not promoted (0 YES) |

## Reviewer Competition Scoreboard

| Reviewer | Findings | Accepted | Neutral (1 YES) | Exonerated (0 YES, 1+ EXON.) | Rejected (0 YES, 0 EXON.) | OOS Proposed | OOS Promoted | Score |
|----------|----------|----------|-----------------|-------------------------------|---------------------------|--------------|--------------|-------|
| Correctness | 7 | 6 | 1 | 0 | 0 | 1 | 0 | +6 |
| Cursor | 4 | 4 | 0 | 0 | 0 | 0 | 0 | +4 |
| Generic | 6 | 4 | 1 | 0 | 1 | 1 | 0 | +3 |
| Architect | 5 | 3 | 1 | 1 | 0 | 3 | 0 | +3 |
| Risk | 3 | 2 | 0 | 0 | 1 | 1 | 0 | +1 |
| Codex | 3 | 2 | 0 | 0 | 1 | 0 | 0 | +1 |

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

| Finding | Generic (Claude) | Cursor | Codex | Result |
|---------|-----------|--------|-------|--------|
| FINDING_1 | YES | EXONERATE | YES | **ACCEPTED** (2/3 YES) |
| FINDING_2 | YES | EXONERATE | NO | Neutral (1/3 YES) |
| FINDING_3 | YES | NO | NO | Neutral (1/3 YES) |
| FINDING_4 | YES | NO | NO | Neutral (1/3 YES) |
| FINDING_5 | YES | EXONERATE | NO | Neutral (1/3 YES) |
| FINDING_6 | YES | NO | EXONERATE | Neutral (1/3 YES) |
| FINDING_7 | YES | EXONERATE | EXONERATE | Neutral (1/3 YES) |
| FINDING_8 | YES | YES | YES | **ACCEPTED** (3/3 YES) |
| FINDING_9 | YES | YES | YES | **ACCEPTED** (3/3 YES) |
| FINDING_10 | YES | EXONERATE | EXONERATE | Neutral (1/3 YES) |
| FINDING_11 | YES | EXONERATE | YES | **ACCEPTED** (2/3 YES) |
| FINDING_12 | YES | EXONERATE | EXONERATE | Neutral (1/3 YES) |

## Reviewer Competition Scoreboard

| Reviewer | Findings | Accepted | Neutral (1 YES) | Exonerated | Rejected | Score |
|----------|----------|----------|-----------------|------------|----------|-------|
| Cursor | 4 | 3 | 1 | 0 | 0 | +3 |
| Codex | 2 | 2 | 0 | 0 | 0 | +2 |
| Generic | 3 | 0 | 3 | 0 | 0 | 0 |
| Correctness | 4 | 0 | 4 | 0 | 0 | 0 |
| Risk | 2 | 0 | 2 | 0 | 0 | 0 |
| Architect | 2 | 0 | 2 | 0 | 0 | 0 |

</details>

<details><summary>Out-of-Scope Observations</summary>

**Plan Review OOS:**
- OOS_1: settings.json references skills without SKILL.md files (admin-add-user, brand-new, optimize, etc.)
- OOS_2: CI installs markdownlint-cli without version pinning
- OOS_3: /shazam SKILL.md has dangling "keep in sync" references to non-existent skills
- OOS_4: /relevant-checks is repo-specific but lives alongside generic skills

**Code Review OOS:**
- Generic: /research skill absent from the workflow-lifecycle diagram (standalone skill, outside hierarchy)
- Generic: Sketch agents described as "5 agents" but orchestrator sketch is inline (4 Agent tool + 1 inline)
- Architect: Negotiation Protocol lacks a standalone doc (asymmetric treatment vs. Voting Protocol)
- Architect: Round 2+ reviewers may still produce OOS output from templates, but it's silently discarded

</details>

<details><summary>Execution Issues</summary>

### Warnings
- **Step 8**: Version bump skipped — no `/bump-version` skill found at `.claude/skills/bump-version/SKILL.md`.

### Tool Failures
- **Step 11**: Slack announcement skipped — `CLAUDIN_SLACK_CHANNEL_ID` is not set.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | 9 accepted, 3 rejected |
| Code review rounds | 1 |
| Code review findings | 4 accepted, 8 neutral |
| Warnings logged | 1 |
| Pre-existing issues noticed | 0 |
| External reviewers | Cursor: ✅, Codex: ✅ |

</details>

Generated with [Claude Code](https://claude.com/claude-code)

