### PR TITLE
Add breadcrumb-style step paths to skill progress output

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation with collaborative reviewers (Claude subagents + Codex + Cursor).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.4] - 2026-04-12
+
+### Changed
+
+- Replaced per-step emoji progress lines with breadcrumb-style step paths across all 5 skill SKILL.md files (e.g., `▸ 1.2a: design plan | sketches` instead of `🤝 Step 1.2a — Collaborative sketches...`).
+- Created `skills/shared/progress-reporting.md` shared formatting contract defining icon taxonomy, breadcrumb format, and `--step-prefix` `::` encoding.
+- Extended `--step-prefix` to carry both numeric prefix and textual breadcrumb path (e.g., `"1.::design plan"`), with backward-compatible fallback for numeric-only values.
+- Added Step Name Registry tables (<=20-char short names per step) to all 5 skill SKILL.md files.
+- Preserved `⏭️`/`⏩` semantic distinction for precondition vs. sub-step skips.
+
 ## [1.3.3] - 2026-04-12
 
 ### Changed

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -14,35 +14,35 @@ Design an implementation plan for a feature and review it with multiple speciali
 - `--auto`: Set a mental flag `auto_mode=true`. When `auto_mode=true`, all interactive question checkpoints (Steps 1c, 1d, 3.5, and 3a) are skipped — the skill runs fully autonomously without user interaction. When `--quick` is set in the caller and `/design` is skipped entirely, `--auto` has no effect.
 - `--debug`: Set a mental flag `debug_mode=true`. Controls output verbosity — see Verbosity Control below. Default: `debug_mode=false`.
 - `--session-env <path>`: Set `SESSION_ENV_PATH` to the given path. This file contains already-discovered session values from a caller skill (e.g., `/implement`) and will be forwarded to `session-setup.sh` via `--caller-env`. If not provided, `SESSION_ENV_PATH` is empty (standalone invocation — full discovery).
-- `--step-prefix <prefix>`: Set `STEP_PREFIX` to the given value (e.g., `"1."`). When non-empty, prepend to step numbers **in emoji status lines only** (e.g., `🔀 Step 1.1 — Creating branch...`). Do NOT prefix section headers (e.g., `## Implementation Plan`), structured output headers, or artifact labels. Default: empty (standalone numbering). This is an internal orchestration flag used when `/design` is invoked from `/implement`.
+- `--step-prefix <prefix>`: Encodes both numeric prefix and textual breadcrumb path using `::` delimiter — see `${CLAUDE_PLUGIN_ROOT}/skills/shared/progress-reporting.md` for the full encoding spec. Examples: `"1.::design plan"` (numeric `1.`, path `design plan`), `"1."` (numeric only, backward compat). Parse into `STEP_NUM_PREFIX` (before `::`) and `STEP_PATH_PREFIX` (after `::`, or empty if `::` absent). Default: empty (standalone numbering). This is an internal orchestration flag used when `/design` is invoked from `/implement`.
 - `--branch-info <values>`: Set `branch_info_supplied=true` and parse `IS_MAIN`, `IS_USER_BRANCH`, `USER_PREFIX`, `CURRENT_BRANCH` from the space-separated `KEY=VALUE` pairs. All 4 keys are required. Values are safe for space-splitting (`USER_PREFIX` is sanitized by `create-branch.sh`'s `derive_user_prefix()`, `CURRENT_BRANCH` cannot contain spaces). **Validation**: If any of the 4 keys is missing, print `**⚠ --branch-info is incomplete. Falling back to create-branch.sh --check.**` and run the script as fallback. **Fallback**: When `--branch-info` is absent (standalone invocation), run `create-branch.sh --check` as usual. This is an internal orchestration flag used when `/design` is invoked from `/implement` to skip the redundant branch-state check.
 
 The feature to design is described by the remainder of `$ARGUMENTS` after flags are stripped.
 
 ## Progress Reporting
 
-**Every step MUST print clearly visible status lines** so the user can instantly see where execution is at. Use distinct emoji prefixes:
+**Every step MUST print clearly visible breadcrumb status lines** so the user can instantly see where execution is and which parent steps they are inside. Follow the formatting rules in `${CLAUDE_PLUGIN_ROOT}/skills/shared/progress-reporting.md`.
 
-- Print a **start line** when entering a step: e.g., `🔀 Step 1 — Creating branch...`
-- Print a **completion line** only when it carries informational payload (counts, outcomes, or conditional-skip reasons). Pure "step complete" announcements without payload are not needed — the start line of the next step signals completion. Only the final step (Step 5) prints an unconditional completion announcement.
-- When `STEP_PREFIX` is non-empty, prepend it to step numbers **in emoji status lines only** (e.g., `🔀 Step 1.1 — Creating branch...` when `STEP_PREFIX="1."`). Do NOT prefix section headers (e.g., `## Implementation Plan`), structured output headers, or artifact labels. **This rule overrides the literal step numbers in `Print:` directives and examples throughout this file** — whenever a `Print:` line or example contains `Step N`, emit `Step ${STEP_PREFIX}N` instead (e.g., `Print: \`❓ Step 1c\`` becomes `❓ Step 1.1c` when `STEP_PREFIX="1."`).
+- Print a **start line** when entering a step: e.g., `▸ 1: branch` (standalone) or `▸ 1.1: design plan | branch` (nested from `/implement`)
+- Print a **completion line** only when it carries informational payload. Only the final step (Step 5) prints an unconditional completion announcement.
+- When `STEP_NUM_PREFIX` is non-empty, prepend it to step numbers: `{STEP_NUM_PREFIX}{local_step}`. When `STEP_PATH_PREFIX` is non-empty, prepend it to breadcrumb paths: `{STEP_PATH_PREFIX} | {step_short_name}`. **This rule overrides the literal step numbers and names in `Print:` directives and examples throughout this file.** Examples shown below assume standalone mode; when nested, prepend the parent context.
 
-Suggested emoji palette (use consistently):
-| Step | Emoji | Description |
-|------|-------|-------------|
-| 0 | 🔧 | Session setup |
-| 1 | 🔀 | Branch creation |
-| 1c | ❓ | Clarifying questions |
-| 1d | 🔥 | Design discussion (round 1) |
-| 2a | 🤝 | Collaborative sketches |
-| 2a.5 | ⚖️ | Dialectic debate |
-| 2b | 📐 | Full plan design |
-| 3 | 🔍 | Plan review |
-| 3.5 | 🔥 | Design discussion (round 2) |
-| 3a | ✅ | Post-review confirmation |
-| 3b | 🗺️ | Architecture diagram |
-| 4 | 📊 | Rejected findings report |
-| 5 | 🏁 | Cleanup |
+Step Name Registry:
+| Step | Short Name |
+|------|------------|
+| 0 | setup |
+| 1 | branch |
+| 1c | questions |
+| 1d | grilling r1 |
+| 2a | sketches |
+| 2a.5 | dialectic |
+| 2b | full plan |
+| 3 | plan review |
+| 3.5 | grilling r2 |
+| 3a | confirmation |
+| 3b | arch diagram |
+| 4 | rejected findings |
+| 5 | cleanup |
 
 ### Verbosity Control
 
@@ -50,7 +50,7 @@ Suggested emoji palette (use consistently):
 
 - Use empty string for the `description` parameter on all Bash tool calls.
 - Use terse 3-5 word descriptions for Agent tool calls.
-- Do not produce explanatory prose between tool call outputs — only print: step start emoji lines, result-bearing completion lines (with counts/outcomes), conditional-skip lines (`⏩`), final completion line (Step 5), all warning/error lines (`**⚠ ...`), structured summaries (voting tallies, scoreboards, round summaries, findings lists, approach synthesis, dialectic resolutions, implementation plans, architecture diagrams), and the compact reviewer status table (see below).
+- Do not produce explanatory prose between tool call outputs — only print: step breadcrumb lines (start `▸`, completion `✅`, skip `⏩`), final completion line (Step 5), all warning/error lines (`**⚠ ...`), structured summaries (voting tallies, scoreboards, round summaries, findings lists, approach synthesis, dialectic resolutions, implementation plans, architecture diagrams), and the compact reviewer status table (see below).
 
 **Compact reviewer status table**: After launching sketch agents (Step 2a) or plan reviewers (Step 3), maintain a mental tracker of each agent's status. Print a compact table after EACH status change:
 
@@ -110,15 +110,15 @@ Parse the output for `CURRENT_BRANCH`, `IS_MAIN`, `IS_USER_BRANCH`, and `USER_PR
   ${CLAUDE_PLUGIN_ROOT}/scripts/create-branch.sh --branch <USER_PREFIX>/<branch-name>
   ```
 
-- If `IS_USER_BRANCH=true`: Verify the branch name (`CURRENT_BRANCH`) aligns with the requested feature. If it appears unrelated (different feature name, unrelated commits), print a warning: `**⚠ Current branch '<branch-name>' may not match the requested feature. Creating a new branch from main.**` and create a new branch as above. Otherwise, skip branch creation. Print: `🔀 Step 1 — Using existing branch: <branch-name>`
+- If `IS_USER_BRANCH=true`: Verify the branch name (`CURRENT_BRANCH`) aligns with the requested feature. If it appears unrelated (different feature name, unrelated commits), print a warning: `**⚠ Current branch '<branch-name>' may not match the requested feature. Creating a new branch from main.**` and create a new branch as above. Otherwise, skip branch creation. Print: `▸ 1: branch — using existing: <branch-name>`
 
 - Otherwise (non-main, non-user branch): Print a warning: `**⚠ Currently on branch '<branch-name>' which doesn't match the expected '<USER_PREFIX>/*' pattern. Creating a new branch from main.**` Then derive a name and create as above.
 
 ## Step 1c — Clarifying Questions
 
-Print: `❓ Step 1c — Clarifying questions...`
+Print: `▸ 1c: questions`
 
-**If `auto_mode=true`**: Print `⏩ Step 1c — Skipped (auto mode).` and proceed to Step 1d.
+**If `auto_mode=true`**: Print `⏩ 1c: questions — skipped (auto mode)` and proceed to Step 1d.
 
 **If `auto_mode=false`**: Before launching the expensive collaborative sketch phase, use `AskUserQuestion` to clarify any ambiguities in the feature description. This is the highest-value question point — answers here reshape what the sketch agents explore.
 
@@ -136,9 +136,9 @@ After the user responds, incorporate their answers into your understanding of th
 
 ## Step 1d — Design Discussion (Round 1)
 
-Print: `🔥 Step 1d — Design discussion (round 1)...`
+Print: `▸ 1d: grilling r1`
 
-**If `auto_mode=true`**: Print `⏩ Step 1d — Skipped (auto mode).` and proceed to Step 2a.
+**If `auto_mode=true`**: Print `⏩ 1d: grilling r1 — skipped (auto mode)` and proceed to Step 2a.
 
 **If `auto_mode=false`**: Before launching the expensive collaborative sketch phase, stress-test the feature's scope and requirements by walking through the decision tree one question at a time. This is a deeper, sequential interrogation that resolves dependencies between decisions — each answer may reshape subsequent questions.
 
@@ -156,7 +156,7 @@ Then walk each branch one question at a time via sequential `AskUserQuestion` ca
 
 ### Short-circuit
 
-If the feature is straightforward with fewer than 2 scope decision branches, print `⏩ Step 1d — No scope decisions require discussion.` and proceed to Step 2a.
+If the feature is straightforward with fewer than 2 scope decision branches, print `⏩ 1d: grilling r1 — no scope decisions require grilling` and proceed to Step 2a.
 
 ### Output
 
@@ -179,7 +179,7 @@ At most **7 `AskUserQuestion` calls** in this step. If more than 7 decision bran
 
 If the user gives a terse or non-responsive answer (e.g., "I don't know", "your recommendation is fine", "sure"), accept the recommended answer and move on without re-asking.
 
-Print: `✅ Step 1d — Design discussion (round 1) complete. <N> decisions resolved.`
+Print: `✅ 1d: grilling r1 — <N> decisions resolved`
 
 ## Step 2a — Collaborative Approach Sketches
 
@@ -198,7 +198,7 @@ Plus 2 external agents (or Claude replacements):
 4. **Cursor** (if available) — or **Claude (Innovation/Exploration)** replacement: proposes creative alternative approaches, questions assumptions, and suggests unconventional solutions
 5. **Codex** (if available) — or **Claude (Edge-cases/Failure-modes)** replacement: focuses on what can go wrong, boundary conditions, error handling, and failure recovery
 
-Print `🤝 Step 2a — Running collaborative sketch phase.` and proceed to 2a.2.
+Print `▸ 2a: sketches` and proceed to 2a.2.
 
 ### 2a.2 — Launch Sketches in Parallel
 
@@ -285,9 +285,9 @@ Print the synthesis under an `## Approach Synthesis` header. Write the synthesis
 
 ### 2a.5 — Dialectic Resolution of Contested Decisions
 
-Print: `⚖️ Step 2a.5 — Running dialectic debate on contested decisions...`
+Print: `▸ 2a.5: dialectic`
 
-Read `$DESIGN_TMPDIR/contested-decisions.md`. If the file contains only `NO_CONTESTED_DECISIONS` (ignoring leading/trailing whitespace and newlines), print `⏩ Step 2a.5 — No contested decisions found. Skipping dialectic debate.` and proceed to Step 2b.
+Read `$DESIGN_TMPDIR/contested-decisions.md`. If the file contains only `NO_CONTESTED_DECISIONS` (ignoring leading/trailing whitespace and newlines), print `⏩ 2a.5: dialectic — no contested decisions` and proceed to Step 2b.
 
 Otherwise, read `$DESIGN_TMPDIR/approach-synthesis.txt` — this provides `{SYNTHESIS_TEXT}` for the agent prompts below. Select up to the first 3 decisions from the file (they are already in priority order from Step 2a.4). For each selected decision, launch a **thesis agent** and an **antithesis agent** as Claude subagents via the Agent tool. **All thesis+antithesis pairs across all decisions must be issued in a single Agent fan-out message** (up to 6 Agent tool calls in one message) to maximize parallelism.
 
@@ -339,7 +339,7 @@ Print resolutions under a `## Dialectic Resolutions` header.
 
 **Scope**: Dialectic resolutions are **binding for Step 2b plan generation only**. They may be superseded later by accepted Step 3 review findings. The finalized plan (after Step 3 review) remains the sole canonical output.
 
-Print: `✅ Step 2a.5 — Dialectic debate complete (<N> decisions resolved).` (where N is the count of decisions that passed the quorum rule).
+Print: `✅ 2a.5: dialectic — <N> decisions resolved` (where N is the count of decisions that passed the quorum rule).
 
 ## Step 2b — Design the Implementation Plan
 
@@ -507,9 +507,9 @@ If no findings were rejected, do not create the file yet.
 
 ## Step 3.5 — Design Discussion (Round 2)
 
-Print: `🔥 Step 3.5 — Design discussion (round 2)...`
+Print: `▸ 3.5: grilling r2`
 
-**If `auto_mode=true`**: Print `⏩ Step 3.5 — Skipped (auto mode).` and proceed to Step 3a.
+**If `auto_mode=true`**: Print `⏩ 3.5: grilling r2 — skipped (auto mode)` and proceed to Step 3a.
 
 **If `auto_mode=false`**: After the plan has been reviewed and revised, stress-test the remaining design decisions that were either (a) not covered in Round 1, or (b) deemed suboptimal by reviewers, or (c) introduced by the plan itself (decisions that didn't exist at the feature-description stage).
 
@@ -536,7 +536,7 @@ Unlike Round 1, Round 2 MAY ask about architectural decisions and implementation
 
 ### Short-circuit
 
-If all plan decisions are already covered by Round 1, no reviewer findings challenged them, and no decisions from `contested-decisions.md` have a close or inconclusive dialectic resolution, print `⏩ Step 3.5 — No additional design decisions require discussion.` and proceed to Step 3a.
+If all plan decisions are already covered by Round 1, no reviewer findings challenged them, and no decisions from `contested-decisions.md` have a close or inconclusive dialectic resolution, print `⏩ 3.5: grilling r2 — no additional decisions require grilling` and proceed to Step 3a.
 
 ### Output
 
@@ -559,15 +559,15 @@ At most **7 `AskUserQuestion` calls** in this step. If more than 7 decision bran
 
 If the user gives a terse or non-responsive answer, accept the recommended answer and move on without re-asking.
 
-Print: `✅ Step 3.5 — Design discussion (round 2) complete. <N> decisions resolved.`
+Print: `✅ 3.5: grilling r2 — <N> decisions resolved`
 
 ## Step 3a — Post-Review Confirmation
 
-Print: `✅ Step 3a — Post-review confirmation...`
+Print: `▸ 3a: confirmation`
 
-**If `auto_mode=true`**: Print `⏩ Step 3a — Skipped (auto mode).` and proceed to Step 3b.
+**If `auto_mode=true`**: Print `⏩ 3a: confirmation — skipped (auto mode)` and proceed to Step 3b.
 
-**If the plan was NOT revised** (voting rejected all findings or was skipped, AND Step 3.5 discussion made no changes): Print `⏩ Step 3a — Skipped (plan unchanged by review or discussion).` and proceed to Step 3b.
+**If the plan was NOT revised** (voting rejected all findings or was skipped, AND Step 3.5 discussion made no changes): Print `⏩ 3a: confirmation — skipped (plan unchanged)` and proceed to Step 3b.
 
 **If `auto_mode=false` AND the plan was revised** (by reviewers or Step 3.5 discussion): Use `AskUserQuestion` to confirm the revised plan addresses the user's original intent. Present a brief summary of what changed and ask the user to approve or reject.
 
@@ -575,7 +575,7 @@ Print: `✅ Step 3a — Post-review confirmation...`
 
 ## Step 3b — Architecture Diagram
 
-Print: `🗺️ Step 3b — Generating architecture diagram...`
+Print: `▸ 3b: arch diagram`
 
 **This step runs on ALL paths through Step 3** — whether voting produced revisions, rejected all findings, or was skipped entirely because all reviewers reported no issues. It always executes before Step 4.
 
@@ -593,9 +593,9 @@ Print the diagram under a `## Architecture Diagram` header with a mermaid code f
 ```
 ```
 
-**If diagram generation succeeds**, print: `✅ Step 3b — Architecture diagram generated.`
+**If diagram generation succeeds**, print: `✅ 3b: arch diagram — generated`
 
-**If diagram generation fails** (e.g., the feature is too abstract to diagram meaningfully), print: `**⚠ Step 3b — Architecture diagram generation failed. Proceeding without diagram.**`
+**If diagram generation fails** (e.g., the feature is too abstract to diagram meaningfully), print: `**⚠ 3b: arch diagram — generation failed, proceeding without diagram**`
 
 ## Step 4 — Rejected Plan Review Findings Report
 
@@ -603,7 +603,7 @@ Print any rejected plan review findings:
 
 1. Check if `$DESIGN_TMPDIR/rejected-findings.md` exists and is non-empty.
 2. If it has content, print it under a `## Unimplemented Plan Review Suggestions` header, formatted clearly with the reviewer name, the suggestion, and the reason for each.
-3. If the file doesn't exist or is empty, print: `📊 Step 4 — All plan review suggestions were implemented.`
+3. If the file doesn't exist or is empty, print: `✅ 4: rejected findings — all suggestions implemented`
 
 ## Step 5 — Cleanup and Final Warnings
 
@@ -626,5 +626,5 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/cleanup-tmpdir.sh --dir "$DESIGN_TMPDIR"
 - `**⚠ Codex sketch timed out / produced empty output**`
 - `**⚠ Step 3b — Architecture diagram generation failed. Proceeding without diagram.**`
 
-If `STEP_PREFIX` is empty (standalone mode): Print: `🏁 Step 5 — Design complete! The implementation plan is ready. Run /implement to proceed with implementation.`
-If `STEP_PREFIX` is non-empty (orchestrated mode): skip this final print — the parent orchestrator handles overall progress.
+If `STEP_NUM_PREFIX` is empty (standalone mode): Print: `✅ 5: cleanup — design complete!`
+If `STEP_NUM_PREFIX` is non-empty (orchestrated mode): skip this final print — the parent orchestrator handles overall progress.

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -33,12 +33,12 @@ Step Name Registry:
 | 0 | setup |
 | 1 | branch |
 | 1c | questions |
-| 1d | grilling r1 |
+| 1d | discussion r1 |
 | 2a | sketches |
 | 2a.5 | dialectic |
 | 2b | full plan |
 | 3 | plan review |
-| 3.5 | grilling r2 |
+| 3.5 | discussion r2 |
 | 3a | confirmation |
 | 3b | arch diagram |
 | 4 | rejected findings |
@@ -130,15 +130,15 @@ Consider asking about:
 **Guidelines**:
 - Only ask questions when there is genuine ambiguity — do NOT ask trivially answerable questions or re-confirm what is already clear.
 - Batch questions into a single `AskUserQuestion` call with 1-4 questions rather than multiple sequential calls.
-- If the feature description is clear and unambiguous, print `✅ Step 1c — No clarifying questions needed.` and proceed to Step 1d.
+- If the feature description is clear and unambiguous, print `✅ 1c: questions — no clarifying questions needed` and proceed to Step 1d.
 
 After the user responds, incorporate their answers into your understanding of the feature for all subsequent steps.
 
 ## Step 1d — Design Discussion (Round 1)
 
-Print: `▸ 1d: grilling r1`
+Print: `▸ 1d: discussion r1`
 
-**If `auto_mode=true`**: Print `⏩ 1d: grilling r1 — skipped (auto mode)` and proceed to Step 2a.
+**If `auto_mode=true`**: Print `⏩ 1d: discussion r1 — skipped (auto mode)` and proceed to Step 2a.
 
 **If `auto_mode=false`**: Before launching the expensive collaborative sketch phase, stress-test the feature's scope and requirements by walking through the decision tree one question at a time. This is a deeper, sequential interrogation that resolves dependencies between decisions — each answer may reshape subsequent questions.
 
@@ -156,7 +156,7 @@ Then walk each branch one question at a time via sequential `AskUserQuestion` ca
 
 ### Short-circuit
 
-If the feature is straightforward with fewer than 2 scope decision branches, print `⏩ 1d: grilling r1 — no scope decisions require grilling` and proceed to Step 2a.
+If the feature is straightforward with fewer than 2 scope decision branches, print `⏩ 1d: discussion r1 — no scope decisions require discussion` and proceed to Step 2a.
 
 ### Output
 
@@ -179,7 +179,7 @@ At most **7 `AskUserQuestion` calls** in this step. If more than 7 decision bran
 
 If the user gives a terse or non-responsive answer (e.g., "I don't know", "your recommendation is fine", "sure"), accept the recommended answer and move on without re-asking.
 
-Print: `✅ 1d: grilling r1 — <N> decisions resolved`
+Print: `✅ 1d: discussion r1 — <N> decisions resolved`
 
 ## Step 2a — Collaborative Approach Sketches
 
@@ -507,9 +507,9 @@ If no findings were rejected, do not create the file yet.
 
 ## Step 3.5 — Design Discussion (Round 2)
 
-Print: `▸ 3.5: grilling r2`
+Print: `▸ 3.5: discussion r2`
 
-**If `auto_mode=true`**: Print `⏩ 3.5: grilling r2 — skipped (auto mode)` and proceed to Step 3a.
+**If `auto_mode=true`**: Print `⏩ 3.5: discussion r2 — skipped (auto mode)` and proceed to Step 3a.
 
 **If `auto_mode=false`**: After the plan has been reviewed and revised, stress-test the remaining design decisions that were either (a) not covered in Round 1, or (b) deemed suboptimal by reviewers, or (c) introduced by the plan itself (decisions that didn't exist at the feature-description stage).
 
@@ -536,7 +536,7 @@ Unlike Round 1, Round 2 MAY ask about architectural decisions and implementation
 
 ### Short-circuit
 
-If all plan decisions are already covered by Round 1, no reviewer findings challenged them, and no decisions from `contested-decisions.md` have a close or inconclusive dialectic resolution, print `⏩ 3.5: grilling r2 — no additional decisions require grilling` and proceed to Step 3a.
+If all plan decisions are already covered by Round 1, no reviewer findings challenged them, and no decisions from `contested-decisions.md` have a close or inconclusive dialectic resolution, print `⏩ 3.5: discussion r2 — no additional decisions require discussion` and proceed to Step 3a.
 
 ### Output
 
@@ -559,7 +559,7 @@ At most **7 `AskUserQuestion` calls** in this step. If more than 7 decision bran
 
 If the user gives a terse or non-responsive answer, accept the recommended answer and move on without re-asking.
 
-Print: `✅ 3.5: grilling r2 — <N> decisions resolved`
+Print: `✅ 3.5: discussion r2 — <N> decisions resolved`
 
 ## Step 3a — Post-Review Confirmation
 
@@ -624,7 +624,7 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/cleanup-tmpdir.sh --dir "$DESIGN_TMPDIR"
 - `**⚠ Cursor review failed: <reason>**`
 - `**⚠ Cursor sketch timed out / produced empty output**`
 - `**⚠ Codex sketch timed out / produced empty output**`
-- `**⚠ Step 3b — Architecture diagram generation failed. Proceeding without diagram.**`
+- `**⚠ 3b: arch diagram — generation failed, proceeding without diagram**`
 
 If `STEP_NUM_PREFIX` is empty (standalone mode): Print: `✅ 5: cleanup — design complete!`
 If `STEP_NUM_PREFIX` is non-empty (orchestrated mode): skip this final print — the parent orchestrator handles overall progress.

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -22,37 +22,41 @@ The feature to implement is described by `$ARGUMENTS` after flag stripping.
 
 ## Progress Reporting
 
-**Every step MUST print clearly visible status lines** so the user can instantly see where execution is at. Use distinct emoji prefixes:
+**Every step MUST print clearly visible breadcrumb status lines** so the user can instantly see where execution is and which parent steps they are inside. Follow the formatting rules in `${CLAUDE_PLUGIN_ROOT}/skills/shared/progress-reporting.md`.
 
-- Print a **start line** when entering a step: e.g., `🛠️ Step 2 — Implementing feature...`
-- Print a **completion line** only when it carries informational payload (counts, outcomes, or conditional-skip reasons). Pure "step complete" announcements without payload are not needed — the start line of the next step signals completion. Only the final step (Step 18) prints an unconditional completion announcement.
-- For long-running steps, print **intermediate progress**: e.g., `⏳ Step 12 — CI running (2m elapsed), main unchanged`
+- Print a **start line** when entering a step: e.g., `▸ 2: implementation`
+- Print a **completion line** only when it carries informational payload. Only the final step (Step 18) prints an unconditional completion announcement.
+- For long-running steps, print **intermediate progress**: e.g., `⏳ 12: CI+merge loop — CI running (2m elapsed), main unchanged`
 
-Suggested emoji palette (use consistently):
-| Step | Emoji | Description |
-|------|-------|-------------|
-| 0 | 🔧 | Session setup |
-| 1 | 📐 | Ensure design plan |
-| 🔃 | 🔃 | Rebase onto latest main |
-| 2 | 🛠️ | Implementation |
-| 3 | 🧹 | Relevant checks (first pass) |
-| 4 | 💾 | First commit |
-| 5 | 🔍 | Code review |
-| 6 | 🧹 | Relevant checks (second pass) |
-| 7 | 💾 | Second commit |
-| 7a | 🗺️ | Code flow diagram |
-| 8 | 🏷️ | Version bump |
-| 8a | 📝 | CHANGELOG update |
-| 9 | 🚀 | Create PR |
-| 10 | 🔄 | CI monitor (initial wait for green) |
-| 11 | 📋 | Slack announcement |
-| 12 | 🔁 | CI + rebase + merge loop |
-| 13 | ✨ | :merged: emoji |
-| 14 | 🧹 | Local cleanup |
-| 15 | ✅ | Verify main |
-| 16 | 📊 | Rejected code review findings report |
-| 17 | 📊 | Final report |
-| 18 | 🏁 | Final cleanup + warnings |
+Step Name Registry:
+| Step | Short Name |
+|------|------------|
+| 0 | setup |
+| 1 | design plan |
+| 1.m | update main |
+| 1.r | rebase |
+| 2 | implementation |
+| 3 | checks (1) |
+| 4 | commit (impl) |
+| 4.r | rebase |
+| 5 | code review |
+| 6 | checks (2) |
+| 7 | commit (review) |
+| 7.r | rebase |
+| 7a | code flow |
+| 7a.r | rebase |
+| 8 | version bump |
+| 8a | changelog |
+| 9 | create PR |
+| 10 | CI monitor |
+| 11 | slack announce |
+| 12 | CI+merge loop |
+| 13 | merged emoji |
+| 14 | local cleanup |
+| 15 | verify main |
+| 16 | rejected findings |
+| 17 | final report |
+| 18 | cleanup |
 
 ### Verbosity Control
 
@@ -62,9 +66,9 @@ Suggested emoji palette (use consistently):
 - Use terse 3-5 word descriptions for Agent tool calls.
 - Do not produce explanatory prose between tool call outputs — only print the designated output categories below.
 
-**Preserved output (NEVER suppressed, regardless of `debug_mode`):** step start emoji lines, result-bearing completion lines (with counts/outcomes), conditional-skip lines (`⏩`) — except the three rebase-skip variants listed in Suppressed output below, final completion line (Step 18), all warning/error lines (`**⚠ ...`), structured summaries (voting tallies, competition scoreboards, round summaries, final summaries/reports), architecture diagrams, code flow diagrams, implementation plans (original and revised), dialectic resolutions, accepted/rejected findings lists, out-of-scope observations, PR body sections.
+**Preserved output (NEVER suppressed, regardless of `debug_mode`):** step breadcrumb lines (start `▸`, completion `✅`, skip `⏩`/`⏭️`) — except the three rebase-skip variants listed in Suppressed output below, final completion line (Step 18), all warning/error lines (`**⚠ ...`), structured summaries (voting tallies, competition scoreboards, round summaries, final summaries/reports), architecture diagrams, code flow diagrams, implementation plans (original and revised), dialectic resolutions, accepted/rejected findings lists, out-of-scope observations, PR body sections.
 
-**Suppressed output (only when `debug_mode=false`):** explanatory prose describing what will happen next or what just happened, script paths and command descriptions, rationale for decisions between tool calls, per-reviewer individual completion messages (replaced by status table in child skills), rebase-skip messages (the following three specific variants: `⏩ Rebase skipped — branch already pushed to origin.`, `⏩ Rebase skipped — already at latest main.`, `⏩ Local main already at latest — no update needed.`). Note: non-rebase `⏩` skip messages and rebase outcomes in the Rebase+Re-bump Sub-procedure (Steps 10/12) are NOT suppressed — they carry CI-debugging semantics.
+**Suppressed output (only when `debug_mode=false`):** explanatory prose describing what will happen next or what just happened, script paths and command descriptions, rationale for decisions between tool calls, per-reviewer individual completion messages (replaced by status table in child skills), rebase-skip messages (the following three specific variants: `⏩ 1.m: design plan | update main — already at latest`, `⏩ 1.r: design plan | rebase — already pushed`, `⏩ 1.r: design plan | rebase — already at latest main`). Note: non-rebase `⏩` skip messages and rebase outcomes in the Rebase+Re-bump Sub-procedure (Steps 10/12) are NOT suppressed — they carry CI-debugging semantics.
 
 **When `debug_mode=true`:** use descriptive text for `description` parameter on all Bash and Agent tool calls; print full explanatory text between tool calls (current verbose behavior).
 
@@ -152,7 +156,7 @@ Parse the output for `CURRENT_BRANCH`, `IS_MAIN`, `IS_USER_BRANCH`, and `USER_PR
 
 **This block runs only when `CURRENT_BRANCH == "main"`.** Detached HEAD also reports `IS_MAIN=true` from `create-branch.sh --check`, but a rebase on detached HEAD would fail (`rebase-push.sh` errors with "Not on a branch"); fall through to the mode-specific branch creation logic below so a new branch can be created from `origin/main`. Also skip this block for `IS_USER_BRANCH=true` (we are not creating a branch from main — the feature branch rebase at the end of Step 1 handles freshness) and for the non-main/non-user-branch warning path (we are on some other branch, and `create-branch.sh --branch` will fetch and create the new branch directly from `origin/main`).
 
-Print: `🔃 Ensuring local main is up to date before branching...`
+Print: `🔃 1.m: design plan | update main`
 
 Run:
 ```bash
@@ -176,7 +180,7 @@ Skip `/design` entirely. Handle branch creation directly, then produce an inline
 - If `IS_USER_BRANCH=true`: Verify the branch name (`CURRENT_BRANCH`) aligns with the requested feature. If it appears unrelated (different feature name, unrelated commits), print a warning: `**⚠ Current branch '<branch-name>' may not match the requested feature. Creating a new branch from main.**` and create a new branch. Otherwise, use the existing branch.
 - Otherwise (non-main, non-user branch): Print a warning: `**⚠ Currently on branch '<branch-name>' which doesn't match the expected '<USER_PREFIX>/*' pattern. Creating a new branch from main.**` and create a new branch.
 
-**Inline design**: Research the codebase (read relevant files, grep for patterns), then produce a concrete implementation plan under a `## Implementation Plan` header. This plan should include files to modify, approach, and edge cases — the same content `/design` would produce, but without collaborative sketches, plan review, or voting. Print: `⚡ Step 1 — Quick mode: skipped /design, produced inline plan.`
+**Inline design**: Research the codebase (read relevant files, grep for patterns), then produce a concrete implementation plan under a `## Implementation Plan` header. This plan should include files to modify, approach, and edge cases — the same content `/design` would produce, but without collaborative sketches, plan review, or voting. Print: `⚡ 1: design plan — quick mode, inline plan`
 
 Proceed to Step 2.
 
@@ -184,8 +188,8 @@ Proceed to Step 2.
 
 **Decision logic**:
 - If `IS_USER_BRANCH=true` **AND** a reviewed implementation plan is visible in the conversation context above: The plan was created by a prior `/design` invocation in this session. Proceed to Step 2.
-- If `IS_USER_BRANCH=true` but **no** implementation plan is visible in the conversation context: Invoke the `/design` skill with flags and feature description. **If `auto_mode=true`, also prepend `--auto`**. **If `debug_mode=true`, also prepend `--debug`**. Always prepend `--step-prefix 1.` and `--branch-info "IS_MAIN=$IS_MAIN IS_USER_BRANCH=$IS_USER_BRANCH USER_PREFIX=$USER_PREFIX CURRENT_BRANCH=$CURRENT_BRANCH"`. Canonical invocation order: `[--debug] [--auto] --step-prefix 1. --branch-info "<values>" --session-env $IMPLEMENT_TMPDIR/session-env.sh <FEATURE_DESCRIPTION>`. After `/design` completes, proceed to Step 2.
-- If on `main` or empty (detached HEAD) or any non-user branch: No design plan exists yet. Invoke the `/design` skill with the same flags. **If `auto_mode=true`, also prepend `--auto`**. **If `debug_mode=true`, also prepend `--debug`**. Always prepend `--step-prefix 1.` and `--branch-info "IS_MAIN=$IS_MAIN IS_USER_BRANCH=$IS_USER_BRANCH USER_PREFIX=$USER_PREFIX CURRENT_BRANCH=$CURRENT_BRANCH"`. Canonical invocation order: `[--debug] [--auto] --step-prefix 1. --branch-info "<values>" --session-env $IMPLEMENT_TMPDIR/session-env.sh <FEATURE_DESCRIPTION>`. After `/design` completes, proceed to Step 2.
+- If `IS_USER_BRANCH=true` but **no** implementation plan is visible in the conversation context: Invoke the `/design` skill with flags and feature description. **If `auto_mode=true`, also prepend `--auto`**. **If `debug_mode=true`, also prepend `--debug`**. Always prepend `--step-prefix "1.::design plan"` and `--branch-info "IS_MAIN=$IS_MAIN IS_USER_BRANCH=$IS_USER_BRANCH USER_PREFIX=$USER_PREFIX CURRENT_BRANCH=$CURRENT_BRANCH"`. Canonical invocation order: `[--debug] [--auto] --step-prefix "1.::design plan" --branch-info "<values>" --session-env $IMPLEMENT_TMPDIR/session-env.sh <FEATURE_DESCRIPTION>`. After `/design` completes, proceed to Step 2.
+- If on `main` or empty (detached HEAD) or any non-user branch: No design plan exists yet. Invoke the `/design` skill with the same flags. **If `auto_mode=true`, also prepend `--auto`**. **If `debug_mode=true`, also prepend `--debug`**. Always prepend `--step-prefix "1.::design plan"` and `--branch-info "IS_MAIN=$IS_MAIN IS_USER_BRANCH=$IS_USER_BRANCH USER_PREFIX=$USER_PREFIX CURRENT_BRANCH=$CURRENT_BRANCH"`. Canonical invocation order: `[--debug] [--auto] --step-prefix "1.::design plan" --branch-info "<values>" --session-env $IMPLEMENT_TMPDIR/session-env.sh <FEATURE_DESCRIPTION>`. After `/design` completes, proceed to Step 2.
 
 ### Cross-Skill Health Update (after /design)
 
@@ -205,7 +209,7 @@ Save the output as `BRANCH_NAME`. This variable is referenced later by Step 14 (
 
 **This rebase runs unconditionally in both quick and normal mode** — freshness is beneficial regardless of mode. Both the quick-mode "Proceed to Step 2" and normal-mode "proceed to Step 2" instructions above lead here before entering Step 2.
 
-Print: `🔃 Rebasing onto latest main before starting implementation...`
+Print: `🔃 1.r: design plan | rebase`
 
 Run:
 ```bash
@@ -244,7 +248,7 @@ The commit message should describe WHAT was implemented and WHY, not HOW.
 
 ### Rebase onto latest main (after implementation commit)
 
-Print: `🔃 Rebasing onto latest main after implementation commit...`
+Print: `🔃 4.r: commit (impl) | rebase`
 
 Run:
 ```bash
@@ -275,13 +279,13 @@ Skip `/review`. Instead, run a simplified one-round review:
 6. **One round only** — no re-review loop.
 7. For rejected findings, write them to `$IMPLEMENT_TMPDIR/rejected-findings.md` using the same format as normal mode (see below), so Step 16 and PR body sections work unchanged.
 
-Print: `🔍 Step 5 — Quick mode: simplified review (2 Claude subagents, 1 round, no voting).`
+Print: `▸ 5: code review — quick mode (2 Claude subagents, 1 round, no voting)`
 
 ### Normal mode (`quick_mode=false`)
 
 **IMPORTANT: Code review must ALWAYS be invoked via `/review`. Never skip this step regardless of the nature of the changes — whether code, skills, documentation, data files, or configuration. All changes require full review.**
 
-Invoke the `/review` skill with `--session-env $IMPLEMENT_TMPDIR/session-env.sh` to forward reviewer health state. Always prepend `--step-prefix 5.`. **If `debug_mode=true`, also prepend `--debug`.** Canonical invocation order: `[--debug] --step-prefix 5. --session-env $IMPLEMENT_TMPDIR/session-env.sh`. This launches 2 parallel Claude subagent reviewers (general, deep-analysis) plus two Codex and Cursor reviewers (if available and healthy), implements their suggestions recursively until clean.
+Invoke the `/review` skill with `--session-env $IMPLEMENT_TMPDIR/session-env.sh` to forward reviewer health state. Always prepend `--step-prefix "5.::code review"`. **If `debug_mode=true`, also prepend `--debug`.** Canonical invocation order: `[--debug] --step-prefix "5.::code review" --session-env $IMPLEMENT_TMPDIR/session-env.sh`. This launches 2 parallel Claude subagent reviewers (general, deep-analysis) plus two Codex and Cursor reviewers (if available and healthy), implements their suggestions recursively until clean.
 
 After `/review` returns, follow the **Cross-Skill Health Propagation** procedure from Step 0 to read the health status file and update `session-env.sh` if any reviewer timed out during the review.
 
@@ -303,7 +307,7 @@ After the code review completes (whether `/review` in normal mode or the simplif
 ${CLAUDE_PLUGIN_ROOT}/skills/implement/scripts/check-review-changes.sh
 ```
 
-Parse the output for `FILES_CHANGED`. If `FILES_CHANGED=false`, print: `⏩ Step 6 — Skipping second validation — review made no changes.` and skip Steps 6 and 7 (but NOT Step 7a — the Code Flow Diagram step runs unconditionally).
+Parse the output for `FILES_CHANGED`. If `FILES_CHANGED=false`, print: `⏩ 6: checks (2) — skipped, no review changes` and skip Steps 6 and 7 (but NOT Step 7a — the Code Flow Diagram step runs unconditionally).
 
 If files **did change**, invoke `/relevant-checks` to ensure review fixes didn't introduce new issues. If checks fail, diagnose and fix, then re-invoke `/relevant-checks`.
 
@@ -321,7 +325,7 @@ If no files changed (review found no issues), skip this commit.
 
 **Conditional**: Only run this rebase if `FILES_CHANGED=true` from Step 6's `check-review-changes.sh` output (meaning Step 7 created a commit). If Steps 6–7 were skipped (no review changes), skip this rebase — the pre-Step-8 rebase provides the safety net.
 
-Print: `🔃 Rebasing onto latest main after review fixes commit...`
+Print: `🔃 7.r: commit (review) | rebase`
 
 Run:
 ```bash
@@ -336,11 +340,11 @@ If successful:
 
 ## Step 7a — Code Flow Diagram
 
-Print: `🗺️ Step 7a — Generating code flow diagram...`
+Print: `▸ 7a: code flow`
 
 **This step runs unconditionally after Step 7** — regardless of whether Steps 6-7 were skipped due to no review changes.
 
-**If `quick_mode=true`**: Print `⏩ Step 7a — Skipped (quick mode).` and proceed to Step 8.
+**If `quick_mode=true`**: Print `⏩ 7a: code flow — skipped (quick mode)` and proceed to Step 8.
 
 **If `quick_mode=false`**: Generate a mermaid Code Flow Diagram based on the actual committed implementation. The diagram should focus on **runtime behavior** — function call sequences, data flow, or control flow through the implemented code paths. Do NOT duplicate the Architecture Diagram's structural/component view.
 
@@ -364,7 +368,7 @@ Print the diagram under a `## Code Flow Diagram` header with a mermaid code fenc
 
 This rebase runs as a final safety net before the version bump and PR creation, even if a previous rebase just ran. It ensures the branch is as fresh as possible before the version bump becomes the last commit. Exception: if the branch is already on origin (e.g., re-run on an existing PR branch), the `--skip-if-pushed` flag causes this rebase to be skipped — freshness of already-pushed branches is the CI+rebase+merge loop's responsibility (Step 12).
 
-Print: `🔃 Rebasing onto latest main before version bump...`
+Print: `🔃 7a.r: code flow | rebase`
 
 Run:
 ```bash
@@ -403,8 +407,8 @@ Parse the output for `HAS_BUMP` and `COMMITS_BEFORE`.
 ## Step 8a — CHANGELOG Update
 
 **Conditional**: Skip Step 8a entirely and proceed to Step 9 if either condition is true:
-- `CHANGELOG.md` does not exist in the project root (check via the Read tool — if Read returns an error, the file does not exist). Print `⏩ Step 8a — No CHANGELOG.md found, skipping.`
-- Step 8 was skipped (`HAS_BUMP=false`). Print `⏩ Step 8a — Skipped (no version bump).`
+- `CHANGELOG.md` does not exist in the project root (check via the Read tool — if Read returns an error, the file does not exist). Print `⏩ 8a: changelog — skipped (no CHANGELOG.md)`
+- Step 8 was skipped (`HAS_BUMP=false`). Print `⏩ 8a: changelog — skipped (no version bump)`
 
 **If `CHANGELOG.md` exists AND Step 8 produced a version bump**:
 
@@ -433,7 +437,7 @@ Parse the output for `HAS_BUMP` and `COMMITS_BEFORE`.
 
    This keeps the bump commit as the single HEAD commit containing both the version bump and the changelog update.
 
-Print: `📝 Step 8a — CHANGELOG.md updated for v<NEW_VERSION>.`
+Print: `✅ 8a: changelog — updated for v<NEW_VERSION>`
 
 ## Step 9 — Create PR
 
@@ -606,10 +610,10 @@ After the initial version bump in Step 8, every subsequent rebase of the feature
        - **Fallback exit 1**: conflict; rebase is in progress. Enter the **Conflict Resolution Procedure** (Phase 1–4, defined in Step 12 below). **Phase 4's `rebase-push.sh --continue` exit-0 handler (at the end of Step 12's Conflict Resolution Procedure) itself dispatches the sub-procedure with `rebase_already_done=true, caller_kind=step12_phase4`** — i.e., the post-conflict re-bump is owned entirely by Phase 4. **Control transfer is terminal**: the moment Phase 1 is entered, the current (fallback) sub-procedure invocation is conceptually suspended and its remaining steps 3–7 are NOT executed. All further action for this rebase (Phase 2, Phase 3, Phase 4, and the sub-procedure dispatched by Phase 4's exit-0 handler) runs under Phase 4's ownership. When Phase 4 completes (success or bail), it returns control directly to Step 12's outer loop via its own caller-return path — it does NOT return back into the current invocation. Do NOT continue executing steps 3–7 of the current invocation, regardless of whether Phase 4 succeeds or bails.
        - **Fallback exit 2**: `force-with-lease` push failure after a successful rebase. The rebase is complete locally but the branch has NOT been pushed. Do NOT skip steps 3–4: proceed to step 3 (fast-forward local main), then step 4 (re-bump), then step 5 (which will try to push the re-bumped branch and apply its own fetch + compare + retry + bail recovery on any subsequent push failure). Setting `rebase_already_done` is NOT appropriate here because step 5 still needs to push. This is the only way to guarantee the freshness invariant is enforced — skipping straight to step 5's recovery would push a rebased-but-unbumped branch, silently violating the invariant.
        - **Fallback exit 3**: non-conflict rebase failure; rebase already aborted. Read `REBASE_ERROR` and bail to 12d.
-     - **step10 family**: print `**⚠ Step 10 — Rebase conflict detected; deferring to Step 12 for conflict resolution. Proceeding to Step 11 without re-bump.**` Log to `$IMPLEMENT_TMPDIR/execution-issues.md` under `CI Issues`. **Break out of Step 10's loop and proceed to Step 11.**
+     - **step10 family**: print `**⚠ 10: CI monitor — rebase conflict, deferring to Step 12. Proceeding to Step 11.**` Log to `$IMPLEMENT_TMPDIR/execution-issues.md` under `CI Issues`. **Break out of Step 10's loop and proceed to Step 11.**
    - **Exit 3** (non-conflict rebase failure in `--no-push` mode; rebase already aborted):
      - **step12 family**: read `REBASE_ERROR` and bail to 12d.
-     - **step10 family**: print `**⚠ Step 10 — Rebase failed (non-conflict): $REBASE_ERROR. Proceeding to Step 11.**` Log to `CI Issues`. Break to Step 11.
+     - **step10 family**: print `**⚠ 10: CI monitor — rebase failed: $REBASE_ERROR. Proceeding to Step 11.**` Log to `CI Issues`. Break to Step 11.
 
 3. **Fast-forward local `main` to `origin/main`**:
    `rebase-push.sh` refreshes `origin/main` via `git fetch`, but local `main` is not automatically updated. `classify-bump.sh` prefers local `main` for its `merge-base` computation, so without this step `BASE` could point to an older commit than the one the branch was just rebased onto, causing the classifier's diff to include commits that belong to main (not the feature).
@@ -627,8 +631,8 @@ After the initial version bump in Step 8, every subsequent rebase of the feature
    ```
    Parse `HAS_BUMP` and `COMMITS_BEFORE`.
    - **If `HAS_BUMP=false`**:
-     - **step12 family**: **HARD FAILURE**. Print `**⚠ Step 12 — /bump-version skill not found at .claude/skills/bump-version/SKILL.md; cannot re-bump after rebase. Merged PR would reflect a stale version. Bailing to 12d.**` Bail to 12d.
-     - **step10 family**: Print `**⚠ Step 10 — /bump-version skill not found; skipping re-bump. Proceeding to Step 11 with whatever version is currently on the branch.**` Log to `Warnings`. Skip ahead to step 5 — the push still needs to happen because the rebase in step 2 rewrote branch history, and that rewritten history must be force-pushed so the remote PR branch reflects the new base (there is just no new bump commit stacked on top). Then fall through to step 6 (PR body refresh — nothing new to refresh) and step 7 (return to caller).
+     - **step12 family**: **HARD FAILURE**. Print `**⚠ 12: CI+merge loop — /bump-version not found, cannot re-bump. Bailing to 12d.**` Bail to 12d.
+     - **step10 family**: Print `**⚠ 10: CI monitor — /bump-version not found, skipping re-bump. Proceeding to Step 11.**` Log to `Warnings`. Skip ahead to step 5 — the push still needs to happen because the rebase in step 2 rewrote branch history, and that rewritten history must be force-pushed so the remote PR branch reflects the new base (there is just no new bump commit stacked on top). Then fall through to step 6 (PR body refresh — nothing new to refresh) and step 7 (return to caller).
    - **If `HAS_BUMP=true`**: Invoke `/bump-version` via the Skill tool. If the skill invocation itself fails (returns an error, or bails internally):
      - **step12 family**: hard failure — bail to 12d.
      - **step10 family**: log warning and break out of Step 10 to Step 11.
@@ -641,11 +645,11 @@ After the initial version bump in Step 8, every subsequent rebase of the feature
      - **`VERIFIED=true`** (a new commit was created — the common case): proceed to step 5.
 
      - **`VERIFIED=false` AND `COMMITS_AFTER == COMMITS_BEFORE`** (zero new commits — `/bump-version` ran a `BUMP_TYPE=NONE` no-op path, because `classify-bump.sh` detected HEAD is already a bump commit). This normally happens when `drop-bump-commit.sh` reported `DROPPED=false` (e.g., Guard 4 refused the drop because the bump commit touched files beyond `.claude-plugin/plugin.json`) and the stale bump commit survived the rebase unchanged. **Note**: this condition is also reached in the degenerate case where `count_commits()` in `check-bump-version.sh` returned `0` for both pre and post calls because neither local `main` nor `origin/main` exists — in that case, a `WARN: ... neither local 'main' nor 'origin/main' exists` line will have been printed to stderr. Before acting on the bail, check the stderr output of the most recent `check-bump-version.sh` calls for that WARN to determine the true root cause. Caller-family handling:
-       - **step12 family**: **HARD FAILURE** — bail to 12d. Print `**⚠ Step 12 — /bump-version created 0 new commits after rebase (BUMP_TYPE=NONE, or neither local 'main' nor 'origin/main' exists — inspect stderr WARN from check-bump-version.sh to distinguish). Either way, cannot verify bump freshness against current origin/main. Bailing to 12d.**` Log to `$IMPLEMENT_TMPDIR/execution-issues.md` under `CI Issues` (including the relevant stderr excerpt if the WARN was seen). Rationale: Step 12 is the last-chance enforcement point for the version bump freshness invariant. Either a stale bump commit classified against an older base or a missing base ref means we cannot guarantee the merged version is correct; we must fail loudly rather than silently merge a potentially-wrong version.
-       - **step10 family**: log warning `**⚠ Step 10 — /bump-version created 0 new commits after rebase (BUMP_TYPE=NONE or missing main ref — inspect stderr WARN). Proceeding to Step 11 with the existing branch state. Step 12 will re-attempt under strict semantics.**` to `Warnings`, then proceed directly to step 5 (the rebased history still needs to be force-pushed). Step 10 can afford to be permissive here because Step 12 re-runs the sub-procedure under strict semantics and will bail then if the drop still cannot happen.
+       - **step12 family**: **HARD FAILURE** — bail to 12d. Print `**⚠ 12: CI+merge loop — /bump-version created 0 new commits after rebase (BUMP_TYPE=NONE or missing main ref). Cannot verify bump freshness. Bailing to 12d.**` Log to `$IMPLEMENT_TMPDIR/execution-issues.md` under `CI Issues` (including the relevant stderr excerpt if the WARN was seen). Rationale: Step 12 is the last-chance enforcement point for the version bump freshness invariant. Either a stale bump commit classified against an older base or a missing base ref means we cannot guarantee the merged version is correct; we must fail loudly rather than silently merge a potentially-wrong version.
+       - **step10 family**: log warning `**⚠ 10: CI monitor — /bump-version created 0 new commits (BUMP_TYPE=NONE or missing main ref). Proceeding to Step 11. Step 12 will re-attempt.**` to `Warnings`, then proceed directly to step 5 (the rebased history still needs to be force-pushed). Step 10 can afford to be permissive here because Step 12 re-runs the sub-procedure under strict semantics and will bail then if the drop still cannot happen.
 
      - **`VERIFIED=false` AND `COMMITS_AFTER != COMMITS_BEFORE`** (unexpected state — `/bump-version` created more than one commit, or somehow decreased the count):
-       - **step12 family**: **HARD FAILURE**. Print `**⚠ Step 12 — /bump-version did not create exactly one new commit after rebase. Expected $EXPECTED, got $COMMITS_AFTER. Cannot verify bump freshness; bailing to 12d.**` Bail to 12d.
+       - **step12 family**: **HARD FAILURE**. Print `**⚠ 12: CI+merge loop — /bump-version created wrong commit count (expected $EXPECTED, got $COMMITS_AFTER). Bailing to 12d.**` Bail to 12d.
        - **step10 family**: log warning and break to Step 11.
 
    **Rationale**: Step 8's permissive warnings are safe because Step 8 is pre-PR — no merge can happen based on a missing bump. Step 12 is pre-merge — missing bump means stale merge. Step 10 is post-PR but pre-merge (Step 12 does the merge) — any bump failure in Step 10 is recoverable by Step 12's mandatory re-bump, so Step 10 can afford to be permissive. **Step 12 is the last-chance enforcement point; Step 10 is best-effort optimization that improves freshness during the Slack-wait phase.**
@@ -670,8 +674,8 @@ After the initial version bump in Step 8, every subsequent rebase of the feature
       git push --force-with-lease
       ```
       If the retry succeeds, proceed to step 6. If it fails again:
-      - **step12 family**: bail to 12d with error `Step 12 — re-bump push failed twice with --force-with-lease; remote feature branch has diverged from local. Manual intervention required.`
-      - **step10 family**: print `**⚠ Step 10 — re-bump push failed twice. Proceeding to Step 11 with whatever remote state is (may be stale).**` Log to `CI Issues`. Break to Step 11.
+      - **step12 family**: bail to 12d with error `12: CI+merge loop — re-bump push failed twice, remote diverged. Manual intervention required.`
+      - **step10 family**: print `**⚠ 10: CI monitor — re-bump push failed twice. Proceeding to Step 11 (may be stale).**` Log to `CI Issues`. Break to Step 11.
 
    **Critical (step12 family only)**: Do NOT simply "log and return to caller" on push failure. That would let the merge loop proceed to `ACTION=merge` on a remote branch that does NOT contain the fresh bump commit, violating the feature's core invariant. `ci-wait.sh` and `merge-pr.sh` operate on remote PR state only; they cannot see unpushed local commits.
 
@@ -699,7 +703,7 @@ Phase 4 enters the sub-procedure AFTER `rebase-push.sh --continue` has already p
 
 ## Step 10 — CI Monitor (initial wait for green)
 
-**If `repo_unavailable=true`**: Print `⏭️ Step 10 — Skipped (repository name could not be determined).` and proceed to Step 11.
+**If `repo_unavailable=true`**: Print `⏭️ 10: CI monitor — skipped (repo unavailable)` and proceed to Step 11.
 
 Wait for CI to go green so the Slack announcement (Step 11) links to a PR with passing CI. This step does **NOT merge** — Step 12 is the merge-aware loop that handles main advancement and merging.
 
@@ -724,9 +728,9 @@ Parse the output for: `ACTION`, `CI_STATUS`, `BEHIND_COUNT`, `FAILED_RUN_ID`, `B
 
 **Execute the action** returned by `ci-wait.sh`:
 
-   - **`ACTION=merge`**: CI passed and branch is up-to-date. Print `✅ Step 10 — CI passed!` and proceed to Step 11. **Do NOT merge here** — Step 12 handles merging.
+   - **`ACTION=merge`**: CI passed and branch is up-to-date. Print `✅ 10: CI monitor — CI passed!` and proceed to Step 11. **Do NOT merge here** — Step 12 handles merging.
 
-   - **`ACTION=already_merged`**: PR was merged externally during CI wait. Print `✅ Step 10 — PR was merged externally.` and proceed to Step 11. (Step 12 will detect `already_merged` again and skip the merge loop.)
+   - **`ACTION=already_merged`**: PR was merged externally during CI wait. Print `✅ 10: CI monitor — PR merged externally` and proceed to Step 11. (Step 12 will detect `already_merged` again and skip the merge loop.)
 
    - **`ACTION=rebase`**: Main advanced. Invoke the **Rebase + Re-bump Sub-procedure** (defined before this step) with `rebase_already_done=false`, `caller_kind=step10_rebase`. The sub-procedure handles drop-before-rebase, rebase, fast-forward local main, re-bump via `/bump-version`, push with recovery, and PR body refresh. On sub-procedure success, counter updates and `ci-wait.sh` re-invocation happen inside the sub-procedure's step 7. On sub-procedure failure (rebase conflict, re-bump failure, or push failure), the sub-procedure logs a warning and breaks out of Step 10 to Step 11 — it does NOT bail to 12d (Step 12 will re-run the sub-procedure under strict semantics).
 
@@ -736,7 +740,7 @@ Parse the output for: `ACTION`, `CI_STATUS`, `BEHIND_COUNT`, `FAILED_RUN_ID`, `B
      1. **Transient failure** (runner provisioning, Docker pull rate limit, "hosted runner lost communication", etc.): If `transient_retries < 2`, run `${CLAUDE_PLUGIN_ROOT}/scripts/sleep-seconds.sh 60`, then run `${CLAUDE_PLUGIN_ROOT}/scripts/ci-rerun-failed.sh --run-id <FAILED_RUN_ID> --repo $REPO`. Parse output for `RERUN_SUBMITTED` and `ERROR`. If `RERUN_SUBMITTED=false`, print the `ERROR` and treat as a real CI failure (fall through to diagnosis). Otherwise increment `transient_retries`, re-invoke `ci-wait.sh`. If `transient_retries >= 2`, treat as real failure.
      2. **Real CI failure**: Run `${CLAUDE_PLUGIN_ROOT}/scripts/gh-run-logs.sh --run-id <FAILED_RUN_ID> --repo $REPO`. Diagnose the issue, fix it, run `/relevant-checks`, stage and commit using `${CLAUDE_PLUGIN_ROOT}/scripts/git-commit.sh -m "Fix CI failure" <fixed-files>`, push. Increment `fix_attempts`. Re-invoke `ci-wait.sh`.
 
-   - **`ACTION=bail`**: Print `BAIL_REASON`. Print `**⚠ Step 10 — CI monitoring bailed. PR may have failing CI.**` and proceed to Step 11.
+   - **`ACTION=bail`**: Print `BAIL_REASON`. Print `**⚠ 10: CI monitor — bailed, PR may have failing CI**` and proceed to Step 11.
 
 **Execution issues**: Log any CI failures, transient retries, or bail events to `$IMPLEMENT_TMPDIR/execution-issues.md` under the `CI Issues` category.
 
@@ -744,9 +748,9 @@ After handling any non-terminal/non-rebase action (e.g., `evaluate_failure`), **
 
 ## Step 11 — Post Slack Announcement
 
-**If `slack_available=false`**: Print `⏭️ Step 11 — Skipped (Slack not configured).` Set `SLACK_TS` to empty and proceed to the post-execution PR body refresh below.
+**If `slack_available=false`**: Print `⏭️ 11: slack announce — skipped (Slack not configured)` Set `SLACK_TS` to empty and proceed to the post-execution PR body refresh below.
 
-**If `PR_STATUS=existing`**: Print `⏭️ Step 11 — Skipped (PR already existed, avoiding duplicate Slack post). Run post-pr-announce.sh --pr <PR-NUMBER> manually to post the announcement.` Set `SLACK_TS` to empty and proceed to the post-execution PR body refresh below.
+**If `PR_STATUS=existing`**: Print `⏭️ 11: slack announce — skipped (PR already existed, run post-pr-announce.sh manually)` Set `SLACK_TS` to empty and proceed to the post-execution PR body refresh below.
 
 **Otherwise** (`slack_available=true` and `PR_STATUS=created`):
 
@@ -784,9 +788,9 @@ If `execution-issues.md` does not exist or is empty, skip this refresh.
 
 ## Step 12 — CI + Rebase + Merge Loop
 
-**If `merge=false`**: Print `⏭️ Step 12 — Skipped (--merge flag not set). PR created but not merged.` and skip to Step 16.
+**If `merge=false`**: Print `⏭️ 12: CI+merge loop — skipped (--merge not set)` and skip to Step 16.
 
-**If `repo_unavailable=true`**: Print `⏭️ Step 12 — Skipped (repository name could not be determined).` and skip to Step 16.
+**If `repo_unavailable=true`**: Print `⏭️ 12: CI+merge loop — skipped (repo unavailable)` and skip to Step 16.
 
 Monitor CI and the main branch **in parallel**. The key optimization: don't wait for CI to finish before checking if main has advanced.
 
@@ -813,9 +817,9 @@ Parse the output for: `ACTION`, `CI_STATUS`, `BEHIND_COUNT`, `FAILED_RUN_ID`, `B
 
 **Execute the action** returned by `ci-wait.sh`:
 
-   - **`ACTION=rebase`**: Print a context-specific message based on `CI_STATUS`: if `CI_STATUS=pass`, print `🔄 CI passed but main advanced — rebasing + re-bumping...`; if `CI_STATUS=pending`, print `🔄 Main advanced while CI running — rebasing + re-bumping...` → invoke the **Rebase + Re-bump Sub-procedure** (defined before Step 10) with `rebase_already_done=false`, `caller_kind=step12_rebase`. The sub-procedure handles drop-before-rebase, rebase (with Phase 1–4 fallback on conflict), fast-forward local main, `/bump-version`, push with recovery, and PR body refresh. On successful return, counter updates (`rebase_count`, `iteration`, `transient_retries` reset) and `ci-wait.sh` re-invocation happen inside the sub-procedure's step 7. On hard failure, the sub-procedure bails to 12d directly.
+   - **`ACTION=rebase`**: Print a context-specific message based on `CI_STATUS`: if `CI_STATUS=pass`, print `🔃 12: CI+merge loop — CI passed, main advanced, rebasing + re-bumping`; if `CI_STATUS=pending`, print `🔃 12: CI+merge loop — main advanced, rebasing + re-bumping` → invoke the **Rebase + Re-bump Sub-procedure** (defined before Step 10) with `rebase_already_done=false`, `caller_kind=step12_rebase`. The sub-procedure handles drop-before-rebase, rebase (with Phase 1–4 fallback on conflict), fast-forward local main, `/bump-version`, push with recovery, and PR body refresh. On successful return, counter updates (`rebase_count`, `iteration`, `transient_retries` reset) and `ci-wait.sh` re-invocation happen inside the sub-procedure's step 7. On hard failure, the sub-procedure bails to 12d directly.
 
-   - **`ACTION=merge`**: Print `✅ CI passed, main up-to-date — merging!` → proceed to **12b**.
+   - **`ACTION=merge`**: Print `✅ 12: CI+merge loop — CI passed, main up-to-date, merging!` → proceed to **12b**.
 
    - **`ACTION=already_merged`**: Print `✅ PR was force-merged externally — skipping CI wait and merge.` → skip **12b** (no merge needed) and proceed directly to Step 13. The PR counts as successfully merged for Steps 13–15.
 
@@ -930,8 +934,8 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/merge-pr.sh --pr <PR-NUMBER> --repo $REPO
 
 Parse the output for `MERGE_RESULT` and `ERROR`. Handle each result:
 
-- **`MERGE_RESULT=merged`**: Print `✅ Step 12 — PR #<NUMBER> merged!` and continue.
-- **`MERGE_RESULT=admin_merged`**: Print `**⚠ Merged with --admin (review requirement overridden).** ✅ Step 12 — PR #<NUMBER> merged!` and continue.
+- **`MERGE_RESULT=merged`**: Print `✅ 12: CI+merge loop — PR #<NUMBER> merged!` and continue.
+- **`MERGE_RESULT=admin_merged`**: Print `**⚠ Merged with --admin (review overridden).** ✅ 12: CI+merge loop — PR #<NUMBER> merged!` and continue.
 - **`MERGE_RESULT=main_advanced`**: Go back to **12a** (the next iteration will detect the branch is behind and rebase).
 - **`MERGE_RESULT=ci_not_ready`**: Go back to **12a** (CI may need more time or a rerun).
 - **`MERGE_RESULT=admin_failed`**: Bail out (Step 12d) with the `ERROR` message.
@@ -975,7 +979,7 @@ When bailing out:
 
 **If `merge=false`**: Skip this step.
 
-**If `slack_available=false`**: Print `⏭️ Step 13 — Skipped (Slack not configured).` and proceed to Step 14.
+**If `slack_available=false`**: Print `⏭️ 13: merged emoji — skipped (Slack not configured)` and proceed to Step 14.
 
 **Only if the PR was successfully merged in Step 12b or force-merged externally** (not bailed in 12d).
 
@@ -991,7 +995,7 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/post-merged-emoji.sh --slack-ts "$SLACK_TS"
 
 ## Step 14 — Local Cleanup
 
-**If `merge=false`**: Print `⏩ Step 14 — Skipped (--merge not set). You are still on branch $BRANCH_NAME.` and skip to Step 16.
+**If `merge=false`**: Print `⏩ 14: local cleanup — skipped (--merge not set), still on $BRANCH_NAME` and skip to Step 16.
 
 **If the PR was successfully merged (Step 12b or force-merged externally)**:
 
@@ -1001,13 +1005,13 @@ Switch back to main, pull the merged changes, and delete the development branch:
 ${CLAUDE_PLUGIN_ROOT}/scripts/local-cleanup.sh --branch "$BRANCH_NAME"
 ```
 
-Parse the output for `CLEANUP_SUCCESS`, `CURRENT_BRANCH`, and `BRANCH_DELETED`. If `CLEANUP_SUCCESS=true`, print: `🧹 Step 14 — Switched to main, deleted local branch $BRANCH_NAME`. If `CLEANUP_SUCCESS=false`, print: `**⚠ Step 14 — Cleanup partially failed. Current branch: <CURRENT_BRANCH>, branch deleted: <BRANCH_DELETED>.**`
+Parse the output for `CLEANUP_SUCCESS`, `CURRENT_BRANCH`, and `BRANCH_DELETED`. If `CLEANUP_SUCCESS=true`, print: `✅ 14: local cleanup — switched to main, deleted $BRANCH_NAME`. If `CLEANUP_SUCCESS=false`, print: `**⚠ 14: local cleanup — partially failed, branch: <CURRENT_BRANCH>, deleted: <BRANCH_DELETED>**`
 
 **If Step 12 bailed out (PR was NOT merged)**:
 
 Do NOT switch branches or delete the local branch. The user will need the branch to continue manually.
 
-Print: `⚠️ Step 14 — Skipped cleanup (PR not merged). You are still on branch $BRANCH_NAME.`
+Print: `⚠ 14: local cleanup — skipped (PR not merged), still on $BRANCH_NAME`
 
 `$BRANCH_NAME` is the variable captured at the end of Step 1 (after branch resolution by `/design` or quick-mode branch creation).
 
@@ -1025,8 +1029,8 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/verify-main.sh --expected-title "<PR_TITLE> (#<PR_
 
 Parse the output for `VERIFIED`, `COMMIT_HASH`, and `COMMIT_MESSAGE`. Print the result:
 
-- If `VERIFIED=true`: `✅ Step 15 — Verified: main is at <COMMIT_HASH> "<COMMIT_MESSAGE>"`
-- If `VERIFIED=false`: `**⚠ Step 15 — Unexpected HEAD on main: <COMMIT_HASH> "<COMMIT_MESSAGE>". Expected: "<PR_TITLE> (#<PR_NUMBER>)". Another merge may have landed simultaneously.**`
+- If `VERIFIED=true`: `✅ 15: verify main — at <COMMIT_HASH> "<COMMIT_MESSAGE>"`
+- If `VERIFIED=false`: `**⚠ 15: verify main — unexpected HEAD: <COMMIT_HASH> "<COMMIT_MESSAGE>". Expected: "<PR_TITLE> (#<PR_NUMBER>)"**`
 
 ## Step 16 — Rejected Code Review Findings Report
 
@@ -1034,17 +1038,17 @@ Print a report of all code review suggestions that were **not** implemented.
 
 1. Check if `$IMPLEMENT_TMPDIR/rejected-findings.md` exists and is non-empty.
 2. If it has content, print it under a `## Unimplemented Code Review Suggestions` header, formatted clearly with the reviewer name, the suggestion, and the reason for each.
-3. If the file doesn't exist or is empty, print: `📊 Step 16 — All code review suggestions were implemented.`
+3. If the file doesn't exist or is empty, print: `✅ 16: rejected findings — all suggestions implemented`
 
 ## Step 17 — Final Report
 
-**If `quick_mode=true`**: Print: `📊 Step 17 — Quick mode: /design was skipped, code review was simplified (2 Claude subagents, 1 round, no voting).`
+**If `quick_mode=true`**: Print: `✅ 17: final report — quick mode (/design skipped, 2 subagent review)`
 
 **If `quick_mode=false`**: Print a summary noting that:
 - Plan review findings were reported by the `/design` phase (visible in conversation above)
 - Code review findings were reported by the `/review` phase (visible in conversation above)
 
-If both phases reported all suggestions implemented, print: `📊 Step 17 — All review suggestions were implemented across both plan review and code review.`
+If both phases reported all suggestions implemented, print: `✅ 17: final report — all suggestions implemented (plan + code review)`
 
 ## Step 18 — Cleanup and Final Warnings
 
@@ -1060,4 +1064,4 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/cleanup-tmpdir.sh --dir "$IMPLEMENT_TMPDIR"
 
 If `merge=false`, remind: `**Note: --merge was not set. PR was created but not merged. Merge manually when ready.**`
 
-Print: `🏁 Step 18 — Implement complete!`
+Print: `✅ 18: cleanup — implement complete!`

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -168,8 +168,8 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/rebase-push.sh --no-push
 If the script exits non-zero, print: `**⚠ Failed to ensure local main is fresh. Bailing to cleanup.**` and skip to Step 18.
 
 If successful:
-- If stdout contains `SKIPPED_ALREADY_FRESH=true`: if `debug_mode=true`, print: `⏩ Local main already at latest — no update needed.` Otherwise, silently continue.
-- Otherwise, print: `✅ Local main rebased onto latest origin/main.`
+- If stdout contains `SKIPPED_ALREADY_FRESH=true`: if `debug_mode=true`, print: `⏩ 1.m: design plan | update main — already at latest` Otherwise, silently continue.
+- Otherwise, print: `✅ 1.m: design plan | update main — rebased onto latest origin/main`
 
 ### Quick mode (`quick_mode=true`)
 
@@ -219,8 +219,9 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/rebase-push.sh --no-push --skip-if-pushed
 If the script exits non-zero, print: `**⚠ Rebase onto main failed. Bailing to cleanup.**` and skip to Step 18.
 
 If successful:
-- If the stdout contains `SKIPPED_ALREADY_PUSHED=true` or `SKIPPED_ALREADY_FRESH=true`: if `debug_mode=true`, print the corresponding skip message. Otherwise, silently continue.
-- Otherwise, print: `✅ Rebased onto latest main.`
+- If stdout contains `SKIPPED_ALREADY_PUSHED=true`: if `debug_mode=true`, print: `⏩ 1.r: design plan | rebase — already pushed` Otherwise, silently continue.
+- If stdout contains `SKIPPED_ALREADY_FRESH=true`: if `debug_mode=true`, print: `⏩ 1.r: design plan | rebase — already at latest main` Otherwise, silently continue.
+- Otherwise, print: `✅ 1.r: design plan | rebase — rebased onto latest main`
 
 ## Step 2 — Implement the Feature
 
@@ -258,8 +259,9 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/rebase-push.sh --no-push --skip-if-pushed
 If the script exits non-zero, print: `**⚠ Rebase onto main failed. Bailing to cleanup.**` and skip to Step 18.
 
 If successful:
-- If the stdout contains `SKIPPED_ALREADY_PUSHED=true` or `SKIPPED_ALREADY_FRESH=true`: if `debug_mode=true`, print the corresponding skip message. Otherwise, silently continue.
-- Otherwise, print: `✅ Rebased onto latest main.`
+- If stdout contains `SKIPPED_ALREADY_PUSHED=true`: if `debug_mode=true`, print: `⏩ 4.r: commit (impl) | rebase — already pushed` Otherwise, silently continue.
+- If stdout contains `SKIPPED_ALREADY_FRESH=true`: if `debug_mode=true`, print: `⏩ 4.r: commit (impl) | rebase — already at latest main` Otherwise, silently continue.
+- Otherwise, print: `✅ 4.r: commit (impl) | rebase — rebased onto latest main`
 
 ## Step 5 — Code Review
 
@@ -335,8 +337,9 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/rebase-push.sh --no-push --skip-if-pushed
 If the script exits non-zero, print: `**⚠ Rebase onto main failed. Bailing to cleanup.**` and skip to Step 18.
 
 If successful:
-- If the stdout contains `SKIPPED_ALREADY_PUSHED=true` or `SKIPPED_ALREADY_FRESH=true`: if `debug_mode=true`, print the corresponding skip message. Otherwise, silently continue.
-- Otherwise, print: `✅ Rebased onto latest main.`
+- If stdout contains `SKIPPED_ALREADY_PUSHED=true`: if `debug_mode=true`, print: `⏩ 7.r: commit (review) | rebase — already pushed` Otherwise, silently continue.
+- If stdout contains `SKIPPED_ALREADY_FRESH=true`: if `debug_mode=true`, print: `⏩ 7.r: commit (review) | rebase — already at latest main` Otherwise, silently continue.
+- Otherwise, print: `✅ 7.r: commit (review) | rebase — rebased onto latest main`
 
 ## Step 7a — Code Flow Diagram
 
@@ -360,9 +363,9 @@ Print the diagram under a `## Code Flow Diagram` header with a mermaid code fenc
 ```
 ```
 
-**If diagram generation succeeds**, print: `✅ Step 7a — Code flow diagram generated.`
+**If diagram generation succeeds**, print: `✅ 7a: code flow — diagram generated`
 
-**If diagram generation fails** (e.g., the implementation is too abstract to diagram meaningfully), print: `**⚠ Step 7a — Code flow diagram generation failed. Proceeding without diagram.**` Log this warning to `$IMPLEMENT_TMPDIR/execution-issues.md` under the `Warnings` category.
+**If diagram generation fails** (e.g., the implementation is too abstract to diagram meaningfully), print: `**⚠ 7a: code flow — generation failed, proceeding without diagram**` Log this warning to `$IMPLEMENT_TMPDIR/execution-issues.md` under the `Warnings` category.
 
 ### Rebase onto latest main (before version bump)
 
@@ -378,8 +381,9 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/rebase-push.sh --no-push --skip-if-pushed
 If the script exits non-zero, print: `**⚠ Rebase onto main failed. Bailing to cleanup.**` and skip to Step 18.
 
 If successful:
-- If the stdout contains `SKIPPED_ALREADY_PUSHED=true` or `SKIPPED_ALREADY_FRESH=true`: if `debug_mode=true`, print the corresponding skip message. Otherwise, silently continue.
-- Otherwise, print: `✅ Rebased onto latest main.`
+- If stdout contains `SKIPPED_ALREADY_PUSHED=true`: if `debug_mode=true`, print: `⏩ 7a.r: code flow | rebase — already pushed` Otherwise, silently continue.
+- If stdout contains `SKIPPED_ALREADY_FRESH=true`: if `debug_mode=true`, print: `⏩ 7a.r: code flow | rebase — already at latest main` Otherwise, silently continue.
+- Otherwise, print: `✅ 7a.r: code flow | rebase — rebased onto latest main`
 
 ## Step 8 — Version Bump
 
@@ -995,7 +999,7 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/post-merged-emoji.sh --slack-ts "$SLACK_TS"
 
 ## Step 14 — Local Cleanup
 
-**If `merge=false`**: Print `⏩ 14: local cleanup — skipped (--merge not set), still on $BRANCH_NAME` and skip to Step 16.
+**If `merge=false`**: Print `⏭️ 14: local cleanup — skipped (--merge not set), still on $BRANCH_NAME` and skip to Step 16.
 
 **If the PR was successfully merged (Step 12b or force-merged externally)**:
 

--- a/skills/loop-review/SKILL.md
+++ b/skills/loop-review/SKILL.md
@@ -17,20 +17,21 @@ Systematically review the entire codebase by partitioning into slices, reviewing
 
 ## Progress Reporting
 
-**Every step MUST print clearly visible status lines** so the user can instantly see where execution is at. Use distinct emoji prefixes:
+**Every step MUST print clearly visible breadcrumb status lines** so the user can instantly see where execution is. Follow the formatting rules in `${CLAUDE_PLUGIN_ROOT}/skills/shared/progress-reporting.md`.
 
-- Print a **start line** when entering a step: e.g., `🔄 Step 3 — Reviewing slice: scripts/...`
-- Print a **completion line** when done: e.g., `✅ Step 3 — Slice complete (3 findings implemented, 1 deferred)`
+- Print a **start line** when entering a step: e.g., `▸ 3: implement/defer — slice: scripts/...`
+- Print a **completion line** when done: e.g., `✅ 3: implement/defer — 3 findings implemented, 1 deferred`
 
-| Step | Emoji | Description |
-|------|-------|-------------|
-| 0 | 🔧 | Session setup |
-| 1 | 📋 | Partition repository |
-| 2 | 🔍 | Review slice |
-| 3 | 🔄 | Implement/defer findings |
-| 4 | 💾 | Final deferred commit |
-| 5 | 📊 | Summary report |
-| 6 | 🏁 | Cleanup |
+Step Name Registry:
+| Step | Short Name |
+|------|------------|
+| 0 | setup |
+| 1 | partition |
+| 2 | review slice |
+| 3 | implement/defer |
+| 4 | deferred commit |
+| 5 | summary |
+| 6 | cleanup |
 
 ### Verbosity Control
 
@@ -38,7 +39,7 @@ Systematically review the entire codebase by partitioning into slices, reviewing
 
 - Use empty string for the `description` parameter on all Bash tool calls.
 - Use terse 3-5 word descriptions for Agent tool calls.
-- Do not produce explanatory prose between tool call outputs — only print: step start/completion emoji lines, all warning/error lines (`**⚠ ...`), structured summaries (slice results, findings lists, deferred items, final report).
+- Do not produce explanatory prose between tool call outputs — only print: step breadcrumb lines (start `▸`, completion `✅`, skip `⏩`), all warning/error lines (`**⚠ ...`), structured summaries (slice results, findings lists, deferred items, final report).
 
 **Suppressed output (only when `debug_mode=false`):** explanatory prose, script paths, rationale for decisions between tool calls.
 

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -104,7 +104,7 @@ Plus 2 external agents (or Claude replacements):
 4. **Cursor** (if available) — or **Claude (Alternative Perspectives)** replacement: questions assumptions, explores unconventional angles, and surfaces insights that the other agents might overlook
 5. **Codex** (if available) — or **Claude (Edge-cases/Gaps)** replacement: focuses on what might be missing, edge cases, gaps in the codebase, failure modes, and boundary conditions relevant to the research question
 
-Print `🔬 Step 1 — Running collaborative research phase.` and proceed to 1.2.
+Print `▸ 1: research` and proceed to 1.2.
 
 ### 1.2 — Launch Research Perspectives in Parallel
 
@@ -181,6 +181,8 @@ Print the synthesis under a `## Research Synthesis` header. Write the synthesis 
 Print: `✅ 1: research — synthesis complete (5 agents)`
 
 ## Step 2 — Findings Validation
+
+Print: `▸ 2: validation`
 
 **IMPORTANT: Findings validation MUST ALWAYS run with all available reviewers (2 Claude subagents + 2 Codex instances and Cursor if available). Never skip or abbreviate this step regardless of how straightforward the findings appear. Reviewers validate against the actual codebase state, catching inaccuracies or omissions that the research phase may have missed.**
 
@@ -277,9 +279,11 @@ If any findings were accepted (from Claude subagents, Codex, or Cursor):
 2. Revise the research synthesis to incorporate corrections and additions.
 3. Print the revised synthesis under a `## Revised Research Findings` header.
 
-If all reviewers report no issues, print: `✅ Step 2 — All findings validated. No corrections needed.`
+If all reviewers report no issues, print: `✅ 2: validation — all findings validated, no corrections needed`
 
 ## Step 3 — Final Research Report
+
+Print: `▸ 3: report`
 
 Print the final research report under a `## Research Report` header with the following structure:
 

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -19,19 +19,19 @@ The research question is described by `RESEARCH_QUESTION` (not raw `$ARGUMENTS`)
 
 ## Progress Reporting
 
-**Every step MUST print clearly visible status lines** so the user can instantly see where execution is at. Use distinct emoji prefixes:
+**Every step MUST print clearly visible breadcrumb status lines** so the user can instantly see where execution is. Follow the formatting rules in `${CLAUDE_PLUGIN_ROOT}/skills/shared/progress-reporting.md`.
 
-- Print a **start line** when entering a step: e.g., `🔬 Step 1 — Launching research perspectives...`
-- Print a **completion line** when done: e.g., `✅ Step 1 — Research synthesis complete (5 agents).`
+- Print a **start line** when entering a step: e.g., `▸ 1: research`
+- Print a **completion line** when done: e.g., `✅ 1: research — synthesis complete (5 agents)`
 
-Suggested emoji palette (use consistently):
-| Step | Emoji | Description |
-|------|-------|-------------|
-| 0 | 🔧 | Session setup |
-| 1 | 🔬 | Collaborative research perspectives |
-| 2 | 🔍 | Findings validation |
-| 3 | 📊 | Final research report |
-| 4 | 🏁 | Cleanup |
+Step Name Registry:
+| Step | Short Name |
+|------|------------|
+| 0 | setup |
+| 1 | research |
+| 2 | validation |
+| 3 | report |
+| 4 | cleanup |
 
 ### Verbosity Control
 
@@ -39,7 +39,7 @@ Suggested emoji palette (use consistently):
 
 - Use empty string for the `description` parameter on all Bash tool calls.
 - Use terse 3-5 word descriptions for Agent tool calls.
-- Do not produce explanatory prose between tool call outputs — only print: step start/completion emoji lines, all warning/error lines (`**⚠ ...`), structured summaries (findings, risk assessments, research report sections), and the compact agent status table (see below).
+- Do not produce explanatory prose between tool call outputs — only print: step breadcrumb lines (start `▸`, completion `✅`, skip `⏩`), all warning/error lines (`**⚠ ...`), structured summaries (findings, risk assessments, research report sections), and the compact agent status table (see below).
 
 **Compact agent status table**: After launching research agents (Step 1) or validation reviewers (Step 2), maintain a mental tracker of each agent's status. Print a compact table after EACH status change:
 
@@ -85,7 +85,7 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/git-branch-info.sh
 
 Parse the output for `HEAD_SHA` and `CURRENT_BRANCH`. If `CURRENT_BRANCH` is empty (detached HEAD), use `"(detached HEAD)"` in the report.
 
-Print: `🔧 Step 0 — Setup complete. Researching on branch <CURRENT_BRANCH> at commit <HEAD_SHA>.`
+Print: `✅ 0: setup — researching on branch <CURRENT_BRANCH> at <HEAD_SHA>`
 
 ## Step 1 — Collaborative Research Perspectives
 
@@ -178,7 +178,7 @@ Print the synthesis under a `## Research Synthesis` header. Write the synthesis 
 - The branch and commit being researched
 - The synthesized findings
 
-Print: `✅ Step 1 — Research synthesis complete (5 agents).`
+Print: `✅ 1: research — synthesis complete (5 agents)`
 
 ## Step 2 — Findings Validation
 
@@ -312,7 +312,7 @@ Print the final research report under a `## Research Report` header with the fol
 
 If risk assessment, difficulty estimate, or feasibility verdict are not applicable to the nature of the research question (e.g., a pure "how does X work?" question), mark them as **N/A** with a brief explanation.
 
-Print: `📊 Step 3 — Research report complete.`
+Print: `✅ 3: report — complete`
 
 ## Step 4 — Cleanup and Final Warnings
 
@@ -328,4 +328,4 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/cleanup-tmpdir.sh --dir "$RESEARCH_TMPDIR"
 - `**⚠ Cursor research timed out / produced empty output**`
 - `**⚠ Codex research timed out / produced empty output**`
 
-Print: `🏁 Step 4 — Research complete!`
+Print: `✅ 4: cleanup — research complete!`

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -13,24 +13,25 @@ Review all changes on the current branch (vs `main`) using two specialized Claud
 
 - `--debug`: Set a mental flag `debug_mode=true`. Controls output verbosity — see Verbosity Control below. Default: `debug_mode=false`.
 - `--session-env <path>`: Set `SESSION_ENV_PATH` to the given path. This file contains already-discovered session values from a caller skill (e.g., `/implement`) including reviewer health state (`CODEX_HEALTHY`, `CURSOR_HEALTHY`). If not provided, `SESSION_ENV_PATH` is empty (standalone invocation — full health probe at Step 0b).
-- `--step-prefix <prefix>`: Set `STEP_PREFIX` to the given value (e.g., `"5."`). When non-empty, prepend to step numbers **in emoji status lines only** (e.g., `🔍 Step 5.2 — Launching reviewers...`). Do NOT prefix section headers (e.g., `## Review Round {N}`), structured output headers, or artifact labels. Default: empty (standalone numbering). This is an internal orchestration flag used when `/review` is invoked from `/implement`.
+- `--step-prefix <prefix>`: Encodes both numeric prefix and textual breadcrumb path using `::` delimiter — see `${CLAUDE_PLUGIN_ROOT}/skills/shared/progress-reporting.md` for the full encoding spec. Examples: `"5.::code review"` (numeric `5.`, path `code review`), `"5."` (numeric only, backward compat). Parse into `STEP_NUM_PREFIX` (before `::`) and `STEP_PATH_PREFIX` (after `::`, or empty if `::` absent). Default: empty (standalone numbering). This is an internal orchestration flag used when `/review` is invoked from `/implement`.
 
 ## Progress Reporting
 
-**Every step MUST print clearly visible status lines** so the user can instantly see where execution is at. Use distinct emoji prefixes:
+**Every step MUST print clearly visible breadcrumb status lines** so the user can instantly see where execution is and which parent steps they are inside. Follow the formatting rules in `${CLAUDE_PLUGIN_ROOT}/skills/shared/progress-reporting.md`.
 
-- Print a **start line** when entering a step: e.g., `🔍 Step 2 — Launching reviewers...`
-- Print a **completion line** only when it carries informational payload (counts, outcomes, or conditional-skip reasons). Pure "step complete" announcements without payload are not needed — the start line of the next step signals completion.
-- When `STEP_PREFIX` is non-empty, prepend it to step numbers **in emoji status lines only** (e.g., `🔍 Step 5.2 — Launching reviewers...` when `STEP_PREFIX="5."`). Do NOT prefix section headers (e.g., `## Review Round {N}`), structured output headers, or artifact labels. **This rule overrides the literal step numbers in `Print:` directives and examples throughout this file** — whenever a `Print:` line or example contains `Step N`, emit `Step ${STEP_PREFIX}N` instead.
+- Print a **start line** when entering a step: e.g., `▸ 2: launch reviewers` (standalone) or `▸ 5.2: code review | launch reviewers` (nested from `/implement`)
+- Print a **completion line** only when it carries informational payload. Pure "step complete" announcements without payload are not needed.
+- When `STEP_NUM_PREFIX` is non-empty, prepend it to step numbers. When `STEP_PATH_PREFIX` is non-empty, prepend it to breadcrumb paths. **This rule overrides the literal step numbers and names in `Print:` directives and examples throughout this file.** Examples shown below assume standalone mode; when nested, prepend the parent context.
 
-| Step | Emoji | Description |
-|------|-------|-------------|
-| 0 | 🔧 | Session setup |
-| 1 | 📋 | Gather context |
-| 2 | 🔍 | Launch reviewers |
-| 3 | 🔄 | Collect, deduplicate, implement |
-| 4 | 📊 | Final summary |
-| 5 | 🧹 | Cleanup |
+Step Name Registry:
+| Step | Short Name |
+|------|------------|
+| 0 | setup |
+| 1 | gather context |
+| 2 | launch reviewers |
+| 3 | review cycle |
+| 4 | final summary |
+| 5 | cleanup |
 
 ### Verbosity Control
 
@@ -38,7 +39,7 @@ Review all changes on the current branch (vs `main`) using two specialized Claud
 
 - Use empty string for the `description` parameter on all Bash tool calls.
 - Use terse 3-5 word descriptions for Agent tool calls.
-- Do not produce explanatory prose between tool call outputs — only print: step start emoji lines, result-bearing completion lines (with counts/outcomes), conditional-skip lines (`⏩`), all warning/error lines (`**⚠ ...`), structured summaries (voting tallies, scoreboards, round summaries, findings lists, final summary), and the compact reviewer status table (see below).
+- Do not produce explanatory prose between tool call outputs — only print: step breadcrumb lines (start `▸`, completion `✅`, skip `⏩`), all warning/error lines (`**⚠ ...`), structured summaries (voting tallies, scoreboards, round summaries, findings lists, final summary), and the compact reviewer status table (see below).
 
 **Compact reviewer status table**: After launching all reviewers (Step 2), maintain a mental tracker of each reviewer's status. Print a compact table after EACH status change:
 

--- a/skills/shared/progress-reporting.md
+++ b/skills/shared/progress-reporting.md
@@ -1,0 +1,82 @@
+# Progress Reporting Contract
+
+Shared formatting rules for step progress output across all larch skills. Each skill maintains its own **Step Name Registry** (mapping step numbers to short names) and references this contract for formatting.
+
+## Breadcrumb Format
+
+Every progress line follows:
+
+```
+{icon} {step_number}: {breadcrumb_path}[ — {payload}]
+```
+
+- **`{icon}`**: One of the icons below, indicating the line type.
+- **`{step_number}`**: The full numeric step designation including any parent prefix (e.g., `1.2a.5` when `/design` step `2a.5` is called from `/implement` step `1`).
+- **`{breadcrumb_path}`**: Human-readable path from root to current step, segments joined by ` | `. Built from `STEP_PATH_PREFIX | step_short_name` when nested, or just `step_short_name` when standalone.
+- **`{payload}`**: Optional description, outcome, or reason — appended after ` — `.
+
+## Icon Taxonomy
+
+| Icon | Line type | When to use |
+|------|-----------|-------------|
+| `▸` | Step start | Entering a new step |
+| `✅` | Completion | Step completed with informational payload |
+| `⏩` | Sub-step skip | Optimization or workflow-conditional skip (quick mode, no changes, etc.) |
+| `⏭️` | Precondition skip | Entire step skipped due to missing precondition (repo unavailable, Slack not configured, merge not set) |
+| `⚠` | Warning | Non-fatal issue within a step |
+| `🔃` | Rebase | Rebase-related operation |
+| `⏳` | Intermediate | Progress update within a long-running step |
+| `⚡` | Quick mode | Special quick-mode announcements |
+
+**Semantic distinction**: `⏩` and `⏭️` are intentionally separate. `⏩` indicates a lightweight skip within the normal flow; `⏭️` indicates a precondition failure that causes an entire major step to be bypassed.
+
+## `--step-prefix` Encoding
+
+When a parent skill invokes a child skill (e.g., `/implement` → `/design`), it passes step context via `--step-prefix` using this encoding:
+
+```
+--step-prefix "NUM_PREFIX::TEXT_PATH"
+```
+
+- **`NUM_PREFIX`**: The numeric prefix to prepend to the child's step numbers (e.g., `"1."` means child step `2a` becomes `1.2a`).
+- **`TEXT_PATH`**: The human-readable breadcrumb segment(s) from the parent (e.g., `"design plan"`).
+- **Delimiter**: Split on the first `::` to separate numeric from textual parts.
+- **Backward compatibility**: If `::` is absent, treat the entire value as a numeric-only prefix. The text path defaults to empty — breadcrumbs show only the leaf step name.
+
+### Parsing in child skills
+
+Child skills parse `--step-prefix` into two mental variables:
+
+- `STEP_NUM_PREFIX`: Everything before the first `::` (or the entire value if `::` absent).
+- `STEP_PATH_PREFIX`: Everything after the first `::` (or empty if `::` absent).
+
+When outputting a step:
+
+- **Step number**: `{STEP_NUM_PREFIX}{local_step_number}` (e.g., `1.` + `2a.5` = `1.2a.5`)
+- **Breadcrumb path**: If `STEP_PATH_PREFIX` is non-empty: `{STEP_PATH_PREFIX} | {step_short_name}`. Otherwise: just `{step_short_name}`.
+
+### Examples
+
+Standalone `/design` (no `--step-prefix`):
+```
+▸ 2a: sketches
+▸ 2a.5: dialectic
+✅ 2a.5: dialectic — 3 decisions resolved
+```
+
+`/design` called from `/implement` with `--step-prefix "1.::design plan"`:
+```
+▸ 1.2a: design plan | sketches
+▸ 1.2a.5: design plan | dialectic
+✅ 1.2a.5: design plan | dialectic — 3 decisions resolved
+```
+
+`/review` called from `/implement` with `--step-prefix "5.::code review"`:
+```
+▸ 5.2: code review | launch reviewers
+▸ 5.3: code review | review cycle
+```
+
+## Section headers and structured output
+
+Do NOT prefix section headers (e.g., `## Implementation Plan`), structured output headers, artifact labels, or compact reviewer status tables with breadcrumb formatting. Breadcrumbs apply only to progress status lines.


### PR DESCRIPTION
## Summary
- Replaced per-step emoji progress lines with breadcrumb-style step paths across all 5 skill SKILL.md files, showing full human-readable paths from root to current step (e.g., `▸ 1.2a: design plan | sketches` instead of `🤝 Step 1.2a — Collaborative sketches...`).
- Created `skills/shared/progress-reporting.md` shared formatting contract with icon taxonomy, breadcrumb format rules, and `--step-prefix` `::` encoding spec.
- Extended `--step-prefix` to carry both numeric prefix and textual breadcrumb path, with backward-compatible fallback for numeric-only values.

<details><summary>Architecture Diagram</summary>

```mermaid
graph TD
    subgraph "Shared Contract"
        PR["skills/shared/progress-reporting.md<br/>Format rules, icon taxonomy,<br/>--step-prefix :: encoding"]
    end

    subgraph "Parent Skills"
        IMP["skills/implement/SKILL.md<br/>Step Name Registry (25 steps)<br/>Passes --step-prefix to children"]
        LR["skills/loop-review/SKILL.md<br/>Step Name Registry (7 steps)<br/>Standalone only"]
    end

    subgraph "Child Skills (receive --step-prefix)"
        DES["skills/design/SKILL.md<br/>Step Name Registry (13 steps)<br/>Parses NUM::TEXT_PATH"]
        REV["skills/review/SKILL.md<br/>Step Name Registry (6 steps)<br/>Parses NUM::TEXT_PATH"]
    end

    subgraph "Standalone Skills"
        RES["skills/research/SKILL.md<br/>Step Name Registry (5 steps)<br/>Leaf-only breadcrumbs"]
    end

    PR -.->|"referenced by<br/>${CLAUDE_PLUGIN_ROOT}/..."| IMP
    PR -.->|"referenced by"| DES
    PR -.->|"referenced by"| REV
    PR -.->|"referenced by"| RES
    PR -.->|"referenced by"| LR

    IMP -->|"--step-prefix '1.::design plan'"| DES
    IMP -->|"--step-prefix '5.::code review'"| REV
    LR -->|"invokes (no prefix)"| IMP
```

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available — changes are prompt instructions only (no runtime code paths).

</details>

<details><summary>Goal</summary>

- Make step progress output self-documenting by showing the full human-readable path from root to current step
  - Replace per-step emojis with single `▸` icon for start lines, retaining status emojis for completion/skip/warning
  - Keep numerical step designation (e.g., `1.2a.5`) for precision
  - Assign short names (<=20 chars) to every step across all skills
  - Display full breadcrumb path separated by ` | ` (e.g., `design plan | dialectic`)
- Preserve `⏭️`/`⏩` semantic distinction for precondition vs. sub-step skips
- Create shared formatting contract to prevent drift across skills
- Extend `--step-prefix` to carry textual breadcrumb path alongside numeric prefix via `::` encoding

</details>

<details><summary>Test plan</summary>

- [x] Run `/relevant-checks` — pre-commit linters + plugin structure validator pass
- [ ] Manually verify breadcrumb output by running `/implement --quick --auto` on a test feature
- [ ] Verify standalone `/design` shows leaf-only breadcrumbs (no parent path)
- [ ] Verify nested `/design` from `/implement` shows `design plan | ...` breadcrumbs
- [ ] Verify `--step-prefix "1."` (backward compat, no `::`) still works with numeric-only prefix

</details>

<details><summary>Final Design</summary>

### Files modified/created

| File | Action | Description |
|------|--------|-------------|
| `skills/shared/progress-reporting.md` | CREATE | Shared formatting contract: icon rules, path assembly, `--step-prefix` encoding |
| `skills/implement/SKILL.md` | EDIT | Step-name table, full status-line audit, --step-prefix invocations, verbosity refs |
| `skills/design/SKILL.md` | EDIT | Step-name table, full status-line audit, --step-prefix flag docs, verbosity refs |
| `skills/review/SKILL.md` | EDIT | Step-name table, full status-line audit, --step-prefix flag docs, verbosity refs |
| `skills/research/SKILL.md` | EDIT | Step-name table, full status-line audit, verbosity refs |
| `skills/loop-review/SKILL.md` | EDIT | Step-name table, full status-line audit, verbosity refs |

### Key decisions
- **`--step-prefix` encoding**: Overload with `::` delimiter (`"1.::design plan"`) rather than adding a separate `--step-path` flag. Dialectic debate resolved this: two correlated flags create coupling risk.
- **Icon taxonomy**: `▸` for start, `✅` for completion, `⏩` for sub-step skip, `⏭️` for precondition skip, `⚠` for warning, `🔃` for rebase, `⏳` for intermediate.
- **`⏭️`/`⏩` distinction**: Preserved per plan review FINDING_2 (3/3 YES votes).
- **Rebase sub-steps**: `.r` suffix (e.g., `1.r`, `4.r`) with explicit breadcrumb format for skip/completion messages.

</details>

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `9864763` (Consolidate skill setup and reviewer collection into shared scripts (#51))
- **Current version**: `1.3.3`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `1.3.4`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH").

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

### [Plan Review] Claude General, Claude Deep Analysis, Cursor
**Finding**: The `::` encoding for `--step-prefix` was flagged as unnecessary complexity. Three reviewers argued a separate `--step-path` flag would be cleaner.
**Reason not implemented**: Dialectic debate resolved in favor of overloading. All 3 voters unanimously rejected (0/3 YES). The coupling risk of two correlated flags outweighs parsing-fragility concerns.

### [Plan Review] Claude General, Claude Deep Analysis
**Finding**: Step name registry was incomplete (showed only "e.g." subset).
**Reason not implemented**: 1/3 YES. The full Implementation Plan already contains exhaustive registries — the abbreviated plan.txt was a summary artifact.

### [Plan Review] Claude General, Claude Deep Analysis
**Finding**: `/research` and `/loop-review` don't need `--step-prefix` flag support.
**Reason not implemented**: 1/3 YES. The plan already does NOT add `--step-prefix` to these standalone skills.

### [Plan Review] Claude Deep Analysis
**Finding**: `🔃`/`⏳` icons conflict with "single `▸` for start lines."
**Reason not implemented**: 0/3 YES, 1 EXONERATE. User explicitly confirmed the icon scheme.

### [Plan Review] Claude Deep Analysis
**Finding**: Compound step numbers (2a.5) create visual ambiguity.
**Reason not implemented**: 0/3 YES, 2 EXONERATE. Minor ergonomic nit.

### [Plan Review] Claude General
**Finding**: Rebase `.r` suffix introduces new numbering convention.
**Reason not implemented**: 0/3 YES, 2 EXONERATE.

</details>

<details><summary>Implementation Deviations</summary>

No deviations from the plan.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

All code review suggestions were implemented.

</details>

<details><summary>Plan Review Voting Tally</summary>

| Finding | Deep | Cursor | Codex | Result |
|---------|------|--------|-------|--------|
| F1: `::` encoding | NO | NO | NO | REJECTED (0/3) |
| F2: `⏭️`/`⏩` distinction | YES | YES | YES | **ACCEPTED** (3/3) |
| F3: Incomplete registry | YES | NO | NO | Rejected (1/3) |
| F4: Validator 15 syntax | NO | YES | YES | **ACCEPTED** (2/3) |
| F5: Standalone skills | EXONERATE | NO | YES | Rejected (1/3) |
| F6: `🔃`/`⏳` conflict | NO | NO | EXONERATE | Rejected (exonerated) |
| F7: Compound numbers | EXONERATE | EXONERATE | NO | Exonerated |
| F8: `.r` suffix | EXONERATE | NO | EXONERATE | Exonerated |
| F9: Broader update surface | YES | YES | YES | **ACCEPTED** (3/3) |
| F10: Validation step | EXONERATE | YES | YES | **ACCEPTED** (2/3) |

**Reviewer Competition Scoreboard:**

| Reviewer | Findings | Accepted | Rejected | Exonerated | Score |
|----------|----------|----------|----------|------------|-------|
| Codex-General | 3 | 3 | 0 | 0 | **+3** |
| Cursor | 4 | 3 | 1 | 0 | **+2** |
| Claude General | 6 | 2 | 2 | 2 | **+1** |
| Claude Deep | 7 | 2 | 2 | 3 | **+1** |
| Codex-Deep | 0 | 0 | 0 | 0 | 0 (timed out) |

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

All 5 reviewers converged unanimously on the same 11 findings (missed format conversions and one terminology regression). Given unanimous agreement, findings were accepted directly without a formal voting panel. All 11 findings were implemented.

</details>

<details><summary>Out-of-Scope Observations</summary>

- **OOS_1** (plan review): `⏭️` renders inconsistently across terminals (pre-existing)
- **OOS_2** (plan review): Shared reviewer/voter instructions in `skills/shared/*.md` also use emoji prefixes
- **OOS_3** (plan review): `/loop-review` progress section is simpler than other skills
- **OOS_4** (code review): loop-review uses non-taxonomy icons `🔍` and `📋` with no breadcrumb Print directives
- **OOS_5** (code review): implement Step 15 silently skipped when `merge=false` with no breadcrumb output

</details>

<details><summary>Execution Issues</summary>

### Warnings
- **Step 7a**: Code flow diagram generation skipped — changes are to SKILL.md prompt instructions only (no runtime code paths to diagram).

### External Reviewer Issues
- **Step 1 (design)**: Codex-Deep timed out during plan review.
- **Step 5 (review)**: Codex installed but not responding (health check failed). Used Claude replacement subagents for both Codex instances.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | 4 accepted, 6 rejected |
| Code review rounds | 1 |
| Code review findings | 11 accepted, 0 rejected |
| Warnings logged | 1 |
| Pre-existing issues noticed | 0 |
| External reviewers | Cursor: ✅, Codex: ❌ (unhealthy) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
