### PR TITLE
Add LARCH_CURSOR_MODEL and LARCH_CODEX_MODEL env var support

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation with collaborative reviewers (Claude subagents + Codex + Cursor).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -39,6 +39,18 @@
       "type": "string",
       "description": "Your Slack user ID (e.g., U0123456789) for @-mentions in announcements. Also accepted via LARCH_SLACK_USER_ID env var.",
       "sensitive": false
+    },
+    "cursor_model": {
+      "title": "Cursor Model",
+      "type": "string",
+      "description": "Model for Cursor reviewer (e.g., gpt-5.4-medium). Also accepted via LARCH_CURSOR_MODEL env var. When unset, Cursor uses its own default.",
+      "sensitive": false
+    },
+    "codex_model": {
+      "title": "Codex Model",
+      "type": "string",
+      "description": "Model for Codex reviewer (e.g., o3). Also accepted via LARCH_CODEX_MODEL env var. When unset, Codex uses its own default.",
+      "sensitive": false
     }
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.7] - 2026-04-13
+
+### Added
+
+- `LARCH_CURSOR_MODEL` and `LARCH_CODEX_MODEL` environment variables for controlling which models Cursor and Codex use as external reviewers.
+- New `scripts/reviewer-model-args.sh` script that centralizes model flag injection for both tools.
+- Plugin `userConfig` entries (`cursor_model`, `codex_model`) as alternative to environment variables.
+- Prominent `═══` banner-style warnings in terminal output when Cursor or Codex health checks fail.
+
 ## [1.3.6] - 2026-04-13
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ There are three ways to run linters, all backed by the same `.pre-commit-config.
 
 ## Environment Variables
 
-Larch uses three environment variables for Slack integration. All are optional — when not set, Slack-related features are skipped with warnings and all other workflow steps continue normally.
+Larch uses environment variables for Slack integration and external reviewer model configuration. All are optional — when not set, Slack-related features are skipped with warnings, and external reviewers use their default models.
 
 > **Important:** Both `LARCH_SLACK_BOT_TOKEN` **and** `LARCH_SLACK_CHANNEL_ID` must be set in your shell environment for Slack features to function. If either is missing, **all** Slack operations (PR announcements, `:merged:` emoji) are skipped with a warning at session setup time identifying which variable(s) are absent. These variables must be present in the environment where `claude` is launched — they are not read from `.env` files or configuration.
 
@@ -207,6 +207,34 @@ A Slack user ID (e.g., `U0123456789`) used to @-mention the PR author in Slack a
 
 **When not set:**
 - Slack announcements are still posted, but without an @-mention — the message appears without a user notification
+
+### External Reviewer Model Configuration
+
+These variables control which model Cursor and Codex use when running as external reviewers. When unset, each tool uses its own default model. The model is passed via the `--model` flag (Cursor) or `-m` flag (Codex).
+
+Model configuration is also available via plugin `userConfig` — environment variables take precedence if both are set.
+
+### `LARCH_CURSOR_MODEL`
+
+The model name to pass to Cursor's `--model` flag (e.g., `gpt-5.4-medium`, `claude-sonnet-4-6`).
+
+**When set:**
+- All Cursor invocations (reviews, sketches, voting, health probes, negotiations) use this model
+- The model flag is injected by `scripts/reviewer-model-args.sh`, which is called from both scripts and skill prompts
+
+**When not set:**
+- Cursor runs without an explicit `--model` flag, using its own configured default
+
+### `LARCH_CODEX_MODEL`
+
+The model name to pass to Codex's `-m` / `--model` flag (e.g., `o3`, `o4-mini`).
+
+**When set:**
+- All Codex invocations (reviews, sketches, voting, health probes, negotiations) use this model
+- The model flag is injected by `scripts/reviewer-model-args.sh`, which is called from both scripts and skill prompts
+
+**When not set:**
+- Codex runs without an explicit `-m` flag, using its own configured default
 
 ## Detailed Documentation
 

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ The model name to pass to Cursor's `--model` flag (e.g., `gpt-5.4-medium`, `clau
 
 ### `LARCH_CODEX_MODEL`
 
-The model name to pass to Codex's `-m` / `--model` flag (e.g., `o3`, `o4-mini`).
+The model name to pass to Codex's `-m` flag (e.g., `o3`, `o4-mini`).
 
 **When set:**
 - All Codex invocations (reviews, sketches, voting, health probes, negotiations) use this model

--- a/scripts/check-reviewers.sh
+++ b/scripts/check-reviewers.sh
@@ -61,11 +61,14 @@ if [[ "$PROBE" == "true" ]]; then
     if [[ "$CODEX_AVAILABLE" == "true" && "$SKIP_CODEX_PROBE" == "true" ]]; then
         CODEX_HEALTHY="false"
     elif [[ "$CODEX_AVAILABLE" == "true" ]]; then
+        # Build codex command with optional model from LARCH_CODEX_MODEL
+        CODEX_MODEL_ARGS=$("$SCRIPT_DIR/reviewer-model-args.sh" --tool codex)
+        # shellcheck disable=SC2086
         "$SCRIPT_DIR/run-external-reviewer.sh" \
             --tool codex \
             --output "$PROBE_DIR/codex-probe.txt" \
             --timeout 60 \
-            -- codex exec --full-auto -C "$PWD" \
+            -- codex exec --full-auto -C "$PWD" $CODEX_MODEL_ARGS \
             --output-last-message "$PROBE_DIR/codex-probe.txt" \
             "Respond with OK" \
             >"$PROBE_DIR/codex-wrapper.log" 2>&1 &
@@ -74,12 +77,15 @@ if [[ "$PROBE" == "true" ]]; then
     if [[ "$CURSOR_AVAILABLE" == "true" && "$SKIP_CURSOR_PROBE" == "true" ]]; then
         CURSOR_HEALTHY="false"
     elif [[ "$CURSOR_AVAILABLE" == "true" ]]; then
+        # Build cursor command with optional model from LARCH_CURSOR_MODEL
+        CURSOR_MODEL_ARGS=$("$SCRIPT_DIR/reviewer-model-args.sh" --tool cursor)
+        # shellcheck disable=SC2086
         "$SCRIPT_DIR/run-external-reviewer.sh" \
             --tool cursor \
             --output "$PROBE_DIR/cursor-probe.txt" \
             --timeout 60 \
             --capture-stdout \
-            -- cursor agent -p --force --trust --model gpt-5.4-medium --workspace "$PWD" \
+            -- cursor agent -p --force --trust $CURSOR_MODEL_ARGS --workspace "$PWD" \
             "Respond with OK" \
             >"$PROBE_DIR/cursor-wrapper.log" 2>&1 &
     fi
@@ -132,5 +138,22 @@ if [[ "$PROBE" == "true" ]]; then
     fi
     if [[ "$CURSOR_AVAILABLE" == "true" ]]; then
         echo "CURSOR_HEALTHY=$CURSOR_HEALTHY"
+    fi
+
+    # Emit prominent banners to stderr for failed health checks so they are
+    # hard to miss in terminal output.
+    if [[ "$CODEX_AVAILABLE" == "true" && "$CODEX_HEALTHY" == "false" && "$SKIP_CODEX_PROBE" == "false" ]]; then
+        echo "═══════════════════════════════════════════════════════════" >&2
+        echo "  ⚠  CODEX HEALTH CHECK FAILED — not responding" >&2
+        echo "     Codex binary found but health probe timed out or errored." >&2
+        echo "     Will use Claude replacement for this session." >&2
+        echo "═══════════════════════════════════════════════════════════" >&2
+    fi
+    if [[ "$CURSOR_AVAILABLE" == "true" && "$CURSOR_HEALTHY" == "false" && "$SKIP_CURSOR_PROBE" == "false" ]]; then
+        echo "═══════════════════════════════════════════════════════════" >&2
+        echo "  ⚠  CURSOR HEALTH CHECK FAILED — not responding" >&2
+        echo "     Cursor binary found but health probe timed out or errored." >&2
+        echo "     Will use Claude replacement for this session." >&2
+        echo "═══════════════════════════════════════════════════════════" >&2
     fi
 fi

--- a/scripts/check-reviewers.sh
+++ b/scripts/check-reviewers.sh
@@ -140,20 +140,4 @@ if [[ "$PROBE" == "true" ]]; then
         echo "CURSOR_HEALTHY=$CURSOR_HEALTHY"
     fi
 
-    # Emit prominent banners to stderr for failed health checks so they are
-    # hard to miss in terminal output.
-    if [[ "$CODEX_AVAILABLE" == "true" && "$CODEX_HEALTHY" == "false" && "$SKIP_CODEX_PROBE" == "false" ]]; then
-        echo "═══════════════════════════════════════════════════════════" >&2
-        echo "  ⚠  CODEX HEALTH CHECK FAILED — not responding" >&2
-        echo "     Codex binary found but health probe timed out or errored." >&2
-        echo "     Will use Claude replacement for this session." >&2
-        echo "═══════════════════════════════════════════════════════════" >&2
-    fi
-    if [[ "$CURSOR_AVAILABLE" == "true" && "$CURSOR_HEALTHY" == "false" && "$SKIP_CURSOR_PROBE" == "false" ]]; then
-        echo "═══════════════════════════════════════════════════════════" >&2
-        echo "  ⚠  CURSOR HEALTH CHECK FAILED — not responding" >&2
-        echo "     Cursor binary found but health probe timed out or errored." >&2
-        echo "     Will use Claude replacement for this session." >&2
-        echo "═══════════════════════════════════════════════════════════" >&2
-    fi
 fi

--- a/scripts/reviewer-model-args.sh
+++ b/scripts/reviewer-model-args.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# reviewer-model-args.sh — Output model arguments for an external reviewer tool.
+#
+# Returns the appropriate --model / -m flag for the given tool based on
+# environment variables. If no model is configured, outputs nothing (the tool
+# uses its own default).
+#
+# Environment variables:
+#   LARCH_CURSOR_MODEL — Model name for Cursor (e.g., gpt-5.4-medium)
+#   LARCH_CODEX_MODEL  — Model name for Codex (e.g., o3)
+#
+# Plugin userConfig fallbacks (lower priority):
+#   CLAUDE_PLUGIN_OPTION_CURSOR_MODEL → LARCH_CURSOR_MODEL
+#   CLAUDE_PLUGIN_OPTION_CODEX_MODEL  → LARCH_CODEX_MODEL
+#
+# Usage:
+#   reviewer-model-args.sh --tool cursor|codex
+#
+# Output (stdout):
+#   The model flag(s) to splice into the command, or empty string if no model configured.
+#   Examples:
+#     --model gpt-5.4-medium    (cursor with LARCH_CURSOR_MODEL=gpt-5.4-medium)
+#     -m o3                     (codex with LARCH_CODEX_MODEL=o3)
+#     (empty)                   (no env var set)
+#
+# Exit codes:
+#   0 — always
+
+set -euo pipefail
+
+TOOL=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --tool) TOOL="${2:?--tool requires a value}"; shift 2 ;;
+        *) echo "reviewer-model-args.sh: unknown argument: $1" >&2; exit 1 ;;
+    esac
+done
+
+if [[ -z "$TOOL" ]]; then
+    echo "reviewer-model-args.sh: --tool is required" >&2
+    exit 1
+fi
+
+case "$TOOL" in
+    cursor)
+        MODEL="${LARCH_CURSOR_MODEL:-${CLAUDE_PLUGIN_OPTION_CURSOR_MODEL:-}}"
+        if [[ -n "$MODEL" ]]; then
+            echo "--model $MODEL"
+        fi
+        ;;
+    codex)
+        MODEL="${LARCH_CODEX_MODEL:-${CLAUDE_PLUGIN_OPTION_CODEX_MODEL:-}}"
+        if [[ -n "$MODEL" ]]; then
+            echo "-m $MODEL"
+        fi
+        ;;
+    *)
+        echo "reviewer-model-args.sh: --tool must be 'cursor' or 'codex' (got: $TOOL)" >&2
+        exit 1
+        ;;
+esac

--- a/scripts/run-negotiation-round.sh
+++ b/scripts/run-negotiation-round.sh
@@ -54,13 +54,19 @@ fi
 # Remove previous output to ensure fresh results
 rm -f "$OUTPUT_FILE"
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 case "$TOOL" in
     codex)
-        codex exec --full-auto -C "$WORKSPACE" \
+        CODEX_MODEL_ARGS=$("$SCRIPT_DIR/reviewer-model-args.sh" --tool codex)
+        # shellcheck disable=SC2086
+        codex exec --full-auto -C "$WORKSPACE" $CODEX_MODEL_ARGS \
             --output-last-message "$OUTPUT_FILE" - < "$PROMPT_FILE" 2>&1
         ;;
     cursor)
-        cursor agent -p --force --trust --model gpt-5.4-medium --workspace "$WORKSPACE" \
+        CURSOR_MODEL_ARGS=$("$SCRIPT_DIR/reviewer-model-args.sh" --tool cursor)
+        # shellcheck disable=SC2086
+        cursor agent -p --force --trust $CURSOR_MODEL_ARGS --workspace "$WORKSPACE" \
             "Read the negotiation prompt from $PROMPT_FILE and respond to it." \
             > "$OUTPUT_FILE" 2>&1
         ;;

--- a/scripts/session-setup.sh
+++ b/scripts/session-setup.sh
@@ -147,6 +147,14 @@ fi
 SESSION_TMPDIR=$(mktemp -d "/tmp/${PREFIX}-XXXXXX")
 echo "SESSION_TMPDIR=$SESSION_TMPDIR"
 
+# --- 2a. Bridge reviewer model env vars from plugin userConfig (always, regardless of --skip-slack-check) ---
+if [[ -z "${LARCH_CURSOR_MODEL:-}" && -n "${CLAUDE_PLUGIN_OPTION_CURSOR_MODEL:-}" ]]; then
+    export LARCH_CURSOR_MODEL="${CLAUDE_PLUGIN_OPTION_CURSOR_MODEL}"
+fi
+if [[ -z "${LARCH_CODEX_MODEL:-}" && -n "${CLAUDE_PLUGIN_OPTION_CODEX_MODEL:-}" ]]; then
+    export LARCH_CODEX_MODEL="${CLAUDE_PLUGIN_OPTION_CODEX_MODEL}"
+fi
+
 # --- 3. Check Slack configuration (LARCH_SLACK_BOT_TOKEN + LARCH_SLACK_CHANNEL_ID) ---
 # Track values for potential --write-session-env use
 SLACK_OK_VALUE=""
@@ -178,14 +186,6 @@ if [[ "$SKIP_SLACK_CHECK" == "false" ]]; then
         # Also bridge user ID (optional, used for @-mentions)
         if [[ -z "${LARCH_SLACK_USER_ID:-}" && -n "${CLAUDE_PLUGIN_OPTION_SLACK_USER_ID:-}" ]]; then
             export LARCH_SLACK_USER_ID="${CLAUDE_PLUGIN_OPTION_SLACK_USER_ID}"
-        fi
-
-        # Bridge reviewer model env vars from plugin userConfig
-        if [[ -z "${LARCH_CURSOR_MODEL:-}" && -n "${CLAUDE_PLUGIN_OPTION_CURSOR_MODEL:-}" ]]; then
-            export LARCH_CURSOR_MODEL="${CLAUDE_PLUGIN_OPTION_CURSOR_MODEL}"
-        fi
-        if [[ -z "${LARCH_CODEX_MODEL:-}" && -n "${CLAUDE_PLUGIN_OPTION_CODEX_MODEL:-}" ]]; then
-            export LARCH_CODEX_MODEL="${CLAUDE_PLUGIN_OPTION_CODEX_MODEL}"
         fi
 
         SLACK_MISSING_VARS=""
@@ -297,6 +297,26 @@ if [[ "$CHECK_REVIEWERS" == "true" ]]; then
     [[ -n "$PROBED_CURSOR_AVAILABLE" ]] && echo "CURSOR_AVAILABLE=$PROBED_CURSOR_AVAILABLE"
     [[ -n "$PROBED_CODEX_HEALTHY" ]] && echo "CODEX_HEALTHY=$PROBED_CODEX_HEALTHY"
     [[ -n "$PROBED_CURSOR_HEALTHY" ]] && echo "CURSOR_HEALTHY=$PROBED_CURSOR_HEALTHY"
+
+    # Emit prominent banners to stderr for failed health checks (must be here,
+    # not in check-reviewers.sh, because session-setup captures its stdout+stderr
+    # via 2>&1 — banners emitted there would be swallowed).
+    if [[ "$PROBED_CODEX_AVAILABLE" == "true" && "$PROBED_CODEX_HEALTHY" == "false" \
+          && "$SKIP_CODEX_PROBE" == "false" ]]; then
+        echo "═══════════════════════════════════════════════════════════" >&2
+        echo "  ⚠  CODEX HEALTH CHECK FAILED — not responding" >&2
+        echo "     Codex binary found but health probe timed out or errored." >&2
+        echo "     Will use Claude replacement for this session." >&2
+        echo "═══════════════════════════════════════════════════════════" >&2
+    fi
+    if [[ "$PROBED_CURSOR_AVAILABLE" == "true" && "$PROBED_CURSOR_HEALTHY" == "false" \
+          && "$SKIP_CURSOR_PROBE" == "false" ]]; then
+        echo "═══════════════════════════════════════════════════════════" >&2
+        echo "  ⚠  CURSOR HEALTH CHECK FAILED — not responding" >&2
+        echo "     Cursor binary found but health probe timed out or errored." >&2
+        echo "     Will use Claude replacement for this session." >&2
+        echo "═══════════════════════════════════════════════════════════" >&2
+    fi
 
     # Use probed values for downstream sections
     FINAL_CODEX_HEALTHY="${PROBED_CODEX_HEALTHY:-}"

--- a/scripts/session-setup.sh
+++ b/scripts/session-setup.sh
@@ -180,6 +180,14 @@ if [[ "$SKIP_SLACK_CHECK" == "false" ]]; then
             export LARCH_SLACK_USER_ID="${CLAUDE_PLUGIN_OPTION_SLACK_USER_ID}"
         fi
 
+        # Bridge reviewer model env vars from plugin userConfig
+        if [[ -z "${LARCH_CURSOR_MODEL:-}" && -n "${CLAUDE_PLUGIN_OPTION_CURSOR_MODEL:-}" ]]; then
+            export LARCH_CURSOR_MODEL="${CLAUDE_PLUGIN_OPTION_CURSOR_MODEL}"
+        fi
+        if [[ -z "${LARCH_CODEX_MODEL:-}" && -n "${CLAUDE_PLUGIN_OPTION_CODEX_MODEL:-}" ]]; then
+            export LARCH_CODEX_MODEL="${CLAUDE_PLUGIN_OPTION_CODEX_MODEL}"
+        fi
+
         SLACK_MISSING_VARS=""
         if [[ -z "$EFFECTIVE_BOT_TOKEN" ]]; then
             SLACK_MISSING_VARS="LARCH_SLACK_BOT_TOKEN"

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -210,7 +210,7 @@ Print `▸ 2a: sketches` and proceed to 2a.2.
 
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/scripts/run-external-reviewer.sh --tool cursor --output "$DESIGN_TMPDIR/cursor-sketch-output.txt" --timeout 1200 --capture-stdout -- \
-  cursor agent -p --force --trust --model gpt-5.4-medium --workspace "$PWD" \
+  cursor agent -p --force --trust $("${CLAUDE_PLUGIN_ROOT}/scripts/reviewer-model-args.sh" --tool cursor) --workspace "$PWD" \
     "You are looking at a codebase and need to propose a high-level implementation approach for this feature: <FEATURE_DESCRIPTION>. Explore the codebase to understand the relevant architecture, then write 2-3 paragraphs covering: (1) Key architectural decisions and the approach you would take, (2) Which files/modules to modify and why, (3) Main tradeoffs you would consider. Do NOT modify files."
 ```
 
@@ -224,7 +224,7 @@ Prompt: `"You are an Innovation/Exploration architect. Propose a high-level impl
 
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/scripts/run-external-reviewer.sh --tool codex --output "$DESIGN_TMPDIR/codex-sketch-output.txt" --timeout 1200 -- \
-  codex exec --full-auto -C "$PWD" \
+  codex exec --full-auto -C "$PWD" $("${CLAUDE_PLUGIN_ROOT}/scripts/reviewer-model-args.sh" --tool codex) \
     --output-last-message "$DESIGN_TMPDIR/codex-sketch-output.txt" \
     "You are looking at a codebase and need to propose a high-level implementation approach for this feature: <FEATURE_DESCRIPTION>. Explore the codebase to understand the relevant architecture, then write 2-3 paragraphs covering: (1) Key architectural decisions and the approach you would take, (2) Which files/modules to modify and why, (3) Main tradeoffs you would consider. Do NOT modify files."
 ```
@@ -379,7 +379,7 @@ Invoke Cursor via the shared monitored wrapper script (with `--capture-stdout` s
 
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/scripts/run-external-reviewer.sh --tool cursor --output "$DESIGN_TMPDIR/cursor-plan-output.txt" --timeout 1800 --capture-stdout -- \
-  cursor agent -p --force --trust --model gpt-5.4-medium --workspace "$PWD" \
+  cursor agent -p --force --trust $("${CLAUDE_PLUGIN_ROOT}/scripts/reviewer-model-args.sh" --tool cursor) --workspace "$PWD" \
     "Review the implementation plan in $DESIGN_TMPDIR/plan.txt for this project. Read the plan file, then explore the codebase to validate the plan. Combine 4 perspectives: (1) General: logical flaws, code reuse, test coverage, backward compat, pattern consistency. (2) Correctness: logic errors, off-by-one, nil handling, type mismatches, races, error paths. (3) Risk/Integration: breaking changes, side effects, thread safety, deployment risks, regressions, CI. (4) Architecture: separation of concerns, contract boundaries, invariants, semantic boundaries. Return numbered findings with perspective, concern, and suggested revision. If NO issues, output exactly NO_ISSUES_FOUND. Do NOT modify files."
 ```
 
@@ -397,7 +397,7 @@ Run both Codex instances **second** in the parallel message (after Cursor). Each
 
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/scripts/run-external-reviewer.sh --tool codex --output "$DESIGN_TMPDIR/codex-general-plan-output.txt" --timeout 1800 -- \
-  codex exec --full-auto -C "$PWD" \
+  codex exec --full-auto -C "$PWD" $("${CLAUDE_PLUGIN_ROOT}/scripts/reviewer-model-args.sh" --tool codex) \
     --output-last-message "$DESIGN_TMPDIR/codex-general-plan-output.txt" \
     "Review the implementation plan in $DESIGN_TMPDIR/plan.txt for this project. Read the plan file, then explore the codebase to validate the plan. Focus on general code quality and risk/integration perspectives: (1) General: logical flaws, code reuse, test coverage, backward compat, pattern consistency. (2) Risk/Integration: breaking changes, side effects, thread safety, deployment risks, regressions, CI. Return numbered findings with perspective, concern, and suggested revision. If NO issues, output exactly NO_ISSUES_FOUND. Do NOT modify files."
 ```
@@ -408,7 +408,7 @@ Use `run_in_background: true` and `timeout: 1860000` on the Bash tool call.
 
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/scripts/run-external-reviewer.sh --tool codex --output "$DESIGN_TMPDIR/codex-deep-plan-output.txt" --timeout 1800 -- \
-  codex exec --full-auto -C "$PWD" \
+  codex exec --full-auto -C "$PWD" $("${CLAUDE_PLUGIN_ROOT}/scripts/reviewer-model-args.sh" --tool codex) \
     --output-last-message "$DESIGN_TMPDIR/codex-deep-plan-output.txt" \
     "Review the implementation plan in $DESIGN_TMPDIR/plan.txt for this project. Read the plan file, then explore the codebase to validate the plan. Focus on correctness and architecture perspectives: (1) Correctness: logic errors, off-by-one, nil handling, type mismatches, races, error paths. (2) Architecture: separation of concerns, contract boundaries, invariants, semantic boundaries. Return numbered findings with perspective, concern, and suggested revision. If NO issues, output exactly NO_ISSUES_FOUND. Do NOT modify files."
 ```

--- a/skills/loop-review/SKILL.md
+++ b/skills/loop-review/SKILL.md
@@ -142,7 +142,7 @@ Run Cursor **first** in the parallel message (it takes the longest):
 
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/scripts/run-external-reviewer.sh --tool cursor --output "$LR_TMPDIR/cursor-output-slice-N.txt" --timeout 1800 --capture-stdout -- \
-  cursor agent -p --force --trust --model gpt-5.4-medium --workspace "$PWD" \
+  cursor agent -p --force --trust $("${CLAUDE_PLUGIN_ROOT}/scripts/reviewer-model-args.sh" --tool cursor) --workspace "$PWD" \
     "Review EXISTING code (not a diff — do NOT run git diff) in this project. The file list is in $LR_TMPDIR/slice-N-files.txt — read it, then read and review each listed file. Also inspect corresponding tests and callers for context. Combine 4 review perspectives: (1) Quality: bugs, logic errors, dead code, duplication, missing error handling. (2) Correctness: off-by-one, nil handling, type mismatches, races, error paths. (3) Risk/Integration: broken contracts, thread safety, deployment risks, CI gaps. (4) Architecture: separation of concerns, contract boundaries, invariants, semantic boundaries. Return numbered findings with perspective, file:line, issue, and specific fix. If NO issues, output exactly NO_ISSUES_FOUND. Do NOT modify files."
 ```
 
@@ -158,7 +158,7 @@ Run Codex-General **second** in the parallel message:
 
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/scripts/run-external-reviewer.sh --tool codex --output "$LR_TMPDIR/codex-general-output-slice-N.txt" --timeout 1800 -- \
-  codex exec --full-auto -C "$PWD" \
+  codex exec --full-auto -C "$PWD" $("${CLAUDE_PLUGIN_ROOT}/scripts/reviewer-model-args.sh" --tool codex) \
     --output-last-message "$LR_TMPDIR/codex-general-output-slice-N.txt" \
     "Review EXISTING code (not a diff — do NOT run git diff) in this project. The file list is in $LR_TMPDIR/slice-N-files.txt — read it, then read and review each listed file. Also inspect corresponding tests and callers for context. Focus on: quality, bugs, risk, integration, CI. Return numbered findings with file:line, issue, and specific fix. If NO issues, output exactly NO_ISSUES_FOUND. Do NOT modify files."
 ```
@@ -171,7 +171,7 @@ Run Codex-Deep-Analysis **third** in the parallel message:
 
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/scripts/run-external-reviewer.sh --tool codex --output "$LR_TMPDIR/codex-deep-output-slice-N.txt" --timeout 1800 -- \
-  codex exec --full-auto -C "$PWD" \
+  codex exec --full-auto -C "$PWD" $("${CLAUDE_PLUGIN_ROOT}/scripts/reviewer-model-args.sh" --tool codex) \
     --output-last-message "$LR_TMPDIR/codex-deep-output-slice-N.txt" \
     "Review EXISTING code (not a diff — do NOT run git diff) in this project. The file list is in $LR_TMPDIR/slice-N-files.txt — read it, then read and review each listed file. Also inspect corresponding tests and callers for context. Focus on: correctness, architecture, invariants, contracts. Return numbered findings with file:line, issue, and specific fix. If NO issues, output exactly NO_ISSUES_FOUND. Do NOT modify files."
 ```

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -116,7 +116,7 @@ Print `▸ 1: research` and proceed to 1.2.
 
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/scripts/run-external-reviewer.sh --tool cursor --output "$RESEARCH_TMPDIR/cursor-research-output.txt" --timeout 1800 --capture-stdout -- \
-  cursor agent -p --force --trust --model gpt-5.4-medium --workspace "$PWD" \
+  cursor agent -p --force --trust $("${CLAUDE_PLUGIN_ROOT}/scripts/reviewer-model-args.sh" --tool cursor) --workspace "$PWD" \
     "You are researching a codebase to answer this question: <RESEARCH_QUESTION>. Explore the codebase to understand the relevant architecture and code. Write 2-3 paragraphs covering: (1) Your key findings and observations relevant to the research question, (2) Which files/modules/areas are most relevant and why, (3) Any risks, constraints, or feasibility concerns you identify. Do NOT modify files."
 ```
 
@@ -130,7 +130,7 @@ Prompt: `"You are an Alternative Perspectives researcher. Investigate this resea
 
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/scripts/run-external-reviewer.sh --tool codex --output "$RESEARCH_TMPDIR/codex-research-output.txt" --timeout 1800 -- \
-  codex exec --full-auto -C "$PWD" \
+  codex exec --full-auto -C "$PWD" $("${CLAUDE_PLUGIN_ROOT}/scripts/reviewer-model-args.sh" --tool codex) \
     --output-last-message "$RESEARCH_TMPDIR/codex-research-output.txt" \
     "You are researching a codebase to answer this question: <RESEARCH_QUESTION>. Explore the codebase to understand the relevant architecture and code. Write 2-3 paragraphs covering: (1) Your key findings and observations relevant to the research question, (2) Which files/modules/areas are most relevant and why, (3) Any risks, constraints, or feasibility concerns you identify. Do NOT modify files."
 ```
@@ -198,7 +198,7 @@ Run Cursor **first** in the parallel message (it takes the longest):
 
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/scripts/run-external-reviewer.sh --tool cursor --output "$RESEARCH_TMPDIR/cursor-validation-output.txt" --timeout 1800 --capture-stdout -- \
-  cursor agent -p --force --trust --model gpt-5.4-medium --workspace "$PWD" \
+  cursor agent -p --force --trust $("${CLAUDE_PLUGIN_ROOT}/scripts/reviewer-model-args.sh" --tool cursor) --workspace "$PWD" \
     "Review the research findings in $RESEARCH_TMPDIR/research-report.txt for accuracy and completeness. Read the report, then explore the codebase to verify claims. Combine 4 perspectives: (1) General: Are findings accurate? Is anything important missing? Are conclusions well-supported by evidence? (2) Correctness: Are specific code references correct? Are there factual errors about the codebase? (3) Risk/Completeness: Are risks properly identified? Are there blind spots or omissions? (4) Architecture: Are architectural observations accurate? Are there structural patterns that were missed? Return numbered findings with perspective, concern, and suggested correction. If the research is accurate and complete, output exactly NO_ISSUES_FOUND. Do NOT modify files."
 ```
 
@@ -210,7 +210,7 @@ Run Codex-General **second** in the parallel message:
 
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/scripts/run-external-reviewer.sh --tool codex --output "$RESEARCH_TMPDIR/codex-general-validation-output.txt" --timeout 1800 -- \
-  codex exec --full-auto -C "$PWD" \
+  codex exec --full-auto -C "$PWD" $("${CLAUDE_PLUGIN_ROOT}/scripts/reviewer-model-args.sh" --tool codex) \
     --output-last-message "$RESEARCH_TMPDIR/codex-general-validation-output.txt" \
     "Review the research findings in $RESEARCH_TMPDIR/research-report.txt for accuracy and completeness. Read the report, then explore the codebase to verify claims. Focus on 2 perspectives: (1) General: Are findings accurate? Is anything important missing? Are conclusions well-supported by evidence? (2) Risk/Completeness: Are risks properly identified? Are there blind spots or omissions? Return numbered findings with perspective, concern, and suggested correction. If the research is accurate and complete, output exactly NO_ISSUES_FOUND. Do NOT modify files."
 ```
@@ -223,7 +223,7 @@ Run Codex-Deep-Analysis **third** in the parallel message:
 
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/scripts/run-external-reviewer.sh --tool codex --output "$RESEARCH_TMPDIR/codex-deep-validation-output.txt" --timeout 1800 -- \
-  codex exec --full-auto -C "$PWD" \
+  codex exec --full-auto -C "$PWD" $("${CLAUDE_PLUGIN_ROOT}/scripts/reviewer-model-args.sh" --tool codex) \
     --output-last-message "$RESEARCH_TMPDIR/codex-deep-validation-output.txt" \
     "Review the research findings in $RESEARCH_TMPDIR/research-report.txt for accuracy and completeness. Read the report, then explore the codebase to verify claims. Focus on 2 perspectives: (1) Correctness: Are specific code references correct? Are there factual errors about the codebase? (2) Architecture: Are architectural observations accurate? Are there structural patterns that were missed? Return numbered findings with perspective, concern, and suggested correction. If the research is accurate and complete, output exactly NO_ISSUES_FOUND. Do NOT modify files."
 ```

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -116,7 +116,7 @@ Invoke Cursor via the shared monitored wrapper script (with `--capture-stdout` s
 
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/scripts/run-external-reviewer.sh --tool cursor --output "$REVIEW_TMPDIR/cursor-output.txt" --timeout 1800 --capture-stdout -- \
-  cursor agent -p --force --trust --model gpt-5.4-medium --workspace "$PWD" \
+  cursor agent -p --force --trust $("${CLAUDE_PLUGIN_ROOT}/scripts/reviewer-model-args.sh" --tool cursor) --workspace "$PWD" \
     "Review all code changes on the current branch vs main. Run git diff main...HEAD to see changes and git log main...HEAD --oneline for commits. For each changed file, read the full file for context. Combine 4 review perspectives: (1) General: bugs, logic, quality, tests, backward compat, style. (2) Correctness: logic errors, off-by-one, nil handling, type mismatches, races, error paths. (3) Risk/Integration: breaking changes, side effects, thread safety, deployment risks, regressions, CI. (4) Architecture: separation of concerns, contract boundaries, invariants, semantic boundaries. Return numbered findings with perspective, file:line, issue, and suggested fix. If NO issues, output exactly NO_ISSUES_FOUND. Do NOT modify files."
 ```
 
@@ -136,7 +136,7 @@ Invoke both Codex instances via the shared monitored wrapper script:
 
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/scripts/run-external-reviewer.sh --tool codex --output "$REVIEW_TMPDIR/codex-general-output.txt" --timeout 1800 -- \
-  codex exec --full-auto -C "$PWD" \
+  codex exec --full-auto -C "$PWD" $("${CLAUDE_PLUGIN_ROOT}/scripts/reviewer-model-args.sh" --tool codex) \
     --output-last-message "$REVIEW_TMPDIR/codex-general-output.txt" \
     "Review all code changes on the current branch vs main. Run git diff main...HEAD to see changes and git log main...HEAD --oneline for commits. For each changed file, read the full file for context. Focus on general code quality and risk/integration: bugs, logic, quality, tests, backward compat, style, breaking changes, deployment risks, regressions, CI constraints. Return numbered findings with file:line, issue, and suggested fix. If NO issues, output exactly NO_ISSUES_FOUND. Do NOT modify files."
 ```
@@ -147,7 +147,7 @@ Use `run_in_background: true` and `timeout: 1860000` on the Bash tool call.
 
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/scripts/run-external-reviewer.sh --tool codex --output "$REVIEW_TMPDIR/codex-deep-output.txt" --timeout 1800 -- \
-  codex exec --full-auto -C "$PWD" \
+  codex exec --full-auto -C "$PWD" $("${CLAUDE_PLUGIN_ROOT}/scripts/reviewer-model-args.sh" --tool codex) \
     --output-last-message "$REVIEW_TMPDIR/codex-deep-output.txt" \
     "Review all code changes on the current branch vs main. Run git diff main...HEAD to see changes and git log main...HEAD --oneline for commits. For each changed file, read the full file for context. Focus on deep correctness and architecture: logic errors, off-by-one, nil handling, type mismatches, races, error paths, separation of concerns, contract boundaries, invariants, semantic boundaries. Return numbered findings with file:line, issue, and suggested fix. If NO issues, output exactly NO_ISSUES_FOUND. Do NOT modify files."
 ```

--- a/skills/shared/voting-protocol.md
+++ b/skills/shared/voting-protocol.md
@@ -92,7 +92,7 @@ Launch all 3 voters **in parallel** (in a single message). When external tools a
 
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/scripts/run-external-reviewer.sh --tool cursor --output "<tmpdir>/cursor-vote-output.txt" --timeout 1200 --capture-stdout -- \
-  cursor agent -p --force --trust --model gpt-5.4-medium --workspace "$PWD" \
+  cursor agent -p --force --trust $("${CLAUDE_PLUGIN_ROOT}/scripts/reviewer-model-args.sh" --tool cursor) --workspace "$PWD" \
     "<voter prompt with ballot>"
 ```
 
@@ -104,7 +104,7 @@ Use `run_in_background: true` and `timeout: 1260000`.
 
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/scripts/run-external-reviewer.sh --tool codex --output "<tmpdir>/codex-vote-output.txt" --timeout 1200 -- \
-  codex exec --full-auto -C "$PWD" \
+  codex exec --full-auto -C "$PWD" $("${CLAUDE_PLUGIN_ROOT}/scripts/reviewer-model-args.sh" --tool codex) \
     --output-last-message "<tmpdir>/codex-vote-output.txt" \
     "<voter prompt with ballot>"
 ```


### PR DESCRIPTION
## Summary
- Added `LARCH_CURSOR_MODEL` and `LARCH_CODEX_MODEL` environment variables to control which models Cursor and Codex use as external reviewers, with plugin `userConfig` fallback support.
- Created `scripts/reviewer-model-args.sh` to centralize model flag injection, replacing hardcoded `--model gpt-5.4-medium` across all skill prompts and scripts.
- Added prominent `═══` banner-style warnings to `session-setup.sh` stderr when Cursor or Codex health checks fail, making failures significantly more visible in terminal output.

<details><summary>Architecture Diagram</summary>

Quick mode — architecture diagram skipped.

</details>

<details><summary>Code Flow Diagram</summary>

Quick mode — code flow diagram skipped.

</details>

<details><summary>Goal</summary>

- Add configurable model selection for external reviewers (Cursor and Codex) via environment variables
  - `LARCH_CURSOR_MODEL` controls Cursor's `--model` flag
  - `LARCH_CODEX_MODEL` controls Codex's `-m` flag
  - When unset, tools run without explicit model flags (using their own defaults)
  - Plugin `userConfig` entries serve as fallbacks when env vars are not set
- Centralize model flag logic in a script (`scripts/reviewer-model-args.sh`), not in skill prompts
- Make health check failure messages notably more visible with banner-style stderr output
- Update documentation (README, CHANGELOG, plugin.json userConfig)

</details>

<details><summary>Test plan</summary>

- [ ] Verify `LARCH_CURSOR_MODEL=gpt-5.4-medium scripts/reviewer-model-args.sh --tool cursor` outputs `--model gpt-5.4-medium`
- [ ] Verify `LARCH_CODEX_MODEL=o3 scripts/reviewer-model-args.sh --tool codex` outputs `-m o3`
- [ ] Verify with no env vars set, `scripts/reviewer-model-args.sh --tool cursor` outputs empty string
- [ ] Verify `scripts/reviewer-model-args.sh --tool unknown` exits non-zero
- [ ] Run `/implement --quick` or `/review` and verify Cursor/Codex invocations use model args from env vars
- [ ] Verify health check failure banners appear visibly in terminal when Cursor/Codex are unhealthy
- [ ] Verify `pre-commit run --all-files` passes
- [ ] Verify `scripts/validate-plugin-structure.sh` passes

</details>

<details><summary>Final Design</summary>

### Implementation Plan

1. **New script: `scripts/reviewer-model-args.sh`** — outputs model flags based on `LARCH_CURSOR_MODEL`/`LARCH_CODEX_MODEL` env vars with `CLAUDE_PLUGIN_OPTION_*` fallbacks
2. **Update `scripts/check-reviewers.sh`** — use dynamic model args from new script
3. **Update `scripts/run-negotiation-round.sh`** — use dynamic model args from new script
4. **Update all SKILL.md files** — replace hardcoded `--model gpt-5.4-medium` with `$("${CLAUDE_PLUGIN_ROOT}/scripts/reviewer-model-args.sh" --tool cursor)` and add codex model args
5. **Update `skills/shared/voting-protocol.md`** — same pattern
6. **Update `session-setup.sh`** — bridge `CLAUDE_PLUGIN_OPTION_*` vars and add prominent health check failure banners to stderr
7. **Update `plugin.json`** — add `cursor_model` and `codex_model` to userConfig
8. **Update `README.md`** — document both new env vars

</details>

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `c1969d7` (Fix claude-lint errors and add config (#55))
- **Current version**: `1.3.6`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `1.3.7`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH").

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

Quick mode — no plan review was conducted.

</details>

<details><summary>Implementation Deviations</summary>

- Health check banners were initially placed in `check-reviewers.sh` (stderr), but code review identified that `session-setup.sh` captures `check-reviewers.sh`'s stderr via `2>&1`, swallowing the banners. Moved banners to `session-setup.sh` where stderr flows through to terminal.
- Model bridging exports in `session-setup.sh` were initially placed inside the `--skip-slack-check` conditional block. Code review identified this was unreachable for reviewer-using skills. Moved to unconditional location.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

### [Code Review] General Reviewer
**Finding**: `scripts/run-negotiation-round.sh` line 25 uses `set -uo pipefail` without `-e` and lacks the inline comment explaining why `-e` is intentionally omitted, which is required by project convention per CLAUDE.md ("When `-e` is intentionally omitted, add an inline comment explaining why").
**Reason not implemented**: This is a pre-existing issue — the script already had `set -uo pipefail` (without `-e`) before this PR's changes. The reviewer correctly identified the convention violation, but since it pre-dates this PR and is unrelated to the LARCH_CURSOR_MODEL/LARCH_CODEX_MODEL feature, it is out of scope for this change.

### [Code Review] General Reviewer
**Finding**: No tests exist for the new `scripts/reviewer-model-args.sh` script. The script is the single source of truth for model flag injection and has multiple code paths (cursor model set, codex model set, no model set, plugin option fallbacks, precedence, error handling) that could regress.
**Reason not implemented**: No test infrastructure exists for any scripts in this repository. Adding a test framework is out of scope for this feature. The script has been manually verified and is straightforward shell logic. The `# shellcheck disable=SC2086` annotations document the intentional word-splitting pattern used by callers.

### [Code Review] Deep Analysis Reviewer
**Finding**: Cursor uses `--model NAME` (long flag) while Codex uses `-m NAME` (short flag), creating asymmetric flag format at the contract boundary. The README does not make this per-tool distinction clear enough in each section.
**Reason not implemented**: The README's "External Reviewer Model Configuration" intro already states: "The model is passed via the `--model` flag (Cursor) or `-m` flag (Codex)." This provides the per-tool distinction. The flags are different because the Cursor and Codex CLIs have different flag conventions — this is not a design choice by larch but a reflection of upstream tool APIs.

</details>

<details><summary>Plan Review Voting Tally</summary>

Quick mode — no plan review voting.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

Quick mode — no voting panel. Main agent reviewed findings from 2 Claude subagents.

</details>

<details><summary>Out-of-Scope Observations</summary>

Quick mode — no out-of-scope observations collected.

</details>

<details><summary>Execution Issues</summary>

### External Reviewer Issues
- **Step 0**: Cursor installed but health check failed. Using Claude replacement for this session.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | N/A (quick mode) |
| Code review rounds | 1 |
| Code review findings | 3 accepted, 3 rejected |
| Warnings logged | 0 |
| Pre-existing issues noticed | 0 |
| External reviewers | N/A (quick mode) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
