### PR TITLE
Re-run /bump-version after every rebase in Steps 10 and 12

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation with collaborative reviewers (Claude subagents + Codex + Cursor).",
   "author": {
     "name": "Sergey Zhupanov"

--- a/scripts/check-bump-version.sh
+++ b/scripts/check-bump-version.sh
@@ -14,9 +14,41 @@
 #     COMMITS_AFTER=<N>
 #     EXPECTED=<N>
 #
+# Commit counting uses local `main` if it exists, falling back to `origin/main`
+# if only the remote ref is present. This matches classify-bump.sh's base
+# resolution and ensures the /implement Rebase + Re-bump Sub-procedure's post-
+# verification check works correctly even when the repo has no local `main`
+# ref (e.g., some CI clones). Without the fallback, `git rev-list main..HEAD`
+# silently returns 0 and the post-check produces a false VERIFIED=false.
+#
 # Exit codes: 0 success, 1 invalid args
 
 set -euo pipefail
+
+# count_commits — Count commits on the current branch that aren't on main.
+# Prefers local `main`; falls back to `origin/main` if local is absent.
+# Prints "0" on any git error to preserve the caller's key=value contract.
+# When neither `main` nor `origin/main` exists (a degenerate repo state that
+# normally cannot occur mid-/implement because `rebase-push.sh` would have
+# already failed on the missing `origin/main` fetch), emits a stderr WARN
+# so the caller can see the edge case in execution logs, and still returns
+# "0" to preserve the KEY=VALUE stdout contract. The downstream VERIFIED
+# check will then report false and /implement's Step 12 will bail — which
+# is the correct outcome when the bump base cannot be determined.
+count_commits() {
+  local base_ref=""
+  if git rev-parse --verify main >/dev/null 2>&1; then
+    base_ref="main"
+  elif git rev-parse --verify origin/main >/dev/null 2>&1; then
+    base_ref="origin/main"
+  fi
+  if [[ -z "$base_ref" ]]; then
+    echo "WARN: check-bump-version.sh: neither local 'main' nor 'origin/main' exists; cannot determine bump base. Returning 0." >&2
+    echo "0"
+    return
+  fi
+  git rev-list "${base_ref}..HEAD" --count 2>/dev/null || echo "0"
+}
 
 MODE=""
 BEFORE_COUNT=""
@@ -41,15 +73,14 @@ case "$MODE" in
     else
       echo "HAS_BUMP=false"
     fi
-    COMMITS=$(git rev-list main..HEAD --count 2>/dev/null || echo "0")
-    echo "COMMITS_BEFORE=$COMMITS"
+    echo "COMMITS_BEFORE=$(count_commits)"
     ;;
   post)
     if [[ -z "$BEFORE_COUNT" ]]; then
       echo "ERROR=--before-count required for --mode post" >&2
       exit 1
     fi
-    COMMITS_AFTER=$(git rev-list main..HEAD --count 2>/dev/null || echo "0")
+    COMMITS_AFTER=$(count_commits)
     EXPECTED=$((BEFORE_COUNT + 1))
     if [[ "$COMMITS_AFTER" -eq "$EXPECTED" ]]; then
       echo "VERIFIED=true"

--- a/scripts/drop-bump-commit.sh
+++ b/scripts/drop-bump-commit.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# drop-bump-commit.sh — Drop a terminal "Bump version to X.Y.Z" commit from HEAD.
+#
+# Narrow primitive used by /implement's Rebase + Re-bump Sub-procedure to
+# strip a stale version-bump commit before rebasing onto latest main.
+# Refuses to do anything destructive unless ALL of these hold:
+#   1. Working tree is clean (no staged, unstaged, or untracked changes).
+#   2. HEAD subject matches ^Bump version to [0-9]+\.[0-9]+\.[0-9]+$.
+#   3. HEAD~1 exists (branch has at least 2 commits).
+#   4. HEAD touches exactly one file: .claude-plugin/plugin.json.
+#
+# If any check fails, the script prints DROPPED=false and exits 0 (no-op).
+# A stderr WARN line explains which guard refused the drop, for callers that
+# want to surface it.
+#
+# Usage:
+#   drop-bump-commit.sh
+#
+# Output (stdout, KEY=VALUE):
+#   DROPPED=true|false
+#   OLD_BUMP_SHA=<sha>   (only when DROPPED=true)
+#
+# Exit codes:
+#   0 — success, including no-op cases (inspect DROPPED to know what happened)
+#   1 — git error during the reset itself (rare)
+
+set -uo pipefail
+# Note: not using set -e — we handle errors explicitly so all no-op paths
+# exit 0 with DROPPED=false, matching the contract used by callers.
+
+# --- Guard 1: clean working tree ---
+# Defense in depth: even though callers are expected to ensure the worktree
+# is clean before invoking, this script refuses destructive `git reset --hard`
+# if anything is uncommitted. `git status --porcelain` covers staged, unstaged,
+# and untracked files — unlike `git diff-index --quiet` which skips untracked.
+if [[ -n "$(git status --porcelain 2>/dev/null)" ]]; then
+    echo "WARN: worktree has uncommitted changes; refusing to drop bump commit" >&2
+    echo "DROPPED=false"
+    exit 0
+fi
+
+# --- Guard 2: HEAD subject must be a bump commit ---
+HEAD_SUBJECT=$(git log -1 --format=%s HEAD 2>/dev/null || true)
+if ! [[ "$HEAD_SUBJECT" =~ ^Bump\ version\ to\ [0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "DROPPED=false"
+    exit 0
+fi
+
+# --- Guard 3: HEAD~1 must exist ---
+if ! git rev-parse --verify HEAD~1 >/dev/null 2>&1; then
+    echo "WARN: HEAD~1 does not exist; cannot drop the only commit on the branch" >&2
+    echo "DROPPED=false"
+    exit 0
+fi
+
+# --- Guard 4: commit must touch only .claude-plugin/plugin.json ---
+# Use diff --name-only against HEAD~1. A legitimate bump commit produced by
+# apply-bump.sh only stages .claude-plugin/plugin.json.
+CHANGED_FILES=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || true)
+if [[ "$CHANGED_FILES" != ".claude-plugin/plugin.json" ]]; then
+    echo "WARN: HEAD subject matches bump pattern but commit touches files other than .claude-plugin/plugin.json (changed: $CHANGED_FILES); refusing to drop" >&2
+    echo "DROPPED=false"
+    exit 0
+fi
+
+# --- All guards passed: capture SHA and drop ---
+OLD_BUMP_SHA=$(git rev-parse HEAD)
+
+if ! git reset --hard HEAD~1 >/dev/null 2>&1; then
+    echo "ERROR: git reset --hard HEAD~1 failed" >&2
+    exit 1
+fi
+
+echo "DROPPED=true"
+echo "OLD_BUMP_SHA=$OLD_BUMP_SHA"
+exit 0

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -367,7 +367,7 @@ Parse the output for `HAS_BUMP` and `COMMITS_BEFORE`.
    ```
    Parse for `VERIFIED`, `COMMITS_AFTER`, `EXPECTED`. If `VERIFIED=false`, print: `**⚠ /bump-version did not create exactly one commit. Expected $EXPECTED, got $COMMITS_AFTER.**`
 
-**Important**: There must be exactly ONE version bump per PR, and it must be the LAST commit before creating the PR. Proceed immediately to Step 9 after `/bump-version` returns — no commits may occur between.
+**Important**: At PR creation time there must be exactly ONE version bump commit as HEAD. Proceed immediately to Step 9 after `/bump-version` returns — no commits may occur between Step 8 and Step 9. Note: after PR creation, Steps 10 and 12's rebase handlers may repeatedly drop and recreate this bump commit as main advances (via the shared **Rebase + Re-bump Sub-procedure** — see before Step 10). The branch history between PR creation and merge may therefore temporarily contain zero or multiple bump commits; the invariant that matters is "the terminal bump commit on HEAD must be based on latest `origin/main` at merge time", enforced strictly by Step 12 and best-effort by Step 10.
 
 ## Step 9 — Create PR
 
@@ -508,11 +508,125 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/gh-pr-body-update.sh --pr <PR_NUMBER> --body-file 
 
 Print the PR URL when done. Save `PR_NUMBER`, `PR_URL`, and `PR_TITLE` for use in Steps 10–15.
 
+## Rebase + Re-bump Sub-procedure (shared by Steps 10 and 12)
+
+After the initial version bump in Step 8, every subsequent rebase of the feature branch onto latest `origin/main` must be followed by a fresh `/bump-version` run so the merged state reflects the version in latest main **at merge time**, not at PR-creation time. This sub-procedure consolidates the drop/rebase/fast-forward/bump/push/refresh sequence so that Steps 10 and 12 can invoke it from multiple places without duplication.
+
+### Inputs
+- `rebase_already_done` — if `true`, steps 1–2 are skipped (the rebase has already happened and been pushed by the caller, e.g., Step 12 Phase 4's `rebase-push.sh --continue`). If `false`, the sub-procedure performs the rebase itself.
+- `caller_kind` — one of: `step12_rebase`, `step12_rebase_then_evaluate`, `step12_phase4`, `step10_rebase`, `step10_rebase_then_evaluate`. Determines:
+  1. **Post-return control flow** (re-invoke `ci-wait.sh`, fall through to 12c, fall through to Step 10's evaluate_failure handler, etc.)
+  2. **Failure semantics** — grouped into two caller families:
+     - **step12 family** (`step12_rebase`, `step12_rebase_then_evaluate`, `step12_phase4`): any hard failure below bails to **Step 12d**. Step 12 is the last-chance enforcement point for the version bump freshness invariant, so it must not silently proceed to merge.
+     - **step10 family** (`step10_rebase`, `step10_rebase_then_evaluate`): any hard failure below logs a warning and **breaks out of Step 10's loop to Step 11**, matching Step 10's existing "never block the pipeline" philosophy. Step 12 will re-run this sub-procedure under strict semantics before merging, so Step 10 failures degrade gracefully.
+  3. **Conflict fallback path** — `step12_*` falls back to a full `rebase-push.sh` + the Conflict Resolution Procedure (Phase 1–4) when `--no-push` exit 1 happens; `step10_*` logs a warning and breaks out of Step 10 to Step 11 (Step 10 has no Phase 1–4).
+
+### Happy path (`rebase_already_done=false`)
+
+1. **Drop existing bump commit**:
+   ```bash
+   ${CLAUDE_PLUGIN_ROOT}/scripts/drop-bump-commit.sh
+   ```
+   Parse `DROPPED`. If `DROPPED=false`, log to `$IMPLEMENT_TMPDIR/execution-issues.md` under `Warnings`: `Step <N> — drop-bump-commit.sh reported DROPPED=false before rebase; HEAD was not a bump commit (CI fix commit may have landed on top, worktree was dirty, or the commit touched files other than .claude-plugin/plugin.json). Re-bump will still run but branch history may temporarily contain two bump commits and the rebase may encounter a plugin.json conflict routed through Phase 1–3.` Continue to step 2. (The guard in `drop-bump-commit.sh` is defense-in-depth — the sub-procedure does not treat `DROPPED=false` as a hard failure.)
+
+2. **Rebase without pushing**:
+   ```bash
+   ${CLAUDE_PLUGIN_ROOT}/scripts/rebase-push.sh --no-push
+   ```
+   - **Exit 0** (rebase clean, branch is local-only fresh — may include `SKIPPED_ALREADY_FRESH=true`): proceed to step 3.
+   - **Exit 1** (conflict; `--no-push` has already called `git rebase --abort`, so no rebase is in progress — the two invocations are independent, any fallback call restarts a fresh fetch + rebase):
+     - **step12 family**: **fall back to full `${CLAUDE_PLUGIN_ROOT}/scripts/rebase-push.sh`** (without `--no-push`). Enumerate all four exit codes of the fallback call:
+       - **Fallback exit 0**: rebase succeeded cleanly AND the branch was force-pushed. Set `rebase_already_done=true` (so step 5's push will be the second push of the iteration, not the first) and proceed to step 3.
+       - **Fallback exit 1**: conflict; rebase is in progress. Enter the **Conflict Resolution Procedure** (Phase 1–4, defined in Step 12 below). After Phase 4's `--continue` exit 0 completes, `rebase_already_done` is effectively `true` (Phase 4 pushed); proceed to step 3.
+       - **Fallback exit 2**: `force-with-lease` push failure after a successful rebase. Apply the step 5 push-failure recovery procedure (fetch + compare + retry + bail) instead of silently returning.
+       - **Fallback exit 3**: non-conflict rebase failure; rebase already aborted. Read `REBASE_ERROR` and bail to 12d.
+     - **step10 family**: print `**⚠ Step 10 — Rebase conflict detected; deferring to Step 12 for conflict resolution. Proceeding to Step 11 without re-bump.**` Log to `$IMPLEMENT_TMPDIR/execution-issues.md` under `CI Issues`. **Break out of Step 10's loop and proceed to Step 11.**
+   - **Exit 3** (non-conflict rebase failure in `--no-push` mode; rebase already aborted):
+     - **step12 family**: read `REBASE_ERROR` and bail to 12d.
+     - **step10 family**: print `**⚠ Step 10 — Rebase failed (non-conflict): $REBASE_ERROR. Proceeding to Step 11.**` Log to `CI Issues`. Break to Step 11.
+
+3. **Fast-forward local `main` to `origin/main`**:
+   `rebase-push.sh` refreshes `origin/main` via `git fetch`, but local `main` is not automatically updated. `classify-bump.sh` prefers local `main` for its `merge-base` computation, so without this step `BASE` could point to an older commit than the one the branch was just rebased onto, causing the classifier's diff to include commits that belong to main (not the feature).
+   ```bash
+   if git rev-parse --verify main >/dev/null 2>&1; then
+     git branch -f main origin/main
+   fi
+   ```
+   This is safe because Step 10 and Step 12's rebase loops always run on a feature branch, never on `main`. If the local `main` ref does not exist, silently skip — `classify-bump.sh` has an `origin/main` fallback.
+
+4. **Re-bump**:
+   Follow the same sequence as Step 8, with caller-family-specific error handling:
+   ```bash
+   ${CLAUDE_PLUGIN_ROOT}/scripts/check-bump-version.sh --mode pre
+   ```
+   Parse `HAS_BUMP` and `COMMITS_BEFORE`.
+   - **If `HAS_BUMP=false`**:
+     - **step12 family**: **HARD FAILURE**. Print `**⚠ Step 12 — /bump-version skill not found at .claude/skills/bump-version/SKILL.md; cannot re-bump after rebase. Merged PR would reflect a stale version. Bailing to 12d.**` Bail to 12d.
+     - **step10 family**: Print `**⚠ Step 10 — /bump-version skill not found; skipping re-bump. Proceeding to Step 11 with whatever version is currently on the branch.**` Log to `Warnings`. Skip ahead to step 5 (the push in step 5 is a no-op since nothing new is staged locally after the rebase; fall through to step 6, then step 7 — return to caller).
+   - **If `HAS_BUMP=true`**: Invoke `/bump-version` via the Skill tool. If the skill invocation itself fails (returns an error, or bails internally):
+     - **step12 family**: hard failure — bail to 12d.
+     - **step10 family**: log warning and break out of Step 10 to Step 11.
+     After the skill returns successfully:
+     ```bash
+     ${CLAUDE_PLUGIN_ROOT}/scripts/check-bump-version.sh --mode post --before-count $COMMITS_BEFORE
+     ```
+     Parse `VERIFIED`. If `VERIFIED=false`:
+     - **step12 family**: **HARD FAILURE**. Print `**⚠ Step 12 — /bump-version did not create exactly one new commit after rebase. Expected $EXPECTED, got $COMMITS_AFTER. Cannot verify bump freshness; bailing to 12d.**` Bail to 12d.
+     - **step10 family**: log warning and break to Step 11.
+
+   **Rationale**: Step 8's permissive warnings are safe because Step 8 is pre-PR — no merge can happen based on a missing bump. Step 12 is pre-merge — missing bump means stale merge. Step 10 is post-PR but pre-merge (Step 12 does the merge) — any bump failure in Step 10 is recoverable by Step 12's mandatory re-bump, so Step 10 can afford to be permissive. **Step 12 is the last-chance enforcement point; Step 10 is best-effort optimization that improves freshness during the Slack-wait phase.**
+
+5. **Push with recovery**:
+   ```bash
+   git push --force-with-lease
+   ```
+   If push exits 0: proceed to step 6. If push fails:
+   a. Refresh the local tracking ref for the feature branch:
+      ```bash
+      BRANCH=$(git symbolic-ref --short HEAD)
+      git fetch origin "$BRANCH"
+      ```
+   b. Compare `git rev-parse HEAD` with `git rev-parse "origin/$BRANCH"`. If equal, the push actually landed (rare race where the remote accepted but the client did not recognize it). Proceed to step 6.
+   c. If they differ, the remote feature branch has something we don't. Log to `$IMPLEMENT_TMPDIR/execution-issues.md` under `CI Issues`: `Step <N> — force-with-lease push failed; local and remote feature branches diverge after re-bump.` Sleep 5s and retry the push ONCE:
+      ```bash
+      ${CLAUDE_PLUGIN_ROOT}/scripts/sleep-seconds.sh 5
+      git push --force-with-lease
+      ```
+      If the retry succeeds, proceed to step 6. If it fails again:
+      - **step12 family**: bail to 12d with error `Step 12 — re-bump push failed twice with --force-with-lease; remote feature branch has diverged from local. Manual intervention required.`
+      - **step10 family**: print `**⚠ Step 10 — re-bump push failed twice. Proceeding to Step 11 with whatever remote state is (may be stale).**` Log to `CI Issues`. Break to Step 11.
+
+   **Critical (step12 family only)**: Do NOT simply "log and return to caller" on push failure. That would let the merge loop proceed to `ACTION=merge` on a remote branch that does NOT contain the fresh bump commit, violating the feature's core invariant. `ci-wait.sh` and `merge-pr.sh` operate on remote PR state only; they cannot see unpushed local commits.
+
+6. **Refresh PR body Version Bump Reasoning block**:
+   If `$IMPLEMENT_TMPDIR/bump-version-reasoning.md` exists and is non-empty:
+   ```bash
+   ${CLAUDE_PLUGIN_ROOT}/scripts/gh-pr-body-read.sh --pr <PR_NUMBER> --output "$IMPLEMENT_TMPDIR/live-body.md"
+   ```
+   Read `$IMPLEMENT_TMPDIR/live-body.md`, replace the entire inner content of the `<details><summary>Version Bump Reasoning</summary>...</details>` block with the current contents of `$IMPLEMENT_TMPDIR/bump-version-reasoning.md` (preserving blank lines after the opening tag and before the closing `</details>` for GitHub Markdown rendering). Write the result to `$IMPLEMENT_TMPDIR/pr-body.md` (same file Step 11 writes to, so subsequent refreshes operate on the fresh canonical copy). Then:
+   ```bash
+   ${CLAUDE_PLUGIN_ROOT}/scripts/gh-pr-body-update.sh --pr <PR_NUMBER> --body-file "$IMPLEMENT_TMPDIR/pr-body.md"
+   ```
+   If the `<details><summary>Version Bump Reasoning</summary>` marker is not found in the fetched body, print `**⚠ Step <N> — Version Bump Reasoning block not found in live PR body. Skipping refresh.**` and skip the update. Log to `Warnings`. **PR body refresh failure is NOT a hard failure** — the bump is already pushed and the merge will be correct; the stale body is documentation-only.
+
+7. **Return to caller based on `caller_kind`**:
+   - **`step12_rebase`** (from 12a `ACTION=rebase`): increment `rebase_count`, `iteration`, reset `transient_retries`, re-invoke `ci-wait.sh` in Step 12.
+   - **`step12_phase4`** (from Phase 4 exit-0): increment `rebase_count`, `iteration`, reset `transient_retries`, re-invoke `ci-wait.sh` in Step 12.
+   - **`step12_rebase_then_evaluate`** (from 12a `ACTION=rebase_then_evaluate`): increment `rebase_count`, `iteration`, reset `transient_retries`, then **fall through to 12c** to evaluate the CI failure. Do NOT re-invoke `ci-wait.sh`.
+   - **`step10_rebase`** (from Step 10 `ACTION=rebase`): increment `rebase_count`, `iteration`, reset `transient_retries`, re-invoke `ci-wait.sh` in Step 10.
+   - **`step10_rebase_then_evaluate`** (from Step 10 `ACTION=rebase_then_evaluate`): increment `rebase_count`, `iteration`, reset `transient_retries`, then **fall through to Step 10's `ACTION=evaluate_failure` handler**. Do NOT re-invoke `ci-wait.sh`.
+
+### Phase 4 caller path (`rebase_already_done=true`, `caller_kind=step12_phase4`)
+
+Phase 4 enters the sub-procedure AFTER `rebase-push.sh --continue` has already pushed the resolved rebase. **Skip steps 1–2 entirely.** Still run steps 3 (fast-forward local main), 4 (re-bump with step12 hard-failure semantics), 5 (push with recovery), 6 (PR body refresh), 7 (return with `step12_phase4`). This path necessarily double-pushes (Phase 4 pushed the rebase, then step 5 pushes the new bump), but the Conflict Resolution Procedure is rare enough that the second push cost is acceptable.
+
 ## Step 10 — CI Monitor (initial wait for green)
 
 **If `repo_unavailable=true`**: Print `⏭️ Step 10 — Skipped (repository name could not be determined).` and proceed to Step 11.
 
 Wait for CI to go green so the Slack announcement (Step 11) links to a PR with passing CI. This step does **NOT merge** — Step 12 is the merge-aware loop that handles main advancement and merging.
+
+**Best-effort re-bump during CI wait**: Step 10's rebase handler invokes the same **Rebase + Re-bump Sub-procedure** (defined just before this step) that Step 12 uses, with step10-family semantics: hard failures degrade gracefully (log warning, break out of Step 10 to Step 11) rather than bailing to 12d. This keeps the PR's version fresh during the Slack-wait phase while ensuring Step 10 never blocks the pipeline — Step 12 remains the last-chance enforcement point for the version bump freshness invariant.
 
 Track these counters (all start at 0):
 - `iteration` — passed to `ci-wait.sh`, returned as `ITERATION`
@@ -537,9 +651,9 @@ Parse the output for: `ACTION`, `CI_STATUS`, `BEHIND_COUNT`, `FAILED_RUN_ID`, `B
 
    - **`ACTION=already_merged`**: PR was merged externally during CI wait. Print `✅ Step 10 — PR was merged externally.` and proceed to Step 11. (Step 12 will detect `already_merged` again and skip the merge loop.)
 
-   - **`ACTION=rebase`**: Main advanced. Run `${CLAUDE_PLUGIN_ROOT}/scripts/rebase-push.sh`. On exit 0: increment `rebase_count` and `iteration`, reset `transient_retries`, re-invoke `ci-wait.sh`. On exit 1 (conflicts): run `${CLAUDE_PLUGIN_ROOT}/scripts/git-rebase-abort.sh`, print warning, and proceed to Step 11 (the merge loop in Step 12 will encounter the same conflict and apply the full Conflict Resolution Procedure with reviewer panel validation). On exit 2: retry once, then proceed to Step 11. On exit 3: proceed to Step 11.
+   - **`ACTION=rebase`**: Main advanced. Invoke the **Rebase + Re-bump Sub-procedure** (defined before this step) with `rebase_already_done=false`, `caller_kind=step10_rebase`. The sub-procedure handles drop-before-rebase, rebase, fast-forward local main, re-bump via `/bump-version`, push with recovery, and PR body refresh. On sub-procedure success, counter updates and `ci-wait.sh` re-invocation happen inside the sub-procedure's step 7. On sub-procedure failure (rebase conflict, re-bump failure, or push failure), the sub-procedure logs a warning and breaks out of Step 10 to Step 11 — it does NOT bail to 12d (Step 12 will re-run the sub-procedure under strict semantics).
 
-   - **`ACTION=rebase_then_evaluate`**: Run rebase first (same as above), then fall through to evaluate the CI failure.
+   - **`ACTION=rebase_then_evaluate`**: Invoke the **Rebase + Re-bump Sub-procedure** with `rebase_already_done=false`, `caller_kind=step10_rebase_then_evaluate`. On sub-procedure success, fall through to the `ACTION=evaluate_failure` handler below. On sub-procedure failure, break to Step 11.
 
    - **`ACTION=evaluate_failure`**: Use `FAILED_RUN_ID` to evaluate:
      1. **Transient failure** (runner provisioning, Docker pull rate limit, "hosted runner lost communication", etc.): If `transient_retries < 2`, run `${CLAUDE_PLUGIN_ROOT}/scripts/sleep-seconds.sh 60`, then run `${CLAUDE_PLUGIN_ROOT}/scripts/ci-rerun-failed.sh --run-id <FAILED_RUN_ID> --repo $REPO`. Parse output for `RERUN_SUBMITTED` and `ERROR`. If `RERUN_SUBMITTED=false`, print the `ERROR` and treat as a real CI failure (fall through to diagnosis). Otherwise increment `transient_retries`, re-invoke `ci-wait.sh`. If `transient_retries >= 2`, treat as real failure.
@@ -599,6 +713,8 @@ If `execution-issues.md` does not exist or is empty, skip this refresh.
 
 Monitor CI and the main branch **in parallel**. The key optimization: don't wait for CI to finish before checking if main has advanced.
 
+**Version bump freshness invariant**: Every successful rebase in this loop is followed by a fresh `/bump-version` run against the new base, so the merged state reflects the version in latest `origin/main` at merge time — not at PR-creation time. This is handled by the **Rebase + Re-bump Sub-procedure** (defined before Step 10 above, shared with Step 10), invoked from 12a's rebase handlers and Phase 4's `--continue` exit-0 path. If re-bumping fails in any way that would leave the branch without a verified fresh bump commit, Step 12 bails to 12d rather than letting the merge loop proceed to a stale merge. (Step 10 uses the same sub-procedure but with best-effort semantics — Step 12 is the last-chance enforcement point.)
+
 ### 12a — Poll Loop
 
 Track these counters (all start at 0):
@@ -620,29 +736,19 @@ Parse the output for: `ACTION`, `CI_STATUS`, `BEHIND_COUNT`, `FAILED_RUN_ID`, `B
 
 **Execute the action** returned by `ci-wait.sh`:
 
-   - **`ACTION=rebase`**: Print a context-specific message based on `CI_STATUS`: if `CI_STATUS=pass`, print `🔄 CI passed but main advanced — rebasing...`; if `CI_STATUS=pending`, print `🔄 Main advanced while CI running — rebasing...` → run `rebase-push.sh` (see rebase handling below) → on success: increment `rebase_count`, increment `iteration`, reset `transient_retries` → re-invoke `ci-wait.sh`.
+   - **`ACTION=rebase`**: Print a context-specific message based on `CI_STATUS`: if `CI_STATUS=pass`, print `🔄 CI passed but main advanced — rebasing + re-bumping...`; if `CI_STATUS=pending`, print `🔄 Main advanced while CI running — rebasing + re-bumping...` → invoke the **Rebase + Re-bump Sub-procedure** (defined before Step 10) with `rebase_already_done=false`, `caller_kind=step12_rebase`. The sub-procedure handles drop-before-rebase, rebase (with Phase 1–4 fallback on conflict), fast-forward local main, `/bump-version`, push with recovery, and PR body refresh. On successful return, counter updates (`rebase_count`, `iteration`, `transient_retries` reset) and `ci-wait.sh` re-invocation happen inside the sub-procedure's step 7. On hard failure, the sub-procedure bails to 12d directly.
 
    - **`ACTION=merge`**: Print `✅ CI passed, main up-to-date — merging!` → proceed to **12b**.
 
    - **`ACTION=already_merged`**: Print `✅ PR was force-merged externally — skipping CI wait and merge.` → skip **12b** (no merge needed) and proceed directly to Step 13. The PR counts as successfully merged for Steps 13–15.
 
-   - **`ACTION=rebase_then_evaluate`**: Run rebase first (same as `rebase` above), then on success fall through to evaluate the CI failure as in **12c**.
+   - **`ACTION=rebase_then_evaluate`**: Invoke the **Rebase + Re-bump Sub-procedure** with `rebase_already_done=false`, `caller_kind=step12_rebase_then_evaluate`. On successful return (counter updates already done inside the sub-procedure), **fall through to 12c** to evaluate the CI failure. Do NOT re-invoke `ci-wait.sh` from the caller — the sub-procedure's `caller_kind=step12_rebase_then_evaluate` branch skips the re-invocation for this path. On hard failure, the sub-procedure bails to 12d.
 
    - **`ACTION=evaluate_failure`**: Evaluate the CI failure → **12c**.
 
    - **`ACTION=bail`**: Print `BAIL_REASON` and bail out → **12d**.
 
-After handling any non-merge/non-bail action (rebase, evaluate_failure, etc.), **re-invoke `ci-wait.sh`** with updated counter values. The adaptive sleep interval is handled by the caller: sleep 30s before re-invoking after a rebase, sleep 60s after a transient retry rerun.
-
-4. **When rebase is needed** (ACTION=rebase or rebase_then_evaluate), use the `rebase-push.sh` script:
-   ```bash
-   ${CLAUDE_PLUGIN_ROOT}/scripts/rebase-push.sh
-   ```
-   Handle exit codes:
-   - **Exit 0**: Rebase and push succeeded.
-   - **Exit 1**: Rebase had conflicts (rebase is still in progress). Read `CONFLICT_FILES=` from stdout. Enter the **Conflict Resolution Procedure** below.
-   - **Exit 2**: `force-with-lease` push failed. Run the script again once (it fetches + rebases internally). If it fails twice, **bail out** (Step 12d).
-   - **Exit 3**: Rebase failed for non-conflict reasons (rebase already aborted). Read `REBASE_ERROR=` from stderr. **Bail out** (Step 12d).
+After handling any non-merge/non-bail/non-rebase action (e.g., `evaluate_failure`), **re-invoke `ci-wait.sh`** with updated counter values. The `rebase` and `rebase_then_evaluate` paths handle their own post-return control flow inside the sub-procedure. The adaptive sleep interval is handled by the caller: sleep 30s before re-invoking after a rebase, sleep 60s after a transient retry rerun.
 
 ### Conflict Resolution Procedure
 
@@ -656,17 +762,19 @@ For each file in `CONFLICT_FILES`:
 
 1. Run `git ls-files -u` to determine the conflict type per file (check which index stages 1/2/3 exist).
 2. **Unsupported conflict types** — If any stage is missing (modify/delete, rename/delete conflicts) or the file is binary (check via `file --mime-type` or absence of text markers), classify as **uncertain**. Do not attempt auto-resolution.
-3. **Trivial files** — If the file is `version.go`, `go.sum`, or auto-generated, classify as **trivial** and auto-resolve immediately. Stage with `git add`.
+3. **Trivial files** — If the file is `version.go`, `go.sum`, `.claude-plugin/plugin.json`, or auto-generated, classify as **trivial** and auto-resolve immediately. Stage with `git add`. For `.claude-plugin/plugin.json` specifically, resolve to the **upstream (main) version** (run `git checkout --ours -- .claude-plugin/plugin.json` — during rebase, `--ours` refers to the base being rebased onto, i.e., upstream main), because the Rebase + Re-bump Sub-procedure will overwrite `plugin.json` with a fresh bump in its step 4 after the rebase completes. See the note below.
 4. **Text conflicts with both sides available** — Read both sides using explicit labels:
    - `git show :2:<file>` → **upstream (main)** version. If this command fails, classify as uncertain.
    - `git show :3:<file>` → **feature branch commit** version. If this command fails, classify as uncertain.
    - Also read the conflict markers in the working tree file for context.
 5. **Classify confidence**:
-   - **Trivial**: `version.go`, `go.sum`, auto-generated files.
+   - **Trivial**: `version.go`, `go.sum`, `.claude-plugin/plugin.json`, auto-generated files.
    - **High-confidence**: Changes are in non-overlapping regions (both sides added content in different locations), or the conflict markers show only whitespace, import-order, or formatting differences. Both sides' intent is clear and composable.
    - **Uncertain**: Overlapping semantic changes to the same function/block, any file where correctness cannot be verified without domain knowledge, any file where `:2:` or `:3:` reads failed, any non-text/binary conflict.
 6. Auto-resolve trivial and high-confidence files. Stage resolved files with `git add`.
 7. **IMPORTANT**: Always use "upstream (main)" and "feature branch commit" labels when describing the two sides of a conflict — never use "ours"/"theirs" which have inverted semantics during rebase and will cause confusion.
+
+**Note on `.claude-plugin/plugin.json` conflicts**: Under normal operation, the Rebase + Re-bump Sub-procedure drops the bump commit before rebasing, so `.claude-plugin/plugin.json` should not appear in `CONFLICT_FILES`. However, when `drop-bump-commit.sh` reported `DROPPED=false` (a CI fix commit landed on top of the bump, the worktree was dirty, or the commit touched more than `plugin.json`), the stale bump remains mid-stack and WILL conflict on `plugin.json` during rebase. The trivial-files rule above handles this case by auto-resolving to the upstream (main) version — safe because sub-procedure step 4 will overwrite `plugin.json` with a fresh `/bump-version` commit after the rebase completes.
 
 #### Phase 2 — User Escalation (for uncertain conflicts)
 
@@ -730,7 +838,7 @@ If the reviewer panel finds no issues or all findings are addressed: proceed to 
 #### Phase 4 — Continue Rebase
 
 Run `${CLAUDE_PLUGIN_ROOT}/scripts/rebase-push.sh --continue` and handle exit codes:
-- **Exit 0**: Rebase and push succeeded. Increment `rebase_count` and `iteration`, reset `transient_retries`. Restart the CI wait loop.
+- **Exit 0**: Rebase and push succeeded. Invoke the **Rebase + Re-bump Sub-procedure** (defined before Step 10) with `rebase_already_done=true`, `caller_kind=step12_phase4`. The sub-procedure performs fast-forward of local main, re-bump via `/bump-version` (with step12 hard-failure semantics), push of the new bump commit with recovery, and PR body refresh. Counter updates and `ci-wait.sh` re-invocation are handled inside the sub-procedure's step 7. If the sub-procedure bails to 12d on hard failure, Phase 4's exit-0 handler also bails to 12d.
 - **Exit 1**: A later commit in the rebase conflicted. Loop back to **Phase 1** for the new conflict (the Conflict Resolution Procedure starts again for the new set of `CONFLICT_FILES`).
 - **Exit 2**: Push `--force-with-lease` failed. Retry `rebase-push.sh --continue` once. If it fails twice, **bail out** (Step 12d — call `git rebase --abort` first if the rebase is still in progress).
 - **Exit 3**: Check the `REBASE_ERROR` output. If it indicates an empty or already-applied commit (e.g., "nothing to commit", "No changes"), run `git rebase --skip` (if `git rebase --skip` itself exits non-zero, run `${CLAUDE_PLUGIN_ROOT}/scripts/git-rebase-abort.sh` and **bail out** — Step 12d) and then `${CLAUDE_PLUGIN_ROOT}/scripts/rebase-push.sh --continue` again (handle the same exit codes). Otherwise, **bail out** (Step 12d).

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -536,9 +536,9 @@ After the initial version bump in Step 8, every subsequent rebase of the feature
    - **Exit 0** (rebase clean, branch is local-only fresh — may include `SKIPPED_ALREADY_FRESH=true`): proceed to step 3.
    - **Exit 1** (conflict; `--no-push` has already called `git rebase --abort`, so no rebase is in progress — the two invocations are independent, any fallback call restarts a fresh fetch + rebase):
      - **step12 family**: **fall back to full `${CLAUDE_PLUGIN_ROOT}/scripts/rebase-push.sh`** (without `--no-push`). Enumerate all four exit codes of the fallback call:
-       - **Fallback exit 0**: rebase succeeded cleanly AND the branch was force-pushed. Set `rebase_already_done=true` (so step 5's push will be the second push of the iteration, not the first) and proceed to step 3.
-       - **Fallback exit 1**: conflict; rebase is in progress. Enter the **Conflict Resolution Procedure** (Phase 1–4, defined in Step 12 below). After Phase 4's `--continue` exit 0 completes, `rebase_already_done` is effectively `true` (Phase 4 pushed); proceed to step 3.
-       - **Fallback exit 2**: `force-with-lease` push failure after a successful rebase. Apply the step 5 push-failure recovery procedure (fetch + compare + retry + bail) instead of silently returning.
+       - **Fallback exit 0**: rebase succeeded cleanly AND the branch was force-pushed by the fallback call. Proceed to step 3. Note: `rebase_already_done` is NOT set here — that flag only gates sub-procedure steps 1–2 at entry, and by this point those steps have already executed. Step 5's push will land the new bump commit on top of the fallback's push (the intended double-push for the conflict-fallback path, necessarily two pushes because the fallback call couldn't avoid pushing).
+       - **Fallback exit 1**: conflict; rebase is in progress. Enter the **Conflict Resolution Procedure** (Phase 1–4, defined in Step 12 below). **Phase 4's `rebase-push.sh --continue` exit-0 handler (at the end of Step 12's Conflict Resolution Procedure) itself dispatches the sub-procedure with `rebase_already_done=true, caller_kind=step12_phase4`** — i.e., the post-conflict re-bump is owned entirely by Phase 4. **Control transfer is terminal**: the moment Phase 1 is entered, the current (fallback) sub-procedure invocation is conceptually suspended and its remaining steps 3–7 are NOT executed. All further action for this rebase (Phase 2, Phase 3, Phase 4, and the sub-procedure dispatched by Phase 4's exit-0 handler) runs under Phase 4's ownership. When Phase 4 completes (success or bail), it returns control directly to Step 12's outer loop via its own caller-return path — it does NOT return back into the current invocation. Do NOT continue executing steps 3–7 of the current invocation, regardless of whether Phase 4 succeeds or bails.
+       - **Fallback exit 2**: `force-with-lease` push failure after a successful rebase. The rebase is complete locally but the branch has NOT been pushed. Do NOT skip steps 3–4: proceed to step 3 (fast-forward local main), then step 4 (re-bump), then step 5 (which will try to push the re-bumped branch and apply its own fetch + compare + retry + bail recovery on any subsequent push failure). Setting `rebase_already_done` is NOT appropriate here because step 5 still needs to push. This is the only way to guarantee the freshness invariant is enforced — skipping straight to step 5's recovery would push a rebased-but-unbumped branch, silently violating the invariant.
        - **Fallback exit 3**: non-conflict rebase failure; rebase already aborted. Read `REBASE_ERROR` and bail to 12d.
      - **step10 family**: print `**⚠ Step 10 — Rebase conflict detected; deferring to Step 12 for conflict resolution. Proceeding to Step 11 without re-bump.**` Log to `$IMPLEMENT_TMPDIR/execution-issues.md` under `CI Issues`. **Break out of Step 10's loop and proceed to Step 11.**
    - **Exit 3** (non-conflict rebase failure in `--no-push` mode; rebase already aborted):
@@ -562,17 +562,25 @@ After the initial version bump in Step 8, every subsequent rebase of the feature
    Parse `HAS_BUMP` and `COMMITS_BEFORE`.
    - **If `HAS_BUMP=false`**:
      - **step12 family**: **HARD FAILURE**. Print `**⚠ Step 12 — /bump-version skill not found at .claude/skills/bump-version/SKILL.md; cannot re-bump after rebase. Merged PR would reflect a stale version. Bailing to 12d.**` Bail to 12d.
-     - **step10 family**: Print `**⚠ Step 10 — /bump-version skill not found; skipping re-bump. Proceeding to Step 11 with whatever version is currently on the branch.**` Log to `Warnings`. Skip ahead to step 5 (the push in step 5 is a no-op since nothing new is staged locally after the rebase; fall through to step 6, then step 7 — return to caller).
+     - **step10 family**: Print `**⚠ Step 10 — /bump-version skill not found; skipping re-bump. Proceeding to Step 11 with whatever version is currently on the branch.**` Log to `Warnings`. Skip ahead to step 5 — the push still needs to happen because the rebase in step 2 rewrote branch history, and that rewritten history must be force-pushed so the remote PR branch reflects the new base (there is just no new bump commit stacked on top). Then fall through to step 6 (PR body refresh — nothing new to refresh) and step 7 (return to caller).
    - **If `HAS_BUMP=true`**: Invoke `/bump-version` via the Skill tool. If the skill invocation itself fails (returns an error, or bails internally):
      - **step12 family**: hard failure — bail to 12d.
      - **step10 family**: log warning and break out of Step 10 to Step 11.
-     After the skill returns successfully:
+     After the skill returns successfully, run the post-verification:
      ```bash
      ${CLAUDE_PLUGIN_ROOT}/scripts/check-bump-version.sh --mode post --before-count $COMMITS_BEFORE
      ```
-     Parse `VERIFIED`. If `VERIFIED=false`:
-     - **step12 family**: **HARD FAILURE**. Print `**⚠ Step 12 — /bump-version did not create exactly one new commit after rebase. Expected $EXPECTED, got $COMMITS_AFTER. Cannot verify bump freshness; bailing to 12d.**` Bail to 12d.
-     - **step10 family**: log warning and break to Step 11.
+     Parse `VERIFIED`, `COMMITS_AFTER`, `EXPECTED`. Use the commit-count delta (not the skill's prose output) to detect the outcome — this is the reliable structured signal:
+
+     - **`VERIFIED=true`** (a new commit was created — the common case): proceed to step 5.
+
+     - **`VERIFIED=false` AND `COMMITS_AFTER == COMMITS_BEFORE`** (zero new commits — `/bump-version` ran a `BUMP_TYPE=NONE` no-op path, because `classify-bump.sh` detected HEAD is already a bump commit). This normally happens when `drop-bump-commit.sh` reported `DROPPED=false` (e.g., Guard 4 refused the drop because the bump commit touched files beyond `.claude-plugin/plugin.json`) and the stale bump commit survived the rebase unchanged. **Note**: this condition is also reached in the degenerate case where `count_commits()` in `check-bump-version.sh` returned `0` for both pre and post calls because neither local `main` nor `origin/main` exists — in that case, a `WARN: ... neither local 'main' nor 'origin/main' exists` line will have been printed to stderr. Before acting on the bail, check the stderr output of the most recent `check-bump-version.sh` calls for that WARN to determine the true root cause. Caller-family handling:
+       - **step12 family**: **HARD FAILURE** — bail to 12d. Print `**⚠ Step 12 — /bump-version created 0 new commits after rebase (BUMP_TYPE=NONE, or neither local 'main' nor 'origin/main' exists — inspect stderr WARN from check-bump-version.sh to distinguish). Either way, cannot verify bump freshness against current origin/main. Bailing to 12d.**` Log to `$IMPLEMENT_TMPDIR/execution-issues.md` under `CI Issues` (including the relevant stderr excerpt if the WARN was seen). Rationale: Step 12 is the last-chance enforcement point for the version bump freshness invariant. Either a stale bump commit classified against an older base or a missing base ref means we cannot guarantee the merged version is correct; we must fail loudly rather than silently merge a potentially-wrong version.
+       - **step10 family**: log warning `**⚠ Step 10 — /bump-version created 0 new commits after rebase (BUMP_TYPE=NONE or missing main ref — inspect stderr WARN). Proceeding to Step 11 with the existing branch state. Step 12 will re-attempt under strict semantics.**` to `Warnings`, then proceed directly to step 5 (the rebased history still needs to be force-pushed). Step 10 can afford to be permissive here because Step 12 re-runs the sub-procedure under strict semantics and will bail then if the drop still cannot happen.
+
+     - **`VERIFIED=false` AND `COMMITS_AFTER != COMMITS_BEFORE`** (unexpected state — `/bump-version` created more than one commit, or somehow decreased the count):
+       - **step12 family**: **HARD FAILURE**. Print `**⚠ Step 12 — /bump-version did not create exactly one new commit after rebase. Expected $EXPECTED, got $COMMITS_AFTER. Cannot verify bump freshness; bailing to 12d.**` Bail to 12d.
+       - **step10 family**: log warning and break to Step 11.
 
    **Rationale**: Step 8's permissive warnings are safe because Step 8 is pre-PR — no merge can happen based on a missing bump. Step 12 is pre-merge — missing bump means stale merge. Step 10 is post-PR but pre-merge (Step 12 does the merge) — any bump failure in Step 10 is recoverable by Step 12's mandatory re-bump, so Step 10 can afford to be permissive. **Step 12 is the last-chance enforcement point; Step 10 is best-effort optimization that improves freshness during the Slack-wait phase.**
 
@@ -610,11 +618,11 @@ After the initial version bump in Step 8, every subsequent rebase of the feature
    If the `<details><summary>Version Bump Reasoning</summary>` marker is not found in the fetched body, print `**⚠ Step <N> — Version Bump Reasoning block not found in live PR body. Skipping refresh.**` and skip the update. Log to `Warnings`. **PR body refresh failure is NOT a hard failure** — the bump is already pushed and the merge will be correct; the stale body is documentation-only.
 
 7. **Return to caller based on `caller_kind`**:
-   - **`step12_rebase`** (from 12a `ACTION=rebase`): increment `rebase_count`, `iteration`, reset `transient_retries`, re-invoke `ci-wait.sh` in Step 12.
-   - **`step12_phase4`** (from Phase 4 exit-0): increment `rebase_count`, `iteration`, reset `transient_retries`, re-invoke `ci-wait.sh` in Step 12.
-   - **`step12_rebase_then_evaluate`** (from 12a `ACTION=rebase_then_evaluate`): increment `rebase_count`, `iteration`, reset `transient_retries`, then **fall through to 12c** to evaluate the CI failure. Do NOT re-invoke `ci-wait.sh`.
-   - **`step10_rebase`** (from Step 10 `ACTION=rebase`): increment `rebase_count`, `iteration`, reset `transient_retries`, re-invoke `ci-wait.sh` in Step 10.
-   - **`step10_rebase_then_evaluate`** (from Step 10 `ACTION=rebase_then_evaluate`): increment `rebase_count`, `iteration`, reset `transient_retries`, then **fall through to Step 10's `ACTION=evaluate_failure` handler**. Do NOT re-invoke `ci-wait.sh`.
+   - **`step12_rebase`** (from 12a `ACTION=rebase`): increment `rebase_count`, `iteration`, reset `transient_retries`, **sleep 30s** via `${CLAUDE_PLUGIN_ROOT}/scripts/sleep-seconds.sh 30` (give GitHub CI time to register the force-push before polling again), then re-invoke `ci-wait.sh` in Step 12.
+   - **`step12_phase4`** (from Phase 4 exit-0): increment `rebase_count`, `iteration`, reset `transient_retries`, **sleep 30s** via `${CLAUDE_PLUGIN_ROOT}/scripts/sleep-seconds.sh 30`, then re-invoke `ci-wait.sh` in Step 12.
+   - **`step12_rebase_then_evaluate`** (from 12a `ACTION=rebase_then_evaluate`): increment `rebase_count`, `iteration`, reset `transient_retries`, then **fall through to 12c** to evaluate the CI failure. Do NOT re-invoke `ci-wait.sh` and do NOT sleep — 12c handles its own timing.
+   - **`step10_rebase`** (from Step 10 `ACTION=rebase`): increment `rebase_count`, `iteration`, reset `transient_retries`, **sleep 30s** via `${CLAUDE_PLUGIN_ROOT}/scripts/sleep-seconds.sh 30`, then re-invoke `ci-wait.sh` in Step 10.
+   - **`step10_rebase_then_evaluate`** (from Step 10 `ACTION=rebase_then_evaluate`): increment `rebase_count`, `iteration`, reset `transient_retries`, then **fall through to Step 10's `ACTION=evaluate_failure` handler**. Do NOT re-invoke `ci-wait.sh` and do NOT sleep.
 
 ### Phase 4 caller path (`rebase_already_done=true`, `caller_kind=step12_phase4`)
 
@@ -663,7 +671,7 @@ Parse the output for: `ACTION`, `CI_STATUS`, `BEHIND_COUNT`, `FAILED_RUN_ID`, `B
 
 **Execution issues**: Log any CI failures, transient retries, or bail events to `$IMPLEMENT_TMPDIR/execution-issues.md` under the `CI Issues` category.
 
-After handling any non-terminal action (rebase, evaluate_failure), **re-invoke `ci-wait.sh`** with updated counter values.
+After handling any non-terminal/non-rebase action (e.g., `evaluate_failure`), **re-invoke `ci-wait.sh`** with updated counter values. The `rebase` and `rebase_then_evaluate` paths handle their own post-return control flow inside the sub-procedure's step 7 — do NOT re-invoke `ci-wait.sh` from here for those paths. The adaptive sleep interval is handled by the caller: sleep 60s after a transient retry rerun before re-invoking `ci-wait.sh`.
 
 ## Step 11 — Post Slack Announcement
 
@@ -748,7 +756,7 @@ Parse the output for: `ACTION`, `CI_STATUS`, `BEHIND_COUNT`, `FAILED_RUN_ID`, `B
 
    - **`ACTION=bail`**: Print `BAIL_REASON` and bail out → **12d**.
 
-After handling any non-merge/non-bail/non-rebase action (e.g., `evaluate_failure`), **re-invoke `ci-wait.sh`** with updated counter values. The `rebase` and `rebase_then_evaluate` paths handle their own post-return control flow inside the sub-procedure. The adaptive sleep interval is handled by the caller: sleep 30s before re-invoking after a rebase, sleep 60s after a transient retry rerun.
+After handling any non-merge/non-bail/non-rebase action (e.g., `evaluate_failure`), **re-invoke `ci-wait.sh`** with updated counter values. The `rebase` and `rebase_then_evaluate` paths handle their own post-return control flow inside the sub-procedure's step 7: `rebase` sleeps 30s and re-invokes `ci-wait.sh` internally; `rebase_then_evaluate` falls through to 12c without sleeping. The remaining sleep interval handled by the caller: sleep 60s after a transient retry rerun.
 
 ### Conflict Resolution Procedure
 


### PR DESCRIPTION
## Summary
- Added a shared Rebase + Re-bump Sub-procedure to `/implement` Steps 10 and 12 that re-runs `/bump-version` after every rebase, ensuring the merged PR's version reflects latest main at merge time — not at PR creation time.
- Introduced `scripts/drop-bump-commit.sh` primitive with quadruple guards (clean worktree, subject regex, HEAD~1 existence, file-scope check) to safely drop stale bump commits before rebasing.
- Fixed `scripts/check-bump-version.sh` to fall back to `origin/main` when local `main` is missing, via a new `count_commits()` helper.

<details><summary>Architecture Diagram</summary>

```mermaid
flowchart TB
    subgraph NEW["New: scripts/drop-bump-commit.sh"]
        DBC[["drop-bump-commit.sh<br/>1. clean worktree check<br/>2. HEAD subject regex<br/>3. HEAD~1 exists<br/>4. only plugin.json touched<br/>5. git reset --hard HEAD~1"]]
    end

    subgraph SUBPROC["Rebase + Re-bump Sub-procedure (shared)"]
        S1[1. drop-bump-commit.sh]
        S2[2. rebase-push.sh --no-push<br/>fallback per family]
        S3[3. git branch -f main origin/main]
        S4[4. check-bump-version pre → /bump-version → post<br/>hard fail step12 / warn step10]
        S5[5. git push --force-with-lease<br/>fetch+compare+retry+bail]
        S6[6. PR body Version Bump Reasoning refresh]
        S7[7. return by caller_kind w/ sleep 30s for rebase paths]
        S1 --> S2 --> S3 --> S4 --> S5 --> S6 --> S7
    end

    subgraph STEP10["Step 10: CI wait for Slack"]
        ST10R[ACTION=rebase]
        ST10RTE[ACTION=rebase_then_evaluate]
        ST10_TO_11["proceed to Step 11<br/>(on success or graceful failure)"]
    end

    subgraph STEP12["Step 12: CI + rebase + merge loop"]
        ST12A[12a ACTION=rebase]
        ST12ARTE[12a ACTION=rebase_then_evaluate]
        ST12B[12b merge]
        ST12C[12c evaluate CI failure]
        ST12D[12d bail]
        subgraph PHASE["Conflict Resolution Procedure"]
            PH1[Phase 1 classify<br/>+ plugin.json trivial]
            PH2[Phase 2 user escalation]
            PH3[Phase 3 reviewer panel]
            PH4[Phase 4 --continue]
            PH1 --> PH2 --> PH3 --> PH4
        end
    end

    ST10R -->|caller_kind=step10_rebase| S1
    ST10RTE -->|caller_kind=step10_rebase_then_evaluate| S1
    ST12A -->|caller_kind=step12_rebase| S1
    ST12ARTE -->|caller_kind=step12_rebase_then_evaluate| S1
    PH4 -->|rebase_already_done=true<br/>caller_kind=step12_phase4| S3

    S2 -.->|step12 exit1| PH1
    S2 -.->|step10 exit1| ST10_TO_11

    S7 -->|step12_rebase| ST12A
    S7 -->|step12_rebase_then_evaluate| ST12C
    S7 -->|step12_phase4| ST12A
    S7 -->|step10_rebase| ST10R
    S7 -->|step10_rebase_then_evaluate| ST10_TO_11
    S7 -.->|step12 hard fail| ST12D
    S7 -.->|step10 hard fail| ST10_TO_11

    ST12A -->|ACTION=merge| ST12B
    DBC -.->|used by step 1| S1

    classDef new fill:#dff,stroke:#077,stroke-width:2px
    classDef step10 fill:#fed,stroke:#a60,stroke-width:1px
    classDef step12 fill:#def,stroke:#069,stroke-width:1px
    classDef subproc fill:#efe,stroke:#070,stroke-width:2px
    class NEW,DBC new
    class STEP10,ST10R,ST10RTE,ST10_TO_11 step10
    class STEP12,ST12A,ST12ARTE,ST12B,ST12C,ST12D,PHASE,PH1,PH2,PH3,PH4 step12
    class SUBPROC,S1,S2,S3,S4,S5,S6,S7 subproc
```

</details>

<details><summary>Code Flow Diagram</summary>

```mermaid
sequenceDiagram
    autonumber
    participant Main as Step 12 Outer Loop
    participant SP as Sub-procedure
    participant DropBC as drop-bump-commit.sh
    participant Rebase as rebase-push.sh
    participant Bump as /bump-version
    participant ChkBV as check-bump-version.sh
    participant Phase4 as Conflict Resolution Phase 1-4
    participant CIWait as ci-wait.sh

    Main->>CIWait: poll for CI / main-advance
    CIWait-->>Main: ACTION=rebase
    Note over Main: caller_kind=step12_rebase<br/>rebase_already_done=false

    Main->>SP: invoke sub-procedure
    SP->>DropBC: drop HEAD bump?
    alt HEAD is bump commit + clean + only plugin.json + HEAD~1 exists
        DropBC->>DropBC: git reset --hard HEAD~1
        DropBC-->>SP: DROPPED=true
    else any guard fails
        DropBC-->>SP: DROPPED=false
        Note over SP: log Warnings
    end

    SP->>Rebase: rebase-push.sh --no-push
    alt exit 0 (clean rebase)
        Rebase-->>SP: fresh local state
    else exit 1 (conflict)
        Rebase-->>SP: aborted
        SP->>Rebase: fallback: full rebase-push.sh
        alt fallback exit 1
            Rebase-->>Phase4: rebase in progress
            Phase4->>Phase4: Phase 1-3 resolution (plugin.json trivial)
            Phase4->>Rebase: rebase-push.sh --continue
            Rebase-->>Phase4: push done
            Phase4->>SP: dispatch with rebase_already_done=true,<br/>caller_kind=step12_phase4
            Note over SP: current invocation terminates<br/>Phase 4 owns remaining flow
        else fallback exit 0
            Note over SP: rebase + push done, proceed to step 3
        else fallback exit 2
            Note over SP: local rebase done, push failed<br/>proceed to step 3 (not skip!)
        else fallback exit 3
            Rebase-->>Main: bail 12d
        end
    else exit 3
        Rebase-->>Main: bail 12d
    end

    SP->>SP: git branch -f main origin/main
    Note right of SP: fast-forward local main ref<br/>(so classify-bump uses fresh base)

    SP->>ChkBV: --mode pre
    ChkBV-->>SP: HAS_BUMP, COMMITS_BEFORE

    alt HAS_BUMP=false
        Note over SP: step12 bails 12d
    else HAS_BUMP=true
        SP->>Bump: invoke /bump-version
        Bump-->>SP: skill returns (success or NONE or error)
        alt skill error
            SP-->>Main: step12 bails 12d
        else skill success
            SP->>ChkBV: --mode post --before-count $COMMITS_BEFORE
            ChkBV-->>SP: VERIFIED, COMMITS_AFTER, EXPECTED
            alt VERIFIED=true
                Note over SP: new bump commit at HEAD
            else VERIFIED=false && COMMITS_AFTER == COMMITS_BEFORE
                Note over SP: BUMP_TYPE=NONE or missing ref<br/>step12 bails 12d<br/>step10 warns + proceeds
            else VERIFIED=false && non-zero delta
                Note over SP: unexpected count<br/>step12 bails 12d<br/>step10 warns + breaks
            end
        end
    end

    SP->>Rebase: git push --force-with-lease
    alt push exit 0
        Note over SP: new bump commit landed on remote
    else push fail
        SP->>SP: git fetch origin $BRANCH
        alt local HEAD == remote HEAD
            Note over SP: push landed despite error
        else diverged
            SP->>SP: sleep-seconds.sh 5
            SP->>Rebase: retry git push --force-with-lease
            alt retry success
                Note over SP: pushed
            else retry fail
                Note over SP: step12 bails 12d<br/>step10 warns + breaks
            end
        end
    end

    SP->>SP: gh-pr-body-read.sh
    SP->>SP: replace Version Bump Reasoning block
    SP->>SP: gh-pr-body-update.sh

    SP->>SP: sleep-seconds.sh 30
    SP->>CIWait: re-invoke with updated counters
    Note over Main: step7 returns to outer loop<br/>via ci-wait.sh re-invocation
```

</details>

<details><summary>Goal</summary>

- Ensure `/implement`'s merged PR always carries a version bump based on latest `origin/main` at merge time
  - Not the version that was live when the PR was first created
  - Addresses the scenario where another PR merges with a version bump while our PR is still waiting for CI or main advancement
- Re-run `/bump-version` after every rebase in the CI+rebase+merge loop (Step 12) and the initial CI wait (Step 10)
  - Step 12 enforces strictly (hard failures bail to 12d)
  - Step 10 runs best-effort (hard failures degrade gracefully to Step 11, since Step 12 remains the last-chance enforcement point)
- Drop stale bump commits before rebasing rather than letting them conflict on `plugin.json`
  - Eliminates guaranteed `plugin.json` conflicts every time another PR bumps
  - Keeps the Conflict Resolution Procedure focused on genuine feature conflicts
- Safely drop only commits that are definitively version bumps
  - Subject matches `^Bump version to X.Y.Z$`
  - Commit touches only `.claude-plugin/plugin.json`
  - Worktree is clean
  - HEAD~1 exists
- Maintain the "exactly one terminal bump commit at any moment" invariant rather than allowing multiple bump commits to accumulate on the branch

</details>

<details><summary>Test plan</summary>

- [ ] Run `/larch:implement --merge <feature>` on a test feature branch while simultaneously landing another PR with a version bump on main. Verify the merged squash reflects the latest main's version bumped by one.
- [ ] Run `/larch:implement --merge <feature>` while landing a non-version-bumping PR on main. Verify single-push happy path (no extra CI cycles).
- [ ] Run `/larch:implement --merge <feature>` and cause a genuine rebase conflict in a feature file (not plugin.json). Verify Phase 1-4 conflict resolution works, then Phase 4 dispatches the sub-procedure with `rebase_already_done=true` and the re-bump commit lands.
- [ ] Verify the `drop-bump-commit.sh` primitive manually: clean worktree + HEAD is a bump → DROPPED=true; dirty worktree → DROPPED=false with WARN; non-bump HEAD → DROPPED=false; bump-subjected commit touching extra files → DROPPED=false with WARN.
- [ ] Verify `check-bump-version.sh` origin/main fallback: in a clone with no local `main` ref, `--mode pre` and `--mode post` should correctly count commits using `origin/main`.
- [ ] Verify `classify-bump.sh` idempotency still works after fast-forward: HEAD is a bump → BUMP_TYPE=NONE (unchanged from before).

</details>

<details><summary>Final Design</summary>

See the "Revised Implementation Plan" section of the original `/design` phase (round 1 voting accepted 8 findings from plan review, plus the user's post-review choice to expand scope from "Step 12 only" to "Step 10 + Step 12"). The final plan includes:

- **New script** `scripts/drop-bump-commit.sh` (~70 lines): clean-worktree guard, HEAD-subject regex guard, HEAD~1 existence guard, file-scope guard. Emits `DROPPED=true|false` + `OLD_BUMP_SHA`.
- **Modified** `scripts/check-bump-version.sh`: added `count_commits()` helper with local `main` → `origin/main` fallback + stderr WARN when neither ref exists.
- **Modified** `skills/implement/SKILL.md`:
  - Step 8 wording updated to reflect multi-bump reality during Steps 10/12.
  - New "Rebase + Re-bump Sub-procedure" section shared by Steps 10 and 12, with 7 ordered steps and caller-family-specific failure semantics (`step12` hard-fails to 12d, `step10` degrades to Step 11).
  - Step 10 rebase handlers call the sub-procedure with `caller_kind=step10_*`.
  - Step 12a rebase handlers call the sub-procedure with `caller_kind=step12_*`.
  - Phase 4 `--continue` exit-0 handler dispatches the sub-procedure with `rebase_already_done=true, caller_kind=step12_phase4`. Phase 4's dispatch is terminal — the parent sub-procedure invocation is suspended.
  - Phase 1 trivial-files list gains `.claude-plugin/plugin.json` (auto-resolve to upstream main) for the `DROPPED=false` edge case.
  - Sub-procedure step 7 sleeps 30s before re-invoking `ci-wait.sh` for rebase paths (not for rebase_then_evaluate).

All 8 plan review findings accepted by voting were incorporated. All 15 code review findings accepted across 5 review rounds were incorporated.

</details>

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `fa6f5f3` (Add plugin structure validator + extend /relevant-checks (#31))
- **Current version**: `1.0.3`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `1.0.4`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH"). All additions are internal workflow improvements to the `/implement` skill's Step 10 and Step 12 rebase handlers — no skill was added/renamed/deleted, no frontmatter `name:` changed, no `--flag` tokens added or removed from any `argument-hint:`. The main agent confirmed no escalation is needed: the changes are strictly additive internal behavior that a reasonable client of `/implement` would not perceive as backward-incompatible.

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

### [Plan Review] Deep-Analysis + General — FINDING_2 (Phase 4 error handling specificity)
**Finding**: Edit 3 (Phase 4 exit-0 path) should explicitly bail to 12d on sub-procedure step 3/5 failures.
**Reason not implemented**: Voted 1 YES + 2 EXONERATE. FINDING_10 (accepted 3-0) fully subsumes the substantive concern by mandating bail-to-12d on `HAS_BUMP=false`, `VERIFIED=false`, and `/bump-version` skill failures across Step 12. PR body refresh failures (step 6) are documentation-only and don't compromise merge correctness.

### [Plan Review] Deep-Analysis + General — FINDING_4 (file path specification)
**Finding**: Sub-procedure step 5 should name `$IMPLEMENT_TMPDIR/live-body.md` and `$IMPLEMENT_TMPDIR/pr-body.md` explicitly.
**Reason not implemented**: Voted 0 YES + 2 EXONERATE + 1 NO. Voters agreed the Step 11 convention is self-evident. The revised plan does name both paths in the Step 6 section as documentation polish.

### [Plan Review] Cursor + Codex-General — FINDING_8 (automated shell tests)
**Finding**: Add automated shell-script tests covering `drop-bump-commit.sh` and Step 12 paths.
**Reason not implemented**: Voted 0 YES + 3 EXONERATE. The concern is legitimate but the repo has no shell test infrastructure — adding one is a separate initiative. Deferred.

</details>

<details><summary>Implementation Deviations</summary>

**Scope expansion**: After the initial `/design` plan was voted in ("Step 12 only"), the post-review confirmation question asked whether to also update Step 10. The user selected "Also update Step 10", expanding the scope to cover both Steps 10 and 12. The revised plan introduced the two caller families (`step12` with strict semantics, `step10` with best-effort semantics) and caller_kind discrimination for the 5 resulting call sites.

Other than the scope expansion, the implementation followed the revised plan. All 5 SKILL.md edits landed as described, the `drop-bump-commit.sh` primitive was created with the four guards specified, and the `check-bump-version.sh` was updated to use the `count_commits()` helper per the F5 fix / OOS_1 promotion.

Subsequent code review rounds (5 total) refined the sub-procedure prose and added safety nets — notably the `BUMP_TYPE=NONE` detection via commit-count delta (not prose parsing), the sleep 30s guidance in step 7, and the neither-ref edge case in the BUMP_TYPE=NONE bail message. These refinements do not change the plan's semantics.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

### [Code Review] Deep-Analysis (Round 1, FINDING_6)
**Finding**: Phase 1 trivial-files resolution for `.claude-plugin/plugin.json` says "run `git checkout --ours -- .claude-plugin/plugin.json`" to resolve to upstream main. But `git checkout --ours` writes to the working tree only — it does NOT stage the file in the index. An LLM may miss the stage step, leaving `.claude-plugin/plugin.json` unstaged, and Phase 4's `git rebase --continue` will fail. Suggested fix: change the plugin.json instruction to `git checkout --ours -- .claude-plugin/plugin.json && git add -- .claude-plugin/plugin.json`.

**Reason not implemented**: Voted 0 YES + 2 EXONERATE (Claude General, Codex) + 1 NO (Cursor). Voters agreed the concern about LLM misinterpretation is legitimate but found the current text acceptable because the "Stage with `git add`" instruction is present in the same bullet as the plugin.json resolution instruction, just separated by a parenthetical.

### [Code Review] Cursor (Round 1, FINDING_7)
**Finding**: Sub-procedure step 3's `git branch -f main origin/main` fails if `main` is checked out in another worktree. Local main stays stale, and `classify-bump.sh` prefers the stale local main. Suggested fix: capture the exit code and handle failure, or skip local main entirely.

**Reason not implemented**: Voted 1 YES (Codex) + 2 EXONERATE (Claude General, Cursor). Voters agreed the multi-worktree failure mode is real but considered it an unusual configuration that doesn't justify scope expansion in this PR. Cursor voted EXONERATE on its own finding.

### [Code Review] General (Round 1, FINDING_8)
**Finding**: Sub-procedure step 7's "re-invoke ci-wait.sh" instruction is missing the 30s adaptive sleep.

**Reason not implemented in round 1**: Voted 1 YES + 2 EXONERATE. Classified as poll-churn/efficiency risk rather than correctness. **Subsequently addressed in round 3 as R3-D-F1**: Claude Deep-Analysis re-raised the concern with sharper framing in round 3, and the fix was auto-accepted per the round 2+ protocol. The final code now includes `sleep-seconds.sh 30` in sub-procedure step 7 for the `step12_rebase`, `step12_phase4`, and `step10_rebase` caller kinds. The "rejected" status only refers to the round-1 voting outcome.

### [Code Review] General (Round 1, FINDING_9)
**Finding**: `drop-bump-commit.sh` suppresses the `git reset` stderr, giving vague error messages on failure.

**Reason not implemented**: Voted 0 YES + 2 EXONERATE + 1 NO. Voters agreed improving diagnostics would help but classified it as a minor quality issue, not a functional bug. The current behavior is functionally correct.

</details>

<details><summary>Plan Review Voting Tally</summary>

### Per-finding results (Round 1)

| Finding | Deep-Analysis | Cursor | Codex | YES | Result |
|---|---|---|---|---|---|
| FINDING_1 | YES | YES | YES | 3 | Accepted |
| FINDING_2 | YES | EXON | EXON | 1 | Neutral |
| FINDING_3 | YES | NO | YES | 2 | Accepted |
| FINDING_4 | EXON | NO | EXON | 0 | Exonerated |
| FINDING_5 | YES | YES | YES | 3 | Accepted |
| FINDING_6 | YES | YES | YES | 3 | Accepted |
| FINDING_7 | EXON | YES | YES | 2 | Accepted |
| FINDING_8 | EXON | EXON | EXON | 0 | Exonerated |
| FINDING_9 | YES | YES | YES | 3 | Accepted |
| FINDING_10 | YES | YES | YES | 3 | Accepted |
| FINDING_11 | YES | YES | YES | 3 | Accepted |
| OOS_1 | NO | EXON | EXON | 0 | Stays as observation |
| OOS_2 | NO | EXON | EXON | 0 | Stays as observation |
| OOS_3 | NO | EXON | EXON | 0 | Stays as observation |

### Reviewer Competition Scoreboard

| Reviewer | Findings | Accepted | Neutral (1 YES) | Exonerated | Rejected | Score | OOS Proposed | OOS Promoted |
|----------|----------|----------|-----------------|------------|----------|-------|--------------|--------------|
| General              | 3 | 1 (F5) | 1 (F2) | 0 | 0 | +1 | 2 | 0 |
| Deep-Analysis        | 4 | 2 (F1, F3, F4 [shared]) | 1 (F2) | 1 (F4) | 0 | +2 | 1 | 0 |
| Codex-General        | 1 | 1 (F6 [shared]) | 0 | 0 | 0 | +1 | 0 | 0 |
| Codex-Deep-Analysis  | 4 | 4 | 0 | 0 | 0 | +4 | 0 | 0 |
| Cursor               | 5 | 4 | 0 | 1 (F8) | 0 | +4 | 0 | 0 |

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

### Per-finding results (Round 1)

| Finding | Claude General | Cursor | Codex | YES | Result |
|---|---|---|---|---|---|
| FINDING_1 | YES | YES | YES | 3 | Accepted |
| FINDING_2 | YES | YES | YES | 3 | Accepted |
| FINDING_3 | YES | YES | YES | 3 | Accepted |
| FINDING_4 | YES | YES | YES | 3 | Accepted |
| FINDING_5 | YES | YES | YES | 3 | Accepted |
| FINDING_6 | EXON | NO | EXON | 0 | Exonerated |
| FINDING_7 | EXON | EXON | YES | 1 | Neutral |
| FINDING_8 | YES | EXON | EXON | 1 | Neutral |
| FINDING_9 | NO | EXON | EXON | 0 | Exonerated |
| OOS_1 | YES | YES | YES | 3 | Promoted to in-scope |
| OOS_2 | NO | NO | NO | 0 | Stays |
| OOS_3 | NO | NO | EXON | 0 | Stays |

### Reviewer Competition Scoreboard (Round 1)

| Reviewer | Findings | Accepted | Neutral (1 YES) | Exonerated | Rejected | Score | OOS Proposed | OOS Promoted |
|----------|----------|----------|-----------------|------------|----------|-------|--------------|--------------|
| General              | 4 | 2 (F3, F4) | 1 (F8) | 1 (F9) | 0 | +2 | 2 | 1 (OOS_1) |
| Deep-Analysis        | 3 | 2 (F2, F3) | 0 | 1 (F6) | 0 | +2 | 1 | 0 |
| Codex-General        | 4 | 3 (F1, F5, incl. shared) | 0 | 0 | 0 | +3 | 1 | 1 (OOS_1) |
| Codex-Deep-Analysis  | 4 | 4 (F1, F2, F4, F5) | 0 | 0 | 0 | +4 | 0 | 0 |
| Cursor               | 3 | 2 (F1, F2) | 1 (F7) | 0 | 0 | +2 | 0 | 0 |

Rounds 2-5 were auto-accepted (no voting panel) per the `/review` round-2+ protocol. Round 2 accepted 5 findings, round 3 accepted 3, round 4 accepted 2, round 5 converged with 0.

</details>

<details><summary>Out-of-Scope Observations</summary>

### Plan Review (`/design` Step 3)
- **OOS_1** [General + Codex-General]: `check-bump-version.sh` pre-existing use of local `main` ref — promoted to in-scope during code review as it was the root cause of FINDING_5. Fix landed in this PR.
- **OOS_2** [General]: `classify-bump.sh` pre-existing double-fetch (harmless redundancy). Not promoted.
- **OOS_3** [Deep-Analysis]: `drop-bump-commit.sh` Guard 1 treats untracked files in `$IMPLEMENT_TMPDIR` as dirty if the tmpdir is ever placed inside the repo. Currently `$IMPLEMENT_TMPDIR` is under `/tmp`, so this is not an active concern. Not promoted.

### Code Review (`/review` rounds 1-5)
- Round 1 OOS_1 promoted to in-scope (check-bump-version.sh local main → origin/main fallback). Implemented.
- Round 1 OOS_2: `classify-bump.sh` redundant `git fetch origin main` after the sub-procedure's step 2 already fetched. Kept as observation.
- Round 1 OOS_3: `drop-bump-commit.sh` Guard 1 clean-worktree check includes untracked files. Matches `apply-bump.sh` pre-existing design; kept as observation.

</details>

<details><summary>Execution Issues</summary>

No execution issues encountered.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | 8 accepted, 3 not accepted (2 exonerated, 1 neutral) |
| Code review rounds | 5 (converged) |
| Code review findings | 15 accepted, 4 not accepted (2 exonerated, 2 neutral in round 1; rounds 2-5 auto-accept) |
| Warnings logged | 0 |
| Pre-existing issues noticed | 3 OOS (1 promoted & fixed, 2 kept as observations) |
| External reviewers | Cursor: ✅, Codex: ✅ |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
