### PR TITLE
Collapse /implement rebase dance to one script call

### DIFF
--- a/.claude/scripts/generic/larch/rebase-push.sh
+++ b/.claude/scripts/generic/larch/rebase-push.sh
@@ -5,29 +5,44 @@
 # conflicts and push failures via exit codes.
 #
 # Usage:
-#   rebase-push.sh [--continue] [--no-push]
+#   rebase-push.sh [--continue] [--no-push [--skip-if-pushed]]
 #
 # Flags:
-#   --continue — Continue an in-progress rebase instead of starting a new one.
-#                Skips fetch and runs `git rebase --continue` instead of
-#                `git rebase origin/main`. Caller must resolve conflicts and
-#                stage files before invoking with --continue.
-#   --no-push  — Skip the push step after a successful rebase. Used by
-#                /implement for local-only freshness rebases where the branch
-#                has not yet been pushed. In this mode, conflicts are aborted
-#                immediately (exit 1) instead of left in progress.
+#   --continue       — Continue an in-progress rebase instead of starting a new
+#                      one. Skips fetch and runs `git rebase --continue` instead
+#                      of `git rebase origin/main`. Caller must resolve conflicts
+#                      and stage files before invoking with --continue.
+#   --no-push        — Skip the push step after a successful rebase. Used by
+#                      /implement for local-only freshness rebases where the
+#                      branch has not yet been pushed. In this mode, conflicts
+#                      are aborted immediately (exit 1) instead of left in
+#                      progress.
+#   --skip-if-pushed — Only valid with --no-push. Before fetching, check whether
+#                      the current branch already exists on origin. If it does,
+#                      print `SKIPPED_ALREADY_PUSHED=true` to stdout and exit 0
+#                      without fetching or rebasing. This lets /implement collapse
+#                      its per-checkpoint "is branch pushed? if so skip, else
+#                      rebase" dance into a single script invocation. If the
+#                      ls-remote check fails (network/auth), the script falls
+#                      through to the normal rebase path so the subsequent fetch
+#                      surfaces the real error.
 #
 # Exit codes:
-#   0 — rebase (and push, unless --no-push) succeeded
+#   0 — rebase (and push, unless --no-push) succeeded, OR skipped because
+#       --skip-if-pushed detected the branch already on origin
 #   1 — rebase failed with conflicts
 #       Default mode: rebase left in progress (CONFLICT_FILES= on stdout)
 #       --no-push mode: rebase aborted, branch restored to pre-rebase state
 #   2 — push --force-with-lease failed (PUSH_ERROR= on stderr, caller should retry after fetch)
 #       Not possible in --no-push mode.
-#   3 — rebase failed for non-conflict reasons (REBASE_ERROR= on stderr)
+#   3 — rebase failed for non-conflict reasons (REBASE_ERROR= on stderr), OR
+#       invalid flag combination (e.g., --skip-if-pushed without --no-push)
 #       In normal mode: rebase is aborted.
 #       In --continue mode: rebase is left in progress (caller can inspect/retry).
 #       In --no-push mode: rebase is aborted.
+#
+# Stdout on exit 0 when --skip-if-pushed skipped the rebase:
+#   SKIPPED_ALREADY_PUSHED=true
 #
 # Stdout on exit 1 (default mode only):
 #   CONFLICT_FILES=<comma-separated list of conflicted files>
@@ -44,10 +59,12 @@ set -uo pipefail
 # --- Parse flags ---
 CONTINUE_MODE=false
 NO_PUSH=false
+SKIP_IF_PUSHED=false
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --continue) CONTINUE_MODE=true; shift ;;
         --no-push) NO_PUSH=true; shift ;;
+        --skip-if-pushed) SKIP_IF_PUSHED=true; shift ;;
         *) echo "Unknown option: $1" >&2; exit 1 ;;
     esac
 done
@@ -55,6 +72,24 @@ done
 if [[ "$CONTINUE_MODE" == "true" && "$NO_PUSH" == "true" ]]; then
     echo "REBASE_ERROR=--continue and --no-push cannot be used together" >&2
     exit 3
+fi
+
+if [[ "$SKIP_IF_PUSHED" == "true" && "$NO_PUSH" != "true" ]]; then
+    echo "REBASE_ERROR=--skip-if-pushed is only valid with --no-push" >&2
+    exit 3
+fi
+
+# --- Early exit: skip if branch already on origin (--skip-if-pushed only) ---
+if [[ "$SKIP_IF_PUSHED" == "true" ]]; then
+    CURRENT_BRANCH=$(git branch --show-current 2>/dev/null)
+    if [[ -n "$CURRENT_BRANCH" ]]; then
+        # If ls-remote fails (network/auth), we fall through to the normal
+        # rebase path; the subsequent fetch will surface the real error.
+        if REMOTE_REFS=$(git ls-remote --heads origin "$CURRENT_BRANCH" 2>/dev/null) && [[ -n "$REMOTE_REFS" ]]; then
+            echo "SKIPPED_ALREADY_PUSHED=true"
+            exit 0
+        fi
+    fi
 fi
 
 if [[ "$CONTINUE_MODE" == "true" ]]; then

--- a/.claude/scripts/generic/larch/rebase-push.sh
+++ b/.claude/scripts/generic/larch/rebase-push.sh
@@ -82,10 +82,15 @@ fi
 # --- Early exit: skip if branch already on origin (--skip-if-pushed only) ---
 if [[ "$SKIP_IF_PUSHED" == "true" ]]; then
     CURRENT_BRANCH=$(git branch --show-current 2>/dev/null)
+    # If detached HEAD (empty branch name), fall through to the normal rebase
+    # path, where the detached-HEAD guard below will error cleanly.
     if [[ -n "$CURRENT_BRANCH" ]]; then
+        # Use the full "refs/heads/<branch>" form to force an exact-match
+        # lookup — ls-remote's pattern arg otherwise uses fnmatch/glob
+        # semantics, which would misbehave for branches containing [, ?, *.
         # If ls-remote fails (network/auth), we fall through to the normal
         # rebase path; the subsequent fetch will surface the real error.
-        if REMOTE_REFS=$(git ls-remote --heads origin "$CURRENT_BRANCH" 2>/dev/null) && [[ -n "$REMOTE_REFS" ]]; then
+        if REMOTE_REFS=$(git ls-remote --heads origin "refs/heads/$CURRENT_BRANCH" 2>/dev/null) && [[ -n "$REMOTE_REFS" ]]; then
             echo "SKIPPED_ALREADY_PUSHED=true"
             exit 0
         fi

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -136,20 +136,16 @@ Proceed to Step 2.
 
 Print: `🔃 Rebasing onto latest main before starting implementation...`
 
-First, check if the branch has already been pushed to origin (e.g., re-running `/implement` on an existing PR branch):
+Run:
 ```bash
-git ls-remote --heads origin "$(git branch --show-current)" 2>/dev/null
-```
-If the output is non-empty (branch exists on origin), print: `⏩ Rebase skipped — branch already pushed to origin.` and skip this rebase.
-
-Otherwise, run:
-```bash
-$PWD/.claude/scripts/generic/larch/rebase-push.sh --no-push
+$PWD/.claude/scripts/generic/larch/rebase-push.sh --no-push --skip-if-pushed
 ```
 
 If the script exits non-zero, print: `**⚠ Rebase onto main failed. Bailing to cleanup.**` and skip to Step 13.
 
-If successful, print: `✅ Rebased onto latest main.`
+If successful:
+- If the stdout contains `SKIPPED_ALREADY_PUSHED=true`, print: `⏩ Rebase skipped — branch already pushed to origin.`
+- Otherwise, print: `✅ Rebased onto latest main.`
 
 ## Step 2 — Implement the Feature
 
@@ -179,20 +175,16 @@ The commit message should describe WHAT was implemented and WHY, not HOW.
 
 Print: `🔃 Rebasing onto latest main after implementation commit...`
 
-First, check if the branch has already been pushed to origin:
+Run:
 ```bash
-git ls-remote --heads origin "$(git branch --show-current)" 2>/dev/null
-```
-If the output is non-empty, print: `⏩ Rebase skipped — branch already pushed to origin.` and skip this rebase.
-
-Otherwise, run:
-```bash
-$PWD/.claude/scripts/generic/larch/rebase-push.sh --no-push
+$PWD/.claude/scripts/generic/larch/rebase-push.sh --no-push --skip-if-pushed
 ```
 
 If the script exits non-zero, print: `**⚠ Rebase onto main failed. Bailing to cleanup.**` and skip to Step 13.
 
-If successful, print: `✅ Rebased onto latest main.`
+If successful:
+- If the stdout contains `SKIPPED_ALREADY_PUSHED=true`, print: `⏩ Rebase skipped — branch already pushed to origin.`
+- Otherwise, print: `✅ Rebased onto latest main.`
 
 ## Step 5 — Code Review
 
@@ -258,20 +250,16 @@ If no files changed (review found no issues), skip this commit.
 
 Print: `🔃 Rebasing onto latest main after review fixes commit...`
 
-First, check if the branch has already been pushed to origin:
+Run:
 ```bash
-git ls-remote --heads origin "$(git branch --show-current)" 2>/dev/null
-```
-If the output is non-empty, print: `⏩ Rebase skipped — branch already pushed to origin.` and skip this rebase.
-
-Otherwise, run:
-```bash
-$PWD/.claude/scripts/generic/larch/rebase-push.sh --no-push
+$PWD/.claude/scripts/generic/larch/rebase-push.sh --no-push --skip-if-pushed
 ```
 
 If the script exits non-zero, print: `**⚠ Rebase onto main failed. Bailing to cleanup.**` and skip to Step 13.
 
-If successful, print: `✅ Rebased onto latest main.`
+If successful:
+- If the stdout contains `SKIPPED_ALREADY_PUSHED=true`, print: `⏩ Rebase skipped — branch already pushed to origin.`
+- Otherwise, print: `✅ Rebased onto latest main.`
 
 ## Step 7a — Code Flow Diagram
 
@@ -305,20 +293,16 @@ This rebase **always runs** as a final safety net before the version bump and PR
 
 Print: `🔃 Rebasing onto latest main before version bump...`
 
-First, check if the branch has already been pushed to origin:
+Run:
 ```bash
-git ls-remote --heads origin "$(git branch --show-current)" 2>/dev/null
-```
-If the output is non-empty, print: `⏩ Rebase skipped — branch already pushed to origin.` and skip this rebase.
-
-Otherwise, run:
-```bash
-$PWD/.claude/scripts/generic/larch/rebase-push.sh --no-push
+$PWD/.claude/scripts/generic/larch/rebase-push.sh --no-push --skip-if-pushed
 ```
 
 If the script exits non-zero, print: `**⚠ Rebase onto main failed. Bailing to cleanup.**` and skip to Step 13.
 
-If successful, print: `✅ Rebased onto latest main.`
+If successful:
+- If the stdout contains `SKIPPED_ALREADY_PUSHED=true`, print: `⏩ Rebase skipped — branch already pushed to origin.`
+- Otherwise, print: `✅ Rebased onto latest main.`
 
 ## Step 8 — Version Bump
 

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -289,7 +289,7 @@ Print the diagram under a `## Code Flow Diagram` header with a mermaid code fenc
 
 ### Rebase onto latest main (before version bump)
 
-This rebase **always runs** as a final safety net before the version bump and PR creation, even if a previous rebase just ran. It ensures the branch is as fresh as possible before the version bump becomes the last commit.
+This rebase runs as a final safety net before the version bump and PR creation, even if a previous rebase just ran. It ensures the branch is as fresh as possible before the version bump becomes the last commit. Exception: if the branch is already on origin (e.g., re-run of `/implement` on an existing PR branch), the `--skip-if-pushed` flag causes this rebase to be skipped — freshness of already-pushed branches is `/shazam`'s responsibility during its CI+rebase+merge loop.
 
 Print: `🔃 Rebasing onto latest main before version bump...`
 


### PR DESCRIPTION
## Summary
- Added a new `--skip-if-pushed` flag to `rebase-push.sh` that is only valid with `--no-push` and, when set, checks `git ls-remote` for the current branch on origin and exits 0 (emitting `SKIPPED_ALREADY_PUSHED=true` on stdout) without fetching or rebasing if the branch is already on origin.
- Collapsed all four rebase checkpoints in `/implement` SKILL.md (before implementation, after implementation commit, after review fixes commit, before version bump) from a two-step dance (direct `git ls-remote ...` Bash call followed by a conditional `rebase-push.sh --no-push` call) into a single `rebase-push.sh --no-push --skip-if-pushed` invocation per checkpoint.

<details><summary>Architecture Diagram</summary>

Quick mode — architecture diagram skipped.

</details>

<details><summary>Code Flow Diagram</summary>

Quick mode — code flow diagram skipped.

</details>

<details><summary>Goal</summary>

- Combine the direct command run via `Bash()` before each rebase in the `/implement` skill with just one script call
  - There should be only one `Bash()` invocation per rebase checkpoint, and it should be calling a script — no direct shell commands
  - Example of the current pre-change output the user wants eliminated:
    - `Bash(git ls-remote --heads origin "$(git branch --show-current)" 2>/dev/null)` → `(No output)`
    - `Bash($PWD/.claude/scripts/generic/larch/rebase-push.sh --no-push)` → `(No output)`
  - The two calls should become a single script invocation that internally handles the "is branch already pushed? if so skip, else rebase" decision

</details>

<details><summary>Test plan</summary>

- [x] shellcheck passes on the modified `rebase-push.sh`
- [x] markdownlint passes on the modified `implement/SKILL.md`
- [x] Verified `--skip-if-pushed` alone (without `--no-push`) exits 3 with `REBASE_ERROR=--skip-if-pushed is only valid with --no-push`
- [x] Verified `--continue --skip-if-pushed` (without `--no-push`) exits 3 with the same error (caught by the same flag-validation check)
- [x] Dogfooded the new flag: all three `/implement` rebase checkpoints on this very branch used `rebase-push.sh --no-push --skip-if-pushed` successfully (the branch was not yet pushed, so the script fell through to the normal rebase path)
- [x] Verified no other callers of `rebase-push.sh` are affected — `/shazam` Step 2 uses plain `rebase-push.sh` (push mode) which is untouched
- [ ] After merge, re-run `/implement` on any branch to confirm only one `Bash()` call appears per rebase checkpoint in the main-agent output
- [ ] After merge, re-run `/implement` on a branch that is already pushed to origin to confirm the `SKIPPED_ALREADY_PUSHED=true` path triggers and the user-facing "⏩ Rebase skipped" message appears

</details>

<details><summary>Final Design</summary>

**Goal**: Collapse the 2-step "check + rebase" dance in `/implement` rebase checkpoints into a single script invocation.

**Files to modify**:
1. `.claude/scripts/generic/larch/rebase-push.sh` — add `--skip-if-pushed` flag
2. `.claude/skills/implement/SKILL.md` — collapse the 4 rebase checkpoint blocks

**Approach**:
- Add `--skip-if-pushed` flag to `rebase-push.sh`, valid only in combination with `--no-push` (error otherwise)
- When set, script first checks `git ls-remote --heads origin refs/heads/<current-branch>` (full ref path to prevent glob interpretation of branch names containing `[`, `?`, `*`). If the branch exists on origin, print `SKIPPED_ALREADY_PUSHED=true` to stdout and exit 0. Otherwise, fall through to the normal `--no-push` rebase flow.
- Update SKILL.md at all 4 rebase checkpoints to use a single `rebase-push.sh --no-push --skip-if-pushed` invocation. Main agent parses stdout for `SKIPPED_ALREADY_PUSHED=true` to decide which user-facing emoji to print.

**Edge cases**:
- `--skip-if-pushed` without `--no-push`: exit 3 with a clear error
- `--skip-if-pushed` with `--continue`: blocked (the dependent `--no-push` is absent, so the flag-validation check catches it)
- Detached HEAD / empty branch name: `git branch --show-current` returns empty → the new block falls through to the normal rebase path, whose existing detached-HEAD guard errors cleanly
- `ls-remote` network failure: treat as "not pushed" and fall through; the subsequent `git fetch` will surface the same network issue with a clear error
- Branch name containing fnmatch metacharacters (`[`, `?`, `*`): fixed by using `refs/heads/<branch>` form instead of the bare branch name

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

Quick mode — no plan review was conducted.

</details>

<details><summary>Implementation Deviations</summary>

No deviations from the plan. (The `refs/heads/` prefix and the detached-HEAD comment were added during the code-review round, not as plan deviations — they are refinements of the already-planned edge-case handling.)

</details>

<details><summary>Rejected Code Review Suggestions</summary>

### [Code Review] General Reviewer (finding #3)
**Finding**: `.claude/scripts/generic/larch/rebase-push.sh`, header comment lines 30-48 — the exit-code documentation under "Exit codes: 0 — ..." should explicitly state that a successful non-skipped rebase in `--no-push --skip-if-pushed` mode produces no stdout (same as `--no-push` alone). A caller inspecting stdout could be confused if they expected some confirmation token on the success path. Suggested fix: add a comment line "Stdout on exit 0 in all other cases: (none)" under the existing "Stdout on exit 0 when --skip-if-pushed skipped the rebase:" entry.

**Reason not implemented**: This is pedantic documentation noise. The header already follows the convention of documenting stdout only when it emits something specific (`CONFLICT_FILES=`, `SKIPPED_ALREADY_PUSHED=true`); cases that emit nothing are implicitly "no stdout" by omission. Adding "(none)" comments for every no-output case would clutter the header without improving clarity. The SKILL.md caller already handles the "no skip marker" case explicitly with its `If the stdout contains SKIPPED_ALREADY_PUSHED=true ... Otherwise ...` branch, so there is no risk of caller confusion. Keeping the header concise is more valuable than exhaustively documenting negative spaces.

</details>

<details><summary>Plan Review Voting Tally</summary>

Quick mode — no plan review voting.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

Quick mode — no voting panel. Main agent reviewed findings from 2 Claude subagents (general-reviewer + deep-analysis-reviewer). Four findings surfaced total across both reviewers; 3 were accepted and implemented, 1 was rejected as pedantic documentation noise.

**Accepted findings (3)**:
- **General Reviewer #1**: Use `refs/heads/$CURRENT_BRANCH` in the ls-remote call to prevent fnmatch/glob interpretation of branch names with `[`, `?`, `*`. (Correctness fix.)
- **General Reviewer #2**: Document the detached-HEAD fall-through behavior in the new `--skip-if-pushed` block with a brief comment. (Maintainer clarity.)
- **Deep-Analysis Reviewer #1**: SKILL.md line 292 prose "always runs" contradicted the new `--skip-if-pushed` behavior. Updated to note the skip exception and point to `/shazam` for freshness of already-pushed branches. (Doc correctness.)

**Rejected findings (1)**:
- **General Reviewer #3**: Add "Stdout on exit 0 in all other cases: (none)" to the header comment. See Rejected Code Review Suggestions section for the full rationale.

</details>

<details><summary>Out-of-Scope Observations</summary>

Pre-existing observations raised by the reviewers but deliberately **not** fixed in this PR:

- **Deep-Analysis #OOS-1**: `rebase-push.sh` line 68 — unknown option exits 1, but exit 1 is documented only as "rebase failed with conflicts." An unknown flag would mislead a caller parsing stdout for `CONFLICT_FILES=`. Suggested fix: change to `exit 3` and emit `REBASE_ERROR=Unknown option: $1`. Pre-existing, low-risk.
- **General #OOS-1**: `rebase-push.sh` line 117 — in `--no-push` mode, `git fetch` stderr is suppressed with `2>/dev/null` before the script exits 3 with a static message. A caller trying to diagnose the failure has no git-layer detail. Suggested fix: capture stderr into `FETCH_ERR` and embed it in the `REBASE_ERROR` line.
- **General #OOS-2**: `/implement` SKILL.md Step 10's comment about "deliberately bails on all rebase conflicts" could be clarified to note that this path is the only place in `/implement` where `rebase-push.sh` runs without `--no-push`. Pre-existing documentation gap.

</details>

<details><summary>Execution Issues</summary>

### Warnings
- **Step 8**: Version bump skipped — no /bump-version skill exists at `.claude/skills/bump-version/SKILL.md`.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | N/A (quick mode) |
| Code review rounds | 1 |
| Code review findings | 3 accepted, 1 rejected |
| Warnings logged | 1 |
| Pre-existing issues noticed | 3 |
| External reviewers | N/A (quick mode) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
