### PR TITLE
Skip relevant-checks skill in setup-claudin.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ git commit -m "Bump claudin submodule"
 **Important notes**:
 
 - **`settings*.json` files are not symlinked.** Your repo must maintain its own `.claude/settings.json` (and any `settings.local.json`) with the permission entries needed by claudin scripts. The recommended approach is to copy the `permissions.allow` array from claudin's `settings.json` as a baseline. At minimum, include bash permissions for `$PWD/.claude/scripts/generic/claudin/*`, `$PWD/.claude/skills/*/scripts/*` (for skill-specific scripts), and the `block-submodule-edit.sh` hook.
+- **`/relevant-checks` is not symlinked.** This skill is repo-specific — each repository defines its own validation checks (linters, test commands, etc.). Claudin ships a `/relevant-checks` as a reference implementation, but `setup-claudin.sh` will never overwrite or symlink it. Create your own `.claude/skills/relevant-checks/` with checks appropriate for your repo.
 - **Edits to `claudin/` are blocked.** The `block-submodule-edit.sh` hook prevents Claude Code from editing files inside git submodules. This is intentional — changes to claudin should be made via PRs to the claudin repo, then pulled in by updating the submodule.
 - **Conflicts**: If a non-symlink file or directory already exists at a path the script needs to symlink, it exits with an error. Resolve the conflict manually (rename or remove the existing file) and re-run.
 

--- a/setup-claudin.sh
+++ b/setup-claudin.sh
@@ -168,6 +168,11 @@ while IFS= read -r -d '' entry; do
 
         # Only process first-level entries under skills/
         if [[ "$local_under_skills" == "$first_component" ]]; then
+            # Skip relevant-checks — repo-specific skill, client must maintain their own
+            if [[ "$first_component" == "relevant-checks" ]]; then
+                echo "  skipped: .claude/skills/relevant-checks (repo-specific, maintain your own)"
+                continue
+            fi
             if [[ -d "$entry" && -f "$entry/SKILL.md" ]]; then
                 # Skill directory — directory-level symlink
                 create_link "$link_path" "$target_path" "skill dir"

--- a/tests/test-setup-claudin.sh
+++ b/tests/test-setup-claudin.sh
@@ -97,8 +97,8 @@ echo "--- relevant-checks conflict test ---"
 mkdir -p ".claude/skills/relevant-checks"
 echo "# Client-specific checks" > ".claude/skills/relevant-checks/SKILL.md"
 # Re-run — should succeed without error despite the pre-existing directory
-./claudin/setup-claudin.sh > /dev/null 2>&1
-rc=$?
+rc=0
+./claudin/setup-claudin.sh > /dev/null 2>&1 || rc=$?
 if [[ $rc -eq 0 ]]; then
     echo "  PASS: setup-claudin.sh succeeds with pre-existing relevant-checks"
 else

--- a/tests/test-setup-claudin.sh
+++ b/tests/test-setup-claudin.sh
@@ -82,10 +82,36 @@ echo "--- Skill directories (directory-level symlinks) ---"
 for skill_dir in "$TEST_REPO_DIR"/claudin/.claude/skills/*/; do
     skill_name="$(basename "$skill_dir")"
     [[ "$skill_name" == "shared" ]] && continue
+    [[ "$skill_name" == "relevant-checks" ]] && continue
     if [[ -f "$skill_dir/SKILL.md" ]]; then
         check_symlink ".claude/skills/$skill_name" "skill dir: $skill_name"
     fi
 done
+
+# relevant-checks should NOT be symlinked (repo-specific skill)
+echo "--- relevant-checks ---"
+check_not_exists ".claude/skills/relevant-checks" "relevant-checks should not be symlinked"
+
+# Verify setup-claudin.sh does not conflict with a pre-existing relevant-checks directory
+echo "--- relevant-checks conflict test ---"
+mkdir -p ".claude/skills/relevant-checks"
+echo "# Client-specific checks" > ".claude/skills/relevant-checks/SKILL.md"
+# Re-run — should succeed without error despite the pre-existing directory
+./claudin/setup-claudin.sh > /dev/null 2>&1
+rc=$?
+if [[ $rc -eq 0 ]]; then
+    echo "  PASS: setup-claudin.sh succeeds with pre-existing relevant-checks"
+else
+    echo "  FAIL: setup-claudin.sh exited $rc with pre-existing relevant-checks"
+    FAILURES=$((FAILURES + 1))
+fi
+# Verify the client's relevant-checks was not replaced
+if [[ ! -L ".claude/skills/relevant-checks" && -f ".claude/skills/relevant-checks/SKILL.md" ]]; then
+    echo "  PASS: client's relevant-checks preserved (not a symlink)"
+else
+    echo "  FAIL: client's relevant-checks was replaced or symlinked"
+    FAILURES=$((FAILURES + 1))
+fi
 
 # Scripts under scripts/generic/claudin/ should be file-level symlinks
 echo "--- Scripts (file-level symlinks under scripts/generic/claudin/) ---"


### PR DESCRIPTION
## Summary
- Added `relevant-checks` to the skip list in `setup-claudin.sh` so it is never symlinked to client repos, preventing conflicts with client-owned check configurations
- Added integration tests verifying the skip behavior and that pre-existing client `relevant-checks` directories are preserved
- Documented the skip in README.md

<details><summary>Architecture Diagram</summary>

Quick mode — architecture diagram skipped.

</details>

<details><summary>Code Flow Diagram</summary>

Quick mode — code flow diagram skipped.

</details>

<details><summary>Goal</summary>

- Prevent `setup-claudin.sh` from symlinking the `relevant-checks` skill directory
  - The `relevant-checks` skill is repo-specific — each repository defines its own validation checks
  - `setup-claudin.sh` should leave it alone whether the client repo has its own or not
  - Previously, the script would exit with an error if the client already had a non-symlink `relevant-checks` directory

</details>

<details><summary>Test plan</summary>

- [x] `bash tests/test-setup-claudin.sh` — all tests pass
- [x] `relevant-checks` is NOT symlinked in fresh setup
- [x] Pre-existing client `relevant-checks` directory is preserved after re-run
- [x] `setup-claudin.sh` exits 0 with pre-existing `relevant-checks`
- [x] All linters pass (`shellcheck`, `markdownlint`)

</details>

<details><summary>Final Design</summary>

1. **setup-claudin.sh** — Add skip for `relevant-checks` skill in the skill directory processing block, before `create_link` is called. When `first_component == "relevant-checks"`, print skip message and continue.
2. **tests/test-setup-claudin.sh** — Skip `relevant-checks` in symlink verification loop, add `check_not_exists` assertion, add conflict test with pre-existing directory.
3. **README.md** — Document that `/relevant-checks` is repo-specific and not symlinked.

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

Quick mode — no plan review was conducted.

</details>

<details><summary>Implementation Deviations</summary>

No deviations from the plan.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

All code review suggestions were implemented.

</details>

<details><summary>Plan Review Voting Tally</summary>

Quick mode — no plan review voting.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

Quick mode — no voting panel. Main agent reviewed findings from 2 Claude subagents.

</details>

<details><summary>Out-of-Scope Observations</summary>

Quick mode — no out-of-scope observations collected.

</details>

<details><summary>Execution Issues</summary>

No execution issues encountered.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | N/A (quick mode) |
| Code review rounds | 1 |
| Code review findings | 1 accepted, 0 rejected |
| Warnings logged | 1 (version bump skipped) |
| Pre-existing issues noticed | 0 |
| External reviewers | N/A (quick mode) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
