### PR TITLE
Document ENV variables and rename Claudin2 to Claudin

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ A Slack Bot User OAuth Token (starts with `xoxb-`) used to authenticate Slack AP
 **When set:**
 - `/implement` and `/shazam` post PR announcements to Slack after creating a PR
 - `/shazam` adds a `:merged:` emoji reaction to the Slack announcement after the PR is merged
-- The token is validated during session setup and its availability is propagated to child skills
+- The token's presence is checked during session setup and its availability is propagated to child skills
 
 **When not set:**
-- Slack announcement steps are skipped with a warning (e.g., `⚠ CLAUDIN_SLACK_BOT_TOKEN is not set. Slack announcement will be skipped.`)
+- Slack announcement steps are skipped with a warning (e.g., `⚠ CLAUDIN_SLACK_BOT_TOKEN is not set. Slack announcement (Step 11) will be skipped.`)
 - The `:merged:` emoji step in `/shazam` is skipped
 - All other workflow steps (design, implementation, code review, CI monitoring, merge) proceed normally
 
@@ -65,7 +65,8 @@ The Slack channel ID (e.g., `C0123456789`) where PR announcements and emoji reac
 
 **When not set:**
 - Slack announcements are skipped even if `CLAUDIN_SLACK_BOT_TOKEN` is set (the bot token alone is not sufficient — a target channel is required)
-- A warning is printed: `WARNING: CLAUDIN_SLACK_CHANNEL_ID is not set. Slack announcement skipped.`
+- The `:merged:` emoji step in `/shazam` is also skipped
+- Warnings are printed by the respective scripts (e.g., `WARNING: CLAUDIN_SLACK_CHANNEL_ID is not set.`)
 
 ## Detailed Documentation
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Claudin2
+# Claudin
 
-Claudin2 is a Claude Code workflow automation framework that orchestrates multi-agent design, code review, and implementation through collaborative AI-driven processes.
+Claudin is a Claude Code workflow automation framework that orchestrates multi-agent design, code review, and implementation through collaborative AI-driven processes.
 
 ## Features
 
@@ -39,7 +39,33 @@ Internal agent definitions used by skills like `/design`, `/review`, and `/loop-
 
 ## Environment Variables
 
-*Coming soon.*
+Claudin uses two environment variables for Slack integration. Both are optional — when not set, Slack-related features are skipped with warnings and all other workflow steps continue normally.
+
+### `CLAUDIN_SLACK_BOT_TOKEN`
+
+A Slack Bot User OAuth Token (starts with `xoxb-`) used to authenticate Slack API calls.
+
+**When set:**
+- `/implement` and `/shazam` post PR announcements to Slack after creating a PR
+- `/shazam` adds a `:merged:` emoji reaction to the Slack announcement after the PR is merged
+- The token is validated during session setup and its availability is propagated to child skills
+
+**When not set:**
+- Slack announcement steps are skipped with a warning (e.g., `⚠ CLAUDIN_SLACK_BOT_TOKEN is not set. Slack announcement will be skipped.`)
+- The `:merged:` emoji step in `/shazam` is skipped
+- All other workflow steps (design, implementation, code review, CI monitoring, merge) proceed normally
+
+### `CLAUDIN_SLACK_CHANNEL_ID`
+
+The Slack channel ID (e.g., `C0123456789`) where PR announcements and emoji reactions are posted.
+
+**When set:**
+- PR announcements are posted to this channel
+- The `:merged:` emoji reaction targets announcements in this channel
+
+**When not set:**
+- Slack announcements are skipped even if `CLAUDIN_SLACK_BOT_TOKEN` is set (the bot token alone is not sufficient — a target channel is required)
+- A warning is printed: `WARNING: CLAUDIN_SLACK_CHANNEL_ID is not set. Slack announcement skipped.`
 
 ## Detailed Documentation
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,6 +1,6 @@
 # Agent System
 
-How Claudin2 skills orchestrate parallel subagents to achieve collaborative multi-perspective workflows.
+How Claudin skills orchestrate parallel subagents to achieve collaborative multi-perspective workflows.
 
 ## What Are Agents?
 
@@ -40,7 +40,7 @@ Skills invoke other skills in sequence, each building on the previous result. Fo
 
 ## Agent Types
 
-Claudin2 uses several categories of agents:
+Claudin uses several categories of agents:
 
 ### Review Agents
 

--- a/docs/external-reviewers.md
+++ b/docs/external-reviewers.md
@@ -1,6 +1,6 @@
 # External Reviewers
 
-Codex and Cursor participate alongside Claude subagents as both reviewers and voters in the Claudin2 workflow. This document covers the shared integration procedures.
+Codex and Cursor participate alongside Claude subagents as both reviewers and voters in the Claudin workflow. This document covers the shared integration procedures.
 
 ## Availability Checks
 

--- a/docs/review-agents.md
+++ b/docs/review-agents.md
@@ -1,6 +1,6 @@
 # Review Agents
 
-Claudin2 uses 4 specialized Claude reviewer archetypes that provide different perspectives during plan review and code review. Each archetype has a distinct focus area, ensuring comprehensive coverage across quality dimensions.
+Claudin uses 4 specialized Claude reviewer archetypes that provide different perspectives during plan review and code review. Each archetype has a distinct focus area, ensuring comprehensive coverage across quality dimensions.
 
 ## The 4 Archetypes
 

--- a/docs/workflow-lifecycle.md
+++ b/docs/workflow-lifecycle.md
@@ -1,6 +1,6 @@
 # Workflow Lifecycle
 
-How skills compose to form the end-to-end development workflow in Claudin2.
+How skills compose to form the end-to-end development workflow in Claudin.
 
 ## Skill Orchestration Hierarchy
 


### PR DESCRIPTION
## Summary
- Documented `CLAUDIN_SLACK_BOT_TOKEN` and `CLAUDIN_SLACK_CHANNEL_ID` environment variables in README.md, replacing the "Coming soon" placeholder with detailed usage, behavior when set, and behavior when not set
- Renamed all "Claudin2" references to "Claudin" across README.md and 4 docs files (agents.md, review-agents.md, workflow-lifecycle.md, external-reviewers.md)

<details><summary>Architecture Diagram</summary>

Quick mode — architecture diagram skipped.

</details>

<details><summary>Code Flow Diagram</summary>

Quick mode — code flow diagram skipped.

</details>

<details><summary>Goal</summary>

- Document the two environment variables expected to be set by the user
  - `CLAUDIN_SLACK_BOT_TOKEN`: explain meaning, use, and expected behavior of skills if set vs not set
  - `CLAUDIN_SLACK_CHANNEL_ID`: explain meaning, use, and expected behavior of skills if set vs not set
- Replace all references to "Claudin2" throughout documentation with "Claudin"
- Refer to the repo as "Claudin" in all documentation changes

</details>

<details><summary>Test plan</summary>

- [ ] Verify no remaining "Claudin2" references exist in any markdown files
- [ ] Verify README.md Environment Variables section accurately describes `CLAUDIN_SLACK_BOT_TOKEN` behavior (compare with session-setup.sh, slack-announce.sh)
- [ ] Verify README.md Environment Variables section accurately describes `CLAUDIN_SLACK_CHANNEL_ID` behavior (compare with post-pr-announce.sh, post-merged-emoji.sh)
- [ ] Verify all 5 docs files are updated consistently

</details>

<details><summary>Final Design</summary>

**Files to modify (5):**

1. **README.md** — Replace `*Coming soon.*` in the Environment Variables section with documentation of `CLAUDIN_SLACK_BOT_TOKEN` and `CLAUDIN_SLACK_CHANNEL_ID`. Also replace "Claudin2" → "Claudin" on lines 1 and 3.
2. **docs/agents.md** — Replace "Claudin2" → "Claudin" (lines 3, 43).
3. **docs/review-agents.md** — Replace "Claudin2" → "Claudin" (line 3).
4. **docs/workflow-lifecycle.md** — Replace "Claudin2" → "Claudin" (line 3).
5. **docs/external-reviewers.md** — Replace "Claudin2" → "Claudin" (line 3).

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

Quick mode — no plan review was conducted.

</details>

<details><summary>Implementation Deviations</summary>

No deviations from the plan.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

### [Code Review] Generic Reviewer
**Finding**: `README.md` lines 62-64 — The `CLAUDIN_SLACK_CHANNEL_ID` "When set" section is claimed to be incomplete because it doesn't explicitly mention the `:merged:` emoji dependency. The reviewer suggested adding a bullet: "The `:merged:` emoji reaction is added to the announcement after the PR is merged by `/shazam`".
**Reason not implemented**: The existing bullet "The `:merged:` emoji reaction targets announcements in this channel" already covers this behavior. Adding a separate bullet would be redundant. The "When set" section is about what the channel ID enables, and the existing bullet accurately describes that the emoji reaction uses this channel.

### [Code Review] Architect Reviewer
**Finding**: `README.md` lines 51 and 67 — The documentation implies both `CLAUDIN_SLACK_BOT_TOKEN` and `CLAUDIN_SLACK_CHANNEL_ID` are validated during session setup, but only the bot token is checked at that stage. The channel ID is checked later at announcement time inside `post-pr-announce.sh` and `post-merged-emoji.sh`. The reviewer suggested documenting this two-phase behavior explicitly or having session setup also check the channel ID.
**Reason not implemented**: This is an implementation detail that would add unnecessary complexity to user-facing documentation. The README's purpose is to tell users what to set and what happens when they do/don't. The two-phase nature of the checks is an internal concern. The documentation already accurately states the user-visible outcome: both must be set for Slack features to work, and warnings are printed when either is missing.

### [Code Review] Architect Reviewer
**Finding**: `README.md` line 83 vs `post-pr-announce.sh` line 80-84 — When `CLAUDIN_SLACK_CHANNEL_ID` is not set, `post-pr-announce.sh` exits with code 0 (graceful skip) but `post-merged-emoji.sh` exits with code 1 (error). The README describes both as "skipped with a warning," suggesting symmetric behavior, but the exit codes differ. The reviewer suggested making both scripts consistent.
**Reason not implemented**: This is a code behavior issue in the shell scripts, not a documentation concern. The PR scope is documentation only (README env vars section and Claudin2→Claudin rename). Fixing script exit code inconsistencies would be a separate code change PR.

</details>

<details><summary>Plan Review Voting Tally</summary>

Quick mode — no plan review voting.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

Quick mode — no voting panel. Main agent reviewed findings from 4 Claude subagents.

</details>

<details><summary>Out-of-Scope Observations</summary>

Quick mode — no out-of-scope observations collected.

</details>

<details><summary>Execution Issues</summary>

No execution issues encountered.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | N/A (quick mode) |
| Code review rounds | 1 |
| Code review findings | 3 accepted, 3 rejected |
| Warnings logged | 1 |
| Pre-existing issues noticed | 0 |
| External reviewers | N/A (quick mode) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
