### PR TITLE
Default cursor model to composer-2-fast when unset

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -43,7 +43,7 @@
     "cursor_model": {
       "title": "Cursor Model",
       "type": "string",
-      "description": "Model for Cursor reviewer (e.g., gpt-5.4-medium). Also accepted via LARCH_CURSOR_MODEL env var. When unset, Cursor uses its own default.",
+      "description": "Model for Cursor reviewer (e.g., gpt-5.4-medium). Also accepted via LARCH_CURSOR_MODEL env var. When unset, defaults to composer-2-fast.",
       "sensitive": false
     },
     "codex_model": {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation with collaborative reviewers (Claude subagents + Codex + Cursor).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.8] - 2026-04-13
+
+### Changed
+
+- Cursor reviewer now defaults to `--model composer-2-fast` when `LARCH_CURSOR_MODEL` is unset, since `cursor agent` CLI does not honor `~/.cursor/cli-config.json` and would otherwise fall back to a potentially rate-limited model.
+
 ## [1.3.7] - 2026-04-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ A Slack user ID (e.g., `U0123456789`) used to @-mention the PR author in Slack a
 
 ### External Reviewer Model Configuration
 
-These variables control which model Cursor and Codex use when running as external reviewers. When unset, each tool uses its own default model. The model is passed via the `--model` flag (Cursor) or `-m` flag (Codex).
+These variables control which model Cursor and Codex use when running as external reviewers. When unset, Cursor defaults to `composer-2-fast` and Codex uses its own configured default. The model is passed via the `--model` flag (Cursor) or `-m` flag (Codex).
 
 Model configuration is also available via plugin `userConfig` — environment variables take precedence if both are set.
 

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ The model name to pass to Cursor's `--model` flag (e.g., `gpt-5.4-medium`, `clau
 - The model flag is injected by `scripts/reviewer-model-args.sh`, which is called from both scripts and skill prompts
 
 **When not set:**
-- Cursor runs without an explicit `--model` flag, using its own configured default
+- Defaults to `composer-2-fast` — Cursor's `cursor agent` CLI does not honor the model configured in `~/.cursor/cli-config.json`, so an explicit default is required to avoid falling back to a potentially rate-limited model
 
 ### `LARCH_CODEX_MODEL`
 

--- a/scripts/reviewer-model-args.sh
+++ b/scripts/reviewer-model-args.sh
@@ -17,7 +17,8 @@
 #   reviewer-model-args.sh --tool cursor|codex
 #
 # Output (stdout):
-#   The model flag(s) to splice into the command, or empty string if no model configured.
+#   The model flag(s) to splice into the command, or empty string (Codex only;
+#   Cursor always emits a model flag).
 #   Examples:
 #     --model gpt-5.4-medium    (cursor with LARCH_CURSOR_MODEL=gpt-5.4-medium)
 #     --model composer-2-fast   (cursor with no env var — default)

--- a/scripts/reviewer-model-args.sh
+++ b/scripts/reviewer-model-args.sh
@@ -2,8 +2,8 @@
 # reviewer-model-args.sh — Output model arguments for an external reviewer tool.
 #
 # Returns the appropriate --model / -m flag for the given tool based on
-# environment variables. If no model is configured, outputs nothing (the tool
-# uses its own default).
+# environment variables. Cursor defaults to composer-2-fast when no model is
+# configured. Codex outputs nothing when unconfigured (uses its own default).
 #
 # Environment variables:
 #   LARCH_CURSOR_MODEL — Model name for Cursor (e.g., gpt-5.4-medium)
@@ -20,8 +20,9 @@
 #   The model flag(s) to splice into the command, or empty string if no model configured.
 #   Examples:
 #     --model gpt-5.4-medium    (cursor with LARCH_CURSOR_MODEL=gpt-5.4-medium)
+#     --model composer-2-fast   (cursor with no env var — default)
 #     -m o3                     (codex with LARCH_CODEX_MODEL=o3)
-#     (empty)                   (no env var set)
+#     (empty)                   (codex with no env var set)
 #
 # Exit codes:
 #   0 — always
@@ -43,10 +44,8 @@ fi
 
 case "$TOOL" in
     cursor)
-        MODEL="${LARCH_CURSOR_MODEL:-${CLAUDE_PLUGIN_OPTION_CURSOR_MODEL:-}}"
-        if [[ -n "$MODEL" ]]; then
-            echo "--model $MODEL"
-        fi
+        MODEL="${LARCH_CURSOR_MODEL:-${CLAUDE_PLUGIN_OPTION_CURSOR_MODEL:-composer-2-fast}}"
+        echo "--model $MODEL"
         ;;
     codex)
         MODEL="${LARCH_CODEX_MODEL:-${CLAUDE_PLUGIN_OPTION_CODEX_MODEL:-}}"


### PR DESCRIPTION
## Summary
- Defaulted Cursor reviewer model to `composer-2-fast` when `LARCH_CURSOR_MODEL` is unset, because `cursor agent` CLI does not honor `~/.cursor/cli-config.json` and falls back to a potentially rate-limited model.
- Updated documentation in README, plugin.json userConfig, and script comments to reflect the new default.

<details><summary>Architecture Diagram</summary>

Quick mode — architecture diagram skipped.

</details>

<details><summary>Code Flow Diagram</summary>

Quick mode — code flow diagram skipped.

</details>

<details><summary>Goal</summary>

- Default Cursor to `--model composer-2-fast` when `LARCH_CURSOR_MODEL` is not set
  - `cursor agent` CLI ignores `~/.cursor/cli-config.json` and falls back to a model that may be rate-limited
  - The default should be set in the centralized `scripts/reviewer-model-args.sh` script, not duplicated in skills
- Update documentation to reflect the new default behavior

</details>

<details><summary>Test plan</summary>

- [ ] Verify `scripts/reviewer-model-args.sh --tool cursor` outputs `--model composer-2-fast` with no env var set
- [ ] Verify `LARCH_CURSOR_MODEL=gpt-5.4-medium scripts/reviewer-model-args.sh --tool cursor` outputs `--model gpt-5.4-medium`
- [ ] Verify `scripts/reviewer-model-args.sh --tool codex` still outputs nothing with no env var set
- [ ] Run Cursor health probe and verify it uses `composer-2-fast`
- [ ] Verify `pre-commit run --all-files` passes

</details>

<details><summary>Final Design</summary>

Single file change to `scripts/reviewer-model-args.sh`: in the `cursor)` case, change the fallback from empty string to `composer-2-fast`. The fallback chain becomes `LARCH_CURSOR_MODEL` → `CLAUDE_PLUGIN_OPTION_CURSOR_MODEL` → `composer-2-fast`. All skills and scripts already call this script, so the default propagates everywhere automatically — no SKILL.md changes needed.

</details>

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `2be2373` (Add LARCH_CURSOR_MODEL and LARCH_CODEX_MODEL env var support (#56))
- **Current version**: `1.3.7`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `1.3.8`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH").

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

Quick mode — no plan review was conducted.

</details>

<details><summary>Implementation Deviations</summary>

No deviations from the plan.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

### [Code Review] Deep Analysis Reviewer
**Finding**: `session-setup.sh` bridges `CLAUDE_PLUGIN_OPTION_CURSOR_MODEL` → `LARCH_CURSOR_MODEL` at startup, while `reviewer-model-args.sh` also checks `CLAUDE_PLUGIN_OPTION_CURSOR_MODEL` directly as a middle tier. The two fallback chains overlap, creating a maintenance trap if a future caller reads `LARCH_CURSOR_MODEL` directly without going through `reviewer-model-args.sh`.
**Reason not implemented**: This is intentional defense-in-depth. All Cursor invocations in the codebase go through `reviewer-model-args.sh` (the reviewer confirmed this). The `session-setup.sh` bridge ensures the env var is normalized for any other potential consumers, while `reviewer-model-args.sh`'s own fallback ensures it works even without `session-setup.sh` running first. Both mechanisms are harmless and protective.

</details>

<details><summary>Plan Review Voting Tally</summary>

Quick mode — no plan review voting.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

Quick mode — no voting panel. Main agent reviewed findings from 2 Claude subagents.

</details>

<details><summary>Out-of-Scope Observations</summary>

Quick mode — no out-of-scope observations collected.

</details>

<details><summary>Execution Issues</summary>

No execution issues encountered.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | N/A (quick mode) |
| Code review rounds | 1 |
| Code review findings | 3 accepted, 1 rejected |
| Warnings logged | 0 |
| Pre-existing issues noticed | 0 |
| External reviewers | N/A (quick mode) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
