### PR TITLE
Add rebase-onto-main steps to /implement skill (#12)

### DIFF
--- a/.claude/scripts/generic/rebase-push.sh
+++ b/.claude/scripts/generic/rebase-push.sh
@@ -1,45 +1,61 @@
 #!/usr/bin/env bash
-# rebase-push.sh — Rebase onto origin/main and force-push with lease.
+# rebase-push.sh — Rebase onto origin/main and optionally force-push with lease.
 #
-# Fetches origin/main, rebases, and pushes. Reports conflicts and
-# push failures via exit codes.
+# Fetches origin/main, rebases, and (unless --no-push) pushes. Reports
+# conflicts and push failures via exit codes.
 #
 # Usage:
-#   rebase-push.sh [--continue]
+#   rebase-push.sh [--continue] [--no-push]
 #
 # Flags:
 #   --continue — Continue an in-progress rebase instead of starting a new one.
 #                Skips fetch and runs `git rebase --continue` instead of
 #                `git rebase origin/main`. Caller must resolve conflicts and
 #                stage files before invoking with --continue.
+#   --no-push  — Skip the push step after a successful rebase. Used by
+#                /implement for local-only freshness rebases where the branch
+#                has not yet been pushed. In this mode, conflicts are aborted
+#                immediately (exit 1) instead of left in progress.
 #
 # Exit codes:
-#   0 — rebase and push succeeded
-#   1 — rebase failed with conflicts (CONFLICT_FILES= on stdout, rebase left in progress)
+#   0 — rebase (and push, unless --no-push) succeeded
+#   1 — rebase failed with conflicts
+#       Default mode: rebase left in progress (CONFLICT_FILES= on stdout)
+#       --no-push mode: rebase aborted, branch restored to pre-rebase state
 #   2 — push --force-with-lease failed (PUSH_ERROR= on stderr, caller should retry after fetch)
+#       Not possible in --no-push mode.
 #   3 — rebase failed for non-conflict reasons (REBASE_ERROR= on stderr)
 #       In normal mode: rebase is aborted.
 #       In --continue mode: rebase is left in progress (caller can inspect/retry).
+#       In --no-push mode: rebase is aborted.
 #
-# Stdout on exit 1:
+# Stdout on exit 1 (default mode only):
 #   CONFLICT_FILES=<comma-separated list of conflicted files>
 #
-# Note: On exit 1, the rebase is left in progress so the caller can resolve
-# conflicts and run `rebase-push.sh --continue`. On exit 3 in normal mode,
-# the rebase is aborted. On exit 3 in --continue mode, the rebase is left
-# in progress to avoid destroying already-resolved work.
+# Note: On exit 1 in default mode, the rebase is left in progress so the
+# caller can resolve conflicts and run `rebase-push.sh --continue`. On exit 1
+# in --no-push mode, the rebase is aborted (caller does not resolve conflicts).
+# On exit 3 in normal mode, the rebase is aborted. On exit 3 in --continue
+# mode, the rebase is left in progress to avoid destroying already-resolved work.
 
 set -uo pipefail
 # Note: not using set -e — we need to capture exit codes explicitly
 
 # --- Parse flags ---
 CONTINUE_MODE=false
+NO_PUSH=false
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --continue) CONTINUE_MODE=true; shift ;;
+        --no-push) NO_PUSH=true; shift ;;
         *) echo "Unknown option: $1" >&2; exit 1 ;;
     esac
 done
+
+if [[ "$CONTINUE_MODE" == "true" && "$NO_PUSH" == "true" ]]; then
+    echo "REBASE_ERROR=--continue and --no-push cannot be used together" >&2
+    exit 3
+fi
 
 if [[ "$CONTINUE_MODE" == "true" ]]; then
     # --- Guard: must have a rebase in progress ---
@@ -71,6 +87,11 @@ if [[ $REBASE_EXIT -ne 0 ]]; then
     # Check if there are conflicts
     CONFLICT_FILES=$(git diff --name-only --diff-filter=U 2>/dev/null | tr '\n' ',' | sed 's/,$//')
     if [[ -n "$CONFLICT_FILES" ]]; then
+        if [[ "$NO_PUSH" == "true" ]]; then
+            # In --no-push mode, abort immediately — caller does not resolve conflicts
+            git rebase --abort 2>/dev/null || true
+            exit 1
+        fi
         echo "CONFLICT_FILES=$CONFLICT_FILES"
         # Leave the rebase in progress so caller can resolve and --continue
         exit 1
@@ -88,6 +109,11 @@ if [[ $REBASE_EXIT -ne 0 ]]; then
             exit 3
         fi
     fi
+fi
+
+# --- Skip push in --no-push mode ---
+if [[ "$NO_PUSH" == "true" ]]; then
+    exit 0
 fi
 
 # --- Attempt force-push ---

--- a/.claude/scripts/generic/rebase-push.sh
+++ b/.claude/scripts/generic/rebase-push.sh
@@ -76,7 +76,16 @@ else
     fi
 
     # --- Fetch latest main ---
-    git fetch origin main --quiet 2>/dev/null || true
+    # In --no-push mode, fetch failure is fatal (the whole point is freshness).
+    # In default mode, fetch failure is tolerated to allow rebasing against cached origin/main.
+    if [[ "$NO_PUSH" == "true" ]]; then
+        if ! git fetch origin main --quiet 2>/dev/null; then
+            echo "REBASE_ERROR=git fetch origin main failed (network/auth issue)" >&2
+            exit 3
+        fi
+    else
+        git fetch origin main --quiet 2>/dev/null || true
+    fi
 
     # --- Attempt rebase ---
     REBASE_OUTPUT=$(git rebase origin/main 2>&1)

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -31,6 +31,7 @@ Suggested emoji palette (use consistently):
 |------|-------|-------------|
 | 0 | 🔧 | Session setup |
 | 1 | 📐 | Ensure design plan |
+| 🔃 | 🔃 | Rebase onto latest main |
 | 2 | 🛠️ | Implementation |
 | 3 | 🧹 | Lint (first pass) |
 | 4 | 💾 | First commit |
@@ -129,6 +130,25 @@ Proceed to Step 2.
 - If `IS_USER_BRANCH=true` but **no** implementation plan is visible in the conversation context: Invoke the `/design` skill with `--session-env $IMPL_TMPDIR/session-env.sh` prepended to the feature description to create a plan on the current branch. **If `auto_mode=true`, also prepend `--auto`** so `/design` suppresses interactive questions. After `/design` completes, proceed to Step 2.
 - If on `main` or empty (detached HEAD) or any non-user branch: No design plan exists yet. Invoke the `/design` skill with `--session-env $IMPL_TMPDIR/session-env.sh` prepended to the feature description to create a branch and design the plan. **If `auto_mode=true`, also prepend `--auto`** so `/design` suppresses interactive questions. After `/design` completes, proceed to Step 2.
 
+### Rebase onto latest main (before implementation)
+
+Print: `🔃 Rebasing onto latest main before starting implementation...`
+
+First, check if the branch has already been pushed to origin (e.g., re-running `/implement` on an existing PR branch):
+```bash
+git ls-remote --heads origin "$(git branch --show-current)" 2>/dev/null
+```
+If the output is non-empty (branch exists on origin), print: `⏩ Rebase skipped — branch already pushed to origin.` and skip this rebase.
+
+Otherwise, run:
+```bash
+$PWD/.claude/scripts/generic/rebase-push.sh --no-push
+```
+
+If the script exits non-zero, print: `**⚠ Rebase onto main failed (likely conflict). Bailing to cleanup.**` and skip to Step 13.
+
+If successful, print: `✅ Rebased onto latest main.`
+
 ## Step 2 — Implement the Feature
 
 **Opportunistic questions** (`auto_mode=false` only): Before starting edits, if the implementation plan leaves genuinely ambiguous choices (e.g., naming conventions, test strategy, which of two valid approaches to use), batch them into a single `AskUserQuestion` call with 1-4 questions. Only ask when the ambiguity cannot be resolved from the plan, codebase, or CLAUDE.md. When `auto_mode=true`, proceed with best judgment — do not ask. Material answers that change scope or approach should be noted for the "Implementation Deviations" section.
@@ -152,6 +172,25 @@ $PWD/.claude/scripts/generic/git-commit.sh -m "<descriptive commit message>" <sp
 ```
 
 The commit message should describe WHAT was implemented and WHY, not HOW.
+
+### Rebase onto latest main (after implementation commit)
+
+Print: `🔃 Rebasing onto latest main after implementation commit...`
+
+First, check if the branch has already been pushed to origin:
+```bash
+git ls-remote --heads origin "$(git branch --show-current)" 2>/dev/null
+```
+If the output is non-empty, print: `⏩ Rebase skipped — branch already pushed to origin.` and skip this rebase.
+
+Otherwise, run:
+```bash
+$PWD/.claude/scripts/generic/rebase-push.sh --no-push
+```
+
+If the script exits non-zero, print: `**⚠ Rebase onto main failed (likely conflict). Bailing to cleanup.**` and skip to Step 13.
+
+If successful, print: `✅ Rebased onto latest main.`
 
 ## Step 5 — Code Review
 
@@ -211,6 +250,27 @@ $PWD/.claude/scripts/generic/git-commit.sh -m "Address code review feedback" <sp
 
 If no files changed (review found no issues), skip this commit.
 
+### Rebase onto latest main (after review fixes commit)
+
+**Conditional**: Only run this rebase if `FILES_CHANGED=true` from Step 6's `check-review-changes.sh` output (meaning Step 7 created a commit). If Steps 6–7 were skipped (no review changes), skip this rebase — the pre-Step-8 rebase provides the safety net.
+
+Print: `🔃 Rebasing onto latest main after review fixes commit...`
+
+First, check if the branch has already been pushed to origin:
+```bash
+git ls-remote --heads origin "$(git branch --show-current)" 2>/dev/null
+```
+If the output is non-empty, print: `⏩ Rebase skipped — branch already pushed to origin.` and skip this rebase.
+
+Otherwise, run:
+```bash
+$PWD/.claude/scripts/generic/rebase-push.sh --no-push
+```
+
+If the script exits non-zero, print: `**⚠ Rebase onto main failed (likely conflict). Bailing to cleanup.**` and skip to Step 13.
+
+If successful, print: `✅ Rebased onto latest main.`
+
 ## Step 7a — Code Flow Diagram
 
 Print: `🗺️ Step 7a — Generating code flow diagram...`
@@ -236,6 +296,27 @@ Print the diagram under a `## Code Flow Diagram` header with a mermaid code fenc
 **If diagram generation succeeds**, print: `✅ Step 7a — Code flow diagram generated.`
 
 **If diagram generation fails** (e.g., the implementation is too abstract to diagram meaningfully), print: `**⚠ Step 7a — Code flow diagram generation failed. Proceeding without diagram.**` Log this warning to `$IMPL_TMPDIR/execution-issues.md` under the `Warnings` category.
+
+### Rebase onto latest main (before version bump)
+
+This rebase **always runs** as a final safety net before the version bump and PR creation, even if a previous rebase just ran. It ensures the branch is as fresh as possible before the version bump becomes the last commit.
+
+Print: `🔃 Rebasing onto latest main before version bump...`
+
+First, check if the branch has already been pushed to origin:
+```bash
+git ls-remote --heads origin "$(git branch --show-current)" 2>/dev/null
+```
+If the output is non-empty, print: `⏩ Rebase skipped — branch already pushed to origin.` and skip this rebase.
+
+Otherwise, run:
+```bash
+$PWD/.claude/scripts/generic/rebase-push.sh --no-push
+```
+
+If the script exits non-zero, print: `**⚠ Rebase onto main failed (likely conflict). Bailing to cleanup.**` and skip to Step 13.
+
+If successful, print: `✅ Rebased onto latest main.`
 
 ## Step 8 — Version Bump
 

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -132,6 +132,8 @@ Proceed to Step 2.
 
 ### Rebase onto latest main (before implementation)
 
+**This rebase runs unconditionally in both quick and normal mode** — freshness is beneficial regardless of mode. Both the quick-mode "Proceed to Step 2" and normal-mode "proceed to Step 2" instructions above lead here before entering Step 2.
+
 Print: `🔃 Rebasing onto latest main before starting implementation...`
 
 First, check if the branch has already been pushed to origin (e.g., re-running `/implement` on an existing PR branch):
@@ -145,7 +147,7 @@ Otherwise, run:
 $PWD/.claude/scripts/generic/rebase-push.sh --no-push
 ```
 
-If the script exits non-zero, print: `**⚠ Rebase onto main failed (likely conflict). Bailing to cleanup.**` and skip to Step 13.
+If the script exits non-zero, print: `**⚠ Rebase onto main failed. Bailing to cleanup.**` and skip to Step 13.
 
 If successful, print: `✅ Rebased onto latest main.`
 
@@ -188,7 +190,7 @@ Otherwise, run:
 $PWD/.claude/scripts/generic/rebase-push.sh --no-push
 ```
 
-If the script exits non-zero, print: `**⚠ Rebase onto main failed (likely conflict). Bailing to cleanup.**` and skip to Step 13.
+If the script exits non-zero, print: `**⚠ Rebase onto main failed. Bailing to cleanup.**` and skip to Step 13.
 
 If successful, print: `✅ Rebased onto latest main.`
 
@@ -267,7 +269,7 @@ Otherwise, run:
 $PWD/.claude/scripts/generic/rebase-push.sh --no-push
 ```
 
-If the script exits non-zero, print: `**⚠ Rebase onto main failed (likely conflict). Bailing to cleanup.**` and skip to Step 13.
+If the script exits non-zero, print: `**⚠ Rebase onto main failed. Bailing to cleanup.**` and skip to Step 13.
 
 If successful, print: `✅ Rebased onto latest main.`
 
@@ -314,7 +316,7 @@ Otherwise, run:
 $PWD/.claude/scripts/generic/rebase-push.sh --no-push
 ```
 
-If the script exits non-zero, print: `**⚠ Rebase onto main failed (likely conflict). Bailing to cleanup.**` and skip to Step 13.
+If the script exits non-zero, print: `**⚠ Rebase onto main failed. Bailing to cleanup.**` and skip to Step 13.
 
 If successful, print: `✅ Rebased onto latest main.`
 
@@ -582,4 +584,6 @@ Remove the session temp directory and all files within it:
 $PWD/.claude/scripts/generic/cleanup-tmpdir.sh --dir "$IMPL_TMPDIR"
 ```
 
-Print: `🏁 Step 13 — Implementation complete! PR created but not merged.`
+If a PR was created (Step 9 completed), print: `🏁 Step 13 — Implementation complete! PR created but not merged.`
+
+If the workflow bailed before PR creation (e.g., rebase failure before Step 9), print: `🏁 Step 13 — Implementation bailed before PR creation. See warnings above.`

--- a/.claude/skills/shazam/SKILL.md
+++ b/.claude/skills/shazam/SKILL.md
@@ -73,6 +73,7 @@ This file will be passed to `/implement` via `--session-env` in Step 1.
 Invoke the `/implement` skill with `--session-env $SHAZAM_TMPDIR/session-env.sh` prepended to the feature description. **If `quick_mode=true`, also prepend `--quick`** so `/implement` runs in quick mode. **If `auto_mode=true`, also prepend `--auto`** so `/implement` and `/design` suppress interactive questions. This will:
 - Create a branch and design the plan (via `/design` in normal mode, or inline in `--quick` mode)
 - Implement the feature, validate, commit
+- **Rebase onto latest main** at multiple checkpoints (before implementation, after each commit, before version bump) to minimize merge conflicts when this step enters the CI+rebase+merge loop
 - Code review (full `/review` in normal mode, or simplified 1-round review in `--quick` mode), validate, commit
 - Version bump, create PR
 - Monitor CI and fix failures (does not merge)


### PR DESCRIPTION
## Summary
- Added `--no-push` flag to `rebase-push.sh` for local-only freshness rebases that abort on conflict
- Inserted four rebase-onto-main checkpoints in `/implement` skill (before implementation, after impl commit, after review fixes, before version bump) to minimize merge conflicts before PR creation
- Updated `/shazam` documentation to note the new rebase behavior

<details><summary>Architecture Diagram</summary>

```mermaid
graph TD
    subgraph "/implement SKILL.md workflow"
        S1["Step 1: Design Plan"]
        R1["🔃 Rebase 1: Before changes"]
        S2["Step 2: Implement"]
        S3["Step 3: Lint"]
        S4["Step 4: Commit impl"]
        R2["🔃 Rebase 2: After impl commit"]
        S5["Step 5: Code Review"]
        S6["Step 6: Lint"]
        S7["Step 7: Commit review fixes"]
        R3["🔃 Rebase 3: After review commit<br/>(conditional: FILES_CHANGED=true)"]
        S7a["Step 7a: Code Flow Diagram"]
        R4["🔃 Rebase 4: Before version bump<br/>(always runs)"]
        S8["Step 8: Version Bump"]
        S9["Step 9: Create PR"]
    end

    subgraph "rebase-push.sh"
        RP_FETCH["git fetch origin main"]
        RP_REBASE["git rebase origin/main"]
        RP_PUSH["git push --force-with-lease"]
        RP_NOPUSH["exit 0 (skip push)"]
    end

    S1 --> R1 --> S2 --> S3 --> S4 --> R2 --> S5 --> S6 --> S7
    S7 --> R3 --> S7a --> R4 --> S8 --> S9

    R1 & R2 & R3 & R4 -->|"--no-push"| RP_FETCH
    RP_FETCH --> RP_REBASE
    RP_REBASE -->|"success + --no-push"| RP_NOPUSH
    RP_REBASE -->|"success + normal"| RP_PUSH

    style R1 fill:#e1f5fe
    style R2 fill:#e1f5fe
    style R3 fill:#e1f5fe
    style R4 fill:#e1f5fe
```

</details>

<details><summary>Code Flow Diagram</summary>

```mermaid
flowchart TD
    Start["Branch created / design complete"]

    subgraph "Rebase Checkpoint Logic"
        CheckOrigin{"Branch on origin?"}
        SkipRebase["⏩ Skip rebase"]
        RunRebase["rebase-push.sh --no-push"]
        FetchMain["git fetch origin main"]
        FetchFail{"Fetch failed?"}
        FetchFatalExit["exit 3: REBASE_ERROR"]
        Rebase["git rebase origin/main"]
        RebaseOK{"Rebase succeeded?"}
        ConflictCheck{"Conflicts?"}
        AbortRebase["git rebase --abort"]
        ConflictExit["exit 1: aborted"]
        NonConflictExit["exit 3: REBASE_ERROR"]
        SuccessExit["exit 0: success"]
    end

    Start --> CheckOrigin
    CheckOrigin -->|Yes| SkipRebase
    CheckOrigin -->|No| RunRebase
    RunRebase --> FetchMain --> FetchFail
    FetchFail -->|"Yes (--no-push)"| FetchFatalExit
    FetchFail -->|No| Rebase --> RebaseOK
    RebaseOK -->|Yes| SuccessExit
    RebaseOK -->|No| ConflictCheck
    ConflictCheck -->|Yes| AbortRebase --> ConflictExit
    ConflictCheck -->|No| NonConflictExit
```

</details>

<details><summary>Goal</summary>

- Minimize merge conflicts post-PR creation by keeping the feature branch fresh with main
  - Add rebase-onto-main step right before starting any changes (before Step 2)
  - Add rebase-onto-main step right after each commit (after Steps 4 and 7)
  - Add rebase-onto-main step right before creating the PR (before Step 8/version bump)
- Reuse existing `rebase-push.sh` with new `--no-push` flag rather than creating a separate script
- Skip rebases for branches already pushed to origin to avoid non-fast-forward push issues
- Update `/shazam` documentation to reflect the new behavior

</details>

<details><summary>Test plan</summary>

- [x] `bash -n` syntax validation on `rebase-push.sh`
- [x] shellcheck passes on modified script
- [x] markdownlint passes on SKILL.md files
- [x] Verify `--no-push` flag: exits 0 on success, does not push
- [x] Verify `--no-push` + `--continue` combination is rejected
- [x] Verify fetch failure is fatal in `--no-push` mode
- [x] Verify existing behavior (without `--no-push`) is unchanged
- [x] Run `/relevant-checks` after all edits

</details>

<details><summary>Final Design</summary>

### Files to Modify
1. `.claude/scripts/generic/rebase-push.sh` — Add `--no-push` flag that skips push step and aborts on conflicts (instead of leaving rebase in progress)
2. `.claude/skills/implement/SKILL.md` — Four rebase insertions + emoji table update:
   - Before Step 2: Rebase before any changes
   - After Step 4: Rebase after implementation commit
   - After Step 7: Rebase after review fixes (conditional on FILES_CHANGED=true from Step 6)
   - Before Step 8: Final safety net rebase before version bump (always runs)
3. `.claude/skills/shazam/SKILL.md` — Documentation update

### Key Design Decisions
- Reuse `rebase-push.sh` via `--no-push` flag (not a new script) per reviewer consensus
- Insertion 4 placed before Step 8 (not after) to preserve "version bump must be last commit" invariant
- Rebases skipped for branches already on origin to avoid non-fast-forward push regression
- `FILES_CHANGED` from Step 6 used as guard for post-Step-7 rebase
- Fetch failure fatal in `--no-push` mode (freshness guarantee)

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

### [Plan Review] Correctness
**Finding**: FINDING_6 — `git rebase --abort` in the new script needs `|| true` idiom (matching `rebase-push.sh` line 87: `git rebase --abort 2>/dev/null || true`). Without it, if abort itself fails, the script exits with unexpected status under `set -e`.
**Reason not implemented**: Exonerated by all 3 voters (1 YES, 2 EXONERATE). The concern is technically valid but is an implementation-level detail that was naturally addressed when modifying `rebase-push.sh` — the existing `|| true` pattern on line 87 was reused in the `--no-push` conflict path.

### [Plan Review] Architect
**Finding**: FINDING_7 — Insertion 1 (before Step 2) is guaranteed to be a no-op when Step 1 just created a fresh branch from `origin/main`. Should be conditional (skip if branch was just created from origin/main). Also, "bail" targets need explicit definition for each insertion point specifying which cleanup steps run.
**Reason not implemented**: Mixed votes (1 YES, 1 NO, 1 EXONERATE). A no-op rebase completes instantly, so the optimization adds complexity for negligible benefit. The bail target concern was addressed in the revised plan by specifying "skip to Step 13 (cleanup)" for all insertion points.

</details>

<details><summary>Implementation Deviations</summary>

No deviations from the plan.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

### [Code Review] Codex-Deep
**Finding**: FINDING_5 — The "branch exists on origin" check (`git ls-remote --heads origin`) in all 4 rebase checkpoints in `.claude/skills/implement/SKILL.md` causes all rebases to be skipped for branches that have already been pushed to origin. This means re-running `/implement` on a branch with an existing PR — which is the most likely scenario for a branch that has drifted behind `origin/main` — bypasses all freshness rebases.
**Reason not implemented**: Exonerated by the voting panel (0 YES, 1 EXONERATE). Skipping rebases for already-pushed branches is a deliberate design decision to avoid rebasing a published branch without force-pushing. Step 10 CI monitoring and `/shazam`'s rebase-merge loop handle freshness for published branches.

### [Code Review] Claude-General
**Finding**: FINDING_6 — All four rebase failure bail paths print warning messages but don't log to `$IMPL_TMPDIR/execution-issues.md`, unlike Step 10 which logs CI failures.
**Reason not implemented**: Received only 1 YES vote (neutral). The bail paths exit before PR creation, so the PR body's Execution Issues section is never written. The bail warning is visible in conversation output.

### [Code Review] Claude-General
**Finding**: FINDING_7 — The pre-implementation rebase block lacks a note that it intentionally runs in both quick and normal mode.
**Reason not implemented**: Rejected by all 3 voters (0 YES). FINDING_1's fix already addresses the underlying concern by adding explicit language about both modes running through the rebase.

</details>

<details><summary>Plan Review Voting Tally</summary>

| Finding | Cursor | Codex | Claude Architect | Result |
|---------|--------|-------|-----------------|--------|
| FINDING_1 (Reuse rebase-push.sh) | YES | YES | YES | **3 YES — ACCEPTED** |
| FINDING_2 (Move Insertion 4 before Step 8) | YES | YES | YES | **3 YES — ACCEPTED** |
| FINDING_3 (Clarify Insertion 3 vs Step 7a) | YES | YES | NO | **2 YES — ACCEPTED** |
| FINDING_4 (Existing-PR push regression) | YES | YES | YES | **3 YES — ACCEPTED** |
| FINDING_5 (Testing strategy) | YES | YES | EXONERATE | **2 YES — ACCEPTED** |
| FINDING_6 (--abort || true) | EXONERATE | EXONERATE | YES | **1 YES, 2 EXON — EXONERATED** |
| FINDING_7 (Insertion 1 no-op + bail def) | YES | NO | EXONERATE | **1 YES, 1 EXON — EXONERATED** |

## Reviewer Competition Scoreboard

| Reviewer | Findings | Accepted | Neutral (1 YES) | Exonerated (0 YES, 1+ EXON.) | Rejected (0 YES, 0 EXON.) | Score |
|----------|----------|----------|-----------------|-------------------------------|---------------------------|-------|
| Generic | 3 | 3 (F1,F2,F3) | 0 | 0 | 0 | +3 |
| Codex | 4 | 4 (F1,F4,F5,F2) | 0 | 0 | 0 | +4 |
| Correctness | 2 | 1 (F3) | 0 | 1 (F6) | 0 | +1 |
| Risk | 2 | 2 (F1,F2) | 0 | 0 | 0 | +2 |
| Architect | 3 | 2 (F1,F2) | 0 | 1 (F7) | 0 | +2 |
| Cursor | 0 (timed out) | 0 | 0 | 0 | 0 | 0 |

Note: In future iterations, token allocation will be weighted proportionally to reviewer scores — higher-scoring reviewers will receive more tokens.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

| Finding | Cursor | Codex | Claude-General | Result |
|---------|--------|-------|---------------|--------|
| FINDING_1 (Quick mode skip) | YES | EXONERATE | YES | **2 YES — ACCEPTED** |
| FINDING_2 (Error contract) | YES | EXONERATE | YES | **2 YES — ACCEPTED** |
| FINDING_3 (Step 13 false message) | YES | YES | YES | **3 YES — ACCEPTED** |
| FINDING_4 (Fetch || true) | YES | YES | NO | **2 YES — ACCEPTED** |
| FINDING_5 (Published branch skip) | NO | NO | EXONERATE | **0 YES, 1 EXON — EXONERATED** |
| FINDING_6 (execution-issues log) | NO | EXONERATE | YES | **1 YES — NEUTRAL** |
| FINDING_7 (Mode note) | NO | NO | NO | **0 YES, 0 EXON — REJECTED** |

## Reviewer Competition Scoreboard

| Reviewer | Findings | Accepted | Neutral (1 YES) | Exonerated (0 YES, 1+ EXON.) | Rejected (0 YES, 0 EXON.) | Score |
|----------|----------|----------|-----------------|-------------------------------|---------------------------|-------|
| Cursor | 3 | 3 (F1,F2,F3) | 0 | 0 | 0 | +3 |
| Codex-General | 0 (garbled) | 0 | 0 | 0 | 0 | 0 |
| Codex-Deep | 2 | 1 (F4) | 0 | 1 (F5) | 0 | +1 |
| Claude-General | 3 | 1 (F2) | 1 (F6) | 0 | 1 (F7) | 0 |
| Claude-Deep | 1 | 1 (F3) | 0 | 0 | 0 | +1 |

Note: In future iterations, token allocation will be weighted proportionally to reviewer scores — higher-scoring reviewers will receive more tokens.

</details>

<details><summary>Out-of-Scope Observations</summary>

**Plan review**: No out-of-scope observations were raised.

**Code review**:
- OOS_1 (Claude-Deep): `rebase-push.sh`'s `--diff-filter=U` may miss some edge-case conflict types (rename/add) where git exits non-zero but no unmerged blobs are in the index. Pre-existing behavior, not introduced by this PR.
- OOS_2 (Claude-Deep): `FILES_CHANGED` condition for the post-Step-7 rebase is a proxy for "Step 7 created a commit" — technically `FILES_CHANGED=true` doesn't guarantee a commit was created. Minor documentation imprecision with no runtime impact.

</details>

<details><summary>Execution Issues</summary>

### External Reviewer Issues
- **Step 5 (Code Review)**: Codex-General produced garbled/unparseable output. Proceeded without Codex-General findings.

### Warnings
- **Step 8**: Version bump skipped — no /bump-version skill found.
- **Design Step 3**: Cursor plan review timed out (exit code 124, 863s elapsed, empty output). Proceeded without Cursor plan review findings.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | 5 accepted, 2 rejected |
| Code review rounds | 1 |
| Code review findings | 4 accepted, 3 rejected |
| Warnings logged | 3 |
| Pre-existing issues noticed | 0 |
| External reviewers | Cursor: ✅, Codex: ✅ (1 garbled output) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
