### PR TITLE
Add retry to health check probes for transient failures

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation with collaborative reviewers (Claude subagents + Codex + Cursor).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.2] - 2026-04-13
+
+### Fixed
+
+- Added 1-retry to Codex and Cursor health check probes to tolerate transient timeouts
+
 ## [2.0.1] - 2026-04-13
 
 ### Changed

--- a/scripts/check-reviewers.sh
+++ b/scripts/check-reviewers.sh
@@ -4,6 +4,7 @@
 # Checks if codex and cursor binaries are installed. With --probe, also sends a
 # trivial prompt to each available tool with a 60-second timeout to verify it is
 # actually responding (catches auth failures, network issues, outages).
+# Failed probes are retried once to tolerate transient timeouts.
 #
 # Usage:
 #   check-reviewers.sh [--probe] [--skip-codex-probe] [--skip-cursor-probe]
@@ -124,6 +125,78 @@ if [[ "$PROBE" == "true" ]]; then
             CURSOR_EXIT=$(cat "$PROBE_DIR/cursor-probe.txt.done")
             if [[ "$CURSOR_EXIT" == "0" ]]; then
                 if [[ -s "$PROBE_DIR/cursor-probe.txt" ]]; then
+                    CURSOR_HEALTHY="true"
+                fi
+            fi
+        fi
+    fi
+
+    # --- Retry once for failed probes (transient timeout recovery) ---
+    RETRY_CODEX=false
+    RETRY_CURSOR=false
+
+    if [[ "$CODEX_AVAILABLE" == "true" && "$SKIP_CODEX_PROBE" == "false" && "$CODEX_HEALTHY" == "false" ]]; then
+        RETRY_CODEX=true
+    fi
+    if [[ "$CURSOR_AVAILABLE" == "true" && "$SKIP_CURSOR_PROBE" == "false" && "$CURSOR_HEALTHY" == "false" ]]; then
+        RETRY_CURSOR=true
+    fi
+
+    if [[ "$RETRY_CODEX" == "true" || "$RETRY_CURSOR" == "true" ]]; then
+        echo "Retrying failed health probes..." >&2
+
+        RETRY_SENTINELS=()
+
+        if [[ "$RETRY_CODEX" == "true" ]]; then
+            rm -f "$PROBE_DIR/codex-probe.txt" "$PROBE_DIR/codex-probe.txt.done" "$PROBE_DIR/codex-probe.txt.meta"
+            CODEX_MODEL_ARGS=$("$SCRIPT_DIR/reviewer-model-args.sh" --tool codex)
+            # shellcheck disable=SC2086
+            "$SCRIPT_DIR/run-external-reviewer.sh" \
+                --tool codex \
+                --output "$PROBE_DIR/codex-probe.txt" \
+                --timeout 60 \
+                -- codex exec --full-auto -C "$PWD" $CODEX_MODEL_ARGS \
+                --output-last-message "$PROBE_DIR/codex-probe.txt" \
+                "Respond with OK" \
+                >"$PROBE_DIR/codex-wrapper.log" 2>&1 &
+            RETRY_SENTINELS+=("$PROBE_DIR/codex-probe.txt.done")
+        fi
+
+        if [[ "$RETRY_CURSOR" == "true" ]]; then
+            rm -f "$PROBE_DIR/cursor-probe.txt" "$PROBE_DIR/cursor-probe.txt.done" "$PROBE_DIR/cursor-probe.txt.meta"
+            CURSOR_MODEL_ARGS=$("$SCRIPT_DIR/reviewer-model-args.sh" --tool cursor)
+            # shellcheck disable=SC2086
+            "$SCRIPT_DIR/run-external-reviewer.sh" \
+                --tool cursor \
+                --output "$PROBE_DIR/cursor-probe.txt" \
+                --timeout 60 \
+                --capture-stdout \
+                -- cursor agent -p --force --trust $CURSOR_MODEL_ARGS --workspace "$PWD" \
+                "Respond with OK" \
+                >"$PROBE_DIR/cursor-wrapper.log" 2>&1 &
+            RETRY_SENTINELS+=("$PROBE_DIR/cursor-probe.txt.done")
+        fi
+
+        if [[ ${#RETRY_SENTINELS[@]} -gt 0 ]]; then
+            "$SCRIPT_DIR/wait-for-reviewers.sh" --timeout 120 "${RETRY_SENTINELS[@]}" \
+                >"$PROBE_DIR/wait-retry.log" 2>&1 || true
+        fi
+
+        # Re-check codex retry result
+        if [[ "$RETRY_CODEX" == "true" ]]; then
+            if [[ -f "$PROBE_DIR/codex-probe.txt.done" ]]; then
+                CODEX_EXIT=$(cat "$PROBE_DIR/codex-probe.txt.done")
+                if [[ "$CODEX_EXIT" == "0" && -s "$PROBE_DIR/codex-probe.txt" ]]; then
+                    CODEX_HEALTHY="true"
+                fi
+            fi
+        fi
+
+        # Re-check cursor retry result
+        if [[ "$RETRY_CURSOR" == "true" ]]; then
+            if [[ -f "$PROBE_DIR/cursor-probe.txt.done" ]]; then
+                CURSOR_EXIT=$(cat "$PROBE_DIR/cursor-probe.txt.done")
+                if [[ "$CURSOR_EXIT" == "0" && -s "$PROBE_DIR/cursor-probe.txt" ]]; then
                     CURSOR_HEALTHY="true"
                 fi
             fi

--- a/scripts/check-reviewers.sh
+++ b/scripts/check-reviewers.sh
@@ -158,7 +158,7 @@ if [[ "$PROBE" == "true" ]]; then
                 -- codex exec --full-auto -C "$PWD" $CODEX_MODEL_ARGS \
                 --output-last-message "$PROBE_DIR/codex-probe.txt" \
                 "Respond with OK" \
-                >"$PROBE_DIR/codex-wrapper.log" 2>&1 &
+                >"$PROBE_DIR/codex-wrapper-retry.log" 2>&1 &
             RETRY_SENTINELS+=("$PROBE_DIR/codex-probe.txt.done")
         fi
 
@@ -173,7 +173,7 @@ if [[ "$PROBE" == "true" ]]; then
                 --capture-stdout \
                 -- cursor agent -p --force --trust $CURSOR_MODEL_ARGS --workspace "$PWD" \
                 "Respond with OK" \
-                >"$PROBE_DIR/cursor-wrapper.log" 2>&1 &
+                >"$PROBE_DIR/cursor-wrapper-retry.log" 2>&1 &
             RETRY_SENTINELS+=("$PROBE_DIR/cursor-probe.txt.done")
         fi
 


### PR DESCRIPTION
## Summary
- Added 1-retry to Codex and Cursor health check probes in `check-reviewers.sh` to tolerate transient timeouts
- Used distinct retry log filenames to preserve first-attempt diagnostics

<details><summary>Architecture Diagram</summary>

Quick mode — architecture diagram skipped.

</details>

<details><summary>Code Flow Diagram</summary>

Quick mode — code flow diagram skipped.

</details>

<details><summary>Goal</summary>

- Improve reliability of external reviewer health checks by retrying failed probes once before marking the reviewer as unhealthy
  - Tolerate transient Cursor timeout failures that would otherwise disable the Cursor reviewer for the entire session
  - Apply the same retry logic to Codex probes for consistency

</details>

<details><summary>Test plan</summary>

- [ ] Run `/implement` with both Cursor and Codex available — verify probes pass on first attempt (no retry triggered)
- [ ] Simulate a transient Cursor timeout (e.g., by temporarily blocking network) — verify the retry fires and recovers on second attempt
- [ ] Verify that persistent failures (both attempts fail) still correctly mark the reviewer as unhealthy
- [ ] Verify retry log files use distinct names (`codex-wrapper-retry.log`, `cursor-wrapper-retry.log`)

</details>

<details><summary>Final Design</summary>

**Problem**: Transient Cursor (and potentially Codex) timeout failures during health check probes cause the reviewer to be marked unhealthy for the entire session. A single transient failure shouldn't disable a reviewer.

**Approach**: Add 1 retry to `scripts/check-reviewers.sh`. After the initial probe results are checked, if either Codex or Cursor probe failed (unhealthy), re-launch only the failed probe(s) with the same parameters and wait again. If the retry succeeds, mark as healthy.

**Files modified**:
- `scripts/check-reviewers.sh` — Added retry logic after initial probe result checking

**Edge cases**:
- Only retry probes that actually failed (don't re-probe healthy tools)
- Only retry when the probe was actually launched (not when skipped via `--skip-*-probe`)
- Clean up retry probe files properly
- The retry reuses the same `PROBE_DIR` (still valid, trap cleanup runs on exit)

</details>

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `94d3326` (Add quality-improvement instructions: TDD, justification gate, proportionality (#63))
- **Current version**: `2.0.1`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `2.0.2`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH").

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

Quick mode — no plan review was conducted.

</details>

<details><summary>Implementation Deviations</summary>

No deviations from the plan.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

### [Code Review] Deep Analysis Reviewer
**Finding**: In `scripts/check-reviewers.sh`, the retry block at lines 147-202 launches new `run-external-reviewer.sh` background processes without first verifying that the first-attempt processes have fully terminated. If the outer `wait-for-reviewers.sh --timeout 120` times out before `run-external-reviewer.sh` internally times out (60s), two concurrent processes could race to write the same `.done` sentinel file and output file, corrupting the retry result.
**Reason not implemented**: The timeout arithmetic makes this race practically impossible. `run-external-reviewer.sh` has a 60s internal timeout with explicit kill logic (SIGTERM + 5s + SIGKILL + wait), completing within ~70s worst case. `wait-for-reviewers.sh` waits 120s — a 50s margin. The first-attempt process will always have exited and written its sentinel before the outer wait completes and the retry fires. Adding PID tracking and explicit kills would add complexity disproportionate to the near-zero probability of this race.

### [Code Review] General Reviewer
**Finding**: In `scripts/check-reviewers.sh` line 146, the `echo "Retrying failed health probes..." >&2` message is emitted to stderr, but `session-setup.sh` captures both stdout and stderr from `check-reviewers.sh` via `2>&1`. The retry banner lands in the captured output but is silently ignored by the `case` parser (lines 286-294 of session-setup.sh), never surfacing to the user. The reviewer suggested either moving the banner to `session-setup.sh` or emitting a structured `PROBE_RETRIED=true` key-value token.
**Reason not implemented**: The message is a diagnostic aid for developers debugging probe failures, not a user-facing status message. `session-setup.sh` already surfaces the final health status to users (healthy/unhealthy lines at lines 304-316). Adding a structured key or moving the message would add cross-script coupling for a diagnostic that is already available in the captured output and has no user-visible impact. The existing pattern of `session-setup.sh` ignoring unrecognized lines is correct — it is designed to be forward-compatible with new diagnostic output.

</details>

<details><summary>Plan Review Voting Tally</summary>

Quick mode — no plan review voting.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

Quick mode — no voting panel. Main agent reviewed findings from 2 Claude subagents.

</details>

<details><summary>Out-of-Scope Observations</summary>

Quick mode — no out-of-scope observations collected.

</details>

<details><summary>Execution Issues</summary>

No execution issues encountered.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | N/A (quick mode) |
| Code review rounds | 1 |
| Code review findings | 1 accepted, 2 rejected |
| Warnings logged | 0 |
| Pre-existing issues noticed | 0 |
| External reviewers | N/A (quick mode) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
