### PR TITLE
Add design grilling steps to /design skill

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation with collaborative reviewers (Claude subagents + Codex + Cursor).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.12] - 2026-04-12
+
+### Added
+
+- Two-round design grilling steps in `/design` skill: Step 1d (pre-sketch, scope/requirements interrogation) and Step 3.5 (post-review, covers decisions not addressed in round 1 or deemed suboptimal by reviewers). Both rounds walk the decision tree one question at a time with recommended answers, explore the codebase first, and are skipped in `--auto` mode.
+- New `accepted-plan-findings.md` artifact written during plan review finalization, bridging Step 3 and Step 3.5.
+
+### Changed
+
+- Updated `docs/workflow-lifecycle.md` mermaid diagram to include both grilling nodes in the design phase.
+
 ## [1.1.11] - 2026-04-12
 
 ### Added

--- a/docs/workflow-lifecycle.md
+++ b/docs/workflow-lifecycle.md
@@ -36,13 +36,15 @@ flowchart TD
 
     subgraph DESIGN_PHASE["Design Phase (/design)"]
         BRANCH[Create branch] --> QUESTIONS[Clarifying questions]
-        QUESTIONS --> SKETCHES[5-agent collaborative sketches]
+        QUESTIONS --> GRILL1[Design grilling round 1]
+        GRILL1 --> SKETCHES[5-agent collaborative sketches]
         SKETCHES --> SYNTHESIS[Approach synthesis]
         SYNTHESIS --> DIALECTIC[Dialectic debate on contested decisions]
         DIALECTIC --> PLAN[Write implementation plan]
         PLAN --> PLAN_REVIEW[Plan review: 5 reviewers]
         PLAN_REVIEW --> VOTE1[Voting panel adjudicates findings]
         VOTE1 --> REVISE[Revise plan if needed]
+        REVISE --> GRILL2[Design grilling round 2]
     end
 
     DESIGN_PHASE --> IMPL_PHASE

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -11,7 +11,7 @@ Design an implementation plan for a feature and review it with multiple speciali
 
 **Flags**: Parse flags from the start of `$ARGUMENTS` before treating the remainder as the feature description. Flags may appear in any order; stop at the first non-flag token.
 
-- `--auto`: Set a mental flag `auto_mode=true`. When `auto_mode=true`, all interactive question checkpoints (Steps 1c and 3a) are skipped — the skill runs fully autonomously without user interaction. When `--quick` is set in the caller and `/design` is skipped entirely, `--auto` has no effect.
+- `--auto`: Set a mental flag `auto_mode=true`. When `auto_mode=true`, all interactive question checkpoints (Steps 1c, 1d, 3.5, and 3a) are skipped — the skill runs fully autonomously without user interaction. When `--quick` is set in the caller and `/design` is skipped entirely, `--auto` has no effect.
 - `--session-env <path>`: Set `SESSION_ENV_PATH` to the given path. This file contains already-discovered session values from a caller skill (e.g., `/implement`) and will be forwarded to `session-setup.sh` via `--caller-env`. If not provided, `SESSION_ENV_PATH` is empty (standalone invocation — full discovery).
 
 The feature to design is described by the remainder of `$ARGUMENTS` after flags are stripped.
@@ -29,10 +29,12 @@ Suggested emoji palette (use consistently):
 | 0 | 🔧 | Session setup |
 | 1 | 🔀 | Branch creation |
 | 1c | ❓ | Clarifying questions |
+| 1d | 🔥 | Design grilling (round 1) |
 | 2a | 🤝 | Collaborative sketches |
 | 2a.5 | ⚖️ | Dialectic debate |
 | 2b | 📐 | Full plan design |
 | 3 | 🔍 | Plan review |
+| 3.5 | 🔥 | Design grilling (round 2) |
 | 3a | ✅ | Post-review confirmation |
 | 3b | 🗺️ | Architecture diagram |
 | 4 | 📊 | Rejected findings report |
@@ -103,6 +105,53 @@ Consider asking about:
 After the user responds, incorporate their answers into your understanding of the feature for all subsequent steps.
 
 Print: `✅ Step 1c — Questions resolved.`
+
+## Step 1d — Design Grilling (Round 1)
+
+Print: `🔥 Step 1d — Design grilling (round 1)...`
+
+**If `auto_mode=true`**: Print `⏩ Step 1d — Skipped (auto mode).` and proceed to Step 2a.
+
+**If `auto_mode=false`**: Before launching the expensive collaborative sketch phase, stress-test the feature's scope and requirements by walking through the decision tree one question at a time. This is a deeper, sequential interrogation that resolves dependencies between decisions — each answer may reshape subsequent questions.
+
+### Behavior
+
+The orchestrator identifies key **scope and requirements decisions** from the feature description by exploring the codebase (Read/Grep/Glob). It builds a mental decision tree covering:
+- **Scope boundaries**: What is explicitly in-scope vs. out-of-scope?
+- **Hard constraints**: What must not break? What existing behavior must be preserved?
+- **Non-goals**: What does the user explicitly NOT want?
+- **Must-have requirements**: What is the minimum viable outcome?
+
+Then walk each branch one question at a time via sequential `AskUserQuestion` calls, providing a **recommended answer** for each question. If a question can be answered by exploring the codebase, do so and report the finding instead of asking the user.
+
+**Explicit prohibition**: Do NOT ask about implementation approach, architectural preferences, library choices, or file organization. Those decisions belong to the sketch phase (Step 2a). Round 1 is strictly requirements/scope clarification.
+
+### Short-circuit
+
+If the feature is straightforward with fewer than 2 scope decision branches, print `⏩ Step 1d — No scope decisions require grilling.` and proceed to Step 2a.
+
+### Output
+
+Write resolved decisions to `$DESIGN_TMPDIR/grilling-round1.md` using a simple Q&A format:
+
+```markdown
+### Decision 1: <short title>
+- **Question**: <the question asked>
+- **Resolution**: <the answer — from user or codebase>
+- **Source**: user / codebase
+```
+
+This file captures scope boundaries and hard constraints only — NOT architectural preferences.
+
+### Cap
+
+At most **7 `AskUserQuestion` calls** in this step. If more than 7 decision branches remain after 7 questions, print: `⏩ Remaining scope questions deferred to implementation.` and proceed.
+
+### Terse answers
+
+If the user gives a terse or non-responsive answer (e.g., "I don't know", "your recommendation is fine", "sure"), accept the recommended answer and move on without re-asking.
+
+Print: `✅ Step 1d — Design grilling (round 1) complete. <N> decisions resolved.`
 
 ## Step 2a — Collaborative Approach Sketches
 
@@ -272,6 +321,8 @@ Before writing any code, create a concrete implementation plan. Research the cod
 
 Read `$DESIGN_TMPDIR/approach-synthesis.txt` from Step 2a and incorporate the synthesis into the plan. The synthesis should inform architectural decisions, file selection, and tradeoff resolutions.
 
+Also read `$DESIGN_TMPDIR/grilling-round1.md` if it exists and is non-empty. Incorporate the scope boundaries and hard constraints established during the design grilling into the plan — these define what is in-scope, what must not break, and what the user explicitly does not want.
+
 Also read `$DESIGN_TMPDIR/dialectic-resolutions.md` if it exists and is non-empty. For each resolved decision, the plan **must** follow the resolution direction and explicitly note how the antithesis concern was addressed. These resolutions are binding for Step 2b — do not override them. (Note: Step 3 plan review may subsequently revise the plan based on accepted review findings, which supersede dialectic resolutions.)
 
 Produce a plan that includes:
@@ -379,7 +430,7 @@ Follow the **Monitoring External Reviewers** and **Validating External Reviewer 
 4. Deduplicate in-scope findings separately. Assign each a stable sequential ID (`FINDING_1`, `FINDING_2`, etc.) and note which reviewer(s) proposed each.
 5. Deduplicate out-of-scope observations separately. Assign each an `OOS_` prefixed ID (`OOS_1`, `OOS_2`, etc.). If the same issue appears in both in-scope and OOS from different reviewers, merge under the in-scope finding (in-scope takes precedence).
 
-If **all reviewers** report no in-scope issues and no out-of-scope observations, skip voting and proceed to Step 3b (Architecture Diagram).
+If **all reviewers** report no in-scope issues and no out-of-scope observations, skip voting and proceed to Step 3.5 (Design Grilling Round 2) if `auto_mode=false`, or Step 3a (Post-Review Confirmation) if `auto_mode=true`.
 
 ### Voting Panel (replaces negotiation)
 
@@ -405,10 +456,16 @@ If any in-scope findings or promoted OOS items were **accepted by vote** (2+ YES
 1. Print them under a `## Plan Review Findings (Voted In)` header with vote counts. Include any promoted OOS items (labelled as `[PROMOTED FROM OUT-OF-SCOPE]`).
 2. Revise the implementation plan to address each accepted finding and promoted OOS item.
 3. Print the revised plan under a `## Revised Implementation Plan` header.
+4. Write the accepted findings to `$DESIGN_TMPDIR/accepted-plan-findings.md` so Step 3.5 (Design Grilling Round 2) has a stable artifact to read. Use the format:
+   ```markdown
+   ### FINDING_N: <title>
+   - **Concern**: <what was raised>
+   - **Resolution**: <how the plan was revised>
+   ```
 
 Print any non-promoted OOS items under a `## Out-of-Scope Observations` header for visibility. These are not implemented but are recorded for future attention.
 
-If voting rejects all in-scope findings and no OOS items are promoted, print: `**ℹ Voting panel rejected all findings. Plan unchanged.**` and proceed to Step 3b (Architecture Diagram).
+If voting rejects all in-scope findings and no OOS items are promoted, print: `**ℹ Voting panel rejected all findings. Plan unchanged.**` and proceed to Step 3.5 (Design Grilling Round 2) if `auto_mode=false`, or Step 3a (Post-Review Confirmation) if `auto_mode=true`.
 
 ### Track Rejected Plan Review Findings
 
@@ -422,15 +479,71 @@ For any **in-scope** findings that were **not accepted by vote** (fewer than 2 Y
 
 If no findings were rejected, do not create the file yet.
 
+## Step 3.5 — Design Grilling (Round 2)
+
+Print: `🔥 Step 3.5 — Design grilling (round 2)...`
+
+**If `auto_mode=true`**: Print `⏩ Step 3.5 — Skipped (auto mode).` and proceed to Step 3a.
+
+**If `auto_mode=false`**: After the plan has been reviewed and revised, stress-test the remaining design decisions that were either (a) not covered in Round 1, or (b) deemed suboptimal by reviewers, or (c) introduced by the plan itself (decisions that didn't exist at the feature-description stage).
+
+### Inputs
+
+Read the following artifacts:
+- `$DESIGN_TMPDIR/grilling-round1.md` — If it exists and is non-empty, use it to identify decisions already covered in Round 1 (avoid re-asking). **If it does not exist or is empty** (Round 1 short-circuited or was skipped), treat all candidate decisions as uncovered by Round 1 and proceed normally.
+- `$DESIGN_TMPDIR/accepted-plan-findings.md` — If it exists and is non-empty, use it to identify decisions that reviewers challenged as suboptimal or that required plan revision.
+- `$DESIGN_TMPDIR/contested-decisions.md` — Decisions that sketch agents disagreed on.
+- `$DESIGN_TMPDIR/dialectic-resolutions.md` — How contested decisions were resolved.
+
+Also reference the revised (or original) implementation plan from Step 3's output visible in conversation context above.
+
+### Behavior
+
+Identify decisions in the implementation plan that meet any of these criteria:
+1. **Not covered in Round 1** — decisions that emerged from the plan design, not from the original feature description.
+2. **Challenged by reviewers** — decisions that appear in `accepted-plan-findings.md` (reviewers found them suboptimal and the plan was revised).
+3. **Still contested** — decisions from `contested-decisions.md` where the dialectic resolution was close or the antithesis had strong arguments.
+
+Walk each uncovered branch one question at a time via sequential `AskUserQuestion` calls, providing a **recommended answer** for each question. If a question can be answered by exploring the codebase, do so and report the finding instead of asking the user.
+
+Unlike Round 1, Round 2 MAY ask about architectural decisions and implementation approach — the sketch phase has already provided divergent perspectives, so anchoring is no longer a concern at this stage.
+
+### Short-circuit
+
+If all plan decisions are already covered by Round 1 and no reviewer findings challenged them, print `⏩ Step 3.5 — No additional design decisions require grilling.` and proceed to Step 3a.
+
+### Output
+
+Write resolved decisions to `$DESIGN_TMPDIR/grilling-round2.md` using the same format as Round 1:
+
+```markdown
+### Decision 1: <short title>
+- **Question**: <the question asked>
+- **Resolution**: <the answer — from user or codebase>
+- **Source**: user / codebase
+```
+
+**Auto-revise**: Update the implementation plan in-place based on answers. Print the revised plan only if substantive changes were made.
+
+### Cap
+
+At most **7 `AskUserQuestion` calls** in this step. If more than 7 decision branches remain, print: `⏩ Remaining design questions deferred to implementation.` and proceed.
+
+### Terse answers
+
+If the user gives a terse or non-responsive answer, accept the recommended answer and move on without re-asking.
+
+Print: `✅ Step 3.5 — Design grilling (round 2) complete. <N> decisions resolved.`
+
 ## Step 3a — Post-Review Confirmation
 
 Print: `✅ Step 3a — Post-review confirmation...`
 
 **If `auto_mode=true`**: Print `⏩ Step 3a — Skipped (auto mode).` and proceed to Step 3b.
 
-**If the plan was NOT revised by reviewers** (voting rejected all findings or was skipped): Print `⏩ Step 3a — Skipped (plan unchanged by review).` and proceed to Step 3b.
+**If the plan was NOT revised** (voting rejected all findings or was skipped, AND Step 3.5 grilling made no changes): Print `⏩ Step 3a — Skipped (plan unchanged by review or grilling).` and proceed to Step 3b.
 
-**If `auto_mode=false` AND the plan was revised by reviewers**: Use `AskUserQuestion` to confirm the revised plan addresses the user's original intent. Present a brief summary of what changed and ask the user to approve or reject.
+**If `auto_mode=false` AND the plan was revised** (by reviewers or Step 3.5 grilling): Use `AskUserQuestion` to confirm the revised plan addresses the user's original intent. Present a brief summary of what changed and ask the user to approve or reject.
 
 **This step is strictly approval-only** — the user confirms the revised plan is acceptable to proceed with implementation. No substantive plan changes are accepted at this point — the reviewed/voted plan is the canonical artifact. If the user rejects the plan, print a warning and proceed anyway (the plan has already been reviewed and voted on; the user can adjust during implementation or in a follow-up PR).
 

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -88,7 +88,7 @@ Parse the output for `CURRENT_BRANCH`, `IS_MAIN`, `IS_USER_BRANCH`, and `USER_PR
 
 Print: `❓ Step 1c — Clarifying questions...`
 
-**If `auto_mode=true`**: Print `⏩ Step 1c — Skipped (auto mode).` and proceed to Step 2a.
+**If `auto_mode=true`**: Print `⏩ Step 1c — Skipped (auto mode).` and proceed to Step 1d.
 
 **If `auto_mode=false`**: Before launching the expensive collaborative sketch phase, use `AskUserQuestion` to clarify any ambiguities in the feature description. This is the highest-value question point — answers here reshape what the sketch agents explore.
 
@@ -100,7 +100,7 @@ Consider asking about:
 **Guidelines**:
 - Only ask questions when there is genuine ambiguity — do NOT ask trivially answerable questions or re-confirm what is already clear.
 - Batch questions into a single `AskUserQuestion` call with 1-4 questions rather than multiple sequential calls.
-- If the feature description is clear and unambiguous, print `✅ Step 1c — No clarifying questions needed.` and proceed to Step 2a.
+- If the feature description is clear and unambiguous, print `✅ Step 1c — No clarifying questions needed.` and proceed to Step 1d.
 
 After the user responds, incorporate their answers into your understanding of the feature for all subsequent steps.
 
@@ -510,7 +510,7 @@ Unlike Round 1, Round 2 MAY ask about architectural decisions and implementation
 
 ### Short-circuit
 
-If all plan decisions are already covered by Round 1 and no reviewer findings challenged them, print `⏩ Step 3.5 — No additional design decisions require grilling.` and proceed to Step 3a.
+If all plan decisions are already covered by Round 1, no reviewer findings challenged them, and no decisions from `contested-decisions.md` have a close or inconclusive dialectic resolution, print `⏩ Step 3.5 — No additional design decisions require grilling.` and proceed to Step 3a.
 
 ### Output
 


### PR DESCRIPTION
## Summary
- Added two-round interactive design grilling steps to the `/design` skill, inspired by the `/grill-me` pattern: Step 1d (pre-sketch scope/requirements interrogation) and Step 3.5 (post-review, covering decisions not addressed in round 1 or deemed suboptimal by reviewers).
- Both rounds walk the decision tree one question at a time with recommended answers, explore the codebase first, and are skipped in `--auto` mode.
- Updated lifecycle documentation to reflect the new design phase flow.

<details><summary>Architecture Diagram</summary>

```mermaid
flowchart TD
    subgraph DESIGN["skills/design/SKILL.md — Step Flow"]
        S0[Step 0: Session Setup] --> S1[Step 1: Create Branch]
        S1 --> S1c[Step 1c: Clarifying Questions]
        S1c --> S1d["Step 1d: Design Grilling Round 1<br/>(scope/requirements only)"]
        S1d --> S2a[Step 2a: Collaborative Sketches]
        S2a --> S2a5[Step 2a.5: Dialectic Debate]
        S2a5 --> S2b[Step 2b: Write Implementation Plan]
        S2b --> S3[Step 3: Plan Review + Voting]
        S3 --> S35["Step 3.5: Design Grilling Round 2<br/>(reviewer-challenged decisions)"]
        S35 --> S3a[Step 3a: Post-Review Confirmation]
        S3a --> S3b[Step 3b: Architecture Diagram]
    end

    subgraph ARTIFACTS["Temp Artifacts ($DESIGN_TMPDIR)"]
        GR1[grilling-round1.md]
        APF[accepted-plan-findings.md]
        GR2[grilling-round2.md]
    end

    S1d -->|writes| GR1
    GR1 -->|read by| S2b
    S3 -->|writes| APF
    GR1 -->|read by| S35
    APF -->|read by| S35
    S35 -->|writes| GR2

    style S1d fill:#c44,color:#fff
    style S35 fill:#c44,color:#fff
    style GR1 fill:#555,color:#fff
    style APF fill:#555,color:#fff
    style GR2 fill:#555,color:#fff
```

</details>

<details><summary>Code Flow Diagram</summary>

```mermaid
sequenceDiagram
    participant U as User
    participant O as Orchestrator
    participant CB as Codebase
    participant AQ as AskUserQuestion

    Note over O: Step 1c: Clarifying Questions
    O->>O: Check auto_mode
    alt auto_mode=true
        O->>O: Skip → Step 1d
    else questions needed
        O->>AQ: Batch 1-4 questions
        AQ->>U: Present questions
        U->>AQ: Answers
        AQ->>O: Incorporate answers
    end

    Note over O: Step 1d: Grilling Round 1 (scope only)
    O->>O: Check auto_mode
    alt auto_mode=true
        O->>O: Skip → Step 2a
    else auto_mode=false
        O->>CB: Explore codebase (Read/Grep/Glob)
        CB->>O: Scope decisions identified
        loop Each decision branch (max 7)
            alt Answerable from codebase
                O->>CB: Read relevant files
                CB->>O: Evidence found
                O->>O: Record decision (source: codebase)
            else Needs user input
                O->>AQ: 1 question + recommended answer
                AQ->>U: Present question
                U->>AQ: Answer
                AQ->>O: Record decision (source: user)
            end
        end
        O->>O: Write grilling-round1.md
    end

    Note over O: Steps 2a→2b→3: Sketches, Plan, Review

    Note over O: Step 3.5: Grilling Round 2
    O->>O: Check auto_mode
    alt auto_mode=true
        O->>O: Skip → Step 3a
    else auto_mode=false
        O->>O: Read grilling-round1.md + accepted-plan-findings.md + contested-decisions.md
        O->>O: Identify uncovered/challenged/contested decisions
        loop Each uncovered decision (max 7)
            alt Answerable from codebase
                O->>CB: Read relevant files
                O->>O: Record decision
            else Needs user input
                O->>AQ: 1 question + recommended answer
                AQ->>U: Present question
                U->>AQ: Answer
                O->>O: Record decision
            end
        end
        O->>O: Write grilling-round2.md, auto-revise plan
    end

    Note over O: Step 3a: Post-Review Confirmation
```

</details>

<details><summary>Goal</summary>

- Incorporate the `/grill-me` skill concept into the `/design` skill to enhance and deepen interactive discussion at design stage
  - Add a pre-sketch grilling step (Step 1d) that stress-tests feature scope and requirements before the expensive 5-agent sketch phase
    - Walk the decision tree one question at a time with recommended answers
    - Explore the codebase to self-answer where possible
    - Explicitly prohibit architectural recommendations (to avoid anchoring sketch agents)
    - Write scope boundaries/constraints to `grilling-round1.md`
  - Add a post-review grilling step (Step 3.5) that revisits decisions not covered in round 1 or deemed suboptimal by reviewers
    - Read round 1 artifact + accepted plan findings + contested decisions to avoid re-asking
    - May ask about architectural decisions (sketches have already diverged)
    - Write to `grilling-round2.md` and auto-revise the plan
  - Both rounds skip in `--auto` mode, preserving fully autonomous operation
  - Both rounds short-circuit on simple features with no decision branches
  - Cap at 7 `AskUserQuestion` calls per round

</details>

<details><summary>Test plan</summary>

- [ ] Run `/design` on a non-trivial feature interactively — verify both grilling rounds execute, produce artifacts, and feed forward
- [ ] Run `/design --auto` — verify both rounds are skipped with `⏩ Skipped (auto mode)` messages
- [ ] Run `/design` on a trivial feature — verify both rounds short-circuit
- [ ] Verify the "no issues" fast-path routes to Step 3.5 when `auto_mode=false`
- [ ] Verify Step 1c exits route to Step 1d (not Step 2a)
- [ ] Run `/relevant-checks` — all checks pass

</details>

<details><summary>Final Design</summary>

### Revised Implementation Plan (after plan review)

**Files modified:**
1. `skills/design/SKILL.md` — Primary change: two new step sections, updated metadata and control flow
2. `docs/workflow-lifecycle.md` — Updated mermaid flowchart with grilling nodes

**Approach:**
- Step 1d (Design Grilling Round 1) between 1c and 2a: strictly scope/requirements (no architectural recommendations), writes `grilling-round1.md`
- Step 3.5 (Design Grilling Round 2) between Step 3 and Step 3a (BEFORE approval): reads round 1 artifact + `accepted-plan-findings.md` + contested decisions, writes `grilling-round2.md`
- New `accepted-plan-findings.md` artifact in Step 3 finalization bridges review findings to Round 2
- Updated "no issues" fast-path to route to Step 3.5 instead of Step 3b
- Updated Step 1c exit paths to route to Step 1d (not Step 2a)
- Updated Step 3a skip logic to account for Step 3.5 changes
- Both rounds gated on `auto_mode=false`, capped at 7 questions, with short-circuit on simple features

</details>

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `f6e8e34` (Add validators 24-25: userConfig title and type fields (#46))
- **Current version**: `1.1.11`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `1.1.12`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH").

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

### [Plan Review] Codex-Deep, Codex-General
**Finding**: FINDING_3 — Round 1 only feeds Step 2b, not sketch agents. Suggested making sketch prompts consume Round 1 output or moving Round 1 after sketches.
**Reason not implemented**: Rejected (1 YES, 1 EXONERATE, 1 NO). Round 1 captures scope/constraints that feed into Step 2b while sketches diverge independently. Feeding into sketches could cause anchoring.

### [Plan Review] Codex-Deep
**Finding**: FINDING_5 — Step 1c and Step 1d overlap in responsibilities.
**Reason not implemented**: Rejected (0 YES, 2 EXONERATE, 1 NO). Step 1c is quick batched requirements gathering; Step 1d is structured scope interrogation derived from codebase exploration.

### [Plan Review] Claude-Deep, Claude-General
**Finding**: FINDING_6 — One-at-a-time contradicts Step 1c's batching convention.
**Reason not implemented**: Rejected (1 YES, 1 EXONERATE, 1 NO). Sequential questioning is deliberate for grilling — each answer informs the next question.

### [Plan Review] Claude-Deep, Claude-General
**Finding**: FINDING_8 — Grilling artifact schema undefined.
**Reason not implemented**: Rejected (1 YES, 2 EXONERATE). Artifacts are intermediate working files, loose markdown is adequate.

### [Plan Review] Claude-Deep
**Finding**: FINDING_9 — "Cap at 7" underspecified.
**Reason not implemented**: Rejected (1 YES, 2 EXONERATE). In context, clearly means 7 AskUserQuestion calls.

### [Plan Review] Codex-General, Claude-General (x2)
**Finding**: FINDING_10 — File list too narrow (missing diagram.svg, README).
**Reason not implemented**: Rejected (0 YES, 3 NO). File list covers files actually modified.

### [Plan Review] Claude-Deep, Claude-General
**Finding**: FINDING_11 — --auto flag description fragility (enumerating step numbers).
**Reason not implemented**: Rejected (0 YES, 2 EXONERATE, 1 NO). Pre-existing pattern, documentation concern only.

### [Plan Review] Claude-Deep
**Finding**: FINDING_12 — Round 1 conflates codebase exploration and user interaction.
**Reason not implemented**: Rejected (0 YES, 1 EXONERATE, 2 NO). Interleaving is natural for context-sensitive grilling.

</details>

<details><summary>Implementation Deviations</summary>

No deviations from the revised plan.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

### [Code Review] Cursor, Claude-General, Claude-Deep
**Finding**: FINDING_3 — Lifecycle diagram shows GRILL2 only via REVISE path, but it runs on all non-auto paths.
**Reason not implemented**: Rejected (1 YES, 2 EXONERATE). Diagram is a high-level simplification; fixing edge accuracy is cosmetic.

### [Code Review] Codex-General
**Finding**: FINDING_4 — Lifecycle prose /design description doesn't mention grilling.
**Reason not implemented**: Rejected (0 YES, 2 EXONERATE, 1 NO). One-line summary that also omits other steps.

### [Code Review] Codex-Deep
**Finding**: FINDING_5 — "Update plan in-place" ambiguous.
**Reason not implemented**: Rejected (0 YES, 3 EXONERATE). Sufficiently clear in context.

</details>

<details><summary>Plan Review Voting Tally</summary>

| Finding | Deep Analysis | Cursor Repl. | Codex | Result |
|---------|:---:|:---:|:---:|:---:|
| FINDING_1 (post-3a invariant) | YES | YES | YES | **ACCEPTED** |
| FINDING_2 (accepted-findings artifact) | YES | YES | YES | **ACCEPTED** |
| FINDING_3 (Round 1 feeds sketches) | EXONERATE | NO | YES | Rejected |
| FINDING_4 (anchoring before sketches) | YES | YES | YES | **ACCEPTED** |
| FINDING_5 (1c/1d overlap) | EXONERATE | NO | EXONERATE | Rejected |
| FINDING_6 (one-at-a-time batching) | NO | EXONERATE | YES | Rejected |
| FINDING_7 (missing file guard) | YES | YES | YES | **ACCEPTED** |
| FINDING_8 (schema undefined) | EXONERATE | EXONERATE | YES | Rejected |
| FINDING_9 (cap underspecified) | YES | EXONERATE | EXONERATE | Rejected |
| FINDING_10 (file list narrow) | NO | NO | NO | Rejected |
| FINDING_11 (--auto fragility) | EXONERATE | EXONERATE | NO | Rejected |
| FINDING_12 (conflate exploration) | NO | NO | EXONERATE | Rejected |
| FINDING_13 (fast-path skip) | YES | YES | YES | **ACCEPTED** |

### Reviewer Competition Scoreboard

| Reviewer | Findings | Accepted | Exonerated | Rejected | Score |
|----------|:---:|:---:|:---:|:---:|:---:|
| Codex-Deep | 4 | 3 | 1 | 0 | +3 |
| Codex-General | 5 | 3 | 1 | 1 | +2 |
| Claude-Deep | 7 | 4 | 2 | 1 | +3 |
| Claude-General | 8 | 4 | 2 | 2 | +2 |

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

| Finding | Codex | General | Cursor Repl. | Result |
|---------|:---:|:---:|:---:|:---:|
| FINDING_1 (1c bypasses 1d) | YES | YES | YES | **ACCEPTED** |
| FINDING_2 (3.5 short-circuit incomplete) | YES | YES | YES | **ACCEPTED** |
| FINDING_3 (diagram inaccuracy) | EXONERATE | YES | EXONERATE | Rejected |
| FINDING_4 (prose not updated) | EXONERATE | EXONERATE | NO | Rejected |
| FINDING_5 (in-place ambiguous) | EXONERATE | EXONERATE | EXONERATE | Exonerated |

### Reviewer Competition Scoreboard

| Reviewer | Findings | Accepted | Exonerated | Rejected | Score |
|----------|:---:|:---:|:---:|:---:|:---:|
| Codex-General | 3 | 2 | 1 | 0 | +2 |
| Cursor | 3 | 2 | 1 | 0 | +2 |
| Codex-Deep | 3 | 2 | 1 | 0 | +2 |
| Claude-Deep | 2 | 1 | 1 | 0 | +1 |
| Claude-General | 3 | 2 | 1 | 0 | +2 |

</details>

<details><summary>Out-of-Scope Observations</summary>

### [Code Review] Claude-Deep
- OOS_1: In auto_mode=true, Step 1c routes directly to Step 2a (now Step 1d), causing Step 1d's auto_mode skip message to never print if Step 1c also skips directly. Minor UX inconsistency in progress reporting (pre-existing pattern).

### [Code Review] Claude-General
- OOS_1: docs/workflow-lifecycle.md DESIGN_PHASE diagram omits Step 3a and Step 3b — pre-existing omission that predates this PR.
- OOS_2: Step 3b wording "runs on ALL paths through Step 3" doesn't mention Step 3.5 as new predecessor.

### [Plan Review] Claude-Deep
- OOS_1: README --session-env discrepancy (pre-existing).
- OOS_2: workflow-lifecycle.md mermaid missing Step 1c (pre-existing).

### [Plan Review] Claude-General
- OOS_3: diagram.svg already stale (pre-existing).
- OOS_4: Step 1c batching upper bound (pre-existing UX limitation).

</details>

<details><summary>Execution Issues</summary>

### External Reviewer Issues
- **Step 1 (Design)**: Cursor sketch timed out (exit code 124, empty output). Replaced with Claude Innovation/Exploration subagent.
- **Step 1 (Design)**: Cursor plan review timed out (exit code 124, empty output). Voting proceeded with 3 available voters (Codex + 2 Claude subagents).

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | 5 accepted, 8 rejected |
| Code review rounds | 1 |
| Code review findings | 2 accepted, 3 rejected |
| Warnings logged | 0 |
| Pre-existing issues noticed | 4 |
| External reviewers | Cursor: ❌ (design sketch/plan review timeout) ✅ (code review), Codex: ✅ |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
