### PR TITLE
Fix verify-main.sh to handle --admin merge titles

### DIFF
--- a/.claude/scripts/generic/verify-main.sh
+++ b/.claude/scripts/generic/verify-main.sh
@@ -3,7 +3,12 @@
 #
 # Checks git log -1 --oneline and compares the commit message against
 # the expected squash-merge title (typically "<PR title> (#<PR number>)").
-# Uses fixed-string matching to avoid regex issues with special characters.
+#
+# Matching strategy (handles both normal and --admin merges):
+#   1. Prefix match: commit message starts with the expected title (normal squash merge)
+#   2. Suffix match: commit message ends with "(#N)" from the expected title
+#      (--admin merge uses the first commit message instead of PR title, but
+#      GitHub still appends the PR number suffix)
 #
 # Usage:
 #   verify-main.sh --expected-title TEXT
@@ -67,13 +72,24 @@ fi
 COMMIT_HASH="${LOG_OUTPUT%% *}"
 COMMIT_MESSAGE="${LOG_OUTPUT#* }"
 
-# --- Compare using prefix matching ---
-# Check if the commit message starts with the expected title
-# Uses bash pattern matching to avoid regex issues with special characters
+# --- Compare using prefix match, then PR number suffix fallback ---
+# Strategy 1: prefix match (normal squash merge — PR title is the commit message)
 if [[ "$COMMIT_MESSAGE" == "$EXPECTED_TITLE"* ]]; then
     VERIFIED="true"
 else
-    VERIFIED="false"
+    # Strategy 2: suffix match on PR number (--admin merge — commit message differs
+    # but GitHub still appends "(#N)")
+    # Extract the "(#N)" suffix from the expected title
+    PR_SUFFIX=""
+    if [[ "$EXPECTED_TITLE" =~ \(#[0-9]+\)$ ]]; then
+        PR_SUFFIX="${BASH_REMATCH[0]}"
+    fi
+
+    if [[ -n "$PR_SUFFIX" && "$COMMIT_MESSAGE" == *"$PR_SUFFIX" ]]; then
+        VERIFIED="true"
+    else
+        VERIFIED="false"
+    fi
 fi
 
 exit 0

--- a/.claude/scripts/generic/verify-main.sh
+++ b/.claude/scripts/generic/verify-main.sh
@@ -87,8 +87,6 @@ else
 
     if [[ -n "$PR_SUFFIX" && "$COMMIT_MESSAGE" == *"$PR_SUFFIX" ]]; then
         VERIFIED="true"
-    else
-        VERIFIED="false"
     fi
 fi
 


### PR DESCRIPTION
## Summary
- Fixed `verify-main.sh` to handle `--admin` merge commit titles by adding a PR number suffix fallback (`(#N)`) when the prefix match fails
- Removed redundant `VERIFIED="false"` assignment in the else branch per code review feedback

<details><summary>Architecture Diagram</summary>

Quick mode — architecture diagram skipped.

</details>

<details><summary>Code Flow Diagram</summary>

Quick mode — code flow diagram skipped.

</details>

<details><summary>Goal</summary>

- Fix `verify-main.sh` Step 5 mismatch when `--admin` merge is used
  - When `merge-pr.sh` falls back to `--admin`, GitHub uses the first commit message instead of the PR title as the squash commit title
  - Add a fallback matching strategy that checks the PR number suffix `(#N)` when the prefix match fails
  - Ensure both normal squash merges and `--admin` merges pass verification

</details>

<details><summary>Test plan</summary>

- [ ] Verify prefix match still works for normal squash merges (commit message = PR title)
- [ ] Verify suffix match works for `--admin` merges (commit message ≠ PR title but ends with `(#N)`)
- [ ] Verify `VERIFIED=false` when commit message has a different `(#N)` suffix
- [ ] Verify `VERIFIED=false` when expected title has no `(#N)` suffix and prefix doesn't match
- [ ] Run shellcheck on the modified script

</details>

<details><summary>Final Design</summary>

**Approach:** Add a two-strategy verification to `verify-main.sh`:
1. Strategy 1 (existing): prefix match — commit message starts with the expected title
2. Strategy 2 (new): extract `(#N)` from expected title via regex, check if commit message ends with it

**Files modified:** `.claude/scripts/generic/verify-main.sh`

**Edge cases:**
- Normal squash merge: Strategy 1 succeeds (no change)
- `--admin` merge: Strategy 1 fails, Strategy 2 succeeds via PR number suffix
- Unrelated commit: neither match → `VERIFIED=false`
- Expected title without `(#N)`: suffix extraction fails, prefix-only match

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

Quick mode — no plan review was conducted.

</details>

<details><summary>Implementation Deviations</summary>

No deviations from the plan.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

### [Code Review] Generic
**Finding**: `verify-main.sh` line 8 header comment says "Prefix match: commit message starts with the expected title" but should more precisely say "full title prefix match" since the expected title includes the `(#N)` suffix.
**Reason not implemented**: The comment is clear enough in context — "prefix match" accurately describes the bash `==...* ` pattern. Trivial wording nit.

### [Code Review] Architect
**Finding**: `verify-main.sh` line 77 uses prefix glob match instead of exact equality. The trailing `*` could cause false-positive verification.
**Reason not implemented**: The trailing `*` is intentional for trailing metadata tolerance. The expected title includes the unique `(#N)` suffix, making false positives practically impossible.

### [Code Review] Architect
**Finding**: `verify-main.sh` lines 56-60 emit `COMMIT_MESSAGE=$COMMIT_MESSAGE` without quoting. Fragile implicit contract.
**Reason not implemented**: Pre-existing pattern across all scripts. Should be addressed systematically, not in this PR.

### [Code Review] Risk
**Finding**: Comment assumes GitHub appends `(#N)` for --admin merges, but this depends on repo settings.
**Reason not implemented**: Accurate for default settings. When non-default settings use PR title, Strategy 1 succeeds anyway. False negative is a safe failure mode.

</details>

<details><summary>Plan Review Voting Tally</summary>

Quick mode — no plan review voting.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

Quick mode — no voting panel. Main agent reviewed findings from 4 Claude subagents.

</details>

<details><summary>Out-of-Scope Observations</summary>

Quick mode — no out-of-scope observations collected.

</details>

<details><summary>Execution Issues</summary>

No execution issues encountered.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | N/A (quick mode) |
| Code review rounds | 1 |
| Code review findings | 1 accepted, 4 rejected |
| Warnings logged | 1 (version bump skipped) |
| Pre-existing issues noticed | 0 |
| External reviewers | N/A (quick mode) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
