### PR TITLE
Fix V19 USER_ID, extract V23, remove rejected marketplace fields

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,5 @@
 {
-  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "larch-local",
-  "description": "Multi-agent workflow automation marketplace for Claude Code: design, code review, implementation, and PR automation with collaborative reviewers.",
   "owner": {
     "name": "Sergey Zhupanov",
     "email": "sergey@zhupanov.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation with collaborative reviewers (Claude subagents + Codex + Cursor).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.8] - 2026-04-10
+
+### Fixed
+
+- V19: added `LARCH_SLACK_USER_ID` to Slack fallback consistency check (was only checking BOT_TOKEN and CHANNEL_ID).
+- V23: extracted from V18 into standalone `validate_userconfig_sensitive_type()` function with own `main()` call, matching the 1-function-per-validator pattern.
+
+### Removed
+
+- Removed `$schema` and top-level `description` from `marketplace.json` — rejected by Claude CLI schema validator. Removed corresponding V12 checks.
+
 ## [1.1.7] - 2026-04-10
 
 ### Added

--- a/scripts/validate-plugin-structure.sh
+++ b/scripts/validate-plugin-structure.sh
@@ -32,8 +32,7 @@
 #  11. Dead-script detection — every scripts/*.sh must have a STRUCTURED invocation reference
 #                              somewhere in the codebase (path-shaped tokens only — prose
 #                              and comments are not counted as references)
-#  12. Marketplace enriched metadata — marketplace.json has $schema (non-empty string),
-#                              top-level description (non-empty), owner.email (non-empty),
+#  12. Marketplace enriched metadata — marketplace.json has owner.email (non-empty),
 #                              every plugin entry has category (non-empty)
 #  13. Plugin enriched metadata — plugin.json has description (non-empty), author.email
 #                              (non-empty), keywords (non-empty array with ≥1 element)
@@ -546,13 +545,7 @@ validate_marketplace_enriched() {
     [ -f "$f" ] || return 0
     jq empty "$f" 2>/dev/null || return 0  # skip if invalid JSON (validator 2 catches this)
 
-    local schema desc email
-    schema=$(jq -r '.["$schema"] // empty' "$f")
-    [ -n "$schema" ] || fail "$f missing required field: \$schema"
-
-    desc=$(jq -r '.description // empty' "$f")
-    [ -n "$desc" ] || fail "$f missing required top-level field: description"
-
+    local email
     email=$(jq -r '.owner.email // empty' "$f")
     [ -n "$email" ] || fail "$f missing required field: owner.email"
 
@@ -680,14 +673,29 @@ validate_userconfig_structure() {
     fi
 
     # Each key must have a description that is a non-empty string.
-    # If sensitive field is present, it must be a boolean (V23 enhancement).
     local key
     while IFS= read -r key; do
         [ -z "$key" ] && continue
         if ! jq -e ".userConfig[\"$key\"].description | type == \"string\" and length > 0" "$f" >/dev/null 2>&1; then
             fail "$f userConfig.$key missing or invalid description (must be a non-empty string)"
         fi
-        # V23: if sensitive field exists, verify it is boolean
+    done < <(jq -r '.userConfig | keys[]' "$f" 2>/dev/null)
+}
+
+# ---------------------------------------------------------------------------
+# Validator 23: userConfig sensitive type
+# ---------------------------------------------------------------------------
+
+validate_userconfig_sensitive_type() {
+    local f=".claude-plugin/plugin.json"
+    [ -f "$f" ] || return 0
+    jq empty "$f" 2>/dev/null || return 0
+    jq -e 'has("userConfig")' "$f" >/dev/null 2>&1 || return 0
+    jq -e '.userConfig | type == "object"' "$f" >/dev/null 2>&1 || return 0
+
+    local key
+    while IFS= read -r key; do
+        [ -z "$key" ] && continue
         if jq -e ".userConfig[\"$key\"] | has(\"sensitive\")" "$f" >/dev/null 2>&1; then
             if ! jq -e ".userConfig[\"$key\"].sensitive | type == \"boolean\"" "$f" >/dev/null 2>&1; then
                 fail "$f userConfig.$key.sensitive must be a boolean (true/false)"
@@ -707,7 +715,7 @@ validate_slack_fallback_consistency() {
     local script var plugin_var
     for script in scripts/*.sh; do
         [ -f "$script" ] || continue
-        for var in LARCH_SLACK_BOT_TOKEN LARCH_SLACK_CHANNEL_ID; do
+        for var in LARCH_SLACK_BOT_TOKEN LARCH_SLACK_CHANNEL_ID LARCH_SLACK_USER_ID; do
             # Only check files that do actual bash fallback reads (${VAR:- pattern)
             if grep -q "\${${var}:-" "$script" 2>/dev/null; then
                 plugin_var="CLAUDE_PLUGIN_OPTION_${var#LARCH_}"
@@ -813,6 +821,7 @@ main() {
     validate_userconfig_env_mapping
     validate_agent_template_count
     validate_docs_references
+    validate_userconfig_sensitive_type
 
     if [ "$ERROR_COUNT" -eq 0 ]; then
         echo "Plugin structure OK"


### PR DESCRIPTION
## Summary
- Fixed V19 to also check `LARCH_SLACK_USER_ID` fallback consistency (was only checking BOT_TOKEN and CHANNEL_ID).
- Extracted V23 (userConfig sensitive boolean check) from V18 into standalone function with own `main()` call, matching 1-function-per-validator pattern.
- Removed `$schema` and top-level `description` from `marketplace.json` since the Claude CLI rejects them, and removed corresponding V12 checks.

<details><summary>Architecture Diagram</summary>

Quick mode — architecture diagram skipped.

</details>

<details><summary>Code Flow Diagram</summary>

Quick mode — code flow diagram skipped.

</details>

<details><summary>Goal</summary>

- Fix 3 remaining gaps identified in post-PR analysis:
  - V19 missing LARCH_SLACK_USER_ID coverage
  - V23 embedded in V18 instead of standalone function
  - marketplace.json $schema/description rejected by Claude CLI

</details>

<details><summary>Test plan</summary>

- [ ] `bash scripts/validate-plugin-structure.sh` passes (all 23 validators)
- [ ] `bash scripts/smoke-test.sh` passes — no more advisory warnings from `claude plugin validate .`
- [ ] `make lint` passes

</details>

<details><summary>Final Design</summary>

3 changes in 2 files: V19 one-line fix (add USER_ID), V23 function extraction (~15 lines), marketplace.json field removal + V12 header/code update.

</details>

<details><summary>Version Bump Reasoning</summary>

PATCH — only scripts/ and .claude-plugin/ changed. No public skill surface changes.

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

Quick mode — no plan review was conducted.

</details>

<details><summary>Implementation Deviations</summary>

No deviations from the plan.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

All code review suggestions were implemented.

</details>

<details><summary>Plan Review Voting Tally</summary>

Quick mode — no plan review voting.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

Quick mode — no voting panel. Main agent reviewed findings from 2 Claude subagents. No issues found.

</details>

<details><summary>Out-of-Scope Observations</summary>

Quick mode — no out-of-scope observations collected.

</details>

<details><summary>Execution Issues</summary>

No execution issues encountered.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | N/A (quick mode) |
| Code review rounds | 1 |
| Code review findings | 0 accepted, 0 rejected |
| Warnings logged | 0 |
| Pre-existing issues noticed | 0 |
| External reviewers | N/A (quick mode) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
