### PR TITLE
Add external reviewer health probe and timeout fallback (#49)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation with collaborative reviewers (Claude subagents + Codex + Cursor).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2026-04-12
+
+### Added
+
+- External reviewer health probe: `check-reviewers.sh --probe` sends a trivial prompt to each external reviewer (Codex/Cursor) with a 60-second timeout at session startup, catching outages before wasting time on long review timeouts.
+- Runtime timeout fallback: when an external reviewer times out during any step, it is replaced by a Claude subagent with similar persona for all subsequent invocations in the session.
+- Cross-skill health propagation: reviewer health state flows from `/implement` → `/design` → `/review` via `--session-env` and structured health status files.
+- `--session-env <path>` flag for `/review` skill (MINOR: new flag in `argument-hint`).
+- `--skip-codex-probe` / `--skip-cursor-probe` flags for `check-reviewers.sh` to avoid re-probing tools already known unhealthy.
+
+### Changed
+
+- `write-session-env.sh`: added `--codex-healthy`/`--cursor-healthy` flags, atomic writes via temp+mv, conditional health key emission.
+- `session-setup.sh`: parses and re-emits `CODEX_HEALTHY`/`CURSOR_HEALTHY` from caller-env.
+- `external-reviewers.md`: renamed "Binary Check" to "Binary Check and Health Probe", added "Runtime Timeout Fallback" section.
+
 ## [1.2.0] - 2026-04-12
 
 ### Added

--- a/scripts/check-reviewers.sh
+++ b/scripts/check-reviewers.sh
@@ -1,20 +1,31 @@
 #!/usr/bin/env bash
-# check-reviewers.sh — Check external reviewer binary availability.
+# check-reviewers.sh — Check external reviewer binary availability and optional health probe.
 #
-# Checks if codex and cursor binaries are installed.
-# This is NOT a full auth test — just binary existence.
+# Checks if codex and cursor binaries are installed. With --probe, also sends a
+# trivial prompt to each available tool with a 60-second timeout to verify it is
+# actually responding (catches auth failures, network issues, outages).
 #
 # Usage:
-#   check-reviewers.sh
+#   check-reviewers.sh [--probe]
 #
 # Outputs (key=value to stdout):
-#   CODEX_AVAILABLE=true|false
-#   CURSOR_AVAILABLE=true|false
+#   CODEX_AVAILABLE=true|false    — binary exists on PATH
+#   CURSOR_AVAILABLE=true|false   — binary exists on PATH
+#   CODEX_HEALTHY=true|false      — (only with --probe) responded to trivial prompt within timeout
+#   CURSOR_HEALTHY=true|false     — (only with --probe) responded to trivial prompt within timeout
 #
 # Exit codes:
-#   0 — always
+#   0 — always (availability/health are informational, not errors)
 
+# No -e: exit codes from probe subprocesses are informational, not errors.
 set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+PROBE=false
+if [[ "${1:-}" == "--probe" ]]; then
+    PROBE=true
+fi
 
 CODEX_AVAILABLE="false"
 CURSOR_AVAILABLE="false"
@@ -29,3 +40,78 @@ fi
 
 echo "CODEX_AVAILABLE=$CODEX_AVAILABLE"
 echo "CURSOR_AVAILABLE=$CURSOR_AVAILABLE"
+
+if [[ "$PROBE" == "true" ]]; then
+    CODEX_HEALTHY="false"
+    CURSOR_HEALTHY="false"
+
+    PROBE_DIR=$(mktemp -d /tmp/larch-probe-XXXXXX)
+    # Clean up probe tmpdir on exit
+    trap 'rm -rf "$PROBE_DIR"' EXIT
+
+    # Launch probes in parallel for available tools
+    if [[ "$CODEX_AVAILABLE" == "true" ]]; then
+        "$SCRIPT_DIR/run-external-reviewer.sh" \
+            --tool codex \
+            --output "$PROBE_DIR/codex-probe.txt" \
+            --timeout 60 \
+            -- codex exec --full-auto -C "$PWD" \
+            --output-last-message "$PROBE_DIR/codex-probe.txt" \
+            "Respond with OK" \
+            >"$PROBE_DIR/codex-wrapper.log" 2>&1 &
+    fi
+
+    if [[ "$CURSOR_AVAILABLE" == "true" ]]; then
+        "$SCRIPT_DIR/run-external-reviewer.sh" \
+            --tool cursor \
+            --output "$PROBE_DIR/cursor-probe.txt" \
+            --timeout 60 \
+            --capture-stdout \
+            -- cursor agent -p --force --trust --model gpt-5.4-medium --workspace "$PWD" \
+            "Respond with OK" \
+            >"$PROBE_DIR/cursor-wrapper.log" 2>&1 &
+    fi
+
+    # Build sentinel list for wait-for-reviewers.sh
+    SENTINELS=()
+    if [[ "$CODEX_AVAILABLE" == "true" ]]; then
+        SENTINELS+=("$PROBE_DIR/codex-probe.txt.done")
+    fi
+    if [[ "$CURSOR_AVAILABLE" == "true" ]]; then
+        SENTINELS+=("$PROBE_DIR/cursor-probe.txt.done")
+    fi
+
+    if [[ ${#SENTINELS[@]} -gt 0 ]]; then
+        # Wait for probes (120s = 60s timeout + 60s grace)
+        "$SCRIPT_DIR/wait-for-reviewers.sh" --timeout 120 "${SENTINELS[@]}" \
+            >"$PROBE_DIR/wait.log" 2>&1 || true
+    fi
+
+    # Check codex probe result
+    if [[ "$CODEX_AVAILABLE" == "true" ]]; then
+        if [[ -f "$PROBE_DIR/codex-probe.txt.done" ]]; then
+            CODEX_EXIT=$(cat "$PROBE_DIR/codex-probe.txt.done")
+            if [[ "$CODEX_EXIT" == "0" ]]; then
+                # Verify output is non-empty
+                if [[ -s "$PROBE_DIR/codex-probe.txt" ]]; then
+                    CODEX_HEALTHY="true"
+                fi
+            fi
+        fi
+    fi
+
+    # Check cursor probe result
+    if [[ "$CURSOR_AVAILABLE" == "true" ]]; then
+        if [[ -f "$PROBE_DIR/cursor-probe.txt.done" ]]; then
+            CURSOR_EXIT=$(cat "$PROBE_DIR/cursor-probe.txt.done")
+            if [[ "$CURSOR_EXIT" == "0" ]]; then
+                if [[ -s "$PROBE_DIR/cursor-probe.txt" ]]; then
+                    CURSOR_HEALTHY="true"
+                fi
+            fi
+        fi
+    fi
+
+    echo "CODEX_HEALTHY=$CODEX_HEALTHY"
+    echo "CURSOR_HEALTHY=$CURSOR_HEALTHY"
+fi

--- a/scripts/check-reviewers.sh
+++ b/scripts/check-reviewers.sh
@@ -6,7 +6,7 @@
 # actually responding (catches auth failures, network issues, outages).
 #
 # Usage:
-#   check-reviewers.sh [--probe]
+#   check-reviewers.sh [--probe] [--skip-codex-probe] [--skip-cursor-probe]
 #
 # Outputs (key=value to stdout):
 #   CODEX_AVAILABLE=true|false    — binary exists on PATH
@@ -23,9 +23,17 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 PROBE=false
-if [[ "${1:-}" == "--probe" ]]; then
-    PROBE=true
-fi
+SKIP_CODEX_PROBE=false
+SKIP_CURSOR_PROBE=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --probe)              PROBE=true; shift ;;
+        --skip-codex-probe)   SKIP_CODEX_PROBE=true; shift ;;
+        --skip-cursor-probe)  SKIP_CURSOR_PROBE=true; shift ;;
+        *) echo "check-reviewers.sh: unknown argument: $1" >&2; exit 1 ;;
+    esac
+done
 
 CODEX_AVAILABLE="false"
 CURSOR_AVAILABLE="false"
@@ -49,8 +57,10 @@ if [[ "$PROBE" == "true" ]]; then
     # Clean up probe tmpdir on exit
     trap 'rm -rf "$PROBE_DIR"' EXIT
 
-    # Launch probes in parallel for available tools
-    if [[ "$CODEX_AVAILABLE" == "true" ]]; then
+    # Launch probes in parallel for available tools (skip already-known-unhealthy)
+    if [[ "$CODEX_AVAILABLE" == "true" && "$SKIP_CODEX_PROBE" == "true" ]]; then
+        CODEX_HEALTHY="false"
+    elif [[ "$CODEX_AVAILABLE" == "true" ]]; then
         "$SCRIPT_DIR/run-external-reviewer.sh" \
             --tool codex \
             --output "$PROBE_DIR/codex-probe.txt" \
@@ -61,7 +71,9 @@ if [[ "$PROBE" == "true" ]]; then
             >"$PROBE_DIR/codex-wrapper.log" 2>&1 &
     fi
 
-    if [[ "$CURSOR_AVAILABLE" == "true" ]]; then
+    if [[ "$CURSOR_AVAILABLE" == "true" && "$SKIP_CURSOR_PROBE" == "true" ]]; then
+        CURSOR_HEALTHY="false"
+    elif [[ "$CURSOR_AVAILABLE" == "true" ]]; then
         "$SCRIPT_DIR/run-external-reviewer.sh" \
             --tool cursor \
             --output "$PROBE_DIR/cursor-probe.txt" \
@@ -72,12 +84,12 @@ if [[ "$PROBE" == "true" ]]; then
             >"$PROBE_DIR/cursor-wrapper.log" 2>&1 &
     fi
 
-    # Build sentinel list for wait-for-reviewers.sh
+    # Build sentinel list for wait-for-reviewers.sh (only for probes actually launched)
     SENTINELS=()
-    if [[ "$CODEX_AVAILABLE" == "true" ]]; then
+    if [[ "$CODEX_AVAILABLE" == "true" && "$SKIP_CODEX_PROBE" == "false" ]]; then
         SENTINELS+=("$PROBE_DIR/codex-probe.txt.done")
     fi
-    if [[ "$CURSOR_AVAILABLE" == "true" ]]; then
+    if [[ "$CURSOR_AVAILABLE" == "true" && "$SKIP_CURSOR_PROBE" == "false" ]]; then
         SENTINELS+=("$PROBE_DIR/cursor-probe.txt.done")
     fi
 
@@ -87,8 +99,8 @@ if [[ "$PROBE" == "true" ]]; then
             >"$PROBE_DIR/wait.log" 2>&1 || true
     fi
 
-    # Check codex probe result
-    if [[ "$CODEX_AVAILABLE" == "true" ]]; then
+    # Check codex probe result (skip if probe was not launched)
+    if [[ "$CODEX_AVAILABLE" == "true" && "$SKIP_CODEX_PROBE" == "false" ]]; then
         if [[ -f "$PROBE_DIR/codex-probe.txt.done" ]]; then
             CODEX_EXIT=$(cat "$PROBE_DIR/codex-probe.txt.done")
             if [[ "$CODEX_EXIT" == "0" ]]; then
@@ -100,8 +112,8 @@ if [[ "$PROBE" == "true" ]]; then
         fi
     fi
 
-    # Check cursor probe result
-    if [[ "$CURSOR_AVAILABLE" == "true" ]]; then
+    # Check cursor probe result (skip if probe was not launched)
+    if [[ "$CURSOR_AVAILABLE" == "true" && "$SKIP_CURSOR_PROBE" == "false" ]]; then
         if [[ -f "$PROBE_DIR/cursor-probe.txt.done" ]]; then
             CURSOR_EXIT=$(cat "$PROBE_DIR/cursor-probe.txt.done")
             if [[ "$CURSOR_EXIT" == "0" ]]; then
@@ -112,6 +124,13 @@ if [[ "$PROBE" == "true" ]]; then
         fi
     fi
 
-    echo "CODEX_HEALTHY=$CODEX_HEALTHY"
-    echo "CURSOR_HEALTHY=$CURSOR_HEALTHY"
+    # Only emit health keys for tools that are installed — absent binaries
+    # are already handled by *_AVAILABLE=false and should not propagate a
+    # misleading *_HEALTHY=false into session-env.
+    if [[ "$CODEX_AVAILABLE" == "true" ]]; then
+        echo "CODEX_HEALTHY=$CODEX_HEALTHY"
+    fi
+    if [[ "$CURSOR_AVAILABLE" == "true" ]]; then
+        echo "CURSOR_HEALTHY=$CURSOR_HEALTHY"
+    fi
 fi

--- a/scripts/session-setup.sh
+++ b/scripts/session-setup.sh
@@ -14,7 +14,8 @@
 #   --skip-slack-check    Skip LARCH_SLACK_BOT_TOKEN and LARCH_SLACK_CHANNEL_ID check entirely
 #   --skip-repo-check     Skip repo name derivation entirely
 #   --caller-env <path>   Path to KEY=value file with already-discovered values.
-#                          Recognized keys: SLACK_OK, SLACK_MISSING, REPO, REPO_UNAVAILABLE.
+#                          Recognized keys: SLACK_OK, SLACK_MISSING, REPO, REPO_UNAVAILABLE,
+#                          CODEX_HEALTHY, CURSOR_HEALTHY.
 #                          If a key is present and non-empty, the script skips re-deriving it.
 #                          SESSION_TMPDIR is never inherited — a fresh tmpdir is always created.
 #                          If the file does not exist or is empty, full discovery happens.
@@ -25,6 +26,8 @@
 #   SLACK_MISSING=<csv>         Output when SLACK_OK=false (comma-separated missing var names)
 #   REPO=<owner/repo>           Output unless --skip-repo-check
 #   REPO_UNAVAILABLE=true|false Output unless --skip-repo-check
+#   CODEX_HEALTHY=<value>       Output if present in --caller-env (passthrough only)
+#   CURSOR_HEALTHY=<value>      Output if present in --caller-env (passthrough only)
 #
 # On preflight failure, outputs PREFLIGHT_ERROR=<message> and exits non-zero.
 #
@@ -74,6 +77,8 @@ CALLER_SLACK_OK=""
 CALLER_SLACK_MISSING=""
 CALLER_REPO=""
 CALLER_REPO_UNAVAILABLE=""
+CALLER_CODEX_HEALTHY=""
+CALLER_CURSOR_HEALTHY=""
 
 if [[ -n "$CALLER_ENV" && -f "$CALLER_ENV" ]]; then
     while IFS='=' read -r key value || [[ -n "$key" ]]; do
@@ -84,6 +89,8 @@ if [[ -n "$CALLER_ENV" && -f "$CALLER_ENV" ]]; then
             SLACK_MISSING)     CALLER_SLACK_MISSING="$value" ;;
             REPO)              CALLER_REPO="$value" ;;
             REPO_UNAVAILABLE)  CALLER_REPO_UNAVAILABLE="$value" ;;
+            CODEX_HEALTHY)     CALLER_CODEX_HEALTHY="$value" ;;
+            CURSOR_HEALTHY)    CALLER_CURSOR_HEALTHY="$value" ;;
             *)                 ;; # Ignore unknown keys
         esac
     done < "$CALLER_ENV"
@@ -190,4 +197,12 @@ if [[ "$SKIP_REPO_CHECK" == "false" ]]; then
         echo "REPO=$REPO"
         echo "REPO_UNAVAILABLE=$REPO_UNAVAILABLE"
     fi
+fi
+
+# --- 5. Re-emit reviewer health keys (passthrough from caller-env) ---
+if [[ -n "$CALLER_CODEX_HEALTHY" ]]; then
+    echo "CODEX_HEALTHY=$CALLER_CODEX_HEALTHY"
+fi
+if [[ -n "$CALLER_CURSOR_HEALTHY" ]]; then
+    echo "CURSOR_HEALTHY=$CALLER_CURSOR_HEALTHY"
 fi

--- a/scripts/write-session-env.sh
+++ b/scripts/write-session-env.sh
@@ -4,13 +4,15 @@
 # Usage:
 #   write-session-env.sh --output <path> --slack-ok <true|false> \
 #                        [--slack-missing <csv>] --repo <owner/repo> \
-#                        --repo-unavailable <true|false>
+#                        --repo-unavailable <true|false> \
+#                        [--codex-healthy <true|false>] [--cursor-healthy <true|false>]
 #
 # Options:
 #   --repo may be empty when --repo-unavailable is true (repo discovery failed).
 #   --slack-missing is optional (only meaningful when --slack-ok is false).
+#   --codex-healthy/--cursor-healthy are optional (reviewer health state from probe).
 #
-# Output: Writes a shell-sourceable file to --output path.
+# Output: Writes a shell-sourceable file to --output path (atomic via temp+mv).
 # Exit codes: 0 success, 1 invalid args
 
 set -euo pipefail
@@ -20,14 +22,18 @@ SLACK_OK=""
 SLACK_MISSING=""
 REPO=""
 REPO_UNAVAILABLE=""
+CODEX_HEALTHY=""
+CURSOR_HEALTHY=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --output)       OUTPUT="$2"; shift 2 ;;
-    --slack-ok)     SLACK_OK="$2"; shift 2 ;;
-    --slack-missing) SLACK_MISSING="$2"; shift 2 ;;
-    --repo)         REPO="$2"; shift 2 ;;
+    --output)           OUTPUT="$2"; shift 2 ;;
+    --slack-ok)         SLACK_OK="$2"; shift 2 ;;
+    --slack-missing)    SLACK_MISSING="$2"; shift 2 ;;
+    --repo)             REPO="$2"; shift 2 ;;
     --repo-unavailable) REPO_UNAVAILABLE="$2"; shift 2 ;;
+    --codex-healthy)    CODEX_HEALTHY="$2"; shift 2 ;;
+    --cursor-healthy)   CURSOR_HEALTHY="$2"; shift 2 ;;
     *) echo "ERROR=Unknown argument: $1" >&2; exit 1 ;;
   esac
 done
@@ -37,9 +43,14 @@ if [[ -z "$OUTPUT" || -z "$SLACK_OK" || -z "$REPO_UNAVAILABLE" ]]; then
   exit 1
 fi
 
-cat > "$OUTPUT" << ENVEOF
+# Atomic write: write to temp file first, then mv into place
+TMPFILE=$(mktemp "${OUTPUT}.tmp.XXXXXX")
+cat > "$TMPFILE" << ENVEOF
 SLACK_OK=$SLACK_OK
 SLACK_MISSING=$SLACK_MISSING
 REPO=$REPO
 REPO_UNAVAILABLE=$REPO_UNAVAILABLE
+CODEX_HEALTHY=$CODEX_HEALTHY
+CURSOR_HEALTHY=$CURSOR_HEALTHY
 ENVEOF
+mv "$TMPFILE" "$OUTPUT"

--- a/scripts/write-session-env.sh
+++ b/scripts/write-session-env.sh
@@ -45,12 +45,13 @@ fi
 
 # Atomic write: write to temp file first, then mv into place
 TMPFILE=$(mktemp "${OUTPUT}.tmp.XXXXXX")
-cat > "$TMPFILE" << ENVEOF
-SLACK_OK=$SLACK_OK
-SLACK_MISSING=$SLACK_MISSING
-REPO=$REPO
-REPO_UNAVAILABLE=$REPO_UNAVAILABLE
-CODEX_HEALTHY=$CODEX_HEALTHY
-CURSOR_HEALTHY=$CURSOR_HEALTHY
-ENVEOF
+{
+  echo "SLACK_OK=$SLACK_OK"
+  echo "SLACK_MISSING=$SLACK_MISSING"
+  echo "REPO=$REPO"
+  echo "REPO_UNAVAILABLE=$REPO_UNAVAILABLE"
+  # Only write health keys when values are non-empty (omit = absent/unknown)
+  [[ -n "$CODEX_HEALTHY" ]] && echo "CODEX_HEALTHY=$CODEX_HEALTHY"
+  [[ -n "$CURSOR_HEALTHY" ]] && echo "CURSOR_HEALTHY=$CURSOR_HEALTHY"
+} > "$TMPFILE"
 mv "$TMPFILE" "$OUTPUT"

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -77,11 +77,22 @@ Only include `--caller-env "$SESSION_ENV_PATH"` if `SESSION_ENV_PATH` is non-emp
 
 If the script exits non-zero, print the `PREFLIGHT_ERROR` from its output and abort.
 
-Parse the output for `SESSION_TMPDIR`. Set `DESIGN_TMPDIR` = `SESSION_TMPDIR`. Substitute the actual path in every command below.
+Parse the output for `SESSION_TMPDIR`, and also `CODEX_HEALTHY`, `CURSOR_HEALTHY` if present (passed through from caller-env). Set `DESIGN_TMPDIR` = `SESSION_TMPDIR`. Substitute the actual path in every command below.
 
 ### 0b — Quick External Reviewer Check
 
-Read and follow the **Binary Check** section in `${CLAUDE_PLUGIN_ROOT}/skills/shared/external-reviewers.md`.
+Read and follow the **Binary Check and Health Probe** section in `${CLAUDE_PLUGIN_ROOT}/skills/shared/external-reviewers.md`. If `session-setup.sh` output included `CODEX_HEALTHY=false` or `CURSOR_HEALTHY=false` (inherited from caller), honor those values per the session-env override procedure in that section.
+
+### 0b.1 — Write Health Status File (if session-env provided)
+
+If `SESSION_ENV_PATH` is non-empty, write the initial reviewer health state to `${SESSION_ENV_PATH}.health` so the calling skill (e.g., `/implement`) can read it after `/design` returns:
+
+```
+CODEX_HEALTHY=<true|false>
+CURSOR_HEALTHY=<true|false>
+```
+
+This file reflects both inherited health state and the probe result. It will be updated again before cleanup if any runtime timeout fallbacks occur during this skill's execution.
 
 ## Step 1 — Create Branch
 
@@ -605,6 +616,12 @@ Print any rejected plan review findings:
 3. If the file doesn't exist or is empty, print: `📊 Step 4 — All plan review suggestions were implemented.`
 
 ## Step 5 — Cleanup and Final Warnings
+
+### 5a — Update Health Status File
+
+If `SESSION_ENV_PATH` is non-empty and any reviewer was marked unhealthy during this session (via the Runtime Timeout Fallback procedure in `external-reviewers.md`), re-write the health status file at `${SESSION_ENV_PATH}.health` with the final health state before cleanup. This ensures the calling skill sees any runtime timeouts that occurred during this skill's execution, not just the initial state.
+
+### 5b — Remove Temp Directory
 
 Remove the session temp directory and all files within it:
 

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -91,13 +91,16 @@ Parse the output for `SESSION_TMPDIR`, `SLACK_OK`, `SLACK_MISSING`, `REPO`, `REP
 
 ### Health Probe
 
-Run the reviewer health probe to determine initial external reviewer availability:
+Run the reviewer health probe to determine initial external reviewer availability. If `SESSION_ENV_PATH` is non-empty, first parse the `session-setup.sh` output for `CODEX_HEALTHY` and `CURSOR_HEALTHY` (passed through from caller-env). If either is `false`, pass the corresponding `--skip-codex-probe` or `--skip-cursor-probe` flag to avoid re-probing a tool already known to be unhealthy:
 
 ```bash
-${CLAUDE_PLUGIN_ROOT}/scripts/check-reviewers.sh --probe
+${CLAUDE_PLUGIN_ROOT}/scripts/check-reviewers.sh --probe [--skip-codex-probe] [--skip-cursor-probe]
 ```
 
-Parse the output for `CODEX_AVAILABLE`, `CURSOR_AVAILABLE`, `CODEX_HEALTHY`, `CURSOR_HEALTHY`. If `CODEX_HEALTHY=false`, print: `**⚠ Codex installed but not responding (health check failed). Using Claude replacement.**` If `CURSOR_HEALTHY=false`, print: `**⚠ Cursor installed but not responding (health check failed). Using Claude replacement.**` If a binary is not found (`*_AVAILABLE=false`), print the standard binary-not-found warning.
+Parse the output for `CODEX_AVAILABLE`, `CURSOR_AVAILABLE`, `CODEX_HEALTHY`, `CURSOR_HEALTHY`. Use the same precedence as `external-reviewers.md`:
+- If `CODEX_AVAILABLE=false`: print `**⚠ Codex not available (binary not found). Proceeding without Codex reviewer.**`
+- Else if `CODEX_HEALTHY=false`: print `**⚠ Codex installed but not responding (health check failed). Using Claude replacement.**`
+- Same for Cursor. Only check `*_HEALTHY` when `*_AVAILABLE=true`.
 
 ### Write Session Env for Child Skills
 
@@ -113,7 +116,12 @@ This file will be passed to `/design` via `--session-env` in Step 1, and to `/re
 
 ### Cross-Skill Health Propagation
 
-After each child skill returns (`/design` in Step 1, `/review` in Step 5), check for a health status file at `$IMPLEMENT_TMPDIR/session-env.sh.health`. If it exists, read `CODEX_HEALTHY` and `CURSOR_HEALTHY` from it. If either value changed to `false` (a reviewer timed out during the child skill), re-write `$IMPLEMENT_TMPDIR/session-env.sh` with updated health flags using `write-session-env.sh` before invoking the next child skill. This ensures runtime timeouts propagate across skill boundaries within the `/implement` flow.
+After each child skill returns (`/design` in Step 1, `/review` in Step 5), check for a health status file at `$IMPLEMENT_TMPDIR/session-env.sh.health`. If it exists, read `CODEX_HEALTHY` and `CURSOR_HEALTHY` from it. If either value changed to `false` (a reviewer timed out during the child skill):
+
+1. Read the current values from `$IMPLEMENT_TMPDIR/session-env.sh` (parse `SLACK_OK`, `SLACK_MISSING`, `REPO`, `REPO_UNAVAILABLE` line-by-line, same safe parsing as `session-setup.sh` — do NOT source the file)
+2. Re-write the file using `write-session-env.sh` with those preserved values plus the updated health flags
+
+This ensures runtime timeouts propagate across skill boundaries within the `/implement` flow without clobbering existing Slack/repo state.
 
 ## Execution Issues Tracking
 

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -89,16 +89,31 @@ Parse the output for `SESSION_TMPDIR`, `SLACK_OK`, `SLACK_MISSING`, `REPO`, `REP
 - If `SLACK_OK=false`, print: `**⚠ Slack is not fully configured (<SLACK_MISSING> not set). Slack announcement (Step 11) and :merged: emoji (Step 13) will be skipped.**` Set a mental flag `slack_available=false`.
 - If `REPO_UNAVAILABLE=true`, print `**⚠ Could not determine repository name. CI monitoring (Steps 10, 12) and merge (Step 12b) will be skipped.**` Set a mental flag `repo_unavailable=true`.
 
+### Health Probe
+
+Run the reviewer health probe to determine initial external reviewer availability:
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/scripts/check-reviewers.sh --probe
+```
+
+Parse the output for `CODEX_AVAILABLE`, `CURSOR_AVAILABLE`, `CODEX_HEALTHY`, `CURSOR_HEALTHY`. If `CODEX_HEALTHY=false`, print: `**⚠ Codex installed but not responding (health check failed). Using Claude replacement.**` If `CURSOR_HEALTHY=false`, print: `**⚠ Cursor installed but not responding (health check failed). Using Claude replacement.**` If a binary is not found (`*_AVAILABLE=false`), print the standard binary-not-found warning.
+
 ### Write Session Env for Child Skills
 
-Write the discovered values to `$IMPLEMENT_TMPDIR/session-env.sh` so they can be forwarded to `/design`:
+Write the discovered values to `$IMPLEMENT_TMPDIR/session-env.sh` so they can be forwarded to child skills (`/design`, `/review`):
 
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/scripts/write-session-env.sh --output "$IMPLEMENT_TMPDIR/session-env.sh" \
-  --slack-ok <value> --slack-missing <value> --repo <value> --repo-unavailable <value>
+  --slack-ok <value> --slack-missing <value> --repo <value> --repo-unavailable <value> \
+  --codex-healthy <value> --cursor-healthy <value>
 ```
 
-This file will be passed to `/design` via `--session-env` in Step 1.
+This file will be passed to `/design` via `--session-env` in Step 1, and to `/review` via `--session-env` in Step 5.
+
+### Cross-Skill Health Propagation
+
+After each child skill returns (`/design` in Step 1, `/review` in Step 5), check for a health status file at `$IMPLEMENT_TMPDIR/session-env.sh.health`. If it exists, read `CODEX_HEALTHY` and `CURSOR_HEALTHY` from it. If either value changed to `false` (a reviewer timed out during the child skill), re-write `$IMPLEMENT_TMPDIR/session-env.sh` with updated health flags using `write-session-env.sh` before invoking the next child skill. This ensures runtime timeouts propagate across skill boundaries within the `/implement` flow.
 
 ## Execution Issues Tracking
 
@@ -175,6 +190,10 @@ Proceed to Step 2.
 - If `IS_USER_BRANCH=true` **AND** a reviewed implementation plan is visible in the conversation context above: The plan was created by a prior `/design` invocation in this session. Proceed to Step 2.
 - If `IS_USER_BRANCH=true` but **no** implementation plan is visible in the conversation context: Invoke the `/design` skill with `--session-env $IMPLEMENT_TMPDIR/session-env.sh` prepended to the feature description to create a plan on the current branch. **If `auto_mode=true`, also prepend `--auto`**. **If `debug_mode=true`, also prepend `--debug`**. Canonical invocation order: `[--debug] [--auto] --session-env $IMPLEMENT_TMPDIR/session-env.sh <FEATURE_DESCRIPTION>`. After `/design` completes, proceed to Step 2.
 - If on `main` or empty (detached HEAD) or any non-user branch: No design plan exists yet. Invoke the `/design` skill with `--session-env $IMPLEMENT_TMPDIR/session-env.sh` prepended to the feature description to create a branch and design the plan. **If `auto_mode=true`, also prepend `--auto`**. **If `debug_mode=true`, also prepend `--debug`**. Canonical invocation order: `[--debug] [--auto] --session-env $IMPLEMENT_TMPDIR/session-env.sh <FEATURE_DESCRIPTION>`. After `/design` completes, proceed to Step 2.
+
+### Cross-Skill Health Update (after /design)
+
+After `/design` returns (in normal mode), follow the **Cross-Skill Health Propagation** procedure from Step 0: read `$IMPLEMENT_TMPDIR/session-env.sh.health` if it exists, and re-write `$IMPLEMENT_TMPDIR/session-env.sh` with updated health flags if any reviewer timed out during `/design`.
 
 ### Capture branch name (`BRANCH_NAME`)
 
@@ -268,7 +287,9 @@ Print: `🔍 Step 5 — Quick mode: simplified review (2 Claude subagents, 1 rou
 
 **IMPORTANT: Code review must ALWAYS be invoked via `/review`. Never skip this step regardless of the nature of the changes — whether code, skills, documentation, data files, or configuration. All changes require full review.**
 
-Invoke the `/review` skill. **If `debug_mode=true`, invoke `/review --debug`.** Otherwise, invoke `/review` with no arguments. This launches 2 parallel Claude subagent reviewers (general, deep-analysis) plus two Codex and Cursor reviewers (if available), implements their suggestions recursively until clean.
+Invoke the `/review` skill with `--session-env $IMPLEMENT_TMPDIR/session-env.sh` to forward reviewer health state. **If `debug_mode=true`, invoke `/review --debug --session-env $IMPLEMENT_TMPDIR/session-env.sh`.** Otherwise, invoke `/review --session-env $IMPLEMENT_TMPDIR/session-env.sh`. This launches 2 parallel Claude subagent reviewers (general, deep-analysis) plus two Codex and Cursor reviewers (if available and healthy), implements their suggestions recursively until clean.
+
+After `/review` returns, follow the **Cross-Skill Health Propagation** procedure from Step 0 to read the health status file and update `session-env.sh` if any reviewer timed out during the review.
 
 ### Track Rejected Code Review Findings
 
@@ -855,7 +876,7 @@ For each file in `CONFLICT_FILES`:
 
 **3a. Create temp directory**: Create `$IMPLEMENT_TMPDIR/conflict-review/` for reviewer artifacts. If it already exists (from a prior conflict resolution in this rebase loop), remove it and recreate.
 
-**3b. Check external reviewer availability**: Run `${CLAUDE_PLUGIN_ROOT}/scripts/check-reviewers.sh` to set `codex_available` and `cursor_available` flags. Follow the Binary Check procedure in `${CLAUDE_PLUGIN_ROOT}/skills/shared/external-reviewers.md`.
+**3b. Check external reviewer availability**: Follow the **Binary Check and Health Probe** procedure in `${CLAUDE_PLUGIN_ROOT}/skills/shared/external-reviewers.md`. Honor any `CODEX_HEALTHY=false` / `CURSOR_HEALTHY=false` state from the session-env (reviewers already known to be unhealthy should not be re-probed or used).
 
 **3c. Prepare review context**: For each non-trivial conflicted file, prepare a per-file conflict context block:
 ```

--- a/skills/loop-review/SKILL.md
+++ b/skills/loop-review/SKILL.md
@@ -74,7 +74,7 @@ ${CLAUDE_PLUGIN_ROOT}/skills/loop-review/scripts/init-session-files.sh --dir "$L
 
 ### 0c — Quick External Reviewer Check
 
-Read and follow the **Binary Check** section in `${CLAUDE_PLUGIN_ROOT}/skills/shared/external-reviewers.md`.
+Read and follow the **Binary Check and Health Probe** section in `${CLAUDE_PLUGIN_ROOT}/skills/shared/external-reviewers.md`.
 
 Set `codex_available` and `cursor_available` flags for the entire session. If either is unavailable, append the warning to `$LR_TMPDIR/warnings.md`.
 

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -69,7 +69,7 @@ Parse the output for `SESSION_TMPDIR`. Set `RESEARCH_TMPDIR` = `SESSION_TMPDIR`.
 
 ### 0b — Quick External Reviewer Check
 
-Read and follow the **Binary Check** section in `${CLAUDE_PLUGIN_ROOT}/skills/shared/external-reviewers.md`.
+Read and follow the **Binary Check and Health Probe** section in `${CLAUDE_PLUGIN_ROOT}/skills/shared/external-reviewers.md`.
 
 ### 0c — Record Research Context
 

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: review
 description: Code review current branch changes with specialized subagents
-argument-hint: "[--debug]"
+argument-hint: "[--debug] [--session-env <path>]"
 allowed-tools: Bash, Read, Edit, Write, Grep, Glob, Agent, Task, WebFetch, Skill
 ---
 
@@ -12,6 +12,7 @@ Review all changes on the current branch (vs `main`) using two specialized Claud
 **Flags**: Parse flags from `$ARGUMENTS`. Flags may appear in any order; stop at the first non-flag token. After stripping all flags, the remainder (if any) is unused — `/review` takes no positional arguments.
 
 - `--debug`: Set a mental flag `debug_mode=true`. Controls output verbosity — see Verbosity Control below. Default: `debug_mode=false`.
+- `--session-env <path>`: Set `SESSION_ENV_PATH` to the given path. This file contains already-discovered session values from a caller skill (e.g., `/implement`) including reviewer health state (`CODEX_HEALTHY`, `CURSOR_HEALTHY`). If not provided, `SESSION_ENV_PATH` is empty (standalone invocation — full health probe at Step 0b).
 
 ## Progress Reporting
 
@@ -82,9 +83,24 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/create-session-tmpdir.sh --prefix claude-review
 
 Parse the output for `SESSION_TMPDIR`. Set `REVIEW_TMPDIR` = `SESSION_TMPDIR`. Substitute the actual path in every command below.
 
+### 0a.1 — Read Session Env (if provided)
+
+If `SESSION_ENV_PATH` is non-empty, read the file and parse `CODEX_HEALTHY` and `CURSOR_HEALTHY` keys (line-by-line, same safe parsing as `session-setup.sh` — do NOT source the file). Save these values for use in Step 0b. If the file does not exist or keys are absent, treat health as unknown (will be probed in Step 0b).
+
 ### 0b — Quick External Reviewer Check
 
-Read and follow the **Binary Check** section in `${CLAUDE_PLUGIN_ROOT}/skills/shared/external-reviewers.md`.
+Read and follow the **Binary Check and Health Probe** section in `${CLAUDE_PLUGIN_ROOT}/skills/shared/external-reviewers.md`. If `SESSION_ENV_PATH` provided `CODEX_HEALTHY=false` or `CURSOR_HEALTHY=false`, honor those values per the session-env override procedure in that section.
+
+### 0b.1 — Write Health Status File (if session-env provided)
+
+If `SESSION_ENV_PATH` is non-empty, write the final reviewer health state to `${SESSION_ENV_PATH}.health` so the calling skill (e.g., `/implement`) can read it after `/review` returns:
+
+```
+CODEX_HEALTHY=<true|false>
+CURSOR_HEALTHY=<true|false>
+```
+
+This file reflects both inherited health state and any runtime timeout fallbacks that occurred during this skill's execution. The calling skill reads this file to update its session-env before invoking the next child skill.
 
 ## Step 1 — Gather Context
 
@@ -276,6 +292,12 @@ Print a final summary:
 - **External reviewer warnings** (repeat any preflight or runtime warnings from Codex/Cursor here so they are visible at the end)
 
 ## Step 5 — Cleanup
+
+### 5a — Update Health Status File
+
+If `SESSION_ENV_PATH` is non-empty and any reviewer was marked unhealthy during this session (via the Runtime Timeout Fallback procedure in `external-reviewers.md`), re-write the health status file at `${SESSION_ENV_PATH}.health` with the final health state before cleanup. This ensures the calling skill sees any runtime timeouts that occurred during this skill's execution, not just the initial state.
+
+### 5b — Remove Temp Directory
 
 Remove the session temp directory and all files within it:
 

--- a/skills/shared/external-reviewers.md
+++ b/skills/shared/external-reviewers.md
@@ -2,21 +2,40 @@
 
 Shared mechanical procedures for running Codex and Cursor as external reviewers. Each skill provides its own reviewer invocation commands (prompts, output paths, tmpdir variables) — this file covers the common scaffolding.
 
-## Binary Check (Step 0b)
+## Binary Check and Health Probe (Step 0b)
 
-Run the shared `check-reviewers.sh` script to check for Codex and Cursor binaries:
+Run the shared `check-reviewers.sh` script with `--probe` to check for binaries **and** verify each tool is actually responding:
 
 ```bash
-${CLAUDE_PLUGIN_ROOT}/scripts/check-reviewers.sh
+${CLAUDE_PLUGIN_ROOT}/scripts/check-reviewers.sh --probe
 ```
 
-Parse the output for `CODEX_AVAILABLE` and `CURSOR_AVAILABLE`.
+Parse the output for `CODEX_AVAILABLE`, `CURSOR_AVAILABLE`, `CODEX_HEALTHY`, `CURSOR_HEALTHY`.
 
-Set mental flags `codex_available` and `cursor_available` from the script output. For each that is `false`, print a **bold** warning:
-- `**⚠ Codex not available (binary not found). Proceeding without Codex reviewer.**`
-- `**⚠ Cursor not available (binary not found). Proceeding without Cursor reviewer.**`
+**Session-env override**: If session-env (from `--caller-env` or `--session-env`) provides `CODEX_HEALTHY=false` or `CURSOR_HEALTHY=false`, set the corresponding `*_available` mental flag to `false` immediately **without re-probing that tool**. Still run the full check (binary + probe) for tools whose health is unknown (not present in session-env). Print: `**⚠ <Codex|Cursor> marked unhealthy by caller — using Claude replacement for this session.**`
 
-**Note**: If either tool is installed but fails during the actual review (e.g., auth issues, timeout), the failure is handled gracefully — the review proceeds with warnings.
+Set mental flags `codex_available` and `cursor_available` based on the combined result:
+- If `CODEX_AVAILABLE=false`: `codex_available=false`. Print: `**⚠ Codex not available (binary not found). Proceeding without Codex reviewer.**`
+- Else if `CODEX_HEALTHY=false`: `codex_available=false`. Print: `**⚠ Codex installed but not responding (health check failed). Using Claude replacement.**`
+- Else: `codex_available=true`
+- Same logic for Cursor.
+
+**Note**: `*_AVAILABLE` is a pure install-state signal (binary exists on PATH). `*_HEALTHY` indicates whether the tool actually responded to a trivial prompt within the 60-second probe timeout. Callers must combine both to determine runtime usability.
+
+## Runtime Timeout Fallback
+
+When processing reviewer results (after `wait-for-reviewers.sh` returns), check each reviewer's sentinel file exit code and output validity. If any of the following are true for a reviewer, set the corresponding `*_available` mental flag to `false` for **all subsequent steps in this session**:
+
+- Sentinel exit code is `124` (timeout — the common case when `run-external-reviewer.sh` enforces its timeout)
+- Sentinel exit code is non-zero (any other failure)
+- Output is empty/invalid after the retry-once procedure (per "Validating External Reviewer Output" below)
+- `wait-for-reviewers.sh` reports `TIMEOUT` for the reviewer (sentinel never appeared — wrapper killed externally)
+
+Print: `**⚠ <Reviewer> timed out — using Claude replacement for remainder of session.**`
+
+This is a mental flag flip within the current skill invocation. For cross-skill propagation within `/implement`, child skills write a structured health status file — see the `/implement` SKILL.md for details.
+
+**Note**: Once a reviewer is marked unhealthy during a session, it stays unhealthy for the remainder of that session. This is intentional — it prevents oscillation and wasted time on flaky tools during extended outages.
 
 ## Monitoring External Reviewers
 

--- a/skills/shared/external-reviewers.md
+++ b/skills/shared/external-reviewers.md
@@ -12,7 +12,7 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/check-reviewers.sh --probe
 
 Parse the output for `CODEX_AVAILABLE`, `CURSOR_AVAILABLE`, `CODEX_HEALTHY`, `CURSOR_HEALTHY`.
 
-**Session-env override**: If session-env (from `--caller-env` or `--session-env`) provides `CODEX_HEALTHY=false` or `CURSOR_HEALTHY=false`, set the corresponding `*_available` mental flag to `false` immediately **without re-probing that tool**. Still run the full check (binary + probe) for tools whose health is unknown (not present in session-env). Print: `**⚠ <Codex|Cursor> marked unhealthy by caller — using Claude replacement for this session.**`
+**Session-env override**: If session-env (from `--caller-env` or `--session-env`) provides `CODEX_HEALTHY=false` or `CURSOR_HEALTHY=false`, set the corresponding `*_available` mental flag to `false` immediately **without re-probing that tool**. Pass `--skip-codex-probe` and/or `--skip-cursor-probe` to `check-reviewers.sh` for tools already known unhealthy. Still run the full check (binary + probe) for tools whose health is unknown (not present in session-env). Print: `**⚠ <Codex|Cursor> marked unhealthy by caller — using Claude replacement for this session.**`
 
 Set mental flags `codex_available` and `cursor_available` based on the combined result:
 - If `CODEX_AVAILABLE=false`: `codex_available=false`. Print: `**⚠ Codex not available (binary not found). Proceeding without Codex reviewer.**`


### PR DESCRIPTION
## Summary
- Added external reviewer health probe (`check-reviewers.sh --probe`) that tests each tool with a 60-second timeout at session startup, catching outages before wasting 20-30 minutes on long review timeouts.
- Implemented runtime timeout fallback: when an external reviewer times out during any step, it is replaced by a Claude subagent with similar persona for all subsequent invocations in the session.
- Extended `--session-env` mechanism to propagate reviewer health state across skill boundaries (`/implement` → `/design` → `/review`).

<details><summary>Architecture Diagram</summary>

```mermaid
graph TD
    subgraph "/implement orchestrator"
        I0["Step 0: session-setup + health probe"]
        I0 -->|writes| SE["session-env.sh<br/>(CODEX_HEALTHY, CURSOR_HEALTHY)"]
        I1["Step 1: /design"]
        I5["Step 5: /review"]
        I12["Step 12: conflict review"]
        
        I0 --> I1
        I1 -->|reads| HF1["session-env.sh.health<br/>(written by /design)"]
        HF1 -->|updates| SE
        SE -->|--session-env| I5
        I5 -->|reads| HF2["session-env.sh.health<br/>(written by /review)"]
        HF2 -->|updates| SE
        SE --> I12
    end
    
    subgraph "check-reviewers.sh --probe"
        BC["Binary Check<br/>(command -v)"]
        HP["Health Probe<br/>(60s timeout per tool)"]
        BC -->|AVAILABLE=true| HP
        BC -->|AVAILABLE=false| OUT["Output:<br/>AVAILABLE + HEALTHY"]
        HP --> OUT
    end
    
    subgraph "Child Skill (design/review)"
        S0b["Step 0b: read session-env"]
        S0b -->|HEALTHY=false inherited| SKIP["Skip probe, use Claude replacement"]
        S0b -->|HEALTHY unknown| PROBE["Run check-reviewers.sh --probe"]
        RT["Runtime: reviewer times out"]
        RT -->|"flip *_available=false"| REPLACE["Use Claude replacement"]
        RT -->|"write health file"| HFout["session-env.sh.health"]
    end
    
    I0 --> BC
```

</details>

<details><summary>Code Flow Diagram</summary>

```mermaid
sequenceDiagram
    participant I as /implement
    participant CR as check-reviewers.sh
    participant WS as write-session-env.sh
    participant D as /design
    participant R as /review
    participant HF as session-env.sh.health

    Note over I: Step 0 — Session Setup
    I->>CR: --probe
    CR-->>CR: Binary check (command -v)
    CR-->>CR: Parallel health probes (60s timeout)
    CR-->>I: CODEX_AVAILABLE, CURSOR_AVAILABLE,<br/>CODEX_HEALTHY, CURSOR_HEALTHY
    I->>WS: --codex-healthy --cursor-healthy
    WS-->>WS: Atomic write (temp+mv)

    Note over I: Step 1 — /design
    I->>D: --session-env session-env.sh
    D-->>D: Read inherited health from session-env
    D-->>CR: --probe --skip-*-probe (for unhealthy)
    D-->>D: Use Claude replacement if unhealthy
    alt Reviewer times out during /design
        D-->>D: Flip *_available=false (mental flag)
    end
    D->>HF: Write final health state
    I-->>HF: Read health status file
    alt Health changed to false
        I->>WS: Re-write session-env with updated flags
    end

    Note over I: Step 5 — /review
    I->>R: --session-env session-env.sh
    R-->>R: Read inherited health
    R-->>CR: --probe --skip-*-probe (for unhealthy)
    R-->>R: Use Claude replacement if unhealthy
    alt Reviewer times out during /review
        R-->>R: Flip *_available=false (mental flag)
    end
    R->>HF: Write final health state
    I-->>HF: Read health status file
```

</details>

<details><summary>Goal</summary>

- Prevent wasting time on extended external reviewer (Cursor/Codex) outages during `/implement` flows
  - Add upfront health check that verifies each tool actually responds (not just binary existence)
  - Implement runtime timeout fallback so a single timeout disables the tool for the rest of the session
  - Propagate health state across skill boundaries within `/implement` via `--session-env`
- Ensure the flow continues productively by substituting Claude subagents with similar personas
- Add `--session-env` support to `/review` for unified state passing

</details>

<details><summary>Test plan</summary>

- [x] `check-reviewers.sh --probe` works when both tools are available (happy path)
- [x] `check-reviewers.sh --probe` handles missing binaries (AVAILABLE=false, no HEALTHY emitted)
- [x] `check-reviewers.sh --skip-codex-probe --skip-cursor-probe` flags work correctly
- [x] `check-reviewers.sh` rejects unknown arguments
- [x] `write-session-env.sh` accepts and serializes health flags with atomic write
- [x] `write-session-env.sh` conditionally omits health keys when values empty
- [x] `session-setup.sh` parses and re-emits health keys from caller-env
- [x] All linters pass (shellcheck, markdownlint)
- [x] Plugin structure validation passes (validator 11 dead-script check, etc.)

</details>

<details><summary>Final Design</summary>

### Overview
Add a health check probe to `check-reviewers.sh` (via `--probe` flag) and implement runtime timeout fallback so that when an external reviewer (Cursor/Codex) fails at any point during the `/implement` flow, a Claude subagent with similar persona is used for all subsequent invocations. State propagates across skill boundaries via the extended `--session-env` mechanism.

### Files Modified
1. `scripts/check-reviewers.sh` — `--probe`, `--skip-codex-probe`, `--skip-cursor-probe` flags. Parallel health probes. Only emits `*_HEALTHY` when `*_AVAILABLE=true`.
2. `scripts/write-session-env.sh` — `--codex-healthy`/`--cursor-healthy` flags, atomic temp+mv writes, conditional health key emission.
3. `scripts/session-setup.sh` — Parse and re-emit health keys from caller-env.
4. `skills/shared/external-reviewers.md` — Document health probe, session-env override, runtime timeout fallback.
5. `skills/review/SKILL.md` — Add `--session-env <path>` flag, read inherited health, write health status file.
6. `skills/implement/SKILL.md` — Health probe in Step 0, `--session-env` to /review, cross-skill health propagation.
7. `skills/design/SKILL.md` — Honor inherited health flags, write health status file.
8. `skills/research/SKILL.md` — Use `--probe` in binary check.
9. `skills/loop-review/SKILL.md` — Use `--probe` in binary check.

### Key Design Principles
- `*_AVAILABLE` = pure install-state signal; `*_HEALTHY` = probe result. Callers combine both.
- Once unhealthy, stays unhealthy for the session (prevents oscillation).
- Inter-skill propagation via structured `.health` files, not conversation context.
- `check-reviewers.sh --skip-*-probe` flags prevent re-probing known-unhealthy tools.

</details>

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `9228736` (Add --debug flag for compact output across all workflow skills (#48))
- **Current version**: `1.2.0`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: MINOR

- **New version**: `1.3.0`

### MINOR evidence
- Added `--session-env` to argument-hint in `skills/review/SKILL.md`

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

### [Plan Review] Deep-Analysis
**Finding**: The plan adds `CODEX_PROBE`/`CURSOR_PROBE` output keys alongside `CODEX_HEALTHY`/`CURSOR_HEALTHY`. These keys are redundant since probe failure already downgrades `*_AVAILABLE` (per the original plan). The concern is that having `PROBE=true, HEALTHY=false` (or vice versa) creates ambiguous semantics that will confuse callers.
**Reason not implemented**: The revised plan already removes the `*_AVAILABLE` downgrade behavior (per FINDING_4). With the revised contract where `*_AVAILABLE` = binary existence and `*_HEALTHY` = probe result, the `*_PROBE` keys were removed from the plan. The finding's underlying concern was addressed through a different mechanism.

### [Plan Review] General
**Finding**: The plan says "run a trivial prompt" but doesn't specify the exact commands for Codex and Cursor probes.
**Reason not implemented**: The voting panel determined that requiring exact probe command strings is over-prescriptive for a design plan. The plan defines the contract and intent clearly.

### [Plan Review] General
**Finding**: `check-reviewers.sh` uses `set -uo pipefail` (no `-e`). Adding background probes introduces non-zero exit codes from `wait`/`kill`.
**Reason not implemented**: The voting panel exonerated this — legitimate concern but implementation-level detail.

</details>

<details><summary>Implementation Deviations</summary>

- **Skip-probe flags**: The plan specified `--skip-codex-probe`/`--skip-cursor-probe` flags on `check-reviewers.sh` — this was added during code review (FINDING_2) rather than during initial implementation. The plan's intent was correct but the implementation was incomplete until review.
- **Conditional health key emission**: `write-session-env.sh` now conditionally emits `CODEX_HEALTHY`/`CURSOR_HEALTHY` only when values are non-empty. The plan specified unconditional emission; this was improved during code review (round 2).
- **Warning precedence**: `implement/SKILL.md` Step 0 warning logic now explicitly checks `*_AVAILABLE` before `*_HEALTHY`, matching `external-reviewers.md`. This was a code review fix (FINDING_3).

</details>

<details><summary>Rejected Code Review Suggestions</summary>

### [Code Review] Cursor, Codex-General
**Finding**: Health probe treats any non-empty output with exit 0 as "healthy". A tool printing login/auth/warning banners but not actually functioning would pass the check. The suggestion was to validate that probe output contains an expected token like "OK" rather than just checking file non-emptiness.
**Reason not implemented**: The voting panel unanimously rejected this finding (0/3 YES). Treating exit 0 plus non-empty output as a liveness check is a reasonable probe heuristic. The claimed false-positive cases (login banners, auth prompts) are speculative rather than demonstrated bugs. Adding a specific token check would be brittle — different tool versions may format output differently. The runtime timeout fallback mechanism provides a second layer of defense for any tools that pass the probe but fail on real tasks.

### [Code Review] Deep-Analysis
**Finding**: `write-session-env.sh` unconditionally writes `CODEX_HEALTHY=`/`CURSOR_HEALTHY=` (empty) when the optional flags are omitted, making "absent" vs "empty-but-present" ambiguous for parsers.
**Reason not implemented**: The voting panel did not accept this finding (1/3 YES). Downstream logic already treats non-empty values as the only meaningful signal. However, this concern was partially addressed in round 2 — `write-session-env.sh` now conditionally emits health keys only when values are non-empty.

### [Code Review] General
**Finding**: `write-session-env.sh` creates a TMPFILE via mktemp but has no trap to clean it up on error.
**Reason not implemented**: The voting panel exonerated this finding (1 YES, 2 EXONERATE). The concern is legitimate but too minor for this PR.

### [Code Review] General, Deep-Analysis
**Finding**: Background probe processes in `check-reviewers.sh` are not reaped after `wait-for-reviewers.sh` returns.
**Reason not implemented**: The voting panel exonerated this finding (0 YES, 3 EXONERATE). The race window is tiny and the wrapper handles its own cleanup.

### [Code Review] General
**Finding**: `check-reviewers.sh` only checks `$1` for `--probe` and silently ignores any other arguments.
**Reason not implemented**: This was addressed in the round 1 fixes — the script now uses a proper `while` loop parser.

</details>

<details><summary>Plan Review Voting Tally</summary>

| Finding | Claude | Cursor | Codex | Result |
|---------|--------|--------|-------|--------|
| FINDING_1 | YES | YES | YES | **ACCEPTED** (3/3) |
| FINDING_2 | YES | YES | YES | **ACCEPTED** (3/3) |
| FINDING_3 | YES | YES | YES | **ACCEPTED** (3/3) |
| FINDING_4 | YES | YES | YES | **ACCEPTED** (3/3) |
| FINDING_5 | YES | EXON. | YES | **ACCEPTED** (2/3) |
| FINDING_6 | EXON. | YES | YES | **ACCEPTED** (2/3) |
| FINDING_7 | NO | NO | NO | Rejected (0/3) |
| FINDING_8 | YES | YES | YES | **ACCEPTED** (3/3) |
| FINDING_9 | EXON. | YES | YES | **ACCEPTED** (2/3) |
| FINDING_10 | YES | YES | YES | **ACCEPTED** (3/3) |
| FINDING_11 | EXON. | NO | NO | Rejected (0/3, exonerated) |
| FINDING_12 | YES | EXON. | EXON. | Not accepted (1/3) |
| FINDING_13 | YES | YES | EXON. | **ACCEPTED** (2/3) |
| FINDING_14 | YES | YES | YES | **ACCEPTED** (3/3) |
| FINDING_15 | YES | YES | YES | **ACCEPTED** (3/3) |
| FINDING_16 | YES | YES | YES | **ACCEPTED** (3/3) |

## Reviewer Competition Scoreboard

| Reviewer | Findings | Accepted | Neutral (1 YES) | Exonerated (0 YES, 1+ EXON.) | Rejected (0 YES, 0 EXON.) | OOS Proposed | OOS Promoted | Score |
|----------|----------|----------|-----------------|-------------------------------|---------------------------|--------------|--------------|-------|
| General | 9 | 8 | 1 | 0 | 0 | 2 | 0 | +8 |
| Deep-Analysis | 8 | 7 | 0 | 1 | 0 | 2 | 0 | +7 |
| Cursor | 6 | 6 | 0 | 0 | 0 | 0 | 0 | +6 |
| Codex-General | 5 | 5 | 0 | 0 | 0 | 0 | 0 | +5 |
| Codex-Deep | 5 | 5 | 0 | 0 | 0 | 0 | 0 | +5 |

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

| Finding | Claude | Cursor | Codex | Result |
|---------|--------|--------|-------|--------|
| FINDING_1 | YES | YES | YES | **ACCEPTED** (3/3) |
| FINDING_2 | EXON. | YES | YES | **ACCEPTED** (2/3) |
| FINDING_3 | YES | YES | YES | **ACCEPTED** (3/3) |
| FINDING_4 | NO | NO | NO | Rejected (0/3) |
| FINDING_5 | YES | NO | NO | Not accepted (1/3) |
| FINDING_6 | YES | EXON. | EXON. | Not accepted (1/3, exonerated) |
| FINDING_7 | EXON. | EXON. | EXON. | Not accepted (0/3, exonerated) |
| FINDING_8 | NO | EXON. | EXON. | Not accepted (0/3, exonerated) |

## Reviewer Competition Scoreboard

| Reviewer | Findings | Accepted | Neutral (1 YES) | Exonerated (0 YES, 1+ EXON.) | Rejected (0 YES, 0 EXON.) | Score |
|----------|----------|----------|-----------------|-------------------------------|---------------------------|-------|
| General | 5 | 3 | 1 | 1 | 0 | +3 |
| Cursor | 3 | 3 | 0 | 0 | 0 | +3 |
| Codex-General | 3 | 3 | 0 | 0 | 0 | +3 |
| Deep-Analysis | 5 | 2 | 1 | 1 | 0 | +2 |
| Codex-Deep | 2 | 2 | 0 | 0 | 0 | +2 |

</details>

<details><summary>Out-of-Scope Observations</summary>

**Plan Review OOS:**
- OOS_1 (Deep-Analysis): `check-reviewers.sh` missing `-e` rationale comment — pre-existing documentation gap
- OOS_2 (Deep-Analysis): `session-setup.sh` caller-env `IFS='='` parsing fragility — pre-existing
- OOS_3 (General): Voting panel has no runtime fallback for voter-specific timeouts — pre-existing gap
- OOS_4 (General): `/loop-review` first-slice 30-min timeout waste — pre-existing, addressed by `--probe`

**Code Review OOS:**
- OOS_1 (Deep-Analysis): `write-session-env.sh` heredoc writes unquoted values — pre-existing fragility
- OOS_2 (Deep-Analysis): `session-setup.sh` `REPO=` empty output ambiguity — pre-existing
- OOS_3 (Deep-Analysis): `/loop-review` doesn't propagate health state to child `/implement` invocations

</details>

<details><summary>Execution Issues</summary>

No execution issues encountered.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | 13 accepted, 3 rejected |
| Code review rounds | 2 |
| Code review findings | 6 accepted, 5 rejected |
| Warnings logged | 0 |
| Pre-existing issues noticed | 0 |
| External reviewers | Cursor: ✅, Codex: ✅ |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
