### PR TITLE
Add Getting Started docs and update-claudin.sh script

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,106 @@
 
 Claudin is a Claude Code workflow automation framework that orchestrates multi-agent design, code review, and implementation through collaborative AI-driven processes.
 
+## Getting Started
+
+There are two ways to integrate claudin into your repository:
+
+- **Flow A (Git Submodule)** — recommended for teams that want automatic upstream updates
+- **Flow B (Copy Skills)** — for teams that want to vendor a subset of skills and own them
+
+Both flows require environment variables for Slack integration (see [Environment Variables](#environment-variables) below). If you don't use Slack, you can skip them — skills degrade gracefully when Slack is not configured.
+
+### Flow A — Git Submodule
+
+Add claudin as a submodule and use `update-claudin.sh` to create symlinks from your `.claude/` directory into the submodule:
+
+```bash
+# 1. Add the submodule
+git submodule add <claudin-repo-url> claudin
+git commit -m "Add claudin submodule"
+
+# 2. Create symlinks from .claude/ into claudin/.claude/
+./claudin/update-claudin.sh
+
+# 3. Commit the symlinks and any new directories
+git add .claude
+git commit -m "Set up claudin symlinks"
+```
+
+**Updating to the latest version**: Every time you bump the claudin submodule to a newer version, re-run the update script to sync symlinks (create new ones, remove stale ones):
+
+```bash
+git submodule update --remote claudin
+git add claudin
+./claudin/update-claudin.sh
+git add .claude
+git commit -m "Bump claudin submodule"
+```
+
+**How it works**: `update-claudin.sh` creates symlinks from your `.claude/` directory tree into `claudin/.claude/`. Skill directories (those containing `SKILL.md`) get directory-level symlinks, while individual files (scripts, agents, shared docs) get file-level symlinks. Your repo can have its own additional skills, scripts, and agents alongside the symlinked ones.
+
+**Important notes**:
+
+- **`settings.json` is not symlinked.** Your repo must maintain its own `.claude/settings.json` with the permission entries needed by claudin scripts. At minimum, include bash permissions for `$PWD/.claude/scripts/generic/*` and the `block-submodule-edit.sh` hook.
+- **Edits to `claudin/` are blocked.** The `block-submodule-edit.sh` hook prevents Claude Code from editing files inside git submodules. This is intentional — changes to claudin should be made via PRs to the claudin repo, then pulled in by updating the submodule.
+- **Conflicts**: If a non-symlink file or directory already exists at a path the script needs to symlink, it exits with an error. Resolve the conflict manually (rename or remove the existing file) and re-run.
+
+### Flow B — Copy Selected Skills
+
+Copy the skills you need along with their shared dependencies into your repo's `.claude/` directory. Understanding the directory structure is essential to avoid missing dependencies.
+
+#### Directory structure
+
+```
+.claude/
+├── settings.json              # Permission and hook configuration (write your own)
+├── agents/                    # Reviewer agent definitions (.md files)
+│   ├── generic-reviewer.md
+│   ├── correctness-reviewer.md
+│   ├── risk-reviewer.md
+│   └── architect-reviewer.md
+├── scripts/
+│   └── generic/               # ~37 reusable shell scripts invoked by skills
+│       ├── session-setup.sh
+│       ├── create-pr.sh
+│       ├── ci-wait.sh
+│       └── ...
+└── skills/
+    ├── shared/                # Shared .md files referenced by multiple skills
+    │   ├── voting-protocol.md
+    │   ├── reviewer-templates.md
+    │   └── external-reviewers.md
+    ├── design/                # Each skill directory contains SKILL.md
+    │   ├── SKILL.md           #   and may include scripts/, agents/,
+    │   └── diagram.svg        #   references/, assets/, diagrams
+    ├── implement/
+    │   ├── SKILL.md
+    │   ├── scripts/
+    │   └── diagram.svg
+    └── ...
+```
+
+#### What to copy
+
+When copying a skill, you must also copy its shared dependencies:
+
+1. **The skill directory** — e.g., `.claude/skills/design/` (the entire directory including any nested `scripts/`, `agents/`, etc.)
+2. **`.claude/skills/shared/`** — shared markdown files referenced by all review-related skills. **Always copy this.**
+3. **`.claude/scripts/generic/`** — shell scripts that skills invoke for git operations, CI, Slack, etc. **Always copy this.**
+4. **`.claude/agents/`** — reviewer agent definitions used by `/design`, `/review`, and `/loop-review`. Copy if using any review-related skill.
+
+#### Transitive skill dependencies
+
+Skills invoke other skills. If you copy `/shazam`, you also need `/implement`, `/design`, `/review`, and `/relevant-checks`. The dependency chain:
+
+- `/shazam` → `/implement` → `/design`, `/review`, `/relevant-checks`
+- `/loop-review` → `/shazam` (full chain above)
+- `/implement` → `/design`, `/review`, `/relevant-checks`
+
+#### Note on `/relevant-checks`
+
+The `/relevant-checks` skill is **repo-specific** — its `SKILL.md` contains build and lint commands tailored to a specific repository. When copying it, treat it as a **template that must be rewritten** for your repo's build system. It will not work as-is.
+
 ## Features
 
 - **Multi-agent design planning** — 5 agents independently propose architectural approaches before a full implementation plan is written, preventing anchoring bias

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ git commit -m "Bump claudin submodule"
 
 **Important notes**:
 
-- **`settings.json` is not symlinked.** Your repo must maintain its own `.claude/settings.json` with the permission entries needed by claudin scripts. At minimum, include bash permissions for `$PWD/.claude/scripts/generic/*` and the `block-submodule-edit.sh` hook.
+- **`settings.json` is not symlinked.** Your repo must maintain its own `.claude/settings.json` with the permission entries needed by claudin scripts. The recommended approach is to copy the `permissions.allow` array from claudin's `settings.json` as a baseline. At minimum, include bash permissions for `$PWD/.claude/scripts/generic/*`, `$PWD/.claude/skills/*/scripts/*` (for skill-specific scripts), and the `block-submodule-edit.sh` hook.
 - **Edits to `claudin/` are blocked.** The `block-submodule-edit.sh` hook prevents Claude Code from editing files inside git submodules. This is intentional — changes to claudin should be made via PRs to the claudin repo, then pulled in by updating the submodule.
 - **Conflicts**: If a non-symlink file or directory already exists at a path the script needs to symlink, it exits with an error. Resolve the conflict manually (rename or remove the existing file) and re-run.
 

--- a/update-claudin.sh
+++ b/update-claudin.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+# update-claudin.sh — Sync symlinks from a client repo's .claude/ into claudin/.claude/ (the submodule).
+#
+# Intended to be run from the root of a client repo that has claudin as a git submodule.
+# The script derives the submodule path from its own location, so it works regardless of
+# the submodule directory name.
+#
+# Symlink strategy (hybrid):
+#   - Skill directories (contain SKILL.md) → directory-level symlinks
+#   - Everything else (scripts, agents, shared docs) → file-level symlinks
+#   - settings.json → always skipped (client must maintain their own)
+#
+# Conflict handling:
+#   - If a non-symlink file or directory exists at a target path → exit 1 with error
+#   - If a correct symlink exists → skip (idempotent)
+#   - If a symlink exists but points to wrong target → update it
+#
+# Dead symlink cleanup:
+#   - Removes symlinks under .claude/ whose resolved target points into the claudin
+#     submodule but whose target no longer exists.
+#
+# Usage:
+#   ./claudin/update-claudin.sh
+#
+# Exit codes:
+#   0 — success
+#   1 — error (conflict, missing submodule, not a git repo, etc.)
+
+set -euo pipefail
+
+# --- Derive paths ---
+# CLAUDIN_DIR: absolute path to the claudin submodule (where this script lives)
+CLAUDIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+
+# REPO_ROOT: the git repository root of the client repo
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+    echo "ERROR: Not inside a git repository." >&2
+    exit 1
+}
+REPO_ROOT="$(cd "$REPO_ROOT" && pwd -P)"
+
+# Verify we are running from the repo root
+if [[ "$(pwd -P)" != "$REPO_ROOT" ]]; then
+    echo "ERROR: Must run from the repository root ($REPO_ROOT), not $(pwd -P)." >&2
+    exit 1
+fi
+
+# Verify the claudin .claude directory exists
+if [[ ! -d "$CLAUDIN_DIR/.claude" ]]; then
+    echo "ERROR: $CLAUDIN_DIR/.claude does not exist. Is the submodule checked out?" >&2
+    exit 1
+fi
+
+# CLAUDIN_REL: relative path from repo root to the claudin submodule
+CLAUDIN_REL="${CLAUDIN_DIR#"$REPO_ROOT"/}"
+
+# --- Helper: compute relative symlink target ---
+# Given a symlink path relative to repo root (e.g., .claude/skills/design)
+# and a target path relative to repo root (e.g., claudin/.claude/skills/design),
+# compute the relative path from the symlink's parent to the target.
+compute_relpath() {
+    local link_path="$1"  # e.g., .claude/scripts/generic/foo.sh
+    local target_path="$2"  # e.g., claudin/.claude/scripts/generic/foo.sh
+
+    local parent_dir
+    parent_dir="$(dirname "$link_path")"
+
+    # Count depth of parent directory (number of / separated components)
+    local depth=0
+    local tmp="$parent_dir"
+    while [[ "$tmp" != "." && -n "$tmp" ]]; do
+        tmp="$(dirname "$tmp")"
+        depth=$((depth + 1))
+    done
+
+    # Build ../ prefix
+    local prefix=""
+    local i
+    for ((i = 0; i < depth; i++)); do
+        prefix="../${prefix}"
+    done
+
+    echo "${prefix}${target_path}"
+}
+
+# --- Helper: create a symlink with validation ---
+create_link() {
+    local link_path="$1"   # relative to repo root
+    local target_path="$2" # relative to repo root (in claudin)
+    local link_type="$3"   # "dir" or "file" (for messages only)
+
+    # Ensure parent directory exists
+    mkdir -p "$(dirname "$link_path")"
+
+    if [[ -L "$link_path" ]]; then
+        # Symlink already exists — check if it points to the right target
+        local current_target
+        current_target="$(readlink "$link_path")"
+        local expected_target
+        expected_target="$(compute_relpath "$link_path" "$target_path")"
+
+        if [[ "$current_target" == "$expected_target" ]]; then
+            # Correct symlink, skip
+            return 0
+        else
+            # Wrong target, update
+            rm "$link_path"
+            ln -s "$expected_target" "$link_path"
+            echo "  updated ($link_type): $link_path -> $expected_target"
+        fi
+    elif [[ -e "$link_path" ]]; then
+        # Non-symlink exists — conflict
+        echo "ERROR: Conflict at '$link_path' — a non-symlink file or directory already exists." >&2
+        echo "  Remove or rename it before re-running this script." >&2
+        exit 1
+    else
+        # Create new symlink
+        local rel_target
+        rel_target="$(compute_relpath "$link_path" "$target_path")"
+        ln -s "$rel_target" "$link_path"
+        echo "  linked ($link_type): $link_path -> $rel_target"
+    fi
+
+    # Validate the symlink resolves to an existing target
+    if [[ ! -e "$link_path" ]]; then
+        echo "ERROR: Symlink '$link_path' was created but does not resolve to an existing target." >&2
+        echo "  This indicates a bug in relative path computation." >&2
+        exit 1
+    fi
+}
+
+# --- Phase 1: Create symlinks ---
+echo "Phase 1: Creating symlinks from .claude/ into $CLAUDIN_REL/.claude/..."
+
+# Walk the claudin .claude directory
+while IFS= read -r -d '' entry; do
+    # entry is relative to CLAUDIN_DIR/.claude, e.g., "skills/design" or "agents/generic-reviewer.md"
+    local_path="${entry#"$CLAUDIN_DIR/.claude/"}"
+
+    # Skip settings.json — client must maintain their own
+    if [[ "$local_path" == "settings.json" ]]; then
+        echo "  skipped: .claude/settings.json (maintain your own)"
+        continue
+    fi
+
+    # Determine the link path in the client repo
+    link_path=".claude/$local_path"
+    target_path="$CLAUDIN_REL/.claude/$local_path"
+
+    # Check if this is a skill directory (first-level child of skills/ with SKILL.md)
+    if [[ "$entry" == "$CLAUDIN_DIR/.claude/skills/"* ]]; then
+        # Extract the first-level name under skills/
+        local_under_skills="${local_path#skills/}"
+        first_component="${local_under_skills%%/*}"
+
+        # Only process first-level entries under skills/
+        if [[ "$local_under_skills" == "$first_component" ]]; then
+            if [[ -d "$entry" && -f "$entry/SKILL.md" ]]; then
+                # Skill directory — directory-level symlink
+                create_link "$link_path" "$target_path" "skill dir"
+            elif [[ -d "$entry" ]]; then
+                # Non-skill directory under skills/ (e.g., shared/) — descend into it
+                # File-level symlinks will be handled when we encounter individual files
+                :
+            elif [[ -f "$entry" ]]; then
+                # File directly under skills/ (unusual but handle it)
+                create_link "$link_path" "$target_path" "file"
+            fi
+        else
+            # Nested entry under skills/ — check if the first-level parent is a skill dir
+            first_level_dir="$CLAUDIN_DIR/.claude/skills/$first_component"
+            if [[ -f "$first_level_dir/SKILL.md" ]]; then
+                # Inside a skill directory — already covered by directory-level symlink, skip
+                :
+            elif [[ -f "$entry" ]]; then
+                # File inside a non-skill directory (e.g., skills/shared/voting-protocol.md)
+                create_link "$link_path" "$target_path" "file"
+            fi
+            # Directories inside non-skill dirs are handled by mkdir -p in create_link
+        fi
+    elif [[ -f "$entry" ]]; then
+        # Non-skills file (agents/*.md, scripts/generic/*.sh, etc.)
+        create_link "$link_path" "$target_path" "file"
+    fi
+    # Directories outside skills/ are traversed automatically by find; we only link files
+done < <(find "$CLAUDIN_DIR/.claude" -not -path "$CLAUDIN_DIR/.claude" \( -type f -o -type d \) -print0 | sort -z)
+
+# --- Phase 2: Remove dead symlinks ---
+echo "Phase 2: Removing dead symlinks pointing into $CLAUDIN_REL/.claude/..."
+
+dead_count=0
+while IFS= read -r -d '' link; do
+    # Only process broken symlinks (target does not exist)
+    if [[ -e "$link" ]]; then
+        continue
+    fi
+
+    # Read the raw symlink target
+    raw_target="$(readlink "$link")"
+
+    # Resolve the target to an absolute path by joining with the link's parent dir
+    link_parent="$(cd "$(dirname "$link")" && pwd -P)"
+    # Attempt to resolve — since the target is broken, we normalize manually
+    # Join parent + raw_target, then check if it would be inside CLAUDIN_DIR/.claude/
+    resolved=""
+    if [[ "$raw_target" == /* ]]; then
+        resolved="$raw_target"
+    else
+        # Normalize: use a subshell to walk the path components
+        # Since the target is broken, we resolve as far as we can
+        resolved="$link_parent/$raw_target"
+    fi
+
+    # Normalize by collapsing .. components
+    # Use Python for reliable cross-platform normalization
+    normalized="$(python3 -c "import os, sys; print(os.path.normpath(sys.argv[1]))" "$resolved" 2>/dev/null)" || {
+        # If python3 is not available, skip this link
+        continue
+    }
+
+    # Check if the normalized path is inside the claudin .claude directory
+    if [[ "$normalized" == "$CLAUDIN_DIR/.claude"* || "$normalized" == "$CLAUDIN_DIR/.claude/"* ]]; then
+        rm "$link"
+        echo "  removed dead symlink: $link -> $raw_target"
+        dead_count=$((dead_count + 1))
+    fi
+done < <(find .claude -type l -print0 2>/dev/null || true)
+
+echo ""
+echo "Done. Dead symlinks removed: $dead_count"
+echo ""
+echo "NOTE: .claude/settings.json was not synced. Ensure your settings.json"
+echo "includes the necessary permissions for claudin scripts. At minimum:"
+echo "  - Bash permission for \$PWD/.claude/scripts/generic/*"
+echo "  - The block-submodule-edit.sh hook (if using submodule flow)"

--- a/update-claudin.sh
+++ b/update-claudin.sh
@@ -51,6 +51,13 @@ if [[ ! -d "$CLAUDIN_DIR/.claude" ]]; then
     exit 1
 fi
 
+# Verify the claudin submodule is inside the repo root
+if [[ "$CLAUDIN_DIR" != "$REPO_ROOT/"* ]]; then
+    echo "ERROR: claudin submodule ($CLAUDIN_DIR) is not inside the repo root ($REPO_ROOT)." >&2
+    echo "  Run this script from the repository that contains claudin as a submodule." >&2
+    exit 1
+fi
+
 # CLAUDIN_REL: relative path from repo root to the claudin submodule
 CLAUDIN_REL="${CLAUDIN_DIR#"$REPO_ROOT"/}"
 
@@ -219,7 +226,7 @@ while IFS= read -r -d '' link; do
     }
 
     # Check if the normalized path is inside the claudin .claude directory
-    if [[ "$normalized" == "$CLAUDIN_DIR/.claude"* || "$normalized" == "$CLAUDIN_DIR/.claude/"* ]]; then
+    if [[ "$normalized" == "$CLAUDIN_DIR/.claude" || "$normalized" == "$CLAUDIN_DIR/.claude/"* ]]; then
         rm "$link"
         echo "  removed dead symlink: $link -> $raw_target"
         dead_count=$((dead_count + 1))


### PR DESCRIPTION
## Summary
- Added comprehensive Getting Started documentation with two integration flows: Flow A (git submodule with symlink management) and Flow B (copy selected skills with dependency guidance)
- Created `update-claudin.sh` script that manages hybrid symlinks between a client repo's `.claude/` and the claudin submodule, with conflict detection and dead symlink cleanup
- Filled in the Environment Variables section with `CLAUDIN_SLACK_BOT_TOKEN`, `CLAUDIN_SLACK_CHANNEL_ID`, and `SLACK_USER_ID` documentation

<details><summary>Architecture Diagram</summary>

```mermaid
graph TD
    subgraph "Client Repository"
        CR_ROOT["."]
        CR_CLAUDE[".claude/"]
        CR_SKILLS[".claude/skills/"]
        CR_AGENTS[".claude/agents/"]
        CR_SCRIPTS[".claude/scripts/generic/"]
        CR_SHARED[".claude/skills/shared/"]
        CR_SETTINGS[".claude/settings.json<br/><i>client-owned, not symlinked</i>"]

        CR_SKILL_A[".claude/skills/design/ →"]
        CR_SKILL_B[".claude/skills/implement/ →"]
        CR_AGENT_F[".claude/agents/*.md →"]
        CR_SCRIPT_F[".claude/scripts/generic/*.sh →"]
        CR_SHARED_F[".claude/skills/shared/*.md →"]
    end

    subgraph "claudin/ (submodule)"
        SUB_SCRIPT["update-claudin.sh"]
        SUB_CLAUDE["claudin/.claude/"]
        SUB_SKILLS["claudin/.claude/skills/"]
        SUB_AGENTS["claudin/.claude/agents/"]
        SUB_SCRIPTS["claudin/.claude/scripts/generic/"]
        SUB_SHARED["claudin/.claude/skills/shared/"]
        SUB_SETTINGS["claudin/.claude/settings.json"]
    end

    SUB_SCRIPT -->|"Phase 1: create symlinks"| CR_CLAUDE
    SUB_SCRIPT -->|"Phase 2: prune dead links"| CR_CLAUDE

    CR_SKILL_A -.->|"dir symlink"| SUB_SKILLS
    CR_SKILL_B -.->|"dir symlink"| SUB_SKILLS
    CR_AGENT_F -.->|"file symlink"| SUB_AGENTS
    CR_SCRIPT_F -.->|"file symlink"| SUB_SCRIPTS
    CR_SHARED_F -.->|"file symlink"| SUB_SHARED

    CR_SETTINGS -.-x|"excluded"| SUB_SETTINGS

    style CR_SETTINGS fill:#fff3cd
    style SUB_SETTINGS fill:#f8d7da
    style SUB_SCRIPT fill:#d4edda
```

</details>

<details><summary>Code Flow Diagram</summary>

```mermaid
flowchart TD
    START([update-claudin.sh]) --> DERIVE[Derive CLAUDIN_DIR from BASH_SOURCE]
    DERIVE --> REPO_ROOT[Get REPO_ROOT via git rev-parse]
    REPO_ROOT --> VALIDATE{Validate paths}
    VALIDATE -->|cwd != root| ERR1[EXIT 1: wrong directory]
    VALIDATE -->|no .claude/| ERR2[EXIT 1: submodule not checked out]
    VALIDATE -->|not under root| ERR3[EXIT 1: script not in repo]
    VALIDATE -->|OK| PHASE1[Phase 1: Create Symlinks]

    PHASE1 --> WALK["find claudin/.claude/ -print0 | sort"]
    WALK --> ENTRY{For each entry}

    ENTRY -->|settings.json| SKIP[Skip — print notice]
    ENTRY -->|skills/ child with SKILL.md| DIR_LINK[create_link: directory symlink]
    ENTRY -->|skills/ child without SKILL.md| DESCEND[Descend — file-level later]
    ENTRY -->|File inside non-skill skills/ dir| FILE_LINK1[create_link: file symlink]
    ENTRY -->|File outside skills/| FILE_LINK2[create_link: file symlink]
    ENTRY --> NEXT_ENTRY[Next entry]

    DIR_LINK --> CREATE{create_link}
    FILE_LINK1 --> CREATE
    FILE_LINK2 --> CREATE

    CREATE -->|symlink exists, correct| SKIP2[Skip silently]
    CREATE -->|symlink exists, wrong target| UPDATE[rm + ln -s]
    CREATE -->|non-symlink exists| CONFLICT[EXIT 1: conflict]
    CREATE -->|no file exists| NEW_LINK["mkdir -p + ln -s"]
    UPDATE --> TEST_E{"test -e link"}
    NEW_LINK --> TEST_E
    TEST_E -->|resolves| OK[Continue]
    TEST_E -->|broken| ERR4[EXIT 1: path computation bug]

    NEXT_ENTRY --> PHASE2[Phase 2: Remove Dead Symlinks]
    PHASE2 --> FIND_DEAD["find .claude -type l"]
    FIND_DEAD --> DEAD_ENTRY{For each symlink}
    DEAD_ENTRY -->|target exists| SKIP3[Skip — alive]
    DEAD_ENTRY -->|target missing| RESOLVE[Canonicalize via python3]
    RESOLVE -->|inside claudin/.claude/| RM[Remove dead symlink]
    RESOLVE -->|outside claudin/| SKIP4[Skip — not ours]
    RM --> DONE([Print summary + settings.json reminder])
```

</details>

<details><summary>Goal</summary>

- Add a Getting Started section to README.md documenting two integration flows for claudin
  - **Flow A (Git Submodule)**: Document submodule setup, `update-claudin.sh` usage for symlink management, submodule-native update commands, `settings.json` manual merge guidance, and `block-submodule-edit.sh` interaction
  - **Flow B (Copy Skills)**: Document the `.claude/` directory structure, shared dependencies that must accompany copied skills, transitive skill dependency chains, and mark `/relevant-checks` as a repo-specific template requiring rewrite
- Create `update-claudin.sh` at the repo root for client repos using Flow A
  - Implement hybrid symlink strategy: directory-level for skill directories (containing SKILL.md), file-level for everything else
  - Derive submodule path from script's own location for portability
  - Validate CLAUDIN_DIR is inside REPO_ROOT before computing relative paths
  - Skip `settings.json` (client-owned), with a reminder message
  - Compute correct relative symlink paths based on parent directory depth
  - Detect and remove dead symlinks pointing into the claudin submodule
  - Fail loudly on conflicts (non-symlink at target path)
- Fill in the Environment Variables section with `CLAUDIN_SLACK_BOT_TOKEN`, `CLAUDIN_SLACK_CHANNEL_ID`, and `SLACK_USER_ID`

</details>

<details><summary>Test plan</summary>

- [ ] Verify `shellcheck update-claudin.sh` passes (enforced by CI)
- [ ] Verify `markdownlint README.md` passes (enforced by CI)
- [ ] Manual test: create a temp directory simulating a client repo with claudin as submodule, run `update-claudin.sh`, verify all symlinks created correctly
- [ ] Manual test: verify idempotent re-runs produce no changes
- [ ] Manual test: delete a file from claudin/.claude/, re-run script, verify dead symlink is cleaned up
- [ ] Manual test: create a non-symlink file at a target path, verify script exits with conflict error
- [ ] Manual test: verify settings.json is skipped with a notice message
- [ ] Verify README rendering on GitHub (Getting Started section, directory tree, ENV vars table)

</details>

<details><summary>Final Design</summary>

### Files to modify/create

1. **README.md** — Add "Getting Started" section between intro and "Features". Fill in "Environment Variables" section.
2. **update-claudin.sh** (new, ~240 lines) — Bash script at repo root for client repos using Flow A.

### update-claudin.sh design

- **Preamble**: `set -euo pipefail`. Derive CLAUDIN_DIR from BASH_SOURCE. Get REPO_ROOT via `git rev-parse --show-toplevel`. Validate cwd == REPO_ROOT, CLAUDIN_DIR is under REPO_ROOT, and claudin/.claude exists.
- **Phase 1**: Walk claudin/.claude/ with find. Skills with SKILL.md → directory-level symlinks. Everything else → file-level symlinks. settings.json → skip. mkdir -p parent dirs. Fail on non-symlink conflicts. Validate with test -e after creation.
- **Phase 2**: find .claude -type l recursively. Canonicalize targets via python3 normalization. Remove dead symlinks whose resolved target is inside CLAUDIN_DIR/.claude.
- **Relative paths**: N = parent directory depth. Correct formula prevents off-by-one.

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

### [Plan Review] Generic, Risk, Architect — FINDING_5
**Finding**: Explicitly enumerate each .claude/ top-level directory with its handling rule; clarify SKILL.md check only at first level.
**Reason not implemented**: Exonerated (0 YES, 2 EXONERATE). The SKILL.md heuristic is clear enough.

### [Plan Review] Risk, Generic — FINDING_7
**Finding**: Script must pass shellcheck and have executable bit.
**Reason not implemented**: Neutral (1 YES). Mechanical CI details that surface on first run.

### [Plan Review] Codex — FINDING_9
**Finding**: Derive submodule path from script's own location instead of hardcoding.
**Reason not implemented**: Neutral (1 YES, 2 EXONERATE). Already incorporated — script derives CLAUDIN_DIR from BASH_SOURCE.

### [Plan Review] Architect — FINDING_13
**Finding**: Use named functions for internal decomposition of the script.
**Reason not implemented**: Rejected (0 YES, 0 EXONERATE). Style preference; script is small enough for sequential code.

</details>

<details><summary>Implementation Deviations</summary>

No significant deviations from the plan. The implementation follows the revised plan closely:
- Hybrid symlink strategy implemented as specified
- settings.json excluded as planned
- Dead symlink cleanup with python3-based path normalization as planned
- All 9 plan review findings addressed in the revised plan were implemented

</details>

<details><summary>Rejected Code Review Suggestions</summary>

### [Code Review] Risk, Architect, Codex
**Finding**: FINDING_3 — update-claudin.sh line 216: Phase 2 silently depends on python3 for path normalization. If python3 is missing, dead symlinks are silently skipped with no warning.
**Reason not implemented**: Neutral (1 YES, 2 EXONERATE). python3 is ubiquitous; cleanup phase is secondary. Can be addressed in follow-up.

### [Code Review] Generic
**Finding**: FINDING_5 — README.md Flow A missing `git submodule update --init` for new clones.
**Reason not implemented**: Neutral (1 YES, 2 EXONERATE). Standard git knowledge; not essential for Getting Started guide.

### [Code Review] Codex
**Finding**: FINDING_6 — README.md line 12 contradicts env var optional status.
**Reason not implemented**: Neutral (1 YES, 2 NO). Sentence self-corrects in same paragraph.

### [Code Review] Risk
**Finding**: FINDING_7 — pwd -P vs git rev-parse --show-toplevel may differ with symlinks.
**Reason not implemented**: Rejected (0 YES, 0 EXONERATE). Both sides already use pwd -P canonicalization.

</details>

<details><summary>Plan Review Voting Tally</summary>

| Finding | Claude Arch | Cursor | Codex | Result |
|---------|------------|--------|-------|--------|
| FINDING_1 (rel path) | YES | YES | YES | ACCEPTED |
| FINDING_2 (settings.json) | YES | YES | YES | ACCEPTED |
| FINDING_3 (mkdir -p) | YES | YES | YES | ACCEPTED |
| FINDING_4 (dead symlink) | YES | YES | YES | ACCEPTED |
| FINDING_5 (dir strategy) | EXONERATE | NO | EXONERATE | Exonerated |
| FINDING_6 (git rev-parse) | YES | YES | YES | ACCEPTED |
| FINDING_7 (shellcheck) | EXONERATE | YES | EXONERATE | Neutral |
| FINDING_8 (block-submod docs) | EXONERATE | YES | YES | ACCEPTED |
| FINDING_9 (derive path) | YES | EXONERATE | EXONERATE | Neutral |
| FINDING_10 (submod update) | YES | YES | YES | ACCEPTED |
| FINDING_11 (flow B deps) | EXONERATE | YES | YES | ACCEPTED |
| FINDING_12 (dir conflicts) | YES | YES | YES | ACCEPTED |
| FINDING_13 (functions) | NO | NO | NO | REJECTED |

## Reviewer Competition Scoreboard

| Reviewer | Findings | Accepted | Neutral | Exonerated | Rejected | Score |
|----------|----------|----------|---------|------------|----------|-------|
| Generic | 7 | 5 | 1 | 1 | 0 | +5 |
| Cursor | 4 | 4 | 0 | 0 | 0 | +4 |
| Correctness | 3 | 3 | 0 | 0 | 0 | +3 |
| Codex | 5 | 3 | 1 | 1 | 0 | +3 |
| Risk | 4 | 2 | 1 | 1 | 0 | +2 |
| Architect | 5 | 3 | 0 | 1 | 1 | +2 |

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

| Finding | Claude Generic | Cursor | Codex | Result |
|---------|---------------|--------|-------|--------|
| FINDING_1 (prefix check) | YES | YES | YES | ACCEPTED |
| FINDING_2 (CLAUDIN_REL) | YES | YES | YES | ACCEPTED |
| FINDING_3 (python3 dep) | EXONERATE | YES | EXONERATE | Neutral |
| FINDING_4 (settings min) | YES | YES | YES | ACCEPTED |
| FINDING_5 (submod init) | EXONERATE | YES | EXONERATE | Neutral |
| FINDING_6 (env var wording) | NO | NO | YES | Neutral |
| FINDING_7 (pwd -P) | NO | NO | NO | REJECTED |

## Reviewer Competition Scoreboard

| Reviewer | Findings | Accepted | Neutral | Exonerated | Rejected | Score |
|----------|----------|----------|---------|------------|----------|-------|
| Cursor | 3 | 3 | 0 | 0 | 0 | +3 |
| Generic | 3 | 2 | 1 | 0 | 0 | +2 |
| Architect | 3 | 2 | 1 | 0 | 0 | +2 |
| Correctness | 1 | 1 | 0 | 0 | 0 | +1 |
| Codex | 3 | 1 | 2 | 0 | 0 | +1 |
| Risk | 3 | 1 | 1 | 0 | 1 | 0 |

</details>

<details><summary>Out-of-Scope Observations</summary>

**Plan Review OOS:**
- OOS_1 (Generic): `post-slack-message.sh` requires `--token` argument instead of reading `CLAUDIN_SLACK_BOT_TOKEN` from environment, inconsistent with other Slack scripts.
- OOS_2 (Correctness): `skill-creator` contains Python dependencies not needed by other skills.
- OOS_3 (Risk): `run-checks.sh` references `make shellcheck` but there is no Makefile in the repo.
- OOS_4 (Risk): `post-slack-message.sh` uses `#!/bin/bash` instead of `#!/usr/bin/env bash`.
- OOS_5 (Architect): `SLACK_USER_ID` doesn't follow the `CLAUDIN_` naming prefix convention.
- OOS_6 (Architect): `settings.json` references skills that don't exist in the repo.

**Code Review OOS:**
- OOS_1 (Generic): `settings.json` contains overly broad Bash permissions.
- OOS_2 (Generic): `settings.json` `defaultMode: acceptEdits` allows edits without confirmation.
- OOS_3 (Correctness): Dead symlink scan uses relative `find .claude` path.
- OOS_4 (Risk): Skill dependency graph not validated anywhere.
- OOS_5 (Architect): Script is monolithic (~240 lines).
- OOS_6 (Architect): `settings.json` references non-existent skills.

</details>

<details><summary>Execution Issues</summary>

No execution issues encountered.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | 9 accepted, 4 rejected |
| Code review rounds | 1 |
| Code review findings | 3 accepted, 4 rejected |
| Warnings logged | 1 (version bump skipped) |
| Pre-existing issues noticed | 12 (6 plan review OOS + 6 code review OOS) |
| External reviewers | Cursor: ✅, Codex: ✅ |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
