### PR TITLE
Add title and type fields to userConfig in plugin.json

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -23,14 +23,20 @@
   ],
   "userConfig": {
     "slack_bot_token": {
+      "title": "Slack Bot Token",
+      "type": "string",
       "description": "Slack Bot User OAuth Token (xoxb-...) for PR announcements. Also accepted via LARCH_SLACK_BOT_TOKEN env var.",
       "sensitive": true
     },
     "slack_channel_id": {
+      "title": "Slack Channel ID",
+      "type": "string",
       "description": "Slack channel ID (e.g., C0123456789) for PR announcements. Also accepted via LARCH_SLACK_CHANNEL_ID env var.",
       "sensitive": false
     },
     "slack_user_id": {
+      "title": "Slack User ID",
+      "type": "string",
       "description": "Your Slack user ID (e.g., U0123456789) for @-mentions in announcements. Also accepted via LARCH_SLACK_USER_ID env var.",
       "sensitive": false
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation with collaborative reviewers (Claude subagents + Codex + Cursor).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.10] - 2026-04-12
+
+### Fixed
+
+- Added missing `title` and `type: "string"` fields to all three `userConfig` entries in `plugin.json` to conform to the Claude CLI plugin manifest schema.
+
 ## [1.1.9] - 2026-04-10
 
 ### Fixed


### PR DESCRIPTION
## Summary
- Added missing `title` and `type: "string"` fields to all three `userConfig` entries in `plugin.json` to conform to the Claude CLI plugin manifest schema.

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Goal</summary>

- Fix `plugin.json` `userConfig` schema compliance
  - Add `title` field to each userConfig entry (`slack_bot_token`, `slack_channel_id`, `slack_user_id`)
  - Add `type: "string"` field to each userConfig entry

</details>

<details><summary>Test plan</summary>

- [ ] Verify `plugin.json` is valid JSON after edit
- [ ] Verify all three userConfig entries have `title` and `type` fields
- [ ] Confirm plugin installs correctly via Claude CLI marketplace

</details>

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `401be4a` (Fix stale V19 comments, reorder V23, update smoke-test comment (#44))
- **Current version**: `1.1.9`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `1.1.10`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH").

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

No plan review was conducted (standalone fix).

</details>

<details><summary>Implementation Deviations</summary>

No deviations from the plan.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

All code review suggestions were implemented.

</details>

<details><summary>Plan Review Voting Tally</summary>

No plan review voting (standalone fix).

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

No code review voting (standalone fix).

</details>

<details><summary>Out-of-Scope Observations</summary>

No out-of-scope observations were raised.

</details>

<details><summary>Execution Issues</summary>

No execution issues encountered.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | N/A (standalone fix) |
| Code review rounds | 0 |
| Code review findings | N/A |
| Warnings logged | 0 |
| Pre-existing issues noticed | 0 |
| External reviewers | Cursor: ❌, Codex: ❌ |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
