### PR TITLE
Add validators 24-25: userConfig title and type fields

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation with collaborative reviewers (Claude subagents + Codex + Cursor).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.11] - 2026-04-12
+
+### Added
+
+- Validators 24-25 in `validate-plugin-structure.sh`: every `userConfig` entry must have a non-empty `title` string field (V24) and a non-empty `type` string field (V25).
+
 ## [1.1.10] - 2026-04-12
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,7 @@ Read these directly when you need depth — CLAUDE.md deliberately does not dupl
 - `docs/agents.md`, `docs/review-agents.md` — subagent orchestration
 - `docs/external-reviewers.md`, `docs/collaborative-sketches.md` — Codex/Cursor integration
 - `.claude/skills/bump-version/SKILL.md` — authoritative version classification rules
-- `scripts/validate-plugin-structure.sh` — the header comment block is the definitive structural spec (23 validators)
+- `scripts/validate-plugin-structure.sh` — the header comment block is the definitive structural spec (25 validators)
 - `SECURITY.md` — security policy (validated by validator 14; do not delete)
 
 ## Conventions

--- a/scripts/validate-plugin-structure.sh
+++ b/scripts/validate-plugin-structure.sh
@@ -59,6 +59,10 @@
 #                              sources section of CLAUDE.md must exist on disk
 #  23. userConfig sensitive type — if a userConfig entry has a "sensitive" field,
 #                              its value must be a boolean (not string/number/null)
+#  24. userConfig title field  — every userConfig entry must have a "title" field
+#                              that is a non-empty string
+#  25. userConfig type field   — every userConfig entry must have a "type" field
+#                              that is a non-empty string
 #
 # Exemption from PWD hygiene check (validator 8):
 #   .claude/skills/bump-version/SKILL.md
@@ -796,6 +800,46 @@ validate_userconfig_sensitive_type() {
 }
 
 # ---------------------------------------------------------------------------
+# Validator 24: userConfig title field
+# ---------------------------------------------------------------------------
+
+validate_userconfig_title() {
+    local f=".claude-plugin/plugin.json"
+    [ -f "$f" ] || return 0
+    jq empty "$f" 2>/dev/null || return 0
+    jq -e 'has("userConfig")' "$f" >/dev/null 2>&1 || return 0
+    jq -e '.userConfig | type == "object"' "$f" >/dev/null 2>&1 || return 0
+
+    local key
+    while IFS= read -r key; do
+        [ -z "$key" ] && continue
+        if ! jq -e ".userConfig[\"$key\"].title | type == \"string\" and length > 0" "$f" >/dev/null 2>&1; then
+            fail "$f userConfig.$key missing or invalid title (must be a non-empty string)"
+        fi
+    done < <(jq -r '.userConfig | keys[]' "$f" 2>/dev/null)
+}
+
+# ---------------------------------------------------------------------------
+# Validator 25: userConfig type field
+# ---------------------------------------------------------------------------
+
+validate_userconfig_type() {
+    local f=".claude-plugin/plugin.json"
+    [ -f "$f" ] || return 0
+    jq empty "$f" 2>/dev/null || return 0
+    jq -e 'has("userConfig")' "$f" >/dev/null 2>&1 || return 0
+    jq -e '.userConfig | type == "object"' "$f" >/dev/null 2>&1 || return 0
+
+    local key
+    while IFS= read -r key; do
+        [ -z "$key" ] && continue
+        if ! jq -e ".userConfig[\"$key\"].type | type == \"string\" and length > 0" "$f" >/dev/null 2>&1; then
+            fail "$f userConfig.$key missing or invalid type (must be a non-empty string)"
+        fi
+    done < <(jq -r '.userConfig | keys[]' "$f" 2>/dev/null)
+}
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
@@ -823,6 +867,8 @@ main() {
     validate_agent_template_count
     validate_docs_references
     validate_userconfig_sensitive_type
+    validate_userconfig_title
+    validate_userconfig_type
 
     if [ "$ERROR_COUNT" -eq 0 ]; then
         echo "Plugin structure OK"


### PR DESCRIPTION
## Summary
- Added validators 24 and 25 to `validate-plugin-structure.sh` to enforce that every `userConfig` entry in `plugin.json` has a non-empty `title` string field and a non-empty `type` string field.
- Updated CLAUDE.md validator count from 23 to 25.

<details><summary>Architecture Diagram</summary>

Quick mode — architecture diagram skipped.

</details>

<details><summary>Code Flow Diagram</summary>

Quick mode — code flow diagram skipped.

</details>

<details><summary>Goal</summary>

- Enhance CI linting of the Claude plugin config by adding validation for the `title` and `type` fields that were manually added to `userConfig` entries in the previous commit (#45)
  - Add validator 24: enforce `title` field presence and non-empty string type on every `userConfig` entry
  - Add validator 25: enforce `type` field presence and non-empty string type on every `userConfig` entry
  - Update CLAUDE.md canonical sources to reflect the new validator count

</details>

<details><summary>Test plan</summary>

- [x] Run `bash scripts/validate-plugin-structure.sh` — passes with current `plugin.json` (all entries have `title` and `type`)
- [x] Manually tested V24 by removing `title` from `slack_bot_token` — correctly reports error
- [x] Manually tested V25 by removing `type` from `slack_channel_id` — correctly reports error
- [x] Run `/relevant-checks` — all checks pass (shellcheck, markdownlint, plugin structure)

</details>

<details><summary>Final Design</summary>

**Inline quick-mode plan:**
- Add two new validator functions (`validate_userconfig_title`, `validate_userconfig_type`) following the established pattern of V18/V23
- Each validator uses the same guard sequence (file exists, valid JSON, has userConfig, userConfig is object) before iterating keys
- Register both in `main()` after V23
- Update the header comment block with V24 and V25 descriptions
- Update CLAUDE.md validator count from 23 to 25

</details>

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `ff2679a` (Add title and type fields to userConfig in plugin.json (#45))
- **Current version**: `1.1.10`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `1.1.11`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH").

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

Quick mode — no plan review was conducted.

</details>

<details><summary>Implementation Deviations</summary>

No deviations from the plan.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

### [Code Review] General Reviewer
**Finding**: Code duplication in `scripts/validate-plugin-structure.sh` — Validators 18, 23, 24, and 25 each repeat identical preamble lines (file existence check, JSON validity, `has("userConfig")`, type check). Suggested extracting a `_userconfig_ready()` helper function to reduce repetition.
**Reason not implemented**: Per CLAUDE.md conventions: "Three similar lines of code is better than a premature abstraction" and "Don't add features, refactor code, or make 'improvements' beyond what was asked." The new validators follow the established pattern consistently with V18 and V23. Introducing a helper function would be a refactoring change beyond the scope of this task.

### [Code Review] General Reviewer
**Finding**: No test coverage for the new validators (or any existing validators) in `scripts/validate-plugin-structure.sh`. Validators 24 and 25 introduce new mandatory requirements with meaningful failure modes (missing `title`/`type`, empty string, non-string types) but the CI only runs the validator against the actual plugin.json which already has correct values, so the failure branches are never exercised.
**Reason not implemented**: No test framework exists for the validators — this is a pre-existing gap across all 25 validators, not specific to this PR. The validators were manually verified to correctly catch errors (missing `title` and missing `type` fields). Adding a fixture-based test framework is out of scope for this task.

</details>

<details><summary>Plan Review Voting Tally</summary>

Quick mode — no plan review voting.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

Quick mode — no voting panel. Main agent reviewed findings from 2 Claude subagents.

</details>

<details><summary>Out-of-Scope Observations</summary>

Quick mode — no out-of-scope observations collected.

</details>

<details><summary>Execution Issues</summary>

No execution issues encountered.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | N/A (quick mode) |
| Code review rounds | 1 |
| Code review findings | 0 accepted, 2 rejected |
| Warnings logged | 0 |
| Pre-existing issues noticed | 0 |
| External reviewers | N/A (quick mode) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
