### PR TITLE
Check both Slack ENV vars before posting

### DIFF
--- a/.claude/scripts/generic/session-setup.sh
+++ b/.claude/scripts/generic/session-setup.sh
@@ -2,7 +2,7 @@
 # session-setup.sh — Shared session setup for /design, /implement, /shazam skills.
 #
 # Consolidates the common Step 0 operations: preflight, temp dir creation,
-# Slack token check, and repo name derivation.
+# Slack configuration check, and repo name derivation.
 #
 # Usage:
 #   session-setup.sh --prefix <name> [--skip-branch-check] [--skip-slack-check] \
@@ -11,17 +11,18 @@
 # Flags:
 #   --prefix <name>       (required) Temp dir prefix for mktemp (e.g., claude-shazam)
 #   --skip-branch-check   Forwarded to preflight.sh (skip on-main/clean-tree assertions)
-#   --skip-slack-check    Skip CLAUDIN_SLACK_BOT_TOKEN check entirely
+#   --skip-slack-check    Skip CLAUDIN_SLACK_BOT_TOKEN and CLAUDIN_SLACK_CHANNEL_ID check entirely
 #   --skip-repo-check     Skip repo name derivation entirely
 #   --caller-env <path>   Path to KEY=value file with already-discovered values.
-#                          Recognized keys: SLACK_TOKEN_OK, REPO, REPO_UNAVAILABLE.
+#                          Recognized keys: SLACK_OK, SLACK_MISSING, REPO, REPO_UNAVAILABLE.
 #                          If a key is present and non-empty, the script skips re-deriving it.
 #                          SESSION_TMPDIR is never inherited — a fresh tmpdir is always created.
 #                          If the file does not exist or is empty, full discovery happens.
 #
 # Output (KEY=value lines on stdout):
 #   SESSION_TMPDIR=<path>       Always output (fresh per invocation)
-#   SLACK_TOKEN_OK=true|false   Output unless --skip-slack-check
+#   SLACK_OK=true|false         Output unless --skip-slack-check
+#   SLACK_MISSING=<csv>         Output when SLACK_OK=false (comma-separated missing var names)
 #   REPO=<owner/repo>           Output unless --skip-repo-check
 #   REPO_UNAVAILABLE=true|false Output unless --skip-repo-check
 #
@@ -69,7 +70,8 @@ fi
 
 # --- Read caller-env file (if provided and exists) ---
 # Parse line-by-line; do NOT source. Only recognized keys with non-empty values are used.
-CALLER_SLACK_TOKEN_OK=""
+CALLER_SLACK_OK=""
+CALLER_SLACK_MISSING=""
 CALLER_REPO=""
 CALLER_REPO_UNAVAILABLE=""
 
@@ -78,7 +80,8 @@ if [[ -n "$CALLER_ENV" && -f "$CALLER_ENV" ]]; then
         # Skip empty lines and lines not matching KEY=value pattern
         [[ -z "$key" || "$key" =~ ^# ]] && continue
         case "$key" in
-            SLACK_TOKEN_OK)    CALLER_SLACK_TOKEN_OK="$value" ;;
+            SLACK_OK)          CALLER_SLACK_OK="$value" ;;
+            SLACK_MISSING)     CALLER_SLACK_MISSING="$value" ;;
             REPO)              CALLER_REPO="$value" ;;
             REPO_UNAVAILABLE)  CALLER_REPO_UNAVAILABLE="$value" ;;
             *)                 ;; # Ignore unknown keys
@@ -105,17 +108,33 @@ fi
 SESSION_TMPDIR=$(mktemp -d "/tmp/${PREFIX}-XXXXXX")
 echo "SESSION_TMPDIR=$SESSION_TMPDIR"
 
-# --- 3. Check CLAUDIN_SLACK_BOT_TOKEN ---
+# --- 3. Check Slack configuration (CLAUDIN_SLACK_BOT_TOKEN + CLAUDIN_SLACK_CHANNEL_ID) ---
 if [[ "$SKIP_SLACK_CHECK" == "false" ]]; then
-    if [[ -n "$CALLER_SLACK_TOKEN_OK" ]]; then
-        # Reuse caller's value
-        echo "SLACK_TOKEN_OK=$CALLER_SLACK_TOKEN_OK"
+    if [[ -n "$CALLER_SLACK_OK" ]]; then
+        # Reuse caller's values
+        echo "SLACK_OK=$CALLER_SLACK_OK"
+        if [[ -n "$CALLER_SLACK_MISSING" ]]; then
+            echo "SLACK_MISSING=$CALLER_SLACK_MISSING"
+        fi
     else
-        # Derive fresh
-        if [[ -n "${CLAUDIN_SLACK_BOT_TOKEN:-}" ]]; then
-            echo "SLACK_TOKEN_OK=true"
+        # Derive fresh: both vars must be set for Slack to be available
+        SLACK_MISSING_VARS=""
+        if [[ -z "${CLAUDIN_SLACK_BOT_TOKEN:-}" ]]; then
+            SLACK_MISSING_VARS="CLAUDIN_SLACK_BOT_TOKEN"
+        fi
+        if [[ -z "${CLAUDIN_SLACK_CHANNEL_ID:-}" ]]; then
+            if [[ -n "$SLACK_MISSING_VARS" ]]; then
+                SLACK_MISSING_VARS="$SLACK_MISSING_VARS,CLAUDIN_SLACK_CHANNEL_ID"
+            else
+                SLACK_MISSING_VARS="CLAUDIN_SLACK_CHANNEL_ID"
+            fi
+        fi
+
+        if [[ -z "$SLACK_MISSING_VARS" ]]; then
+            echo "SLACK_OK=true"
         else
-            echo "SLACK_TOKEN_OK=false"
+            echo "SLACK_OK=false"
+            echo "SLACK_MISSING=$SLACK_MISSING_VARS"
         fi
     fi
 fi

--- a/.claude/scripts/generic/write-session-env.sh
+++ b/.claude/scripts/generic/write-session-env.sh
@@ -2,11 +2,13 @@
 # write-session-env.sh — Write session environment values to a file for child skills.
 #
 # Usage:
-#   write-session-env.sh --output <path> --slack-token-ok <true|false> \
-#                        --repo <owner/repo> --repo-unavailable <true|false>
+#   write-session-env.sh --output <path> --slack-ok <true|false> \
+#                        [--slack-missing <csv>] --repo <owner/repo> \
+#                        --repo-unavailable <true|false>
 #
 # Options:
 #   --repo may be empty when --repo-unavailable is true (repo discovery failed).
+#   --slack-missing is optional (only meaningful when --slack-ok is false).
 #
 # Output: Writes a shell-sourceable file to --output path.
 # Exit codes: 0 success, 1 invalid args
@@ -14,27 +16,30 @@
 set -euo pipefail
 
 OUTPUT=""
-SLACK_TOKEN_OK=""
+SLACK_OK=""
+SLACK_MISSING=""
 REPO=""
 REPO_UNAVAILABLE=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --output)       OUTPUT="$2"; shift 2 ;;
-    --slack-token-ok) SLACK_TOKEN_OK="$2"; shift 2 ;;
+    --slack-ok)     SLACK_OK="$2"; shift 2 ;;
+    --slack-missing) SLACK_MISSING="$2"; shift 2 ;;
     --repo)         REPO="$2"; shift 2 ;;
     --repo-unavailable) REPO_UNAVAILABLE="$2"; shift 2 ;;
     *) echo "ERROR=Unknown argument: $1" >&2; exit 1 ;;
   esac
 done
 
-if [[ -z "$OUTPUT" || -z "$SLACK_TOKEN_OK" || -z "$REPO_UNAVAILABLE" ]]; then
-  echo "ERROR=Missing required arguments: --output, --slack-token-ok, --repo-unavailable" >&2
+if [[ -z "$OUTPUT" || -z "$SLACK_OK" || -z "$REPO_UNAVAILABLE" ]]; then
+  echo "ERROR=Missing required arguments: --output, --slack-ok, --repo-unavailable" >&2
   exit 1
 fi
 
 cat > "$OUTPUT" << ENVEOF
-SLACK_TOKEN_OK=$SLACK_TOKEN_OK
+SLACK_OK=$SLACK_OK
+SLACK_MISSING=$SLACK_MISSING
 REPO=$REPO
 REPO_UNAVAILABLE=$REPO_UNAVAILABLE
 ENVEOF

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -56,9 +56,9 @@ Only include `--caller-env "$SESSION_ENV_PATH"` if `SESSION_ENV_PATH` is non-emp
 
 If the script exits non-zero, print the `PREFLIGHT_ERROR` from its output and abort.
 
-Parse the output for `SESSION_TMPDIR`, `SLACK_TOKEN_OK`, `REPO`, `REPO_UNAVAILABLE`. Set:
+Parse the output for `SESSION_TMPDIR`, `SLACK_OK`, `SLACK_MISSING`, `REPO`, `REPO_UNAVAILABLE`. Set:
 - `IMPL_TMPDIR` = `SESSION_TMPDIR`
-- If `SLACK_TOKEN_OK=false`, print: `**⚠ CLAUDIN_SLACK_BOT_TOKEN is not set. Slack announcement (Step 11) will be skipped.**` Set a mental flag `slack_available=false`.
+- If `SLACK_OK=false`, print: `**⚠ Slack is not fully configured (<SLACK_MISSING> not set). Slack announcement (Step 11) will be skipped.**` Set a mental flag `slack_available=false`.
 - If `REPO_UNAVAILABLE=true`, print `**⚠ Could not determine repository name. CI monitoring (Step 10) will be skipped.**` Set a mental flag `repo_unavailable=true`.
 
 ### Write Session Env for Child Skills
@@ -67,7 +67,7 @@ Write the discovered values to `$IMPL_TMPDIR/session-env.sh` so they can be forw
 
 ```bash
 $PWD/.claude/scripts/generic/write-session-env.sh --output "$IMPL_TMPDIR/session-env.sh" \
-  --slack-token-ok <value> --repo <value> --repo-unavailable <value>
+  --slack-ok <value> --slack-missing <value> --repo <value> --repo-unavailable <value>
 ```
 
 This file will be passed to `/design` via `--session-env` in Step 1.
@@ -443,7 +443,7 @@ After handling any non-terminal action (rebase, evaluate_failure), **re-invoke `
 
 ## Step 11 — Post Slack Announcement
 
-**If `slack_available=false`**: Print `⏭️ Step 11 — Skipped (CLAUDIN_SLACK_BOT_TOKEN not set).` Print `SLACK_TS=` and proceed to the post-execution PR body refresh below.
+**If `slack_available=false`**: Print `⏭️ Step 11 — Skipped (Slack not configured).` Print `SLACK_TS=` and proceed to the post-execution PR body refresh below.
 
 **If `PR_STATUS=existing`**: Print `⏭️ Step 11 — Skipped (PR already existed, avoiding duplicate Slack post). Run post-pr-announce.sh --pr <PR-NUMBER> manually to post the announcement.` Print `SLACK_TS=` and proceed to the post-execution PR body refresh below.
 

--- a/.claude/skills/shazam/SKILL.md
+++ b/.claude/skills/shazam/SKILL.md
@@ -50,9 +50,9 @@ Only include `--caller-env "$SESSION_ENV_PATH"` if `SESSION_ENV_PATH` is non-emp
 
 If the script exits non-zero, print the `PREFLIGHT_ERROR` from its output and abort.
 
-Parse the output for `SESSION_TMPDIR`, `SLACK_TOKEN_OK`, `REPO`, `REPO_UNAVAILABLE`. Set:
+Parse the output for `SESSION_TMPDIR`, `SLACK_OK`, `SLACK_MISSING`, `REPO`, `REPO_UNAVAILABLE`. Set:
 - `SHAZAM_TMPDIR` = `SESSION_TMPDIR`
-- If `SLACK_TOKEN_OK=false`, print: `**⚠ CLAUDIN_SLACK_BOT_TOKEN is not set. :merged: emoji (Step 3) will be skipped.**` Set a mental flag `slack_available=false`.
+- If `SLACK_OK=false`, print: `**⚠ Slack is not fully configured (<SLACK_MISSING> not set). :merged: emoji (Step 3) will be skipped.**` Set a mental flag `slack_available=false`.
 - If `REPO_UNAVAILABLE=true`, print `**❌ Could not determine repository name. Cannot proceed with CI/merge steps.**` Set a mental flag `repo_unavailable=true`.
 
 ### Write Session Env for Child Skills
@@ -61,7 +61,7 @@ Write the discovered values to `$SHAZAM_TMPDIR/session-env.sh` so they can be fo
 
 ```bash
 $PWD/.claude/scripts/generic/write-session-env.sh --output "$SHAZAM_TMPDIR/session-env.sh" \
-  --slack-token-ok <value> --repo <value> --repo-unavailable <value>
+  --slack-ok <value> --slack-missing <value> --repo <value> --repo-unavailable <value>
 ```
 
 This file will be passed to `/implement` via `--session-env` in Step 1.
@@ -295,7 +295,7 @@ When bailing out:
 
 **If `no_merge=true`**: Skip this step.
 
-**If `slack_available=false`**: Print `⏭️ Step 3 — Skipped (CLAUDIN_SLACK_BOT_TOKEN not set).` and proceed to Step 4.
+**If `slack_available=false`**: Print `⏭️ Step 3 — Skipped (Slack not configured).` and proceed to Step 4.
 
 **Only if the PR was successfully merged in Step 2b or force-merged externally** (not bailed in 2d).
 

--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ There are three ways to run linters, all backed by the same `.pre-commit-config.
 
 Claudin uses three environment variables for Slack integration. All are optional — when not set, Slack-related features are skipped with warnings and all other workflow steps continue normally.
 
+> **Note:** Both `CLAUDIN_SLACK_BOT_TOKEN` and `CLAUDIN_SLACK_CHANNEL_ID` must be set for Slack features to function. If either is missing, all Slack operations (PR announcements, `:merged:` emoji) are skipped with a warning at session setup time identifying which variable(s) are absent.
+
 ### `CLAUDIN_SLACK_BOT_TOKEN`
 
 A Slack Bot User OAuth Token (starts with `xoxb-`) used to authenticate Slack API calls.
@@ -185,7 +187,7 @@ A Slack Bot User OAuth Token (starts with `xoxb-`) used to authenticate Slack AP
 - The token's presence is checked during session setup and its availability is propagated to child skills
 
 **When not set:**
-- Slack announcement steps are skipped with a warning (e.g., `⚠ CLAUDIN_SLACK_BOT_TOKEN is not set. Slack announcement (Step 11) will be skipped.`)
+- All Slack operations are skipped with a warning at session setup (e.g., `⚠ Slack is not fully configured (CLAUDIN_SLACK_BOT_TOKEN not set). Slack announcement (Step 11) will be skipped.`)
 - The `:merged:` emoji step in `/shazam` is skipped
 - All other workflow steps (design, implementation, code review, CI monitoring, merge) proceed normally
 
@@ -198,9 +200,9 @@ The Slack channel ID (e.g., `C0123456789`) where PR announcements and emoji reac
 - The `:merged:` emoji reaction targets announcements in this channel
 
 **When not set:**
-- Slack announcements are skipped even if `CLAUDIN_SLACK_BOT_TOKEN` is set (the bot token alone is not sufficient — a target channel is required)
+- All Slack operations are skipped with a warning at session setup (e.g., `⚠ Slack is not fully configured (CLAUDIN_SLACK_CHANNEL_ID not set).`)
 - The `:merged:` emoji step in `/shazam` is also skipped
-- Warnings are printed by the respective scripts (e.g., `WARNING: CLAUDIN_SLACK_CHANNEL_ID is not set.`)
+- All other workflow steps proceed normally
 
 ### `CLAUDIN_SLACK_USER_ID`
 


### PR DESCRIPTION
## Summary
- Extended `session-setup.sh` to validate both `CLAUDIN_SLACK_BOT_TOKEN` and `CLAUDIN_SLACK_CHANNEL_ID`, renaming `SLACK_TOKEN_OK` to `SLACK_OK` with a new `SLACK_MISSING` diagnostic field
- Updated `/implement` and `/shazam` skill definitions to use the composite Slack readiness check and display specific warnings about which variable(s) are absent
- Added documentation in README noting both variables are required together for Slack features

<details><summary>Architecture Diagram</summary>

```mermaid
graph TD
    subgraph "Session Setup Layer"
        SS[session-setup.sh]
        WS[write-session-env.sh]
    end

    subgraph "Environment Variables"
        BOT[CLAUDIN_SLACK_BOT_TOKEN]
        CHAN[CLAUDIN_SLACK_CHANNEL_ID]
    end

    subgraph "Skill Definitions"
        IMPL["implement/SKILL.md<br/>Step 0: parse SLACK_OK<br/>Step 11: skip if !slack_available"]
        SHAZ["shazam/SKILL.md<br/>Step 0: parse SLACK_OK<br/>Step 3: skip if !slack_available"]
    end

    subgraph "Slack Scripts (defense-in-depth)"
        PPA[post-pr-announce.sh]
        PME[post-merged-emoji.sh]
    end

    BOT -->|checked| SS
    CHAN -->|checked| SS
    SS -->|"SLACK_OK=true/false<br/>SLACK_MISSING=..."| WS
    WS -->|session-env.sh| IMPL
    WS -->|session-env.sh| SHAZ
    IMPL -->|"if slack_available"| PPA
    SHAZ -->|"if slack_available"| PME
    PPA -.->|"defense-in-depth<br/>checks channel"| CHAN
    PME -.->|"defense-in-depth<br/>checks channel"| CHAN
```

</details>

<details><summary>Code Flow Diagram</summary>

```mermaid
sequenceDiagram
    participant Skill as /implement or /shazam
    participant SS as session-setup.sh
    participant WS as write-session-env.sh
    participant Child as Child Skill (/design)

    Skill->>SS: --prefix claude-impl [--caller-env]

    alt Caller-env has SLACK_OK
        SS->>SS: Reuse SLACK_OK + SLACK_MISSING
    else Fresh derivation
        SS->>SS: Check CLAUDIN_SLACK_BOT_TOKEN
        SS->>SS: Check CLAUDIN_SLACK_CHANNEL_ID
        SS->>SS: Build SLACK_MISSING CSV if any missing
    end

    SS-->>Skill: SLACK_OK=true|false, SLACK_MISSING=csv

    alt SLACK_OK=false
        Skill->>Skill: Print warning with SLACK_MISSING
        Skill->>Skill: Set slack_available=false
    end

    Skill->>WS: --slack-ok val --slack-missing val
    WS->>WS: Write session-env.sh file

    Skill->>Child: --session-env path
    Child->>SS: --caller-env session-env.sh
    SS->>SS: Reuse cached SLACK_OK + SLACK_MISSING

    alt slack_available=false (Step 11 / Step 3)
        Skill->>Skill: Skip Slack operations
    else slack_available=true
        Skill->>Skill: Call post-pr-announce.sh / post-merged-emoji.sh
    end
```

</details>

<details><summary>Goal</summary>

- Check for presence of both required ENV vars for Slack posting in `/implement` workflow
  - Validate `CLAUDIN_SLACK_BOT_TOKEN` and `CLAUDIN_SLACK_CHANNEL_ID` at session setup time
  - Emit specific warnings identifying which variable(s) are absent
  - Skip all Slack manipulations (posting, merged update) when either is missing
- Update skill documentation to reflect the unified Slack readiness check
  - Update `/implement` SKILL.md Steps 0 and 11
  - Update `/shazam` SKILL.md Steps 0 and 3
- Add appropriate note in ENV section of README

</details>

<details><summary>Test plan</summary>

- [ ] Verify `session-setup.sh` output with both vars set: `SLACK_OK=true`, no `SLACK_MISSING`
- [ ] Verify with only token set: `SLACK_OK=false`, `SLACK_MISSING=CLAUDIN_SLACK_CHANNEL_ID`
- [ ] Verify with only channel set: `SLACK_OK=false`, `SLACK_MISSING=CLAUDIN_SLACK_BOT_TOKEN`
- [ ] Verify with neither set: `SLACK_OK=false`, `SLACK_MISSING=CLAUDIN_SLACK_BOT_TOKEN,CLAUDIN_SLACK_CHANNEL_ID`
- [ ] Verify `write-session-env.sh` writes correct format with `--slack-ok` and `--slack-missing`
- [ ] Verify caller-env round-trip: write with `--slack-ok false --slack-missing CLAUDIN_SLACK_CHANNEL_ID`, read back via `--caller-env`
- [ ] Verify SKILL.md text consistency between `/implement` and `/shazam`
- [ ] Run shellcheck on modified scripts

</details>

<details><summary>Final Design</summary>

### Overview

Extend the shared session-setup layer to validate both required Slack ENV vars (`CLAUDIN_SLACK_BOT_TOKEN` and `CLAUDIN_SLACK_CHANNEL_ID`) as a single composite readiness check. Rename the output from `SLACK_TOKEN_OK` to `SLACK_OK` and add a `SLACK_MISSING` diagnostic field. Update all consumers (skill definitions, session-env propagation, documentation).

### Files to modify

1. **`session-setup.sh`** — Check both vars, rename output from `SLACK_TOKEN_OK` to `SLACK_OK`, add `SLACK_MISSING` output
2. **`write-session-env.sh`** — Rename `--slack-token-ok` to `--slack-ok`, add `--slack-missing` parameter
3. **`implement/SKILL.md`** — Update Steps 0 and 11 to parse `SLACK_OK`/`SLACK_MISSING`
4. **`shazam/SKILL.md`** — Update Steps 0 and 3 to parse `SLACK_OK`/`SLACK_MISSING`
5. **`README.md`** — Add note about both vars required, update "When not set" descriptions

### Edge cases

- Both vars set: `SLACK_OK=true`, `SLACK_MISSING` not output
- Only token set: `SLACK_OK=false`, `SLACK_MISSING=CLAUDIN_SLACK_CHANNEL_ID`
- Only channel set: `SLACK_OK=false`, `SLACK_MISSING=CLAUDIN_SLACK_BOT_TOKEN`
- Neither set: `SLACK_OK=false`, `SLACK_MISSING=CLAUDIN_SLACK_BOT_TOKEN,CLAUDIN_SLACK_CHANNEL_ID`

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

9 plan review findings were not accepted by the voting panel. Notable rejections:

- **FINDING_3 (Architect, Correctness, Generic)**: Add `SLACK_MISSING` to session-setup.sh caller-env parser — unanimously rejected as unnecessary complexity (SLACK_MISSING is a pass-through diagnostic)
- **FINDING_6 (/loop-review scope)**: Exonerated — deferred to separate PR
- **FINDING_8 (backward compat)**: Exonerated — session-env files are ephemeral
- **FINDING_10 (two booleans vs composite)**: Unanimously rejected — adds complexity

</details>

<details><summary>Implementation Deviations</summary>

No deviations from the plan.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

All code review suggestions were exonerated or rejected by the voting panel. No in-scope findings received 2+ YES votes. Notable exonerations:

- **FINDING_1 (write-session-env.sh SLACK_MISSING= noise)**: Exonerated — functionally harmless
- **FINDING_3 (grammar in warning message)**: Exonerated — message remains comprehensible
- **FINDING_5 (value domain validation)**: Exonerated — internal trusted handoff format

</details>

<details><summary>Plan Review Voting Tally</summary>

| Finding | Architect | Cursor | Codex | YES | Result |
|---------|-----------|--------|-------|-----|--------|
| FINDING_1 (skip messages) | YES | NO | YES | 2 | **Accepted** |
| FINDING_2 (validation guard) | YES | NO | NO | 1 | Neutral |
| FINDING_3 (caller-env parser) | NO | NO | NO | 0 | Rejected |
| FINDING_4 (format spec) | EXONERATE | NO | NO | 0 | Exonerated |
| FINDING_5 (invocation sites) | NO | NO | NO | 0 | Rejected |
| FINDING_6 (/loop-review) | EXONERATE | EXONERATE | NO | 0 | Exonerated |
| FINDING_7 (comments) | EXONERATE | NO | NO | 0 | Exonerated |
| FINDING_8 (backward compat) | NO | NO | EXONERATE | 0 | Exonerated |
| FINDING_9 (testing matrix) | EXONERATE | YES | YES | 2 | **Accepted** |
| FINDING_10 (two booleans) | NO | NO | NO | 0 | Rejected |
| FINDING_11 (manual hint) | EXONERATE | NO | EXONERATE | 0 | Exonerated |

## Reviewer Competition Scoreboard

| Reviewer | Findings | Accepted | Neutral (1 YES) | Exonerated | Rejected | OOS Proposed | OOS Promoted | Score |
|----------|----------|----------|-----------------|------------|----------|-------------|-------------|-------|
| Generic | 5 | 1 | 1 | 2 | 1 | 2 | 0 | 0 |
| Correctness | 3 | 1 | 1 | 0 | 1 | 3 | 0 | 0 |
| Risk | 4 | 1 | 1 | 1 | 1 | 0 | 0 | 0 |
| Architect | 4 | 1 | 0 | 1 | 2 | 1 | 0 | -1 |
| Cursor | 3 | 1 | 0 | 2 | 0 | 0 | 0 | +1 |
| Codex | 2 | 1 | 0 | 1 | 0 | 1 | 0 | +1 |

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

| Finding | Claude Generic | Cursor | Codex | YES | Result |
|---------|---------------|--------|-------|-----|--------|
| FINDING_1 (env file noise) | EXONERATE | NO | NO | 0 | Exonerated |
| FINDING_2 (README example) | YES | EXONERATE | NO | 1 | Neutral |
| FINDING_3 (grammar) | NO | EXONERATE | EXONERATE | 0 | Exonerated |
| FINDING_4 (reuse invariant) | YES | NO | NO | 1 | Neutral |
| FINDING_5 (value validation) | EXONERATE | NO | NO | 0 | Exonerated |

## Reviewer Competition Scoreboard

| Reviewer | Findings | Accepted | Neutral (1 YES) | Exonerated | Rejected | OOS Proposed | OOS Promoted | Score |
|----------|----------|----------|-----------------|------------|----------|-------------|-------------|-------|
| Generic | 2 | 0 | 1 | 1 | 0 | 2 | 0 | 0 |
| Correctness | 0 | 0 | 0 | 0 | 0 | 1 | 0 | 0 |
| Risk | 1 | 0 | 0 | 1 | 0 | 1 | 0 | 0 |
| Architect | 3 | 0 | 1 | 1 | 0 | 2 | 0 | -1 |
| Cursor | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |
| Codex | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |

Note: Scores apply to round 1 only. Cursor and Codex both found NO_ISSUES_FOUND.

</details>

<details><summary>Out-of-Scope Observations</summary>

**Plan review OOS:**
- `post-pr-announce.sh` exits 0 on missing channel vs exit 1 on missing token — pre-existing asymmetry (5 reviewers flagged)
- `session-setup.sh` caller-env parser `IFS='='` limitation (pre-existing)
- `post-pr-announce.sh` allocates tmpdir before checking channel (pre-existing)
- `write-session-env.sh` --repo validation inconsistency (pre-existing)

**Code review OOS:**
- `post-pr-announce.sh` exit 0 on missing channel (pre-existing, 3 reviewers)
- `/loop-review` bypasses session-setup Slack readiness check (pre-existing)
- `write-session-env.sh` shift 2 arms lack `$# -ge 2` guard (pre-existing)

</details>

<details><summary>Execution Issues</summary>

No execution issues encountered.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | 2 accepted, 9 rejected |
| Code review rounds | 1 |
| Code review findings | 0 accepted, 5 rejected |
| Warnings logged | 1 (version bump skipped) |
| Pre-existing issues noticed | 7 (across plan + code review OOS) |
| External reviewers | Cursor: ✅, Codex: ✅ |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
