### PR TITLE
Bump /research skill research-phase timeouts to 900s

### DIFF
--- a/.claude/skills/research/SKILL.md
+++ b/.claude/skills/research/SKILL.md
@@ -85,12 +85,12 @@ Print `🔬 Step 1 — Running collaborative research phase.` and proceed to 1.2
 **Cursor research** (if `cursor_available`):
 
 ```bash
-$PWD/.claude/scripts/generic/claudin/run-external-reviewer.sh --tool cursor --output "$RESEARCH_TMPDIR/cursor-research-output.txt" --timeout 600 --capture-stdout -- \
+$PWD/.claude/scripts/generic/claudin/run-external-reviewer.sh --tool cursor --output "$RESEARCH_TMPDIR/cursor-research-output.txt" --timeout 900 --capture-stdout -- \
   cursor agent -p --force --trust --model gpt-5.4-medium --workspace "$PWD" \
     "You are researching a codebase to answer this question: <RESEARCH_QUESTION>. Explore the codebase to understand the relevant architecture and code. Write 2-3 paragraphs covering: (1) Your key findings and observations relevant to the research question, (2) Which files/modules/areas are most relevant and why, (3) Any risks, constraints, or feasibility concerns you identify. Do NOT modify files."
 ```
 
-Use `run_in_background: true` and `timeout: 660000` on the Bash tool call.
+Use `run_in_background: true` and `timeout: 960000` on the Bash tool call.
 
 **Cursor replacement** (if `cursor_available` is false): Launch a Claude subagent (Alternative Perspectives) via the Agent tool instead:
 
@@ -99,13 +99,13 @@ Prompt: `"You are an Alternative Perspectives researcher. Investigate this resea
 **Codex research** (if `codex_available`):
 
 ```bash
-$PWD/.claude/scripts/generic/claudin/run-external-reviewer.sh --tool codex --output "$RESEARCH_TMPDIR/codex-research-output.txt" --timeout 600 -- \
+$PWD/.claude/scripts/generic/claudin/run-external-reviewer.sh --tool codex --output "$RESEARCH_TMPDIR/codex-research-output.txt" --timeout 900 -- \
   codex exec --full-auto -C "$PWD" \
     --output-last-message "$RESEARCH_TMPDIR/codex-research-output.txt" \
     "You are researching a codebase to answer this question: <RESEARCH_QUESTION>. Explore the codebase to understand the relevant architecture and code. Write 2-3 paragraphs covering: (1) Your key findings and observations relevant to the research question, (2) Which files/modules/areas are most relevant and why, (3) Any risks, constraints, or feasibility concerns you identify. Do NOT modify files."
 ```
 
-Use `run_in_background: true` and `timeout: 660000` on the Bash tool call.
+Use `run_in_background: true` and `timeout: 960000` on the Bash tool call.
 
 **Codex replacement** (if `codex_available` is false): Launch a Claude subagent (Edge-cases/Gaps) via the Agent tool instead:
 
@@ -126,10 +126,10 @@ Prompt: `"You are a Risk/Feasibility researcher. Investigate this research quest
 Wait for external research sentinels using `wait-for-reviewers.sh`. Only include paths for external reviewers that were actually launched (not Claude replacements — those return via Agent tool):
 
 ```bash
-$PWD/.claude/scripts/generic/claudin/wait-for-reviewers.sh --timeout 660 "$RESEARCH_TMPDIR/cursor-research-output.txt.done" "$RESEARCH_TMPDIR/codex-research-output.txt.done"
+$PWD/.claude/scripts/generic/claudin/wait-for-reviewers.sh --timeout 960 "$RESEARCH_TMPDIR/cursor-research-output.txt.done" "$RESEARCH_TMPDIR/codex-research-output.txt.done"
 ```
 
-Use `timeout: 660000` on the Bash tool call. **Do NOT** set `run_in_background: true` — this call must block. Only include sentinel paths for external reviewers that were actually launched.
+Use `timeout: 960000` on the Bash tool call. **Do NOT** set `run_in_background: true` — this call must block. Only include sentinel paths for external reviewers that were actually launched.
 
 **Validate research outputs**: For research outputs, the validation criteria differ from the standard review validation in `.claude/skills/shared/claudin/external-reviewers.md`: instead of checking for numbered findings or `NO_ISSUES_FOUND`, check that the output is non-empty and contains at least one paragraph of substantive prose. Use `$RESEARCH_TMPDIR/cursor-research-output.txt` and `$RESEARCH_TMPDIR/codex-research-output.txt` as the output files. If an output is empty despite exit code 0, retry once with a `-retry` suffix per the shared procedure in `external-reviewers.md`.
 


### PR DESCRIPTION
## Summary
- Bumped `/research` skill research-phase Cursor and Codex timeouts from 600s to 900s to match the validation phase
- Updated corresponding Bash tool timeouts (660000ms to 960000ms) and wait-for-reviewers timeout (660s to 960s)

<details><summary>Architecture Diagram</summary>

Quick mode — architecture diagram skipped.

</details>

<details><summary>Code Flow Diagram</summary>

Quick mode — code flow diagram skipped.

</details>

<details><summary>Goal</summary>

- Align research-phase timeouts with validation-phase timeouts in `/research` skill
  - Cursor research timed out at 600s during earlier session; validation phase already uses 900s
  - Bump all three timeout layers (script, Bash tool, wait-for-reviewers) consistently

</details>

<details><summary>Test plan</summary>

- [x] Verified all 6 changed values are internally consistent (900s script + 960s/960000ms Bash tool)
- [x] Verified validation phase (Step 2) was NOT modified — already at 900s
- [x] markdownlint passes on the modified SKILL.md

</details>

<details><summary>Final Design</summary>

Change 6 values in `.claude/skills/research/SKILL.md` Step 1 (research phase):
1. Cursor research `--timeout 600` → `900`
2. Cursor Bash tool `timeout: 660000` → `960000`
3. Codex research `--timeout 600` → `900`
4. Codex Bash tool `timeout: 660000` → `960000`
5. wait-for-reviewers `--timeout 660` → `960`
6. wait-for-reviewers Bash tool `timeout: 660000` → `960000`

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

Quick mode — no plan review was conducted.

</details>

<details><summary>Implementation Deviations</summary>

No deviations from the plan.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

All code review suggestions were implemented.

</details>

<details><summary>Plan Review Voting Tally</summary>

Quick mode — no plan review voting.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

Quick mode — no voting panel. Main agent reviewed findings from 2 Claude subagents. Both reported no issues.

</details>

<details><summary>Out-of-Scope Observations</summary>

Quick mode — no out-of-scope observations collected.

</details>

<details><summary>Execution Issues</summary>

No execution issues encountered.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | N/A (quick mode) |
| Code review rounds | 1 |
| Code review findings | 0 accepted, 0 rejected |
| Warnings logged | 1 (version bump skipped) |
| Pre-existing issues noticed | 0 |
| External reviewers | N/A (quick mode) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
