### PR TITLE
Add CLAUDE.md with editing-agent invariants and repo layout

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation with collaborative reviewers (Claude subagents + Codex + Cursor).",
   "author": {
     "name": "Sergey Zhupanov"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,118 @@
+# CLAUDE.md
+
+This repository **is** the larch Claude Code plugin. When you edit here, you are modifying the plugin that ships to consumers. See `README.md` for installation, feature matrix, env vars, and the full skill catalog — do not duplicate that content in this file.
+
+This file orients editing agents. Every rule below is framed as an invariant to prevent a mistake Claude would otherwise make.
+
+## Repository layout — two independent axes
+
+larch has two overlapping but distinct classifications. Treat them separately when reasoning about a change.
+
+### Axis A — What ships to consumers (plugin surface) vs. repo-private infrastructure
+
+**Shipped (installed into consumers' Claude Code environments):**
+
+- `skills/` — public skills (`/design`, `/implement`, `/review`, `/research`, `/loop-review`)
+- `agents/` — reviewer archetype definitions
+- `hooks/hooks.json` — `PreToolUse` hook registrations
+- `scripts/` — invoked from shipped skills and hooks as `${CLAUDE_PLUGIN_ROOT}/scripts/…`
+- `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` — plugin manifests
+
+**Repo-private (NOT shipped to consumers):**
+
+- `.claude/skills/bump-version/` — classifier and applier; owned by `/implement` Step 8
+- `.claude/skills/relevant-checks/` — reference implementation only; each consumer repo provides its own
+- `.claude/settings.json` — local Claude Code harness config (permissions, dev hooks)
+- `docs/` — prose documentation
+- `.github/`, `Makefile`, `.pre-commit-config.yaml`, `.markdownlint.json`, `CHANGELOG.md`
+
+**Shared fragments (not a skill):** `skills/shared/larch/` — reviewer templates, voting protocol, external-reviewer conventions. No `SKILL.md`.
+
+### Axis B — What drives MAJOR/MINOR version bumps
+
+**Only `skills/**` and `agents/**` drive MAJOR/MINOR classification.** Changes under every other directory — including shipped `scripts/`, `hooks/`, and `.claude-plugin/` — default to **PATCH**. Authority: `.claude/skills/bump-version/SKILL.md` and `.claude/skills/bump-version/scripts/classify-bump.sh`.
+
+Inside `skills/**` and `agents/**`, the specific triggers are:
+
+- **MAJOR**: deleting or renaming a `SKILL.md`/agent file, changing its `name:` frontmatter, or removing a `--flag` token from `argument-hint:`
+- **MINOR**: adding a new `SKILL.md`/agent file, or adding a `--flag` token to `argument-hint:`
+- **PATCH**: everything else
+
+## Golden rules for edits
+
+These invariants are what an editing agent will otherwise get wrong.
+
+### Path conventions
+
+- Public `skills/*/SKILL.md` **MUST** use `${CLAUDE_PLUGIN_ROOT}/…` — never `$PWD`, `${PWD}`, or hardcoded absolute paths. Enforced by validator 8 in `scripts/validate-plugin-structure.sh`.
+- `hooks/hooks.json` SHOULD also use `${CLAUDE_PLUGIN_ROOT}/…`. **This is a convention, not validator-enforced** — validator 8 only scans `skills/*/SKILL.md`.
+- Repo-private `.claude/skills/*/SKILL.md` intentionally use `$PWD/…` and are exempt from the hygiene check by design.
+
+### Version and release
+
+- **Never hand-edit `.claude-plugin/plugin.json`'s `version` field.** `/bump-version` owns that commit and is invoked automatically by `/implement` Step 8. The commit message `Bump version to X.Y.Z` is reserved for this skill.
+
+### Scripts and references
+
+- **Dead-script invariant**: every `scripts/*.sh` must have a structured reference somewhere in the repo. The authoritative list of accepted reference patterns (SKILL.md files, `hooks/hooks.json`, `.claude/settings.json`, workflow `run:` blocks, inter-script `$SCRIPT_DIR/` references, and fenced code blocks in `skills/shared/larch/*.md`) is defined by **validator 11** in `scripts/validate-plugin-structure.sh` — consult its header when in doubt.
+- **Script reference integrity** (validator 9): any script path referenced from a `SKILL.md` or `skills/shared/larch/*.md` must exist on disk.
+- **Executability** (validator 10): every `.sh` file under `scripts/`, `skills/*/scripts/`, and `.claude/skills/*/scripts/` must be `chmod +x`.
+
+### SKILL.md and agents
+
+- **Frontmatter** (validator 6): `name:` must equal `basename(dirname)`; `description:` is required.
+- **Agents** (validator 7): every `agents/*.md` must have YAML frontmatter with `name:` and `description:`.
+- **Reviewer archetypes must stay aligned**: `agents/<name>.md` and `skills/shared/larch/reviewer-templates.md` are two sides of the same contract. The shared-templates file is the prompt source; the agent file is the harness registration. Never change one without the other.
+
+### Linter configuration
+
+- `.pre-commit-config.yaml` is the single source of truth for **hook selection and version pinning**. Tool-specific rule configuration lives in dedicated files (e.g., `.markdownlint.json`). Do not split hook definitions or versions across multiple files, but do keep tool rule files where they are.
+
+### Validation gate
+
+- After any change, run `/relevant-checks`. It runs `pre-commit run --files <changed>` then `scripts/validate-plugin-structure.sh` — mirroring what CI enforces.
+
+### Hooks
+
+- Never disable or bypass `scripts/block-submodule-edit.sh` (wired as a `PreToolUse` hook on `Edit`/`Write`). If a hook blocks a write, investigate the path — don't work around the hook.
+
+## Workflow entry points — slash commands
+
+Use the bare form (matches `README.md` and all `SKILL.md` references):
+
+- `/design <feature>` — collaborative plan with 5 sketch agents + 5 plan reviewers + voting panel
+- `/implement [--quick] [--auto] [--merge] <feature>` — end-to-end: design → code → PR; with `--merge` also runs the CI+rebase+merge loop
+- `/review` — code review of current branch with 2 Claude + 2 Codex + Cursor reviewers
+- `/research <topic>` — read-only research; 5 researchers + 5 validators, no repo modifications
+- `/loop-review [partition]` — systematic repo-wide review, partitioned into slices
+- `/relevant-checks` — pre-commit linters + plugin-structure validator, scoped to changed files
+- `/bump-version` — classify and apply the semver bump (invoked by `/implement` Step 8)
+
+Full lifecycle: `docs/workflow-lifecycle.md`.
+
+## Common editing tasks — where to look
+
+- **Changing a skill's behavior** → **start** at `skills/<name>/SKILL.md`, then **trace every called helper script** in `skills/<name>/scripts/`, shared scripts in `scripts/`, and shared templates in `skills/shared/larch/` before making changes. Editing only `SKILL.md` is often incomplete — behavior is frequently split between the prompt and executable helpers.
+- **Adding or modifying a reviewer archetype** → edit BOTH `agents/<name>.md` AND `skills/shared/larch/reviewer-templates.md`; they must stay aligned.
+- **Changing a shared workflow script** → edit `scripts/<name>.sh`, then grep for every caller across `skills/`, `hooks/`, `.claude/settings.json`, `.github/workflows/`, and other scripts.
+- **Changing repo-private skills** → edit under `.claude/skills/bump-version/` or `.claude/skills/relevant-checks/`. Classified as PATCH.
+- **Docs or scripts only** → classified as PATCH. No MAJOR/MINOR impact.
+
+## Canonical sources
+
+Read these directly when you need depth — CLAUDE.md deliberately does not duplicate them.
+
+- `README.md` — installation, feature matrix, env vars, skill catalog, Makefile targets
+- `docs/workflow-lifecycle.md` — how skills compose end-to-end
+- `docs/voting-process.md`, `docs/point-competition.md` — review mechanics
+- `docs/agents.md`, `docs/review-agents.md` — subagent orchestration
+- `docs/external-reviewers.md`, `docs/collaborative-sketches.md` — Codex/Cursor integration
+- `.claude/skills/bump-version/SKILL.md` — authoritative version classification rules
+- `scripts/validate-plugin-structure.sh` — the header comment block is the definitive structural spec (11 validators)
+
+## Conventions
+
+- **Shell scripts use `set -euo pipefail` by default.** When `-e` is intentionally omitted (e.g., collect-then-report patterns in validators, CI-wait loops), add an inline comment explaining why. See the header of `scripts/validate-plugin-structure.sh` for an example of the rationale.
+- Follow recent history style for commit messages. The string `Bump version to X.Y.Z` is reserved for `/bump-version`.
+- PR creation, Slack posting, and CI polling are automated inside `/implement`. Do not run `gh pr create` manually from inside a workflow — drive it through the skill.
+- Slack env vars (`LARCH_SLACK_BOT_TOKEN`, `LARCH_SLACK_CHANNEL_ID`, `LARCH_SLACK_USER_ID`) are optional; skills degrade gracefully with a warning at session setup when absent.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ larch has two overlapping but distinct classifications. Treat them separately wh
 
 **Repo-private (NOT shipped to consumers):**
 
-- `.claude/skills/bump-version/` — classifier and applier; owned by `/implement` Step 8
+- `.claude/skills/bump-version/` — classifier and applier; invoked by `/implement` (Step 8 initial bump; Steps 10/12 re-bump after each rebase)
 - `.claude/skills/relevant-checks/` — reference implementation only; each consumer repo provides its own
 - `.claude/settings.json` — local Claude Code harness config (permissions, dev hooks)
 - `docs/` — prose documentation
@@ -37,6 +37,8 @@ Inside `skills/**` and `agents/**`, the specific triggers are:
 - **MAJOR**: deleting or renaming a `SKILL.md`/agent file, changing its `name:` frontmatter, or removing a `--flag` token from `argument-hint:`
 - **MINOR**: adding a new `SKILL.md`/agent file, or adding a `--flag` token to `argument-hint:`
 - **PATCH**: everything else
+
+The main agent may **escalate** severity (never downgrade) for backward-incompatible behavioral changes anywhere in the diff — see the escalation-only caveat in `.claude/skills/bump-version/SKILL.md`.
 
 ## Golden rules for edits
 
@@ -70,7 +72,7 @@ These invariants are what an editing agent will otherwise get wrong.
 
 ### Validation gate
 
-- After any change, run `/relevant-checks`. It runs `pre-commit run --files <changed>` then `scripts/validate-plugin-structure.sh` — mirroring what CI enforces.
+- After any change, run `/relevant-checks`. It runs `pre-commit run --files <changed>` on branch-modified files; if pre-commit passes, it additionally runs `scripts/validate-plugin-structure.sh`. This is a fast local gate — CI's `lint` job runs repo-wide `make lint`, so a local pass does not guarantee CI passes.
 
 ### Hooks
 
@@ -78,7 +80,7 @@ These invariants are what an editing agent will otherwise get wrong.
 
 ## Workflow entry points — slash commands
 
-Use the bare form (matches `README.md` and all `SKILL.md` references):
+Use the bare form (matches `README.md`; see each `SKILL.md` for full argument details):
 
 - `/design <feature>` — collaborative plan with 5 sketch agents + 5 plan reviewers + voting panel
 - `/implement [--quick] [--auto] [--merge] <feature>` — end-to-end: design → code → PR; with `--merge` also runs the CI+rebase+merge loop
@@ -86,7 +88,7 @@ Use the bare form (matches `README.md` and all `SKILL.md` references):
 - `/research <topic>` — read-only research; 5 researchers + 5 validators, no repo modifications
 - `/loop-review [partition]` — systematic repo-wide review, partitioned into slices
 - `/relevant-checks` — pre-commit linters + plugin-structure validator, scoped to changed files
-- `/bump-version` — classify and apply the semver bump (invoked by `/implement` Step 8)
+- `/bump-version` — classify and apply the semver bump (invoked by `/implement` Step 8 and after each rebase in Steps 10/12)
 
 Full lifecycle: `docs/workflow-lifecycle.md`.
 


### PR DESCRIPTION
## Summary
- Added a minimal, complete `CLAUDE.md` (120 lines) optimized for editing agents working on larch's skills, scripts, agents, and Claude config
- Organized around two independent axes (shipped vs private surface, semver classification) plus golden rules, workflow entry points, editing task guides, and canonical source pointers
- Incorporated all 7 plan review findings and 4 code review findings through full collaborative review with voting panels

<details><summary>Architecture Diagram</summary>

```mermaid
graph TD
    subgraph RepoRoot["larch repository root"]
        CLAUDE_MD["CLAUDE.md<br/>(NEW — this PR)"]
        README["README.md<br/>(installation / features)"]
    end

    subgraph PublicSurface["Shipped plugin surface"]
        SKILLS["skills/**<br/>(MAJOR/MINOR)"]
        AGENTS["agents/**<br/>(MAJOR/MINOR)"]
        HOOKS["hooks/hooks.json<br/>(PATCH)"]
        SCRIPTS["scripts/*.sh<br/>(PATCH)"]
        PLUGIN_JSON[".claude-plugin/<br/>plugin.json<br/>(PATCH)"]
    end

    subgraph PrivateSurface["Repo-private infrastructure"]
        CLAUDE_SKILLS[".claude/skills/<br/>{bump-version,relevant-checks}"]
        SETTINGS[".claude/settings.json"]
        DOCS["docs/*.md"]
        PRECOMMIT[".pre-commit-config.yaml<br/>+ .markdownlint.json"]
        VALIDATOR["scripts/<br/>validate-plugin-structure.sh"]
    end

    subgraph Workflows["Claude Code slash workflows"]
        IMPLEMENT["/implement"]
        DESIGN["/design"]
        REVIEW["/review"]
        RELEVANT["/relevant-checks"]
        BUMP["/bump-version"]
    end

    CLAUDE_MD -.->|"orients editor"| PublicSurface
    CLAUDE_MD -.->|"orients editor"| PrivateSurface
    CLAUDE_MD -.->|"points to"| Workflows
    CLAUDE_MD -.->|"references for details"| README
    CLAUDE_MD -.->|"references for details"| DOCS
    CLAUDE_MD -.->|"cites structural spec"| VALIDATOR

    IMPLEMENT -->|"after edits"| RELEVANT
    RELEVANT -->|"runs"| PRECOMMIT
    RELEVANT -->|"runs"| VALIDATOR
    IMPLEMENT -->|"Step 8"| BUMP
    BUMP -->|"inspects only"| SKILLS
    BUMP -->|"inspects only"| AGENTS
    BUMP -->|"edits"| PLUGIN_JSON

    VALIDATOR -->|"validators 6,9,10"| SKILLS
    VALIDATOR -->|"validator 7"| AGENTS
    VALIDATOR -->|"validator 8 (hygiene)"| SKILLS
    VALIDATOR -->|"validators 3,11"| HOOKS
    VALIDATOR -->|"validators 10,11"| SCRIPTS

    style CLAUDE_MD fill:#90ee90,stroke:#000,stroke-width:3px
    style PublicSurface fill:#ffeaa7
    style PrivateSurface fill:#dfe6e9
    style Workflows fill:#a8dadc
```

</details>

<details><summary>Code Flow Diagram</summary>

```mermaid
flowchart TD
    Start["Claude Code session starts<br/>in larch repo"]
    Load["CLAUDE.md auto-loaded<br/>into session context"]

    subgraph AgentReads["Agent reads CLAUDE.md sections"]
        Orientation["§ Orientation<br/>'This repo IS the plugin'"]
        Layout["§ Repository Layout<br/>Axis A: shipped vs private<br/>Axis B: semver classification"]
        Rules["§ Golden Rules<br/>Path conventions, dead-script,<br/>executability, frontmatter"]
        Workflows["§ Workflow Entry Points<br/>Which /command for which task"]
        Tasks["§ Common Editing Tasks<br/>Where to start for each change type"]
        Sources["§ Canonical Sources<br/>Pointers to deeper docs"]
        Conventions["§ Conventions<br/>Shell defaults, commit style"]
    end

    Start --> Load
    Load --> AgentReads

    subgraph AgentActs["Agent applies knowledge"]
        Edit["Edit files following<br/>path conventions + rules"]
        Validate["Run /relevant-checks<br/>(pre-commit + validator)"]
        Version["Understand version<br/>bump implications"]
    end

    Rules --> Edit
    Layout --> Version
    Edit --> Validate

    subgraph Prevention["Mistakes prevented"]
        P1["❌ $PWD in public SKILL.md"]
        P2["❌ Hand-edit plugin.json version"]
        P3["❌ Orphan script (no reference)"]
        P4["❌ Misclassify version bump"]
        P5["❌ Edit SKILL.md without tracing helpers"]
    end

    Edit -.-> Prevention
    Version -.-> Prevention
```

</details>

<details><summary>Goal</summary>

- Add a minimal but complete CLAUDE.md for the larch repo, optimized for editing agents making modifications to skills, scripts, agents, and Claude config
  - Research what other Claude plugin repos (Anthropic plugin store) have in their CLAUDE.md files and apply what's relevant
  - Keep the file under 200 lines (target 120–160)
  - Encode the two-axis layout (shipped vs private, semver classification)
  - Document non-obvious invariants that editing agents would otherwise violate (path conventions, dead-script rule, executability, frontmatter requirements, reviewer alignment)
  - Point to canonical sources (README, docs/, SKILL.md files) rather than duplicating content

</details>

<details><summary>Test plan</summary>

- [x] `/relevant-checks` passes (markdownlint + plugin structure validation)
- [x] `wc -l CLAUDE.md` confirms under 200 lines (actual: 120)
- [x] Every file path cited in CLAUDE.md exists in the repo
- [x] Validator numbers (6, 7, 8, 9, 10, 11) align with `scripts/validate-plugin-structure.sh` header
- [x] No CI changes needed (markdownlint already enforced by existing pipeline)

</details>

<details><summary>Final Design</summary>

## Revised Implementation Plan (post plan-review)

Create a single `CLAUDE.md` at repo root (~120–160 lines) with these sections:

1. **Orientation** (3–5 lines) — "This repo IS the larch plugin"
2. **Repository layout — two axes** (~25 lines) — Axis A: shipped vs repo-private; Axis B: semver classification (only skills/** and agents/** drive MAJOR/MINOR)
3. **Golden rules** (~30 lines) — Path conventions (${CLAUDE_PLUGIN_ROOT} vs $PWD), never hand-edit version, dead-script invariant, executability, script reference integrity, SKILL.md frontmatter, agent alignment, linter config, validation gate, hooks
4. **Workflow entry points** (~12 lines) — Bare-form slash commands with one-line descriptions
5. **Common editing tasks** (~18 lines) — Where to start for each type of change
6. **Canonical sources** (~10 lines) — Plain Markdown links to deeper docs
7. **Conventions** (~10 lines) — Shell defaults, commit style, PR automation, Slack env vars

Key decisions from plan review (all 7 findings accepted):
- Two-axis layout separating "shipped" from "semver-classified" (FINDING_2)
- Bare slash commands without `/larch:` prefix (FINDING_1)
- Linter config nuance: `.pre-commit-config.yaml` for hooks/versions, `.markdownlint.json` for rules (FINDING_3)
- `set -euo pipefail` as default (FINDING_4)
- Validator 11 scope deferred to script header (FINDING_5)
- hooks.json hygiene marked as convention, not enforced (FINDING_6)
- Skill behavior requires tracing helper scripts (FINDING_7)

</details>

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `bc43337` (Re-run /bump-version after every rebase in Steps 10 and 12 (#32))
- **Current version**: `1.0.4`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `1.0.5`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH").

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

All plan review suggestions were implemented.

</details>

<details><summary>Implementation Deviations</summary>

No deviations from the plan.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

### [Code Review] Claude-Deep (Deep Analysis Reviewer)
**Finding**: CLAUDE.md line 48 states that `hooks/hooks.json` using `${CLAUDE_PLUGIN_ROOT}` is "a convention, not validator-enforced." The reviewer argued this is factually wrong because validator 3 in `scripts/validate-plugin-structure.sh` explicitly calls `validate_hook_command_paths "hooks/hooks.json"`, which resolves every `${CLAUDE_PLUGIN_ROOT}/...sh` path and fails if any is missing or not executable. The suggested fix was to replace the sentence with a more nuanced description citing validator 3's existence and executable checks alongside validator 8's narrower $PWD hygiene scope.
**Reason not implemented**: The voting panel (1 YES, 2 NO) found the current wording defensible. Validator 3 checks that referenced hook script paths *exist and are executable*, but it does not enforce the *convention of using `${CLAUDE_PLUGIN_ROOT}` specifically* — a `$PWD`-based path in hooks.json would also pass validator 3 as long as the script exists and is executable. The CLAUDE.md statement is accurate in the sense that no validator rejects `$PWD` in hooks.json. Validator 8 (the hygiene check that does reject $PWD) only scans skills/*/SKILL.md.

### [Code Review] Claude-Deep (Deep Analysis Reviewer)
**Finding**: CLAUDE.md line 23 describes `.claude/skills/relevant-checks/` as a "reference implementation only; each consumer repo provides its own." The reviewer argued that "reference implementation" mischaracterizes the directory because it is actually this repo's own working instance (with repo-specific linter invocations tied to this repo's `.pre-commit-config.yaml`), not a template to copy from. The suggested fix was to change to: "this repo's own /relevant-checks instance; each consumer repo writes its own independently. Not a template."
**Reason not implemented**: The voting panel (0 YES, 3 NO) found the concern unsupported. The repo's own `README.md` (line 48-50) explicitly uses the phrase "reference implementation" for this directory, making the CLAUDE.md wording consistent with existing documentation. The risk of an agent treating it as a safe template to copy from is low.

### [Code Review] Claude-General (General Reviewer)
**Finding**: CLAUDE.md line 109 groups `docs/external-reviewers.md` and `docs/collaborative-sketches.md` together with the label "Codex/Cursor integration." The reviewer argued that `docs/collaborative-sketches.md` covers the diverge-then-converge sketch design phase, not Codex/Cursor integration procedures, and suggested splitting into two separate bullets with accurate labels.
**Reason not implemented**: The voting panel (1 YES, 2 EXONERATE) found the concern legitimate but not worth fixing in this PR. While the label is slightly imprecise, `docs/collaborative-sketches.md` does cover Codex/Cursor roles within the sketch phase, and this is a minor docs taxonomy issue rather than a meaningful source of agent error.

### [Code Review] Codex-General
**Finding**: CLAUDE.md lines 81-89 list `/relevant-checks` and `/bump-version` as regular workflow entry points alongside shipped plugin commands like `/design`. The reviewer argued that both are repo-private skills (under `.claude/skills/`), not shipped by the plugin, and listing them without distinction could mislead an editing agent into assuming these commands always exist in consumer repos.
**Reason not implemented**: The voting panel (1 YES, 1 EXONERATE, 1 NO) found the distinction already adequately addressed. CLAUDE.md's earlier repo-layout section (Axis A) already clearly classifies these skills as "Repo-private (NOT shipped to consumers)." The workflow entry points section is documenting what's available in *this repo*, not what consumers get. Splitting would add complexity without preventing a likely agent error.

### [Code Review] Cursor
**Finding**: CLAUDE.md line 118 groups all three Slack env vars together as optional with a note about session-setup warnings. The reviewer noted that `scripts/session-setup.sh` only checks `LARCH_SLACK_BOT_TOKEN` and `LARCH_SLACK_CHANNEL_ID` — `LARCH_SLACK_USER_ID` only affects @-mention formatting, no session-setup warning. Suggested separating the required-for-Slack vars from the optional mentions var.
**Reason not implemented**: The voting panel (1 YES, 2 EXONERATE) found the concern legitimate but too minor to warrant a change in this PR. The operational impact is minimal because `LARCH_SLACK_USER_ID` only affects mention formatting, and the current wording is correct that all three are optional.

### [Code Review] Claude-General (General Reviewer)
**Finding**: CLAUDE.md line 85 describes `/review` as "code review of current branch with 2 Claude + 2 Codex + Cursor reviewers" without an explicit total count, while `/design` spells out "5 sketch agents + 5 plan reviewers." Style inconsistency.
**Reason not implemented**: The voting panel (0 YES, 3 NO) rejected this as a trivial style nit. The count is easily derivable (2+2+1=5) and does not identify a substantive issue.

</details>

<details><summary>Plan Review Voting Tally</summary>

| Finding | Claude Deep | Cursor | Codex | Result |
|---------|-------------|--------|-------|--------|
| FINDING_1 (slash commands) | YES | YES | YES | **ACCEPTED (3/3)** |
| FINDING_2 (shipped vs semver) | YES | YES | YES | **ACCEPTED (3/3)** |
| FINDING_3 (linter single source) | YES | YES | YES | **ACCEPTED (3/3)** |
| FINDING_4 (set -euo pipefail) | YES | YES | YES | **ACCEPTED (3/3)** |
| FINDING_5 (validator 11 scope) | YES | YES | YES | **ACCEPTED (3/3)** |
| FINDING_6 (hooks hygiene not enforced) | YES | NO | YES | **ACCEPTED (2/3)** |
| FINDING_7 (skill behavior tracing) | YES | YES | YES | **ACCEPTED (3/3)** |
| OOS_1–5 | — | — | — | Not promoted |

### Reviewer Competition Scoreboard (Plan Review)

| Reviewer | Accepted Findings | Score |
|----------|------------------|-------|
| Codex-Deep | F1, F2, F3, F5, F7 | **+5** (winner) |
| Cursor | F1, F2, F3, F5 | +4 |
| Codex-General | F1, F2, F3, F6 | +4 |
| Claude-General | F1, F2, F4 | +3 |
| Claude-Deep | F2, F4 | +2 |

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

| Finding | Claude General | Cursor | Codex | Result |
|---------|-------------|--------|-------|--------|
| FINDING_1 (/relevant-checks desc) | YES | YES | YES | **ACCEPTED (3/3)** |
| FINDING_2 (hooks validator) | YES | NO | NO | Neutral (1/3) |
| FINDING_3 (reference impl) | NO | NO | NO | Rejected (0/3) |
| FINDING_4 (collab-sketches label) | YES | EXON | EXON | Neutral (1/3) |
| FINDING_5 (bump-version Steps 10/12) | YES | EXON | YES | **ACCEPTED (2/3)** |
| FINDING_6 (escalation-only) | EXON | YES | YES | **ACCEPTED (2/3)** |
| FINDING_7 (repo-private commands) | YES | EXON | NO | Neutral (1/3) |
| FINDING_8 (--session-env omission) | YES | NO | YES | **ACCEPTED (2/3)** |
| FINDING_9 (Slack var distinction) | YES | EXON | EXON | Neutral (1/3) |
| FINDING_10 (review count style) | NO | NO | NO | Rejected (0/3) |
| OOS_1 | NO | EXON | NO | Not promoted |

### Reviewer Competition Scoreboard (Code Review)

| Reviewer | Accepted | Neutral | Exonerated | Rejected | Score |
|----------|----------|---------|------------|----------|-------|
| Cursor | F1, F8 | F9 | — | — | **+2** (winner) |
| Claude-General | F1, F5 | F4 | — | F10 | +1 |
| Codex-General | F6 | F7 | — | — | +1 |
| Codex-Deep | F1 | — | — | — | +1 |
| Claude-Deep | F1 | F2 | — | F3 | 0 |

</details>

<details><summary>Out-of-Scope Observations</summary>

**Plan review OOS (not promoted):**
- OOS_1: `.claude-plugin/marketplace.json` source field path portability (Claude-General)
- OOS_2: Pre-existing `set -e` inconsistency across scripts (Claude-General)
- OOS_3: `.claude/settings.json` has workspace-specific Go/k8s allowlist entries (Claude-General)
- OOS_4: `.claude/settings.json` dual-hook architecture not documented (Claude-Deep)
- OOS_5: Pre-existing `scripts/` classification ambiguity — subsumed by plan FINDING_2 (Claude-Deep)

**Code review OOS (not promoted):**
- OOS_1: `skills/shared/larch/` not mentioning exemption from validator 5 (Claude-General)

</details>

<details><summary>Execution Issues</summary>

No execution issues encountered.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | 7 accepted, 0 rejected |
| Code review rounds | 1 |
| Code review findings | 4 accepted, 6 rejected/neutral |
| Warnings logged | 0 |
| Pre-existing issues noticed | 6 OOS (plan) + 1 OOS (code) |
| External reviewers | Cursor: ✅, Codex: ✅ |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
