### PR TITLE
Cutover claudin→larch references (PR #2a of migration)

### DIFF
--- a/.claude/agents/deep-analysis-reviewer.md
+++ b/.claude/agents/deep-analysis-reviewer.md
@@ -8,7 +8,7 @@ tools:
   - Glob
 ---
 
-<!-- Derived from .claude/skills/shared/claudin/reviewer-templates.md Reviewer B. Keep in sync. -->
+<!-- Derived from .claude/skills/shared/larch/reviewer-templates.md Reviewer B. Keep in sync. -->
 
 You are a senior systems architect and correctness specialist reviewing code for this project. You combine deep correctness analysis with architectural rigor. You have access to the full codebase via Read, Grep, and Glob tools.
 

--- a/.claude/agents/general-reviewer.md
+++ b/.claude/agents/general-reviewer.md
@@ -8,7 +8,7 @@ tools:
   - Glob
 ---
 
-<!-- Derived from .claude/skills/shared/claudin/reviewer-templates.md Reviewer A. Keep in sync. -->
+<!-- Derived from .claude/skills/shared/larch/reviewer-templates.md Reviewer A. Keep in sync. -->
 
 You are a general-purpose code reviewer for this project covering both code quality and risk/integration concerns. You have access to the full codebase via Read, Grep, and Glob tools.
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -233,7 +233,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$PWD/.claude/scripts/generic/claudin/block-submodule-edit.sh"
+            "command": "$PWD/.claude/scripts/generic/larch/block-submodule-edit.sh"
           }
         ]
       },
@@ -242,7 +242,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$PWD/.claude/scripts/generic/claudin/block-submodule-edit.sh"
+            "command": "$PWD/.claude/scripts/generic/larch/block-submodule-edit.sh"
           }
         ]
       }
@@ -253,7 +253,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$PWD/.claude/scripts/generic/claudin/auto-goimports.sh"
+            "command": "$PWD/.claude/scripts/generic/larch/auto-goimports.sh"
           }
         ]
       },
@@ -262,7 +262,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$PWD/.claude/scripts/generic/claudin/auto-goimports.sh"
+            "command": "$PWD/.claude/scripts/generic/larch/auto-goimports.sh"
           }
         ]
       }

--- a/.claude/skills/design/SKILL.md
+++ b/.claude/skills/design/SKILL.md
@@ -44,7 +44,7 @@ Suggested emoji palette (use consistently):
 Run the shared session setup script. Since `/design` does not need Slack or repo checks, pass `--skip-slack-check` and `--skip-repo-check`. If `SESSION_ENV_PATH` is non-empty (passed via `--session-env`), include `--caller-env`:
 
 ```bash
-$PWD/.claude/scripts/generic/claudin/session-setup.sh --prefix claude-design --skip-branch-check --skip-slack-check --skip-repo-check [--caller-env "$SESSION_ENV_PATH"]
+$PWD/.claude/scripts/generic/larch/session-setup.sh --prefix claude-design --skip-branch-check --skip-slack-check --skip-repo-check [--caller-env "$SESSION_ENV_PATH"]
 ```
 
 Only include `--caller-env "$SESSION_ENV_PATH"` if `SESSION_ENV_PATH` is non-empty. This is behavior-preserving: `/design` today has no Slack or repo steps, and the skip flags ensure the script skips them.
@@ -55,7 +55,7 @@ Parse the output for `SESSION_TMPDIR`. Set `DESIGN_TMPDIR` = `SESSION_TMPDIR`. S
 
 ### 0b — Quick External Reviewer Check
 
-Read and follow the **Binary Check** section in `.claude/skills/shared/claudin/external-reviewers.md`.
+Read and follow the **Binary Check** section in `.claude/skills/shared/larch/external-reviewers.md`.
 
 ## Step 1 — Create Branch
 
@@ -64,7 +64,7 @@ Read and follow the **Binary Check** section in `.claude/skills/shared/claudin/e
 Run the `create-branch.sh` script in check mode to get the current branch state:
 
 ```bash
-$PWD/.claude/scripts/generic/claudin/create-branch.sh --check
+$PWD/.claude/scripts/generic/larch/create-branch.sh --check
 ```
 
 Parse the output for `CURRENT_BRANCH`, `IS_MAIN`, `IS_USER_BRANCH`, and `USER_PREFIX`.
@@ -74,7 +74,7 @@ Parse the output for `CURRENT_BRANCH`, `IS_MAIN`, `IS_USER_BRANCH`, and `USER_PR
 **Decision logic** (using the script output):
 - If `IS_MAIN=true`: Derive a short kebab-case branch name from the feature description (e.g., "add user auth" → `<USER_PREFIX>/add-user-auth`). Keep it under 50 characters. Then create it:
   ```bash
-  $PWD/.claude/scripts/generic/claudin/create-branch.sh --branch <USER_PREFIX>/<branch-name>
+  $PWD/.claude/scripts/generic/larch/create-branch.sh --branch <USER_PREFIX>/<branch-name>
   ```
 
 - If `IS_USER_BRANCH=true`: Verify the branch name (`CURRENT_BRANCH`) aligns with the requested feature. If it appears unrelated (different feature name, unrelated commits), print a warning: `**⚠ Current branch '<branch-name>' may not match the requested feature. Creating a new branch from main.**` and create a new branch as above. Otherwise, skip branch creation. Print: `🔀 Step 1 — Using existing branch: <branch-name>`
@@ -131,7 +131,7 @@ Print `🤝 Step 2a — Running collaborative sketch phase.` and proceed to 2a.2
 **Cursor sketch** (if `cursor_available`):
 
 ```bash
-$PWD/.claude/scripts/generic/claudin/run-external-reviewer.sh --tool cursor --output "$DESIGN_TMPDIR/cursor-sketch-output.txt" --timeout 600 --capture-stdout -- \
+$PWD/.claude/scripts/generic/larch/run-external-reviewer.sh --tool cursor --output "$DESIGN_TMPDIR/cursor-sketch-output.txt" --timeout 600 --capture-stdout -- \
   cursor agent -p --force --trust --model gpt-5.4-medium --workspace "$PWD" \
     "You are looking at a codebase and need to propose a high-level implementation approach for this feature: <FEATURE_DESCRIPTION>. Explore the codebase to understand the relevant architecture, then write 2-3 paragraphs covering: (1) Key architectural decisions and the approach you would take, (2) Which files/modules to modify and why, (3) Main tradeoffs you would consider. Do NOT modify files."
 ```
@@ -145,7 +145,7 @@ Prompt: `"You are an Innovation/Exploration architect. Propose a high-level impl
 **Codex sketch** (if `codex_available`):
 
 ```bash
-$PWD/.claude/scripts/generic/claudin/run-external-reviewer.sh --tool codex --output "$DESIGN_TMPDIR/codex-sketch-output.txt" --timeout 600 -- \
+$PWD/.claude/scripts/generic/larch/run-external-reviewer.sh --tool codex --output "$DESIGN_TMPDIR/codex-sketch-output.txt" --timeout 600 -- \
   codex exec --full-auto -C "$PWD" \
     --output-last-message "$DESIGN_TMPDIR/codex-sketch-output.txt" \
     "You are looking at a codebase and need to propose a high-level implementation approach for this feature: <FEATURE_DESCRIPTION>. Explore the codebase to understand the relevant architecture, then write 2-3 paragraphs covering: (1) Key architectural decisions and the approach you would take, (2) Which files/modules to modify and why, (3) Main tradeoffs you would consider. Do NOT modify files."
@@ -172,14 +172,14 @@ Prompt: `"You are a Pragmatism/Safety engineer. Propose a high-level implementat
 Wait for external sketch sentinels using `wait-for-reviewers.sh`. Only include paths for external reviewers that were actually launched (not Claude replacements — those return via Agent tool):
 
 ```bash
-$PWD/.claude/scripts/generic/claudin/wait-for-reviewers.sh --timeout 660 "$DESIGN_TMPDIR/cursor-sketch-output.txt.done" "$DESIGN_TMPDIR/codex-sketch-output.txt.done"
+$PWD/.claude/scripts/generic/larch/wait-for-reviewers.sh --timeout 660 "$DESIGN_TMPDIR/cursor-sketch-output.txt.done" "$DESIGN_TMPDIR/codex-sketch-output.txt.done"
 ```
 
 Use `timeout: 660000` on the Bash tool call. **Do NOT** set `run_in_background: true` — this call must block. Only include sentinel paths for external reviewers that were actually launched — omit any path whose reviewer was replaced by a Claude subagent.
 
 Note: This is a separate `wait-for-reviewers.sh` call from the one in Step 3. Both are permitted because they operate on completely distinct sentinel file sets (`*-sketch-output.txt.done` vs `*-plan-output.txt.done`).
 
-**Validate sketch outputs**: Follow the **Validating External Reviewer Output** section in `.claude/skills/shared/claudin/external-reviewers.md`, using `$DESIGN_TMPDIR/cursor-sketch-output.txt` and `$DESIGN_TMPDIR/codex-sketch-output.txt` as the output files. For sketches, a valid output is non-empty and contains substantive architectural content (at least a paragraph). If a sketch is empty despite exit code 0, retry once with a `-retry` suffix per the shared procedure.
+**Validate sketch outputs**: Follow the **Validating External Reviewer Output** section in `.claude/skills/shared/larch/external-reviewers.md`, using `$DESIGN_TMPDIR/cursor-sketch-output.txt` and `$DESIGN_TMPDIR/codex-sketch-output.txt` as the output files. For sketches, a valid output is non-empty and contains substantive architectural content (at least a paragraph). If a sketch is empty despite exit code 0, retry once with a `-retry` suffix per the shared procedure.
 
 ### 2a.4 — Synthesis
 
@@ -228,7 +228,7 @@ Run Cursor **first** in the parallel message (it takes the longest). Cursor has 
 Invoke Cursor via the shared monitored wrapper script (with `--capture-stdout` since Cursor writes results to stdout):
 
 ```bash
-$PWD/.claude/scripts/generic/claudin/run-external-reviewer.sh --tool cursor --output "$DESIGN_TMPDIR/cursor-plan-output.txt" --timeout 900 --capture-stdout -- \
+$PWD/.claude/scripts/generic/larch/run-external-reviewer.sh --tool cursor --output "$DESIGN_TMPDIR/cursor-plan-output.txt" --timeout 900 --capture-stdout -- \
   cursor agent -p --force --trust --model gpt-5.4-medium --workspace "$PWD" \
     "Review the implementation plan in $DESIGN_TMPDIR/plan.txt for this project. Read the plan file, then explore the codebase to validate the plan. Combine 4 perspectives: (1) General: logical flaws, code reuse, test coverage, backward compat, pattern consistency. (2) Correctness: logic errors, off-by-one, nil handling, type mismatches, races, error paths. (3) Risk/Integration: breaking changes, side effects, thread safety, deployment risks, regressions, CI. (4) Architecture: separation of concerns, contract boundaries, invariants, semantic boundaries. Return numbered findings with perspective, concern, and suggested revision. If NO issues, output exactly NO_ISSUES_FOUND. Do NOT modify files."
 ```
@@ -242,7 +242,7 @@ Run both Codex instances **second** in the parallel message (after Cursor). Each
 **Codex-General** — focuses on general code quality and risk/integration perspectives:
 
 ```bash
-$PWD/.claude/scripts/generic/claudin/run-external-reviewer.sh --tool codex --output "$DESIGN_TMPDIR/codex-general-plan-output.txt" --timeout 900 -- \
+$PWD/.claude/scripts/generic/larch/run-external-reviewer.sh --tool codex --output "$DESIGN_TMPDIR/codex-general-plan-output.txt" --timeout 900 -- \
   codex exec --full-auto -C "$PWD" \
     --output-last-message "$DESIGN_TMPDIR/codex-general-plan-output.txt" \
     "Review the implementation plan in $DESIGN_TMPDIR/plan.txt for this project. Read the plan file, then explore the codebase to validate the plan. Focus on general code quality and risk/integration perspectives: (1) General: logical flaws, code reuse, test coverage, backward compat, pattern consistency. (2) Risk/Integration: breaking changes, side effects, thread safety, deployment risks, regressions, CI. Return numbered findings with perspective, concern, and suggested revision. If NO issues, output exactly NO_ISSUES_FOUND. Do NOT modify files."
@@ -253,7 +253,7 @@ Use `run_in_background: true` and `timeout: 960000` on the Bash tool call.
 **Codex-Deep-Analysis** — focuses on correctness and architecture perspectives:
 
 ```bash
-$PWD/.claude/scripts/generic/claudin/run-external-reviewer.sh --tool codex --output "$DESIGN_TMPDIR/codex-deep-plan-output.txt" --timeout 900 -- \
+$PWD/.claude/scripts/generic/larch/run-external-reviewer.sh --tool codex --output "$DESIGN_TMPDIR/codex-deep-plan-output.txt" --timeout 900 -- \
   codex exec --full-auto -C "$PWD" \
     --output-last-message "$DESIGN_TMPDIR/codex-deep-plan-output.txt" \
     "Review the implementation plan in $DESIGN_TMPDIR/plan.txt for this project. Read the plan file, then explore the codebase to validate the plan. Focus on correctness and architecture perspectives: (1) Correctness: logic errors, off-by-one, nil handling, type mismatches, races, error paths. (2) Architecture: separation of concerns, contract boundaries, invariants, semantic boundaries. Return numbered findings with perspective, concern, and suggested revision. If NO issues, output exactly NO_ISSUES_FOUND. Do NOT modify files."
@@ -265,7 +265,7 @@ Use `run_in_background: true` and `timeout: 960000` on the Bash tool call.
 
 Launch both Claude subagents **last** in the same message (they finish fastest).
 
-Use the two reviewer archetypes from `.claude/skills/shared/claudin/reviewer-templates.md`, filling in the variables for **plan review**:
+Use the two reviewer archetypes from `.claude/skills/shared/larch/reviewer-templates.md`, filling in the variables for **plan review**:
 
 - **`{REVIEW_TARGET}`** = `"an implementation plan"`
 - **`{CONTEXT_BLOCK}`**:
@@ -284,7 +284,7 @@ Additionally, append the following competition context to each reviewer's prompt
 
 ### Monitoring External Reviewers
 
-Follow the **Monitoring External Reviewers** and **Validating External Reviewer Output** sections in `.claude/skills/shared/claudin/external-reviewers.md`, using `$DESIGN_TMPDIR/codex-general-plan-output.txt`, `$DESIGN_TMPDIR/codex-deep-plan-output.txt`, and `$DESIGN_TMPDIR/cursor-plan-output.txt` as the output files.
+Follow the **Monitoring External Reviewers** and **Validating External Reviewer Output** sections in `.claude/skills/shared/larch/external-reviewers.md`, using `$DESIGN_TMPDIR/codex-general-plan-output.txt`, `$DESIGN_TMPDIR/codex-deep-plan-output.txt`, and `$DESIGN_TMPDIR/cursor-plan-output.txt` as the output files.
 
 ### After all reviewers return
 
@@ -300,7 +300,7 @@ If **all reviewers** report no in-scope issues and no out-of-scope observations,
 
 ### Voting Panel (replaces negotiation)
 
-After deduplication, submit both in-scope findings and out-of-scope observations to a 3-agent voting panel per the **Voting Protocol** in `.claude/skills/shared/claudin/voting-protocol.md`. Include OOS items on the ballot with `[OUT_OF_SCOPE]` prefix per the protocol's OOS section — voters can promote OOS items to in-scope by voting YES. For plan review:
+After deduplication, submit both in-scope findings and out-of-scope observations to a 3-agent voting panel per the **Voting Protocol** in `.claude/skills/shared/larch/voting-protocol.md`. Include OOS items on the ballot with `[OUT_OF_SCOPE]` prefix per the protocol's OOS section — voters can promote OOS items to in-scope by voting YES. For plan review:
 
 - **Voter 1**: Claude Deep Analysis reviewer subagent — fresh Agent tool invocation with the voting prompt. Instruct: `"You are a senior architect and correctness specialist on a voting panel. You will vote YES, NO, or EXONERATE on proposed modifications to an implementation plan. Be scrupulous — only vote YES for findings that are correct, important, and worth revising the plan for. Vote EXONERATE if the concern is legitimate but not worth implementing in this PR."`
 - **Voter 2**: Codex — via `run-external-reviewer.sh` with the ballot
@@ -392,7 +392,7 @@ Print any rejected plan review findings:
 Remove the session temp directory and all files within it:
 
 ```bash
-$PWD/.claude/scripts/generic/claudin/cleanup-tmpdir.sh --dir "$DESIGN_TMPDIR"
+$PWD/.claude/scripts/generic/larch/cleanup-tmpdir.sh --dir "$DESIGN_TMPDIR"
 ```
 
 **Repeat any external reviewer warnings** from earlier steps (Step 0b binary checks, Step 2a sketch-phase failures/timeouts, Step 3 runtime failures, or Step 3b diagram generation failure) so they are visible at the end of the workflow. For example:

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -50,7 +50,7 @@ Suggested emoji palette (use consistently):
 Run the shared session setup script. If `SESSION_ENV_PATH` is non-empty (passed via `--session-env`), include `--caller-env` to reuse already-discovered values:
 
 ```bash
-$PWD/.claude/scripts/generic/claudin/session-setup.sh --prefix claude-impl --skip-branch-check [--caller-env "$SESSION_ENV_PATH"]
+$PWD/.claude/scripts/generic/larch/session-setup.sh --prefix claude-impl --skip-branch-check [--caller-env "$SESSION_ENV_PATH"]
 ```
 
 Only include `--caller-env "$SESSION_ENV_PATH"` if `SESSION_ENV_PATH` is non-empty.
@@ -67,7 +67,7 @@ Parse the output for `SESSION_TMPDIR`, `SLACK_OK`, `SLACK_MISSING`, `REPO`, `REP
 Write the discovered values to `$IMPL_TMPDIR/session-env.sh` so they can be forwarded to `/design`:
 
 ```bash
-$PWD/.claude/scripts/generic/claudin/write-session-env.sh --output "$IMPL_TMPDIR/session-env.sh" \
+$PWD/.claude/scripts/generic/larch/write-session-env.sh --output "$IMPL_TMPDIR/session-env.sh" \
   --slack-ok <value> --slack-missing <value> --repo <value> --repo-unavailable <value>
 ```
 
@@ -105,7 +105,7 @@ Throughout execution, log noteworthy issues to `$IMPL_TMPDIR/execution-issues.md
 First, determine the user's branch prefix by running the branch check script:
 
 ```bash
-$PWD/.claude/scripts/generic/claudin/create-branch.sh --check
+$PWD/.claude/scripts/generic/larch/create-branch.sh --check
 ```
 
 Parse the output for `CURRENT_BRANCH`, `IS_MAIN`, `IS_USER_BRANCH`, and `USER_PREFIX`.
@@ -115,7 +115,7 @@ Parse the output for `CURRENT_BRANCH`, `IS_MAIN`, `IS_USER_BRANCH`, and `USER_PR
 Skip `/design` entirely. Handle branch creation directly, then produce an inline implementation plan.
 
 **Branch handling** (same logic as `/design` Step 1, replicated here since `/design` is skipped):
-- If `IS_MAIN=true`: Derive a short kebab-case branch name from the feature description. Create it via `$PWD/.claude/scripts/generic/claudin/create-branch.sh --branch <USER_PREFIX>/<branch-name>`.
+- If `IS_MAIN=true`: Derive a short kebab-case branch name from the feature description. Create it via `$PWD/.claude/scripts/generic/larch/create-branch.sh --branch <USER_PREFIX>/<branch-name>`.
 - If `IS_USER_BRANCH=true`: Verify the branch name (`CURRENT_BRANCH`) aligns with the requested feature. If it appears unrelated (different feature name, unrelated commits), print a warning: `**⚠ Current branch '<branch-name>' may not match the requested feature. Creating a new branch from main.**` and create a new branch. Otherwise, use the existing branch.
 - Otherwise (non-main, non-user branch): Print a warning: `**⚠ Currently on branch '<branch-name>' which doesn't match the expected '<USER_PREFIX>/*' pattern. Creating a new branch from main.**` and create a new branch.
 
@@ -144,7 +144,7 @@ If the output is non-empty (branch exists on origin), print: `⏩ Rebase skipped
 
 Otherwise, run:
 ```bash
-$PWD/.claude/scripts/generic/claudin/rebase-push.sh --no-push
+$PWD/.claude/scripts/generic/larch/rebase-push.sh --no-push
 ```
 
 If the script exits non-zero, print: `**⚠ Rebase onto main failed. Bailing to cleanup.**` and skip to Step 13.
@@ -170,7 +170,7 @@ Invoke `/relevant-checks` to run validation checks relevant to the modified file
 Stage and commit all changed files using the wrapper script:
 
 ```bash
-$PWD/.claude/scripts/generic/claudin/git-commit.sh -m "<descriptive commit message>" <specific-files>
+$PWD/.claude/scripts/generic/larch/git-commit.sh -m "<descriptive commit message>" <specific-files>
 ```
 
 The commit message should describe WHAT was implemented and WHY, not HOW.
@@ -187,7 +187,7 @@ If the output is non-empty, print: `⏩ Rebase skipped — branch already pushed
 
 Otherwise, run:
 ```bash
-$PWD/.claude/scripts/generic/claudin/rebase-push.sh --no-push
+$PWD/.claude/scripts/generic/larch/rebase-push.sh --no-push
 ```
 
 If the script exits non-zero, print: `**⚠ Rebase onto main failed. Bailing to cleanup.**` and skip to Step 13.
@@ -202,10 +202,10 @@ Skip `/review`. Instead, run a simplified one-round review:
 
 1. Gather the diff using the context script:
    ```bash
-   $PWD/.claude/scripts/generic/claudin/gather-branch-context.sh --output-dir "$IMPL_TMPDIR"
+   $PWD/.claude/scripts/generic/larch/gather-branch-context.sh --output-dir "$IMPL_TMPDIR"
    ```
    Parse the output for `DIFF_FILE`, `FILE_LIST_FILE`, and `COMMIT_LOG_FILE`. Read these files to get the full diff, file list, and commit log.
-2. Launch **2 Claude subagent reviewers** (general, deep-analysis) using the same reviewer archetypes from `.claude/skills/shared/claudin/reviewer-templates.md` with these variable bindings: `{REVIEW_TARGET}` = `"code changes"`, `{CONTEXT_BLOCK}` = the commit log + file list + full diff, `{OUTPUT_INSTRUCTION}` = `"File path and line number(s)"` + `"What the issue is"` + `"Suggested fix"`. **No Codex, no Cursor, no external reviewers. No competition notice** (there is no voting panel in quick mode).
+2. Launch **2 Claude subagent reviewers** (general, deep-analysis) using the same reviewer archetypes from `.claude/skills/shared/larch/reviewer-templates.md` with these variable bindings: `{REVIEW_TARGET}` = `"code changes"`, `{CONTEXT_BLOCK}` = the commit log + file list + full diff, `{OUTPUT_INSTRUCTION}` = `"File path and line number(s)"` + `"What the issue is"` + `"Suggested fix"`. **No Codex, no Cursor, no external reviewers. No competition notice** (there is no voting panel in quick mode).
 3. Collect findings from all 2 subagents. Deduplicate.
 4. **Main agent decides**: Evaluate each finding and unilaterally accept or reject it. No voting panel. Accept findings that identify genuine bugs, logic errors, or important improvements. Reject trivial style nits or speculative concerns.
 5. Implement accepted fixes. Run `/relevant-checks` if files changed.
@@ -247,7 +247,7 @@ If files **did change**, invoke `/relevant-checks` to ensure review fixes didn't
 If any files changed during review/checks (Steps 5–6), stage and commit them:
 
 ```bash
-$PWD/.claude/scripts/generic/claudin/git-commit.sh -m "Address code review feedback" <specific-files>
+$PWD/.claude/scripts/generic/larch/git-commit.sh -m "Address code review feedback" <specific-files>
 ```
 
 If no files changed (review found no issues), skip this commit.
@@ -266,7 +266,7 @@ If the output is non-empty, print: `⏩ Rebase skipped — branch already pushed
 
 Otherwise, run:
 ```bash
-$PWD/.claude/scripts/generic/claudin/rebase-push.sh --no-push
+$PWD/.claude/scripts/generic/larch/rebase-push.sh --no-push
 ```
 
 If the script exits non-zero, print: `**⚠ Rebase onto main failed. Bailing to cleanup.**` and skip to Step 13.
@@ -313,7 +313,7 @@ If the output is non-empty, print: `⏩ Rebase skipped — branch already pushed
 
 Otherwise, run:
 ```bash
-$PWD/.claude/scripts/generic/claudin/rebase-push.sh --no-push
+$PWD/.claude/scripts/generic/larch/rebase-push.sh --no-push
 ```
 
 If the script exits non-zero, print: `**⚠ Rebase onto main failed. Bailing to cleanup.**` and skip to Step 13.
@@ -325,7 +325,7 @@ If successful, print: `✅ Rebased onto latest main.`
 Check if the repo has a `/bump-version` skill and capture commit count:
 
 ```bash
-$PWD/.claude/scripts/generic/claudin/check-bump-version.sh --mode pre
+$PWD/.claude/scripts/generic/larch/check-bump-version.sh --mode pre
 ```
 
 Parse the output for `HAS_BUMP` and `COMMITS_BEFORE`.
@@ -337,7 +337,7 @@ Parse the output for `HAS_BUMP` and `COMMITS_BEFORE`.
 1. Invoke `/bump-version` via the Skill tool.
 2. Verify a new commit was created:
    ```bash
-   $PWD/.claude/scripts/generic/claudin/check-bump-version.sh --mode post --before-count $COMMITS_BEFORE
+   $PWD/.claude/scripts/generic/larch/check-bump-version.sh --mode post --before-count $COMMITS_BEFORE
    ```
    Parse for `VERIFIED`, `COMMITS_AFTER`, `EXPECTED`. If `VERIFIED=false`, print: `**⚠ /bump-version did not create exactly one commit. Expected $EXPECTED, got $COMMITS_AFTER.**`
 
@@ -461,7 +461,7 @@ Populate Run Statistics from conversation context: count accepted/rejected findi
 Run the `create-pr.sh` script with a concise title (under 70 chars):
 
 ```bash
-$PWD/.claude/scripts/generic/claudin/create-pr.sh --title "<title>" --body-file "$IMPL_TMPDIR/pr-body.md"
+$PWD/.claude/scripts/generic/larch/create-pr.sh --title "<title>" --body-file "$IMPL_TMPDIR/pr-body.md"
 ```
 
 Parse the output for `PR_NUMBER`, `PR_URL`, `PR_TITLE`, and `PR_STATUS`. The script handles pushing the branch, detecting existing PRs, and creating new ones with `--assignee @me`. `PR_STATUS` is `created` for new PRs or `existing` for already-open PRs. Save `PR_STATUS` — it is used in Step 11 to decide whether to post to Slack.
@@ -470,7 +470,7 @@ Parse the output for `PR_NUMBER`, `PR_URL`, `PR_TITLE`, and `PR_STATUS`. The scr
 
 **If `PR_STATUS=existing`**: The PR body was not updated by `create-pr.sh`. Update it now:
 ```bash
-$PWD/.claude/scripts/generic/claudin/gh-pr-body-update.sh --pr <PR_NUMBER> --body-file "$IMPL_TMPDIR/pr-body.md"
+$PWD/.claude/scripts/generic/larch/gh-pr-body-update.sh --pr <PR_NUMBER> --body-file "$IMPL_TMPDIR/pr-body.md"
 ```
 
 Print the PR URL when done. Then print the PR number, URL, and title in a machine-parseable format (consumed by `/shazam` Step 1 — keep in sync):
@@ -496,7 +496,7 @@ Track these counters (all start at 0):
 **Wait for CI** using the `ci-wait.sh` script:
 
 ```bash
-$PWD/.claude/scripts/generic/claudin/ci-wait.sh --pr <PR-NUMBER> --repo $REPO \
+$PWD/.claude/scripts/generic/larch/ci-wait.sh --pr <PR-NUMBER> --repo $REPO \
   --rebase-count "$rebase_count" --fix-attempts "$fix_attempts" --iteration "$iteration"
 ```
 
@@ -510,13 +510,13 @@ Parse the output for: `ACTION`, `CI_STATUS`, `BEHIND_COUNT`, `FAILED_RUN_ID`, `B
 
    - **`ACTION=already_merged`**: PR was merged externally during CI wait. Print `✅ Step 10 — PR was merged externally.` and proceed to Step 11.
 
-   - **`ACTION=rebase`**: Main advanced. Run `$PWD/.claude/scripts/generic/claudin/rebase-push.sh`. On exit 0: increment `rebase_count` and `iteration`, reset `transient_retries`, re-invoke `ci-wait.sh`. On exit 1 (conflicts): run `$PWD/.claude/scripts/generic/claudin/git-rebase-abort.sh`, print warning, and proceed to Step 11 (bail). On exit 2: retry once, then bail. On exit 3: bail. **Note**: `/implement` deliberately bails on all rebase conflicts because it does not merge — intelligent conflict resolution with reviewer panel validation is `/shazam`'s responsibility in Step 2. When invoked via `/shazam`, conflicts encountered after `/implement` exits will be handled by `/shazam`'s enhanced conflict resolution procedure.
+   - **`ACTION=rebase`**: Main advanced. Run `$PWD/.claude/scripts/generic/larch/rebase-push.sh`. On exit 0: increment `rebase_count` and `iteration`, reset `transient_retries`, re-invoke `ci-wait.sh`. On exit 1 (conflicts): run `$PWD/.claude/scripts/generic/larch/git-rebase-abort.sh`, print warning, and proceed to Step 11 (bail). On exit 2: retry once, then bail. On exit 3: bail. **Note**: `/implement` deliberately bails on all rebase conflicts because it does not merge — intelligent conflict resolution with reviewer panel validation is `/shazam`'s responsibility in Step 2. When invoked via `/shazam`, conflicts encountered after `/implement` exits will be handled by `/shazam`'s enhanced conflict resolution procedure.
 
    - **`ACTION=rebase_then_evaluate`**: Run rebase first (same as above), then fall through to evaluate the CI failure.
 
    - **`ACTION=evaluate_failure`**: Use `FAILED_RUN_ID` to evaluate:
-     1. **Transient failure** (runner provisioning, Docker pull rate limit, "hosted runner lost communication", etc.): If `transient_retries < 2`, run `$PWD/.claude/scripts/generic/claudin/sleep-seconds.sh 60`, then run `$PWD/.claude/scripts/generic/claudin/ci-rerun-failed.sh --run-id <FAILED_RUN_ID> --repo $REPO`. Parse output for `RERUN_SUBMITTED` and `ERROR`. If `RERUN_SUBMITTED=false`, print the `ERROR` and treat as a real CI failure (fall through to diagnosis). Otherwise increment `transient_retries`, re-invoke `ci-wait.sh`. If `transient_retries >= 2`, treat as real failure.
-     2. **Real CI failure**: Run `$PWD/.claude/scripts/generic/claudin/gh-run-logs.sh --run-id <FAILED_RUN_ID> --repo $REPO`. Diagnose the issue, fix it, run `/relevant-checks`, stage and commit using `$PWD/.claude/scripts/generic/claudin/git-commit.sh -m "Fix CI failure" <fixed-files>`, push. Increment `fix_attempts`. Re-invoke `ci-wait.sh`.
+     1. **Transient failure** (runner provisioning, Docker pull rate limit, "hosted runner lost communication", etc.): If `transient_retries < 2`, run `$PWD/.claude/scripts/generic/larch/sleep-seconds.sh 60`, then run `$PWD/.claude/scripts/generic/larch/ci-rerun-failed.sh --run-id <FAILED_RUN_ID> --repo $REPO`. Parse output for `RERUN_SUBMITTED` and `ERROR`. If `RERUN_SUBMITTED=false`, print the `ERROR` and treat as a real CI failure (fall through to diagnosis). Otherwise increment `transient_retries`, re-invoke `ci-wait.sh`. If `transient_retries >= 2`, treat as real failure.
+     2. **Real CI failure**: Run `$PWD/.claude/scripts/generic/larch/gh-run-logs.sh --run-id <FAILED_RUN_ID> --repo $REPO`. Diagnose the issue, fix it, run `/relevant-checks`, stage and commit using `$PWD/.claude/scripts/generic/larch/git-commit.sh -m "Fix CI failure" <fixed-files>`, push. Increment `fix_attempts`. Re-invoke `ci-wait.sh`.
 
    - **`ACTION=bail`**: Print `BAIL_REASON`. Print `**⚠ Step 10 — CI monitoring bailed. PR may have failing CI.**` and proceed to Step 11.
 
@@ -535,7 +535,7 @@ After handling any non-terminal action (rebase, evaluate_failure), **re-invoke `
 Post the PR to Slack using the shared script:
 
 ```bash
-$PWD/.claude/scripts/generic/claudin/post-pr-announce.sh --pr <PR-NUMBER>
+$PWD/.claude/scripts/generic/larch/post-pr-announce.sh --pr <PR-NUMBER>
 ```
 
 Parse the output for `SLACK_TS=<value>` (emitted by `post-pr-announce.sh` — keep in sync).
@@ -556,14 +556,14 @@ If `$IMPL_TMPDIR/execution-issues.md` exists and is non-empty, update the PR bod
 
 1. Fetch the current live PR body using the read script (do NOT re-read `$IMPL_TMPDIR/pr-body.md` — the live body may differ from the local copy):
    ```bash
-   $PWD/.claude/scripts/generic/claudin/gh-pr-body-read.sh --pr <PR_NUMBER> --output "$IMPL_TMPDIR/live-body.md"
+   $PWD/.claude/scripts/generic/larch/gh-pr-body-read.sh --pr <PR_NUMBER> --output "$IMPL_TMPDIR/live-body.md"
    ```
    Read `$IMPL_TMPDIR/live-body.md` to get the current body text.
 2. Replace the entire inner content of the `<details><summary>Execution Issues</summary>...</details>` block with the full current contents of `$IMPL_TMPDIR/execution-issues.md`, preserving the blank lines after the opening tag and before the closing `</details>` (required for GitHub Markdown rendering). If the `<details><summary>Execution Issues</summary>` block is not found in the fetched body, print `**⚠ Execution Issues block not found in live PR body. Skipping refresh.**` and skip the update.
 3. Write the result to `$IMPL_TMPDIR/pr-body.md`
 4. Update the PR:
    ```bash
-   $PWD/.claude/scripts/generic/claudin/gh-pr-body-update.sh --pr <PR_NUMBER> --body-file "$IMPL_TMPDIR/pr-body.md"
+   $PWD/.claude/scripts/generic/larch/gh-pr-body-update.sh --pr <PR_NUMBER> --body-file "$IMPL_TMPDIR/pr-body.md"
    ```
 
 If `execution-issues.md` does not exist or is empty, skip this refresh.
@@ -581,7 +581,7 @@ Print a report of all review suggestions that were **not** implemented.
 Remove the session temp directory and all files within it:
 
 ```bash
-$PWD/.claude/scripts/generic/claudin/cleanup-tmpdir.sh --dir "$IMPL_TMPDIR"
+$PWD/.claude/scripts/generic/larch/cleanup-tmpdir.sh --dir "$IMPL_TMPDIR"
 ```
 
 If a PR was created (Step 9 completed), print: `🏁 Step 13 — Implementation complete! PR created but not merged.`

--- a/.claude/skills/loop-review/SKILL.md
+++ b/.claude/skills/loop-review/SKILL.md
@@ -18,7 +18,7 @@ Systematically review the entire codebase by partitioning into slices, reviewing
 Ensure you are on the `main` branch with a clean working tree and the latest code:
 
 ```bash
-$PWD/.claude/scripts/generic/claudin/preflight.sh
+$PWD/.claude/scripts/generic/larch/preflight.sh
 ```
 
 If it exits non-zero, print the `PREFLIGHT_ERROR` from stdout and abort.
@@ -28,7 +28,7 @@ If it exits non-zero, print the `PREFLIGHT_ERROR` from stdout and abort.
 Create a session-scoped temp directory:
 
 ```bash
-$PWD/.claude/scripts/generic/claudin/create-session-tmpdir.sh --prefix claude-loop-review
+$PWD/.claude/scripts/generic/larch/create-session-tmpdir.sh --prefix claude-loop-review
 ```
 
 Parse the output for `SESSION_TMPDIR`. Set `LR_TMPDIR` = `SESSION_TMPDIR`. Initialize tracking files:
@@ -39,7 +39,7 @@ $PWD/.claude/skills/loop-review/scripts/init-session-files.sh --dir "$LR_TMPDIR"
 
 ### 0c — Quick External Reviewer Check
 
-Read and follow the **Binary Check** section in `.claude/skills/shared/claudin/external-reviewers.md`.
+Read and follow the **Binary Check** section in `.claude/skills/shared/larch/external-reviewers.md`.
 
 Set `codex_available` and `cursor_available` flags for the entire session. If either is unavailable, append the warning to `$LR_TMPDIR/warnings.md`.
 
@@ -105,7 +105,7 @@ Launch ALL available reviewers in a **single message**. **Spawn order matters fo
 Run Cursor **first** in the parallel message (it takes the longest):
 
 ```bash
-$PWD/.claude/scripts/generic/claudin/run-external-reviewer.sh --tool cursor --output "$LR_TMPDIR/cursor-output-slice-N.txt" --timeout 900 --capture-stdout -- \
+$PWD/.claude/scripts/generic/larch/run-external-reviewer.sh --tool cursor --output "$LR_TMPDIR/cursor-output-slice-N.txt" --timeout 900 --capture-stdout -- \
   cursor agent -p --force --trust --model gpt-5.4-medium --workspace "$PWD" \
     "Review EXISTING code (not a diff — do NOT run git diff) in this project. The file list is in $LR_TMPDIR/slice-N-files.txt — read it, then read and review each listed file. Also inspect corresponding tests and callers for context. Combine 4 review perspectives: (1) Quality: bugs, logic errors, dead code, duplication, missing error handling. (2) Correctness: off-by-one, nil handling, type mismatches, races, error paths. (3) Risk/Integration: broken contracts, thread safety, deployment risks, CI gaps. (4) Architecture: separation of concerns, contract boundaries, invariants, semantic boundaries. Return numbered findings with perspective, file:line, issue, and specific fix. If NO issues, output exactly NO_ISSUES_FOUND. Do NOT modify files."
 ```
@@ -117,7 +117,7 @@ Use `run_in_background: true` and `timeout: 960000` on the Bash tool call.
 Run Codex-General **second** in the parallel message:
 
 ```bash
-$PWD/.claude/scripts/generic/claudin/run-external-reviewer.sh --tool codex --output "$LR_TMPDIR/codex-general-output-slice-N.txt" --timeout 900 -- \
+$PWD/.claude/scripts/generic/larch/run-external-reviewer.sh --tool codex --output "$LR_TMPDIR/codex-general-output-slice-N.txt" --timeout 900 -- \
   codex exec --full-auto -C "$PWD" \
     --output-last-message "$LR_TMPDIR/codex-general-output-slice-N.txt" \
     "Review EXISTING code (not a diff — do NOT run git diff) in this project. The file list is in $LR_TMPDIR/slice-N-files.txt — read it, then read and review each listed file. Also inspect corresponding tests and callers for context. Focus on: quality, bugs, risk, integration, CI. Return numbered findings with file:line, issue, and specific fix. If NO issues, output exactly NO_ISSUES_FOUND. Do NOT modify files."
@@ -130,7 +130,7 @@ Use `run_in_background: true` and `timeout: 960000` on the Bash tool call.
 Run Codex-Deep-Analysis **third** in the parallel message:
 
 ```bash
-$PWD/.claude/scripts/generic/claudin/run-external-reviewer.sh --tool codex --output "$LR_TMPDIR/codex-deep-output-slice-N.txt" --timeout 900 -- \
+$PWD/.claude/scripts/generic/larch/run-external-reviewer.sh --tool codex --output "$LR_TMPDIR/codex-deep-output-slice-N.txt" --timeout 900 -- \
   codex exec --full-auto -C "$PWD" \
     --output-last-message "$LR_TMPDIR/codex-deep-output-slice-N.txt" \
     "Review EXISTING code (not a diff — do NOT run git diff) in this project. The file list is in $LR_TMPDIR/slice-N-files.txt — read it, then read and review each listed file. Also inspect corresponding tests and callers for context. Focus on: correctness, architecture, invariants, contracts. Return numbered findings with file:line, issue, and specific fix. If NO issues, output exactly NO_ISSUES_FOUND. Do NOT modify files."
@@ -148,7 +148,7 @@ Use `run_in_background: true` and `timeout: 960000` on the Bash tool call.
 
 **Monitoring External Reviewers:**
 
-If any external reviewer was launched, follow the **Monitoring External Reviewers** and **Validating External Reviewer Output** sections in `.claude/skills/shared/claudin/external-reviewers.md`, using `$LR_TMPDIR/codex-general-output-slice-N.txt`, `$LR_TMPDIR/codex-deep-output-slice-N.txt`, and `$LR_TMPDIR/cursor-output-slice-N.txt` as the output files. Poll for sentinel files: `$LR_TMPDIR/cursor-output-slice-N.txt.done`, `$LR_TMPDIR/codex-general-output-slice-N.txt.done`, and `$LR_TMPDIR/codex-deep-output-slice-N.txt.done`. Only monitor reviewers that were actually launched.
+If any external reviewer was launched, follow the **Monitoring External Reviewers** and **Validating External Reviewer Output** sections in `.claude/skills/shared/larch/external-reviewers.md`, using `$LR_TMPDIR/codex-general-output-slice-N.txt`, `$LR_TMPDIR/codex-deep-output-slice-N.txt`, and `$LR_TMPDIR/cursor-output-slice-N.txt` as the output files. Poll for sentinel files: `$LR_TMPDIR/cursor-output-slice-N.txt.done`, `$LR_TMPDIR/codex-general-output-slice-N.txt.done`, and `$LR_TMPDIR/codex-deep-output-slice-N.txt.done`. Only monitor reviewers that were actually launched.
 
 **Critical**: Do NOT read Cursor's output file until `$LR_TMPDIR/cursor-output-slice-N.txt.done` exists. Cursor buffers all stdout — the file is empty (0 bytes) until the process exits. The `.done` sentinel file is the reliable completion signal.
 
@@ -162,7 +162,7 @@ If validation fails (empty output after retry, timeout, or non-zero exit), appen
 
 **2. Negotiate** with external reviewers (if they produced findings):
 
-Follow the **Negotiation Protocol** in `.claude/skills/shared/claudin/external-reviewers.md`, using `$LR_TMPDIR` as the tmpdir, with `max_rounds=1`. With 2 Codex instances (Codex-General and Codex-Deep-Analysis), negotiate with each separately using distinct prompt/output file paths (e.g., `codex-general-negotiation-prompt.txt` / `codex-general-negotiation-output.txt` and `codex-deep-negotiation-prompt.txt` / `codex-deep-negotiation-output.txt`). Accept findings unless factually incorrect or contradicting CLAUDE.md.
+Follow the **Negotiation Protocol** in `.claude/skills/shared/larch/external-reviewers.md`, using `$LR_TMPDIR` as the tmpdir, with `max_rounds=1`. With 2 Codex instances (Codex-General and Codex-Deep-Analysis), negotiate with each separately using distinct prompt/output file paths (e.g., `codex-general-negotiation-prompt.txt` / `codex-general-negotiation-output.txt` and `codex-deep-negotiation-prompt.txt` / `codex-deep-negotiation-output.txt`). Accept findings unless factually incorrect or contradicting CLAUDE.md.
 
 Note: "accepted" in the negotiation sense means the finding is valid — it may still be classified as DEFER below.
 
@@ -259,12 +259,12 @@ If there are uncommitted deferred items in `$LR_TMPDIR/deferred-accumulated.md` 
 
 1. Create a branch: `git checkout -b $USER_PREFIX/loop-review-deferred`
 2. Update `LOOP_REVIEW_DEFERRED.md` with the accumulated deferred items
-3. Commit: `$PWD/.claude/scripts/generic/claudin/git-commit.sh -m "Update LOOP_REVIEW_DEFERRED.md with deferred review suggestions" LOOP_REVIEW_DEFERRED.md`
-4. Create PR via `$PWD/.claude/scripts/generic/claudin/create-pr.sh`
-5. Post to Slack: `$PWD/.claude/scripts/generic/claudin/post-pr-announce.sh --pr <PR_NUMBER>` — parse `SLACK_TS` from output
+3. Commit: `$PWD/.claude/scripts/generic/larch/git-commit.sh -m "Update LOOP_REVIEW_DEFERRED.md with deferred review suggestions" LOOP_REVIEW_DEFERRED.md`
+4. Create PR via `$PWD/.claude/scripts/generic/larch/create-pr.sh`
+5. Post to Slack: `$PWD/.claude/scripts/generic/larch/post-pr-announce.sh --pr <PR_NUMBER>` — parse `SLACK_TS` from output
 6. Monitor CI and merge (same loop as `/shazam` Step 3)
-7. Add :merged: emoji: `$PWD/.claude/scripts/generic/claudin/post-merged-emoji.sh --slack-ts "$SLACK_TS"`
-8. Cleanup: `$PWD/.claude/scripts/generic/claudin/local-cleanup.sh --branch $USER_PREFIX/loop-review-deferred`
+7. Add :merged: emoji: `$PWD/.claude/scripts/generic/larch/post-merged-emoji.sh --slack-ts "$SLACK_TS"`
+8. Cleanup: `$PWD/.claude/scripts/generic/larch/local-cleanup.sh --branch $USER_PREFIX/loop-review-deferred`
 
 If no remaining items, skip this step.
 
@@ -292,5 +292,5 @@ Deferred suggestions: see LOOP_REVIEW_DEFERRED.md
 ## Step 6 — Cleanup
 
 ```bash
-$PWD/.claude/scripts/generic/claudin/cleanup-tmpdir.sh --dir "$LR_TMPDIR"
+$PWD/.claude/scripts/generic/larch/cleanup-tmpdir.sh --dir "$LR_TMPDIR"
 ```

--- a/.claude/skills/research/SKILL.md
+++ b/.claude/skills/research/SKILL.md
@@ -36,21 +36,21 @@ Suggested emoji palette (use consistently):
 Create a session-scoped temporary directory:
 
 ```bash
-$PWD/.claude/scripts/generic/claudin/create-session-tmpdir.sh --prefix claude-research
+$PWD/.claude/scripts/generic/larch/create-session-tmpdir.sh --prefix claude-research
 ```
 
 Parse the output for `SESSION_TMPDIR`. Set `RESEARCH_TMPDIR` = `SESSION_TMPDIR`. Substitute the actual path in every command below.
 
 ### 0b — Quick External Reviewer Check
 
-Read and follow the **Binary Check** section in `.claude/skills/shared/claudin/external-reviewers.md`.
+Read and follow the **Binary Check** section in `.claude/skills/shared/larch/external-reviewers.md`.
 
 ### 0c — Record Research Context
 
 Record the current branch and commit for inclusion in the final report:
 
 ```bash
-$PWD/.claude/scripts/generic/claudin/git-branch-info.sh
+$PWD/.claude/scripts/generic/larch/git-branch-info.sh
 ```
 
 Parse the output for `HEAD_SHA` and `CURRENT_BRANCH`. If `CURRENT_BRANCH` is empty (detached HEAD), use `"(detached HEAD)"` in the report.
@@ -85,7 +85,7 @@ Print `🔬 Step 1 — Running collaborative research phase.` and proceed to 1.2
 **Cursor research** (if `cursor_available`):
 
 ```bash
-$PWD/.claude/scripts/generic/claudin/run-external-reviewer.sh --tool cursor --output "$RESEARCH_TMPDIR/cursor-research-output.txt" --timeout 900 --capture-stdout -- \
+$PWD/.claude/scripts/generic/larch/run-external-reviewer.sh --tool cursor --output "$RESEARCH_TMPDIR/cursor-research-output.txt" --timeout 900 --capture-stdout -- \
   cursor agent -p --force --trust --model gpt-5.4-medium --workspace "$PWD" \
     "You are researching a codebase to answer this question: <RESEARCH_QUESTION>. Explore the codebase to understand the relevant architecture and code. Write 2-3 paragraphs covering: (1) Your key findings and observations relevant to the research question, (2) Which files/modules/areas are most relevant and why, (3) Any risks, constraints, or feasibility concerns you identify. Do NOT modify files."
 ```
@@ -99,7 +99,7 @@ Prompt: `"You are an Alternative Perspectives researcher. Investigate this resea
 **Codex research** (if `codex_available`):
 
 ```bash
-$PWD/.claude/scripts/generic/claudin/run-external-reviewer.sh --tool codex --output "$RESEARCH_TMPDIR/codex-research-output.txt" --timeout 900 -- \
+$PWD/.claude/scripts/generic/larch/run-external-reviewer.sh --tool codex --output "$RESEARCH_TMPDIR/codex-research-output.txt" --timeout 900 -- \
   codex exec --full-auto -C "$PWD" \
     --output-last-message "$RESEARCH_TMPDIR/codex-research-output.txt" \
     "You are researching a codebase to answer this question: <RESEARCH_QUESTION>. Explore the codebase to understand the relevant architecture and code. Write 2-3 paragraphs covering: (1) Your key findings and observations relevant to the research question, (2) Which files/modules/areas are most relevant and why, (3) Any risks, constraints, or feasibility concerns you identify. Do NOT modify files."
@@ -126,12 +126,12 @@ Prompt: `"You are a Risk/Feasibility researcher. Investigate this research quest
 Wait for external research sentinels using `wait-for-reviewers.sh`. Only include paths for external reviewers that were actually launched (not Claude replacements — those return via Agent tool):
 
 ```bash
-$PWD/.claude/scripts/generic/claudin/wait-for-reviewers.sh --timeout 960 "$RESEARCH_TMPDIR/cursor-research-output.txt.done" "$RESEARCH_TMPDIR/codex-research-output.txt.done"
+$PWD/.claude/scripts/generic/larch/wait-for-reviewers.sh --timeout 960 "$RESEARCH_TMPDIR/cursor-research-output.txt.done" "$RESEARCH_TMPDIR/codex-research-output.txt.done"
 ```
 
 Use `timeout: 960000` on the Bash tool call. **Do NOT** set `run_in_background: true` — this call must block. Only include sentinel paths for external reviewers that were actually launched.
 
-**Validate research outputs**: For research outputs, the validation criteria differ from the standard review validation in `.claude/skills/shared/claudin/external-reviewers.md`: instead of checking for numbered findings or `NO_ISSUES_FOUND`, check that the output is non-empty and contains at least one paragraph of substantive prose. Use `$RESEARCH_TMPDIR/cursor-research-output.txt` and `$RESEARCH_TMPDIR/codex-research-output.txt` as the output files. If an output is empty despite exit code 0, retry once with a `-retry` suffix per the shared procedure in `external-reviewers.md`.
+**Validate research outputs**: For research outputs, the validation criteria differ from the standard review validation in `.claude/skills/shared/larch/external-reviewers.md`: instead of checking for numbered findings or `NO_ISSUES_FOUND`, check that the output is non-empty and contains at least one paragraph of substantive prose. Use `$RESEARCH_TMPDIR/cursor-research-output.txt` and `$RESEARCH_TMPDIR/codex-research-output.txt` as the output files. If an output is empty despite exit code 0, retry once with a `-retry` suffix per the shared procedure in `external-reviewers.md`.
 
 ### 1.4 — Synthesis
 
@@ -165,7 +165,7 @@ The research report is already written to `$RESEARCH_TMPDIR/research-report.txt`
 Run Cursor **first** in the parallel message (it takes the longest):
 
 ```bash
-$PWD/.claude/scripts/generic/claudin/run-external-reviewer.sh --tool cursor --output "$RESEARCH_TMPDIR/cursor-validation-output.txt" --timeout 900 --capture-stdout -- \
+$PWD/.claude/scripts/generic/larch/run-external-reviewer.sh --tool cursor --output "$RESEARCH_TMPDIR/cursor-validation-output.txt" --timeout 900 --capture-stdout -- \
   cursor agent -p --force --trust --model gpt-5.4-medium --workspace "$PWD" \
     "Review the research findings in $RESEARCH_TMPDIR/research-report.txt for accuracy and completeness. Read the report, then explore the codebase to verify claims. Combine 4 perspectives: (1) General: Are findings accurate? Is anything important missing? Are conclusions well-supported by evidence? (2) Correctness: Are specific code references correct? Are there factual errors about the codebase? (3) Risk/Completeness: Are risks properly identified? Are there blind spots or omissions? (4) Architecture: Are architectural observations accurate? Are there structural patterns that were missed? Return numbered findings with perspective, concern, and suggested correction. If the research is accurate and complete, output exactly NO_ISSUES_FOUND. Do NOT modify files."
 ```
@@ -177,7 +177,7 @@ Use `run_in_background: true` and `timeout: 960000` on the Bash tool call.
 Run Codex-General **second** in the parallel message:
 
 ```bash
-$PWD/.claude/scripts/generic/claudin/run-external-reviewer.sh --tool codex --output "$RESEARCH_TMPDIR/codex-general-validation-output.txt" --timeout 900 -- \
+$PWD/.claude/scripts/generic/larch/run-external-reviewer.sh --tool codex --output "$RESEARCH_TMPDIR/codex-general-validation-output.txt" --timeout 900 -- \
   codex exec --full-auto -C "$PWD" \
     --output-last-message "$RESEARCH_TMPDIR/codex-general-validation-output.txt" \
     "Review the research findings in $RESEARCH_TMPDIR/research-report.txt for accuracy and completeness. Read the report, then explore the codebase to verify claims. Focus on 2 perspectives: (1) General: Are findings accurate? Is anything important missing? Are conclusions well-supported by evidence? (2) Risk/Completeness: Are risks properly identified? Are there blind spots or omissions? Return numbered findings with perspective, concern, and suggested correction. If the research is accurate and complete, output exactly NO_ISSUES_FOUND. Do NOT modify files."
@@ -190,7 +190,7 @@ Use `run_in_background: true` and `timeout: 960000` on the Bash tool call.
 Run Codex-Deep-Analysis **third** in the parallel message:
 
 ```bash
-$PWD/.claude/scripts/generic/claudin/run-external-reviewer.sh --tool codex --output "$RESEARCH_TMPDIR/codex-deep-validation-output.txt" --timeout 900 -- \
+$PWD/.claude/scripts/generic/larch/run-external-reviewer.sh --tool codex --output "$RESEARCH_TMPDIR/codex-deep-validation-output.txt" --timeout 900 -- \
   codex exec --full-auto -C "$PWD" \
     --output-last-message "$RESEARCH_TMPDIR/codex-deep-validation-output.txt" \
     "Review the research findings in $RESEARCH_TMPDIR/research-report.txt for accuracy and completeness. Read the report, then explore the codebase to verify claims. Focus on 2 perspectives: (1) Correctness: Are specific code references correct? Are there factual errors about the codebase? (2) Architecture: Are architectural observations accurate? Are there structural patterns that were missed? Return numbered findings with perspective, concern, and suggested correction. If the research is accurate and complete, output exactly NO_ISSUES_FOUND. Do NOT modify files."
@@ -202,7 +202,7 @@ Use `run_in_background: true` and `timeout: 960000` on the Bash tool call.
 
 Launch both Claude subagents **last** in the same message (they finish fastest).
 
-Use the two reviewer archetypes from `.claude/skills/shared/claudin/reviewer-templates.md`, filling in the variables for **research validation**:
+Use the two reviewer archetypes from `.claude/skills/shared/larch/reviewer-templates.md`, filling in the variables for **research validation**:
 
 - **`{REVIEW_TARGET}`** = `"research findings"`
 - **`{CONTEXT_BLOCK}`**:
@@ -219,7 +219,7 @@ Use the two reviewer archetypes from `.claude/skills/shared/claudin/reviewer-tem
 
 ### Monitoring External Reviewers
 
-Follow the **Monitoring External Reviewers** and **Validating External Reviewer Output** sections in `.claude/skills/shared/claudin/external-reviewers.md`, using `$RESEARCH_TMPDIR/codex-general-validation-output.txt`, `$RESEARCH_TMPDIR/codex-deep-validation-output.txt`, and `$RESEARCH_TMPDIR/cursor-validation-output.txt` as the output files.
+Follow the **Monitoring External Reviewers** and **Validating External Reviewer Output** sections in `.claude/skills/shared/larch/external-reviewers.md`, using `$RESEARCH_TMPDIR/codex-general-validation-output.txt`, `$RESEARCH_TMPDIR/codex-deep-validation-output.txt`, and `$RESEARCH_TMPDIR/cursor-validation-output.txt` as the output files.
 
 ### After all reviewers return
 
@@ -232,17 +232,17 @@ Follow the **Monitoring External Reviewers** and **Validating External Reviewer 
 After processing Claude findings, wait for external reviewer sentinels using `wait-for-reviewers.sh`. Only include paths for external reviewers that were actually launched:
 
 ```bash
-$PWD/.claude/scripts/generic/claudin/wait-for-reviewers.sh --timeout 960 "$RESEARCH_TMPDIR/cursor-validation-output.txt.done" "$RESEARCH_TMPDIR/codex-general-validation-output.txt.done" "$RESEARCH_TMPDIR/codex-deep-validation-output.txt.done"
+$PWD/.claude/scripts/generic/larch/wait-for-reviewers.sh --timeout 960 "$RESEARCH_TMPDIR/cursor-validation-output.txt.done" "$RESEARCH_TMPDIR/codex-general-validation-output.txt.done" "$RESEARCH_TMPDIR/codex-deep-validation-output.txt.done"
 ```
 
 Use `timeout: 960000` on the Bash tool call. **Do NOT** set `run_in_background: true` — this call must block.
 
-2. Read each reviewer's exit code from its sentinel file, then validate its output per the shared procedure in `.claude/skills/shared/claudin/external-reviewers.md`.
+2. Read each reviewer's exit code from its sentinel file, then validate its output per the shared procedure in `.claude/skills/shared/larch/external-reviewers.md`.
 3. Merge external reviewer findings into the already-processed Claude findings.
 
 ### Codex and Cursor Negotiation (in parallel)
 
-If any external reviewers produced findings, negotiate with each independently. With 2 Codex instances (Codex-General and Codex-Deep-Analysis), negotiate with each separately using distinct prompt/output file paths (e.g., `codex-general-negotiation-prompt.txt` / `codex-general-negotiation-output.txt` and `codex-deep-negotiation-prompt.txt` / `codex-deep-negotiation-output.txt`). Run all negotiations **in parallel** when multiple external reviewers produced findings. Use the **Negotiation Protocol** in `.claude/skills/shared/claudin/external-reviewers.md`, using `$RESEARCH_TMPDIR` as the tmpdir. Merge accepted/rejected outcomes after all complete.
+If any external reviewers produced findings, negotiate with each independently. With 2 Codex instances (Codex-General and Codex-Deep-Analysis), negotiate with each separately using distinct prompt/output file paths (e.g., `codex-general-negotiation-prompt.txt` / `codex-general-negotiation-output.txt` and `codex-deep-negotiation-prompt.txt` / `codex-deep-negotiation-output.txt`). Run all negotiations **in parallel** when multiple external reviewers produced findings. Use the **Negotiation Protocol** in `.claude/skills/shared/larch/external-reviewers.md`, using `$RESEARCH_TMPDIR` as the tmpdir. Merge accepted/rejected outcomes after all complete.
 
 ### Finalize Validation
 
@@ -293,7 +293,7 @@ Print: `📊 Step 3 — Research report complete.`
 Remove the session temp directory and all files within it:
 
 ```bash
-$PWD/.claude/scripts/generic/claudin/cleanup-tmpdir.sh --dir "$RESEARCH_TMPDIR"
+$PWD/.claude/scripts/generic/larch/cleanup-tmpdir.sh --dir "$RESEARCH_TMPDIR"
 ```
 
 **Repeat any external reviewer warnings** from earlier steps (Step 0b binary checks, Step 1 research-phase failures/timeouts, or Step 2 validation failures) so they are visible at the end of the workflow. For example:

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -30,21 +30,21 @@ When changes touch files under `.claude/scripts/generic/` or `.claude/skills/sha
 Create a session-scoped temporary directory to avoid collisions with parallel sessions:
 
 ```bash
-$PWD/.claude/scripts/generic/claudin/create-session-tmpdir.sh --prefix claude-review
+$PWD/.claude/scripts/generic/larch/create-session-tmpdir.sh --prefix claude-review
 ```
 
 Parse the output for `SESSION_TMPDIR`. Set `REVIEW_TMPDIR` = `SESSION_TMPDIR`. Substitute the actual path in every command below.
 
 ### 0b — Quick External Reviewer Check
 
-Read and follow the **Binary Check** section in `.claude/skills/shared/claudin/external-reviewers.md`.
+Read and follow the **Binary Check** section in `.claude/skills/shared/larch/external-reviewers.md`.
 
 ## Step 1 — Gather Context
 
 Run the gather script to collect the diff and context:
 
 ```bash
-$PWD/.claude/scripts/generic/claudin/gather-branch-context.sh --output-dir "$REVIEW_TMPDIR"
+$PWD/.claude/scripts/generic/larch/gather-branch-context.sh --output-dir "$REVIEW_TMPDIR"
 ```
 
 Parse the output for `DIFF_FILE`, `FILE_LIST_FILE`, and `COMMIT_LOG_FILE`. Read these files to get the full diff, file list, and commit log — you will pass these to each subagent.
@@ -60,7 +60,7 @@ Run Cursor **first** in the parallel message (it takes the longest). Cursor has 
 Invoke Cursor via the shared monitored wrapper script (with `--capture-stdout` since Cursor writes results to stdout):
 
 ```bash
-$PWD/.claude/scripts/generic/claudin/run-external-reviewer.sh --tool cursor --output "$REVIEW_TMPDIR/cursor-output.txt" --timeout 900 --capture-stdout -- \
+$PWD/.claude/scripts/generic/larch/run-external-reviewer.sh --tool cursor --output "$REVIEW_TMPDIR/cursor-output.txt" --timeout 900 --capture-stdout -- \
   cursor agent -p --force --trust --model gpt-5.4-medium --workspace "$PWD" \
     "Review all code changes on the current branch vs main. Run git diff main...HEAD to see changes and git log main...HEAD --oneline for commits. For each changed file, read the full file for context. Combine 4 review perspectives: (1) General: bugs, logic, quality, tests, backward compat, style. (2) Correctness: logic errors, off-by-one, nil handling, type mismatches, races, error paths. (3) Risk/Integration: breaking changes, side effects, thread safety, deployment risks, regressions, CI. (4) Architecture: separation of concerns, contract boundaries, invariants, semantic boundaries. Return numbered findings with perspective, file:line, issue, and suggested fix. If NO issues, output exactly NO_ISSUES_FOUND. Do NOT modify files."
 ```
@@ -76,7 +76,7 @@ Invoke both Codex instances via the shared monitored wrapper script:
 **Codex-General** (general code quality and risk/integration):
 
 ```bash
-$PWD/.claude/scripts/generic/claudin/run-external-reviewer.sh --tool codex --output "$REVIEW_TMPDIR/codex-general-output.txt" --timeout 900 -- \
+$PWD/.claude/scripts/generic/larch/run-external-reviewer.sh --tool codex --output "$REVIEW_TMPDIR/codex-general-output.txt" --timeout 900 -- \
   codex exec --full-auto -C "$PWD" \
     --output-last-message "$REVIEW_TMPDIR/codex-general-output.txt" \
     "Review all code changes on the current branch vs main. Run git diff main...HEAD to see changes and git log main...HEAD --oneline for commits. For each changed file, read the full file for context. Focus on general code quality and risk/integration: bugs, logic, quality, tests, backward compat, style, breaking changes, deployment risks, regressions, CI constraints. Return numbered findings with file:line, issue, and suggested fix. If NO issues, output exactly NO_ISSUES_FOUND. Do NOT modify files."
@@ -87,7 +87,7 @@ Use `run_in_background: true` and `timeout: 960000` on the Bash tool call.
 **Codex-Deep-Analysis** (deep correctness and architecture):
 
 ```bash
-$PWD/.claude/scripts/generic/claudin/run-external-reviewer.sh --tool codex --output "$REVIEW_TMPDIR/codex-deep-output.txt" --timeout 900 -- \
+$PWD/.claude/scripts/generic/larch/run-external-reviewer.sh --tool codex --output "$REVIEW_TMPDIR/codex-deep-output.txt" --timeout 900 -- \
   codex exec --full-auto -C "$PWD" \
     --output-last-message "$REVIEW_TMPDIR/codex-deep-output.txt" \
     "Review all code changes on the current branch vs main. Run git diff main...HEAD to see changes and git log main...HEAD --oneline for commits. For each changed file, read the full file for context. Focus on deep correctness and architecture: logic errors, off-by-one, nil handling, type mismatches, races, error paths, separation of concerns, contract boundaries, invariants, semantic boundaries. Return numbered findings with file:line, issue, and suggested fix. If NO issues, output exactly NO_ISSUES_FOUND. Do NOT modify files."
@@ -99,7 +99,7 @@ Use `run_in_background: true` and `timeout: 960000` on the Bash tool call.
 
 Launch both Claude subagents **last** in the same message (they finish fastest).
 
-Use the two reviewer archetypes from `.claude/skills/shared/claudin/reviewer-templates.md`, filling in the variables for **code review**:
+Use the two reviewer archetypes from `.claude/skills/shared/larch/reviewer-templates.md`, filling in the variables for **code review**:
 
 - **`{REVIEW_TARGET}`** = `"code changes"`
 - **`{CONTEXT_BLOCK}`**:
@@ -122,7 +122,7 @@ Additionally, append the following competition context to each reviewer's prompt
 
 ### Monitoring External Reviewers
 
-Follow the **Monitoring External Reviewers** and **Validating External Reviewer Output** sections in `.claude/skills/shared/claudin/external-reviewers.md`, using `$REVIEW_TMPDIR/codex-general-output.txt`, `$REVIEW_TMPDIR/codex-deep-output.txt`, and `$REVIEW_TMPDIR/cursor-output.txt` as the output files.
+Follow the **Monitoring External Reviewers** and **Validating External Reviewer Output** sections in `.claude/skills/shared/larch/external-reviewers.md`, using `$REVIEW_TMPDIR/codex-general-output.txt`, `$REVIEW_TMPDIR/codex-deep-output.txt`, and `$REVIEW_TMPDIR/cursor-output.txt` as the output files.
 
 **Critical**: Do NOT read `$REVIEW_TMPDIR/cursor-output.txt` until `$REVIEW_TMPDIR/cursor-output.txt.done` exists. Cursor buffers all stdout — the file is empty (0 bytes) until the process exits. The `.done` sentinel file is written by the wrapper script upon completion and contains the exit code.
 
@@ -135,7 +135,7 @@ This step repeats until reviewers find no more issues. Track the current **round
 **Process Claude findings immediately** — do not wait for external reviewers before starting. After both Claude subagents return:
 
 1. Collect findings from the two Claude subagents right away. Claude subagents produce **dual-list output** (per `reviewer-templates.md`): "In-Scope Findings" and "Out-of-Scope Observations". Parse both lists from each subagent.
-2. **Then** poll for external reviewer sentinel files (`$REVIEW_TMPDIR/cursor-output.txt.done`, `$REVIEW_TMPDIR/codex-general-output.txt.done`, and `$REVIEW_TMPDIR/codex-deep-output.txt.done`, only for reviewers that were actually launched) using the polling procedure in `.claude/skills/shared/claudin/external-reviewers.md`.
+2. **Then** poll for external reviewer sentinel files (`$REVIEW_TMPDIR/cursor-output.txt.done`, `$REVIEW_TMPDIR/codex-general-output.txt.done`, and `$REVIEW_TMPDIR/codex-deep-output.txt.done`, only for reviewers that were actually launched) using the polling procedure in `.claude/skills/shared/larch/external-reviewers.md`.
 3. Once sentinel files exist, read each reviewer's exit code, then read and validate the output per the shared procedure. External reviewers (Codex, Cursor) produce single-list output — treat their entire output as in-scope findings.
 4. Merge external reviewer in-scope findings into the Claude in-scope findings. Deduplicate in-scope findings and OOS observations separately (see `voting-protocol.md` OOS section). If the same issue appears in both lists from different reviewers, merge under the in-scope finding.
 
@@ -151,7 +151,7 @@ Merge findings from all reviewers into a single deduplicated list, grouped by fi
 
 ### 3c.1 — Voting Panel (round 1 only)
 
-**In round 1**: Submit both in-scope findings and out-of-scope observations to a 3-agent voting panel per the **Voting Protocol** in `.claude/skills/shared/claudin/voting-protocol.md`. Include OOS items on the ballot with `[OUT_OF_SCOPE]` prefix per the protocol's OOS section. For code review:
+**In round 1**: Submit both in-scope findings and out-of-scope observations to a 3-agent voting panel per the **Voting Protocol** in `.claude/skills/shared/larch/voting-protocol.md`. Include OOS items on the ballot with `[OUT_OF_SCOPE]` prefix per the protocol's OOS section. For code review:
 
 - **Voter 1**: Claude General reviewer subagent — fresh Agent tool invocation with the voting prompt. Instruct: `"You are a very scrupulous senior engineer code reviewer on a voting panel. You will vote YES, NO, or EXONERATE on proposed code changes. Be extremely rigorous — only vote YES for findings that identify genuine bugs, logic errors, security issues, or clearly important improvements. Vote EXONERATE if the concern is legitimate but not worth implementing in this PR. Vote NO for trivial style nits, subjective preferences, or speculative concerns."`
 - **Voter 2**: Codex — via `run-external-reviewer.sh` with the ballot. Instruct similarly as a "very scrupulous senior engineer code reviewer."
@@ -225,5 +225,5 @@ Print a final summary:
 Remove the session temp directory and all files within it:
 
 ```bash
-$PWD/.claude/scripts/generic/claudin/cleanup-tmpdir.sh --dir "$REVIEW_TMPDIR"
+$PWD/.claude/scripts/generic/larch/cleanup-tmpdir.sh --dir "$REVIEW_TMPDIR"
 ```

--- a/.claude/skills/shazam/SKILL.md
+++ b/.claude/skills/shazam/SKILL.md
@@ -43,7 +43,7 @@ Suggested emoji palette (use consistently):
 Run the shared session setup script. If `SESSION_ENV_PATH` is non-empty (passed via `--session-env`), include `--caller-env` to reuse already-discovered values:
 
 ```bash
-$PWD/.claude/scripts/generic/claudin/session-setup.sh --prefix claude-shazam [--caller-env "$SESSION_ENV_PATH"]
+$PWD/.claude/scripts/generic/larch/session-setup.sh --prefix claude-shazam [--caller-env "$SESSION_ENV_PATH"]
 ```
 
 Only include `--caller-env "$SESSION_ENV_PATH"` if `SESSION_ENV_PATH` is non-empty.
@@ -60,7 +60,7 @@ Parse the output for `SESSION_TMPDIR`, `SLACK_OK`, `SLACK_MISSING`, `REPO`, `REP
 Write the discovered values to `$SHAZAM_TMPDIR/session-env.sh` so they can be forwarded to `/implement`:
 
 ```bash
-$PWD/.claude/scripts/generic/claudin/write-session-env.sh --output "$SHAZAM_TMPDIR/session-env.sh" \
+$PWD/.claude/scripts/generic/larch/write-session-env.sh --output "$SHAZAM_TMPDIR/session-env.sh" \
   --slack-ok <value> --slack-missing <value> --repo <value> --repo-unavailable <value>
 ```
 
@@ -116,7 +116,7 @@ Track these counters (all start at 0):
 **Wait for CI** using the `ci-wait.sh` script, which polls `ci-status.sh` + `ci-decide.sh` internally and prints compact dot-based progress to stderr:
 
 ```bash
-$PWD/.claude/scripts/generic/claudin/ci-wait.sh --pr <PR-NUMBER> --repo $REPO \
+$PWD/.claude/scripts/generic/larch/ci-wait.sh --pr <PR-NUMBER> --repo $REPO \
   --rebase-count "$rebase_count" --fix-attempts "$fix_attempts" --iteration "$iteration"
 ```
 
@@ -142,7 +142,7 @@ After handling any non-merge/non-bail action (rebase, evaluate_failure, etc.), *
 
 4. **When rebase is needed** (ACTION=rebase or rebase_then_evaluate), use the `rebase-push.sh` script:
    ```bash
-   $PWD/.claude/scripts/generic/claudin/rebase-push.sh
+   $PWD/.claude/scripts/generic/larch/rebase-push.sh
    ```
    Handle exit codes:
    - **Exit 0**: Rebase and push succeeded.
@@ -154,7 +154,7 @@ After handling any non-merge/non-bail action (rebase, evaluate_failure, etc.), *
 
 When `rebase-push.sh` exits with code 1, the rebase is paused with conflicts. This procedure resolves them intelligently, with user escalation when uncertain and a full reviewer panel to validate the resolution.
 
-**Bail invariant**: Any bail from any phase below must call `$PWD/.claude/scripts/generic/claudin/git-rebase-abort.sh` before proceeding to Step 2d, since the rebase is in progress throughout all phases.
+**Bail invariant**: Any bail from any phase below must call `$PWD/.claude/scripts/generic/larch/git-rebase-abort.sh` before proceeding to Step 2d, since the rebase is in progress throughout all phases.
 
 #### Phase 1 — Conflict Classification and Resolution
 
@@ -189,7 +189,7 @@ For each file in `CONFLICT_FILES`:
 
 **3a. Create temp directory**: Create `$SHAZAM_TMPDIR/conflict-review/` for reviewer artifacts. If it already exists (from a prior conflict resolution in this rebase loop), remove it and recreate.
 
-**3b. Check external reviewer availability**: Run `$PWD/.claude/scripts/generic/claudin/check-reviewers.sh` to set `codex_available` and `cursor_available` flags. Follow the Binary Check procedure in `.claude/skills/shared/claudin/external-reviewers.md`.
+**3b. Check external reviewer availability**: Run `$PWD/.claude/scripts/generic/larch/check-reviewers.sh` to set `codex_available` and `cursor_available` flags. Follow the Binary Check procedure in `.claude/skills/shared/larch/external-reviewers.md`.
 
 **3c. Prepare review context**: For each non-trivial conflicted file, prepare a per-file conflict context block:
 ```
@@ -209,16 +209,16 @@ For each file in `CONFLICT_FILES`:
 
 Also capture `git diff --cached` as supplementary context showing the full staged state.
 
-**3d. Launch reviewers**: Launch 2 Claude subagent reviewers + Codex + Cursor (if available) using the reviewer archetypes from `.claude/skills/shared/claudin/reviewer-templates.md` with:
+**3d. Launch reviewers**: Launch 2 Claude subagent reviewers + Codex + Cursor (if available) using the reviewer archetypes from `.claude/skills/shared/larch/reviewer-templates.md` with:
 - `{REVIEW_TARGET}` = `"merge conflict resolution"`
 - `{CONTEXT_BLOCK}` = the per-file conflict context blocks from 3c + supplementary `git diff --cached`
 - `{OUTPUT_INSTRUCTION}` = `"File path and line number(s)"` + `"What the issue is with the resolution"` + `"Suggested correction"`
 
-Follow `.claude/skills/shared/claudin/external-reviewers.md` for launch order (Cursor first, Codex, then Claude subagents), background execution, sentinel polling via `wait-for-reviewers.sh`, and output validation. Use `$SHAZAM_TMPDIR/conflict-review/` as the tmpdir for all reviewer output files, sentinel files, and ballot files.
+Follow `.claude/skills/shared/larch/external-reviewers.md` for launch order (Cursor first, Codex, then Claude subagents), background execution, sentinel polling via `wait-for-reviewers.sh`, and output validation. Use `$SHAZAM_TMPDIR/conflict-review/` as the tmpdir for all reviewer output files, sentinel files, and ballot files.
 
 **3d-ii. Collect and deduplicate**: After all reviewers complete, collect their findings. Parse Claude subagent dual-list outputs (in-scope findings + OOS observations). Read and validate external reviewer outputs per `external-reviewers.md`. Merge all findings, deduplicate (same file + same issue = one finding), assign stable sequential IDs (`FINDING_1`, `FINDING_2`, etc.), and write the ballot to `$SHAZAM_TMPDIR/conflict-review/ballot.txt` following the ballot format in `voting-protocol.md`.
 
-**3e. Voting**: Run the voting protocol from `.claude/skills/shared/claudin/voting-protocol.md` with code review voter composition:
+**3e. Voting**: Run the voting protocol from `.claude/skills/shared/larch/voting-protocol.md` with code review voter composition:
 - **Voter 1**: Claude General Reviewer subagent (fresh Agent invocation)
 - **Voter 2**: Codex (if available) — via `run-external-reviewer.sh`
 - **Voter 3**: Cursor (if available) — via `run-external-reviewer.sh`
@@ -235,18 +235,18 @@ If the reviewer panel finds no issues or all findings are addressed: proceed to 
 
 #### Phase 4 — Continue Rebase
 
-Run `$PWD/.claude/scripts/generic/claudin/rebase-push.sh --continue` and handle exit codes:
+Run `$PWD/.claude/scripts/generic/larch/rebase-push.sh --continue` and handle exit codes:
 - **Exit 0**: Rebase and push succeeded. Increment `rebase_count` and `iteration`, reset `transient_retries`. Restart the CI wait loop.
 - **Exit 1**: A later commit in the rebase conflicted. Loop back to **Phase 1** for the new conflict (the Conflict Resolution Procedure starts again for the new set of `CONFLICT_FILES`).
 - **Exit 2**: Push `--force-with-lease` failed. Retry `rebase-push.sh --continue` once. If it fails twice, **bail out** (Step 2d — call `git rebase --abort` first if the rebase is still in progress).
-- **Exit 3**: Check the `REBASE_ERROR` output. If it indicates an empty or already-applied commit (e.g., "nothing to commit", "No changes"), run `git rebase --skip` (if `git rebase --skip` itself exits non-zero, run `$PWD/.claude/scripts/generic/claudin/git-rebase-abort.sh` and **bail out** — Step 2d) and then `$PWD/.claude/scripts/generic/claudin/rebase-push.sh --continue` again (handle the same exit codes). Otherwise, **bail out** (Step 2d).
+- **Exit 3**: Check the `REBASE_ERROR` output. If it indicates an empty or already-applied commit (e.g., "nothing to commit", "No changes"), run `git rebase --skip` (if `git rebase --skip` itself exits non-zero, run `$PWD/.claude/scripts/generic/larch/git-rebase-abort.sh` and **bail out** — Step 2d) and then `$PWD/.claude/scripts/generic/larch/rebase-push.sh --continue` again (handle the same exit codes). Otherwise, **bail out** (Step 2d).
 
 ### 2b — Merge
 
 When CI passes and the branch is up-to-date with main, use the `merge-pr.sh` script:
 
 ```bash
-$PWD/.claude/scripts/generic/claudin/merge-pr.sh --pr <PR-NUMBER> --repo $REPO
+$PWD/.claude/scripts/generic/larch/merge-pr.sh --pr <PR-NUMBER> --repo $REPO
 ```
 
 Parse the output for `MERGE_RESULT` and `ERROR`. Handle each result:
@@ -264,18 +264,18 @@ Save the expected commit title for verification in Step 5: `<PR_TITLE> (#<PR_NUM
 
 ### 2c — Evaluate CI Failure
 
-Use `FAILED_RUN_ID` from the `ci-status.sh` output. If `FAILED_RUN_ID` is empty, use `$PWD/.claude/scripts/generic/claudin/gh-pr-checks.sh --pr <PR-NUMBER> --repo $REPO` to identify the failed check and its run URL manually.
+Use `FAILED_RUN_ID` from the `ci-status.sh` output. If `FAILED_RUN_ID` is empty, use `$PWD/.claude/scripts/generic/larch/gh-pr-checks.sh --pr <PR-NUMBER> --repo $REPO` to identify the failed check and its run URL manually.
 
 1. **Transient/infrastructure failure** (GitHub API timeout, runner provisioning failure, flaky network, `RUNNER_TEMP` errors, Docker pull rate limit, "The hosted runner lost communication", etc.):
    ```bash
-   $PWD/.claude/scripts/generic/claudin/sleep-seconds.sh 60
-   $PWD/.claude/scripts/generic/claudin/ci-rerun-failed.sh --run-id <FAILED_RUN_ID> --repo $REPO
+   $PWD/.claude/scripts/generic/larch/sleep-seconds.sh 60
+   $PWD/.claude/scripts/generic/larch/ci-rerun-failed.sh --run-id <FAILED_RUN_ID> --repo $REPO
    ```
    Parse the output for `RERUN_SUBMITTED` and `ERROR`. If `RERUN_SUBMITTED=false`, print the `ERROR` and treat as a real CI failure (fall through to diagnosis). Allow up to **2 consecutive transient retries** before treating as a real failure. The counter resets after a successful rebase, code fix, or a CI run that fails for a different (non-transient) reason. Go back to **2a**.
 
 2. **Real CI failure** — Diagnose and fix:
    ```bash
-   $PWD/.claude/scripts/generic/claudin/gh-run-logs.sh --run-id <FAILED_RUN_ID> --repo $REPO
+   $PWD/.claude/scripts/generic/larch/gh-run-logs.sh --run-id <FAILED_RUN_ID> --repo $REPO
    ```
    Analyze the logs. Fix the issue, run `/relevant-checks`, commit, push. Go back to **2a**.
 
@@ -287,7 +287,7 @@ Use `FAILED_RUN_ID` from the `ci-status.sh` output. If `FAILED_RUN_ID` is empty,
 - The fix would require **reverting the core feature** to pass CI.
 
 When bailing out:
-1. If a rebase is in progress (exit 1 from `rebase-push.sh`), run `$PWD/.claude/scripts/generic/claudin/git-rebase-abort.sh` first.
+1. If a rebase is in progress (exit 1 from `rebase-push.sh`), run `$PWD/.claude/scripts/generic/larch/git-rebase-abort.sh` first.
 2. Clearly explain what failed, what you attempted, and suggest manual steps.
 
 **Do NOT skip Steps 4, 6, and 7** when bailing — still clean up and print the review report. **Skip Steps 3 and 5** since the PR was not merged.
@@ -305,7 +305,7 @@ When bailing out:
 Add the :merged: emoji using the shared script:
 
 ```bash
-$PWD/.claude/scripts/generic/claudin/post-merged-emoji.sh --slack-ts "$SLACK_TS"
+$PWD/.claude/scripts/generic/larch/post-merged-emoji.sh --slack-ts "$SLACK_TS"
 ```
 
 **If the script exits non-zero**, print `**⚠ Failed to add :merged: emoji to Slack post. Continuing.**` and proceed to Step 4. **Do not abort.**
@@ -319,7 +319,7 @@ $PWD/.claude/scripts/generic/claudin/post-merged-emoji.sh --slack-ts "$SLACK_TS"
 Switch back to main, pull the merged changes, and delete the development branch:
 
 ```bash
-$PWD/.claude/scripts/generic/claudin/local-cleanup.sh --branch <branch-name>
+$PWD/.claude/scripts/generic/larch/local-cleanup.sh --branch <branch-name>
 ```
 
 Parse the output for `CLEANUP_SUCCESS`, `CURRENT_BRANCH`, and `BRANCH_DELETED`. If `CLEANUP_SUCCESS=true`, print: `🧹 Step 4 — Switched to main, deleted local branch <branch-name>`. If `CLEANUP_SUCCESS=false`, print: `**⚠ Step 4 — Cleanup partially failed. Current branch: <CURRENT_BRANCH>, branch deleted: <BRANCH_DELETED>.**`
@@ -339,7 +339,7 @@ Print: `⚠️ Step 4 — Skipped cleanup (PR not merged). You are still on bran
 Confirm the last commit on main is the expected squash-merged commit using the `verify-main.sh` script:
 
 ```bash
-$PWD/.claude/scripts/generic/claudin/verify-main.sh --expected-title "<PR_TITLE> (#<PR_NUMBER>)"
+$PWD/.claude/scripts/generic/larch/verify-main.sh --expected-title "<PR_TITLE> (#<PR_NUMBER>)"
 ```
 
 Parse the output for `VERIFIED`, `COMMIT_HASH`, and `COMMIT_MESSAGE`. Print the result:
@@ -362,7 +362,7 @@ If both phases reported all suggestions implemented, print: `📊 Step 6 — All
 Remove the session temp directory and all files within it:
 
 ```bash
-$PWD/.claude/scripts/generic/claudin/cleanup-tmpdir.sh --dir "$SHAZAM_TMPDIR"
+$PWD/.claude/scripts/generic/larch/cleanup-tmpdir.sh --dir "$SHAZAM_TMPDIR"
 ```
 
 **Repeat any external reviewer warnings** from earlier in the workflow (from `/design` or `/review` phases) so they are visible at the end. **If `quick_mode=true`**, there are no external reviewer warnings to repeat (no external reviewers were used). For example:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,8 +28,5 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
-      - name: Run claudin integration test
-        run: bash tests/test-setup-claudin.sh
       - name: Run larch integration test
-        if: always()
         run: bash tests/test-setup-larch.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# Claudin pre-commit configuration
+# Larch pre-commit configuration
 # Single source of truth for linter definitions.
 # CI uses: make lint (repo-wide via pre-commit run --all-files)
 # /relevant-checks uses: pre-commit run --files <changed-files> (scoped)

--- a/CLAUDIN-TO-LARCH-MIGRATION.md
+++ b/CLAUDIN-TO-LARCH-MIGRATION.md
@@ -51,34 +51,51 @@ During the PR #1 window the new larch scripts are dead code (not invoked by any 
 
 Once PR #2 cuts over (SKILL.md files, agents, settings.json hooks, and docs are all re-pointed to the larch paths, and the claudin originals are deleted), operators running these scripts **must** set the `LARCH_*` environment variables in their shell/CI environment. If an operator's existing environment has `CLAUDIN_SLACK_BOT_TOKEN` set but not `LARCH_SLACK_BOT_TOKEN`, the new larch scripts will treat the Slack token as missing and skip Slack posting with a warning. Document this clearly in the PR #2 release notes.
 
-## PR #2 — Cutover and cleanup (follow-up, not done in this PR)
+## PR #2a — Cutover only (this PR)
 
-Goal: Switch all internal references from `claudin` paths to `larch` paths, then delete the claudin-named originals. After this PR, `grep -ri claudin .` (excluding `.git/` and this migration doc) should return zero matches.
+Goal: Switch all internal references from `claudin` paths to `larch` paths, but leave the claudin-named originals on disk. The final `grep -ri claudin .` zero-match verification is deferred to PR #2b.
 
-- [TODO] Update content of `README.md` (replace `claudin` with `larch`, case-preserving)
-- [TODO] Update content of `.claude/agents/general-reviewer.md`
-- [TODO] Update content of `.claude/agents/deep-analysis-reviewer.md`
-- [TODO] Update content of `.claude/skills/design/SKILL.md`
-- [TODO] Update content of `.claude/skills/implement/SKILL.md`
-- [TODO] Update content of `.claude/skills/research/SKILL.md`
-- [TODO] Update content of `.claude/skills/review/SKILL.md`
-- [TODO] Update content of `.claude/skills/loop-review/SKILL.md`
-- [TODO] Update content of `.claude/skills/shazam/SKILL.md`
-- [TODO] Update content of `docs/review-agents.md`
-- [TODO] Update content of `.pre-commit-config.yaml` (header comment mentions "Claudin")
-- [TODO] Update content of `Makefile` (header comment mentions "Claudin")
+- [DONE] Update content of `README.md` (replace `claudin` with `larch`, case-preserving)
+- [DONE] Update content of `.claude/agents/general-reviewer.md`
+- [DONE] Update content of `.claude/agents/deep-analysis-reviewer.md`
+- [DONE] Update content of `.claude/skills/design/SKILL.md`
+- [DONE] Update content of `.claude/skills/implement/SKILL.md`
+- [DONE] Update content of `.claude/skills/research/SKILL.md`
+- [DONE] Update content of `.claude/skills/review/SKILL.md`
+- [DONE] Update content of `.claude/skills/loop-review/SKILL.md`
+- [DONE] Update content of `.claude/skills/shazam/SKILL.md`
+- [DONE] Update content of `docs/review-agents.md`
+- [DONE] Update content of `docs/agents.md` (not in the original PR #2 list — contains "Claudin" references that would fail final grep verification)
+- [DONE] Update content of `docs/external-reviewers.md` (not in the original PR #2 list)
+- [DONE] Update content of `docs/workflow-lifecycle.md` (not in the original PR #2 list)
+- [DONE] Update content of `.pre-commit-config.yaml` (header comment mentions "Claudin")
+- [DONE] Update content of `Makefile` (header comment mentions "Claudin")
+- [DONE] Re-point the four hook entries in `.claude/settings.json` from `.claude/scripts/generic/claudin/block-submodule-edit.sh` and `.claude/scripts/generic/claudin/auto-goimports.sh` to the `.claude/scripts/generic/larch/` equivalents
+- [DONE] Remove the `Run claudin integration test` step from `.github/workflows/ci.yaml` (keeping only the larch integration test step, with the `if: always()` guard removed since there is no longer a predecessor step it needs to run after)
+- [DONE] Extend `tests/test-setup-larch.sh` to simulate a PR #1-upgraded client repo with stale `.claude/scripts/generic/claudin/*` and `.claude/skills/shared/claudin/*` symlinks and assert they are removed after rerunning `setup-larch.sh` (validates the Phase 2 dead-symlink cleanup that PR #2b's deletion will trigger in real client repos)
+- [DONE] Document the `CLAUDIN_* → LARCH_*` env var rename and the downstream client settings.json migration requirement in this PR's release notes
+
+## PR #2b — Cleanup (follow-up, not done in this PR)
+
+Goal: Remove the claudin-named originals. After this PR, `grep -ri claudin .` (excluding `.git/` and this migration doc) must return zero matches.
+
 - [TODO] Remove `Bash($PWD/.claude/scripts/generic/claudin/*)` permission entry from `.claude/settings.json`
-- [TODO] Remove `Bash(CLAUDIN_SLACK_USER_ID=:*)` from `.claude/settings.json` (if it proves vestigial — verify first that no script uses the inline env-var-prefix form)
-- [TODO] Re-point the four hook entries in `.claude/settings.json` from `.claude/scripts/generic/claudin/block-submodule-edit.sh` and `.claude/scripts/generic/claudin/auto-goimports.sh` to the `.claude/scripts/generic/larch/` equivalents (lines ~235, 244, 255, 264 in the current file)
-- [TODO] Remove the `Run claudin integration test` step from `.github/workflows/ci.yaml` (keeping only the larch integration test step, with the `if: always()` guard removed since there is no longer a predecessor step it needs to run after)
+- [TODO] Remove `Bash(CLAUDIN_SLACK_USER_ID=:*)` from `.claude/settings.json` (verified vestigial in PR #2a — only used as bare assignment inside `slack-announce.sh`, never as inline env-var-prefix form)
 - [TODO] Delete `.claude/scripts/generic/claudin/` (directory and all 38 scripts)
 - [TODO] Delete `.claude/skills/shared/claudin/` (directory and all 3 docs)
 - [TODO] Delete `setup-claudin.sh`
 - [TODO] Delete `tests/test-setup-claudin.sh`
 - [TODO] Run `grep -ri claudin .` (excluding `.git/` and this migration doc) and verify zero matches
-- [TODO] Document the `CLAUDIN_* → LARCH_*` env var rename in the PR #2 release notes so operators update their shell/CI environment variables
-- [TODO] Mark this section DONE and merge PR #2
+- [TODO] Mark this section DONE and merge PR #2b
 
-## Why two PRs?
+## Why three PRs (PR #1, PR #2a, PR #2b)?
 
-The in-flight `/shazam` and `/implement` skill sessions running at the moment this migration is executed are currently invoking scripts under `.claude/scripts/generic/claudin/`. A single-PR rename would require modifying those scripts (or the SKILL.md files that reference them) mid-flight, risking breakage of the very skill session doing the migration. Splitting the work across two PRs guarantees that every file needed by the in-flight session remains byte-identical throughout PR #1; only after PR #1 has safely merged is it safe to mutate the originals in PR #2.
+The in-flight `/shazam` and `/implement` skill sessions running at the moment this migration is executed are currently invoking scripts under `.claude/scripts/generic/claudin/`. A single-PR rename would require modifying those scripts (or the SKILL.md files that reference them) mid-flight, risking breakage of the very skill session doing the migration. PR #1 solved half the problem by creating byte-identical `larch`-named copies without touching the originals.
+
+Initially PR #2 was planned as a single cutover+deletion PR, but during plan review (by the 5-reviewer voting panel) a critical hazard was surfaced: **the running /shazam session has SKILL.md files already loaded in its context window with claudin-path references for ALL later steps** (version bump, CI monitor, Slack, cleanup, merge loop). Rewriting the SKILL.md files on disk in the same session does NOT retarget the already-running agent — it continues to invoke claudin paths from its in-memory instructions. Deleting the claudin script tree in the same live session that depends on those scripts would cause every subsequent `.claude/scripts/generic/claudin/*` invocation to fail with ENOENT after the deletion commit lands.
+
+PR #2 was therefore split into two:
+
+- **PR #2a** (this PR) — Cutover only: rewrite all references to point at larch paths, but leave the claudin script tree intact on disk. The running /shazam session's in-memory SKILL.md still references claudin paths, but those claudin scripts still exist, so everything works. The final `grep -ri claudin` zero-match verification is deferred.
+
+- **PR #2b** (follow-up, separate session) — Cleanup: delete the claudin script tree, remove the claudin Bash permission entries from settings.json, and verify the final grep. PR #2b must be run in a **fresh /shazam or /implement session** — one that loads the rewritten (larch-referencing) SKILL.md files from the outset, so all its tool invocations use larch paths and the claudin scripts can be safely deleted.

--- a/CLAUDIN-TO-LARCH-MIGRATION.md
+++ b/CLAUDIN-TO-LARCH-MIGRATION.md
@@ -1,6 +1,6 @@
 # Claudin → Larch Migration Plan
 
-The repository was renamed from `claudin` to `larch` via the GitHub UI. This document tracks the internal rename of all `claudin` references to `larch`, which is being done in two PRs to avoid disrupting in-flight skill sessions that depend on the current `claudin/` script paths.
+The repository was renamed from `claudin` to `larch` via the GitHub UI. This document tracks the internal rename of all `claudin` references to `larch`, which is being done in three PRs (PR #1, PR #2a, PR #2b) to avoid disrupting in-flight skill sessions that depend on the current `claudin/` script paths.
 
 ## PR #1 — Additive copy (this PR)
 
@@ -26,7 +26,7 @@ All three rules are applied as literal `sed` substitutions (not regex). The orde
 
 ### Dual-namespace behavior of `setup-larch.sh` during PR #1
 
-During the PR #1 → PR #2 transition window, both `.claude/scripts/generic/claudin/` and `.claude/scripts/generic/larch/` subtrees coexist inside the (renamed) larch submodule. Because `setup-larch.sh` is a literal `sed`-substituted copy of `setup-claudin.sh`, it walks the entire submodule's `.claude/` tree (via the same `find` loop its parent uses) and creates symlinks for files in **both** subtrees.
+During the PR #1 → PR #2a transition window, both `.claude/scripts/generic/claudin/` and `.claude/scripts/generic/larch/` subtrees coexist inside the (renamed) larch submodule. Because `setup-larch.sh` is a literal `sed`-substituted copy of `setup-claudin.sh`, it walks the entire submodule's `.claude/` tree (via the same `find` loop its parent uses) and creates symlinks for files in **both** subtrees.
 
 This means a client repo running `setup-larch.sh` during the PR #1 window will end up with symlinks at **both** `.claude/scripts/generic/claudin/*` and `.claude/scripts/generic/larch/*`, both resolving into the (renamed) larch submodule. Similarly for the two shared-doc trees under `.claude/skills/shared/`.
 
@@ -35,8 +35,8 @@ This dual-namespace behavior is **intentional** and **benign**:
 - New larch-pathed callers also work because the larch symlinks and their target files also exist.
 - It is the safest possible behavior for the dual-tree window: nothing that used to work stops working, and the new namespace is fully populated.
 
-**This dual-namespace behavior resolves naturally in PR #2** when the claudin subtree is deleted from the submodule:
-- `setup-larch.sh` in PR #2 sees only the larch tree and only creates larch symlinks.
+**This dual-namespace behavior resolves naturally in PR #2b** when the claudin subtree is deleted from the submodule:
+- `setup-larch.sh` after PR #2b sees only the larch tree and only creates larch symlinks.
 - Any orphan claudin symlinks in the client repo (carried over from PR #1) will be removed by Phase 2 (dead-symlink cleanup) of `setup-larch.sh` because their resolved targets — for example `larch/.claude/scripts/generic/claudin/foo.sh` — will then point at deleted files, and Phase 2 specifically removes symlinks whose resolved targets live inside the larch submodule and no longer exist.
 
 ### Behavioral callout: `CLAUDIN_*` environment variables become `LARCH_*` in the copies
@@ -49,7 +49,7 @@ The case-preserving substitution rewrites `CLAUDIN_*` environment variable names
 
 During the PR #1 window the new larch scripts are dead code (not invoked by any SKILL.md or hook — the in-flight skills still call the claudin paths), so this rename has **no runtime effect in PR #1**.
 
-Once PR #2 cuts over (SKILL.md files, agents, settings.json hooks, and docs are all re-pointed to the larch paths, and the claudin originals are deleted), operators running these scripts **must** set the `LARCH_*` environment variables in their shell/CI environment. If an operator's existing environment has `CLAUDIN_SLACK_BOT_TOKEN` set but not `LARCH_SLACK_BOT_TOKEN`, the new larch scripts will treat the Slack token as missing and skip Slack posting with a warning. Document this clearly in the PR #2 release notes.
+Once PR #2a cuts over (SKILL.md files, agents, settings.json hooks, and docs are all re-pointed to the larch paths) and PR #2b deletes the claudin originals, operators running these scripts **must** set the `LARCH_*` environment variables in their shell/CI environment. If an operator's existing environment has `CLAUDIN_SLACK_BOT_TOKEN` set but not `LARCH_SLACK_BOT_TOKEN`, the new larch scripts will treat the Slack token as missing and skip Slack posting with a warning. Document this clearly in the PR #2a and PR #2b release notes.
 
 ## PR #2a — Cutover only (this PR)
 
@@ -94,8 +94,8 @@ The in-flight `/shazam` and `/implement` skill sessions running at the moment th
 
 Initially PR #2 was planned as a single cutover+deletion PR, but during plan review (by the 5-reviewer voting panel) a critical hazard was surfaced: **the running /shazam session has SKILL.md files already loaded in its context window with claudin-path references for ALL later steps** (version bump, CI monitor, Slack, cleanup, merge loop). Rewriting the SKILL.md files on disk in the same session does NOT retarget the already-running agent — it continues to invoke claudin paths from its in-memory instructions. Deleting the claudin script tree in the same live session that depends on those scripts would cause every subsequent `.claude/scripts/generic/claudin/*` invocation to fail with ENOENT after the deletion commit lands.
 
-PR #2 was therefore split into two:
+PR #2 was therefore split into PR #2a and PR #2b:
 
 - **PR #2a** (this PR) — Cutover only: rewrite all references to point at larch paths, but leave the claudin script tree intact on disk. The running /shazam session's in-memory SKILL.md still references claudin paths, but those claudin scripts still exist, so everything works. The final `grep -ri claudin` zero-match verification is deferred.
 
-- **PR #2b** (follow-up, separate session) — Cleanup: delete the claudin script tree, remove the claudin Bash permission entries from settings.json, and verify the final grep. PR #2b must be run in a **fresh /shazam or /implement session** — one that loads the rewritten (larch-referencing) SKILL.md files from the outset, so all its tool invocations use larch paths and the claudin scripts can be safely deleted.
+- **PR #2b** (follow-up, separate session) — Cleanup: delete the claudin script tree (`.claude/scripts/generic/claudin/` and `.claude/skills/shared/claudin/`) along with the legacy entry-point scripts (`setup-claudin.sh` and `tests/test-setup-claudin.sh`), remove the claudin Bash permission entries from settings.json, and verify the final grep. (See the PR #2b checklist above for the full item list.) PR #2b must be run in a **fresh /shazam or /implement session** — one that loads the rewritten (larch-referencing) SKILL.md files from the outset, so all its tool invocations use larch paths and the claudin scripts can be safely deleted.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Claudin Makefile
+# Larch Makefile
 # Thin wrapper around pre-commit. Linter definitions live in .pre-commit-config.yaml.
 
 .PHONY: lint shellcheck markdownlint jsonlint actionlint ruff setup

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Claudin
+# Larch
 
-Claudin is a Claude Code workflow automation framework that orchestrates multi-agent design, code review, and implementation through collaborative AI-driven processes.
+Larch is a Claude Code workflow automation framework that orchestrates multi-agent design, code review, and implementation through collaborative AI-driven processes.
 
 ## Getting Started
 
-There are two ways to integrate claudin into your repository:
+There are two ways to integrate larch into your repository:
 
 - **Flow A (Git Submodule)** — recommended for teams that want automatic upstream updates
 - **Flow B (Copy Skills)** — for teams that want to vendor a subset of skills and own them
@@ -13,38 +13,38 @@ Both flows require environment variables for Slack integration (see [Environment
 
 ### Flow A — Git Submodule
 
-Add claudin as a submodule and use `setup-claudin.sh` to create symlinks from your `.claude/` directory into the submodule:
+Add larch as a submodule and use `setup-larch.sh` to create symlinks from your `.claude/` directory into the submodule:
 
 ```bash
 # 1. Add the submodule
-git submodule add <claudin-repo-url> claudin
-git commit -m "Add claudin submodule"
+git submodule add <larch-repo-url> larch
+git commit -m "Add larch submodule"
 
-# 2. Create symlinks from .claude/ into claudin/.claude/
-./claudin/setup-claudin.sh
+# 2. Create symlinks from .claude/ into larch/.claude/
+./larch/setup-larch.sh
 
 # 3. Commit the symlinks and any new directories
 git add .claude
-git commit -m "Set up claudin symlinks"
+git commit -m "Set up larch symlinks"
 ```
 
-**Updating to the latest version**: Every time you bump the claudin submodule to a newer version, re-run the update script to sync symlinks (create new ones, remove stale ones):
+**Updating to the latest version**: Every time you bump the larch submodule to a newer version, re-run the update script to sync symlinks (create new ones, remove stale ones):
 
 ```bash
-git submodule update --remote claudin
-git add claudin
-./claudin/setup-claudin.sh
+git submodule update --remote larch
+git add larch
+./larch/setup-larch.sh
 git add .claude
-git commit -m "Bump claudin submodule"
+git commit -m "Bump larch submodule"
 ```
 
-**How it works**: `setup-claudin.sh` creates symlinks from your `.claude/` directory tree into `claudin/.claude/`. Skill directories (those containing `SKILL.md`) get directory-level symlinks, while individual files (scripts, agents, shared docs) get file-level symlinks. Your repo can have its own additional skills, scripts, and agents alongside the symlinked ones.
+**How it works**: `setup-larch.sh` creates symlinks from your `.claude/` directory tree into `larch/.claude/`. Skill directories (those containing `SKILL.md`) get directory-level symlinks, while individual files (scripts, agents, shared docs) get file-level symlinks. Your repo can have its own additional skills, scripts, and agents alongside the symlinked ones.
 
 **Important notes**:
 
-- **`settings*.json` files are not symlinked.** Your repo must maintain its own `.claude/settings.json` (and any `settings.local.json`) with the permission entries needed by claudin scripts. The recommended approach is to copy the `permissions.allow` array from claudin's `settings.json` as a baseline. At minimum, include bash permissions for `$PWD/.claude/scripts/generic/claudin/*`, `$PWD/.claude/skills/*/scripts/*` (for skill-specific scripts), and the `block-submodule-edit.sh` hook.
-- **`/relevant-checks` is not symlinked.** This skill is repo-specific — each repository defines its own validation checks (linters, test commands, etc.). Claudin ships a `/relevant-checks` as a reference implementation, but `setup-claudin.sh` will never overwrite or symlink it. Create your own `.claude/skills/relevant-checks/` with checks appropriate for your repo.
-- **Edits to `claudin/` are blocked.** The `block-submodule-edit.sh` hook prevents Claude Code from editing files inside git submodules. This is intentional — changes to claudin should be made via PRs to the claudin repo, then pulled in by updating the submodule.
+- **`settings*.json` files are not symlinked.** Your repo must maintain its own `.claude/settings.json` (and any `settings.local.json`) with the permission entries needed by larch scripts. The recommended approach is to copy the `permissions.allow` array from larch's `settings.json` as a baseline. At minimum, include bash permissions for `$PWD/.claude/scripts/generic/larch/*`, `$PWD/.claude/skills/*/scripts/*` (for skill-specific scripts), and the `block-submodule-edit.sh` hook.
+- **`/relevant-checks` is not symlinked.** This skill is repo-specific — each repository defines its own validation checks (linters, test commands, etc.). Larch ships a `/relevant-checks` as a reference implementation, but `setup-larch.sh` will never overwrite or symlink it. Create your own `.claude/skills/relevant-checks/` with checks appropriate for your repo.
+- **Edits to `larch/` are blocked.** The `block-submodule-edit.sh` hook prevents Claude Code from editing files inside git submodules. This is intentional — changes to larch should be made via PRs to the larch repo, then pulled in by updating the submodule.
 - **Conflicts**: If a non-symlink file or directory already exists at a path the script needs to symlink, it exits with an error. Resolve the conflict manually (rename or remove the existing file) and re-run.
 
 ### Flow B — Copy Selected Skills
@@ -61,14 +61,14 @@ Copy the skills you need along with their shared dependencies into your repo's `
 │   └── deep-analysis-reviewer.md
 ├── scripts/
 │   └── generic/
-│       └── claudin/           # ~37 reusable shell scripts invoked by skills
+│       └── larch/             # ~37 reusable shell scripts invoked by skills
 │           ├── session-setup.sh
 │           ├── create-pr.sh
 │           ├── ci-wait.sh
 │           └── ...
 └── skills/
     ├── shared/
-    │   └── claudin/           # Shared .md files referenced by multiple skills
+    │   └── larch/             # Shared .md files referenced by multiple skills
     │       ├── voting-protocol.md
     │       ├── reviewer-templates.md
     │       └── external-reviewers.md
@@ -87,8 +87,8 @@ Copy the skills you need along with their shared dependencies into your repo's `
 When copying a skill, you must also copy its shared dependencies:
 
 1. **The skill directory** — e.g., `.claude/skills/design/` (the entire directory including any nested `scripts/`, `agents/`, etc.)
-2. **`.claude/skills/shared/claudin/`** — shared markdown files referenced by all review-related skills. **Always copy this.**
-3. **`.claude/scripts/generic/claudin/`** — shell scripts that skills invoke for git operations, CI, Slack, etc. **Always copy this.**
+2. **`.claude/skills/shared/larch/`** — shared markdown files referenced by all review-related skills. **Always copy this.**
+3. **`.claude/scripts/generic/larch/`** — shell scripts that skills invoke for git operations, CI, Slack, etc. **Always copy this.**
 4. **`.claude/agents/`** — reviewer agent definitions used by `/design`, `/review`, and `/loop-review`. Copy if using any review-related skill.
 
 #### Transitive skill dependencies
@@ -138,7 +138,7 @@ Internal agent definitions used by skills like `/design`, `/review`, and `/loop-
 
 ## Linting
 
-Claudin uses [pre-commit](https://pre-commit.com/) as the single source of truth for linter configuration. All linter definitions, versions, and file filters live in `.pre-commit-config.yaml`.
+Larch uses [pre-commit](https://pre-commit.com/) as the single source of truth for linter configuration. All linter definitions, versions, and file filters live in `.pre-commit-config.yaml`.
 
 ### Linters
 
@@ -172,11 +172,11 @@ There are three ways to run linters, all backed by the same `.pre-commit-config.
 
 ## Environment Variables
 
-Claudin uses three environment variables for Slack integration. All are optional — when not set, Slack-related features are skipped with warnings and all other workflow steps continue normally.
+Larch uses three environment variables for Slack integration. All are optional — when not set, Slack-related features are skipped with warnings and all other workflow steps continue normally.
 
-> **Note:** Both `CLAUDIN_SLACK_BOT_TOKEN` and `CLAUDIN_SLACK_CHANNEL_ID` must be set for Slack features to function. If either is missing, all Slack operations (PR announcements, `:merged:` emoji) are skipped with a warning at session setup time identifying which variable(s) are absent.
+> **Note:** Both `LARCH_SLACK_BOT_TOKEN` and `LARCH_SLACK_CHANNEL_ID` must be set for Slack features to function. If either is missing, all Slack operations (PR announcements, `:merged:` emoji) are skipped with a warning at session setup time identifying which variable(s) are absent.
 
-### `CLAUDIN_SLACK_BOT_TOKEN`
+### `LARCH_SLACK_BOT_TOKEN`
 
 A Slack Bot User OAuth Token (starts with `xoxb-`) used to authenticate Slack API calls.
 
@@ -186,11 +186,11 @@ A Slack Bot User OAuth Token (starts with `xoxb-`) used to authenticate Slack AP
 - The token's presence is checked during session setup and its availability is propagated to child skills
 
 **When not set:**
-- All Slack operations are skipped with a warning at session setup (e.g., `⚠ Slack is not fully configured (CLAUDIN_SLACK_BOT_TOKEN not set). Slack announcement (Step 11) will be skipped.`)
+- All Slack operations are skipped with a warning at session setup (e.g., `⚠ Slack is not fully configured (LARCH_SLACK_BOT_TOKEN not set). Slack announcement (Step 11) will be skipped.`)
 - The `:merged:` emoji step in `/shazam` is skipped
 - All other workflow steps (design, implementation, code review, CI monitoring, merge) proceed normally
 
-### `CLAUDIN_SLACK_CHANNEL_ID`
+### `LARCH_SLACK_CHANNEL_ID`
 
 The Slack channel ID (e.g., `C0123456789`) where PR announcements and emoji reactions are posted.
 
@@ -199,11 +199,11 @@ The Slack channel ID (e.g., `C0123456789`) where PR announcements and emoji reac
 - The `:merged:` emoji reaction targets announcements in this channel
 
 **When not set:**
-- All Slack operations are skipped with a warning at session setup (e.g., `⚠ Slack is not fully configured (CLAUDIN_SLACK_CHANNEL_ID not set).`)
+- All Slack operations are skipped with a warning at session setup (e.g., `⚠ Slack is not fully configured (LARCH_SLACK_CHANNEL_ID not set).`)
 - The `:merged:` emoji step in `/shazam` is also skipped
 - All other workflow steps proceed normally
 
-### `CLAUDIN_SLACK_USER_ID`
+### `LARCH_SLACK_USER_ID`
 
 A Slack user ID (e.g., `U0123456789`) used to @-mention the PR author in Slack announcements.
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,6 +1,6 @@
 # Agent System
 
-How Claudin skills orchestrate parallel subagents to achieve collaborative multi-perspective workflows.
+How Larch skills orchestrate parallel subagents to achieve collaborative multi-perspective workflows.
 
 ## What Are Agents?
 
@@ -42,7 +42,7 @@ Skills invoke other skills in sequence, each building on the previous result. Fo
 
 ## Agent Types
 
-Claudin uses several categories of agents:
+Larch uses several categories of agents:
 
 ### Review Agents
 

--- a/docs/external-reviewers.md
+++ b/docs/external-reviewers.md
@@ -1,6 +1,6 @@
 # External Reviewers
 
-Codex and Cursor participate alongside Claude subagents as both reviewers and voters in the Claudin workflow. This document covers the shared integration procedures.
+Codex and Cursor participate alongside Claude subagents as both reviewers and voters in the Larch workflow. This document covers the shared integration procedures.
 
 ## Availability Checks
 

--- a/docs/review-agents.md
+++ b/docs/review-agents.md
@@ -1,6 +1,6 @@
 # Review Agents
 
-Claudin uses 2 specialized Claude reviewer archetypes that provide different perspectives during plan review and code review. Each archetype has a distinct focus area, ensuring comprehensive coverage across quality dimensions.
+Larch uses 2 specialized Claude reviewer archetypes that provide different perspectives during plan review and code review. Each archetype has a distinct focus area, ensuring comprehensive coverage across quality dimensions.
 
 ## The 2 Archetypes
 
@@ -57,7 +57,7 @@ There are two related but distinct mechanisms for invoking these archetypes:
 
 **Persistent agent definitions** (`.claude/agents/*.md`) — Standalone agent files with frontmatter specifying name, description, model, and allowed tools. These can be referenced by the Agent tool by name.
 
-**Inline reviewer templates** (`.claude/skills/shared/claudin/reviewer-templates.md`) — Parameterized prompt templates that skills fill in with context-specific variables. Skills use these templates to spawn fresh Agent tool invocations with the full review prompt.
+**Inline reviewer templates** (`.claude/skills/shared/larch/reviewer-templates.md`) — Parameterized prompt templates that skills fill in with context-specific variables. Skills use these templates to spawn fresh Agent tool invocations with the full review prompt.
 
 The persistent agents and inline templates are derived from the same source and kept in sync.
 

--- a/docs/workflow-lifecycle.md
+++ b/docs/workflow-lifecycle.md
@@ -1,6 +1,6 @@
 # Workflow Lifecycle
 
-How skills compose to form the end-to-end development workflow in Claudin.
+How skills compose to form the end-to-end development workflow in Larch.
 
 ## Skill Orchestration Hierarchy
 

--- a/tests/test-setup-larch.sh
+++ b/tests/test-setup-larch.sh
@@ -174,9 +174,21 @@ echo "=== Testing Phase 2: Dead symlink removal ==="
 # Create a fake stale symlink simulating a pre-migration path pointing into larch
 mkdir -p .claude/scripts/generic
 ln -s "../../../larch/.claude/scripts/generic/nonexistent-old-script.sh" ".claude/scripts/generic/stale-old.sh"
-# Re-run setup-larch.sh — Phase 2 should remove the stale symlink
+
+# --- Phase 2 migration scenario: stale claudin-namespace symlinks ---
+# Simulate a client repo that was upgraded with PR #1 (which populated both
+# claudin/ and larch/ subtrees) and is now being upgraded past PR #2b (which
+# deleted the claudin/ subtree). The client carries over orphan claudin
+# symlinks whose targets no longer exist. Phase 2 must remove them.
+mkdir -p .claude/scripts/generic/claudin .claude/skills/shared/claudin
+ln -s "../../../../larch/.claude/scripts/generic/claudin/nonexistent-post-migration.sh" ".claude/scripts/generic/claudin/stale-migration.sh"
+ln -s "../../../../larch/.claude/skills/shared/claudin/nonexistent-post-migration.md" ".claude/skills/shared/claudin/stale-migration.md"
+
+# Re-run setup-larch.sh — Phase 2 should remove all stale symlinks
 ./larch/setup-larch.sh
 check_not_exists ".claude/scripts/generic/stale-old.sh" "stale symlink should be removed by Phase 2"
+check_not_exists ".claude/scripts/generic/claudin/stale-migration.sh" "stale claudin-namespace script symlink should be removed by Phase 2"
+check_not_exists ".claude/skills/shared/claudin/stale-migration.md" "stale claudin-namespace shared-doc symlink should be removed by Phase 2"
 
 # --- Summary ---
 echo ""


### PR DESCRIPTION
## Summary
- Rewrote all internal references from `claudin` paths to `larch` paths across 15 prose/config files (README, agents, all SKILL.md files, docs, .pre-commit-config.yaml, Makefile), and re-pointed the four `.claude/settings.json` hook entries to `larch/` equivalents.
- Removed the `Run claudin integration test` step from `.github/workflows/ci.yaml` and dropped the now-unnecessary `if: always()` guard from the larch step.
- Split the original PR #2 plan into PR #2a (this PR — cutover only) and PR #2b (follow-up — deletion in a fresh session) to avoid the in-memory-SKILL.md self-deletion hazard surfaced during plan review. Extended `tests/test-setup-larch.sh` with a stale claudin-namespace symlink cleanup test to validate the migration regression path PR #2b will trigger in client repos.

> **Release notes for operators**:
> 1. **Env var rename (from PR #1)**: `CLAUDIN_SLACK_BOT_TOKEN`, `CLAUDIN_SLACK_CHANNEL_ID`, `CLAUDIN_SLACK_USER_ID` → `LARCH_SLACK_BOT_TOKEN`, `LARCH_SLACK_CHANNEL_ID`, `LARCH_SLACK_USER_ID`. Operators must set the new vars before running skills, or Slack posting will silently skip with a warning.
> 2. **Downstream client `settings.json` migration**: `setup-larch.sh` does NOT sync `settings.json`. Downstream clients must (a) rerun `setup-larch.sh` after bumping the submodule, AND (b) manually update their local `.claude/settings.json` to replace claudin hook paths and the `Bash($PWD/.claude/scripts/generic/claudin/*)` permission entry with larch equivalents.
> 3. **`setup-claudin.sh` removal (PR #2b)**: The `setup-claudin.sh` entrypoint will be removed in the follow-up PR #2b. Use `setup-larch.sh` instead.
> 4. **PR split**: This is part 1 of 2. PR #2b will remove the claudin originals entirely, run in a fresh session that loads the rewritten SKILL.md files from this PR.

<details><summary>Architecture Diagram</summary>

```mermaid
graph TB
    subgraph "PR #2a (this PR)"
        A1[15 prose rewrites<br/>README, SKILL.md, agents, docs]
        A2[.claude/settings.json<br/>hook re-points only]
        A3[.github/workflows/ci.yaml<br/>remove claudin test step]
        A4[CLAUDIN-TO-LARCH-MIGRATION.md<br/>split PR #2 → #2a/#2b]
        A5[tests/test-setup-larch.sh<br/>add stale-symlink migration test]
    end

    subgraph "Files KEPT in PR #2a (deferred to #2b)"
        K1[claudin Bash permission entry]
        K2[CLAUDIN_SLACK_USER_ID permission]
        K3[.claude/scripts/generic/claudin/]
        K4[.claude/skills/shared/claudin/]
        K5[setup-claudin.sh]
        K6[tests/test-setup-claudin.sh]
    end

    subgraph "PR #2b (follow-up, fresh session)"
        B1[Remove claudin permission entries]
        B2[Delete claudin script tree]
        B3[Delete claudin shared docs]
        B4[Delete setup-claudin.sh]
        B5[Delete tests/test-setup-claudin.sh]
        B6[Final grep -ri claudin → 0 matches]
    end

    subgraph "In-memory /shazam session"
        S1[SKILL.md loaded with<br/>claudin path references]
        S2[Bash calls to claudin/ scripts<br/>for Steps 2-7, 8-13]
    end

    A1 -->|enables| PR2B["Fresh /shazam session<br/>loads larch SKILL.md"]
    A2 -->|hook re-point<br/>safe in-flight| S2
    PR2B --> B1
    PR2B --> B2
    PR2B --> B3
    PR2B --> B4
    PR2B --> B5
    B2 -->|enables| B6

    K1 -.->|safe to remove<br/>after B2| B1
    K2 -.->|safe to remove<br/>after B2| B1
    K3 -.->|deletion = B2| B2
    K4 -.->|deletion = B3| B3
    K5 -.->|deletion = B4| B4
    K6 -.->|deletion = B5| B5

    S1 -.->|already loaded<br/>can't retarget| S2
    S2 -->|still works because<br/>claudin/ not deleted in #2a| K3
```

</details>

<details><summary>Code Flow Diagram</summary>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant Repo as PR #2a Repo State
    participant InMem as In-flight /shazam Session<br/>(SKILL.md in memory)
    participant Disk as Disk (claudin tree)
    participant CI as CI Workflow
    participant Future as PR #2b Fresh Session

    Note over Dev,Future: PR #2a — Cutover commits
    Dev->>Repo: Commit 0d18fb7: rewrite 15 prose files +<br/>settings.json hooks + ci.yaml + migration doc<br/>+ test extension
    Repo->>InMem: Hooks now point to larch/<br/>(but in-memory SKILL.md still has claudin paths)
    Repo->>Disk: claudin tree intact (deferred)
    Dev->>Repo: Commit 1903167: round-1 + round-2 review fixes<br/>(migration doc prose consistency)

    Note over Dev,Future: While in-flight session continues
    InMem->>Disk: bash claudin/{ci-wait, merge-pr, post-pr-announce}.sh
    Disk-->>InMem: Scripts still resolve (intact)
    InMem->>CI: Open PR via claudin/create-pr.sh
    CI->>CI: integration-test job runs<br/>only larch test (claudin step removed)
    CI->>InMem: All checks green
    InMem->>InMem: /shazam Step 2-7: rebase, merge, Slack, cleanup<br/>(all use claudin/* scripts in memory)
    InMem->>Disk: bash claudin/local-cleanup.sh
    Disk-->>InMem: OK (still on disk)

    Note over Dev,Future: PR #2a merged. New session boundary.
    Dev->>Future: Invoke /shazam in fresh context
    Future->>Repo: Read SKILL.md (now references larch/)
    Future->>Disk: bash larch/* scripts (claudin still on disk)
    Disk-->>Future: All resolves
    Future->>Future: Rewrite settings.json: remove claudin permissions
    Future->>Future: Delete claudin/ scripts, shared docs,<br/>setup-claudin.sh, test-setup-claudin.sh
    Future->>Repo: Commit: PR #2b cleanup
    Future->>Repo: Final grep -ri claudin: 0 matches ✓
```

</details>

<details><summary>Goal</summary>

- Execute the cutover phase of the claudin → larch migration described in `CLAUDIN-TO-LARCH-MIGRATION.md`
  - Rewrite all internal references from `claudin` to `larch` (case-preserving: `CLAUDIN → LARCH`, `Claudin → Larch`, `claudin → larch`) in:
    - 12 originally-listed files: `README.md`, `.claude/agents/{general,deep-analysis}-reviewer.md`, the 6 `SKILL.md` files (design, implement, research, review, loop-review, shazam), `docs/review-agents.md`, `.pre-commit-config.yaml` header, `Makefile` header
    - 3 additional files surfaced during plan review (not in the original list — would have failed final grep verification): `docs/agents.md`, `docs/external-reviewers.md`, `docs/workflow-lifecycle.md`
  - Re-point the four `.claude/settings.json` hook entries from `claudin/` paths to `larch/` paths (`block-submodule-edit.sh` × 2, `auto-goimports.sh` × 2)
  - Remove the `Run claudin integration test` step from `.github/workflows/ci.yaml` and drop the `if: always()` guard from the larch step (no longer has a predecessor)
  - Mark the appropriate items in `CLAUDIN-TO-LARCH-MIGRATION.md` as `[DONE]`
- Defer to PR #2b (separate follow-up session) — the deletion of claudin originals
  - This split was made because the running /shazam session has SKILL.md loaded in its context window with `.claude/scripts/generic/claudin/*` references for ALL later steps (version bump, CI monitor, Slack, cleanup, merge loop). Rewriting SKILL.md on disk does NOT retarget the in-memory instructions — the running agent continues to invoke claudin paths from its loaded context. Deleting the claudin tree in this same session would cause every subsequent claudin-path invocation to fail with ENOENT.
  - The reviewer voting panel unanimously identified this hazard during plan review (FINDING_1, 3-0 YES) and suggested running the cleanup in a fresh session.
  - PR #2b will run in a fresh /shazam invocation that loads the rewritten (larch-referencing) SKILL.md files from the outset, so all its tool invocations use larch paths and the claudin scripts can be safely deleted.
  - PR #2a leaves on disk: `.claude/scripts/generic/claudin/`, `.claude/skills/shared/claudin/`, `setup-claudin.sh`, `tests/test-setup-claudin.sh`, the `Bash($PWD/.claude/scripts/generic/claudin/*)` permission entry, and the `Bash(CLAUDIN_SLACK_USER_ID=:*)` permission entry — all to be removed by PR #2b.
- Validate the migration regression path
  - Extend `tests/test-setup-larch.sh` to seed stale `.claude/scripts/generic/claudin/*` and `.claude/skills/shared/claudin/*` symlinks in the test client repo, rerun `setup-larch.sh`, and assert Phase 2 cleans them up. This validates the dead-symlink cleanup that real client repos will undergo when PR #2b ships.
- Document the operator-facing release notes
  - Env var rename (`CLAUDIN_SLACK_*` → `LARCH_SLACK_*`) — already in PR #1's larch script copies
  - Downstream client `settings.json` migration — `setup-larch.sh` doesn't sync settings.json; clients must update their own
  - `setup-claudin.sh` removal in PR #2b — direct operators to `setup-larch.sh`
- Success criteria
  - The scoped grep `grep -r -l -i claudin . --exclude-dir=.git --exclude-dir=claudin --exclude=CLAUDIN-TO-LARCH-MIGRATION.md --exclude=setup-claudin.sh --exclude=test-setup-claudin.sh` returns only the 2 expected/intentional retentions: `.claude/settings.json` (lines 4 + 32) and `tests/test-setup-larch.sh` (intentional test fixture content)
  - All `/relevant-checks` linters pass (shellcheck, markdownlint, jsonlint, actionlint, ruff)
  - `bash tests/test-setup-larch.sh` passes locally
  - The full `grep -ri claudin .` zero-match verification is **deferred to PR #2b**

</details>

<details><summary>Test plan</summary>

- [ ] CI lint job passes (`make lint` runs all linters repo-wide)
- [ ] CI integration-test job passes (`bash tests/test-setup-larch.sh` runs the full setup test including the new stale claudin-namespace symlink test block)
- [ ] Manually verify `.claude/settings.json` has valid JSON (`jq . .claude/settings.json`)
- [ ] Manually verify `.claude/settings.json` permissions.allow array remains in strict ASCII code-point order
- [ ] Manually verify the four hook entries in `.claude/settings.json` point at `.claude/scripts/generic/larch/{block-submodule-edit,auto-goimports}.sh`
- [ ] Manually verify `.github/workflows/ci.yaml` has only the larch integration-test step (no claudin step, no `if: always()`)
- [ ] Manually verify `tests/test-setup-larch.sh` passes locally with all 3 new stale-symlink assertions
- [ ] Manually verify `CLAUDIN-TO-LARCH-MIGRATION.md` is internally consistent — all "PR #2" references either marked as historical narrative (lines 68-70, 95, 97) or refer to the correct PR #2a/PR #2b
- [ ] Manually verify the scoped grep returns only the 2 intentional retentions

</details>

<details><summary>Final Design</summary>

The full revised implementation plan from `/design`:

**Scope change**: Single-commit cutover only (deletion deferred to PR #2b).

The critical constraint is that the running /shazam session's in-memory SKILL.md contains claudin-path references for ALL later steps (version bump, PR creation, CI monitor, Slack, cleanup, merge loop). Deleting the claudin tree in this session would cause every subsequent claudin-path invocation to fail with ENOENT. Therefore, PR #2a does the cutover only. The deletion becomes PR #2b, run in a fresh session that loads the rewritten (larch-referencing) SKILL.md files from the outset.

**Files to modify (PR #2a)**:

Rewrite (case-preserving substitution):
1. README.md (30 hits) — full rewrite via Write
2. .claude/agents/general-reviewer.md (1 hit) — single Edit
3. .claude/agents/deep-analysis-reviewer.md (1 hit) — single Edit
4-9. .claude/skills/{design,implement,research,review,loop-review,shazam}/SKILL.md — replace_all Edit
10. docs/review-agents.md (2 hits)
11. .pre-commit-config.yaml (header line 1)
12. Makefile (header line 1)
13. docs/agents.md (2 hits, capital-C only) — added per sketch-phase finding
14. docs/external-reviewers.md (1 hit, capital-C only) — added per sketch-phase finding
15. docs/workflow-lifecycle.md (1 hit, capital-C only) — added per sketch-phase finding

Structured edits:
16. .claude/settings.json — hook re-points only (not permission removals):
    - Line 236: claudin/block-submodule-edit.sh → larch/block-submodule-edit.sh
    - Line 245: same (PreToolUse/Write)
    - Line 256: claudin/auto-goimports.sh → larch/auto-goimports.sh
    - Line 265: same (PostToolUse/Write)
    - KEEP line 4 (claudin Bash permission) — defer to PR #2b
    - KEEP line 32 (CLAUDIN_SLACK_USER_ID permission) — defer to PR #2b
    - Validate: jq . .claude/settings.json
17. .github/workflows/ci.yaml:
    - Delete the "Run claudin integration test" step
    - Delete the if: always() guard from the larch step
    - Validate: actionlint via /relevant-checks
18. CLAUDIN-TO-LARCH-MIGRATION.md — split PR #2 into PR #2a / PR #2b sections; mark #2a items as DONE; explain split in "Why three PRs" section
19. tests/test-setup-larch.sh — add stale claudin-namespace symlink test in the Phase 2 block

Paths NOT deleted in this PR (deferred to PR #2b):
- .claude/scripts/generic/claudin/
- .claude/skills/shared/claudin/
- setup-claudin.sh
- tests/test-setup-claudin.sh

**Commit structure**:
- Commit 1: "Cutover claudin→larch references (PR #2a of migration)" — all 15 prose rewrites + settings.json hook re-points + ci.yaml + migration doc split + test extension
- Commit 2: "Address code review feedback" — round-1 + round-2 review fixes (4 line edits in CLAUDIN-TO-LARCH-MIGRATION.md to fix prose drift)
- No Commit 3 (no /bump-version skill in this repo)

**Verification**: Scoped grep before commit (excludes to-be-deleted-in-PR-#2b paths and files) must return only 2 intentional retentions. Full zero-match verification deferred to PR #2b.

**Release notes** (4 items): Env var rename, downstream settings.json migration, setup-claudin.sh removal in PR #2b, PR split explanation.

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

7 in-scope findings were not accepted by the round-1 voting panel during /design's plan review. See the inline rejected-findings report from /design above for details. Briefly:

- **FINDING_2** (Claude Deep, exonerated 1-2): Defer claudin Bash permission removal to Commit 2 — became moot after FINDING_1 resolution moved all deletion-related changes to PR #2b.
- **FINDING_10** (Claude General, rejected 1-2): Annotate files 13-15 as "capital-C form only" — voters agreed plan's case-preserving rule already handles this.
- **FINDING_11** (Claude General + Cursor OOS, rejected 1-2): Standardize the verification grep command across plan sections — minor doc cleanup.
- **FINDING_12** (Claude General, exonerated 0-3): Add explicit note about ci.yaml + test deletion coupling — only relevant under partial rollback.
- **FINDING_13** (Claude Deep, exonerated 0-3): Add `--exclude-dir=node_modules` to verification grep — repo doesn't have node_modules.
- **FINDING_14** (Claude Deep, rejected 1-2): Rewrite plan's edge-case sentence about reviewer subagent vs hook script claudin/larch coexistence — wording imprecision, not actionable.
- **FINDING_15** (Claude Deep, rejected 1-2): Make target-string-matching methodology explicit in settings.json edits section — plan already states it in edge cases.

</details>

<details><summary>Implementation Deviations</summary>

No deviations from the plan. The 19 files modified exactly match the plan's enumerated list. Commit structure followed plan exactly: Commit 1 = full cutover, Commit 2 = round-1+round-2 review fixes, no Commit 3 (version bump skipped as expected).

</details>

<details><summary>Rejected Code Review Suggestions</summary>

### [Code Review] Codex-General
**Finding (FINDING_1, Round 1)**: PR #2a removes the "Run claudin integration test" step from `.github/workflows/ci.yaml` but leaves the entire claudin compatibility surface (`setup-claudin.sh`, `tests/test-setup-claudin.sh`, `.claude/scripts/generic/claudin/`, `.claude/skills/shared/claudin/`) on disk for PR #2b to delete. This creates a window between PR #2a merging and PR #2b merging where the still-shipped claudin entrypoints have zero CI coverage. During this window, any follow-up change on `main` could silently break the claudin path and would only be caught by users running older /shazam sessions or client repos pinned to a pre-cleanup state. The principle "never remove test coverage before removing the code under test" is violated. The reviewer suggested either (a) keeping `bash tests/test-setup-claudin.sh` in CI until PR #2b actually deletes the claudin tree, or (b) moving the ci.yaml edit (the claudin test step removal) into PR #2b so the shipped behavior stays covered for its full lifetime.

**Reason not implemented**: Exonerated 0-3 by the round-1 voting panel (all three voters — Claude General, Cursor, Codex — voted EXONERATE). The voters agreed the principle is procedurally legitimate but the specific PR #2a → PR #2b window is expected to be a single-developer migration sequence where PR #2b is the immediate next /shazam invocation after PR #2a merges (window measured in minutes, not hours or days). The risk of an unrelated change landing on `main` during this window that breaks the claudin path is essentially zero. Keeping the claudin test step would add CI noise without meaningful safety benefit. Additionally, moving the ci.yaml edit to PR #2b would split a single conceptually-coherent CI configuration change across two PRs, which is its own form of process complexity. The decision to remove the claudin test step in PR #2a was deliberate and documented in the migration plan; the reviewer panel concurred that it's an acceptable trade-off in this specific migration sequence.

</details>

<details><summary>Plan Review Voting Tally</summary>

15 findings + 6 OOS items raised across 5 reviewers (2 Claude + 2 Codex + Cursor). Voted on by 3 voters (Claude Deep + Codex + Cursor).

**Accepted (7 findings + 1 OOS promoted)**:
- FINDING_1 (3 YES): Destructive delete timing vs. in-memory SKILL.md hazard — **the critical finding driving the PR split**
- FINDING_3 (2 YES): Second commit bypasses /review (moot after FINDING_1 resolution)
- FINDING_4 (3 YES): /bump-version skill doesn't exist
- FINDING_5 (2 YES): No CI test for migration cleanup behavior — extend test-setup-larch.sh
- FINDING_6 (3 YES): Downstream client settings.json migration guidance missing
- FINDING_7 (3 YES): Pre-flight grep after Commit 1 unusable — scope it
- FINDING_8 (2 YES): yq is not a declared prerequisite — use actionlint
- OOS_6 promoted (3 YES): Add setup-claudin.sh removal to release notes

**Rejected (8 findings — see Rejected Plan Review Suggestions section above)**:
- FINDING_2, 9, 10, 11, 12, 13, 14, 15

**Reviewer Competition Scoreboard**:
| Reviewer | Score |
|---|---|
| Cursor | **+4** |
| Codex-General | **+4** |
| Codex-Deep | **+2** |
| Claude General | **-1** |
| Claude Deep | **-1** |

External reviewers dominated this round — they caught the critical in-memory-SKILL.md hazard that Claude subagents underweighted.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

2 in-scope findings raised in round 1 (1 from Codex-General, 1 from Codex-Deep). Both Claude subagents and Cursor reported NO_ISSUES_FOUND in scope. Voted on by 3 voters (Claude General + Codex + Cursor).

| Finding | Claude General | Cursor | Codex | YES Count | Result |
|---|---|---|---|---|---|
| FINDING_1 (CI coverage gap) | EXONERATE | EXONERATE | EXONERATE | 0 | Rejected (exonerated) |
| FINDING_2 (migration doc prose drift) | YES | YES | YES | 3 | **ACCEPTED** |

**Reviewer Competition Scoreboard (Round 1 only)**:
| Reviewer | Score |
|---|---|
| Codex-Deep | **+1** |
| Codex-General | 0 |
| Cursor | 0 |
| Claude General | 0 |
| Claude Deep | 0 |

Round 2 added 3 more findings (all Claude subagents) about additional prose drift in CLAUDIN-TO-LARCH-MIGRATION.md (lines 29, 97, 101). Round 2+ findings are auto-accepted without voting per the /review skill protocol. Round 3 converged with no new findings.

</details>

<details><summary>Out-of-Scope Observations</summary>

**From /design plan review** (5 OOS items, none promoted):
- **OOS_1**: `tests/test-setup-claudin.sh` cannot pass post-PR-#2b deletion — pre-existing quirk, resolved naturally by deletion.
- **OOS_2**: `.gitignore` doesn't exclude `.venv/` — pre-existing hygiene gap.
- **OOS_3**: Flow B downstream documentation drift — pre-existing concern for vendored-skills users.
- **OOS_4**: `CLAUDIN_SLACK_USER_ID=:*` permission "vestigial" analysis under-justified — verified correct by Pragmatism agent (no inline VAR=value cmd callsite anywhere).
- **OOS_5**: `.claude/agents/*.md` and `reviewer-templates.md` "Keep in sync" drift detection gap — pre-existing structural concern, no automated check.

**From /review code review**:
- **Claude General OOS**: Empty `claudin/` directories may persist in client repos after Phase 2 cleanup removes the symlinks — current `setup-larch.sh` doesn't `rmdir` them. Harmless but slightly untidy. Out of scope for PR #2a.
- **Claude Deep OOS-1**: `setup-larch.sh` MIGRATION message mentions migrating `generic/*` → `generic/larch/*` but doesn't mention the claudin→larch namespace migration introduced by PR #2a. Pre-existing in setup-larch.sh.
- **Claude Deep OOS-2**: `tests/test-setup-larch.sh` line 33 copies `.git/` via `cp -R`, creating a real inner git directory. Latent fragility if `git rev-parse --show-toplevel` is ever called from inside the inner repo. Pre-existing.

</details>

<details><summary>Execution Issues</summary>

### Warnings
- **Step 8**: Version bump skipped — no /bump-version skill exists in this repo (.claude/skills/bump-version/SKILL.md not found). Step proceeded without version bump per /implement Step 8 fallback.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | 7 accepted, 8 rejected (15 total) |
| Plan review OOS items | 1 promoted (OOS_6), 5 not promoted |
| Code review rounds | 3 (converged in round 3) |
| Code review findings | 4 accepted (1 in round 1 + 3 in round 2), 1 rejected (round 1) |
| Warnings logged | 1 (version bump skipped) |
| Pre-existing issues noticed | ~5 (OOS observations from plan and code review) |
| External reviewers | Cursor: ✅, Codex: ✅ |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
