### PR TITLE
Add larch copies of claudin scripts/docs (PR #1 of rename migration)

### DIFF
--- a/.claude/scripts/generic/larch/add-merged-emoji.sh
+++ b/.claude/scripts/generic/larch/add-merged-emoji.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# add-merged-emoji.sh — Add :merged: emoji to a Slack PR announcement.
+#
+# Wraps add-slack-emoji.sh with token cleaning.
+# This wrapper exists so that callers (skills, ad-hoc commands) can invoke
+# it without $() command substitution, which triggers Claude Code's
+# interactive permission prompt.
+#
+# Usage:
+#   add-merged-emoji.sh --slack-ts TIMESTAMP --channel-id CHANNEL_ID
+#
+# Environment:
+#   LARCH_SLACK_BOT_TOKEN — required
+#
+# Exit codes:
+#   0 — emoji added successfully
+#   1 — LARCH_SLACK_BOT_TOKEN not set
+#   2 — missing arguments
+#   3 — add-slack-emoji.sh failed
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+usage() { echo "Usage: add-merged-emoji.sh --slack-ts TIMESTAMP --channel-id CHANNEL_ID" >&2; }
+
+SLACK_TS=""
+CHANNEL_ID=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --slack-ts) SLACK_TS="${2:?--slack-ts requires a value}"; shift 2 ;;
+        --channel-id) CHANNEL_ID="${2:?--channel-id requires a value}"; shift 2 ;;
+        --help) usage; exit 0 ;;
+        *) echo "Unknown option: $1" >&2; usage; exit 2 ;;
+    esac
+done
+
+if [[ -z "$SLACK_TS" ]] || [[ -z "$CHANNEL_ID" ]]; then
+    echo "ERROR: --slack-ts and --channel-id are required" >&2
+    usage; exit 2
+fi
+
+if [[ -z "${LARCH_SLACK_BOT_TOKEN:-}" ]]; then
+    echo "⚠ LARCH_SLACK_BOT_TOKEN not set. Skipping :merged: emoji."
+    exit 1
+fi
+
+CLEAN_TOKEN=$(echo -n "$LARCH_SLACK_BOT_TOKEN" | tr -d '[:space:]')
+
+bash "$SCRIPT_DIR/add-slack-emoji.sh" \
+    --channel-id "$CHANNEL_ID" \
+    --emoji ":merged:" \
+    --slack_timestamp "$SLACK_TS" \
+    --token "$CLEAN_TOKEN"

--- a/.claude/scripts/generic/larch/add-slack-emoji.sh
+++ b/.claude/scripts/generic/larch/add-slack-emoji.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# add-slack-emoji.sh — Add an emoji reaction to a Slack message.
+#
+# Usage:
+#   add-slack-emoji.sh --channel-id CHANNEL_ID --emoji ":emoji:" \
+#       --slack_timestamp "timestamp" --token "SLACK_TOKEN"
+#
+# Arguments:
+#   --channel-id        Slack channel ID (e.g., C12345678)
+#   --emoji             Emoji name with colons (e.g., :merged:)
+#   --slack_timestamp   Message timestamp to react to
+#   --token             Slack bot token
+#
+# Outputs to stdout:
+#   Emoji name (on success)
+#
+# Exit codes:
+#   0 — emoji added successfully
+#   1 — missing arguments or API failure
+
+set -euo pipefail
+
+CHANNEL_ID=""
+EMOJI=""
+SLACK_TIMESTAMP=""
+TOKEN=""
+
+while [[ "$#" -gt 0 ]]; do
+  case $1 in
+    --channel-id) CHANNEL_ID="$2"; shift ;;
+    --emoji) EMOJI="$2"; shift ;;
+    --slack_timestamp) SLACK_TIMESTAMP="$2"; shift ;;
+    --token) TOKEN="$2"; shift ;;
+    *) echo "Unknown parameter: $1" >&2; exit 1 ;;
+  esac
+  shift
+done
+
+if [[ -z "$CHANNEL_ID" || -z "$EMOJI" || -z "$SLACK_TIMESTAMP" || -z "$TOKEN" ]]; then
+  echo "Error: Missing required arguments" >&2
+  echo "Usage: $0 --channel-id CHANNEL_ID --emoji \":emoji:\" --slack_timestamp \"timestamp\" --token \"SLACK_TOKEN\"" >&2
+  exit 1
+fi
+
+# Remove ':' from emoji for API
+EMOJI_NAME="${EMOJI#:}"
+EMOJI_NAME="${EMOJI_NAME%:}"
+
+# Construct JSON payload safely using jq
+PAYLOAD=$(jq -n \
+  --arg channel "$CHANNEL_ID" \
+  --arg name "$EMOJI_NAME" \
+  --arg timestamp "$SLACK_TIMESTAMP" \
+  '{channel: $channel, name: $name, timestamp: $timestamp}')
+
+# Add emoji using reactions.add
+response=$(curl -s -X POST https://slack.com/api/reactions.add \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json; charset=utf-8" \
+  -d "$PAYLOAD")
+
+if echo "$response" | grep -q '"ok":true'; then
+  echo "$EMOJI_NAME"
+else
+  echo "Failed to add emoji: $response" >&2
+  exit 1
+fi

--- a/.claude/scripts/generic/larch/auto-goimports.sh
+++ b/.claude/scripts/generic/larch/auto-goimports.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# PostToolUse hook: Auto-run goimports on .go files after Edit/Write tool calls.
+# Note: Bash-driven writes (make format, shell scripts) are not intercepted by this hook.
+#
+# Stdin: JSON with tool_input.file_path (absolute path)
+# Always exits 0 (non-blocking). Failures are silently ignored.
+
+set -uo pipefail
+
+INPUT=$(cat)
+
+# Extract file_path. If parsing fails, silently exit.
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null) || exit 0
+
+# No path or not a .go file → nothing to do.
+[ -z "$FILE_PATH" ] && exit 0
+[[ "$FILE_PATH" != *.go ]] && exit 0
+
+# Run goimports if available. Silently ignore errors.
+if command -v goimports >/dev/null 2>&1; then
+  goimports -w "$FILE_PATH" 2>/dev/null || true
+fi
+
+exit 0

--- a/.claude/scripts/generic/larch/block-submodule-edit.sh
+++ b/.claude/scripts/generic/larch/block-submodule-edit.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# PreToolUse hook: Block edits to files inside any checked-out git submodule
+# of the current superproject.
+#
+# Stdin: JSON with tool_input.file_path (absolute path)
+# Exit 0: allow the operation
+# Exit 2: block the operation (stdout is the reason shown to Claude)
+#
+# Behavior:
+# - Fails CLOSED on stdin / JSON parse failure
+# - Fails OPEN for clearly non-git situations
+# - Blocks only true submodules of the current repo, not arbitrary nested repos
+
+set -uo pipefail
+
+block() {
+  printf '%s\n' "$1"
+  exit 2
+}
+
+# --- Read stdin ---
+INPUT=$(cat) || block "submodule edit guard: failed to read stdin, blocking as precaution"
+
+# --- Extract file_path from JSON ---
+if ! command -v jq >/dev/null 2>&1; then
+  block "submodule edit guard: jq is required but not installed; install jq and retry"
+fi
+FILE_PATH=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null) \
+  || block "submodule edit guard: failed to parse tool input, blocking as precaution"
+
+# No file_path means not a file operation we care about.
+if [[ -z "$FILE_PATH" ]]; then
+  exit 0
+fi
+
+# Require absolute path per contract.
+if [[ "$FILE_PATH" != /* ]]; then
+  block "submodule edit guard: tool_input.file_path is not absolute, blocking as precaution"
+fi
+
+# --- Determine the superproject root ---
+# If we're not running inside a git repo, do not interfere.
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || true)
+if [[ -z "$REPO_ROOT" ]]; then
+  exit 0
+fi
+# Canonicalize once to avoid symlink/path ambiguity in later comparisons.
+REPO_ROOT=$(cd "$REPO_ROOT" 2>/dev/null && pwd -P) || {
+  echo "submodule edit guard: warning: could not canonicalize repo root" >&2
+  exit 0
+}
+
+# --- Find the nearest existing ancestor of the target path ---
+# Handles Write to a new file in a new subdirectory inside a submodule.
+PROBE_PATH="$FILE_PATH"
+while [[ ! -e "$PROBE_PATH" ]] && [[ "$PROBE_PATH" != "/" ]]; do
+  PROBE_PATH=$(dirname "$PROBE_PATH")
+done
+
+# If we walked all the way to / without finding anything, allow.
+if [[ "$PROBE_PATH" == "/" ]]; then
+  exit 0
+fi
+
+# If we landed on a file, inspect its directory.
+if [[ -f "$PROBE_PATH" ]]; then
+  PROBE_DIR=$(dirname "$PROBE_PATH")
+else
+  PROBE_DIR="$PROBE_PATH"
+fi
+
+# Canonicalize the probe directory.
+PROBE_DIR=$(cd "$PROBE_DIR" 2>/dev/null && pwd -P) || {
+  echo "submodule edit guard: warning: could not canonicalize probe dir" >&2
+  exit 0
+}
+
+# --- Resolve the git repo containing the target path ---
+FILE_REPO_ROOT=$(git -C "$PROBE_DIR" rev-parse --show-toplevel 2>/dev/null || true)
+if [[ -z "$FILE_REPO_ROOT" ]]; then
+  # Target is not in any git repo, allow.
+  exit 0
+fi
+FILE_REPO_ROOT=$(cd "$FILE_REPO_ROOT" 2>/dev/null && pwd -P) || {
+  echo "submodule edit guard: warning: could not canonicalize file repo root" >&2
+  exit 0
+}
+
+# Same repo root => not in a submodule.
+if [[ "$FILE_REPO_ROOT" == "$REPO_ROOT" ]]; then
+  exit 0
+fi
+
+# --- Verify it's actually a submodule of this repo, not an unrelated nested repo ---
+FILE_SUPERPROJECT=$(git -C "$FILE_REPO_ROOT" rev-parse --show-superproject-working-tree 2>/dev/null || true)
+if [[ -z "$FILE_SUPERPROJECT" ]]; then
+  # No superproject — it's a standalone nested repo, not a submodule. Allow.
+  exit 0
+fi
+FILE_SUPERPROJECT=$(cd "$FILE_SUPERPROJECT" 2>/dev/null && pwd -P) || {
+  echo "submodule edit guard: warning: could not canonicalize superproject path" >&2
+  exit 0
+}
+
+if [[ "$FILE_SUPERPROJECT" != "$REPO_ROOT" ]]; then
+  # Superproject is some other repo, not ours. Allow.
+  exit 0
+fi
+
+# --- Block: file is in a submodule of this repo ---
+SUBMODULE_PATH="${FILE_REPO_ROOT#"$REPO_ROOT"/}"
+block "This file is inside the '$SUBMODULE_PATH' submodule. Never edit submodules directly here; file PRs in the submodule's own repo instead."

--- a/.claude/scripts/generic/larch/check-bump-version.sh
+++ b/.claude/scripts/generic/larch/check-bump-version.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# check-bump-version.sh — Check for /bump-version skill and verify commit count.
+#
+# Usage:
+#   check-bump-version.sh --mode pre    # Check if skill exists, count commits before
+#   check-bump-version.sh --mode post --before-count <N>  # Verify one new commit was added
+#
+# Output (stdout, KEY=VALUE):
+#   --mode pre:
+#     HAS_BUMP=true|false
+#     COMMITS_BEFORE=<N>
+#   --mode post:
+#     VERIFIED=true|false
+#     COMMITS_AFTER=<N>
+#     EXPECTED=<N>
+#
+# Exit codes: 0 success, 1 invalid args
+
+set -euo pipefail
+
+MODE=""
+BEFORE_COUNT=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --mode)         MODE="$2"; shift 2 ;;
+    --before-count) BEFORE_COUNT="$2"; shift 2 ;;
+    *) echo "ERROR=Unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+if [[ -z "$MODE" ]]; then
+  echo "ERROR=Missing required argument: --mode" >&2
+  exit 1
+fi
+
+case "$MODE" in
+  pre)
+    if [[ -f "$PWD/.claude/skills/bump-version/SKILL.md" ]]; then
+      echo "HAS_BUMP=true"
+    else
+      echo "HAS_BUMP=false"
+    fi
+    COMMITS=$(git rev-list main..HEAD --count 2>/dev/null || echo "0")
+    echo "COMMITS_BEFORE=$COMMITS"
+    ;;
+  post)
+    if [[ -z "$BEFORE_COUNT" ]]; then
+      echo "ERROR=--before-count required for --mode post" >&2
+      exit 1
+    fi
+    COMMITS_AFTER=$(git rev-list main..HEAD --count 2>/dev/null || echo "0")
+    EXPECTED=$((BEFORE_COUNT + 1))
+    if [[ "$COMMITS_AFTER" -eq "$EXPECTED" ]]; then
+      echo "VERIFIED=true"
+    else
+      echo "VERIFIED=false"
+    fi
+    echo "COMMITS_AFTER=$COMMITS_AFTER"
+    echo "EXPECTED=$EXPECTED"
+    ;;
+  *)
+    echo "ERROR=Invalid mode: $MODE (expected pre or post)" >&2
+    exit 1
+    ;;
+esac

--- a/.claude/scripts/generic/larch/check-reviewers.sh
+++ b/.claude/scripts/generic/larch/check-reviewers.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# check-reviewers.sh — Check external reviewer binary availability.
+#
+# Checks if codex and cursor binaries are installed.
+# This is NOT a full auth test — just binary existence.
+#
+# Usage:
+#   check-reviewers.sh
+#
+# Outputs (key=value to stdout):
+#   CODEX_AVAILABLE=true|false
+#   CURSOR_AVAILABLE=true|false
+#
+# Exit codes:
+#   0 — always
+
+set -uo pipefail
+
+CODEX_AVAILABLE="false"
+CURSOR_AVAILABLE="false"
+
+if command -v codex >/dev/null 2>&1; then
+    CODEX_AVAILABLE="true"
+fi
+
+if command -v cursor >/dev/null 2>&1; then
+    CURSOR_AVAILABLE="true"
+fi
+
+echo "CODEX_AVAILABLE=$CODEX_AVAILABLE"
+echo "CURSOR_AVAILABLE=$CURSOR_AVAILABLE"

--- a/.claude/scripts/generic/larch/ci-decide.sh
+++ b/.claude/scripts/generic/larch/ci-decide.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# ci-decide.sh — Decision matrix for CI merge loop.
+#
+# Pure decision logic with no side effects. Takes the current CI state
+# and loop counters, returns the action the caller should take.
+#
+# Merge is always allowed when CI passes and branch is up-to-date,
+# regardless of safety limits. Safety limits only block non-merge actions:
+#   - iteration >= 50: bail (timeout)
+#   - rebase_count >= 5: bail (too many rebases)
+#   - fix_attempts >= 3: bail (too many fixes)
+#
+# Decision matrix (when no safety limit triggers):
+#   CI_STATUS | BEHIND_COUNT > 0 | ACTION
+#   ----------|------------------|-------------------
+#   merged    | *                | already_merged
+#   pending   | yes              | rebase
+#   pending   | no               | wait
+#   pass      | yes              | rebase
+#   pass      | no               | merge
+#   fail      | yes              | rebase_then_evaluate
+#   fail      | no               | evaluate_failure
+#
+# Usage:
+#   ci-decide.sh --status STATUS --behind N --iteration N --rebase-count N --fix-attempts N
+#
+# Arguments:
+#   --status       — "pass", "fail", "pending", or "merged"
+#   --behind       — Number of commits behind origin/main (non-negative integer)
+#   --iteration    — Current poll loop iteration (non-negative integer)
+#   --rebase-count — Number of rebases performed so far (non-negative integer)
+#   --fix-attempts — Number of CI fix attempts so far (non-negative integer)
+#
+# Outputs (key=value to stdout):
+#   ACTION=wait|rebase|merge|already_merged|rebase_then_evaluate|evaluate_failure|bail
+#   BAIL_REASON=<text>    (only when ACTION=bail)
+#
+# Exit codes:
+#   0 — always (decision communicated via output)
+#   1 — invalid input
+
+set -euo pipefail
+
+usage() { echo "Usage: ci-decide.sh --status STATUS --behind N --iteration N --rebase-count N --fix-attempts N" >&2; }
+
+CI_STATUS=""
+BEHIND_COUNT=""
+ITERATION=""
+REBASE_COUNT=""
+FIX_ATTEMPTS=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --status) CI_STATUS="${2:?--status requires a value}"; shift 2 ;;
+        --behind) BEHIND_COUNT="${2:?--behind requires a value}"; shift 2 ;;
+        --iteration) ITERATION="${2:?--iteration requires a value}"; shift 2 ;;
+        --rebase-count) REBASE_COUNT="${2:?--rebase-count requires a value}"; shift 2 ;;
+        --fix-attempts) FIX_ATTEMPTS="${2:?--fix-attempts requires a value}"; shift 2 ;;
+        --help) usage; exit 0 ;;
+        *) echo "Unknown option: $1" >&2; usage; exit 1 ;;
+    esac
+done
+
+if [[ -z "$CI_STATUS" ]] || [[ -z "$BEHIND_COUNT" ]] || [[ -z "$ITERATION" ]] || [[ -z "$REBASE_COUNT" ]] || [[ -z "$FIX_ATTEMPTS" ]]; then
+    echo "ERROR: all arguments are required" >&2
+    usage; exit 1
+fi
+
+# --- Input validation ---
+if [[ "$CI_STATUS" != "pass" ]] && [[ "$CI_STATUS" != "fail" ]] && [[ "$CI_STATUS" != "pending" ]] && [[ "$CI_STATUS" != "merged" ]] && [[ "$CI_STATUS" != "error" ]]; then
+    echo "ERROR: --status must be pass|fail|pending|merged|error, got: $CI_STATUS" >&2
+    exit 1
+fi
+
+# ci-status.sh emits "error" when it fails to parse its own arguments
+if [[ "$CI_STATUS" == "error" ]]; then
+    echo "ACTION=bail"
+    echo "BAIL_REASON=ci-status.sh returned error — check script arguments"
+    exit 0
+fi
+
+for var_name in BEHIND_COUNT ITERATION REBASE_COUNT FIX_ATTEMPTS; do
+    val="${!var_name}"
+    if ! [[ "$val" =~ ^[0-9]+$ ]]; then
+        echo "ERROR: $var_name must be a non-negative integer, got: $val" >&2
+        exit 1
+    fi
+done
+
+# --- Decision matrix ---
+# PR already merged (force-merged by user) — stop waiting immediately
+if [[ "$CI_STATUS" == "merged" ]]; then
+    echo "ACTION=already_merged"
+    exit 0
+fi
+
+# Evaluate CI state first — if CI passes and branch is up-to-date, always merge
+# (even if safety limits have been reached). Safety limits only block non-merge actions.
+BEHIND=$( [[ "$BEHIND_COUNT" -gt 0 ]] && echo "true" || echo "false" )
+
+# Allow merge regardless of safety limits
+if [[ "$CI_STATUS" == "pass" ]] && [[ "$BEHIND" == "false" ]]; then
+    echo "ACTION=merge"
+    exit 0
+fi
+
+# --- Safety limits (checked before non-merge actions) ---
+if [[ "$ITERATION" -ge 50 ]]; then
+    echo "ACTION=bail"
+    echo "BAIL_REASON=Timeout: 50 iterations (~25 minutes) without successful merge"
+    exit 0
+fi
+
+if [[ "$REBASE_COUNT" -ge 5 ]]; then
+    echo "ACTION=bail"
+    echo "BAIL_REASON=Too many rebases (5) without converging — main branch too active"
+    exit 0
+fi
+
+if [[ "$FIX_ATTEMPTS" -ge 3 ]]; then
+    echo "ACTION=bail"
+    echo "BAIL_REASON=Too many fix attempts (3) without CI passing"
+    exit 0
+fi
+
+# --- Remaining decision matrix ---
+case "$CI_STATUS" in
+    pending)
+        if [[ "$BEHIND" == "true" ]]; then
+            echo "ACTION=rebase"
+        else
+            echo "ACTION=wait"
+        fi
+        ;;
+    pass)
+        # pass + behind=true (pass + behind=false handled above)
+        echo "ACTION=rebase"
+        ;;
+    fail)
+        if [[ "$BEHIND" == "true" ]]; then
+            echo "ACTION=rebase_then_evaluate"
+        else
+            echo "ACTION=evaluate_failure"
+        fi
+        ;;
+esac

--- a/.claude/scripts/generic/larch/ci-rerun-failed.sh
+++ b/.claude/scripts/generic/larch/ci-rerun-failed.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# ci-rerun-failed.sh — Rerun failed jobs in a GitHub Actions workflow run.
+#
+# Wraps `gh run rerun --failed` with structured output. The caller is
+# responsible for any sleep/delay before invoking this script (separation
+# of concerns: timing policy belongs to the orchestrator).
+#
+# Usage:
+#   ci-rerun-failed.sh --run-id ID --repo OWNER/REPO
+#
+# Arguments:
+#   --run-id — The GitHub Actions workflow run ID to rerun
+#   --repo   — Owner/repo identifier (e.g., "myorg/myrepo")
+#
+# Outputs (key=value to stdout, always emitted via EXIT trap):
+#   RERUN_SUBMITTED=true|false
+#   ERROR=<message>    (empty string on success)
+#
+# Exit codes:
+#   0 — always (result communicated via output keys)
+#   1 — usage/argument error (no output emitted)
+
+set -uo pipefail
+
+usage() { echo "Usage: ci-rerun-failed.sh --run-id ID --repo OWNER/REPO" >&2; }
+
+# --- Parse arguments (before installing EXIT trap) ---
+RUN_ID=""
+REPO=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --run-id) RUN_ID="${2:?--run-id requires a value}"; shift 2 ;;
+        --repo) REPO="${2:?--repo requires a value}"; shift 2 ;;
+        --help) usage; exit 0 ;;
+        *) echo "Unknown option: $1" >&2; usage; exit 1 ;;
+    esac
+done
+
+if [[ -z "$RUN_ID" ]] || [[ -z "$REPO" ]]; then
+    echo "ERROR: --run-id and --repo are required" >&2
+    usage; exit 1
+fi
+
+# --- Output defaults ---
+RERUN_SUBMITTED="false"
+ERROR="ci-rerun-failed.sh exited unexpectedly"
+
+# shellcheck disable=SC2329,SC2317  # invoked via EXIT trap
+emit_output() {
+    echo "RERUN_SUBMITTED=$RERUN_SUBMITTED"
+    echo "ERROR=$ERROR"
+}
+trap 'emit_output' EXIT
+
+# --- Attempt rerun ---
+RERUN_OUTPUT=$(gh run rerun "$RUN_ID" --failed --repo "$REPO" 2>&1)
+RERUN_EXIT=$?
+
+if [[ $RERUN_EXIT -eq 0 ]]; then
+    RERUN_SUBMITTED="true"
+    ERROR=""
+else
+    RERUN_SUBMITTED="false"
+    ERROR="gh run rerun failed (exit $RERUN_EXIT): $RERUN_OUTPUT"
+fi
+
+exit 0

--- a/.claude/scripts/generic/larch/ci-status.sh
+++ b/.claude/scripts/generic/larch/ci-status.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# ci-status.sh — Check CI status and main branch advancement for a PR.
+#
+# Fetches origin/main, checks PR CI status via `gh pr checks --json`,
+# and counts commits behind origin/main.
+#
+# Usage:
+#   ci-status.sh --pr NUMBER --repo OWNER/REPO
+#
+# Outputs (always all three lines, in order):
+#   CI_STATUS=pass|fail|pending|merged
+#   BEHIND_COUNT=<N>
+#   FAILED_RUN_ID=<id>    (empty string if no failure)
+#
+# Exit codes:
+#   0 — always (status is communicated via output lines)
+
+set -uo pipefail
+# Note: not using set -e — we need to guarantee output on all paths
+
+# Defaults — these will always be emitted even on unexpected errors
+CI_STATUS="pending"
+BEHIND_COUNT="0"
+FAILED_RUN_ID=""
+
+# Ensure output is always emitted, even on unexpected errors
+trap 'echo "CI_STATUS=$CI_STATUS"; echo "BEHIND_COUNT=$BEHIND_COUNT"; echo "FAILED_RUN_ID=$FAILED_RUN_ID"' EXIT
+
+usage() { echo "Usage: ci-status.sh --pr NUMBER --repo OWNER/REPO" >&2; }
+
+PR_NUMBER=""
+REPO=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --pr) PR_NUMBER="${2:?--pr requires a value}"; shift 2 ;;
+        --repo) REPO="${2:?--repo requires a value}"; shift 2 ;;
+        --help) usage; exit 0 ;;
+        *) echo "Unknown option: $1" >&2; usage; CI_STATUS="error"; exit 0 ;;
+    esac
+done
+
+if [[ -z "$PR_NUMBER" ]] || [[ -z "$REPO" ]]; then
+    echo "ERROR: --pr and --repo are required" >&2
+    usage; CI_STATUS="error"; exit 0
+fi
+
+# --- Check if PR has been force-merged ---
+PR_STATE=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json state -q '.state' 2>/dev/null || echo "")
+if [[ "$PR_STATE" == "MERGED" ]]; then
+    CI_STATUS="merged"
+    exit 0
+fi
+
+# --- Fetch origin/main for staleness check ---
+if ! git fetch origin main --quiet 2>/dev/null; then
+    # Fetch failed — cannot reliably compute BEHIND_COUNT.
+    # Force pending status so the caller retries instead of trusting stale refs.
+    echo "⚠ git fetch origin main failed — reporting pending to force retry" >&2
+    CI_STATUS="pending"
+    BEHIND_COUNT="0"
+    exit 0
+fi
+
+# --- Check CI status ---
+# Try JSON output first (gh CLI v2.x)
+# Use 'bucket' field which is reliably available (pass/fail/pending)
+CHECKS_JSON=$(gh pr checks "$PR_NUMBER" --repo "$REPO" --json name,state,bucket,link 2>/dev/null || echo "")
+
+if [[ -n "$CHECKS_JSON" ]] && [[ "$CHECKS_JSON" != "null" ]] \
+    && echo "$CHECKS_JSON" | jq -e 'type == "array"' >/dev/null 2>&1; then
+    # Parse JSON output
+    TOTAL=$(echo "$CHECKS_JSON" | jq 'length' 2>/dev/null || echo "0")
+
+    if [[ "$TOTAL" -eq 0 ]]; then
+        CI_STATUS="pending"
+    else
+        FAILED=$(echo "$CHECKS_JSON" | jq '[.[] | select(.bucket == "fail")] | length' 2>/dev/null || echo "0")
+        PENDING=$(echo "$CHECKS_JSON" | jq '[.[] | select(.bucket == "pending")] | length' 2>/dev/null || echo "0")
+
+        if [[ "$FAILED" -gt 0 ]]; then
+            CI_STATUS="fail"
+            # Extract the run ID from the first failed check's link URL
+            # Link format: https://github.com/<owner>/<repo>/actions/runs/<run-id>/job/<job-id>
+            FAILED_LINK=$(echo "$CHECKS_JSON" | jq -r '[.[] | select(.bucket == "fail")][0].link // empty' 2>/dev/null || echo "")
+            if [[ -n "$FAILED_LINK" ]]; then
+                FAILED_RUN_ID=$(echo "$FAILED_LINK" | grep -oE 'runs/[0-9]+' | head -1 | sed 's/runs\///' || echo "")
+            fi
+        elif [[ "$PENDING" -gt 0 ]]; then
+            CI_STATUS="pending"
+        else
+            CI_STATUS="pass"
+        fi
+    fi
+else
+    # Fallback: parse text output
+    CHECKS_TEXT=$(gh pr checks "$PR_NUMBER" --repo "$REPO" 2>/dev/null || echo "")
+
+    if [[ -z "$CHECKS_TEXT" ]]; then
+        CI_STATUS="pending"
+    elif echo "$CHECKS_TEXT" | grep -qiE '\bfail'; then
+        CI_STATUS="fail"
+        # Try to extract run ID from the URL column
+        FAILED_LINK=$(echo "$CHECKS_TEXT" | grep -iE '\bfail' | head -1 | grep -oE 'https://[^ ]+' | head -1 || echo "")
+        if [[ -n "$FAILED_LINK" ]]; then
+            FAILED_RUN_ID=$(echo "$FAILED_LINK" | grep -oE 'runs/[0-9]+' | head -1 | sed 's/runs\///' || echo "")
+        fi
+    elif echo "$CHECKS_TEXT" | grep -qiE 'pending|in_progress|queued'; then
+        CI_STATUS="pending"
+    else
+        CI_STATUS="pass"
+    fi
+fi
+
+# --- Check behind count ---
+BEHIND_COUNT=$(git rev-list HEAD..origin/main --count 2>/dev/null || echo "0")
+
+# --- Git-based merge detection (catches race where git refs update before GitHub API) ---
+# If main advanced, check if this PR's squash-merge commit landed.
+# Uses fixed-string match for "(#N)" — GitHub's squash-merge subject format.
+# Note: only works for squash merges (this project uses --squash exclusively).
+# False positive would trigger premature cleanup; remote branch preserved for recovery.
+if [[ "$BEHIND_COUNT" -gt 0 ]]; then
+    if git log HEAD..origin/main --oneline 2>/dev/null | grep -Fq "(#${PR_NUMBER})"; then
+        CI_STATUS="merged"
+        BEHIND_COUNT="0"
+        FAILED_RUN_ID=""
+    fi
+fi

--- a/.claude/scripts/generic/larch/ci-wait.sh
+++ b/.claude/scripts/generic/larch/ci-wait.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# ci-wait.sh — Poll CI status until the action changes from "wait".
+#
+# Consolidates the CI polling loop into a single blocking call, replacing
+# many individual sleep + ci-status.sh + ci-decide.sh tool calls.
+# Prints compact dot-based progress to stderr (like wait-for-reviewers.sh).
+# Outputs machine-parseable results to stdout when the action is NOT "wait".
+#
+# Usage:
+#   ci-wait.sh --pr NUMBER --repo OWNER/REPO [--rebase-count N] [--fix-attempts N] [--iteration N] [--timeout SECONDS]
+#
+# Options:
+#   --pr             PR number (required)
+#   --repo           Owner/repo identifier (required)
+#   --rebase-count   Current rebase count, passed through to ci-decide.sh (default: 0)
+#   --fix-attempts   Current fix attempt count, passed through to ci-decide.sh (default: 0)
+#   --iteration      Starting iteration count (default: 0). Incremented internally each poll cycle.
+#   --timeout        Wall-clock timeout in seconds (default: 1800 = 30 minutes)
+#
+# Outputs (stdout, key=value — always all lines, in order):
+#   ACTION=merge|rebase|already_merged|rebase_then_evaluate|evaluate_failure|bail
+#   CI_STATUS=pass|fail|pending|merged
+#   BEHIND_COUNT=<N>
+#   FAILED_RUN_ID=<id>          (empty string if no failure)
+#   BAIL_REASON=<text>          (empty string if ACTION != bail)
+#   ITERATION=<N>               (final iteration count)
+#   ELAPSED=<N>                 (seconds elapsed)
+#
+# Progress (stderr):
+#   Dots every 10s, status line every ~1 minute (every 6th check)
+#
+# Exit codes:
+#   0 — valid decision reached (read ACTION from stdout)
+#   1 — usage/argument error
+
+# No -e: we must guarantee output on all paths. Subshell failures handled explicitly.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+usage() { echo "Usage: ci-wait.sh --pr NUMBER --repo OWNER/REPO [--rebase-count N] [--fix-attempts N] [--iteration N] [--timeout SECONDS]" >&2; }
+
+# --- Defaults ---
+PR_NUMBER=""
+REPO=""
+REBASE_COUNT=0
+FIX_ATTEMPTS=0
+ITERATION=0
+TIMEOUT=1800
+
+# --- Parse arguments (before installing EXIT trap to avoid emitting output on usage errors) ---
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --pr) PR_NUMBER="${2:?--pr requires a value}"; shift 2 ;;
+        --repo) REPO="${2:?--repo requires a value}"; shift 2 ;;
+        --rebase-count) REBASE_COUNT="${2:?--rebase-count requires a value}"; shift 2 ;;
+        --fix-attempts) FIX_ATTEMPTS="${2:?--fix-attempts requires a value}"; shift 2 ;;
+        --iteration) ITERATION="${2:?--iteration requires a value}"; shift 2 ;;
+        --timeout) TIMEOUT="${2:?--timeout requires a value}"; shift 2 ;;
+        --help) usage; exit 0 ;;
+        *) echo "Unknown option: $1" >&2; usage; exit 1 ;;
+    esac
+done
+
+if [[ -z "$PR_NUMBER" ]] || [[ -z "$REPO" ]]; then
+    echo "ERROR: --pr and --repo are required" >&2
+    usage; exit 1
+fi
+
+# Validate numeric arguments
+for var_name in REBASE_COUNT FIX_ATTEMPTS ITERATION TIMEOUT; do
+    val="${!var_name}"
+    if ! [[ "$val" =~ ^[0-9]+$ ]]; then
+        echo "ERROR: --$(echo "$var_name" | tr '_' '-' | tr '[:upper:]' '[:lower:]') must be a non-negative integer, got: $val" >&2
+        exit 1
+    fi
+done
+
+# --- Output defaults (emitted via trap on any exit after validation passes) ---
+ACTION="bail"
+CI_STATUS="pending"
+BEHIND_COUNT="0"
+FAILED_RUN_ID=""
+BAIL_REASON="ci-wait.sh exited unexpectedly"
+
+emit_output() {
+    echo "ACTION=$ACTION"
+    echo "CI_STATUS=$CI_STATUS"
+    echo "BEHIND_COUNT=$BEHIND_COUNT"
+    echo "FAILED_RUN_ID=$FAILED_RUN_ID"
+    echo "BAIL_REASON=$BAIL_REASON"
+    echo "ITERATION=$ITERATION"
+    # ELAPSED is per-invocation only (resets each time ci-wait.sh is called)
+    echo "ELAPSED=$SECONDS"
+}
+trap 'emit_output' EXIT
+
+# --- Polling loop ---
+SECONDS=0
+checks=0
+ci_failures=0
+
+printf "⏳ CI: waiting" >&2
+
+while true; do
+    # Wall-clock timeout
+    if [[ "$SECONDS" -ge "$TIMEOUT" ]]; then
+        ACTION="bail"
+        BAIL_REASON="Wall-clock timeout (${TIMEOUT}s) exceeded"
+        printf "\n⚠ CI wait timed out after %ds\n" "$TIMEOUT" >&2
+        exit 0
+    fi
+
+    # 1. Check CI status
+    CI_OUTPUT=$("$SCRIPT_DIR/ci-status.sh" --pr "$PR_NUMBER" --repo "$REPO" ) || true
+    CI_STATUS=$(echo "$CI_OUTPUT" | grep '^CI_STATUS=' | head -1 | cut -d= -f2-)
+    BEHIND_COUNT=$(echo "$CI_OUTPUT" | grep '^BEHIND_COUNT=' | head -1 | cut -d= -f2-)
+    FAILED_RUN_ID=$(echo "$CI_OUTPUT" | grep '^FAILED_RUN_ID=' | head -1 | cut -d= -f2-)
+
+    # If ci-status.sh produced no valid output, bail rather than silently defaulting to pending
+    if [[ -z "$CI_STATUS" ]]; then
+        ci_failures=$((ci_failures + 1))
+        if [[ "$ci_failures" -ge 3 ]]; then
+            ACTION="bail"
+            BAIL_REASON="ci-status.sh returned no valid output 3 times consecutively"
+            printf "\n❌ ci-status.sh failed repeatedly\n" >&2
+            exit 0
+        fi
+        CI_STATUS="pending"
+        BEHIND_COUNT="${BEHIND_COUNT:-0}"
+        FAILED_RUN_ID="${FAILED_RUN_ID:-}"
+    else
+        ci_failures=0
+        BEHIND_COUNT="${BEHIND_COUNT:-0}"
+        FAILED_RUN_ID="${FAILED_RUN_ID:-}"
+    fi
+
+    # 2. Get decision
+    DECIDE_OUTPUT=$("$SCRIPT_DIR/ci-decide.sh" \
+        --status "$CI_STATUS" \
+        --behind "$BEHIND_COUNT" \
+        --iteration "$ITERATION" \
+        --rebase-count "$REBASE_COUNT" \
+        --fix-attempts "$FIX_ATTEMPTS" 2>&2)
+    DECIDE_EXIT=$?
+
+    if [[ "$DECIDE_EXIT" -ne 0 ]]; then
+        ACTION="bail"
+        BAIL_REASON="ci-decide.sh exited with error (code $DECIDE_EXIT)"
+        printf "\n❌ ci-decide.sh failed (exit %d)\n" "$DECIDE_EXIT" >&2
+        exit 0
+    fi
+
+    ACTION=$(echo "$DECIDE_OUTPUT" | grep '^ACTION=' | head -1 | cut -d= -f2-)
+    BAIL_REASON=$(echo "$DECIDE_OUTPUT" | grep '^BAIL_REASON=' | head -1 | cut -d= -f2-)
+    ACTION="${ACTION:-bail}"
+    BAIL_REASON="${BAIL_REASON:-}"
+
+    # 3. If not wait, stop and return
+    if [[ "$ACTION" != "wait" ]]; then
+        printf "\n" >&2
+        if [[ "$ACTION" == "merge" ]]; then
+            printf "✓ CI passed (%ds, %d checks)\n" "$SECONDS" "$checks" >&2
+        elif [[ "$ACTION" == "already_merged" ]]; then
+            printf "✓ PR already merged (%ds)\n" "$SECONDS" >&2
+        elif [[ "$ACTION" == "bail" ]]; then
+            printf "⚠ Bailing: %s (%ds, %d checks)\n" "$BAIL_REASON" "$SECONDS" "$checks" >&2
+        else
+            printf "→ Action: %s (%ds, %d checks)\n" "$ACTION" "$SECONDS" "$checks" >&2
+        fi
+        exit 0
+    fi
+
+    # 4. ACTION=wait — print dot, sleep, continue
+    # Note: ITERATION is NOT incremented on internal wait polls. It counts outer-loop
+    # cycles (caller re-invocations after rebase/fix), not internal 10s polls.
+    # The 1800s wall-clock timeout is the safety net for long waits.
+    # ci-decide.sh's iteration limit (50) guards against infinite rebase/fix loops.
+    checks=$((checks + 1))
+
+    printf "." >&2
+    # Print status line every 6 checks (~1 minute)
+    if [[ $((checks % 6)) -eq 0 ]]; then
+        printf "\n⏳ CI: %dm elapsed, %d checks, status=%s\n" \
+            "$((SECONDS / 60))" "$checks" "$CI_STATUS" >&2
+    fi
+
+    sleep 10
+done

--- a/.claude/scripts/generic/larch/cleanup-tmpdir.sh
+++ b/.claude/scripts/generic/larch/cleanup-tmpdir.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# cleanup-tmpdir.sh — Safely remove a session temp directory.
+#
+# Validates that the path is non-empty and under /tmp/ (or /private/tmp/
+# on macOS) before running rm -rf. This prevents accidental deletion of
+# non-temp directories if the caller passes an empty or wrong path.
+#
+# Usage:
+#   cleanup-tmpdir.sh --dir <path>
+#
+# Arguments:
+#   --dir — Path to the temp directory to remove
+#
+# Exit codes:
+#   0 — directory removed (or already absent)
+#   1 — validation failed (path empty, not under /tmp/, or argument error)
+
+set -euo pipefail
+
+usage() { echo "Usage: cleanup-tmpdir.sh --dir <path>" >&2; }
+
+DIR=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dir) DIR="${2:?--dir requires a value}"; shift 2 ;;
+        --help) usage; exit 0 ;;
+        *) echo "Unknown option: $1" >&2; usage; exit 1 ;;
+    esac
+done
+
+if [[ -z "$DIR" ]]; then
+    echo "ERROR: --dir is required and must be non-empty" >&2
+    exit 1
+fi
+
+# Validate path is under /tmp/ or /private/tmp/ (macOS canonical path)
+if [[ "$DIR" != /tmp/* && "$DIR" != /private/tmp/* ]]; then
+    echo "ERROR: --dir must be under /tmp/ (got: $DIR)" >&2
+    exit 1
+fi
+
+rm -rf "$DIR"

--- a/.claude/scripts/generic/larch/create-branch.sh
+++ b/.claude/scripts/generic/larch/create-branch.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# create-branch.sh — Branch creation for /design skill.
+#
+# Two modes:
+#   --check          Output current branch state (no side effects)
+#   --branch NAME    Create a new branch from latest origin/main
+#
+# Usage:
+#   create-branch.sh --check
+#   create-branch.sh --branch <branch-name>
+#
+# Outputs (key=value to stdout):
+#   --check mode:
+#     CURRENT_BRANCH=<name>     (empty if detached HEAD)
+#     IS_MAIN=true|false
+#     IS_USER_BRANCH=true|false
+#     USER_PREFIX=<value>       (derived from git config user.name)
+#
+#   --branch mode:
+#     BRANCH_NAME=<name>
+#     ACTION=created
+#
+# Exit codes:
+#   0 — success
+#   1 — branch already exists (--branch mode only)
+#   2 — git operation failed
+
+set -euo pipefail
+
+usage() { echo "Usage: create-branch.sh --check | create-branch.sh --branch NAME" >&2; }
+
+# Derive user prefix from git config user.name:
+# lowercase, spaces→hyphens, strip non-alphanumeric-hyphens, truncate to 20 chars, fallback "dev"
+derive_user_prefix() {
+    local raw
+    raw=$(git config user.name 2>/dev/null || echo "")
+    if [[ -z "$raw" ]]; then
+        echo "dev"
+        return
+    fi
+    local sanitized
+    sanitized=$(printf '%s\n' "$raw" | tr '[:upper:]' '[:lower:]' | tr ' ' '-' | sed 's/[^a-z0-9-]//g' | head -c 20 | sed 's/-*$//')
+    if [[ -z "$sanitized" ]]; then
+        echo "dev"
+        return
+    fi
+    echo "$sanitized"
+}
+
+MODE=""
+BRANCH_NAME=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --check) MODE="check"; shift ;;
+        --branch) MODE="create"; BRANCH_NAME="${2:?--branch requires a value}"; shift 2 ;;
+        --help) usage; exit 0 ;;
+        *) echo "Unknown option: $1" >&2; usage; exit 2 ;;
+    esac
+done
+
+if [[ -z "$MODE" ]]; then
+    echo "ERROR: --check or --branch is required" >&2
+    usage; exit 2
+fi
+
+USER_PREFIX=$(derive_user_prefix)
+
+if [[ "$MODE" == "check" ]]; then
+    # --- Check mode: report current branch state ---
+    CURRENT_BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
+
+    IS_MAIN="false"
+    IS_USER_BRANCH="false"
+
+    if [[ -z "$CURRENT_BRANCH" ]] || [[ "$CURRENT_BRANCH" == "main" ]]; then
+        IS_MAIN="true"
+    elif [[ "$CURRENT_BRANCH" == "${USER_PREFIX}"/* ]]; then
+        IS_USER_BRANCH="true"
+    fi
+
+    echo "CURRENT_BRANCH=$CURRENT_BRANCH"
+    echo "IS_MAIN=$IS_MAIN"
+    echo "IS_USER_BRANCH=$IS_USER_BRANCH"
+    echo "USER_PREFIX=$USER_PREFIX"
+    exit 0
+fi
+
+# --- Create mode: create branch from latest main ---
+
+# Validate branch name format
+if [[ ! "$BRANCH_NAME" == "${USER_PREFIX}"/* ]]; then
+    echo "ERROR: Branch name must start with '${USER_PREFIX}/': $BRANCH_NAME" >&2
+    exit 2
+fi
+
+# Check if branch already exists
+if git show-ref --verify --quiet "refs/heads/$BRANCH_NAME" 2>/dev/null; then
+    echo "ERROR: Branch already exists: $BRANCH_NAME" >&2
+    exit 1
+fi
+
+# Fetch latest main and create branch directly from origin/main
+# (avoids unnecessary checkout main + pull round-trip)
+if ! git fetch origin main --quiet >/dev/null 2>&1; then
+    echo "ERROR: Failed to fetch origin/main" >&2
+    exit 2
+fi
+
+if ! git checkout -b "$BRANCH_NAME" origin/main >/dev/null 2>&1; then
+    echo "ERROR: Failed to create branch: $BRANCH_NAME" >&2
+    exit 2
+fi
+
+echo "BRANCH_NAME=$BRANCH_NAME"
+echo "ACTION=created"

--- a/.claude/scripts/generic/larch/create-pr.sh
+++ b/.claude/scripts/generic/larch/create-pr.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# create-pr.sh — Push branch and create a GitHub PR.
+#
+# Checks for an existing open PR on the current branch first.
+# If none exists, pushes the branch and creates a new PR.
+#
+# Usage:
+#   create-pr.sh --title TEXT --body-file FILE
+#
+# Arguments:
+#   --title     — PR title (under 70 chars recommended)
+#   --body-file — Path to a file containing the PR body (markdown)
+#
+# Outputs (key=value to stdout):
+#   PR_NUMBER=<N>
+#   PR_URL=<url>
+#   PR_TITLE=<title>
+#   PR_STATUS=created|existing
+#
+# Exit codes:
+#   0 — success (PR created or already exists)
+#   1 — push failed
+#   2 — PR creation failed
+
+set -euo pipefail
+
+usage() { echo "Usage: create-pr.sh --title TEXT --body-file FILE" >&2; }
+
+TITLE=""
+BODY_FILE=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --title) TITLE="${2:?--title requires a value}"; shift 2 ;;
+        --body-file) BODY_FILE="${2:?--body-file requires a value}"; shift 2 ;;
+        --help) usage; exit 0 ;;
+        *) echo "Unknown option: $1" >&2; usage; exit 2 ;;
+    esac
+done
+
+if [[ -z "$TITLE" ]] || [[ -z "$BODY_FILE" ]]; then
+    echo "ERROR: --title and --body-file are required" >&2
+    usage; exit 2
+fi
+
+if [[ ! -f "$BODY_FILE" ]]; then
+    echo "ERROR: Body file not found: $BODY_FILE" >&2
+    exit 2
+fi
+
+# --- Get current branch ---
+BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
+if [[ -z "$BRANCH" ]]; then
+    echo "ERROR: Not on a branch (detached HEAD)" >&2
+    exit 2
+fi
+
+# --- Check for existing open PR ---
+EXISTING_PR=$(gh pr view --json number,url,state,title 2>/dev/null || echo "")
+if [[ -n "$EXISTING_PR" ]]; then
+    PR_STATE=$(echo "$EXISTING_PR" | jq -r '.state // empty' 2>/dev/null || echo "")
+    if [[ "$PR_STATE" == "OPEN" ]]; then
+        PR_NUMBER=$(echo "$EXISTING_PR" | jq -r '.number // empty' 2>/dev/null || echo "")
+        PR_URL=$(echo "$EXISTING_PR" | jq -r '.url // empty' 2>/dev/null || echo "")
+        if [[ -n "$PR_NUMBER" ]] && [[ -n "$PR_URL" ]]; then
+            # Push any new local commits before returning
+            git push -u origin HEAD >/dev/null 2>&1 || true
+            # Fetch the existing PR title
+            PR_TITLE=$(echo "$EXISTING_PR" | jq -r '.title // empty' 2>/dev/null || echo "")
+            if [[ -z "$PR_TITLE" ]]; then
+                PR_TITLE=$(gh pr view "$PR_NUMBER" --json title -q '.title' 2>/dev/null || echo "")
+            fi
+            echo "PR_NUMBER=$PR_NUMBER"
+            echo "PR_URL=$PR_URL"
+            echo "PR_TITLE=$PR_TITLE"
+            echo "PR_STATUS=existing"
+            exit 0
+        fi
+    fi
+fi
+
+# --- Push branch ---
+PUSH_STDERR=$(mktemp)
+PR_STDERR_FILE=""
+trap 'rm -f "$PUSH_STDERR" "$PR_STDERR_FILE"' EXIT
+if ! git push -u origin HEAD >"$PUSH_STDERR" 2>&1; then
+    echo "ERROR: Failed to push branch: $(cat "$PUSH_STDERR")" >&2
+    exit 1
+fi
+
+# --- Create PR ---
+PR_STDERR_FILE=$(mktemp)
+PR_OUTPUT=$(gh pr create \
+    --assignee @me \
+    --head "$BRANCH" \
+    --base main \
+    --title "$TITLE" \
+    --body-file "$BODY_FILE" 2>"$PR_STDERR_FILE")
+PR_EXIT=$?
+
+if [[ $PR_EXIT -ne 0 ]]; then
+    PR_STDERR=$(cat "$PR_STDERR_FILE" 2>/dev/null)
+    echo "ERROR: Failed to create PR: $PR_STDERR $PR_OUTPUT" >&2
+    exit 2
+fi
+
+# --- Extract PR number and URL ---
+# gh pr create outputs the PR URL on success
+PR_URL="$PR_OUTPUT"
+
+# Parse PR number from URL first (avoids extra API call)
+# URL format: https://github.com/owner/repo/pull/N
+PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$' || echo "")
+
+if [[ -z "$PR_NUMBER" ]]; then
+    # Fallback: fetch via gh pr view if URL parsing failed
+    PR_NUMBER=$(gh pr view --json number -q '.number' 2>/dev/null || echo "")
+fi
+
+if [[ -z "$PR_NUMBER" ]] || [[ -z "$PR_URL" ]]; then
+    echo "ERROR: Could not extract PR number/URL from output: $PR_OUTPUT" >&2
+    exit 2
+fi
+
+echo "PR_NUMBER=$PR_NUMBER"
+echo "PR_URL=$PR_URL"
+echo "PR_TITLE=$TITLE"
+echo "PR_STATUS=created"

--- a/.claude/scripts/generic/larch/create-session-tmpdir.sh
+++ b/.claude/scripts/generic/larch/create-session-tmpdir.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# create-session-tmpdir.sh — Create a session-scoped temporary directory.
+#
+# Lightweight alternative to session-setup.sh for skills that only need
+# a temp directory without preflight checks, Slack token checks, or repo
+# name derivation. If your skill also needs those, use session-setup.sh.
+#
+# Usage:
+#   create-session-tmpdir.sh --prefix <name>
+#
+# Arguments:
+#   --prefix — Prefix for the temp directory (e.g., "claude-review")
+#
+# Outputs (key=value to stdout):
+#   SESSION_TMPDIR=<path>
+#
+# Exit codes:
+#   0 — success
+#   1 — usage/argument error
+
+set -euo pipefail
+
+usage() { echo "Usage: create-session-tmpdir.sh --prefix <name>" >&2; }
+
+PREFIX=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --prefix) PREFIX="${2:?--prefix requires a value}"; shift 2 ;;
+        --help) usage; exit 0 ;;
+        *) echo "Unknown option: $1" >&2; usage; exit 1 ;;
+    esac
+done
+
+if [[ -z "$PREFIX" ]]; then
+    echo "ERROR: --prefix is required" >&2
+    usage; exit 1
+fi
+
+TMPDIR=$(mktemp -d "/tmp/${PREFIX}-XXXXXX")
+echo "SESSION_TMPDIR=$TMPDIR"

--- a/.claude/scripts/generic/larch/gather-branch-context.sh
+++ b/.claude/scripts/generic/larch/gather-branch-context.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# gather-branch-context.sh — Gather git diff, file list, and commit log for
+# the current branch vs main.
+#
+# Writes each output to a separate file in the specified output directory,
+# then emits the file paths as key=value output to stdout.
+#
+# Usage:
+#   gather-branch-context.sh --output-dir <path>
+#
+# Arguments:
+#   --output-dir — Directory to write output files into (must exist)
+#
+# Creates:
+#   <output-dir>/diff.txt      — Full diff (git diff main...HEAD)
+#   <output-dir>/file-list.txt — Changed file names (git diff main...HEAD --name-only)
+#   <output-dir>/commit-log.txt — Commit log (git log main...HEAD --oneline)
+#
+# Outputs (key=value to stdout):
+#   DIFF_FILE=<path>
+#   FILE_LIST_FILE=<path>
+#   COMMIT_LOG_FILE=<path>
+#
+# Exit codes:
+#   0 — success
+#   1 — usage/argument error or git command failure
+
+set -euo pipefail
+
+usage() { echo "Usage: gather-branch-context.sh --output-dir <path>" >&2; }
+
+# --- Parse arguments ---
+OUTPUT_DIR=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --output-dir) OUTPUT_DIR="${2:?--output-dir requires a value}"; shift 2 ;;
+        --help) usage; exit 0 ;;
+        *) echo "Unknown option: $1" >&2; usage; exit 1 ;;
+    esac
+done
+
+if [[ -z "$OUTPUT_DIR" ]]; then
+    echo "ERROR: --output-dir is required" >&2
+    usage; exit 1
+fi
+
+if [[ ! -d "$OUTPUT_DIR" ]]; then
+    echo "ERROR: output directory does not exist: $OUTPUT_DIR" >&2
+    exit 1
+fi
+
+# --- Gather context ---
+DIFF_FILE="$OUTPUT_DIR/diff.txt"
+FILE_LIST_FILE="$OUTPUT_DIR/file-list.txt"
+COMMIT_LOG_FILE="$OUTPUT_DIR/commit-log.txt"
+
+git diff main...HEAD > "$DIFF_FILE"
+git diff main...HEAD --name-only > "$FILE_LIST_FILE"
+git log main...HEAD --oneline > "$COMMIT_LOG_FILE"
+
+# --- Emit output ---
+echo "DIFF_FILE=$DIFF_FILE"
+echo "FILE_LIST_FILE=$FILE_LIST_FILE"
+echo "COMMIT_LOG_FILE=$COMMIT_LOG_FILE"

--- a/.claude/scripts/generic/larch/gh-pr-body-read.sh
+++ b/.claude/scripts/generic/larch/gh-pr-body-read.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# gh-pr-body-read.sh — Read a PR's body text to a file.
+#
+# Wraps `gh pr view --json body` and writes the body content to a
+# specified output file. Uses file output (not stdout) to avoid
+# breaking the repo's KEY=value parsing convention — PR bodies can
+# contain arbitrary text including KEY=value-like strings.
+#
+# Usage:
+#   gh-pr-body-read.sh --pr <number> --output <path>
+#
+# Arguments:
+#   --pr     — PR number
+#   --output — Path to write the body text to
+#
+# Outputs (key=value to stdout):
+#   BODY_FILE=<path>
+#
+# Exit codes:
+#   0 — success
+#   1 — usage/argument error or gh command failure
+
+set -euo pipefail
+
+usage() { echo "Usage: gh-pr-body-read.sh --pr <number> --output <path>" >&2; }
+
+PR=""
+OUTPUT_FILE=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --pr) PR="${2:?--pr requires a value}"; shift 2 ;;
+        --output) OUTPUT_FILE="${2:?--output requires a value}"; shift 2 ;;
+        --help) usage; exit 0 ;;
+        *) echo "Unknown option: $1" >&2; usage; exit 1 ;;
+    esac
+done
+
+if [[ -z "$PR" ]] || [[ -z "$OUTPUT_FILE" ]]; then
+    echo "ERROR: --pr and --output are required" >&2
+    usage; exit 1
+fi
+
+gh pr view "$PR" --json body -q '.body' > "$OUTPUT_FILE"
+echo "BODY_FILE=$OUTPUT_FILE"

--- a/.claude/scripts/generic/larch/gh-pr-body-update.sh
+++ b/.claude/scripts/generic/larch/gh-pr-body-update.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# gh-pr-body-update.sh — Update a PR's body from a file.
+#
+# Wraps `gh pr edit --body-file` with structured output. Uses --body-file
+# only (not inline --body) to avoid shell argument length limits with
+# large PR bodies.
+#
+# Usage:
+#   gh-pr-body-update.sh --pr <number> --body-file <path>
+#
+# Arguments:
+#   --pr        — PR number
+#   --body-file — Path to file containing the new PR body
+#
+# Outputs (key=value to stdout, always emitted via EXIT trap):
+#   UPDATED=true|false
+#   ERROR=<message>    (empty on success)
+#
+# Exit codes:
+#   0 — update succeeded (UPDATED=true)
+#   1 — usage/argument error (no output emitted)
+#   2 — update failed (UPDATED=false, ERROR=<message> emitted via EXIT trap)
+
+set -uo pipefail
+
+usage() { echo "Usage: gh-pr-body-update.sh --pr <number> --body-file <path>" >&2; }
+
+PR=""
+BODY_FILE=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --pr) PR="${2:?--pr requires a value}"; shift 2 ;;
+        --body-file) BODY_FILE="${2:?--body-file requires a value}"; shift 2 ;;
+        --help) usage; exit 0 ;;
+        *) echo "Unknown option: $1" >&2; usage; exit 1 ;;
+    esac
+done
+
+if [[ -z "$PR" ]] || [[ -z "$BODY_FILE" ]]; then
+    echo "ERROR: --pr and --body-file are required" >&2
+    usage; exit 1
+fi
+
+# --- Output defaults ---
+UPDATED="false"
+ERROR="gh-pr-body-update.sh exited unexpectedly"
+
+# shellcheck disable=SC2329,SC2317
+emit_output() {
+    echo "UPDATED=$UPDATED"
+    echo "ERROR=$ERROR"
+}
+trap 'emit_output' EXIT
+
+if [[ ! -f "$BODY_FILE" ]]; then
+    ERROR="body file not found: $BODY_FILE"
+    exit 2
+fi
+
+OUTPUT=$(gh pr edit "$PR" --body-file "$BODY_FILE" 2>&1)
+EXIT_CODE=$?
+
+if [[ $EXIT_CODE -eq 0 ]]; then
+    UPDATED="true"
+    ERROR=""
+    exit 0
+else
+    UPDATED="false"
+    OUTPUT="${OUTPUT//$'\n'/ }"
+    ERROR="gh pr edit failed (exit $EXIT_CODE): $OUTPUT"
+    exit 2
+fi

--- a/.claude/scripts/generic/larch/gh-pr-checks.sh
+++ b/.claude/scripts/generic/larch/gh-pr-checks.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# gh-pr-checks.sh — List PR check statuses.
+#
+# Wraps `gh pr checks` for fallback CI diagnosis when FAILED_RUN_ID
+# is not available from ci-status.sh. Output is raw checks text to
+# stdout since callers parse it for failed check identification.
+#
+# Usage:
+#   gh-pr-checks.sh --pr <number> --repo <owner/repo>
+#
+# Arguments:
+#   --pr   — PR number
+#   --repo — Owner/repo identifier (e.g., "myorg/myrepo")
+#
+# Exit codes:
+#   0 — success (checks printed to stdout)
+#   1 — usage/argument error or gh command failure
+
+set -euo pipefail
+
+usage() { echo "Usage: gh-pr-checks.sh --pr <number> --repo <owner/repo>" >&2; }
+
+PR=""
+REPO=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --pr) PR="${2:?--pr requires a value}"; shift 2 ;;
+        --repo) REPO="${2:?--repo requires a value}"; shift 2 ;;
+        --help) usage; exit 0 ;;
+        *) echo "Unknown option: $1" >&2; usage; exit 1 ;;
+    esac
+done
+
+if [[ -z "$PR" ]] || [[ -z "$REPO" ]]; then
+    echo "ERROR: --pr and --repo are required" >&2
+    usage; exit 1
+fi
+
+gh pr checks "$PR" --repo "$REPO"

--- a/.claude/scripts/generic/larch/gh-run-logs.sh
+++ b/.claude/scripts/generic/larch/gh-run-logs.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# gh-run-logs.sh — View failed CI run logs.
+#
+# Wraps `gh run view --log-failed` for diagnostic purposes.
+# Output is raw log text to stdout (not KEY=value) since callers
+# need the full unstructured log for AI-driven diagnosis.
+#
+# Usage:
+#   gh-run-logs.sh --run-id <id> --repo <owner/repo>
+#
+# Arguments:
+#   --run-id — GitHub Actions workflow run ID
+#   --repo   — Owner/repo identifier (e.g., "myorg/myrepo")
+#
+# Exit codes:
+#   0 — success (logs printed to stdout)
+#   1 — usage/argument error or gh command failure
+
+set -euo pipefail
+
+usage() { echo "Usage: gh-run-logs.sh --run-id <id> --repo <owner/repo>" >&2; }
+
+RUN_ID=""
+REPO=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --run-id) RUN_ID="${2:?--run-id requires a value}"; shift 2 ;;
+        --repo) REPO="${2:?--repo requires a value}"; shift 2 ;;
+        --help) usage; exit 0 ;;
+        *) echo "Unknown option: $1" >&2; usage; exit 1 ;;
+    esac
+done
+
+if [[ -z "$RUN_ID" ]] || [[ -z "$REPO" ]]; then
+    echo "ERROR: --run-id and --repo are required" >&2
+    usage; exit 1
+fi
+
+gh run view "$RUN_ID" --repo "$REPO" --log-failed

--- a/.claude/scripts/generic/larch/git-branch-info.sh
+++ b/.claude/scripts/generic/larch/git-branch-info.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# git-branch-info.sh — Get current HEAD SHA and branch name.
+#
+# Wraps `git rev-parse --short HEAD` and `git branch --show-current`
+# into a single script with KEY=value output.
+#
+# Usage:
+#   git-branch-info.sh
+#
+# Outputs (key=value to stdout):
+#   HEAD_SHA=<short hash>
+#   CURRENT_BRANCH=<branch name>  (empty string if detached HEAD)
+#
+# Exit codes:
+#   0 — success
+#   1 — not in a git repository
+
+set -euo pipefail
+
+HEAD_SHA=$(git rev-parse --short HEAD)
+CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || echo "")
+
+echo "HEAD_SHA=$HEAD_SHA"
+echo "CURRENT_BRANCH=$CURRENT_BRANCH"

--- a/.claude/scripts/generic/larch/git-commit.sh
+++ b/.claude/scripts/generic/larch/git-commit.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# git-commit.sh — Stage files and commit with Co-Authored-By trailer.
+#
+# Usage: git-commit.sh -m "message" [--no-trailer] [file1 file2 ...]
+#
+# Stages the specified files (if any) via `git add`, then commits using
+# `git commit --file <tmpfile>` to avoid shell quoting issues with
+# multi-line messages. Appends the Co-Authored-By trailer by default.
+#
+# Options:
+#   -m <message>     Commit message (required). Written verbatim to a temp
+#                    file, so newlines and special characters are safe.
+#   --no-trailer     Omit the Co-Authored-By trailer.
+#
+# Positional args:   Files to stage via `git add`. If none are provided,
+#                    commits whatever is already staged.
+#
+# Exit codes:
+#   0  Success
+#   1  Usage error (missing -m, empty message)
+#   >0 git add or git commit failure (passthrough)
+
+set -euo pipefail
+
+TRAILER="Co-Authored-By: Claude Code <noreply@anthropic.com>"
+MESSAGE=""
+NO_TRAILER=false
+FILES=()
+
+# --- Parse arguments ---
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -m)
+      if [[ $# -lt 2 ]]; then
+        echo "git-commit.sh: -m requires a message argument" >&2
+        exit 1
+      fi
+      MESSAGE="$2"
+      shift 2
+      ;;
+    --no-trailer)
+      NO_TRAILER=true
+      shift
+      ;;
+    --)
+      shift
+      FILES+=("$@")
+      break
+      ;;
+    *)
+      FILES+=("$1")
+      shift
+      ;;
+  esac
+done
+
+# --- Validate message ---
+TRIMMED="${MESSAGE#"${MESSAGE%%[![:space:]]*}"}"
+TRIMMED="${TRIMMED%"${TRIMMED##*[![:space:]]}"}"
+if [[ -z "$TRIMMED" ]]; then
+  echo "git-commit.sh: commit message must be non-empty" >&2
+  exit 1
+fi
+
+# --- Stage files ---
+if [[ ${#FILES[@]} -gt 0 ]]; then
+  git add -- "${FILES[@]}"
+fi
+
+# --- Write message and append trailer ---
+TMPFILE=$(mktemp)
+trap 'rm -f "$TMPFILE"' EXIT
+
+printf '%s\n' "$MESSAGE" > "$TMPFILE"
+
+if [[ "$NO_TRAILER" == false ]]; then
+  # Use git's native trailer machinery to append Co-Authored-By.
+  # --if-exists addIfDifferent avoids duplicates when the message
+  # already contains a Co-Authored-By with a different value, and
+  # skips appending when the exact same trailer is already present.
+  git interpret-trailers --in-place \
+    --if-exists addIfDifferent --if-missing add \
+    --trailer "$TRAILER" "$TMPFILE"
+fi
+
+git commit --file "$TMPFILE"

--- a/.claude/scripts/generic/larch/git-rebase-abort.sh
+++ b/.claude/scripts/generic/larch/git-rebase-abort.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# git-rebase-abort.sh — Abort an in-progress rebase (idempotent).
+#
+# Wraps `git rebase --abort`. Safe to call when no rebase is in progress
+# (the command will simply report "No rebase in progress" and exit 0).
+#
+# Usage:
+#   git-rebase-abort.sh
+#
+# Exit codes:
+#   0 — always (abort succeeded or no rebase was in progress)
+
+# Intentionally not using set -e — we want to always exit 0
+git rebase --abort 2>/dev/null || true
+exit 0

--- a/.claude/scripts/generic/larch/local-cleanup.sh
+++ b/.claude/scripts/generic/larch/local-cleanup.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# local-cleanup.sh — Post-merge local cleanup: switch to main and delete feature branch.
+#
+# Switches to main, fetches and pulls the latest, then deletes the
+# specified feature branch. Each action is logged to stderr for
+# user-visible progress. Treats branch deletion failure as non-fatal
+# (the branch may have already been deleted).
+#
+# Usage:
+#   local-cleanup.sh --branch BRANCH_NAME
+#
+# Arguments:
+#   --branch — Name of the feature branch to delete (required, must not be "main")
+#
+# Outputs (key=value to stdout, always emitted via EXIT trap):
+#   CLEANUP_SUCCESS=true|false
+#   CURRENT_BRANCH=<branch name after cleanup>
+#   BRANCH_DELETED=true|false
+#
+# Exit codes:
+#   0 — always (result communicated via output keys)
+#   1 — usage/argument error (no output emitted)
+
+set -uo pipefail
+
+usage() { echo "Usage: local-cleanup.sh --branch BRANCH_NAME" >&2; }
+
+# --- Parse arguments (before installing EXIT trap) ---
+BRANCH_NAME=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --branch) BRANCH_NAME="${2:?--branch requires a value}"; shift 2 ;;
+        --help) usage; exit 0 ;;
+        *) echo "Unknown option: $1" >&2; usage; exit 1 ;;
+    esac
+done
+
+if [[ -z "$BRANCH_NAME" ]]; then
+    echo "ERROR: --branch is required" >&2
+    usage; exit 1
+fi
+
+if [[ "$BRANCH_NAME" == "main" ]]; then
+    echo "ERROR: --branch must not be 'main'" >&2
+    exit 1
+fi
+
+# --- Output defaults (emitted via trap on any exit after validation) ---
+CLEANUP_SUCCESS="false"
+CURRENT_BRANCH="unknown"
+BRANCH_DELETED="false"
+
+# shellcheck disable=SC2329,SC2317  # invoked via EXIT trap
+emit_output() {
+    echo "CLEANUP_SUCCESS=$CLEANUP_SUCCESS"
+    echo "CURRENT_BRANCH=$CURRENT_BRANCH"
+    echo "BRANCH_DELETED=$BRANCH_DELETED"
+}
+trap 'emit_output' EXIT
+
+# --- Step 1: Checkout main ---
+echo "🔄 Switching to main..." >&2
+if ! git checkout main >/dev/null 2>&1; then
+    echo "❌ Failed to checkout main" >&2
+    CURRENT_BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || echo "unknown")
+    exit 0
+fi
+CURRENT_BRANCH="main"
+
+# --- Step 2: Fetch origin main ---
+echo "🔄 Fetching origin main..." >&2
+if ! git fetch origin main >/dev/null 2>&1; then
+    echo "⚠ Failed to fetch origin main (continuing)" >&2
+fi
+
+# --- Step 3: Pull origin main ---
+echo "🔄 Pulling latest main..." >&2
+if ! git pull origin main >/dev/null 2>&1; then
+    echo "❌ Failed to pull origin main" >&2
+    exit 0
+fi
+
+# --- Step 4: Delete feature branch ---
+echo "🔄 Deleting local branch $BRANCH_NAME..." >&2
+if git branch -D "$BRANCH_NAME" >/dev/null 2>&1; then
+    BRANCH_DELETED="true"
+else
+    echo "⚠ Failed to delete branch $BRANCH_NAME (may already be deleted)" >&2
+    BRANCH_DELETED="false"
+fi
+
+CLEANUP_SUCCESS="true"
+echo "✅ Local cleanup complete" >&2
+exit 0

--- a/.claude/scripts/generic/larch/merge-pr.sh
+++ b/.claude/scripts/generic/larch/merge-pr.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# merge-pr.sh — Squash-merge a PR with --admin fallback.
+#
+# Attempts a squash merge. On failure, checks if the branch is behind
+# main or if CI is not ready. If CI is confirmed passing and the branch
+# is up-to-date, retries with --admin to override review requirements.
+#
+# CRITICAL: The --admin flag overrides ALL branch protection rules
+# including review requirements. It is ONLY used after confirming:
+#   1. All CI checks are passing (bucket == "pass" for every check)
+#   2. The branch is up-to-date with main (mergeStateStatus != "BEHIND")
+# Keep in sync with the same --admin fallback in:
+#   - /admin-upgrade-clients Sub-Step 7
+#   - /admin-add-user Step 10
+#
+# Usage:
+#   merge-pr.sh --pr NUMBER --repo OWNER/REPO
+#
+# Outputs (key=value to stdout, always emitted via EXIT trap):
+#   MERGE_RESULT=merged|admin_merged|main_advanced|ci_not_ready|admin_failed|error
+#   ERROR=<message>    (empty string when no error)
+#
+# Exit codes:
+#   0 — always (result communicated via MERGE_RESULT)
+#   1 — usage/argument error (no output emitted)
+
+set -uo pipefail
+
+usage() { echo "Usage: merge-pr.sh --pr NUMBER --repo OWNER/REPO" >&2; }
+
+# --- Parse arguments (before installing EXIT trap) ---
+PR_NUMBER=""
+REPO=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --pr) PR_NUMBER="${2:?--pr requires a value}"; shift 2 ;;
+        --repo) REPO="${2:?--repo requires a value}"; shift 2 ;;
+        --help) usage; exit 0 ;;
+        *) echo "Unknown option: $1" >&2; usage; exit 1 ;;
+    esac
+done
+
+if [[ -z "$PR_NUMBER" ]] || [[ -z "$REPO" ]]; then
+    echo "ERROR: --pr and --repo are required" >&2
+    usage; exit 1
+fi
+
+# --- Output defaults (emitted via trap on any exit after validation) ---
+MERGE_RESULT="error"
+ERROR="merge-pr.sh exited unexpectedly"
+
+# shellcheck disable=SC2329,SC2317  # invoked via EXIT trap
+emit_output() {
+    echo "MERGE_RESULT=$MERGE_RESULT"
+    echo "ERROR=$ERROR"
+}
+trap 'emit_output' EXIT
+
+# --- Attempt squash merge ---
+MERGE_OUTPUT=$(gh pr merge "$PR_NUMBER" --repo "$REPO" --squash 2>&1)
+MERGE_EXIT=$?
+
+if [[ $MERGE_EXIT -eq 0 ]]; then
+    MERGE_RESULT="merged"
+    ERROR=""
+    exit 0
+fi
+
+# --- Merge failed — check why ---
+echo "ℹ Merge attempt failed: $MERGE_OUTPUT" >&2
+
+# Check if branch is behind main
+MERGE_STATE=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json mergeStateStatus -q '.mergeStateStatus' 2>/dev/null || echo "")
+
+if [[ "$MERGE_STATE" == "BEHIND" ]]; then
+    MERGE_RESULT="main_advanced"
+    ERROR=""
+    exit 0
+fi
+
+# --- Re-verify CI before attempting --admin ---
+# Use gh pr checks --json with bucket field (consistent with ci-status.sh)
+CHECKS_JSON=$(gh pr checks "$PR_NUMBER" --repo "$REPO" --json name,state,bucket,link 2>/dev/null || echo "")
+
+CI_GOOD=false
+if [[ -n "$CHECKS_JSON" ]] && [[ "$CHECKS_JSON" != "null" ]] \
+    && echo "$CHECKS_JSON" | jq -e 'type == "array"' >/dev/null 2>&1; then
+    TOTAL=$(echo "$CHECKS_JSON" | jq 'length' 2>/dev/null || echo "0")
+
+    if [[ "$TOTAL" -eq 0 ]]; then
+        # Zero checks — conservative: treat as not ready
+        CI_GOOD=false
+    else
+        # Require every check to have bucket == "pass" (not just absence of fail/pending).
+        # This rejects cancelled, skipping, or any other non-pass bucket.
+        PASSED=$(echo "$CHECKS_JSON" | jq '[.[] | select(.bucket == "pass")] | length' 2>/dev/null || echo "0")
+
+        if [[ "$PASSED" -eq "$TOTAL" ]]; then
+            CI_GOOD=true
+        fi
+    fi
+else
+    # Fallback: parse text output — conservative: only accept if all lines show pass
+    CHECKS_TEXT=$(gh pr checks "$PR_NUMBER" --repo "$REPO" 2>/dev/null || echo "")
+    if [[ -n "$CHECKS_TEXT" ]]; then
+        if ! echo "$CHECKS_TEXT" | grep -qiE '\bfail|pending|in_progress|queued|cancelled|skipping'; then
+            CI_GOOD=true
+        fi
+    fi
+    # Empty or unparseable — conservative: treat as not ready
+fi
+
+if [[ "$CI_GOOD" != "true" ]]; then
+    MERGE_RESULT="ci_not_ready"
+    ERROR="CI checks are not all passing"
+    exit 0
+fi
+
+# Double-check freshness (may have changed since first check)
+# CLEAN = mergeable normally; UNSTABLE = CI passed but review not approved;
+# BLOCKED = review/policy block (--admin handles this); HAS_HOOKS = has pre-receive hooks.
+# Anything else (BEHIND, DIRTY, DRAFT, UNKNOWN) = not ready.
+if [[ "$MERGE_STATE" != "CLEAN" ]] && [[ "$MERGE_STATE" != "UNSTABLE" ]] && [[ "$MERGE_STATE" != "HAS_HOOKS" ]] && [[ "$MERGE_STATE" != "BLOCKED" ]]; then
+    MERGE_RESULT="main_advanced"
+    ERROR="Branch mergeStateStatus is $MERGE_STATE"
+    exit 0
+fi
+
+# --- All checks passed — retry with --admin ---
+echo "ℹ CI is green and branch is fresh. Retrying with --admin..." >&2
+ADMIN_OUTPUT=$(gh pr merge "$PR_NUMBER" --repo "$REPO" --squash --admin 2>&1)
+ADMIN_EXIT=$?
+
+if [[ $ADMIN_EXIT -eq 0 ]]; then
+    MERGE_RESULT="admin_merged"
+    ERROR=""
+    exit 0
+fi
+
+MERGE_RESULT="admin_failed"
+ERROR="Admin merge failed: $ADMIN_OUTPUT"
+exit 0

--- a/.claude/scripts/generic/larch/parse-pr-summary.sh
+++ b/.claude/scripts/generic/larch/parse-pr-summary.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# parse-pr-summary.sh — Extract "## Summary" bullets from a PR body.
+#
+# Fetches the PR body via gh, extracts bullet lines between "## Summary"
+# and the next "##" heading, counts them, and outputs the results.
+#
+# Note: Similar extraction logic exists in slack-announce.sh.
+# Both implementations extract the "## Summary" section from PR bodies.
+#
+# Usage:
+#   parse-pr-summary.sh --pr NUMBER
+#
+# Outputs (key=value to stdout):
+#   BULLET_COUNT=<N>
+#   BULLETS=<pipe-separated bullet text, without "- " prefix>
+#
+# Exit codes:
+#   0 — success (even if no Summary section found — outputs BULLET_COUNT=0)
+#   1 — failed to fetch PR body
+
+set -euo pipefail
+
+usage() { echo "Usage: parse-pr-summary.sh --pr NUMBER" >&2; }
+
+PR_NUMBER=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --pr) PR_NUMBER="${2:?--pr requires a value}"; shift 2 ;;
+        --help) usage; exit 0 ;;
+        *) echo "Unknown option: $1" >&2; usage; exit 1 ;;
+    esac
+done
+
+if [[ -z "$PR_NUMBER" ]]; then
+    echo "ERROR: --pr is required" >&2
+    usage; exit 1
+fi
+
+# Fetch PR body
+PR_BODY=$(gh pr view "$PR_NUMBER" --json body -q '.body' 2>/dev/null || echo "")
+if [[ -z "$PR_BODY" ]]; then
+    echo "ERROR: Failed to fetch PR body for #$PR_NUMBER" >&2
+    exit 1
+fi
+
+# Extract text between "## Summary" and the next "##" heading or "<details>" block
+# Strip bullet prefixes ("- " or "* ") and blank lines
+BULLETS=$(printf '%s\n' "$PR_BODY" | \
+    sed -En '/^## Summary/,/^(## |<details>)/{ /^## Summary/d; /^(## |<details>)/d; p; }' | \
+    sed 's/^[[:space:]]*[-*][[:space:]]*//' | \
+    sed '/^[[:space:]]*$/d')
+
+if [[ -z "$BULLETS" ]]; then
+    echo "BULLET_COUNT=0"
+    echo "BULLETS="
+    exit 0
+fi
+
+# Count non-empty lines
+BULLET_COUNT=$(printf '%s\n' "$BULLETS" | wc -l | tr -d ' ')
+
+# Join bullets with pipe separator to keep KEY=value on a single line
+BULLETS_ONELINE=$(printf '%s\n' "$BULLETS" | tr '\n' '|' | sed 's/|$//')
+
+echo "BULLET_COUNT=$BULLET_COUNT"
+echo "BULLETS=$BULLETS_ONELINE"

--- a/.claude/scripts/generic/larch/post-merged-emoji.sh
+++ b/.claude/scripts/generic/larch/post-merged-emoji.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# post-merged-emoji.sh — Add :merged: emoji to a Slack PR announcement.
+#
+# Replaces the /post-merged skill. Reads $LARCH_SLACK_CHANNEL_ID
+# and calls add-merged-emoji.sh.
+#
+# Usage:
+#   post-merged-emoji.sh --slack-ts <timestamp>
+#
+# Arguments:
+#   --slack-ts — Slack message timestamp (as returned by post-pr-announce.sh)
+#
+# Exit codes:
+#   0 — emoji added successfully (or no-op if timestamp is empty)
+#   1 — failed to add emoji (channel missing, token missing, API error)
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+usage() { echo "Usage: post-merged-emoji.sh --slack-ts <timestamp>" >&2; }
+
+# --- Parse arguments ---
+SLACK_TS=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --slack-ts) SLACK_TS="${2:-}"; shift 2 ;;
+        --help) usage; exit 0 ;;
+        *) echo "Unknown option: $1" >&2; usage; exit 1 ;;
+    esac
+done
+
+# --- Guard: empty timestamp is a no-op ---
+if [[ -z "$SLACK_TS" ]]; then
+    echo "WARNING: No Slack timestamp provided. Skipping :merged: emoji." >&2
+    exit 0
+fi
+
+# --- Read Slack channel ---
+SLACK_CHANNEL_ID="${LARCH_SLACK_CHANNEL_ID:-}"
+
+if [[ -z "$SLACK_CHANNEL_ID" ]]; then
+    echo "WARNING: LARCH_SLACK_CHANNEL_ID is not set. Skipping :merged: emoji." >&2
+    exit 1
+fi
+
+# --- Add emoji ---
+"$SCRIPT_DIR/add-merged-emoji.sh" --slack-ts "$SLACK_TS" --channel-id "$SLACK_CHANNEL_ID"

--- a/.claude/scripts/generic/larch/post-pr-announce.sh
+++ b/.claude/scripts/generic/larch/post-pr-announce.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# post-pr-announce.sh — Post a PR announcement to Slack.
+#
+# Replaces the /post-pr skill. Composes: parse-pr-summary.sh →
+# slack-announce.sh with $LARCH_SLACK_CHANNEL_ID.
+#
+# Note: This script does NOT perform bullet condensation (the former skill
+# condensed > 3 bullets using LLM reasoning). In practice, /implement always
+# creates PR bodies with ≤ 3 bullets, so condensation never fired. If a PR
+# has > 3 bullets, a warning is emitted but the announcement proceeds with
+# all bullets.
+#
+# Usage:
+#   post-pr-announce.sh --pr <number>
+#
+# Arguments:
+#   --pr — PR number to announce
+#
+# Outputs (key=value to stdout, always emitted via EXIT trap):
+#   SLACK_TS=<value>    (Slack message timestamp on success)
+#   SLACK_TS=           (empty on failure)
+#
+# Exit codes:
+#   0 — announcement posted successfully
+#   1 — LARCH_SLACK_BOT_TOKEN not set
+#   2 — could not resolve PR metadata
+#   3 — Slack announcement failed
+#   4 — usage/argument error
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+usage() { echo "Usage: post-pr-announce.sh --pr <number>" >&2; }
+
+# --- Output defaults (install trap BEFORE parsing to guarantee SLACK_TS= on all paths) ---
+SLACK_TS=""
+
+# shellcheck disable=SC2329,SC2317
+emit_output() {
+    echo "SLACK_TS=$SLACK_TS"
+}
+trap 'emit_output' EXIT
+
+# --- Parse arguments ---
+PR=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --pr) PR="${2:?--pr requires a value}"; shift 2 ;;
+        --help) usage; exit 0 ;;
+        *) echo "Unknown option: $1" >&2; usage; exit 4 ;;
+    esac
+done
+
+if [[ -z "$PR" ]]; then
+    echo "ERROR: --pr is required" >&2
+    usage; exit 4
+fi
+
+# --- Create temp directory ---
+TMPDIR_OUTPUT=$("$SCRIPT_DIR/create-session-tmpdir.sh" --prefix claude-post-pr)
+POST_PR_TMPDIR=$(echo "$TMPDIR_OUTPUT" | grep '^SESSION_TMPDIR=' | cut -d= -f2-)
+
+if [[ -z "$POST_PR_TMPDIR" ]]; then
+    echo "ERROR: Failed to create temp directory" >&2
+    exit 3
+fi
+
+# --- Check bullet count (informational only, no condensation) ---
+SUMMARY_OUTPUT=$("$SCRIPT_DIR/parse-pr-summary.sh" --pr "$PR" 2>/dev/null || echo "BULLET_COUNT=0")
+BULLET_COUNT=$(echo "$SUMMARY_OUTPUT" | grep '^BULLET_COUNT=' | cut -d= -f2-)
+
+if [[ "${BULLET_COUNT:-0}" -gt 3 ]]; then
+    echo "WARNING: PR #$PR has $BULLET_COUNT summary bullets (> 3). Proceeding without condensation." >&2
+fi
+
+# --- Read Slack channel ---
+SLACK_CHANNEL_ID="${LARCH_SLACK_CHANNEL_ID:-}"
+
+if [[ -z "$SLACK_CHANNEL_ID" ]]; then
+    echo "WARNING: LARCH_SLACK_CHANNEL_ID is not set. Slack announcement skipped." >&2
+    "$SCRIPT_DIR/cleanup-tmpdir.sh" --dir "$POST_PR_TMPDIR" 2>/dev/null || true
+    exit 0
+fi
+
+# --- Post to Slack ---
+ANNOUNCE_OUTPUT=$("$SCRIPT_DIR/slack-announce.sh" --pr "$PR" --tmpdir "$POST_PR_TMPDIR" --channel-id "$SLACK_CHANNEL_ID" 2>&1)
+ANNOUNCE_EXIT=$?
+
+SLACK_TS=$(echo "$ANNOUNCE_OUTPUT" | grep '^SLACK_TS=' | cut -d= -f2-)
+
+# --- Cleanup ---
+"$SCRIPT_DIR/cleanup-tmpdir.sh" --dir "$POST_PR_TMPDIR" 2>/dev/null || true
+
+if [[ $ANNOUNCE_EXIT -ne 0 ]]; then
+    SLACK_TS=""
+    exit "$ANNOUNCE_EXIT"
+fi
+if [[ -z "$SLACK_TS" ]]; then
+    SLACK_TS=""
+    exit 3
+fi
+
+exit 0

--- a/.claude/scripts/generic/larch/post-slack-message.sh
+++ b/.claude/scripts/generic/larch/post-slack-message.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# post-slack-message.sh — Post a message to Slack via the chat.postMessage API.
+#
+# Usage:
+#   post-slack-message.sh --channel-id CHANNEL_ID --text "Message" \
+#       [--username "Name"] [--slack_timestamp "timestamp"] --token "SLACK_TOKEN"
+#
+# Arguments:
+#   --channel-id        Slack channel ID (e.g., C12345678)
+#   --text              Message text (Slack mrkdwn format)
+#   --token             Slack bot token
+#   --username          Optional display name for the bot
+#   --slack_timestamp   Optional thread timestamp (replies in thread)
+#
+# Outputs to stdout:
+#   Slack message timestamp (on success)
+#
+# Exit codes:
+#   0 — message posted successfully
+#   1 — missing arguments or API failure
+
+set -euo pipefail
+
+CHANNEL_ID=""
+TEXT=""
+USERNAME=""
+SLACK_TIMESTAMP=""
+TOKEN=""
+
+while [[ "$#" -gt 0 ]]; do
+  case $1 in
+    --channel-id) CHANNEL_ID="$2"; shift ;;
+    --text) TEXT="$2"; shift ;;
+    --username) USERNAME="$2"; shift ;;
+    --slack_timestamp) SLACK_TIMESTAMP="$2"; shift ;;
+    --token) TOKEN="$2"; shift ;;
+    *) echo "Unknown parameter: $1" >&2; exit 1 ;;
+  esac
+  shift
+done
+
+if [[ -z "$CHANNEL_ID" || -z "$TEXT" || -z "$TOKEN" ]]; then
+  echo "Error: Missing required arguments" >&2
+  echo "Usage: $0 --channel-id CHANNEL_ID --text \"Message\" --token \"SLACK_TOKEN\"" >&2
+  exit 1
+fi
+
+# Construct JSON payload safely using jq
+PAYLOAD=$(jq -n \
+  --arg channel "$CHANNEL_ID" \
+  --arg text "$TEXT" \
+  --arg username "$USERNAME" \
+  --arg thread_ts "$SLACK_TIMESTAMP" \
+  '{channel: $channel, text: $text}
+   + (if $username != "" then {username: $username} else {} end)
+   + (if $thread_ts != "" then {thread_ts: $thread_ts} else {} end)')
+
+# Send message to Slack
+response=$(curl -s -X POST https://slack.com/api/chat.postMessage \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json; charset=utf-8" \
+  -d "$PAYLOAD")
+
+if echo "$response" | grep -q '"ok":true'; then
+  echo "$response" | jq -r '.ts'
+else
+  echo "Failed to post Slack message: $response" >&2
+  exit 1
+fi

--- a/.claude/scripts/generic/larch/preflight.sh
+++ b/.claude/scripts/generic/larch/preflight.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# preflight.sh — Pre-skill sanity checks.
+#
+# Default: verify on main, clean working tree, then fetch+rebase to latest main.
+# With --skip-branch-check: skip on-main and clean-status checks, only fetch.
+#
+# Usage:
+#   preflight.sh [--skip-branch-check]
+#
+# Exit codes:
+#   0 — all checks passed
+#   1 — not on main branch (only without --skip-branch-check)
+#   2 — dirty working tree (only without --skip-branch-check)
+#   3 — git fetch or rebase failed
+
+set -euo pipefail
+
+SKIP_BRANCH_CHECK=false
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --skip-branch-check) SKIP_BRANCH_CHECK=true; shift ;;
+        *) echo "Unknown option: $1" >&2; exit 3 ;;
+    esac
+done
+
+if [[ "$SKIP_BRANCH_CHECK" == "false" ]]; then
+    # Check on main
+    CURRENT_BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
+    if [[ "$CURRENT_BRANCH" != "main" ]]; then
+        echo "PREFLIGHT=fail"
+        echo "PREFLIGHT_ERROR=Not on main branch (on '$CURRENT_BRANCH'). Switch to main first, or pass --skip-branch-check."
+        exit 1
+    fi
+
+    # Check clean status
+    if [[ -n "$(git status --porcelain 2>/dev/null)" ]]; then
+        echo "PREFLIGHT=fail"
+        echo "PREFLIGHT_ERROR=Working tree is not clean. Commit or stash changes first."
+        exit 2
+    fi
+
+    # Fetch and rebase main to latest
+    if ! git fetch origin main --quiet 2>/dev/null; then
+        echo "PREFLIGHT=fail"
+        echo "PREFLIGHT_ERROR=git fetch origin main failed."
+        exit 3
+    fi
+    if ! git rebase origin/main --quiet 2>/dev/null; then
+        echo "PREFLIGHT=fail"
+        echo "PREFLIGHT_ERROR=git rebase origin/main failed."
+        exit 3
+    fi
+else
+    # Skip branch/status checks, only fetch to ensure origin/main is current
+    if ! git fetch origin main --quiet 2>/dev/null; then
+        echo "PREFLIGHT=fail"
+        echo "PREFLIGHT_ERROR=git fetch origin main failed."
+        exit 3
+    fi
+fi
+
+echo "PREFLIGHT=ok"

--- a/.claude/scripts/generic/larch/rebase-push.sh
+++ b/.claude/scripts/generic/larch/rebase-push.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# rebase-push.sh — Rebase onto origin/main and optionally force-push with lease.
+#
+# Fetches origin/main, rebases, and (unless --no-push) pushes. Reports
+# conflicts and push failures via exit codes.
+#
+# Usage:
+#   rebase-push.sh [--continue] [--no-push]
+#
+# Flags:
+#   --continue — Continue an in-progress rebase instead of starting a new one.
+#                Skips fetch and runs `git rebase --continue` instead of
+#                `git rebase origin/main`. Caller must resolve conflicts and
+#                stage files before invoking with --continue.
+#   --no-push  — Skip the push step after a successful rebase. Used by
+#                /implement for local-only freshness rebases where the branch
+#                has not yet been pushed. In this mode, conflicts are aborted
+#                immediately (exit 1) instead of left in progress.
+#
+# Exit codes:
+#   0 — rebase (and push, unless --no-push) succeeded
+#   1 — rebase failed with conflicts
+#       Default mode: rebase left in progress (CONFLICT_FILES= on stdout)
+#       --no-push mode: rebase aborted, branch restored to pre-rebase state
+#   2 — push --force-with-lease failed (PUSH_ERROR= on stderr, caller should retry after fetch)
+#       Not possible in --no-push mode.
+#   3 — rebase failed for non-conflict reasons (REBASE_ERROR= on stderr)
+#       In normal mode: rebase is aborted.
+#       In --continue mode: rebase is left in progress (caller can inspect/retry).
+#       In --no-push mode: rebase is aborted.
+#
+# Stdout on exit 1 (default mode only):
+#   CONFLICT_FILES=<comma-separated list of conflicted files>
+#
+# Note: On exit 1 in default mode, the rebase is left in progress so the
+# caller can resolve conflicts and run `rebase-push.sh --continue`. On exit 1
+# in --no-push mode, the rebase is aborted (caller does not resolve conflicts).
+# On exit 3 in normal mode, the rebase is aborted. On exit 3 in --continue
+# mode, the rebase is left in progress to avoid destroying already-resolved work.
+
+set -uo pipefail
+# Note: not using set -e — we need to capture exit codes explicitly
+
+# --- Parse flags ---
+CONTINUE_MODE=false
+NO_PUSH=false
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --continue) CONTINUE_MODE=true; shift ;;
+        --no-push) NO_PUSH=true; shift ;;
+        *) echo "Unknown option: $1" >&2; exit 1 ;;
+    esac
+done
+
+if [[ "$CONTINUE_MODE" == "true" && "$NO_PUSH" == "true" ]]; then
+    echo "REBASE_ERROR=--continue and --no-push cannot be used together" >&2
+    exit 3
+fi
+
+if [[ "$CONTINUE_MODE" == "true" ]]; then
+    # --- Guard: must have a rebase in progress ---
+    GIT_DIR=$(git rev-parse --git-dir 2>/dev/null)
+    if [[ -z "$GIT_DIR" || (! -d "$GIT_DIR/rebase-merge" && ! -d "$GIT_DIR/rebase-apply") ]]; then
+        echo "REBASE_ERROR=--continue called but no rebase is in progress" >&2
+        exit 3
+    fi
+
+    # --- Continue an in-progress rebase (GIT_EDITOR=true prevents editor hang) ---
+    REBASE_OUTPUT=$(GIT_EDITOR=true git rebase --continue 2>&1)
+    REBASE_EXIT=$?
+else
+    # --- Guard: must be on a branch, not detached HEAD ---
+    if ! git symbolic-ref --quiet HEAD > /dev/null 2>&1; then
+        echo "REBASE_ERROR=Not on a branch (detached HEAD)" >&2
+        exit 3
+    fi
+
+    # --- Fetch latest main ---
+    # In --no-push mode, fetch failure is fatal (the whole point is freshness).
+    # In default mode, fetch failure is tolerated to allow rebasing against cached origin/main.
+    if [[ "$NO_PUSH" == "true" ]]; then
+        if ! git fetch origin main --quiet 2>/dev/null; then
+            echo "REBASE_ERROR=git fetch origin main failed (network/auth issue)" >&2
+            exit 3
+        fi
+    else
+        git fetch origin main --quiet 2>/dev/null || true
+    fi
+
+    # --- Attempt rebase ---
+    REBASE_OUTPUT=$(git rebase origin/main 2>&1)
+    REBASE_EXIT=$?
+fi
+
+if [[ $REBASE_EXIT -ne 0 ]]; then
+    # Check if there are conflicts
+    CONFLICT_FILES=$(git diff --name-only --diff-filter=U 2>/dev/null | tr '\n' ',' | sed 's/,$//')
+    if [[ -n "$CONFLICT_FILES" ]]; then
+        if [[ "$NO_PUSH" == "true" ]]; then
+            # In --no-push mode, abort immediately — caller does not resolve conflicts
+            git rebase --abort 2>/dev/null || true
+            exit 1
+        fi
+        echo "CONFLICT_FILES=$CONFLICT_FILES"
+        # Leave the rebase in progress so caller can resolve and --continue
+        exit 1
+    else
+        # Rebase failed for another reason (not conflicts)
+        # Sanitize multi-line git output to single line for key=value protocol
+        REBASE_OUTPUT="${REBASE_OUTPUT//$'\n'/ }"
+        echo "REBASE_ERROR=$REBASE_OUTPUT" >&2
+        if [[ "$CONTINUE_MODE" == "true" ]]; then
+            # In --continue mode, leave rebase in progress to avoid destroying
+            # already-resolved work. Caller can inspect and retry.
+            exit 3
+        else
+            git rebase --abort 2>/dev/null || true
+            exit 3
+        fi
+    fi
+fi
+
+# --- Skip push in --no-push mode ---
+if [[ "$NO_PUSH" == "true" ]]; then
+    exit 0
+fi
+
+# --- Attempt force-push ---
+PUSH_OUTPUT=$(git push --force-with-lease 2>&1)
+PUSH_EXIT=$?
+
+if [[ $PUSH_EXIT -ne 0 ]]; then
+    PUSH_OUTPUT="${PUSH_OUTPUT//$'\n'/ }"
+    echo "PUSH_ERROR=$PUSH_OUTPUT" >&2
+    exit 2
+fi
+
+exit 0

--- a/.claude/scripts/generic/larch/run-external-reviewer.sh
+++ b/.claude/scripts/generic/larch/run-external-reviewer.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# run-external-reviewer.sh — Monitored wrapper for external code reviewers (Codex, Cursor).
+# Launches the reviewer in the background, polls every 60s with status messages,
+# kills after a configurable timeout (default 15 minutes).
+#
+# Usage:
+#   run-external-reviewer.sh --tool NAME --output FILE --timeout SECS [--capture-stdout] -- CMD...
+#
+# Options:
+#   --tool            Tool name (e.g., "codex", "cursor") — used only for log messages
+#   --output          Path where tool output is written
+#   --timeout         Timeout in seconds (e.g., 900 for 15 minutes)
+#   --capture-stdout  Redirect the tool's stdout/stderr to the output file.
+#                     Use for tools like Cursor that write results to stdout.
+#                     Omit for tools like Codex that use their own output flags.
+#   --               End of wrapper options. Everything after is the command to execute.
+#
+# Examples:
+#   # Codex review (uses --output-last-message flag to write output)
+#   run-external-reviewer.sh --tool codex --output /tmp/review-abc/codex-output.txt --timeout 900 -- \
+#     codex exec --full-auto -C /path/to/repo --output-last-message /tmp/review-abc/codex-output.txt "Review prompt..."
+#
+#   # Cursor review (stdout captured to file via --capture-stdout)
+#   run-external-reviewer.sh --tool cursor --output /tmp/review-abc/cursor-output.txt --timeout 900 --capture-stdout -- \
+#     cursor agent -p --force --trust --workspace /path/to/repo "Review prompt..."
+
+set -euo pipefail
+
+usage() { echo "Usage: run-external-reviewer.sh --tool NAME --output FILE --timeout SECS [--capture-stdout] -- CMD..." >&2; }
+
+CAPTURE_STDOUT=false
+TOOL_NAME=""
+OUTPUT_FILE=""
+TIMEOUT_SECONDS=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --tool) TOOL_NAME="${2:?--tool requires a value}"; shift 2 ;;
+        --output) OUTPUT_FILE="${2:?--output requires a value}"; shift 2 ;;
+        --timeout) TIMEOUT_SECONDS="${2:?--timeout requires a value}"; shift 2 ;;
+        --capture-stdout) CAPTURE_STDOUT=true; shift ;;
+        --help) usage; exit 0 ;;
+        --) shift; break ;;
+        *) echo "Unknown option: $1" >&2; usage; exit 1 ;;
+    esac
+done
+
+if [[ -z "$TOOL_NAME" ]] || [[ -z "$OUTPUT_FILE" ]] || [[ -z "$TIMEOUT_SECONDS" ]]; then
+    echo "ERROR: --tool, --output, and --timeout are required" >&2
+    usage; exit 1
+fi
+
+case "$TIMEOUT_SECONDS" in
+    ''|*[!0-9]*) echo "ERROR: --timeout must be a positive integer, got '$TIMEOUT_SECONDS'" >&2; exit 1 ;;
+esac
+
+if [[ $# -eq 0 ]]; then
+    echo "ERROR: no command specified after --" >&2
+    usage; exit 1
+fi
+
+# Clear stale output and sentinel file
+rm -f "$OUTPUT_FILE" "${OUTPUT_FILE}.done"
+
+# Write sentinel file on ANY exit — the reliable completion signal for callers.
+# Callers poll for <output-file>.done instead of waiting for runtime notifications.
+EXIT_CODE=99  # default: wrapper crashed before capturing real exit code
+trap 'echo "$EXIT_CODE" > "${OUTPUT_FILE}.done" 2>/dev/null || true' EXIT
+
+# Launch the reviewer in the background
+if [ "$CAPTURE_STDOUT" = true ]; then
+    "$@" > "$OUTPUT_FILE" 2>&1 &
+else
+    "$@" &
+fi
+PID=$!
+SECONDS=0
+
+# Poll until the process exits or times out
+# Check timeout BEFORE sleeping to avoid overshooting by a full interval.
+# Use 10s intervals for more responsive timeout detection.
+while kill -0 "$PID" 2>/dev/null; do
+    if [ "$SECONDS" -ge "$TIMEOUT_SECONDS" ]; then
+        echo "⚠ ${TOOL_NAME} review: TIMED OUT after $(( TIMEOUT_SECONDS / 60 )) minutes, killing"
+        kill "$PID" 2>/dev/null
+        sleep 5
+        kill -9 "$PID" 2>/dev/null || true
+        wait "$PID" 2>/dev/null || true
+        # Report diagnostics even on timeout
+        OUTPUT_SIZE=0
+        if [ -f "$OUTPUT_FILE" ]; then
+            OUTPUT_SIZE=$(wc -c < "$OUTPUT_FILE" | tr -d ' ')
+        fi
+        echo "❌ ${TOOL_NAME} review: TIMED OUT (exit code 124, ${SECONDS}s elapsed, output ${OUTPUT_SIZE} bytes)"
+        EXIT_CODE=124
+        exit "$EXIT_CODE"
+    fi
+    sleep 10
+    # Print progress every 60s (every 6th iteration)
+    if [ $(( SECONDS % 60 )) -lt 10 ]; then
+        echo "⏳ ${TOOL_NAME} review: still running ($(( SECONDS / 60 ))m elapsed)"
+    fi
+done
+
+# Capture exit code without triggering set -e (wait propagates child exit code)
+wait "$PID" && EXIT_CODE=0 || EXIT_CODE=$?
+
+# Diagnostics: report completion with details to help debug failures
+OUTPUT_SIZE=0
+if [ -f "$OUTPUT_FILE" ]; then
+    OUTPUT_SIZE=$(wc -c < "$OUTPUT_FILE" | tr -d ' ')
+fi
+
+if [ "$EXIT_CODE" -ne 0 ]; then
+    echo "❌ ${TOOL_NAME} review: FAILED (exit code ${EXIT_CODE}, ${SECONDS}s elapsed, output ${OUTPUT_SIZE} bytes)"
+    if [ "$OUTPUT_SIZE" -gt 0 ]; then
+        echo "--- ${TOOL_NAME} output (last 5 lines) ---"
+        tail -5 "$OUTPUT_FILE"
+        echo "--- end ---"
+    fi
+elif [ "$OUTPUT_SIZE" -eq 0 ]; then
+    echo "⚠ ${TOOL_NAME} review: completed but OUTPUT IS EMPTY (exit code 0, ${SECONDS}s elapsed)"
+    echo "This typically means ${TOOL_NAME} exited without producing findings."
+else
+    echo "✓ ${TOOL_NAME} review: completed (exit code 0, ${SECONDS}s elapsed, output ${OUTPUT_SIZE} bytes)"
+fi
+exit "$EXIT_CODE"

--- a/.claude/scripts/generic/larch/run-negotiation-round.sh
+++ b/.claude/scripts/generic/larch/run-negotiation-round.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# run-negotiation-round.sh — Run one negotiation round with an external reviewer.
+#
+# Wraps the Codex stdin-pipe and Cursor agent-prompt negotiation flows
+# from the Negotiation Protocol in external-reviewers.md. Removes the
+# previous output file before running to ensure fresh results.
+#
+# Usage:
+#   run-negotiation-round.sh --tool codex|cursor --prompt-file <path> --output <path> --workspace <path>
+#
+# Arguments:
+#   --tool        — Which reviewer tool (codex or cursor)
+#   --prompt-file — Path to the negotiation prompt file
+#   --output      — Path to write the reviewer's response
+#   --workspace   — Path to the repository workspace
+#
+# Outputs (key=value to stdout):
+#   RESPONSE_FILE=<path>
+#
+# Exit codes:
+#   0 — success (response written)
+#   1 — usage/argument error
+#   2 — reviewer command failed
+
+set -uo pipefail
+
+usage() { echo "Usage: run-negotiation-round.sh --tool codex|cursor --prompt-file <path> --output <path> --workspace <path>" >&2; }
+
+TOOL=""
+PROMPT_FILE=""
+OUTPUT_FILE=""
+WORKSPACE=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --tool) TOOL="${2:?--tool requires a value}"; shift 2 ;;
+        --prompt-file) PROMPT_FILE="${2:?--prompt-file requires a value}"; shift 2 ;;
+        --output) OUTPUT_FILE="${2:?--output requires a value}"; shift 2 ;;
+        --workspace) WORKSPACE="${2:?--workspace requires a value}"; shift 2 ;;
+        --help) usage; exit 0 ;;
+        *) echo "Unknown option: $1" >&2; usage; exit 1 ;;
+    esac
+done
+
+if [[ -z "$TOOL" ]] || [[ -z "$PROMPT_FILE" ]] || [[ -z "$OUTPUT_FILE" ]] || [[ -z "$WORKSPACE" ]]; then
+    echo "ERROR: --tool, --prompt-file, --output, and --workspace are all required" >&2
+    usage; exit 1
+fi
+
+if [[ ! -f "$PROMPT_FILE" ]]; then
+    echo "ERROR: prompt file not found: $PROMPT_FILE" >&2
+    exit 1
+fi
+
+# Remove previous output to ensure fresh results
+rm -f "$OUTPUT_FILE"
+
+case "$TOOL" in
+    codex)
+        codex exec --full-auto -C "$WORKSPACE" \
+            --output-last-message "$OUTPUT_FILE" - < "$PROMPT_FILE" 2>&1
+        ;;
+    cursor)
+        cursor agent -p --force --trust --model gpt-5.4-medium --workspace "$WORKSPACE" \
+            "Read the negotiation prompt from $PROMPT_FILE and respond to it." \
+            > "$OUTPUT_FILE" 2>&1
+        ;;
+    *)
+        echo "ERROR: --tool must be 'codex' or 'cursor' (got: $TOOL)" >&2
+        exit 1
+        ;;
+esac
+
+EXIT_CODE=$?
+if [[ $EXIT_CODE -ne 0 ]]; then
+    echo "RESPONSE_FILE=$OUTPUT_FILE"
+    exit 2
+fi
+
+echo "RESPONSE_FILE=$OUTPUT_FILE"

--- a/.claude/scripts/generic/larch/session-setup.sh
+++ b/.claude/scripts/generic/larch/session-setup.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# session-setup.sh — Shared session setup for /design, /implement, /shazam skills.
+#
+# Consolidates the common Step 0 operations: preflight, temp dir creation,
+# Slack configuration check, and repo name derivation.
+#
+# Usage:
+#   session-setup.sh --prefix <name> [--skip-branch-check] [--skip-slack-check] \
+#     [--skip-repo-check] [--caller-env <path>]
+#
+# Flags:
+#   --prefix <name>       (required) Temp dir prefix for mktemp (e.g., claude-shazam)
+#   --skip-branch-check   Forwarded to preflight.sh (skip on-main/clean-tree assertions)
+#   --skip-slack-check    Skip LARCH_SLACK_BOT_TOKEN and LARCH_SLACK_CHANNEL_ID check entirely
+#   --skip-repo-check     Skip repo name derivation entirely
+#   --caller-env <path>   Path to KEY=value file with already-discovered values.
+#                          Recognized keys: SLACK_OK, SLACK_MISSING, REPO, REPO_UNAVAILABLE.
+#                          If a key is present and non-empty, the script skips re-deriving it.
+#                          SESSION_TMPDIR is never inherited — a fresh tmpdir is always created.
+#                          If the file does not exist or is empty, full discovery happens.
+#
+# Output (KEY=value lines on stdout):
+#   SESSION_TMPDIR=<path>       Always output (fresh per invocation)
+#   SLACK_OK=true|false         Output unless --skip-slack-check
+#   SLACK_MISSING=<csv>         Output when SLACK_OK=false (comma-separated missing var names)
+#   REPO=<owner/repo>           Output unless --skip-repo-check
+#   REPO_UNAVAILABLE=true|false Output unless --skip-repo-check
+#
+# On preflight failure, outputs PREFLIGHT_ERROR=<message> and exits non-zero.
+#
+# Exit codes:
+#   0 — success
+#   1-3 — passthrough from preflight.sh
+#   4 — missing --prefix or other session-setup.sh error
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+PREFIX=""
+SKIP_BRANCH_CHECK=false
+SKIP_SLACK_CHECK=false
+SKIP_REPO_CHECK=false
+CALLER_ENV=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --prefix)
+            [[ $# -ge 2 ]] || { echo "session-setup.sh: --prefix requires a value" >&2; exit 4; }
+            PREFIX="$2"; shift 2 ;;
+        --skip-branch-check)
+            SKIP_BRANCH_CHECK=true; shift ;;
+        --skip-slack-check)
+            SKIP_SLACK_CHECK=true; shift ;;
+        --skip-repo-check)
+            SKIP_REPO_CHECK=true; shift ;;
+        --caller-env)
+            [[ $# -ge 2 ]] || { echo "session-setup.sh: --caller-env requires a path" >&2; exit 4; }
+            CALLER_ENV="$2"; shift 2 ;;
+        *)
+            echo "session-setup.sh: unknown option: $1" >&2
+            exit 4 ;;
+    esac
+done
+
+if [[ -z "$PREFIX" ]]; then
+    echo "session-setup.sh: --prefix is required" >&2
+    exit 4
+fi
+
+# --- Read caller-env file (if provided and exists) ---
+# Parse line-by-line; do NOT source. Only recognized keys with non-empty values are used.
+CALLER_SLACK_OK=""
+CALLER_SLACK_MISSING=""
+CALLER_REPO=""
+CALLER_REPO_UNAVAILABLE=""
+
+if [[ -n "$CALLER_ENV" && -f "$CALLER_ENV" ]]; then
+    while IFS='=' read -r key value || [[ -n "$key" ]]; do
+        # Skip empty lines and lines not matching KEY=value pattern
+        [[ -z "$key" || "$key" =~ ^# ]] && continue
+        case "$key" in
+            SLACK_OK)          CALLER_SLACK_OK="$value" ;;
+            SLACK_MISSING)     CALLER_SLACK_MISSING="$value" ;;
+            REPO)              CALLER_REPO="$value" ;;
+            REPO_UNAVAILABLE)  CALLER_REPO_UNAVAILABLE="$value" ;;
+            *)                 ;; # Ignore unknown keys
+        esac
+    done < "$CALLER_ENV"
+fi
+
+# --- 1. Preflight ---
+PREFLIGHT_OUTPUT=""
+PREFLIGHT_EXIT=0
+if [[ "$SKIP_BRANCH_CHECK" == "true" ]]; then
+    PREFLIGHT_OUTPUT=$("$SCRIPT_DIR/preflight.sh" --skip-branch-check 2>&1) || PREFLIGHT_EXIT=$?
+else
+    PREFLIGHT_OUTPUT=$("$SCRIPT_DIR/preflight.sh" 2>&1) || PREFLIGHT_EXIT=$?
+fi
+
+if [[ $PREFLIGHT_EXIT -ne 0 ]]; then
+    # Re-emit preflight output (contains PREFLIGHT_ERROR=...)
+    echo "$PREFLIGHT_OUTPUT"
+    exit "$PREFLIGHT_EXIT"
+fi
+
+# --- 2. Create temp directory (always fresh, never inherited) ---
+SESSION_TMPDIR=$(mktemp -d "/tmp/${PREFIX}-XXXXXX")
+echo "SESSION_TMPDIR=$SESSION_TMPDIR"
+
+# --- 3. Check Slack configuration (LARCH_SLACK_BOT_TOKEN + LARCH_SLACK_CHANNEL_ID) ---
+if [[ "$SKIP_SLACK_CHECK" == "false" ]]; then
+    if [[ -n "$CALLER_SLACK_OK" ]]; then
+        # Reuse caller's values
+        echo "SLACK_OK=$CALLER_SLACK_OK"
+        if [[ -n "$CALLER_SLACK_MISSING" ]]; then
+            echo "SLACK_MISSING=$CALLER_SLACK_MISSING"
+        fi
+    else
+        # Derive fresh: both vars must be set for Slack to be available
+        SLACK_MISSING_VARS=""
+        if [[ -z "${LARCH_SLACK_BOT_TOKEN:-}" ]]; then
+            SLACK_MISSING_VARS="LARCH_SLACK_BOT_TOKEN"
+        fi
+        if [[ -z "${LARCH_SLACK_CHANNEL_ID:-}" ]]; then
+            if [[ -n "$SLACK_MISSING_VARS" ]]; then
+                SLACK_MISSING_VARS="$SLACK_MISSING_VARS,LARCH_SLACK_CHANNEL_ID"
+            else
+                SLACK_MISSING_VARS="LARCH_SLACK_CHANNEL_ID"
+            fi
+        fi
+
+        if [[ -z "$SLACK_MISSING_VARS" ]]; then
+            echo "SLACK_OK=true"
+        else
+            echo "SLACK_OK=false"
+            echo "SLACK_MISSING=$SLACK_MISSING_VARS"
+        fi
+    fi
+fi
+
+# --- 4. Derive repository name ---
+if [[ "$SKIP_REPO_CHECK" == "false" ]]; then
+    if [[ -n "$CALLER_REPO" || -n "$CALLER_REPO_UNAVAILABLE" ]]; then
+        # Reuse caller's values (treat REPO + REPO_UNAVAILABLE as one result shape)
+        echo "REPO=${CALLER_REPO}"
+        echo "REPO_UNAVAILABLE=${CALLER_REPO_UNAVAILABLE:-false}"
+    else
+        # Derive fresh: try gh first, then git remote fallback
+        REPO=""
+        REPO_UNAVAILABLE="false"
+
+        if REPO=$(gh repo view --json nameWithOwner -q '.nameWithOwner' 2>/dev/null) && [[ -n "$REPO" ]]; then
+            : # Success
+        else
+            # Fallback: parse from git remote
+            REMOTE_URL=$(git remote get-url origin 2>/dev/null || echo "")
+            if [[ -n "$REMOTE_URL" ]]; then
+                # Strip .git suffix, then extract owner/repo
+                REMOTE_URL="${REMOTE_URL%.git}"
+                if [[ "$REMOTE_URL" =~ git@github\.com:([^/]+/[^/]+)$ ]]; then
+                    REPO="${BASH_REMATCH[1]}"
+                elif [[ "$REMOTE_URL" =~ github\.com/([^/]+/[^/]+)$ ]]; then
+                    REPO="${BASH_REMATCH[1]}"
+                fi
+            fi
+        fi
+
+        if [[ -z "$REPO" ]]; then
+            REPO_UNAVAILABLE="true"
+        fi
+
+        echo "REPO=$REPO"
+        echo "REPO_UNAVAILABLE=$REPO_UNAVAILABLE"
+    fi
+fi

--- a/.claude/scripts/generic/larch/slack-announce.sh
+++ b/.claude/scripts/generic/larch/slack-announce.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# slack-announce.sh — Post a Slack announcement for a PR.
+#
+# Resolves git identity, constructs a Slack message from PR metadata,
+# posts via post-slack-message.sh, and saves the Slack timestamp to
+# $TMPDIR/slack-ts.txt.
+#
+# Usage:
+#   slack-announce.sh --pr NUMBER --tmpdir DIR --channel-id CHANNEL_ID
+#
+# Environment:
+#   LARCH_SLACK_BOT_TOKEN — required, the Slack bot token
+#   LARCH_SLACK_USER_ID   — optional Slack user ID (e.g., U12345678) for @-mentioning
+#                     the PR author. If unset, the message is posted without a mention.
+#
+# Outputs to stdout:
+#   SLACK_TS=<timestamp>     (on success)
+#   SLACK_TS=                (on failure)
+#   SLACK_ERROR=<message>    (on failure)
+#
+# Exit codes:
+#   0 — message posted successfully
+#   1 — LARCH_SLACK_BOT_TOKEN not set
+#   2 — failed to resolve PR metadata
+#   3 — failed to post message
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+usage() { echo "Usage: slack-announce.sh --pr NUMBER --tmpdir DIR --channel-id CHANNEL_ID" >&2; }
+
+PR_NUMBER=""
+TMPDIR_PATH=""
+CHANNEL_ID=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --pr) PR_NUMBER="${2:?--pr requires a value}"; shift 2 ;;
+        --tmpdir) TMPDIR_PATH="${2:?--tmpdir requires a value}"; shift 2 ;;
+        --channel-id) CHANNEL_ID="${2:?--channel-id requires a value}"; shift 2 ;;
+        --help) usage; exit 0 ;;
+        *) echo "Unknown option: $1" >&2; usage; exit 3 ;;
+    esac
+done
+
+if [[ -z "$PR_NUMBER" ]] || [[ -z "$TMPDIR_PATH" ]] || [[ -z "$CHANNEL_ID" ]]; then
+    echo "SLACK_TS="
+    echo "SLACK_ERROR=--pr, --tmpdir, and --channel-id are required"
+    usage; exit 3
+fi
+
+# --- Check token ---
+if [[ -z "${LARCH_SLACK_BOT_TOKEN:-}" ]]; then
+    echo "SLACK_TS="
+    echo "SLACK_ERROR=LARCH_SLACK_BOT_TOKEN not set"
+    exit 1
+fi
+CLEAN_TOKEN=$(echo -n "$LARCH_SLACK_BOT_TOKEN" | tr -d '[:space:]')
+
+# --- Resolve git identity ---
+GIT_USER_NAME=$(git config user.name 2>/dev/null || echo "")
+LARCH_SLACK_USER_ID="${LARCH_SLACK_USER_ID:-}"
+
+# --- Fetch PR metadata and derive repo name from PR URL ---
+set +e
+PR_JSON=$(gh pr view "$PR_NUMBER" --json url,title,body 2>/dev/null)
+set -e
+
+PR_URL=$(echo "$PR_JSON" | jq -r '.url // empty' 2>/dev/null || echo "")
+PR_TITLE=$(echo "$PR_JSON" | jq -r '.title // empty' 2>/dev/null || echo "")
+PR_BODY=$(echo "$PR_JSON" | jq -r '.body // empty' 2>/dev/null || echo "")
+REPO_NAME=$(echo "$PR_URL" | sed -E 's|.*/([^/]+)/pull/[0-9]+$|\1|')
+# Guard: if sed didn't match (REPO_NAME still looks like a URL), treat as empty
+if [[ "$REPO_NAME" == */* ]]; then
+    REPO_NAME=""
+fi
+
+if [[ -z "$PR_URL" ]] || [[ -z "$PR_TITLE" ]] || [[ -z "$REPO_NAME" ]]; then
+    echo "SLACK_TS="
+    echo "SLACK_ERROR=Failed to resolve PR metadata"
+    exit 2
+fi
+
+# --- Extract Summary bullets from PR body ---
+# Get everything between "## Summary" and the next "##" heading or "<details>" block
+SUMMARY_BULLETS=$(echo "$PR_BODY" | \
+    sed -En '/^## Summary/,/^(## |<details>)/{ /^## Summary/d; /^(## |<details>)/d; p; }' | \
+    sed 's/^- //' | \
+    sed '/^[[:space:]]*$/d')
+
+# --- Construct message ---
+# post-slack-message.sh embeds the text via string interpolation into a JSON
+# string (PAYLOAD="{... \"text\": \"$TEXT\"}"). We must pre-escape characters
+# that would break JSON: backslashes, double quotes, and newlines.
+# For the title, replace " with the left curly quote character to avoid JSON breakage.
+
+LDQUOTE=$'\xe2\x80\x9c'  # U+201C "
+BULLET=$'\xe2\x80\xa2'   # U+2022 •
+
+SAFE_TITLE="${PR_TITLE//\"/${LDQUOTE}}"
+
+# Line 1: mention + PR link
+if [[ -n "$LARCH_SLACK_USER_ID" ]]; then
+    LINE1="<@${LARCH_SLACK_USER_ID}>: FYI \`${REPO_NAME}\` <${PR_URL}|#${PR_NUMBER}> ${LDQUOTE}${SAFE_TITLE}${LDQUOTE}"
+else
+    LINE1="FYI \`${REPO_NAME}\` <${PR_URL}|#${PR_NUMBER}> ${LDQUOTE}${SAFE_TITLE}${LDQUOTE}"
+fi
+
+# Build bullet lines with actual newlines and bullet chars
+BULLET_LINES=""
+while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    if [[ -z "$BULLET_LINES" ]]; then
+        BULLET_LINES="${BULLET} ${line}"
+    else
+        BULLET_LINES="${BULLET_LINES}"$'\n'"${BULLET} ${line}"
+    fi
+done <<< "$SUMMARY_BULLETS"
+
+# Combine: LINE1 + bullets (only add newline where content exists)
+MESSAGE="${LINE1}"
+if [[ -n "$BULLET_LINES" ]]; then
+    MESSAGE="${MESSAGE}"$'\n'"${BULLET_LINES}"
+fi
+
+# --- Post to Slack ---
+# post-slack-message.sh uses jq --arg for JSON construction, so pass raw text.
+set +e
+SLACK_TS=$(bash "$SCRIPT_DIR/post-slack-message.sh" \
+    --channel-id "$CHANNEL_ID" \
+    --text "$MESSAGE" \
+    --username "$GIT_USER_NAME" \
+    --token "$CLEAN_TOKEN" 2>/dev/null)
+POST_EXIT=$?
+set -e
+
+if [[ $POST_EXIT -ne 0 ]] || [[ -z "$SLACK_TS" ]]; then
+    echo "SLACK_TS="
+    echo "SLACK_ERROR=Failed to post Slack message (exit code $POST_EXIT)"
+    exit 3
+fi
+
+# --- Save timestamp ---
+echo "$SLACK_TS" > "$TMPDIR_PATH/slack-ts.txt"
+echo "SLACK_TS=$SLACK_TS"

--- a/.claude/scripts/generic/larch/sleep-seconds.sh
+++ b/.claude/scripts/generic/larch/sleep-seconds.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# sleep-seconds.sh — Sleep for a specified number of seconds.
+#
+# Thin wrapper around `sleep` to avoid direct Bash commands in
+# skill SKILL.md files.
+#
+# Usage:
+#   sleep-seconds.sh <seconds>
+#
+# Arguments:
+#   First positional argument — number of seconds to sleep
+#
+# Exit codes:
+#   0 — always
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: sleep-seconds.sh <seconds>" >&2
+    exit 1
+fi
+
+sleep "$1"

--- a/.claude/scripts/generic/larch/verify-main.sh
+++ b/.claude/scripts/generic/larch/verify-main.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# verify-main.sh — Verify that main's HEAD matches the expected squash-merge commit.
+#
+# Checks git log -1 --oneline and compares the commit message against
+# the expected squash-merge title (typically "<PR title> (#<PR number>)").
+#
+# Matching strategy (handles both normal and --admin merges):
+#   1. Prefix match: commit message starts with the expected title (normal squash merge)
+#   2. Suffix match: commit message ends with "(#N)" from the expected title
+#      (--admin merge uses the first commit message instead of PR title, but
+#      GitHub still appends the PR number suffix)
+#
+# Usage:
+#   verify-main.sh --expected-title TEXT
+#
+# Arguments:
+#   --expected-title — The expected commit title prefix to match against
+#
+# Outputs (key=value to stdout, always emitted via EXIT trap):
+#   VERIFIED=true|false
+#   COMMIT_HASH=<short hash>
+#   COMMIT_MESSAGE=<commit message>
+#
+# Preconditions:
+#   Caller must have already checked out and pulled main (e.g., via local-cleanup.sh).
+#
+# Exit codes:
+#   0 — always (result communicated via VERIFIED output key)
+#   2 — usage/argument error (no output emitted)
+
+set -uo pipefail
+
+usage() { echo "Usage: verify-main.sh --expected-title TEXT" >&2; }
+
+# --- Parse arguments (before installing EXIT trap) ---
+EXPECTED_TITLE=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --expected-title) EXPECTED_TITLE="${2:?--expected-title requires a value}"; shift 2 ;;
+        --help) usage; exit 0 ;;
+        *) echo "Unknown option: $1" >&2; usage; exit 2 ;;
+    esac
+done
+
+if [[ -z "$EXPECTED_TITLE" ]]; then
+    echo "ERROR: --expected-title is required" >&2
+    usage; exit 2
+fi
+
+# --- Output defaults ---
+VERIFIED="false"
+COMMIT_HASH=""
+COMMIT_MESSAGE=""
+
+# shellcheck disable=SC2329,SC2317  # invoked via EXIT trap
+emit_output() {
+    echo "VERIFIED=$VERIFIED"
+    echo "COMMIT_HASH=$COMMIT_HASH"
+    echo "COMMIT_MESSAGE=$COMMIT_MESSAGE"
+}
+trap 'emit_output' EXIT
+
+# --- Get HEAD commit ---
+LOG_OUTPUT=$(git log -1 --oneline 2>/dev/null || echo "")
+
+if [[ -z "$LOG_OUTPUT" ]]; then
+    COMMIT_MESSAGE="(no commits found)"
+    exit 0
+fi
+
+# Parse hash and message from "abc1234 commit message here"
+COMMIT_HASH="${LOG_OUTPUT%% *}"
+COMMIT_MESSAGE="${LOG_OUTPUT#* }"
+
+# --- Compare using prefix match, then PR number suffix fallback ---
+# Strategy 1: prefix match (normal squash merge — PR title is the commit message)
+if [[ "$COMMIT_MESSAGE" == "$EXPECTED_TITLE"* ]]; then
+    VERIFIED="true"
+else
+    # Strategy 2: suffix match on PR number (--admin merge — commit message differs
+    # but GitHub still appends "(#N)")
+    # Extract the "(#N)" suffix from the expected title
+    PR_SUFFIX=""
+    if [[ "$EXPECTED_TITLE" =~ \(#[0-9]+\)$ ]]; then
+        PR_SUFFIX="${BASH_REMATCH[0]}"
+    fi
+
+    if [[ -n "$PR_SUFFIX" && "$COMMIT_MESSAGE" == *"$PR_SUFFIX" ]]; then
+        VERIFIED="true"
+    fi
+fi
+
+exit 0

--- a/.claude/scripts/generic/larch/wait-for-reviewers.sh
+++ b/.claude/scripts/generic/larch/wait-for-reviewers.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# wait-for-reviewers.sh — Poll for external reviewer sentinel files with compact progress.
+#
+# Usage:
+#   wait-for-reviewers.sh [--timeout <seconds>] <sentinel.done> [sentinel2.done ...]
+#
+# Sentinel files are the .done files created by run-external-reviewer.sh.
+# Progress (dots, status lines) goes to stderr.
+# Machine-parseable results (DONE/TIMEOUT lines) go to stdout.
+# Always exits 0 for normal operation (including timeouts) — callers inspect stdout
+# to determine which reviewers completed vs timed out. Exits 1 only for usage errors.
+#
+# The default timeout is 960 seconds (16 minutes), matching the run-external-reviewer.sh
+# default of 15 minutes + 1 minute grace period. Override with --timeout if a different
+# wrapper timeout was used.
+
+# No -e: script always exits 0 for normal operation; subshell failures must not abort.
+set -uo pipefail
+
+# --- Parse arguments ---
+usage() { echo "Usage: wait-for-reviewers.sh [--timeout SECONDS] <sentinel.done> [sentinel2.done ...]" >&2; }
+
+TIMEOUT=960
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --timeout) TIMEOUT="${2:?--timeout requires a value}"; shift 2 ;;
+        --help) usage; exit 0 ;;
+        -*) echo "Unknown option: $1" >&2; usage; exit 1 ;;
+        *) break ;;
+    esac
+done
+
+case "$TIMEOUT" in
+    ''|*[!0-9]*) echo "Error: --timeout value must be a positive integer, got '$TIMEOUT'" >&2; exit 1 ;;
+esac
+
+if [[ $# -eq 0 ]]; then
+    echo "ERROR: at least one sentinel file path is required" >&2
+    usage; exit 1
+fi
+
+TOTAL=$#
+MARKER_DIR=$(mktemp -d /tmp/wait-reviewers-XXXXXX) || { echo "fatal: mktemp failed" >&2; exit 1; }
+trap 'rm -rf "$MARKER_DIR"' EXIT
+
+# read_exit_code <sentinel-file> — read and validate the exit code from a sentinel file.
+read_exit_code() {
+    local code
+    code=$(tr -d '[:space:]' < "$1" 2>/dev/null)
+    case "$code" in
+        ''|*[!0-9]*) code="unknown" ;;
+    esac
+    printf '%s' "$code"
+}
+
+# check_sentinels — scan all sentinel files, update markers and found_count.
+check_sentinels() {
+    local idx=0
+    for sentinel in "$@"; do
+        idx=$((idx + 1))
+        if [ -f "$MARKER_DIR/$idx" ]; then
+            continue
+        fi
+        if [ -f "$sentinel" ]; then
+            local exit_code
+            exit_code=$(read_exit_code "$sentinel")
+            echo "$exit_code" > "$MARKER_DIR/$idx"
+            found_count=$((found_count + 1))
+            printf "\n✓ %s: exit=%s\n" "$(basename "$sentinel" .done)" "$exit_code" >&2
+        fi
+    done
+}
+
+# --- Polling loop ---
+SECONDS=0
+found_count=0
+checks=0
+
+# Check before first sleep — detect pre-existing sentinels immediately
+check_sentinels "$@"
+
+while [ "$found_count" -lt "$TOTAL" ] && [ "$SECONDS" -lt "$TIMEOUT" ]; do
+    # Print dot progress
+    printf "." >&2
+    checks=$((checks + 1))
+    # Print status line every 12 checks (~1 minute)
+    if [ $((checks % 12)) -eq 0 ]; then
+        printf "\n⏳ Waiting: %dm elapsed, %d checks, %d/%d done\n" \
+            "$((SECONDS / 60))" "$checks" "$found_count" "$TOTAL" >&2
+    fi
+
+    sleep 5
+
+    check_sentinels "$@"
+done
+
+# Snapshot elapsed time before summary output
+ELAPSED=$SECONDS
+
+# --- Summary output (stdout, machine-parseable) ---
+printf "\n" >&2
+idx=0
+timed_out=0
+for sentinel in "$@"; do
+    idx=$((idx + 1))
+    name=$(basename "$sentinel" .done)
+    if [ -f "$MARKER_DIR/$idx" ]; then
+        exit_code=$(cat "$MARKER_DIR/$idx" 2>/dev/null)
+        echo "DONE $name: exit=$exit_code"
+    else
+        echo "TIMEOUT $name"
+        timed_out=$((timed_out + 1))
+    fi
+done
+
+if [ "$timed_out" -gt 0 ]; then
+    printf "⚠ %d/%d reviewer(s) timed out after %d seconds\n" "$timed_out" "$TOTAL" "$TIMEOUT" >&2
+else
+    printf "✓ All %d reviewer(s) completed in %ds\n" "$TOTAL" "$ELAPSED" >&2
+fi
+
+exit 0

--- a/.claude/scripts/generic/larch/write-session-env.sh
+++ b/.claude/scripts/generic/larch/write-session-env.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# write-session-env.sh — Write session environment values to a file for child skills.
+#
+# Usage:
+#   write-session-env.sh --output <path> --slack-ok <true|false> \
+#                        [--slack-missing <csv>] --repo <owner/repo> \
+#                        --repo-unavailable <true|false>
+#
+# Options:
+#   --repo may be empty when --repo-unavailable is true (repo discovery failed).
+#   --slack-missing is optional (only meaningful when --slack-ok is false).
+#
+# Output: Writes a shell-sourceable file to --output path.
+# Exit codes: 0 success, 1 invalid args
+
+set -euo pipefail
+
+OUTPUT=""
+SLACK_OK=""
+SLACK_MISSING=""
+REPO=""
+REPO_UNAVAILABLE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output)       OUTPUT="$2"; shift 2 ;;
+    --slack-ok)     SLACK_OK="$2"; shift 2 ;;
+    --slack-missing) SLACK_MISSING="$2"; shift 2 ;;
+    --repo)         REPO="$2"; shift 2 ;;
+    --repo-unavailable) REPO_UNAVAILABLE="$2"; shift 2 ;;
+    *) echo "ERROR=Unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+if [[ -z "$OUTPUT" || -z "$SLACK_OK" || -z "$REPO_UNAVAILABLE" ]]; then
+  echo "ERROR=Missing required arguments: --output, --slack-ok, --repo-unavailable" >&2
+  exit 1
+fi
+
+cat > "$OUTPUT" << ENVEOF
+SLACK_OK=$SLACK_OK
+SLACK_MISSING=$SLACK_MISSING
+REPO=$REPO
+REPO_UNAVAILABLE=$REPO_UNAVAILABLE
+ENVEOF

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,6 +2,7 @@
   "permissions": {
     "allow": [
       "Bash($PWD/.claude/scripts/generic/claudin/*)",
+      "Bash($PWD/.claude/scripts/generic/larch/*)",
       "Bash($PWD/.claude/skills/*)",
       "Bash($PWD/.claude/skills/implement/scripts/*)",
       "Bash($PWD/.claude/skills/loop-review/scripts/*)",

--- a/.claude/skills/shared/larch/external-reviewers.md
+++ b/.claude/skills/shared/larch/external-reviewers.md
@@ -1,0 +1,68 @@
+# External Reviewer Procedures (Codex + Cursor)
+
+Shared mechanical procedures for running Codex and Cursor as external reviewers. Each skill provides its own reviewer invocation commands (prompts, output paths, tmpdir variables) — this file covers the common scaffolding.
+
+## Binary Check (Step 0b)
+
+Run the shared `check-reviewers.sh` script to check for Codex and Cursor binaries:
+
+```bash
+$PWD/.claude/scripts/generic/larch/check-reviewers.sh
+```
+
+Parse the output for `CODEX_AVAILABLE` and `CURSOR_AVAILABLE`.
+
+Set mental flags `codex_available` and `cursor_available` from the script output. For each that is `false`, print a **bold** warning:
+- `**⚠ Codex not available (binary not found). Proceeding without Codex reviewer.**`
+- `**⚠ Cursor not available (binary not found). Proceeding without Cursor reviewer.**`
+
+**Note**: If either tool is installed but fails during the actual review (e.g., auth issues, timeout), the failure is handled gracefully — the review proceeds with warnings.
+
+## Monitoring External Reviewers
+
+After launching Codex and/or Cursor as background tasks, **poll for `.done` sentinel files** to detect completion. The wrapper script (`run-external-reviewer.sh`) writes `<output-file>.done` (containing the exit code) when it finishes. Do NOT poll the output files directly — Cursor buffers all stdout until exit, so its output file is empty until the process finishes.
+
+1. Continue working on other tasks (e.g., processing Claude subagent results) while external reviewers run in the background.
+2. After all other tasks are done, invoke the wait script with the sentinel file paths for all launched reviewers:
+   ```bash
+   $PWD/.claude/scripts/generic/larch/wait-for-reviewers.sh "<cursor-output-file>.done" "<codex-output-file>.done"
+   ```
+   Only include paths for reviewers that were actually launched. For this `wait-for-reviewers.sh` Bash tool call, use `timeout: 960000` (960 seconds = 960 000 ms) and **do NOT** set `run_in_background: true` — this call must block until all sentinels are found. The script polls every 5 seconds, prints compact dot-based progress to stderr, and outputs machine-parseable `DONE <name>: exit=<code>` or `TIMEOUT <name>` lines to stdout. It always exits 0. **Important**: Invoke the wait script exactly ONCE with ALL sentinel file paths in a SINGLE Bash tool call. Do NOT make multiple Bash calls or write ad-hoc polling loops. If you launched the reviewer with a custom timeout via `run-external-reviewer.sh`, pass the matching value plus 60 seconds grace with `--timeout <seconds>` (seconds) and set the Bash tool `timeout` to the same value in milliseconds.
+3. **Do NOT read output files until the corresponding `.done` sentinel file exists.** Reading early will see an empty file (especially for Cursor, whose stdout is fully buffered). Parse the script's stdout `DONE`/`TIMEOUT` lines to determine which reviewers completed.
+4. For any reviewer that shows `TIMEOUT` in the script output, print `**⚠ <Reviewer> sentinel file not found after timeout. The wrapper may have been killed externally. Proceeding without <Reviewer> findings.**` and continue without that reviewer.
+
+## Validating External Reviewer Output
+
+**Only after** the corresponding `.done` sentinel file exists, read the output file. The exit code is in the sentinel file (e.g., `cat "<output-file>.done"`). The wrapper script (`run-external-reviewer.sh`) also prints diagnostic lines to its own stdout (captured in the background task output):
+- `✓ <tool> review: completed (exit code 0, Xs elapsed, output N bytes)` — success
+- `❌ <tool> review: FAILED (exit code N, Xs elapsed, output N bytes)` — failure with details
+- `⚠ <tool> review: completed but OUTPUT IS EMPTY` — process succeeded but wrote nothing
+
+**Validation steps:**
+1. Read the output file with the Read tool.
+2. Check that it is non-empty and looks like a review (contains numbered findings or "NO_ISSUES_FOUND").
+3. If the output is empty despite exit code 0, **retry the reviewer once** with a fresh invocation (same prompt, new output file path with `-retry` suffix). Some tools have transient startup failures that resolve on retry.
+4. If the output is empty after retry, or if the reviewer exited non-zero, print a detailed warning including the exit code and elapsed time from the wrapper's diagnostic output: `**⚠ <Reviewer> review failed (exit code X, Ys elapsed, 0 bytes output). Proceeding without <Reviewer> findings.**`
+
+## Negotiation Protocol
+
+> **Note**: `/design` and `/review` now use the **Voting Protocol** in `voting-protocol.md` instead of this Negotiation Protocol. This section is retained for skills that still use negotiation: `/loop-review` and `/research`.
+
+> **Variable substitution**: Replace `<skill-tmpdir>` in all paths below with the session tmpdir variable passed by the caller (e.g., `$DESIGN_TMPDIR` or `$REVIEW_TMPDIR`).
+
+> **Parameters**: `max_rounds` (default: 3) — the maximum number of negotiation rounds. Callers may override this (e.g., `/loop-review` uses `max_rounds=1` to keep runtime manageable across multiple slices).
+
+Negotiate with each external reviewer (Codex, Cursor) for up to **`max_rounds` rounds** of back-and-forth:
+
+1. Evaluate each finding. **Accept** it unless it is factually incorrect (references wrong file/line, misunderstands the code) or contradicts a project convention documented in CLAUDE.md.
+2. For findings you disagree with, write a response to a negotiation prompt file explaining your reasoning. Use the Write tool if available; if the skill does not allow Write (e.g., `/research`), write the prompt file via the `run-negotiation-round.sh` script's `--prompt-file` argument (the caller must create the file through whatever means the skill permits). The prompt should include the original finding, your counter-argument, and ask the reviewer to either maintain its position with additional justification or withdraw the finding.
+   - **Codex**: Write to `<skill-tmpdir>/codex-negotiation-prompt.txt`, then:
+     ```bash
+     $PWD/.claude/scripts/generic/larch/run-negotiation-round.sh --tool codex --prompt-file "<skill-tmpdir>/codex-negotiation-prompt.txt" --output "<skill-tmpdir>/codex-negotiation-output.txt" --workspace "$PWD"
+     ```
+   - **Cursor**: Write to `<skill-tmpdir>/cursor-negotiation-prompt.txt`, then:
+     ```bash
+     $PWD/.claude/scripts/generic/larch/run-negotiation-round.sh --tool cursor --prompt-file "<skill-tmpdir>/cursor-negotiation-prompt.txt" --output "<skill-tmpdir>/cursor-negotiation-output.txt" --workspace "$PWD"
+     ```
+   Use `timeout: 300000` on both Bash tool calls.
+3. Repeat up to 3 rounds total. After round 3 (or earlier if all disagreements are resolved), **Claude makes the final call** on any remaining disputes.

--- a/.claude/skills/shared/larch/reviewer-templates.md
+++ b/.claude/skills/shared/larch/reviewer-templates.md
@@ -1,0 +1,148 @@
+# Reviewer Templates
+
+Shared reviewer prompt archetypes used by `/design` (plan review) and `/review` (code review). Each skill fills in the context-specific variables.
+
+## Variables
+
+Each skill provides:
+
+- **`{REVIEW_TARGET}`**: What is being reviewed. Examples:
+  - Plan review: `"an implementation plan"`
+  - Code review: `"code changes"`
+
+- **`{CONTEXT_BLOCK}`**: The material to review. Examples:
+  - Plan review:
+    ```
+    ## Feature to implement
+    {FEATURE_DESCRIPTION}
+
+    ## Proposed implementation plan
+    {PLAN}
+    ```
+  - Code review:
+    ```
+    ## Changes to review
+    Commits:
+    {COMMIT_LOG}
+
+    Files changed:
+    {FILE_LIST}
+
+    Full diff:
+    {DIFF}
+    ```
+
+- **`{OUTPUT_INSTRUCTION}`**: What each finding should contain. Examples:
+  - Plan review: `"What the concern is"` + `"Suggested revision to the plan"`
+  - Code review: `"File path and line number(s)"` + `"What the issue is"` + `"Suggested fix (be specific)"`
+
+## Reviewer A: General
+
+```
+You are reviewing {REVIEW_TARGET} for this project. Perform a thorough general review covering code quality and risk/integration concerns. You have access to the full codebase via Read, Grep, Glob tools.
+
+{CONTEXT_BLOCK}
+
+## Your review checklist
+
+### Code quality
+1. **Bugs/logic**: Look for logical flaws, incorrect conditions, wrong variable usage, broken control flow.
+2. **Code quality**: Search the codebase (Grep/Glob) for existing implementations that overlap. Flag duplication and suggest reusing existing code. Flag unnecessary complexity.
+3. **Test coverage**: Are tests missing or insufficient? Specify what test cases should be added.
+4. **Backward compatibility**: Will the changes break existing callers, CLI commands, API contracts, or downstream consumers? Check for removed/renamed exports, changed function signatures, or modified behavior.
+5. **Style consistency**: Does the new content match existing patterns, naming conventions, and formatting?
+
+### Risk/integration
+6. **Breaking changes**: Check for removed/renamed exports, changed signatures, modified validation that could break callers.
+7. **Cache invalidation**: If caching is involved, will stale data be served? Are cache keys correct after the change?
+8. **Import side effects**: Do new imports trigger init() functions, register global state, or cause circular dependencies?
+9. **Thread safety**: Is shared mutable state properly synchronized? Are maps accessed concurrently? Are channels used correctly?
+10. **Deployment risks**: Could the changes cause issues during rollout? (Schema migrations, config changes, feature flags, backward-incompatible wire formats.)
+11. **Regression risk**: Will the changes cause existing tests to fail or become flaky? Are edge cases in existing tests still covered?
+12. **Module interaction**: Do the changes affect other packages or services? Trace callers of modified functions. Check if changes to shared types propagate correctly.
+13. **CI constraints**: CI workflows live in `.github/workflows/ci*.yaml`. Check if new files are covered by test globs, if CLI changes need E2E updates, if workflow YAML syntax is correct.
+
+## Output format
+Return findings in two separate sections:
+
+### In-Scope Findings
+A numbered list of issues that should be fixed in this PR. For each finding:
+- {OUTPUT_INSTRUCTION}
+- Note if it's a risk/integration-specific finding
+
+### Out-of-Scope Observations
+A numbered list of pre-existing issues or concerns beyond the scope of this PR that are still worth surfacing for future attention. For each observation:
+- {OUTPUT_INSTRUCTION}
+- Note if it's a risk/integration-specific finding
+- Note why this is out of scope (pre-existing, unrelated to PR, etc.)
+
+If no in-scope issues found, say "No in-scope issues found." If no out-of-scope observations, omit that section entirely. Do NOT edit any files.
+```
+
+## Reviewer B: Deep Analysis
+
+```
+You are a senior systems architect and correctness specialist reviewing {REVIEW_TARGET} for this project. You combine deep correctness analysis with architectural rigor. You have access to the full codebase via Read, Grep, Glob tools.
+
+{CONTEXT_BLOCK}
+
+## Correctness focus — apply extra scrutiny to:
+1. **Logic errors**: Incorrect boolean conditions, inverted checks, wrong operator (< vs <=), swapped arguments.
+2. **Off-by-one errors**: Loop bounds, slice indices, string offsets, pagination limits.
+3. **Null/nil/None handling**: Dereferencing without nil check, missing zero-value handling, optional fields assumed present.
+4. **Type mismatches**: Wrong type assertions, implicit conversions, struct field type changes that break callers.
+5. **Incorrect return values**: Functions returning wrong error, swapped return values, missing early returns.
+6. **Race conditions**: Shared state accessed without synchronization, goroutine leaks, channel misuse.
+7. **Exception/error paths**: Errors swallowed silently, panic recovery gaps, deferred cleanup not running on error.
+8. **Math errors**: Integer overflow, division by zero, floating-point comparison, incorrect rounding.
+
+## Architecture focus:
+
+### Separation of Concerns (SOC)
+- Does each module/class have exactly ONE responsibility?
+- Is business logic mixed with I/O, presentation, or infrastructure?
+- Are there god classes doing too many things?
+- Could this be split into smaller, focused components?
+
+### Contract Boundaries
+- Are cross-repo data contracts explicit? (API request/response types, workflow/activity contracts, configuration schemas, event payload shapes)
+- When a new field is added or renamed, will the other side break silently?
+- Are function return types and struct fields consistent across layers (API schema, internal model, persistence)?
+- Do CLI request types match what the server handler expects?
+- Are peer fields consistent? (If one field allows nil, do similar sibling fields also allow it?)
+
+### Invariants
+- Are edge cases validated at system boundaries? (nil, empty slices, missing keys)
+- Do silent defaults mask real errors? (Prefer loud failures over plausible-looking fallbacks)
+- Is config-driven behavior consistent? (No product logic in infrastructure layers)
+- Is ordering correct when values are set before a normalization or copy step?
+- Are background jobs and polling loops properly managed? Do long-running operations have a liveness/heartbeat signal so supervisors can detect stalled workers?
+
+### Semantic Boundaries
+- Does product or domain logic live in the right layer?
+- Are new framework-level fields actually framework concerns?
+- Do imports flow in the right direction? (Infrastructure does not import from product code.)
+- Are data shapes that cross system boundaries explicitly declared?
+
+## Your process
+1. Verify single purpose for each changed class/struct.
+2. Trace every data boundary to check both sides agree on the contract.
+3. Check every import for layer violations.
+4. For every new or changed field, ask: "what breaks silently if this field changes?"
+
+## Output format
+Return findings in two separate sections:
+
+### In-Scope Findings
+A numbered list of issues that should be fixed in this PR. For each finding:
+- Focus area (correctness / SOC / contract boundaries / invariants / semantic boundaries)
+- {OUTPUT_INSTRUCTION}
+
+### Out-of-Scope Observations
+A numbered list of pre-existing issues or concerns beyond the scope of this PR that are still worth surfacing. For each observation:
+- Focus area (correctness / SOC / contract boundaries / invariants / semantic boundaries)
+- {OUTPUT_INSTRUCTION}
+- Note why this is out of scope (pre-existing, unrelated to PR, etc.)
+
+If no in-scope issues found, say "No in-scope issues found." If no out-of-scope observations, omit that section entirely. Do NOT edit any files.
+```

--- a/.claude/skills/shared/larch/voting-protocol.md
+++ b/.claude/skills/shared/larch/voting-protocol.md
@@ -1,0 +1,202 @@
+# Voting Protocol
+
+Shared voting protocol for adjudicating review findings. Used by `/design` (plan review) and `/review` (code review). This protocol **replaces** the Negotiation Protocol for `/design` and `/review`. `/loop-review` and `/research` continue using the Negotiation Protocol in `external-reviewers.md`.
+
+## Overview
+
+After reviewers submit findings and findings are deduplicated, a 3-agent voting panel votes YES/NO/EXONERATE on each finding. Findings with 2+ YES votes are accepted; others are not implemented. Original reviewers earn competition points based on how their findings perform in voting. EXONERATE is a third option meaning "legitimate concern, but not worth implementing in this PR" — it spares the proposing reviewer from losing a point.
+
+## Ballot Format
+
+Before sending to voters, assign each deduplicated finding a stable sequential ID. Format the ballot as:
+
+```
+## Findings Ballot
+
+Vote YES, NO, or EXONERATE on each finding. A finding should receive YES if it is correct, important, and worth implementing. Vote NO if the finding is incorrect, trivial, or would cause more harm than good. Vote EXONERATE if the finding raises a legitimate concern worth noting, but is not worth implementing in this PR — this spares the proposing reviewer from a penalty.
+
+FINDING_1: <reviewer attribution> — <finding description>
+FINDING_2: <reviewer attribution> — <finding description>
+...
+```
+
+Include the reviewer attribution (e.g., "General", "Deep-Analysis", "Codex-General", "Codex-Deep-Analysis", "Cursor") so voters have context, but instruct voters to evaluate each finding on its merits regardless of who proposed it.
+
+## Voter Output Format
+
+Each voter must output one line per finding:
+
+```
+FINDING_1: YES — <one-line rationale>
+FINDING_2: NO — <one-line rationale>
+FINDING_3: EXONERATE — <one-line rationale>
+...
+```
+
+Valid vote tokens are `YES`, `NO`, and `EXONERATE`. If a voter's output contains valid votes for some findings but is missing votes for others, use the valid votes and treat only the missing findings as abstentions (reduce the voter pool size for those findings). Treat the entire output as unparseable only if zero findings can be matched to the expected format — in that case, treat all their votes as abstentions.
+
+## Threshold Rules
+
+| Eligible Voters | YES Votes Required | Notes |
+|---|---|---|
+| 3 | 2+ | Standard majority |
+| 2 | 2 (unanimous) | When one voter unavailable/timed out |
+| 1 | Skip voting | Fall back to accepting all findings |
+| 0 | Skip voting | Fall back to accepting all findings |
+
+When voting is skipped due to insufficient voters, print: `**⚠ Voting skipped (<N> voter(s) available, minimum 2 required). All findings accepted.**`
+
+## Voter Panel Composition
+
+**For plan review** (`/design` Step 3):
+- **Voter 1**: Claude Deep Analysis reviewer subagent — launched as a fresh Agent tool invocation with a focused voting prompt (separate from the reviewer subagents)
+- **Voter 2**: Codex — via `run-external-reviewer.sh`
+- **Voter 3**: Cursor — via `run-external-reviewer.sh`
+
+**For code review** (`/review` Step 3):
+- **Voter 1**: Claude General reviewer subagent — launched as a fresh Agent tool invocation
+- **Voter 2**: Codex — via `run-external-reviewer.sh`
+- **Voter 3**: Cursor — via `run-external-reviewer.sh`
+
+All voters vote on **all** findings — no self-voting exclusion. Voters are instructed to evaluate each finding objectively regardless of who proposed it.
+
+## Voter Prompt Template
+
+Customize the `{VOTER_ROLE}` and `{REVIEW_CONTEXT}` per skill:
+
+```
+You are a {VOTER_ROLE} participating in a voting panel. You will be presented with a list of proposed changes to {REVIEW_CONTEXT}. For each finding, vote YES, NO, or EXONERATE:
+- **YES**: The finding is correct, important, and worth implementing.
+- **NO**: The finding is incorrect, trivial, duplicative, or would cause more harm than good.
+- **EXONERATE**: The finding raises a legitimate concern worth noting, but is not worth implementing in this PR. This spares the proposing reviewer from a penalty.
+
+Be scrupulous — only vote YES for findings that genuinely improve the {REVIEW_CONTEXT}. Use EXONERATE when a concern is valid but not actionable now.
+
+{BALLOT}
+
+For each finding, output exactly one line:
+FINDING_N: YES — <one-line rationale>
+or
+FINDING_N: NO — <one-line rationale>
+or
+FINDING_N: EXONERATE — <one-line rationale>
+
+You must vote on every finding. Do NOT skip any. Do NOT modify files.
+```
+
+## Launching Voters
+
+Launch all 3 voters **in parallel** (in a single message). Spawn order: Cursor first (slowest), then Codex, then Claude subagent (fastest).
+
+**Cursor voter** (if `cursor_available`):
+
+```bash
+$PWD/.claude/scripts/generic/larch/run-external-reviewer.sh --tool cursor --output "<tmpdir>/cursor-vote-output.txt" --timeout 600 --capture-stdout -- \
+  cursor agent -p --force --trust --model gpt-5.4-medium --workspace "$PWD" \
+    "<voter prompt with ballot>"
+```
+
+Use `run_in_background: true` and `timeout: 660000`.
+
+**Codex voter** (if `codex_available`):
+
+```bash
+$PWD/.claude/scripts/generic/larch/run-external-reviewer.sh --tool codex --output "<tmpdir>/codex-vote-output.txt" --timeout 600 -- \
+  codex exec --full-auto -C "$PWD" \
+    --output-last-message "<tmpdir>/codex-vote-output.txt" \
+    "<voter prompt with ballot>"
+```
+
+Use `run_in_background: true` and `timeout: 660000`.
+
+**Claude voter**: Launch via Agent tool with the voter prompt.
+
+Wait for external voter sentinels using `wait-for-reviewers.sh` (use the same tmpdir as the review phase — do not create a new temp directory for voting). Only include sentinel paths for voters that were actually launched:
+
+```bash
+$PWD/.claude/scripts/generic/larch/wait-for-reviewers.sh --timeout 660 \
+  "<tmpdir>/cursor-vote-output.txt.done" \
+  "<tmpdir>/codex-vote-output.txt.done"
+```
+
+Use `timeout: 660000` on the Bash tool call. **Do NOT** set `run_in_background: true` — this call must block. Note: voter output files use the `-vote-` infix to avoid collision with reviewer output files (`-plan-output` or `-output`).
+
+## Competition Scoring
+
+After tallying votes, compute a score for each **original reviewer** (not voters):
+
+| Vote Result | Points | Description |
+|---|---|---|
+| Finding accepted (2+ YES) | +1 | Reviewer's finding was validated by the panel |
+| Finding got exactly 1 YES | 0 | Neutral — not enough support but not rejected |
+| Finding got 0 YES but 1+ EXONERATE | 0 | Exonerated — legitimate concern, not actionable now |
+| Finding got 0 YES and 0 EXONERATE | -1 | Rejected — finding was unanimously dismissed |
+
+If a deduplicated finding was proposed by multiple reviewers (merged during deduplication), **all** contributing reviewers receive the same points for that finding.
+
+## Scoreboard
+
+After voting, print a scoreboard to the session:
+
+```
+## Reviewer Competition Scoreboard
+
+| Reviewer | Findings | Accepted | Neutral (1 YES) | Exonerated (0 YES, 1+ EXON.) | Rejected (0 YES, 0 EXON.) | Score |
+|----------|----------|----------|-----------------|-------------------------------|---------------------------|-------|
+| General              | 3        | 2        | 1               | 0                             | 0                         | +2    |
+| Deep-Analysis        | 2        | 1        | 0               | 1                             | 0                         | +1    |
+| Codex-General        | 1        | 0        | 0               | 0                             | 1                         | -1    |
+| Codex-Deep-Analysis  | 1        | 1        | 0               | 0                             | 0                         | +1    |
+| Cursor               | 2        | 1        | 1               | 0                             | 0                         | +1    |
+
+Note: In future iterations, token allocation will be weighted proportionally
+to reviewer scores — higher-scoring reviewers will receive more tokens.
+```
+
+## Out-of-Scope Observations
+
+Reviewers may return a second list of **out-of-scope observations** — pre-existing issues or concerns beyond the PR's scope that are worth surfacing for future attention. These are handled alongside in-scope findings but with different semantics:
+
+### OOS on the Ballot
+
+Out-of-scope items are deduplicated separately from in-scope findings and assigned IDs with an `OOS_` prefix (e.g., `OOS_1`, `OOS_2`). They are included on the same ballot as in-scope findings, labeled with `[OUT_OF_SCOPE]`:
+
+```
+OOS_1: [OUT_OF_SCOPE] General — <description of pre-existing issue>
+```
+
+### OOS Vote Semantics
+
+For out-of-scope items, the vote meanings are:
+- **YES**: Promote this observation to in-scope — it should be implemented in this PR.
+- **NO**: Keep as observation — not worth addressing now.
+- **EXONERATE**: Legitimate observation worth documenting — keep as observation.
+
+If an OOS item receives 2+ YES votes, it is **promoted** to in-scope and treated as an accepted finding (implemented/revised). Otherwise it remains an observation.
+
+### OOS Scoring
+
+Out-of-scope items use a **per-item scoring floor of 0**. This floor applies **only to OOS items** — in-scope findings retain normal scoring including -1 for rejected.
+
+| OOS Vote Result | Points | Description |
+|---|---|---|
+| OOS promoted (2+ YES) | +1 | Reviewer surfaced an issue worth fixing now |
+| OOS not promoted | 0 | Reviewer surfaced a useful observation (no penalty) |
+
+### OOS Scoreboard
+
+The scoreboard includes additional columns for OOS items:
+
+```
+| Reviewer | ... | OOS Proposed | OOS Promoted | ...
+```
+
+### OOS Reporting
+
+Non-promoted OOS items are **not** written to `rejected-findings.md`. They are collected separately and reported in a dedicated `<details><summary>Out-of-Scope Observations</summary>` section in the PR body. This section is populated by `/implement` Step 9a from conversation context.
+
+External reviewers (Codex, Cursor) use single-list prompts and do not produce OOS items — their entire output is treated as in-scope findings. Only Claude subagent reviewers (which use the dual-list templates from `reviewer-templates.md`) produce OOS items.
+
+## Zero Accepted Findings
+
+If voting filters out **all** in-scope findings (every in-scope finding rejected by the panel), print: `**ℹ Voting panel rejected all findings. No changes to implement.**` and skip the implementation/revision step. Proceed directly to the rejected findings report. (OOS items that were not promoted are still collected for reporting.)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,5 +28,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
-      - name: Run integration tests
+      - name: Run claudin integration test
         run: bash tests/test-setup-claudin.sh
+      - name: Run larch integration test
+        if: always()
+        run: bash tests/test-setup-larch.sh

--- a/CLAUDIN-TO-LARCH-MIGRATION.md
+++ b/CLAUDIN-TO-LARCH-MIGRATION.md
@@ -1,0 +1,84 @@
+# Claudin → Larch Migration Plan
+
+The repository was renamed from `claudin` to `larch` via the GitHub UI. This document tracks the internal rename of all `claudin` references to `larch`, which is being done in two PRs to avoid disrupting in-flight skill sessions that depend on the current `claudin/` script paths.
+
+## PR #1 — Additive copy (this PR)
+
+Goal: Create `larch`-named copies of every `claudin`-named file/directory, with file contents in the copies rewritten (case-preserving) so that all `claudin` substrings become `larch`. The original `claudin`-named files remain byte-identical so in-flight sessions and existing references continue to work.
+
+- [DONE] Copy `.claude/scripts/generic/claudin/` → `.claude/scripts/generic/larch/` with content rewritten (38 shell scripts)
+- [DONE] Copy `.claude/skills/shared/claudin/` → `.claude/skills/shared/larch/` with content rewritten (3 markdown docs: `voting-protocol.md`, `external-reviewers.md`, `reviewer-templates.md`)
+- [DONE] Copy `setup-claudin.sh` → `setup-larch.sh` with content rewritten
+- [DONE] Copy `tests/test-setup-claudin.sh` → `tests/test-setup-larch.sh` with content rewritten
+- [DONE] Add `.claude/scripts/generic/larch/*` Bash permission entry to `.claude/settings.json` (claudin entry kept)
+- [DONE] Extend `.github/workflows/ci.yaml` to also run `tests/test-setup-larch.sh` as a separate named step with `if: always()` so both tests run independently (claudin test kept)
+- [DONE] Verify each new larch file contains zero `claudin`/`Claudin`/`CLAUDIN` substrings
+- [DONE] Verify each original claudin-named file is byte-identical to the pre-PR version
+- [DONE] Verify `tests/test-setup-larch.sh` passes locally
+
+### Case-preserving substitution rules applied in the copies
+
+- `claudin` → `larch`
+- `Claudin` → `Larch`
+- `CLAUDIN` → `LARCH`
+
+All three rules are applied as literal `sed` substitutions (not regex). The order — `CLAUDIN` first, then `Claudin`, then `claudin` — is defensive: even though the three substrings are mutually exclusive at the character level, longest-first case order is standard best practice.
+
+### Dual-namespace behavior of `setup-larch.sh` during PR #1
+
+During the PR #1 → PR #2 transition window, both `.claude/scripts/generic/claudin/` and `.claude/scripts/generic/larch/` subtrees coexist inside the (renamed) larch submodule. Because `setup-larch.sh` is a literal `sed`-substituted copy of `setup-claudin.sh`, it walks the entire submodule's `.claude/` tree (via the same `find` loop its parent uses) and creates symlinks for files in **both** subtrees.
+
+This means a client repo running `setup-larch.sh` during the PR #1 window will end up with symlinks at **both** `.claude/scripts/generic/claudin/*` and `.claude/scripts/generic/larch/*`, both resolving into the (renamed) larch submodule. Similarly for the two shared-doc trees under `.claude/skills/shared/`.
+
+This dual-namespace behavior is **intentional** and **benign**:
+- Existing claudin-pathed callers (SKILL.md files, hooks, etc.) continue to work because the claudin symlinks and their target files both still exist.
+- New larch-pathed callers also work because the larch symlinks and their target files also exist.
+- It is the safest possible behavior for the dual-tree window: nothing that used to work stops working, and the new namespace is fully populated.
+
+**This dual-namespace behavior resolves naturally in PR #2** when the claudin subtree is deleted from the submodule:
+- `setup-larch.sh` in PR #2 sees only the larch tree and only creates larch symlinks.
+- Any orphan claudin symlinks in the client repo (carried over from PR #1) will be removed by Phase 2 (dead-symlink cleanup) of `setup-larch.sh` because their resolved targets — for example `larch/.claude/scripts/generic/claudin/foo.sh` — will then point at deleted files, and Phase 2 specifically removes symlinks whose resolved targets live inside the larch submodule and no longer exist.
+
+### Behavioral callout: `CLAUDIN_*` environment variables become `LARCH_*` in the copies
+
+The case-preserving substitution rewrites `CLAUDIN_*` environment variable names to `LARCH_*` inside every new larch script. Specifically:
+
+- `CLAUDIN_SLACK_BOT_TOKEN` → `LARCH_SLACK_BOT_TOKEN`
+- `CLAUDIN_SLACK_CHANNEL_ID` → `LARCH_SLACK_CHANNEL_ID`
+- `CLAUDIN_SLACK_USER_ID` → `LARCH_SLACK_USER_ID`
+
+During the PR #1 window the new larch scripts are dead code (not invoked by any SKILL.md or hook — the in-flight skills still call the claudin paths), so this rename has **no runtime effect in PR #1**.
+
+Once PR #2 cuts over (SKILL.md files, agents, settings.json hooks, and docs are all re-pointed to the larch paths, and the claudin originals are deleted), operators running these scripts **must** set the `LARCH_*` environment variables in their shell/CI environment. If an operator's existing environment has `CLAUDIN_SLACK_BOT_TOKEN` set but not `LARCH_SLACK_BOT_TOKEN`, the new larch scripts will treat the Slack token as missing and skip Slack posting with a warning. Document this clearly in the PR #2 release notes.
+
+## PR #2 — Cutover and cleanup (follow-up, not done in this PR)
+
+Goal: Switch all internal references from `claudin` paths to `larch` paths, then delete the claudin-named originals. After this PR, `grep -ri claudin .` (excluding `.git/` and this migration doc) should return zero matches.
+
+- [TODO] Update content of `README.md` (replace `claudin` with `larch`, case-preserving)
+- [TODO] Update content of `.claude/agents/general-reviewer.md`
+- [TODO] Update content of `.claude/agents/deep-analysis-reviewer.md`
+- [TODO] Update content of `.claude/skills/design/SKILL.md`
+- [TODO] Update content of `.claude/skills/implement/SKILL.md`
+- [TODO] Update content of `.claude/skills/research/SKILL.md`
+- [TODO] Update content of `.claude/skills/review/SKILL.md`
+- [TODO] Update content of `.claude/skills/loop-review/SKILL.md`
+- [TODO] Update content of `.claude/skills/shazam/SKILL.md`
+- [TODO] Update content of `docs/review-agents.md`
+- [TODO] Update content of `.pre-commit-config.yaml` (header comment mentions "Claudin")
+- [TODO] Update content of `Makefile` (header comment mentions "Claudin")
+- [TODO] Remove `Bash($PWD/.claude/scripts/generic/claudin/*)` permission entry from `.claude/settings.json`
+- [TODO] Remove `Bash(CLAUDIN_SLACK_USER_ID=:*)` from `.claude/settings.json` (if it proves vestigial — verify first that no script uses the inline env-var-prefix form)
+- [TODO] Re-point the four hook entries in `.claude/settings.json` from `.claude/scripts/generic/claudin/block-submodule-edit.sh` and `.claude/scripts/generic/claudin/auto-goimports.sh` to the `.claude/scripts/generic/larch/` equivalents (lines ~235, 244, 255, 264 in the current file)
+- [TODO] Remove the `Run claudin integration test` step from `.github/workflows/ci.yaml` (keeping only the larch integration test step, with the `if: always()` guard removed since there is no longer a predecessor step it needs to run after)
+- [TODO] Delete `.claude/scripts/generic/claudin/` (directory and all 38 scripts)
+- [TODO] Delete `.claude/skills/shared/claudin/` (directory and all 3 docs)
+- [TODO] Delete `setup-claudin.sh`
+- [TODO] Delete `tests/test-setup-claudin.sh`
+- [TODO] Run `grep -ri claudin .` (excluding `.git/` and this migration doc) and verify zero matches
+- [TODO] Document the `CLAUDIN_* → LARCH_*` env var rename in the PR #2 release notes so operators update their shell/CI environment variables
+- [TODO] Mark this section DONE and merge PR #2
+
+## Why two PRs?
+
+The in-flight `/shazam` and `/implement` skill sessions running at the moment this migration is executed are currently invoking scripts under `.claude/scripts/generic/claudin/`. A single-PR rename would require modifying those scripts (or the SKILL.md files that reference them) mid-flight, risking breakage of the very skill session doing the migration. Splitting the work across two PRs guarantees that every file needed by the in-flight session remains byte-identical throughout PR #1; only after PR #1 has safely merged is it safe to mutate the originals in PR #2.

--- a/setup-larch.sh
+++ b/setup-larch.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+# setup-larch.sh — Sync symlinks from a client repo's .claude/ into larch/.claude/ (the submodule).
+#
+# Intended to be run from the root of a client repo that has larch as a git submodule.
+# The script derives the submodule path from its own location, so it works regardless of
+# the submodule directory name.
+#
+# Symlink strategy (hybrid):
+#   - Skill directories (contain SKILL.md) → directory-level symlinks
+#   - Everything else (scripts, agents, shared docs) → file-level symlinks
+#   - settings*.json → always skipped (client must maintain their own)
+#
+# Conflict handling:
+#   - If a non-symlink file or directory exists at a target path → exit 1 with error
+#   - If a correct symlink exists → skip (idempotent)
+#   - If a symlink exists but points to wrong target → update it
+#
+# Dead symlink cleanup:
+#   - Removes symlinks under .claude/ whose resolved target points into the larch
+#     submodule but whose target no longer exists.
+#
+# Usage:
+#   ./larch/setup-larch.sh
+#
+# Exit codes:
+#   0 — success
+#   1 — error (conflict, missing submodule, not a git repo, etc.)
+
+set -euo pipefail
+
+# --- Derive paths ---
+# LARCH_DIR: absolute path to the larch submodule (where this script lives)
+LARCH_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+
+# REPO_ROOT: the git repository root of the client repo
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+    echo "ERROR: Not inside a git repository." >&2
+    exit 1
+}
+REPO_ROOT="$(cd "$REPO_ROOT" && pwd -P)"
+
+# Verify we are running from the repo root
+if [[ "$(pwd -P)" != "$REPO_ROOT" ]]; then
+    echo "ERROR: Must run from the repository root ($REPO_ROOT), not $(pwd -P)." >&2
+    exit 1
+fi
+
+# Verify the larch .claude directory exists
+if [[ ! -d "$LARCH_DIR/.claude" ]]; then
+    echo "ERROR: $LARCH_DIR/.claude does not exist. Is the submodule checked out?" >&2
+    exit 1
+fi
+
+# Verify the larch submodule is inside the repo root
+if [[ "$LARCH_DIR" != "$REPO_ROOT/"* ]]; then
+    echo "ERROR: larch submodule ($LARCH_DIR) is not inside the repo root ($REPO_ROOT)." >&2
+    echo "  Run this script from the repository that contains larch as a submodule." >&2
+    exit 1
+fi
+
+# LARCH_REL: relative path from repo root to the larch submodule
+LARCH_REL="${LARCH_DIR#"$REPO_ROOT"/}"
+
+# --- Helper: compute relative symlink target ---
+# Given a symlink path relative to repo root (e.g., .claude/skills/design)
+# and a target path relative to repo root (e.g., larch/.claude/skills/design),
+# compute the relative path from the symlink's parent to the target.
+compute_relpath() {
+    local link_path="$1"  # e.g., .claude/scripts/generic/larch/foo.sh
+    local target_path="$2"  # e.g., larch/.claude/scripts/generic/larch/foo.sh
+
+    local parent_dir
+    parent_dir="$(dirname "$link_path")"
+
+    # Count depth of parent directory (number of / separated components)
+    local depth=0
+    local tmp="$parent_dir"
+    while [[ "$tmp" != "." && -n "$tmp" ]]; do
+        tmp="$(dirname "$tmp")"
+        depth=$((depth + 1))
+    done
+
+    # Build ../ prefix
+    local prefix=""
+    local i
+    for ((i = 0; i < depth; i++)); do
+        prefix="../${prefix}"
+    done
+
+    echo "${prefix}${target_path}"
+}
+
+# --- Helper: create a symlink with validation ---
+create_link() {
+    local link_path="$1"   # relative to repo root
+    local target_path="$2" # relative to repo root (in larch)
+    local link_type="$3"   # "dir" or "file" (for messages only)
+
+    # Ensure parent directory exists
+    mkdir -p "$(dirname "$link_path")"
+
+    if [[ -L "$link_path" ]]; then
+        # Symlink already exists — check if it points to the right target
+        local current_target
+        current_target="$(readlink "$link_path")"
+        local expected_target
+        expected_target="$(compute_relpath "$link_path" "$target_path")"
+
+        if [[ "$current_target" == "$expected_target" ]]; then
+            # Correct symlink, skip
+            return 0
+        else
+            # Wrong target, update
+            rm "$link_path"
+            ln -s "$expected_target" "$link_path"
+            echo "  updated ($link_type): $link_path -> $expected_target"
+        fi
+    elif [[ -e "$link_path" ]]; then
+        # Non-symlink exists — conflict
+        echo "ERROR: Conflict at '$link_path' — a non-symlink file or directory already exists." >&2
+        echo "  Remove or rename it before re-running this script." >&2
+        exit 1
+    else
+        # Create new symlink
+        local rel_target
+        rel_target="$(compute_relpath "$link_path" "$target_path")"
+        ln -s "$rel_target" "$link_path"
+        echo "  linked ($link_type): $link_path -> $rel_target"
+    fi
+
+    # Validate the symlink resolves to an existing target
+    if [[ ! -e "$link_path" ]]; then
+        echo "ERROR: Symlink '$link_path' was created but does not resolve to an existing target." >&2
+        echo "  This indicates a bug in relative path computation." >&2
+        exit 1
+    fi
+}
+
+# --- Phase 1: Create symlinks ---
+echo "Phase 1: Creating symlinks from .claude/ into $LARCH_REL/.claude/..."
+
+# Walk the larch .claude directory
+while IFS= read -r -d '' entry; do
+    # entry is relative to LARCH_DIR/.claude, e.g., "skills/design" or "agents/generic-reviewer.md"
+    local_path="${entry#"$LARCH_DIR/.claude/"}"
+
+    # Skip settings*.json — client must maintain their own
+    if [[ "$local_path" == settings*.json ]]; then
+        # Remove any existing symlink from a prior version that linked settings files
+        if [[ -L ".claude/$local_path" ]]; then
+            rm ".claude/$local_path"
+            echo "  removed stale symlink: .claude/$local_path (maintain your own)"
+        else
+            echo "  skipped: .claude/$local_path (maintain your own)"
+        fi
+        continue
+    fi
+
+    # Determine the link path in the client repo
+    link_path=".claude/$local_path"
+    target_path="$LARCH_REL/.claude/$local_path"
+
+    # Check if this is a skill directory (first-level child of skills/ with SKILL.md)
+    if [[ "$entry" == "$LARCH_DIR/.claude/skills/"* ]]; then
+        # Extract the first-level name under skills/
+        local_under_skills="${local_path#skills/}"
+        first_component="${local_under_skills%%/*}"
+
+        # Only process first-level entries under skills/
+        if [[ "$local_under_skills" == "$first_component" ]]; then
+            # Skip relevant-checks — repo-specific skill, client must maintain their own
+            if [[ "$first_component" == "relevant-checks" ]]; then
+                echo "  skipped: .claude/skills/relevant-checks (repo-specific, maintain your own)"
+                continue
+            fi
+            if [[ -d "$entry" && -f "$entry/SKILL.md" ]]; then
+                # Skill directory — directory-level symlink
+                create_link "$link_path" "$target_path" "skill dir"
+            elif [[ -d "$entry" ]]; then
+                # Non-skill directory under skills/ (e.g., shared/) — descend into it
+                # File-level symlinks will be handled when we encounter individual files
+                :
+            elif [[ -f "$entry" ]]; then
+                # File directly under skills/ (unusual but handle it)
+                create_link "$link_path" "$target_path" "file"
+            fi
+        else
+            # Nested entry under skills/ — check if the first-level parent is a skill dir
+            first_level_dir="$LARCH_DIR/.claude/skills/$first_component"
+            if [[ -f "$first_level_dir/SKILL.md" ]]; then
+                # Inside a skill directory — already covered by directory-level symlink, skip
+                :
+            elif [[ -f "$entry" ]]; then
+                # File inside a non-skill directory (e.g., skills/shared/voting-protocol.md)
+                create_link "$link_path" "$target_path" "file"
+            fi
+            # Directories inside non-skill dirs are handled by mkdir -p in create_link
+        fi
+    elif [[ -f "$entry" ]]; then
+        # Non-skills file (agents/*.md, scripts/generic/*.sh, etc.)
+        create_link "$link_path" "$target_path" "file"
+    fi
+    # Directories outside skills/ are traversed automatically by find; we only link files
+done < <(find "$LARCH_DIR/.claude" -not -path "$LARCH_DIR/.claude" \( -type f -o -type d \) -print0 | sort -z)
+
+# --- Phase 2: Remove dead symlinks ---
+echo "Phase 2: Removing dead symlinks pointing into $LARCH_REL/.claude/..."
+
+dead_count=0
+while IFS= read -r -d '' link; do
+    # Only process broken symlinks (target does not exist)
+    if [[ -e "$link" ]]; then
+        continue
+    fi
+
+    # Read the raw symlink target
+    raw_target="$(readlink "$link")"
+
+    # Resolve the target to an absolute path by joining with the link's parent dir
+    link_parent="$(cd "$(dirname "$link")" && pwd -P)"
+    # Attempt to resolve — since the target is broken, we normalize manually
+    # Join parent + raw_target, then check if it would be inside LARCH_DIR/.claude/
+    resolved=""
+    if [[ "$raw_target" == /* ]]; then
+        resolved="$raw_target"
+    else
+        # Normalize: use a subshell to walk the path components
+        # Since the target is broken, we resolve as far as we can
+        resolved="$link_parent/$raw_target"
+    fi
+
+    # Normalize by collapsing .. components
+    # Use Python for reliable cross-platform normalization
+    normalized="$(python3 -c "import os, sys; print(os.path.normpath(sys.argv[1]))" "$resolved" 2>/dev/null)" || {
+        # If python3 is not available, skip this link
+        continue
+    }
+
+    # Check if the normalized path is inside the larch .claude directory
+    if [[ "$normalized" == "$LARCH_DIR/.claude" || "$normalized" == "$LARCH_DIR/.claude/"* ]]; then
+        rm "$link"
+        echo "  removed dead symlink: $link -> $raw_target"
+        dead_count=$((dead_count + 1))
+    fi
+done < <(find .claude -type l -print0 2>/dev/null || true)
+
+echo ""
+echo "Done. Dead symlinks removed: $dead_count"
+echo ""
+echo "NOTE: .claude/settings*.json files were not synced. Ensure your settings.json"
+echo "includes the necessary permissions for larch scripts. At minimum:"
+echo "  - Bash permission for \$PWD/.claude/scripts/generic/larch/*"
+echo "  - The block-submodule-edit.sh hook (if using submodule flow)"
+echo ""
+echo "MIGRATION: If upgrading from an older larch version, update your"
+echo "settings.json to replace old paths with new ones:"
+echo "  - \$PWD/.claude/scripts/generic/*  →  \$PWD/.claude/scripts/generic/larch/*"
+echo "  - \$PWD/.claude/scripts/generic/block-submodule-edit.sh  →  \$PWD/.claude/scripts/generic/larch/block-submodule-edit.sh"
+echo "  - \$PWD/.claude/scripts/generic/auto-goimports.sh  →  \$PWD/.claude/scripts/generic/larch/auto-goimports.sh"

--- a/tests/test-setup-larch.sh
+++ b/tests/test-setup-larch.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# test-setup-larch.sh — Integration test for setup-larch.sh
+#
+# Creates a temporary fake client repo with larch as a subdirectory,
+# runs setup-larch.sh, and verifies symlinks are created correctly
+# for the larch/ subdirectory structure under scripts/generic/ and
+# skills/shared/.
+#
+# Exit codes:
+#   0 — all tests passed
+#   1 — one or more tests failed
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+LARCH_DIR="$(cd "$SCRIPT_DIR/.." && pwd -P)"
+
+# Create a temporary directory for the fake client repo
+TEST_REPO_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_REPO_DIR"' EXIT
+
+echo "=== Setting up fake client repo in $TEST_REPO_DIR ==="
+
+# Initialize a git repo
+cd "$TEST_REPO_DIR"
+git init -q
+git config user.email "test@larch.test"
+git config user.name "Larch Test"
+git commit --allow-empty -m "init" -q
+
+# Copy larch into the fake client repo as a subdirectory
+# (not a real submodule, but setup-larch.sh only needs the directory structure)
+cp -R "$LARCH_DIR" "$TEST_REPO_DIR/larch"
+
+# Create settings.local.json fixture in the source so the settings*.json skip
+# is exercised during Phase 1. In CI this file is gitignored and absent from
+# the cp -R copy, so we create it explicitly to test the glob skip.
+if [[ ! -f "$TEST_REPO_DIR/larch/.claude/settings.local.json" ]]; then
+    echo '{}' > "$TEST_REPO_DIR/larch/.claude/settings.local.json"
+fi
+
+# Run setup-larch.sh from the repo root
+echo ""
+echo "=== Running setup-larch.sh ==="
+./larch/setup-larch.sh
+
+# --- Verification ---
+FAILURES=0
+
+check_symlink() {
+    local path="$1"
+    local description="$2"
+    if [[ -L "$path" ]]; then
+        if [[ -e "$path" ]]; then
+            echo "  PASS: $description ($path)"
+        else
+            echo "  FAIL: $description — symlink exists but target does not resolve ($path -> $(readlink "$path"))"
+            FAILURES=$((FAILURES + 1))
+        fi
+    else
+        echo "  FAIL: $description — not a symlink ($path)"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+check_not_exists() {
+    local path="$1"
+    local description="$2"
+    if [[ -e "$path" || -L "$path" ]]; then
+        echo "  FAIL: $description — should not exist ($path)"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "  PASS: $description ($path does not exist)"
+    fi
+}
+
+echo ""
+echo "=== Verifying symlinks ==="
+
+# Skill directories should be directory-level symlinks
+echo "--- Skill directories (directory-level symlinks) ---"
+for skill_dir in "$TEST_REPO_DIR"/larch/.claude/skills/*/; do
+    skill_name="$(basename "$skill_dir")"
+    [[ "$skill_name" == "shared" ]] && continue
+    [[ "$skill_name" == "relevant-checks" ]] && continue
+    if [[ -f "$skill_dir/SKILL.md" ]]; then
+        check_symlink ".claude/skills/$skill_name" "skill dir: $skill_name"
+    fi
+done
+
+# relevant-checks should NOT be symlinked (repo-specific skill)
+echo "--- relevant-checks ---"
+check_not_exists ".claude/skills/relevant-checks" "relevant-checks should not be symlinked"
+
+# Verify setup-larch.sh does not conflict with a pre-existing relevant-checks directory
+echo "--- relevant-checks conflict test ---"
+mkdir -p ".claude/skills/relevant-checks"
+echo "# Client-specific checks" > ".claude/skills/relevant-checks/SKILL.md"
+# Re-run — should succeed without error despite the pre-existing directory
+rc=0
+./larch/setup-larch.sh > /dev/null 2>&1 || rc=$?
+if [[ $rc -eq 0 ]]; then
+    echo "  PASS: setup-larch.sh succeeds with pre-existing relevant-checks"
+else
+    echo "  FAIL: setup-larch.sh exited $rc with pre-existing relevant-checks"
+    FAILURES=$((FAILURES + 1))
+fi
+# Verify the client's relevant-checks was not replaced
+if [[ ! -L ".claude/skills/relevant-checks" && -f ".claude/skills/relevant-checks/SKILL.md" ]]; then
+    echo "  PASS: client's relevant-checks preserved (not a symlink)"
+else
+    echo "  FAIL: client's relevant-checks was replaced or symlinked"
+    FAILURES=$((FAILURES + 1))
+fi
+
+# Scripts under scripts/generic/larch/ should be file-level symlinks
+echo "--- Scripts (file-level symlinks under scripts/generic/larch/) ---"
+script_count=0
+for script in "$TEST_REPO_DIR"/larch/.claude/scripts/generic/larch/*.sh; do
+    script_name="$(basename "$script")"
+    check_symlink ".claude/scripts/generic/larch/$script_name" "script: $script_name"
+    script_count=$((script_count + 1))
+done
+echo "  (checked $script_count scripts)"
+
+# Shared .md files under skills/shared/larch/ should be file-level symlinks
+echo "--- Shared .md files (file-level symlinks under skills/shared/larch/) ---"
+md_count=0
+for md_file in "$TEST_REPO_DIR"/larch/.claude/skills/shared/larch/*.md; do
+    md_name="$(basename "$md_file")"
+    check_symlink ".claude/skills/shared/larch/$md_name" "shared md: $md_name"
+    md_count=$((md_count + 1))
+done
+echo "  (checked $md_count shared .md files)"
+
+# Agent files should be file-level symlinks
+echo "--- Agent files ---"
+for agent in "$TEST_REPO_DIR"/larch/.claude/agents/*.md; do
+    agent_name="$(basename "$agent")"
+    check_symlink ".claude/agents/$agent_name" "agent: $agent_name"
+done
+
+# settings.json should NOT be symlinked
+echo "--- settings*.json ---"
+check_not_exists ".claude/settings.json" "settings.json should not be symlinked"
+
+# settings.local.json should NOT be symlinked (covered by settings*.json glob skip)
+# Fixture was created before the first run (see above), so this assertion is meaningful.
+check_not_exists ".claude/settings.local.json" "settings.local.json should not be symlinked"
+
+# --- Re-run test (idempotency) ---
+echo ""
+echo "=== Re-running setup-larch.sh (idempotency test) ==="
+./larch/setup-larch.sh
+
+echo ""
+echo "=== Verifying symlinks still correct after re-run ==="
+rerun_ok=true
+for script in "$TEST_REPO_DIR"/larch/.claude/scripts/generic/larch/*.sh; do
+    script_name="$(basename "$script")"
+    if [[ ! -L ".claude/scripts/generic/larch/$script_name" ]] || [[ ! -e ".claude/scripts/generic/larch/$script_name" ]]; then
+        echo "  FAIL: script $script_name broken after re-run"
+        FAILURES=$((FAILURES + 1))
+        rerun_ok=false
+    fi
+done
+if $rerun_ok; then
+    echo "  PASS: All symlinks correct after re-run"
+fi
+
+# --- Phase 2: Dead symlink removal ---
+echo ""
+echo "=== Testing Phase 2: Dead symlink removal ==="
+# Create a fake stale symlink simulating a pre-migration path pointing into larch
+mkdir -p .claude/scripts/generic
+ln -s "../../../larch/.claude/scripts/generic/nonexistent-old-script.sh" ".claude/scripts/generic/stale-old.sh"
+# Re-run setup-larch.sh — Phase 2 should remove the stale symlink
+./larch/setup-larch.sh
+check_not_exists ".claude/scripts/generic/stale-old.sh" "stale symlink should be removed by Phase 2"
+
+# --- Summary ---
+echo ""
+if [[ $FAILURES -eq 0 ]]; then
+    echo "=== ALL TESTS PASSED ==="
+    exit 0
+else
+    echo "=== $FAILURES TEST(S) FAILED ==="
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- Added larch-named copies of all 38 claudin shell scripts, 3 shared markdown docs, `setup-claudin.sh`, and `tests/test-setup-claudin.sh` with file contents rewritten via case-preserving sed (CLAUDIN→LARCH, Claudin→Larch, claudin→larch). The original claudin-named files remain byte-identical so in-flight `/shazam` and `/implement` sessions continue to work.
- Added `CLAUDIN-TO-LARCH-MIGRATION.md` tracking doc with PR #1 DONE + PR #2 TODO checklists, an explicit section documenting the intentional dual-namespace symlink behavior of `setup-larch.sh` during the transition window, and a callout that `CLAUDIN_*` env vars become `LARCH_*` in the copies.
- Added one `Bash($PWD/.claude/scripts/generic/larch/*)` permission entry to `.claude/settings.json` and extended `.github/workflows/ci.yaml` with a second integration test step for larch (`if: always()` so both tests run independently of each other's outcome).

<details><summary>Architecture Diagram</summary>

```mermaid
graph TB
    subgraph Source["Source: claudin (untouched)"]
        S1[".claude/scripts/generic/claudin/<br/>38 shell scripts"]
        S2[".claude/skills/shared/claudin/<br/>3 markdown docs"]
        S3["setup-claudin.sh"]
        S4["tests/test-setup-claudin.sh"]
    end

    subgraph Dest["Destination: larch (new copies)"]
        D1[".claude/scripts/generic/larch/<br/>38 shell scripts<br/>(content rewritten)"]
        D2[".claude/skills/shared/larch/<br/>3 markdown docs<br/>(content rewritten)"]
        D3["setup-larch.sh<br/>(content rewritten)"]
        D4["tests/test-setup-larch.sh<br/>(content rewritten)"]
    end

    subgraph Modified["Existing files: 2 surgical edits"]
        M1[".claude/settings.json<br/>+1 Bash(...larch/*) entry"]
        M2[".github/workflows/ci.yaml<br/>2 separate test steps<br/>(claudin + larch with if:always)"]
    end

    subgraph Tracking["New tracking artifact"]
        T1["CLAUDIN-TO-LARCH-MIGRATION.md<br/>PR #1 done checklist<br/>PR #2 todo checklist<br/>Dual-namespace behavior doc<br/>LARCH_* env var callout"]
    end

    subgraph Untouched["Untouched (deferred to PR #2)"]
        U1["README.md"]
        U2[".claude/skills/*/SKILL.md (6 files)"]
        U3[".claude/agents/*.md (2 files)"]
        U4["docs/review-agents.md"]
        U5["settings.json hook entries"]
    end

    S1 -. "cp + sed<br/>3-pass case-preserving" .-> D1
    S2 -. "cp + sed" .-> D2
    S3 -. "cp + sed" .-> D3
    S4 -. "cp + sed" .-> D4

    Source -. "still functional, drives in-flight skill sessions" .-> InFlight((In-flight<br/>/shazam<br/>/implement))
    Dest -. "dead code in PR #1, activated in PR #2" .-> Future((PR #2<br/>cutover))

    style Source fill:#e8f4f8
    style Dest fill:#e8f8e8
    style Modified fill:#fff8e8
    style Tracking fill:#f8e8f8
    style Untouched fill:#f0f0f0
    style InFlight fill:#ffd0d0
    style Future fill:#d0e8ff
```

</details>

<details><summary>Code Flow Diagram</summary>

```mermaid
flowchart LR
    A[("38 claudin scripts<br/>3 claudin shared docs<br/>setup-claudin.sh<br/>test-setup-claudin.sh")]
    A --> B["bash loop<br/>sed -e s|CLAUDIN|LARCH|g<br/>    -e s|Claudin|Larch|g<br/>    -e s|claudin|larch|g"]
    B --> C["chmod<br/>stat -f '%A' src → dst"]
    C --> D[("38 larch scripts<br/>3 larch shared docs<br/>setup-larch.sh<br/>test-setup-larch.sh")]

    E["Edit tool"] --> F[".claude/settings.json<br/>+1 Bash(...larch/*) entry"]
    G["Edit tool"] --> H[".github/workflows/ci.yaml<br/>+1 larch test step<br/>with if: always()"]

    I["Write tool"] --> J["CLAUDIN-TO-LARCH-MIGRATION.md<br/>PR #1 DONE + PR #2 TODO<br/>+ dual-namespace section<br/>+ LARCH_* env var callout"]

    D --> K[["Pre-commit verification"]]
    F --> K
    H --> K
    J --> K
    K --> L{"zero claudin in<br/>new larch tree?"}
    L -->|"PASS"| M{"originals<br/>byte-identical?"}
    L -->|"FAIL"| X["abort"]
    M -->|"PASS"| N{"bash -n on<br/>every new script?"}
    M -->|"FAIL"| X
    N -->|"PASS"| O{"JSON+YAML<br/>valid?"}
    N -->|"FAIL"| X
    O -->|"PASS"| P{"tests/test-setup-larch.sh<br/>exits 0?"}
    O -->|"FAIL"| X
    P -->|"PASS"| Q["git commit<br/>46 files,<br/>4077 insertions"]
    P -->|"FAIL"| X

    style A fill:#e8f4f8
    style D fill:#e8f8e8
    style F fill:#fff8e8
    style H fill:#fff8e8
    style J fill:#f8e8f8
    style Q fill:#d0f0d0
    style X fill:#f8d0d0
```

</details>

<details><summary>Goal</summary>

- Begin the claudin→larch rename migration of the internal repository references. The repository itself was already renamed from `claudin` to `larch` via the GitHub UI; this PR is the first of two PRs that rename internal path references and script names from `claudin` to `larch`.
- Split the work into two PRs to avoid "cutting the branch we are sitting on" — the in-flight `/shazam` and `/implement` skill sessions that are driving this migration must continue to invoke scripts under `.claude/scripts/generic/claudin/` throughout PR #1. A single-PR rename would require mutating the very files the session is using.
- In PR #1 (this PR), make all the additive changes: create larch-named copies of every claudin-named file/directory, with file contents in the copies rewritten via case-preserving sed (CLAUDIN→LARCH, Claudin→Larch, claudin→larch). Keep the original claudin-named files byte-identical.
  - Add two narrow surgical additions to existing files so the new larch tree is usable and exercised:
    - `.claude/settings.json`: add one `Bash($PWD/.claude/scripts/generic/larch/*)` permission glob entry, keeping the existing claudin entry.
    - `.github/workflows/ci.yaml`: add a second `Run larch integration test` step with `if: always()` so both the claudin and larch integration tests run independently on every CI run.
  - Add a `CLAUDIN-TO-LARCH-MIGRATION.md` tracking doc at the repo root with PR #1 DONE / PR #2 TODO checklists, a documented "dual-namespace behavior of setup-larch.sh during PR #1" section, and an operator callout about the `CLAUDIN_* → LARCH_*` environment variable rename that takes effect in PR #2.
- In PR #2 (follow-up, NOT in this PR), re-point all consumer references (all SKILL.md files, agents, `README.md`, `docs/review-agents.md`, settings.json hooks, CI yaml) to the new larch paths, remove all claudin-named files, and verify `grep -ri claudin .` (excluding `.git/` and the migration doc) returns zero matches.
- Success criteria for PR #1:
  - Every new larch file contains ZERO `claudin`/`Claudin`/`CLAUDIN` substrings (verified by grep).
  - Every original claudin file is byte-identical to main (verified by `git diff --exit-code`).
  - File counts match: 38 scripts in the new larch scripts dir, 3 shared docs in the new larch shared dir.
  - Executable bits preserved on all copied scripts.
  - `.claude/settings.json` remains valid JSON and `.github/workflows/ci.yaml` remains valid YAML.
  - `tests/test-setup-larch.sh` passes locally.
  - All pre-commit lint hooks (shellcheck, markdownlint, JSON validation, actionlint) pass on the changed files.

</details>

<details><summary>Test plan</summary>

- [x] Pre-commit verification: zero `claudin`/`Claudin`/`CLAUDIN` substrings anywhere in the new larch tree (scripts + shared docs + setup-larch.sh + tests/test-setup-larch.sh). Verified via `grep -rEi 'claudin' ...` → zero matches.
- [x] Originals byte-identical: `git diff --exit-code -- .claude/scripts/generic/claudin/ .claude/skills/shared/claudin/ setup-claudin.sh tests/test-setup-claudin.sh` → clean.
- [x] File counts: 38 in `.claude/scripts/generic/larch/` and 3 in `.claude/skills/shared/larch/` (matching the claudin originals).
- [x] Executable bits: all 38 new scripts have `100755`, `setup-larch.sh` and `tests/test-setup-larch.sh` have `100755`.
- [x] `bash -n` syntax check on every new larch shell script: PASS on all 40.
- [x] `.claude/settings.json` is still valid JSON (`python3 -m json.tool`).
- [x] `.github/workflows/ci.yaml` is still valid YAML (`python3 -c 'import yaml; yaml.safe_load(...)'`).
- [x] `tests/test-setup-larch.sh` exits 0 locally (full run: symlink creation, idempotency re-run, Phase 2 dead-symlink removal — all passed).
- [x] Existing `tests/test-setup-claudin.sh` still exits 0 (no regression).
- [x] `/relevant-checks` on 46 changed files: shellcheck + markdownlint + JSON validation + actionlint all pass.
- [ ] CI integration-test job runs both `tests/test-setup-claudin.sh` and `tests/test-setup-larch.sh` as independent steps (to be verified by CI after push).
- [ ] CI lint job runs `make lint` / pre-commit on all changed files (to be verified by CI after push).

</details>

<details><summary>Final Design</summary>

### Files created (43 new files)

**New larch script directory (38 files)** under `.claude/scripts/generic/larch/`, mirroring `.claude/scripts/generic/claudin/` with file contents rewritten via 3-pass case-preserving sed. All 38 names: `add-merged-emoji.sh, add-slack-emoji.sh, auto-goimports.sh, block-submodule-edit.sh, check-bump-version.sh, check-reviewers.sh, ci-decide.sh, ci-rerun-failed.sh, ci-status.sh, ci-wait.sh, cleanup-tmpdir.sh, create-branch.sh, create-pr.sh, create-session-tmpdir.sh, gather-branch-context.sh, gh-pr-body-read.sh, gh-pr-body-update.sh, gh-pr-checks.sh, gh-run-logs.sh, git-branch-info.sh, git-commit.sh, git-rebase-abort.sh, local-cleanup.sh, merge-pr.sh, parse-pr-summary.sh, post-merged-emoji.sh, post-pr-announce.sh, post-slack-message.sh, preflight.sh, rebase-push.sh, run-external-reviewer.sh, run-negotiation-round.sh, session-setup.sh, slack-announce.sh, sleep-seconds.sh, verify-main.sh, wait-for-reviewers.sh, write-session-env.sh`.

Note: **38 scripts, not 37** — the earlier brief had a count typo; the actual directory listing confirms 38.

**New larch shared docs (3 files)** under `.claude/skills/shared/larch/`: `voting-protocol.md`, `external-reviewers.md`, `reviewer-templates.md`.

**Top-level larch files (2 files)**: `setup-larch.sh` (10705 bytes, mode 100755) and `tests/test-setup-larch.sh` (6846 bytes, mode 100755).

**Migration tracking doc**: `CLAUDIN-TO-LARCH-MIGRATION.md` at the repo root with sections:
- PR #1 — Additive copy (this PR) — 9 DONE items
- Case-preserving substitution rules (`claudin → larch`, `Claudin → Larch`, `CLAUDIN → LARCH`)
- Dual-namespace behavior of `setup-larch.sh` during PR #1
- Behavioral callout: `CLAUDIN_*` environment variables become `LARCH_*` in the copies (operators must set `LARCH_SLACK_BOT_TOKEN` etc. after PR #2 cuts over)
- PR #2 — Cutover and cleanup — 19 TODO items enumerating every SKILL.md file, agent file, doc, hook re-pointing step, and deletion
- Why two PRs? — explanatory section

### Files modified (2 surgical additions)

**`.claude/settings.json`**: added `"Bash($PWD/.claude/scripts/generic/larch/*)"` at line 5, immediately after the existing `"Bash($PWD/.claude/scripts/generic/claudin/*)"` entry. Existing claudin entries all preserved. Hook entries NOT mirrored — see below.

**`.github/workflows/ci.yaml`**: replaced the single `Run integration tests` step (line 31-32) with two independent steps:

```yaml
      - name: Run claudin integration test
        run: bash tests/test-setup-claudin.sh
      - name: Run larch integration test
        if: always()
        run: bash tests/test-setup-larch.sh
```

The `if: always()` guard on the second step ensures the larch integration test runs on every CI invocation regardless of whether the claudin test passes or fails — important for catching independent regressions during the dual-tree window.

### Deliberate deferrals to PR #2

- **Hook entries in `.claude/settings.json`** (lines 235, 244, 255, 264) are NOT mirrored — mirroring them would cause both claudin and larch versions of `block-submodule-edit.sh` and `auto-goimports.sh` to fire on every Edit/Write tool use, wasting CPU and potentially causing side effects (e.g., auto-goimports contention on Go file rewrites). PR #2 will atomically re-point the hook entries to the larch paths when the claudin originals are deleted.
- **No `Bash(LARCH_SLACK_USER_ID=:*)` or similar env-var permission entries** — the `Bash(VAR=:*)` pattern is for inline env-var prefixes (e.g., `VAR=val ./script.sh`), which no SKILL.md or script actually uses. The larch scripts read these variables from the operator's environment via `${VAR:-}` expansion, which needs no special permission.
- **All non-claudin-named existing files** (README.md, all 6 SKILL.md files, 2 agent files, docs/review-agents.md, .pre-commit-config.yaml, Makefile) remain untouched. PR #2 will substitute claudin→larch throughout.

### Approach

Inline Bash loop (no committed helper script, per CLAUDE.md "Don't create helpers for one-time operations"):

```bash
for src in .claude/scripts/generic/claudin/*; do
    name=$(basename "$src")
    dst=.claude/scripts/generic/larch/$name
    sed -e 's|CLAUDIN|LARCH|g' -e 's|Claudin|Larch|g' -e 's|claudin|larch|g' < "$src" > "$dst"
    chmod "$(stat -f '%A' "$src")" "$dst"
done
```

Same pattern for shared docs and the two standalone files. Edit tool for the two surgical JSON/YAML additions. Write tool for the migration doc.

### Pre-commit verification (run before commit)

1. `grep -rEi 'claudin' <new-larch-paths>` → zero matches.
2. `git diff --exit-code -- '.claude/scripts/generic/claudin/' '.claude/skills/shared/claudin/' setup-claudin.sh tests/test-setup-claudin.sh` → no diff.
3. `ls .claude/scripts/generic/larch/ | wc -l` = 38; `ls .claude/skills/shared/larch/ | wc -l` = 3.
4. `bash -n` on every new larch script → all pass.
5. `python3 -m json.tool .claude/settings.json` → valid.
6. `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yaml'))"` → valid.
7. `bash tests/test-setup-larch.sh` → exits 0.

All verifications passed.

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

### [Plan Review] Claude deep-analysis-reviewer (FINDING_4)
**Finding**: The plan describes the migration doc CLAUDIN-TO-LARCH-MIGRATION.md as containing "the spec's structure plus a LARCH_* env var callout" but does not enumerate the PR #2 checklist items inline. A reader of the plan alone (without seeing the /shazam spec) might think the migration doc only covers env vars. The reviewer suggested the plan should explicitly list every PR #2 checklist item: all six SKILL.md files needing path substitution, the two agent files needing "Keep in sync" comment updates, hook re-pointing in settings.json, deletion of the four claudin file/dir paths, and the final grep -ri claudin verification step.

**Reason not implemented**: Voting panel (Claude DA, Cursor, Codex) all voted NO. The plan explicitly says the migration doc is "structured per the spec" and the spec from /shazam already provides the full PR #2 checklist content. The finding is about plan self-documentation clarity, not a real gap in the planned work — the implementer reads both the plan AND the spec, so the content will be present in the migration doc as written. Re-listing the full checklist in the plan body would be redundant noise.

### [Plan Review] Codex-General (FINDING_5)
**Finding**: The plan adds one new CI check (running tests/test-setup-larch.sh) but does not add any direct CI validation of the 38 new larch shell scripts. A bad sed substitution could go undetected until PR #2 cutover. The reviewer suggested adding a `bash -n .claude/scripts/generic/larch/*.sh` syntax check step plus a grep assertion that no claudin/CLAUDIN tokens remain in the copied larch tree.

**Reason not implemented**: Voting panel (Claude DA, Cursor, Codex) all voted NO. The plan's pre-commit verification step already runs `bash -n` on every new larch script before commit, and the existing `lint` job in ci.yaml runs `make lint` which routes all shell files through pre-commit/shellcheck — including the new larch scripts as soon as they exist. Adding a third syntax check would be redundant. The grep assertion is also covered by the plan's pre-commit verification ("zero claudin substring matches" check).

### [Plan Review] Claude general-reviewer (FINDING_6)
**Finding**: The plan's pre-commit grep verification ("zero claudin substring matches") is one-sided. It would pass even if sed corrupted a script and removed all LARCH_ strings along with all CLAUDIN_ strings. The reviewer suggested adding a positive grep assertion that target strings (LARCH_SLACK_BOT_TOKEN, etc.) are present in expected places after substitution.

**Reason not implemented**: Voting panel (Claude DA, Cursor, Codex) all voted NO. The plan uses 3 case-sensitive `sed -e 's|...|...|g'` literal substitutions; sed substitution can rename tokens but cannot delete unrelated content in the way the finding hypothesizes. The "corruption" scenario the finding defends against is structurally impossible with the planned substitution form. Furthermore, the plan also runs `bash -n` syntax checks on every new larch script, which catches any structural corruption that might happen by other means.

</details>

<details><summary>Implementation Deviations</summary>

No material deviations from the revised plan. The implementation followed the 3 accepted plan-review findings:

1. **FINDING_1 (plan review)**: `Bash(LARCH_SLACK_USER_ID=:*)` was NOT added to settings.json (only the `Bash($PWD/.claude/scripts/generic/larch/*)` path glob was added).
2. **FINDING_2 (plan review)**: The migration doc explicitly documents the intentional dual-namespace symlink behavior of `setup-larch.sh` in a dedicated section.
3. **FINDING_3 (plan review)**: The ci.yaml modification uses two separate `- name:` steps, with `if: always()` on the second step so both integration tests run independently.

Minor implementation detail: used `stat -f '%A'` (BSD format, returns octal mode directly) instead of `stat -f '%p'` (which returns a full mode string including file-type bits) for `chmod`. `%A` is cleaner for `chmod` input and is equivalent for preserving the u/g/o permission bits of a regular file. This is a local-only concern (the script is run once on macOS) and doesn't affect the committed artifacts.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

### [Code Review] Claude general-reviewer, Codex-General (FINDING_1, rejected 0/3 YES)
**Finding**: Both reviewers claimed the new larch `slack-announce.sh` uses `LARCH_SLACK_USER_ID` as an inline env-var prefix (form: `LARCH_SLACK_USER_ID=U123 ./slack-announce.sh ...`), and therefore `.claude/settings.json` needs a new `"Bash(LARCH_SLACK_USER_ID=:*)"` permission entry. The reviewers suggested adding that entry at the alphabetically correct position (between `KUBECONFIG=:*` and `LINE1=:*`) so that any post-cutover skill or operator invoking the larch script with the inline prefix form would not be blocked by Claude Code's permission system.

**Reason not implemented**: Factual check against the actual script refuted the claim. `.claude/scripts/generic/larch/slack-announce.sh` line 62 is `LARCH_SLACK_USER_ID="${LARCH_SLACK_USER_ID:-}"` — a read-from-environment pattern. No SKILL.md, script, or agent in the repo issues a `CLAUDIN_SLACK_USER_ID=<literal> ./script.sh` or `LARCH_SLACK_USER_ID=<literal> ./script.sh` command. The `Bash(VAR=:*)` permission pattern in Claude Code is specifically for inline env-var prefixes, not for environment reads. Voting panel (Claude general, Cursor, Codex) all voted NO unanimously. The existing `"Bash(CLAUDIN_SLACK_USER_ID=:*)"` entry in settings.json line 31 is itself likely vestigial and is already flagged as an OOS item in `CLAUDIN-TO-LARCH-MIGRATION.md` for PR #2 "verify first" evaluation. The /design phase voting panel had already ruled on this same question 3-0 (accept removing the entry from PR #1); both code-review reviewers resurrected the concern from the opposite angle without checking the current runtime invocation pattern.

### [Code Review] Cursor, Codex-General (FINDING_2, neutral 1/3 YES + 2 EXONERATE)
**Finding**: `tests/test-setup-larch.sh` is a literal sed copy that only asserts larch-namespace symlinks (iterates `.claude/scripts/generic/larch/*.sh` and `.claude/skills/shared/larch/*.md`). It does NOT assert the claudin-side symlinks that `setup-larch.sh` is also expected to create during PR #1's dual-namespace window. This creates a CI gap: a regression where `setup-larch.sh` stops creating claudin-side symlinks would pass the larch test undetected while silently breaking the dual-namespace guarantee. Both reviewers suggested extending `tests/test-setup-larch.sh` with additional assertion blocks iterating the claudin source tree and checking for corresponding client-side symlinks.

**Reason not implemented**: The user's explicit /shazam spec instructs `tests/test-setup-claudin.sh → tests/test-setup-larch.sh` with "content rewritten (claudin→larch, etc.)" — a literal sed substitution. Adding new assertion blocks beyond the substitution violates the "pure copy" contract. The /design phase voting panel had already considered a functionally identical concern (FINDING_2 there, "filter setup-larch.sh or add migration-compat test") and accepted only the documentation option (describe the dual-namespace behavior in CLAUDIN-TO-LARCH-MIGRATION.md), which was implemented. Cursor voted YES but two voters (Claude general, Codex) voted EXONERATE, explicitly acknowledging the concern as legitimate-but-out-of-scope. Per the voting protocol, 1 YES + 2 EXONERATE is a neutral outcome — noted for future (PR #2 testing work) but not implemented in PR #1.

### [Code Review] Cursor (FINDING_3, neutral 1/3 YES + 2 EXONERATE)
**Finding**: `setup-larch.sh` lines 250-259 (after substitution) print a post-run NOTE/MIGRATION block that tells users to UPDATE settings.json paths — specifically: `"$PWD/.claude/scripts/generic/*  →  $PWD/.claude/scripts/generic/larch/*"` and corresponding replacements for the two hook scripts. In PR #1's dual-namespace window, a client repo currently using the claudin submodule that runs `setup-larch.sh` and follows this advice literally would REPLACE their existing claudin permission/hook entries with larch equivalents, breaking their in-flight claudin skill sessions. Cursor suggested rewriting the echo block to say: "keep the existing claudin permission and hook entries, ADD the new larch Bash glob, and defer claudin hook replacement to PR #2."

**Reason not implemented**: Modifying the echo text beyond literal sed substitution violates the user's "pure sed copy" contract for `setup-larch.sh`. The text is inherited from `setup-claudin.sh` where it was originally written as historical-migration guidance (migrating from a pre-claudin layout to the claudin layout — not a claudin→larch transition). After substitution the text becomes "If upgrading from an older larch version..." which is vacuously true (there are no older larch versions yet). A user in PR #1's window who reads the qualifier "older larch version" would correctly infer the message doesn't apply to them. PR #2 is the natural place to rewrite this message for the post-cutover world. Voting panel: Cursor YES, Claude general EXONERATE, Codex EXONERATE. 1 YES + 2 EXONERATE = neutral — noted for PR #2 follow-up but not implemented in PR #1.

### [Code Review] Claude general-reviewer (FINDING_4, rejected 0/3 YES)
**Finding**: `.github/workflows/ci.yaml` integration-test job has `timeout-minutes: 5`. After PR #1 this job runs TWO integration tests (claudin and larch) sequentially within the same 5-minute budget. Each test does `cp -R` of the full repo, `git init`, and three sequential invocations of the setup script (initial, idempotency re-run, and dead-symlink re-run). The reviewer argued this doubles the cumulative runtime and creates a spurious-timeout risk on slow/loaded GitHub Actions runners. The suggested fix was to increase `timeout-minutes` from 5 to 10.

**Reason not implemented**: Factual check: each integration test takes approximately 10-30 seconds locally (bash integration test with small file operations). Two tests = 20-60 seconds against a 300-second budget = 5-15x safety margin. There is no realistic spurious-timeout risk. Voting panel all voted NO unanimously (Claude general, Cursor, Codex all called the concern "speculative" or "too speculative to count as a bug"). The existing 5-minute budget is already very generous for bash integration tests of this size.

</details>

<details><summary>Plan Review Voting Tally</summary>

| Finding | Claude DA | Cursor | Codex | YES count | Result |
|---------|-----------|--------|-------|-----------|--------|
| FINDING_1 (remove LARCH_SLACK_USER_ID) | YES | YES | YES | 3 | **ACCEPTED** |
| FINDING_2 (document dual-namespace in migration doc) | EXONERATE | YES | YES | 2 | **ACCEPTED** |
| FINDING_3 (two separate ci.yaml steps) | YES | YES | NO | 2 | **ACCEPTED** |
| FINDING_4 (enumerate PR #2 in plan text) | NO | NO | NO | 0 | REJECTED |
| FINDING_5 (add bash -n + grep CI checks) | NO | NO | NO | 0 | REJECTED |
| FINDING_6 (positive grep verification) | NO | NO | NO | 0 | REJECTED |

**Reviewer Competition Scoreboard (plan review round 1)**:

| Reviewer | Findings raised | Accepted | Neutral/Exonerated | Rejected | Score |
|----------|----------------|----------|--------------------|----------|-------|
| Codex-Deep | F1, F2, F3 | 3 | 0 | 0 | **+3** |
| Claude general-reviewer | F1, F3, F6 | 2 | 0 | 1 | **+1** |
| Cursor | F1 (OOS), F2 | 1 | 1 (OOS, no points) | 0 | **+1** |
| Codex-General | F2, F5 | 1 | 0 | 1 | **0** |
| Claude deep-analysis-reviewer | F1, F4 | 1 | 0 | 1 | **0** |

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

| Finding | Claude gen | Cursor | Codex | YES count | Result |
|---------|-----------|--------|-------|-----------|--------|
| FINDING_1 (add LARCH_SLACK_USER_ID entry) | NO | NO | NO | 0 | **REJECTED** (0 YES, 0 EXONERATE) |
| FINDING_2 (extend test to assert claudin symlinks) | EXONERATE | YES | EXONERATE | 1 | **NEUTRAL** (1 YES, 2 EXONERATE) |
| FINDING_3 (rewrite setup-larch.sh post-run message) | EXONERATE | YES | EXONERATE | 1 | **NEUTRAL** (1 YES, 2 EXONERATE) |
| FINDING_4 (increase timeout-minutes) | NO | NO | NO | 0 | **REJECTED** (0 YES, 0 EXONERATE) |

**Reviewer Competition Scoreboard (code review round 1)**:

| Reviewer | Findings raised | Accepted | Neutral/Exonerated | Rejected | Score |
|----------|----------------|----------|--------------------|----------|-------|
| Cursor | F2, F3 | 0 | 2 | 0 | **0** |
| Codex-Deep | (output failed) | 0 | 0 | 0 | **0** |
| Claude deep-analysis-reviewer | NO_ISSUES_FOUND | 0 | 0 | 0 | **0** |
| Codex-General | F1, F2 | 0 | 1 | 1 | **-1** |
| Claude general-reviewer | F1, F4 | 0 | 0 | 2 | **-2** |

</details>

<details><summary>Out-of-Scope Observations</summary>

**From /design plan review:**
- `Bash(CLAUDIN_SLACK_USER_ID=:*)` in settings.json line 31 may itself be vestigial (no script uses the inline-prefix form). Could be cleaned up in PR #2 alongside other settings.json work.
- `.pre-commit-config.yaml` line 1 has comment "Claudin pre-commit configuration" — needs update in PR #2 (sed substitution).
- `Makefile` line 1 has comment "Claudin Makefile" — needs update in PR #2.
- `.claude/agents/{deep-analysis-reviewer,general-reviewer}.md` have "Keep in sync" comments referencing `.claude/skills/shared/claudin/reviewer-templates.md` with no automated enforcement — needs update in PR #2.
- README.md still describes only the claudin install flow — PR #2 will substitute throughout.

**From /review code review:**
- **Cursor**: `.claude/scripts/generic/larch/create-pr.sh` line 65 (and the identical original in `.claude/scripts/generic/claudin/create-pr.sh`): the existing-PR path swallows `git push -u origin HEAD` failures and still reports success, so callers can believe the PR branch was updated when the push actually failed. Pre-existing bug, copied verbatim from claudin. Out of scope for PR #1.
- **Claude general**: `CLAUDIN_SLACK_BOT_TOKEN=:*` and `CLAUDIN_SLACK_CHANNEL_ID=:*` are absent from `.claude/settings.json`, even though the claudin scripts reference them as env vars. Pre-existing gap — when those scripts are invoked via Claude Code with inline prefixes, Claude Code may prompt for permission. Out of scope.
- **Claude general**: `setup-larch.sh` Phase 2 (dead-symlink cleanup) depends on `python3` (line 234). If `python3` is absent, cleanup silently skips. Inherited from `setup-claudin.sh`, out of scope.
- **Claude deep-analysis**: `.claude/scripts/generic/{claudin,larch}/ci-wait.sh` line 144 has a no-op `2>&2` stderr redirect (`DECIDE_OUTPUT=$("$SCRIPT_DIR/ci-decide.sh" ... 2>&2)`). Pre-existing in claudin, faithfully copied. Possibly intended as `2>/dev/null` or `2>&1`. Out of scope.
- **Claude deep-analysis**: `CLAUDIN-TO-LARCH-MIGRATION.md` does not explicitly specify disposal of the migration doc itself in PR #2 — a future reader running `grep -ri claudin .` without the exclusion would get false positives on the doc. Minor, out of scope for PR #1.

</details>

<details><summary>Execution Issues</summary>

### External Reviewer Issues
- **Step /design Step 2a (sketch phase)**: Cursor sketch initial attempt timed out (exit 124, 0 bytes after 7 minutes). Retry in background succeeded with valid output; synthesis used 4 sketches (Claude General + Architecture/Standards + Pragmatism/Safety + Codex) plus the retry Cursor output once it arrived.
- **Step /review Step 2 (code review)**: Both Codex instances produced 0 bytes despite exit 0 on the initial attempt. Retries were launched; Codex-General retry succeeded with valid output, but Codex-Deep retry also produced 0 bytes. Proceeded without Codex-Deep findings for the code review phase.

### Warnings
- **Step 8 (version bump)**: Skipped — no `/bump-version` skill present at `.claude/skills/bump-version/SKILL.md`. Warning emitted per the /implement skill procedure.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | 3 accepted, 3 rejected |
| Code review rounds | 1 |
| Code review findings | 0 accepted, 2 neutral, 2 rejected |
| Warnings logged | 1 (version bump skipped) |
| Pre-existing issues noticed | 5 (create-pr.sh push swallow, CLAUDIN_SLACK_* permission gaps, python3 dependency, ci-wait.sh no-op redirect, migration doc self-disposal) |
| External reviewers | Cursor: ✅ (sketch retry + plan review + code review + voting), Codex: ⚠ partial (sketch OK, plan review OK, code review Codex-Deep failed after retry, voting OK) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
