### PR TITLE
Fix stale V19 comments, reorder V23, update smoke-test comment

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation with collaborative reviewers (Claude subagents + Codex + Cursor).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.9] - 2026-04-10
+
+### Fixed
+
+- Updated V19 header and function comments to include `LARCH_SLACK_USER_ID` (was stale after adding USER_ID to the loop).
+- Moved V23 (`validate_userconfig_sensitive_type`) function definition to after V22 to match numeric and `main()` call order.
+- Updated `smoke-test.sh` advisory comment to remove stale `$schema`/`description` examples.
+
 ## [1.1.8] - 2026-04-10
 
 ### Fixed

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -33,10 +33,9 @@ else
 fi
 
 # --- 2. Run claude plugin validate (if available) ---
-# NOTE: treated as advisory (warning, not error) because the CLI schema may not
-# yet recognize fields we add ahead of the official schema (e.g., $schema,
-# top-level description in marketplace.json). The plugin structure validator
-# above is the authoritative gate.
+# NOTE: treated as advisory (warning, not error) because the CLI schema may
+# evolve independently of the plugin structure validator. The plugin structure
+# validator (validate-plugin-structure.sh) is the authoritative gate.
 if command -v claude >/dev/null 2>&1; then
     echo "=== Running claude plugin validate (advisory) ==="
     if claude plugin validate . 2>&1; then

--- a/scripts/validate-plugin-structure.sh
+++ b/scripts/validate-plugin-structure.sh
@@ -46,8 +46,9 @@
 #  18. userConfig structure    — if plugin.json has userConfig, it must be an object
 #                              where each key has a "description" string field
 #  19. Slack fallback consistency — every scripts/*.sh that does a bash fallback read
-#                              of LARCH_SLACK_BOT_TOKEN or LARCH_SLACK_CHANNEL_ID must
-#                              also reference the corresponding CLAUDE_PLUGIN_OPTION_* var
+#                              of LARCH_SLACK_BOT_TOKEN, LARCH_SLACK_CHANNEL_ID, or
+#                              LARCH_SLACK_USER_ID must also reference the corresponding
+#                              CLAUDE_PLUGIN_OPTION_* var
 #  20. userConfig key→env mapping — every userConfig key in plugin.json must have a
 #                              corresponding CLAUDE_PLUGIN_OPTION_<UPPER_KEY> reference
 #                              in at least one scripts/*.sh file
@@ -683,35 +684,13 @@ validate_userconfig_structure() {
 }
 
 # ---------------------------------------------------------------------------
-# Validator 23: userConfig sensitive type
-# ---------------------------------------------------------------------------
-
-validate_userconfig_sensitive_type() {
-    local f=".claude-plugin/plugin.json"
-    [ -f "$f" ] || return 0
-    jq empty "$f" 2>/dev/null || return 0
-    jq -e 'has("userConfig")' "$f" >/dev/null 2>&1 || return 0
-    jq -e '.userConfig | type == "object"' "$f" >/dev/null 2>&1 || return 0
-
-    local key
-    while IFS= read -r key; do
-        [ -z "$key" ] && continue
-        if jq -e ".userConfig[\"$key\"] | has(\"sensitive\")" "$f" >/dev/null 2>&1; then
-            if ! jq -e ".userConfig[\"$key\"].sensitive | type == \"boolean\"" "$f" >/dev/null 2>&1; then
-                fail "$f userConfig.$key.sensitive must be a boolean (true/false)"
-            fi
-        fi
-    done < <(jq -r '.userConfig | keys[]' "$f" 2>/dev/null)
-}
-
-# ---------------------------------------------------------------------------
 # Validator 19: Slack fallback consistency
 # ---------------------------------------------------------------------------
 
 validate_slack_fallback_consistency() {
-    # For each script that does a bash fallback read of LARCH_SLACK_BOT_TOKEN or
-    # LARCH_SLACK_CHANNEL_ID (the ${VAR:-...} pattern), verify it also references
-    # the corresponding CLAUDE_PLUGIN_OPTION_* variable in the same file.
+    # For each script that does a bash fallback read of LARCH_SLACK_BOT_TOKEN,
+    # LARCH_SLACK_CHANNEL_ID, or LARCH_SLACK_USER_ID (the ${VAR:-...} pattern),
+    # verify it also references the corresponding CLAUDE_PLUGIN_OPTION_* variable.
     local script var plugin_var
     for script in scripts/*.sh; do
         [ -f "$script" ] || continue
@@ -792,6 +771,28 @@ validate_docs_references() {
         [ -f "$doc_path" ] || fail "docs reference in CLAUDE.md canonical sources not found on disk: $doc_path"
     done < <(awk '/^## Canonical sources/,/^## [^C]/' "$claude_md" 2>/dev/null \
                 | grep -oE 'docs/[a-zA-Z0-9._-]+\.md' | sort -u)
+}
+
+# ---------------------------------------------------------------------------
+# Validator 23: userConfig sensitive type
+# ---------------------------------------------------------------------------
+
+validate_userconfig_sensitive_type() {
+    local f=".claude-plugin/plugin.json"
+    [ -f "$f" ] || return 0
+    jq empty "$f" 2>/dev/null || return 0
+    jq -e 'has("userConfig")' "$f" >/dev/null 2>&1 || return 0
+    jq -e '.userConfig | type == "object"' "$f" >/dev/null 2>&1 || return 0
+
+    local key
+    while IFS= read -r key; do
+        [ -z "$key" ] && continue
+        if jq -e ".userConfig[\"$key\"] | has(\"sensitive\")" "$f" >/dev/null 2>&1; then
+            if ! jq -e ".userConfig[\"$key\"].sensitive | type == \"boolean\"" "$f" >/dev/null 2>&1; then
+                fail "$f userConfig.$key.sensitive must be a boolean (true/false)"
+            fi
+        fi
+    done < <(jq -r '.userConfig | keys[]' "$f" 2>/dev/null)
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Fixed stale V19 comments to include `LARCH_SLACK_USER_ID` alongside BOT_TOKEN and CHANNEL_ID.
- Moved V23 function definition to after V22, matching numeric order and `main()` call sequence.
- Updated `smoke-test.sh` advisory comment to remove stale `$schema`/`description` references.

<details><summary>Goal</summary>

- Fix 3 cosmetic documentation issues identified by code review agents after PR #43

</details>

<details><summary>Test plan</summary>

- [ ] `bash scripts/validate-plugin-structure.sh` passes
- [ ] `bash scripts/smoke-test.sh` passes

</details>

<details><summary>Version Bump Reasoning</summary>

PATCH — comment-only changes in scripts.

</details>

Generated with [Claude Code](https://claude.com/claude-code)
