### PR TITLE
Add CHANGELOG automation to /implement, backfill v1.0.3-v1.1.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation with collaborative reviewers (Claude subagents + Codex + Cursor).",
   "author": {
     "name": "Sergey Zhupanov"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.3] - 2026-04-09
+
+### Added
+
+- `/implement` Step 8a: automatically updates `CHANGELOG.md` (if present) with a brief summary after the version bump, amending it into the bump commit.
+- Backfilled CHANGELOG entries for versions 1.0.3 through 1.1.2.
+
+### Changed
+
+- Updated `drop-bump-commit.sh` Guard 4 to accept `CHANGELOG.md` alongside `plugin.json` in the bump commit, preventing re-bump failures when Step 8a has amended the changelog.
+- Added CHANGELOG re-update (step 4a) to the Rebase+Re-bump sub-procedure so changelog entries survive rebases.
+
 ## [1.1.2] - 2026-04-09
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,52 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.2] - 2026-04-09
+
+### Changed
+
+- Added `actions/cache@v4` for pre-commit tool cache in CI, reducing lint job time from ~44s to ~2s on cache hits.
+- Flattened `skills/shared/larch/` to `skills/shared/` and updated all path references across 14 files.
+
+## [1.1.1] - 2026-04-09
+
+### Changed
+
+- Increased external reviewer timeouts from 15 to 30 minutes (review/plan review) and 10 to 20 minutes (sketch/voting).
+- Added Claude subagent fallbacks for all skills when Cursor/Codex are unavailable, ensuring total reviewer count (5) and voter count (3) remain constant.
+
+## [1.1.0] - 2026-04-09
+
+### Added
+
+- `/alias` skill for creating project-level alias shortcuts that forward to existing larch skills with preset flags. Generates `.claude/skills/<name>/SKILL.md` and commits.
+
+## [1.0.6] - 2026-04-09
+
+### Changed
+
+- Switched `.claude/settings.json` to `bypassPermissions` mode for local development.
+- Fixed CLAUDE.md shipped-vs-runtime classification for supplementary files.
+
+## [1.0.5] - 2026-04-09
+
+### Added
+
+- `CLAUDE.md` with editing-agent invariants, repository layout documentation, golden rules for edits, and canonical source references.
+
+## [1.0.4] - 2026-04-09
+
+### Changed
+
+- `/implement` now re-runs `/bump-version` after every rebase in Steps 10 and 12 (the Rebase + Re-bump Sub-procedure), ensuring the merged version reflects `origin/main` at merge time rather than at PR-creation time.
+
+## [1.0.3] - 2026-04-09
+
+### Added
+
+- Plugin structure validator (`scripts/validate-plugin-structure.sh`) with 11 validators covering manifests, frontmatter, path hygiene, script references, executability, and dead-script detection.
+- Extended `/relevant-checks` to run the plugin structure validator after pre-commit passes.
+
 ## [1.0.2] - 2026-04-08
 
 ### Removed

--- a/scripts/drop-bump-commit.sh
+++ b/scripts/drop-bump-commit.sh
@@ -53,12 +53,15 @@ if ! git rev-parse --verify HEAD~1 >/dev/null 2>&1; then
     exit 0
 fi
 
-# --- Guard 4: commit must touch only .claude-plugin/plugin.json ---
+# --- Guard 4: commit must touch only allowed bump files ---
 # Use diff --name-only against HEAD~1. A legitimate bump commit produced by
-# apply-bump.sh only stages .claude-plugin/plugin.json.
-CHANGED_FILES=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || true)
-if [[ "$CHANGED_FILES" != ".claude-plugin/plugin.json" ]]; then
-    echo "WARN: HEAD subject matches bump pattern but commit touches files other than .claude-plugin/plugin.json (changed: $CHANGED_FILES); refusing to drop" >&2
+# apply-bump.sh stages .claude-plugin/plugin.json. Step 8a of /implement may
+# additionally amend CHANGELOG.md into the same commit. Both are acceptable.
+CHANGED_FILES=$(git diff --name-only HEAD~1 HEAD 2>/dev/null | sort)
+ALLOWED_ONE=".claude-plugin/plugin.json"
+ALLOWED_TWO=$'CHANGELOG.md\n.claude-plugin/plugin.json'
+if [[ "$CHANGED_FILES" != "$ALLOWED_ONE" && "$CHANGED_FILES" != "$ALLOWED_TWO" ]]; then
+    echo "WARN: HEAD subject matches bump pattern but commit touches unexpected files (changed: $CHANGED_FILES); refusing to drop" >&2
     echo "DROPPED=false"
     exit 0
 fi

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -41,6 +41,7 @@ Suggested emoji palette (use consistently):
 | 7 | 💾 | Second commit |
 | 7a | 🗺️ | Code flow diagram |
 | 8 | 🏷️ | Version bump |
+| 8a | 📝 | CHANGELOG update |
 | 9 | 🚀 | Create PR |
 | 10 | 🔄 | CI monitor (initial wait for green) |
 | 11 | 📋 | Slack announcement |
@@ -367,7 +368,40 @@ Parse the output for `HAS_BUMP` and `COMMITS_BEFORE`.
    ```
    Parse for `VERIFIED`, `COMMITS_AFTER`, `EXPECTED`. If `VERIFIED=false`, print: `**⚠ /bump-version did not create exactly one commit. Expected $EXPECTED, got $COMMITS_AFTER.**`
 
-**Important**: At PR creation time there must be exactly ONE version bump commit as HEAD. Proceed immediately to Step 9 after `/bump-version` returns — no commits may occur between Step 8 and Step 9. Note: after PR creation, Steps 10 and 12's rebase handlers may repeatedly drop and recreate this bump commit as main advances (via the shared **Rebase + Re-bump Sub-procedure** — see before Step 10). The branch history between PR creation and merge may therefore temporarily contain zero or multiple bump commits; the invariant that matters is "the terminal bump commit on HEAD must be based on latest `origin/main` at merge time", enforced strictly by Step 12 and best-effort by Step 10.
+**Important**: At PR creation time there must be exactly ONE version bump commit as HEAD. Proceed immediately to Step 8a after `/bump-version` returns. No additional commits may occur between Step 8a and Step 9. Note: after PR creation, Steps 10 and 12's rebase handlers may repeatedly drop and recreate this bump commit as main advances (via the shared **Rebase + Re-bump Sub-procedure** — see before Step 10). The branch history between PR creation and merge may therefore temporarily contain zero or multiple bump commits; the invariant that matters is "the terminal bump commit on HEAD must be based on latest `origin/main` at merge time", enforced strictly by Step 12 and best-effort by Step 10.
+
+## Step 8a — CHANGELOG Update
+
+**Conditional**: Check if `CHANGELOG.md` exists in the project root using the Read tool. If the file does not exist (Read returns an error), print `⏩ Step 8a — No CHANGELOG.md found, skipping.` and proceed to Step 9.
+
+**If `CHANGELOG.md` exists**:
+
+1. Read the current `CHANGELOG.md`.
+2. Read the `NEW_VERSION` from the `/bump-version` output (saved in Step 8). If Step 8 was skipped (`HAS_BUMP=false`), skip this step.
+3. Compose a brief changelog entry using the Summary bullets from the implementation (the same 1-3 bullet points used in Step 9a's PR body `## Summary` section). Use today's date. Format:
+
+   ```markdown
+   ## [X.Y.Z] - YYYY-MM-DD
+
+   ### Changed
+
+   - <bullet point 1>
+   - <bullet point 2>
+   ```
+
+   Use the appropriate Keep a Changelog category header (`Added`, `Changed`, `Fixed`, `Removed`) based on the nature of the changes. Multiple categories are fine if the PR spans them.
+
+4. Insert the new section immediately after the file's header block (after the `and this project adheres to [Semantic Versioning]` line, before the first existing `## [` section). If there is an `## [Unreleased]` section, insert after it.
+5. Stage `CHANGELOG.md` and amend the bump commit:
+
+   ```bash
+   git add CHANGELOG.md
+   git commit --amend --no-edit
+   ```
+
+   This keeps the bump commit as the single HEAD commit containing both the version bump and the changelog update.
+
+Print: `📝 Step 8a — CHANGELOG.md updated for v<NEW_VERSION>.`
 
 ## Step 9 — Create PR
 

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -372,12 +372,14 @@ Parse the output for `HAS_BUMP` and `COMMITS_BEFORE`.
 
 ## Step 8a — CHANGELOG Update
 
-**Conditional**: Check if `CHANGELOG.md` exists in the project root using the Read tool. If the file does not exist (Read returns an error), print `⏩ Step 8a — No CHANGELOG.md found, skipping.` and proceed to Step 9.
+**Conditional**: Skip Step 8a entirely and proceed to Step 9 if either condition is true:
+- `CHANGELOG.md` does not exist in the project root (check via the Read tool — if Read returns an error, the file does not exist). Print `⏩ Step 8a — No CHANGELOG.md found, skipping.`
+- Step 8 was skipped (`HAS_BUMP=false`). Print `⏩ Step 8a — Skipped (no version bump).`
 
-**If `CHANGELOG.md` exists**:
+**If `CHANGELOG.md` exists AND Step 8 produced a version bump**:
 
 1. Read the current `CHANGELOG.md`.
-2. Read the `NEW_VERSION` from the `/bump-version` output (saved in Step 8). If Step 8 was skipped (`HAS_BUMP=false`), skip this step.
+2. Read the `NEW_VERSION` from the `/bump-version` output (saved in Step 8).
 3. Compose a brief changelog entry using the Summary bullets from the implementation (the same 1-3 bullet points used in Step 9a's PR body `## Summary` section). Use today's date. Format:
 
    ```markdown
@@ -617,6 +619,9 @@ After the initial version bump in Step 8, every subsequent rebase of the feature
        - **step10 family**: log warning and break to Step 11.
 
    **Rationale**: Step 8's permissive warnings are safe because Step 8 is pre-PR — no merge can happen based on a missing bump. Step 12 is pre-merge — missing bump means stale merge. Step 10 is post-PR but pre-merge (Step 12 does the merge) — any bump failure in Step 10 is recoverable by Step 12's mandatory re-bump, so Step 10 can afford to be permissive. **Step 12 is the last-chance enforcement point; Step 10 is best-effort optimization that improves freshness during the Slack-wait phase.**
+
+4a. **Re-apply CHANGELOG update** (mirrors Step 8a):
+   If `CHANGELOG.md` exists in the project root (check via Read tool) and a new bump commit was created (`VERIFIED=true` from step 4), update the CHANGELOG entry to reflect the new version from the re-bump. Follow the same logic as Step 8a: read `CHANGELOG.md`, compose an entry with the `NEW_VERSION` from the re-bump and the same Summary bullets, insert it (or replace the existing entry for the prior version if present), stage, and amend the bump commit via `git add CHANGELOG.md && git commit --amend --no-edit`. If CHANGELOG.md does not exist or the bump was skipped, skip this sub-step silently. **This is best-effort and non-blocking** — failure to update CHANGELOG does not affect the bump or push.
 
 5. **Push with recovery**:
    ```bash


### PR DESCRIPTION
## Summary
- Added automatic CHANGELOG.md updates to `/implement` (Step 8a) — appends a version entry after the bump and amends it into the bump commit
- Backfilled CHANGELOG entries for versions 1.0.3 through 1.1.2 (PRs #31-#37)
- Fixed `drop-bump-commit.sh` Guard 4 to accept CHANGELOG.md alongside plugin.json, and added CHANGELOG re-update to the Rebase+Re-bump sub-procedure

<details><summary>Architecture Diagram</summary>

Quick mode — architecture diagram skipped.

</details>

<details><summary>Code Flow Diagram</summary>

Quick mode — code flow diagram skipped.

</details>

<details><summary>Goal</summary>

- Automate CHANGELOG.md maintenance in `/implement`
  - Add Step 8a that conditionally updates CHANGELOG.md after version bump
  - Amend the changelog into the bump commit to preserve single-commit-as-HEAD invariant
  - Skip gracefully if CHANGELOG.md does not exist or version bump was skipped
- Backfill missing CHANGELOG entries for versions 1.0.3-1.1.2
- Ensure CHANGELOG automation is compatible with the Rebase+Re-bump sub-procedure
  - Update `drop-bump-commit.sh` Guard 4 to accept CHANGELOG.md alongside plugin.json
  - Add step 4a to sub-procedure to re-apply CHANGELOG after re-bump

</details>

<details><summary>Test plan</summary>

- [ ] Run `/implement --quick --auto --merge` on a repo with CHANGELOG.md — verify Step 8a adds entry and amends bump commit
- [ ] Verify `drop-bump-commit.sh` correctly drops a bump commit that includes CHANGELOG.md
- [ ] Run `make lint` — all linters pass
- [ ] Run `scripts/validate-plugin-structure.sh` — all validators pass
- [ ] Verify CHANGELOG backfill entries are accurate and follow Keep a Changelog format

</details>

<details><summary>Final Design</summary>

### Files modified
1. **skills/implement/SKILL.md** — Added Step 8a (CHANGELOG update), step 4a in sub-procedure (CHANGELOG re-update after re-bump), updated progress table
2. **scripts/drop-bump-commit.sh** — Relaxed Guard 4 to accept both `plugin.json` alone and `plugin.json + CHANGELOG.md`
3. **CHANGELOG.md** — Backfilled entries for v1.0.3-v1.1.2, added v1.1.3 entry via Step 8a

### Key design decisions
- CHANGELOG amends into bump commit (not separate commit) to preserve HEAD invariant
- Guard 4 uses sorted file list comparison for deterministic matching
- Sub-procedure step 4a mirrors Step 8a logic, is best-effort and non-blocking
- Step 8a skips entirely if CHANGELOG.md doesn't exist or version bump was skipped

</details>

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `3f9b6f5` (Add CI pre-commit cache, flatten skills/shared/larch/ (#37))
- **Current version**: `1.1.2`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `1.1.3`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH").

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

Quick mode — no plan review was conducted.

</details>

<details><summary>Implementation Deviations</summary>

- Added `drop-bump-commit.sh` Guard 4 fix and sub-procedure step 4a — not in original plan but accepted from code review to prevent re-bump failures when CHANGELOG.md is amended into the bump commit
- Clarified Step 8a skip logic to be unambiguous — accepted from code review

</details>

<details><summary>Rejected Code Review Suggestions</summary>

All code review suggestions were implemented.

</details>

<details><summary>Plan Review Voting Tally</summary>

Quick mode — no plan review voting.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

Quick mode — no voting panel. Main agent reviewed findings from 2 Claude subagents.

</details>

<details><summary>Out-of-Scope Observations</summary>

Quick mode — no out-of-scope observations collected.

</details>

<details><summary>Execution Issues</summary>

No execution issues encountered.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | N/A (quick mode) |
| Code review rounds | 1 |
| Code review findings | 3 accepted, 0 rejected |
| Warnings logged | 0 |
| Pre-existing issues noticed | 0 |
| External reviewers | N/A (quick mode) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
