### PR TITLE
Ensure on-latest-main before branching; skip needless rebases

### DIFF
--- a/.claude/scripts/generic/larch/rebase-push.sh
+++ b/.claude/scripts/generic/larch/rebase-push.sh
@@ -29,8 +29,9 @@
 #
 # Exit codes:
 #   0 — rebase (and push, unless --no-push) succeeded, OR skipped because
-#       --skip-if-pushed detected the branch already on origin, OR skipped
-#       because HEAD already contains origin/main (nothing to rebase)
+#       --skip-if-pushed detected the branch already on origin, OR (in
+#       --no-push mode only) skipped because HEAD already contains
+#       origin/main (nothing to rebase)
 #   1 — rebase failed with conflicts
 #       Default mode: rebase left in progress (CONFLICT_FILES= on stdout)
 #       --no-push mode: rebase aborted, branch restored to pre-rebase state
@@ -45,8 +46,12 @@
 # Stdout on exit 0 when --skip-if-pushed skipped the rebase:
 #   SKIPPED_ALREADY_PUSHED=true
 #
-# Stdout on exit 0 when HEAD already contains origin/main (after fetch):
+# Stdout on exit 0 when --no-push and HEAD already contains origin/main:
 #   SKIPPED_ALREADY_FRESH=true
+#   Only emitted in --no-push mode. In default (push) mode the script
+#   always proceeds to the push step even if the rebase would be a no-op,
+#   because a feature branch may have local commits that still need to
+#   reach origin.
 #
 # Stdout on exit 1 (default mode only):
 #   CONFLICT_FILES=<comma-separated list of conflicted files>
@@ -135,10 +140,12 @@ else
     # If origin/main is an ancestor of HEAD, HEAD already has every commit
     # from main, so `git rebase origin/main` would be a no-op. Exit 0 with a
     # SKIPPED_ALREADY_FRESH=true marker so callers can log it distinctly.
-    # In default (push) mode, skipping the rebase also skips the force-push:
-    # since HEAD did not change, there is nothing new to push, and the caller
-    # will re-check status on the next loop iteration.
-    if git merge-base --is-ancestor origin/main HEAD 2>/dev/null; then
+    #
+    # This optimization is gated on --no-push mode. In default (push) mode we
+    # must still reach the push step: a feature branch may have local commits
+    # that have never been pushed, and HEAD containing origin/main says
+    # nothing about whether the remote tracking branch is up to date.
+    if [[ "$NO_PUSH" == "true" ]] && git merge-base --is-ancestor origin/main HEAD 2>/dev/null; then
         echo "SKIPPED_ALREADY_FRESH=true"
         exit 0
     fi

--- a/.claude/scripts/generic/larch/rebase-push.sh
+++ b/.claude/scripts/generic/larch/rebase-push.sh
@@ -29,7 +29,8 @@
 #
 # Exit codes:
 #   0 — rebase (and push, unless --no-push) succeeded, OR skipped because
-#       --skip-if-pushed detected the branch already on origin
+#       --skip-if-pushed detected the branch already on origin, OR skipped
+#       because HEAD already contains origin/main (nothing to rebase)
 #   1 — rebase failed with conflicts
 #       Default mode: rebase left in progress (CONFLICT_FILES= on stdout)
 #       --no-push mode: rebase aborted, branch restored to pre-rebase state
@@ -43,6 +44,9 @@
 #
 # Stdout on exit 0 when --skip-if-pushed skipped the rebase:
 #   SKIPPED_ALREADY_PUSHED=true
+#
+# Stdout on exit 0 when HEAD already contains origin/main (after fetch):
+#   SKIPPED_ALREADY_FRESH=true
 #
 # Stdout on exit 1 (default mode only):
 #   CONFLICT_FILES=<comma-separated list of conflicted files>
@@ -125,6 +129,18 @@ else
         fi
     else
         git fetch origin main --quiet 2>/dev/null || true
+    fi
+
+    # --- Early exit: skip rebase if HEAD already contains origin/main ---
+    # If origin/main is an ancestor of HEAD, HEAD already has every commit
+    # from main, so `git rebase origin/main` would be a no-op. Exit 0 with a
+    # SKIPPED_ALREADY_FRESH=true marker so callers can log it distinctly.
+    # In default (push) mode, skipping the rebase also skips the force-push:
+    # since HEAD did not change, there is nothing new to push, and the caller
+    # will re-check status on the next loop iteration.
+    if git merge-base --is-ancestor origin/main HEAD 2>/dev/null; then
+        echo "SKIPPED_ALREADY_FRESH=true"
+        exit 0
     fi
 
     # --- Attempt rebase ---

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -121,7 +121,7 @@ Parse the output for `CURRENT_BRANCH`, `IS_MAIN`, `IS_USER_BRANCH`, and `USER_PR
 
 ### Ensure local main is fresh before branch creation
 
-**This block runs only when `IS_MAIN=true`** (we are on `main` and about to branch off). Skip it for `IS_USER_BRANCH=true` (we are not creating a branch from main — the feature branch rebase at the end of Step 1 handles freshness) and for the non-main/non-user-branch warning path (we are on some other branch, and `create-branch.sh --branch` will fetch and create the new branch directly from `origin/main`).
+**This block runs only when `CURRENT_BRANCH == "main"`.** Detached HEAD also reports `IS_MAIN=true` from `create-branch.sh --check`, but a rebase on detached HEAD would fail (`rebase-push.sh` errors with "Not on a branch"); fall through to the mode-specific branch creation logic below so a new branch can be created from `origin/main`. Also skip this block for `IS_USER_BRANCH=true` (we are not creating a branch from main — the feature branch rebase at the end of Step 1 handles freshness) and for the non-main/non-user-branch warning path (we are on some other branch, and `create-branch.sh --branch` will fetch and create the new branch directly from `origin/main`).
 
 Print: `🔃 Ensuring local main is up to date before branching...`
 
@@ -130,13 +130,13 @@ Run:
 $PWD/.claude/scripts/generic/larch/rebase-push.sh --no-push
 ```
 
-`--skip-if-pushed` is intentionally **not** used here: `main` is always on origin, so that flag would always short-circuit. The new `SKIPPED_ALREADY_FRESH=true` optimization makes this call cheap (fetch + ancestor check) when local `main` is already at `origin/main`.
+`--skip-if-pushed` is intentionally **not** used here: `main` is always on origin, so that flag would always short-circuit. The `SKIPPED_ALREADY_FRESH=true` optimization makes this call cheap (fetch + ancestor check) when local `main` is already at `origin/main`.
 
 If the script exits non-zero, print: `**⚠ Failed to ensure local main is fresh. Bailing to cleanup.**` and skip to Step 18.
 
 If successful:
 - If stdout contains `SKIPPED_ALREADY_FRESH=true`, print: `⏩ Local main already at latest — no update needed.`
-- Otherwise, print: `✅ Local main fast-forwarded to latest origin/main.`
+- Otherwise, print: `✅ Local main rebased onto latest origin/main.`
 
 ### Quick mode (`quick_mode=true`)
 

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -119,6 +119,25 @@ $PWD/.claude/scripts/generic/larch/create-branch.sh --check
 
 Parse the output for `CURRENT_BRANCH`, `IS_MAIN`, `IS_USER_BRANCH`, and `USER_PREFIX`.
 
+### Ensure local main is fresh before branch creation
+
+**This block runs only when `IS_MAIN=true`** (we are on `main` and about to branch off). Skip it for `IS_USER_BRANCH=true` (we are not creating a branch from main — the feature branch rebase at the end of Step 1 handles freshness) and for the non-main/non-user-branch warning path (we are on some other branch, and `create-branch.sh --branch` will fetch and create the new branch directly from `origin/main`).
+
+Print: `🔃 Ensuring local main is up to date before branching...`
+
+Run:
+```bash
+$PWD/.claude/scripts/generic/larch/rebase-push.sh --no-push
+```
+
+`--skip-if-pushed` is intentionally **not** used here: `main` is always on origin, so that flag would always short-circuit. The new `SKIPPED_ALREADY_FRESH=true` optimization makes this call cheap (fetch + ancestor check) when local `main` is already at `origin/main`.
+
+If the script exits non-zero, print: `**⚠ Failed to ensure local main is fresh. Bailing to cleanup.**` and skip to Step 18.
+
+If successful:
+- If stdout contains `SKIPPED_ALREADY_FRESH=true`, print: `⏩ Local main already at latest — no update needed.`
+- Otherwise, print: `✅ Local main fast-forwarded to latest origin/main.`
+
 ### Quick mode (`quick_mode=true`)
 
 Skip `/design` entirely. Handle branch creation directly, then produce an inline implementation plan.
@@ -164,6 +183,7 @@ If the script exits non-zero, print: `**⚠ Rebase onto main failed. Bailing to 
 
 If successful:
 - If the stdout contains `SKIPPED_ALREADY_PUSHED=true`, print: `⏩ Rebase skipped — branch already pushed to origin.`
+- Else if the stdout contains `SKIPPED_ALREADY_FRESH=true`, print: `⏩ Rebase skipped — already at latest main.`
 - Otherwise, print: `✅ Rebased onto latest main.`
 
 ## Step 2 — Implement the Feature
@@ -203,6 +223,7 @@ If the script exits non-zero, print: `**⚠ Rebase onto main failed. Bailing to 
 
 If successful:
 - If the stdout contains `SKIPPED_ALREADY_PUSHED=true`, print: `⏩ Rebase skipped — branch already pushed to origin.`
+- Else if the stdout contains `SKIPPED_ALREADY_FRESH=true`, print: `⏩ Rebase skipped — already at latest main.`
 - Otherwise, print: `✅ Rebased onto latest main.`
 
 ## Step 5 — Code Review
@@ -278,6 +299,7 @@ If the script exits non-zero, print: `**⚠ Rebase onto main failed. Bailing to 
 
 If successful:
 - If the stdout contains `SKIPPED_ALREADY_PUSHED=true`, print: `⏩ Rebase skipped — branch already pushed to origin.`
+- Else if the stdout contains `SKIPPED_ALREADY_FRESH=true`, print: `⏩ Rebase skipped — already at latest main.`
 - Otherwise, print: `✅ Rebased onto latest main.`
 
 ## Step 7a — Code Flow Diagram
@@ -321,6 +343,7 @@ If the script exits non-zero, print: `**⚠ Rebase onto main failed. Bailing to 
 
 If successful:
 - If the stdout contains `SKIPPED_ALREADY_PUSHED=true`, print: `⏩ Rebase skipped — branch already pushed to origin.`
+- Else if the stdout contains `SKIPPED_ALREADY_FRESH=true`, print: `⏩ Rebase skipped — already at latest main.`
 - Otherwise, print: `✅ Rebased onto latest main.`
 
 ## Step 8 — Version Bump


### PR DESCRIPTION
## Summary
- Added an explicit "ensure local main is fresh" step at the top of `/implement` Step 1 that runs before any new branch is created (only when `CURRENT_BRANCH == "main"`).
- Added a `SKIPPED_ALREADY_FRESH=true` early exit to `rebase-push.sh` (gated on `--no-push` mode) so the four downstream "Rebase onto latest main" checkpoints in `/implement` collapse to a fetch + ancestor check when HEAD already contains `origin/main`.
- Updated all four existing rebase status blocks in the skill to recognize and report the new skip reason distinctly from `SKIPPED_ALREADY_PUSHED`.

<details><summary>Architecture Diagram</summary>

Quick mode — architecture diagram skipped.

</details>

<details><summary>Code Flow Diagram</summary>

Quick mode — code flow diagram skipped.

</details>

<details><summary>Goal</summary>

- Ensure `/implement` either already does this or change it to:
  - At the start, where it is right about to create a branch, ascertain that we are on latest main, and if not, do a fetch & rebase on main.
  - When it does rebase onto latest main (at several points in the flow), it should be optimized to only do the rebase if it's needed.

</details>

<details><summary>Test plan</summary>

- [x] Smoke test `rebase-push.sh --no-push` on a fresh-from-main branch → prints `SKIPPED_ALREADY_FRESH=true`, exits 0.
- [x] Smoke test `rebase-push.sh --no-push --skip-if-pushed` on a fresh, unpushed branch → falls through `--skip-if-pushed`, hits the new freshness check, prints `SKIPPED_ALREADY_FRESH=true`, exits 0.
- [x] Smoke test `rebase-push.sh --skip-if-pushed` (without `--no-push`) → still errors with the existing `REBASE_ERROR=--skip-if-pushed is only valid with --no-push`, exit 3.
- [x] `pre-commit run --files` (shellcheck + markdownlint) passes on both modified files.
- [x] Run `/implement --quick --merge` end-to-end on this very change: the Step 4 and Step 7 post-commit rebase checkpoints correctly print `⏩ Rebase skipped — already at latest main.` — the new optimization is exercised by the workflow that produced it.
- [ ] Validate on a subsequent `/implement` run where `main` has actually advanced: the Step 1 "Ensure local main is fresh" block fast-forwards local main, and subsequent rebase checkpoints do real work only when needed.

</details>

<details><summary>Final Design</summary>

Two-part change:

### Part 1 — `rebase-push.sh` — `SKIPPED_ALREADY_FRESH=true` early exit (gated on `--no-push`)

After the fetch (in non-`--continue` mode), if `NO_PUSH=true` and `git merge-base --is-ancestor origin/main HEAD` succeeds, HEAD already contains every commit from `origin/main` — a rebase would be a no-op. Print `SKIPPED_ALREADY_FRESH=true` and exit 0.

**Why gated on `--no-push`:** In default (push) mode, the force-push step MUST run, because a feature branch may have local commits that have never reached `origin`. HEAD containing `origin/main` says nothing about whether the remote tracking branch is up to date. Gating the optimization avoids silently skipping a needed push.

### Part 2 — `/implement` SKILL.md Step 1 — pre-branch-creation freshness step

Inserted after `create-branch.sh --check` and before both quick-mode and normal-mode branch handling. Runs only when `CURRENT_BRANCH == "main"` (explicitly excludes detached HEAD, which also reports `IS_MAIN=true`). Uses `rebase-push.sh --no-push` (no `--skip-if-pushed`, because `main` is always on origin and that flag would always short-circuit). On failure, bails to Step 18.

All four existing "Rebase onto latest main" status blocks (Steps 1-post, 4, 7, 7a) were updated to recognize `SKIPPED_ALREADY_FRESH=true` alongside the existing `SKIPPED_ALREADY_PUSHED=true` signal, with the mutually-exclusive decision tree: `pushed` → `fresh` → `rebased`.

**Scope decisions:**
- Pre-create freshness step does NOT run for `IS_USER_BRANCH=true` — the existing end-of-Step-1 feature-branch rebase handles freshness on reuse.
- Pre-create freshness step does NOT run for the warning path (non-main, non-user branch) — we are on some random branch and `create-branch.sh --branch` will fetch + branch from `origin/main` directly.
- The optimization applies to Step 10/Step 12 CI+rebase+merge loop callers **only** through push-mode invocation, where it is now correctly a no-op (gated off).

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

Quick mode — no plan review was conducted.

</details>

<details><summary>Implementation Deviations</summary>

No deviations from the inline plan.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

All code review suggestions were implemented.

</details>

<details><summary>Plan Review Voting Tally</summary>

Quick mode — no plan review voting.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

Quick mode — no voting panel. Main agent reviewed findings from 2 Claude subagents (general-reviewer and deep-analysis-reviewer) and accepted all in-scope findings:

- **general-reviewer**: 3 in-scope findings, all accepted (detached-HEAD false bail, "fast-forwarded" wording, over-specific inline comment which became moot).
- **deep-analysis-reviewer**: 3 in-scope findings, all accepted (critical push-mode silent skip, duplicate detached-HEAD bug, duplicate wording nit).

The most consequential finding was the deep-analysis reviewer's catch that `SKIPPED_ALREADY_FRESH` in default (push) mode could silently skip a needed force-push for a feature branch with unpushed local commits. Fixed by gating the early-exit on `NO_PUSH=true`.

</details>

<details><summary>Out-of-Scope Observations</summary>

Surfaced by the code review but left as pre-existing issues:

- **`create-branch.sh` conflates detached HEAD with `IS_MAIN=true`** (`.claude/scripts/generic/larch/create-branch.sh:75`). A detached HEAD state is semantically different from being on the `main` branch, but `IS_MAIN=true` fires for both. A dedicated `IS_DETACHED=true` output would let callers distinguish the two cases cleanly. This PR works around it in SKILL.md by guarding on `CURRENT_BRANCH == "main"` instead of `IS_MAIN=true`.
- **Flag-validation errors in `rebase-push.sh` use `REBASE_ERROR=` as the key** even though no rebase has occurred (lines 77, 82). Minor protocol inconsistency.
- **Step 10/Step 12 exit-0 handling docs** describe exit 0 as "Rebase and push succeeded" — after this PR, the contract is narrower (default mode still pushes; `--no-push` mode may skip), but the CI-loop docs in SKILL.md were not updated because the optimization does not fire in push mode and the CI loop only uses push mode.

</details>

<details><summary>Execution Issues</summary>

### Warnings
- **Step 8**: Version bump skipped — no `/bump-version` skill exists at `.claude/skills/bump-version/SKILL.md`. This is a repo-wide situation, not specific to this PR.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | N/A (quick mode) |
| Code review rounds | 1 (quick mode simplified review) |
| Code review findings | 6 accepted (3 from general-reviewer, 3 from deep-analysis-reviewer; the two reviewers independently identified the same detached-HEAD and "fast-forwarded" issues), 0 rejected |
| Warnings logged | 1 (version bump skipped) |
| Pre-existing issues noticed | 3 (create-branch.sh detached-HEAD conflation, REBASE_ERROR= key on flag errors, Step 10/12 exit-0 docs) |
| External reviewers | N/A (quick mode) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
