### PR TITLE
Switch to bypassPermissions, fix CLAUDE.md shipped-vs-runtime classification

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation with collaborative reviewers (Claude subagents + Codex + Cursor).",
   "author": {
     "name": "Sergey Zhupanov"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -202,7 +202,7 @@
       "Write"
     ],
     "deny": [],
-    "defaultMode": "acceptEdits",
+    "defaultMode": "bypassPermissions",
     "additionalDirectories": [
       "/tmp",
       "/var/folders"

--- a/.claude/skills/bump-version/SKILL.md
+++ b/.claude/skills/bump-version/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: Bash, Read
 
 # Bump Version
 
-Classify and apply a semantic version bump for this PR. This is a repo-private skill invoked by `/implement` Step 8. It produces exactly ONE commit: a version-only edit of `.claude-plugin/plugin.json`.
+Classify and apply a semantic version bump for this PR. This is a development-only skill invoked by `/implement` Step 8. It produces exactly ONE commit: a version-only edit of `.claude-plugin/plugin.json`.
 
 ## Classification rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,9 +25,9 @@ The plugin source (`"./"` in `marketplace.json`) ships the **entire repository**
 - `docs/` — prose documentation (linked from `README.md` with relative paths, readable locally by consumers)
 - `README.md`, `CHANGELOG.md` — project-level documentation
 - `.github/`, `Makefile`, `.pre-commit-config.yaml`, `.markdownlint.json` — CI and linter configuration
-- `.claude/skills/bump-version/` — version classifier and applier; only used during plugin development (invoked by `/implement` Step 8; Steps 10/12 re-bump after each rebase)
+- `.claude/skills/bump-version/` — version classifier and applier; reference implementation for consumers (each consumer repo provides its own); invoked during plugin development by `/implement` Steps 8, 10, 12
 - `.claude/skills/relevant-checks/` — reference implementation; each consumer repo provides its own
-- `.claude/settings.json` — local Claude Code harness config (permissions, dev hooks); not loaded in consumer projects
+- `.claude/settings.json` — local Claude Code harness config (permissions, dev hooks); not loaded when installed via the marketplace (only active for `--plugin-dir .` development)
 
 **Shared fragments (not a skill):** `skills/shared/larch/` — reviewer templates, voting protocol, external-reviewer conventions. No `SKILL.md`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,9 +8,11 @@ This file orients editing agents. Every rule below is framed as an invariant to 
 
 larch has two overlapping but distinct classifications. Treat them separately when reasoning about a change.
 
-### Axis A — What ships to consumers (plugin surface) vs. repo-private infrastructure
+### Axis A — Plugin surface (active at runtime) vs. supplementary files
 
-**Shipped (installed into consumers' Claude Code environments):**
+The plugin source (`"./"` in `marketplace.json`) ships the **entire repository** to consumers — every file below is physically present in the consumer's plugin install directory. The distinction here is about what the plugin runtime references, not what is physically present.
+
+**Plugin surface (referenced at runtime by skills, hooks, and scripts):**
 
 - `skills/` — public skills (`/design`, `/implement`, `/review`, `/research`, `/loop-review`)
 - `agents/` — reviewer archetype definitions
@@ -18,13 +20,14 @@ larch has two overlapping but distinct classifications. Treat them separately wh
 - `scripts/` — invoked from shipped skills and hooks as `${CLAUDE_PLUGIN_ROOT}/scripts/…`
 - `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` — plugin manifests
 
-**Repo-private (NOT shipped to consumers):**
+**Supplementary (shipped but not referenced by plugin code at runtime):**
 
-- `.claude/skills/bump-version/` — classifier and applier; invoked by `/implement` (Step 8 initial bump; Steps 10/12 re-bump after each rebase)
-- `.claude/skills/relevant-checks/` — reference implementation only; each consumer repo provides its own
-- `.claude/settings.json` — local Claude Code harness config (permissions, dev hooks)
-- `docs/` — prose documentation
-- `.github/`, `Makefile`, `.pre-commit-config.yaml`, `.markdownlint.json`, `CHANGELOG.md`
+- `docs/` — prose documentation (linked from `README.md` with relative paths, readable locally by consumers)
+- `README.md`, `CHANGELOG.md` — project-level documentation
+- `.github/`, `Makefile`, `.pre-commit-config.yaml`, `.markdownlint.json` — CI and linter configuration
+- `.claude/skills/bump-version/` — version classifier and applier; only used during plugin development (invoked by `/implement` Step 8; Steps 10/12 re-bump after each rebase)
+- `.claude/skills/relevant-checks/` — reference implementation; each consumer repo provides its own
+- `.claude/settings.json` — local Claude Code harness config (permissions, dev hooks); not loaded in consumer projects
 
 **Shared fragments (not a skill):** `skills/shared/larch/` — reviewer templates, voting protocol, external-reviewer conventions. No `SKILL.md`.
 
@@ -48,7 +51,7 @@ These invariants are what an editing agent will otherwise get wrong.
 
 - Public `skills/*/SKILL.md` **MUST** use `${CLAUDE_PLUGIN_ROOT}/…` — never `$PWD`, `${PWD}`, or hardcoded absolute paths. Enforced by validator 8 in `scripts/validate-plugin-structure.sh`.
 - `hooks/hooks.json` SHOULD also use `${CLAUDE_PLUGIN_ROOT}/…`. **This is a convention, not validator-enforced** — validator 8 only scans `skills/*/SKILL.md`.
-- Repo-private `.claude/skills/*/SKILL.md` intentionally use `$PWD/…` and are exempt from the hygiene check by design.
+- Development-only `.claude/skills/*/SKILL.md` intentionally use `$PWD/…` and are exempt from the hygiene check by design.
 
 ### Version and release
 
@@ -97,7 +100,7 @@ Full lifecycle: `docs/workflow-lifecycle.md`.
 - **Changing a skill's behavior** → **start** at `skills/<name>/SKILL.md`, then **trace every called helper script** in `skills/<name>/scripts/`, shared scripts in `scripts/`, and shared templates in `skills/shared/larch/` before making changes. Editing only `SKILL.md` is often incomplete — behavior is frequently split between the prompt and executable helpers.
 - **Adding or modifying a reviewer archetype** → edit BOTH `agents/<name>.md` AND `skills/shared/larch/reviewer-templates.md`; they must stay aligned.
 - **Changing a shared workflow script** → edit `scripts/<name>.sh`, then grep for every caller across `skills/`, `hooks/`, `.claude/settings.json`, `.github/workflows/`, and other scripts.
-- **Changing repo-private skills** → edit under `.claude/skills/bump-version/` or `.claude/skills/relevant-checks/`. Classified as PATCH.
+- **Changing development-only skills** → edit under `.claude/skills/bump-version/` or `.claude/skills/relevant-checks/`. Classified as PATCH.
 - **Docs or scripts only** → classified as PATCH. No MAJOR/MINOR impact.
 
 ## Canonical sources

--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ claude plugin install larch@larch-local
 | Agents | `general-reviewer`, `deep-analysis-reviewer` |
 | PreToolUse hook | `block-submodule-edit.sh` — blocks `Edit`/`Write` on files inside any checked-out git submodule of the consuming project |
 
-### `/relevant-checks` is repo-specific (not part of the plugin)
+### `/relevant-checks` is repo-specific (not part of the plugin surface)
 
-The `/relevant-checks` skill is **intentionally not shipped by the larch plugin**. Each consuming repo must provide its own `/relevant-checks` as a project-level skill at `.claude/skills/relevant-checks/` with build and lint commands tailored to that repo. Larch's own copy lives at `.claude/skills/relevant-checks/` in this repo as a reference implementation. The `/implement` and `/review` workflows invoke `/relevant-checks` after each commit, so your repo must define one for those workflows to run cleanly.
+The `/relevant-checks` skill is **not part of the plugin surface** — it is present in the install directory but not loaded by the plugin runtime. Each consuming repo must provide its own `/relevant-checks` as a project-level skill at `.claude/skills/relevant-checks/` with build and lint commands tailored to that repo. Larch's own copy lives at `.claude/skills/relevant-checks/` in this repo as a reference implementation. The `/implement` and `/review` workflows invoke `/relevant-checks` after each commit, so your repo must define one for those workflows to run cleanly.
 
 ## Features
 
@@ -69,7 +69,7 @@ Slash commands available in Claude Code sessions. They automate multi-step workf
 | [`/review`](skills/review/SKILL.md) | *(none)* | Code review current branch changes with specialized subagents (2 Claude + 2 Codex + Cursor, if available), implementing accepted suggestions in a recursive loop (up to 5 rounds). Reviews the diff between main and HEAD. [(Diagram).](skills/review/diagram.svg) |
 | [`/implement`](skills/implement/SKILL.md) | `[--quick] [--auto] [--merge] <feature description>` | Full end-to-end feature workflow — design, implement, PR, and Slack announce. `--quick` skips `/design` and uses simplified code review (2 Claude subagents, 1 round). `--auto` suppresses all interactive question checkpoints. `--merge` additionally runs the CI+rebase+merge loop, :merged: emoji, local branch cleanup, and main verification (without `--merge`, the PR is created and the workflow stops after the initial CI wait, Slack announcement, and reports). [(Diagram).](skills/implement/diagram.svg) |
 | [`/loop-review`](skills/loop-review/SKILL.md) | `[partition criteria]` | Systematic code review of entire repository by partitioning into slices, reviewing each with specialized subagents (2 Claude + 2 Codex + Cursor, if available), implementing improvements via `/implement`, and logging deferred suggestions. The optional argument specifies how to partition the codebase (e.g., by directory, by file type). [(Diagram).](skills/loop-review/diagram.svg) |
-| [`/relevant-checks`](.claude/skills/relevant-checks/SKILL.md) | *(none)* | Run pre-commit linters (shellcheck, markdownlint, jsonlint, actionlint) scoped to files modified on the current branch. Invoked automatically by `/implement` and `/review` after code changes. **Repo-private; not shipped by the plugin.** |
+| [`/relevant-checks`](.claude/skills/relevant-checks/SKILL.md) | *(none)* | Run pre-commit linters (shellcheck, markdownlint, jsonlint, actionlint) scoped to files modified on the current branch. Invoked automatically by `/implement` and `/review` after code changes. **Not part of the plugin surface; each consuming repo provides its own.** |
 
 ## Review Agents
 


### PR DESCRIPTION
## Summary
- Switched `.claude/settings.json` `defaultMode` from `"acceptEdits"` to `"bypassPermissions"` to eliminate redundant permission prompts during plugin development
- Reframed CLAUDE.md's Axis A classification from "shipped vs. repo-private" to "plugin surface (active at runtime) vs. supplementary (shipped but not referenced by plugin code)" — reflecting that `source: "./"` ships the entire repo to consumers
- Updated README.md and `.claude/skills/bump-version/SKILL.md` to use consistent terminology

<details><summary>Architecture Diagram</summary>

Quick mode — architecture diagram skipped.

</details>

<details><summary>Code Flow Diagram</summary>

Quick mode — code flow diagram skipped.

</details>

<details><summary>Goal</summary>

- Switch permission mode to `bypassPermissions` for frictionless plugin development
  - The existing ~170-entry `allow` list was attempting to achieve the same thing but could never be exhaustive for all Bash command patterns
- Fix misleading "repo-private (NOT shipped to consumers)" classification in CLAUDE.md
  - The plugin source `"./"` in `marketplace.json` ships the entire repository — `docs/`, `README.md`, `.claude/` etc. are all physically present on the consumer's machine
  - Reframe to distinguish "plugin surface (referenced at runtime)" vs. "supplementary (shipped but not referenced by plugin code at runtime)"
  - Update all references to "repo-private" in CLAUDE.md to "development-only" for consistency
  - Fix README.md lines that said "not shipped by the plugin" to say "not part of the plugin surface"
  - Fix `.claude/skills/bump-version/SKILL.md` terminology to match

</details>

<details><summary>Test plan</summary>

- [ ] Verify `pre-commit run --files` passes on all modified files
- [ ] Verify `scripts/validate-plugin-structure.sh` passes
- [ ] Confirm `.claude/settings.json` is valid JSON with accepted `defaultMode` enum value
- [ ] Read through CLAUDE.md Axis A section and verify the new framing is accurate and internally consistent
- [ ] Verify README.md `/relevant-checks` section uses updated terminology
- [ ] Verify `.claude/skills/bump-version/SKILL.md` uses "development-only" instead of "repo-private"

</details>

<details><summary>Final Design</summary>

**Inline implementation plan (quick mode):**

1. `.claude/settings.json`: Change `"defaultMode": "acceptEdits"` to `"defaultMode": "bypassPermissions"`
2. `CLAUDE.md` Axis A (lines 7-29): Rewrite section header, add introductory note about `source: "./"`, rename categories, reorder supplementary items with clarified descriptions
3. `CLAUDE.md` line 51: "Repo-private" to "Development-only"
4. `CLAUDE.md` line 100: "Changing repo-private skills" to "Changing development-only skills"

</details>

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `cc9b874` (Add CLAUDE.md with editing-agent invariants and repo layout (#33))
- **Current version**: `1.0.5`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `1.0.6`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH").

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

Quick mode — no plan review was conducted.

</details>

<details><summary>Implementation Deviations</summary>

Code review surfaced three additional files that needed terminology updates beyond the original plan:
- `README.md` lines 48-50, 72: Updated "not shipped by the plugin" to "not part of the plugin surface"
- `.claude/skills/bump-version/SKILL.md` line 9: Updated "repo-private" to "development-only"
- `CLAUDE.md` `.claude/skills/bump-version/` description: Reframed as "reference implementation for consumers" (matching `/relevant-checks/` pattern) instead of "only used during plugin development"
- `CLAUDE.md` `.claude/settings.json` description: Clarified "not loaded when installed via the marketplace (only active for `--plugin-dir .` development)"

</details>

<details><summary>Rejected Code Review Suggestions</summary>

### [Code Review] General Reviewer
**Finding**: `.claude/settings.json` — `bypassPermissions` is a significant security escalation that makes the ~170-entry `allow` list dead code. The reviewer suggested adding a comment above `defaultMode` explaining why `bypassPermissions` is safe, and verifying no scripts copy this file to consumer locations.
**Reason not implemented**: JSON does not support comments. The user explicitly requested this change after a detailed conversation about the trade-offs. The `allow` list remains as a reference/fallback if the mode is ever reverted. No scripts in the codebase copy `.claude/settings.json` to consumer locations — it is only referenced by `validate-plugin-structure.sh` validator 4 for structural checks.

### [Code Review] Deep Analysis Reviewer
**Finding**: `skills/review/SKILL.md` enforces a strict ASCII sort-order invariant on the `permissions.allow` array, but with `bypassPermissions` in effect, the allow list has no operational effect. The reviewer suggested updating the sort-order invariant to note it applies "when `defaultMode` is not `bypassPermissions`".
**Reason not implemented**: The sort-order invariant in `skills/review/SKILL.md` is a pre-existing concern that predates this PR. The allow list serves as documentation/reference for what was previously permitted, and maintaining sort order prevents diff noise if the mode is ever reverted. Modifying review skill behavior is out of scope for this documentation/config PR.

</details>

<details><summary>Plan Review Voting Tally</summary>

Quick mode — no plan review voting.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

Quick mode — no voting panel. Main agent reviewed findings from 2 Claude subagents.

</details>

<details><summary>Out-of-Scope Observations</summary>

Quick mode — no out-of-scope observations collected.

</details>

<details><summary>Execution Issues</summary>

No execution issues encountered.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | N/A (quick mode) |
| Code review rounds | 1 |
| Code review findings | 4 accepted, 2 rejected |
| Warnings logged | 0 |
| Pre-existing issues noticed | 0 |
| External reviewers | N/A (quick mode) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
