### PR TITLE
Add OOS voting, symmetric scoring, and GitHub issue filing

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation with collaborative reviewers (Claude subagents + Codex + Cursor).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.4] - 2026-04-13
+
+### Changed
+
+- Replaced OOS promotion with GitHub issue filing — accepted OOS items are filed as issues instead of being implemented in the PR
+- Switched OOS scoring from floor-of-0 to symmetric -1/0/+1, matching in-scope finding scoring
+- Added `scripts/create-oos-issues.sh` for automated OOS issue creation at PR time
+- Updated voter prompt template with OOS-specific vote semantics and output format examples
+
 ## [2.0.3] - 2026-04-13
 
 ### Removed

--- a/docs/point-competition.md
+++ b/docs/point-competition.md
@@ -17,16 +17,16 @@ If a deduplicated finding was proposed by multiple reviewers (merged during dedu
 
 ## Out-of-Scope Scoring
 
-Out-of-scope (OOS) observations use a **per-item scoring floor of 0**. This asymmetry is a deliberate design decision: reviewers should feel free to surface pre-existing issues and observations beyond the PR's scope without risking penalty.
+Out-of-scope (OOS) observations use the **same symmetric scoring** as in-scope findings. Both classes of proposals carry the same risk/reward profile, creating two identical competitions running in parallel on the same ballot.
 
 | OOS Vote Result | Points | Description |
 |---|---|---|
-| **OOS Promoted** (2+ YES) | +1 | Reviewer surfaced an issue worth fixing in this PR |
-| **OOS Not Promoted** | 0 | Useful observation, no penalty regardless of vote outcome |
+| **OOS Accepted** (2+ YES) | +1 | Reviewer surfaced an issue worth tracking as a GitHub issue |
+| **OOS Neutral** (exactly 1 YES) | 0 | Insufficient support, but not dismissed |
+| **OOS Exonerated** (0 YES, 1+ EXONERATE) | 0 | Legitimate observation, but not worth filing an issue |
+| **OOS Rejected** (0 YES, 0 EXONERATE) | -1 | Observation was unanimously dismissed by the panel |
 
-The key invariant: **OOS items can never score below 0.** This encourages reviewers to report pre-existing code issues, technical debt, and architectural concerns freely.
-
-## OOS Promotion Mechanics
+## OOS Issue Filing
 
 Out-of-scope items go on the same voting ballot as in-scope findings, labeled with `[OUT_OF_SCOPE]`:
 
@@ -34,22 +34,24 @@ Out-of-scope items go on the same voting ballot as in-scope findings, labeled wi
 OOS_1: [OUT_OF_SCOPE] General — <description>
 ```
 
-Voters can promote an OOS item to in-scope by voting YES:
+Voters decide whether each OOS item deserves a GitHub issue:
 
-- **2+ YES** → Promoted to in-scope, implemented in this PR, reviewer earns +1
-- **Fewer than 2 YES** → Remains an observation, reported in the PR body, reviewer earns 0
+- **2+ YES** → Accepted: filed as a GitHub issue by `/implement` for future attention, reviewer earns +1
+- **Fewer than 2 YES** → Not accepted: remains an observation reported in the PR body
+
+**OOS items are never implemented in the current PR.** Accepted OOS items result in GitHub issue creation only — this cleanly separates "fix now" (in-scope findings) from "fix later" (OOS observations).
 
 ## Scoreboard
 
 After voting completes, a scoreboard is printed showing each reviewer's performance:
 
-| Reviewer | Findings | Accepted | Neutral (1 YES) | Exonerated (0 YES, 1+ EXON.) | Rejected (0 YES, 0 EXON.) | OOS Proposed | OOS Promoted | Score |
+| Reviewer | Findings | Accepted | Neutral (1 YES) | Exonerated (0 YES, 1+ EXON.) | Rejected (0 YES, 0 EXON.) | OOS Proposed | OOS Accepted | Score |
 |----------|----------|----------|-----------------|-------------------------------|---------------------------|--------------|--------------|-------|
 | General | 3 | 2 | 1 | 0 | 0 | 1 | 0 | +2 |
 | Deep-Analysis | 2 | 1 | 0 | 1 | 0 | 0 | 0 | +1 |
 | Codex-General | 1 | 0 | 0 | 0 | 1 | 0 | 0 | -1 |
 | Codex-Deep-Analysis | 1 | 1 | 0 | 0 | 0 | 0 | 0 | +1 |
-| Cursor | 2 | 1 | 1 | 0 | 0 | 0 | 0 | +1 |
+| Cursor | 2 | 1 | 1 | 0 | 0 | 1 | 1 | +2 |
 
 ## Future Plans
 

--- a/docs/voting-process.md
+++ b/docs/voting-process.md
@@ -69,33 +69,40 @@ flowchart TD
     LAUNCH --> COLLECT[Collect votes]
     COLLECT --> TALLY{Tally per finding}
 
-    TALLY -->|2+ YES| ACCEPT[Finding accepted]
+    TALLY -->|In-scope 2+ YES| ACCEPT[Finding accepted]
     TALLY -->|1 YES| NEUTRAL[Finding neutral]
     TALLY -->|0 YES, 1+ EXON| EXON[Finding exonerated]
     TALLY -->|0 YES, 0 EXON| REJECT[Finding rejected]
+    TALLY -->|OOS 2+ YES| OOS_ACCEPT[OOS accepted]
 
     ACCEPT --> IMPLEMENT[Implement accepted findings]
+    OOS_ACCEPT --> ISSUE[File GitHub issue]
     NEUTRAL --> SCORE[Score reviewers]
     EXON --> SCORE
     REJECT --> SCORE
     IMPLEMENT --> SCORE
+    ISSUE --> SCORE
 
     style ACCEPT fill:#2d5a27,color:#fff
     style REJECT fill:#8b1a1a,color:#fff
     style EXON fill:#4a3a6e,color:#fff
     style NEUTRAL fill:#555,color:#fff
+    style OOS_ACCEPT fill:#1a3a5a,color:#fff
+    style ISSUE fill:#1a3a5a,color:#fff
 ```
 
 ## Out-of-Scope Observations
 
-Reviewers may surface **out-of-scope (OOS) observations** — pre-existing issues or concerns beyond the PR's scope. These are handled alongside in-scope findings but with different semantics:
+Reviewers may surface **out-of-scope (OOS) observations** — pre-existing issues or concerns beyond the PR's scope. These are handled alongside in-scope findings on the same ballot but with different vote semantics and outcomes:
 
 - OOS items are included on the ballot with the `[OUT_OF_SCOPE]` prefix
-- **YES** on an OOS item means "promote to in-scope — implement in this PR"
-- **NO** means "keep as observation"
-- **EXONERATE** means "legitimate observation worth documenting"
-- If an OOS item receives 2+ YES votes, it is **promoted** to in-scope and implemented
-- Non-promoted OOS items are collected and reported in the PR body for future attention
+- **YES** on an OOS item means "this deserves a GitHub issue for future attention"
+- **NO** means "not worth tracking"
+- **EXONERATE** means "legitimate observation but not worth filing an issue"
+- If an OOS item receives 2+ YES votes, it is **accepted** and filed as a GitHub issue by `/implement`
+- Non-accepted OOS items are collected and reported in the PR body for future attention
+- **OOS items are never implemented in the current PR** — accepted items result in issue creation only
+- OOS scoring uses the same symmetric -1/0/+1 rules as in-scope findings (see [Point Competition](point-competition.md))
 
 Only Claude subagent reviewers produce OOS observations (via their dual-list output format). External reviewers (Codex, Cursor) produce single-list output treated entirely as in-scope.
 

--- a/scripts/create-oos-issues.sh
+++ b/scripts/create-oos-issues.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# create-oos-issues.sh — Create GitHub issues for accepted OOS items.
+#
+# Reads a structured markdown file of accepted out-of-scope observations
+# and creates one GitHub issue per item. Best-effort: continues on
+# per-item failure and reports partial success.
+#
+# Usage:
+#   create-oos-issues.sh --input-file FILE --repo OWNER/REPO
+#
+# Arguments:
+#   --input-file — Path to markdown file with accepted OOS items
+#   --repo       — Repository in OWNER/REPO format
+#
+# Input file format (one or more blocks):
+#   ### OOS_N: <short title>
+#   - **Description**: <full description>
+#   - **Reviewer**: <attribution>
+#   - **Vote tally**: <YES/NO/EXONERATE counts>
+#   - **Phase**: design|review
+#
+# Outputs (key=value to stdout):
+#   ISSUES_CREATED=<N>
+#   ISSUES_FAILED=<N>
+#   ISSUE_1_NUMBER=<N>
+#   ISSUE_1_URL=<url>
+#   ISSUE_1_TITLE=<title>
+#   ...
+#
+# Exit codes:
+#   0 — success (even partial — check ISSUES_FAILED)
+#   1 — usage error or input file not found
+#   2 — repo not accessible
+
+set -euo pipefail
+
+usage() { echo "Usage: create-oos-issues.sh --input-file FILE --repo OWNER/REPO" >&2; }
+
+INPUT_FILE=""
+REPO=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --input-file) INPUT_FILE="${2:?--input-file requires a value}"; shift 2 ;;
+        --repo) REPO="${2:?--repo requires a value}"; shift 2 ;;
+        *) echo "Unknown option: $1" >&2; usage; exit 1 ;;
+    esac
+done
+
+if [[ -z "$INPUT_FILE" ]] || [[ -z "$REPO" ]]; then
+    usage
+    exit 1
+fi
+
+if [[ ! -f "$INPUT_FILE" ]]; then
+    echo "ERROR=Input file not found: $INPUT_FILE" >&2
+    exit 1
+fi
+
+# Verify repo access
+if ! gh repo view "$REPO" --json name >/dev/null 2>&1; then
+    echo "ERROR=Cannot access repository: $REPO" >&2
+    exit 2
+fi
+
+# Check if the "out-of-scope" label exists
+LABEL_FLAG=""
+if gh label list --repo "$REPO" --search "out-of-scope" --json name --jq '.[].name' 2>/dev/null | grep -qx "out-of-scope"; then
+    LABEL_FLAG="--label out-of-scope"
+fi
+
+# Parse OOS items from the input file
+# Each item starts with "### OOS_" and contains Description, Reviewer, Vote tally, Phase
+ISSUES_CREATED=0
+ISSUES_FAILED=0
+ITEM_INDEX=0
+CURRENT_TITLE=""
+CURRENT_DESCRIPTION=""
+CURRENT_REVIEWER=""
+CURRENT_VOTE=""
+CURRENT_PHASE=""
+
+create_issue() {
+    local title="$1"
+    local description="$2"
+    local reviewer="$3"
+    local vote="$4"
+    local phase="$5"
+
+    ITEM_INDEX=$((ITEM_INDEX + 1))
+
+    # Write issue body to temp file (avoids shell quoting issues)
+    local body_file
+    body_file=$(mktemp)
+    cat > "$body_file" <<BODY_EOF
+## Out-of-Scope Observation
+
+**Surfaced by**: $reviewer
+**Phase**: $phase review
+**Vote tally**: $vote
+
+## Description
+
+$description
+
+---
+*This issue was automatically created by the larch \`/implement\` workflow from an out-of-scope observation that received majority YES votes during review.*
+BODY_EOF
+
+    local issue_url
+    # shellcheck disable=SC2086
+    if issue_url=$(gh issue create --repo "$REPO" --title "[OOS] $title" --body-file "$body_file" $LABEL_FLAG 2>/dev/null); then
+        # gh issue create outputs the issue URL on stdout (e.g., https://github.com/owner/repo/issues/42)
+        local number
+        number=$(echo "$issue_url" | grep -oE '[0-9]+$')
+        ISSUES_CREATED=$((ISSUES_CREATED + 1))
+        echo "ISSUE_${ITEM_INDEX}_NUMBER=$number"
+        echo "ISSUE_${ITEM_INDEX}_URL=$issue_url"
+        echo "ISSUE_${ITEM_INDEX}_TITLE=$title"
+    else
+        ISSUES_FAILED=$((ISSUES_FAILED + 1))
+        echo "ISSUE_${ITEM_INDEX}_FAILED=true" >&2
+        echo "ISSUE_${ITEM_INDEX}_TITLE=$title" >&2
+    fi
+
+    rm -f "$body_file"
+}
+
+flush_item() {
+    if [[ -n "$CURRENT_TITLE" ]] && [[ -n "$CURRENT_DESCRIPTION" ]]; then
+        create_issue "$CURRENT_TITLE" "$CURRENT_DESCRIPTION" "$CURRENT_REVIEWER" "$CURRENT_VOTE" "$CURRENT_PHASE"
+    fi
+    CURRENT_TITLE=""
+    CURRENT_DESCRIPTION=""
+    CURRENT_REVIEWER=""
+    CURRENT_VOTE=""
+    CURRENT_PHASE=""
+}
+
+while IFS= read -r line; do
+    if [[ "$line" =~ ^###\ OOS_[0-9]+:\ (.+)$ ]]; then
+        flush_item
+        CURRENT_TITLE="${BASH_REMATCH[1]}"
+    elif [[ "$line" =~ ^-\ \*\*Description\*\*:\ (.+)$ ]]; then
+        CURRENT_DESCRIPTION="${BASH_REMATCH[1]}"
+    elif [[ "$line" =~ ^-\ \*\*Reviewer\*\*:\ (.+)$ ]]; then
+        CURRENT_REVIEWER="${BASH_REMATCH[1]}"
+    elif [[ "$line" =~ ^-\ \*\*Vote\ tally\*\*:\ (.+)$ ]]; then
+        CURRENT_VOTE="${BASH_REMATCH[1]}"
+    elif [[ "$line" =~ ^-\ \*\*Phase\*\*:\ (.+)$ ]]; then
+        CURRENT_PHASE="${BASH_REMATCH[1]}"
+    fi
+done < "$INPUT_FILE"
+
+# Flush the last item
+flush_item
+
+echo "ISSUES_CREATED=$ISSUES_CREATED"
+echo "ISSUES_FAILED=$ISSUES_FAILED"

--- a/scripts/create-oos-issues.sh
+++ b/scripts/create-oos-issues.sh
@@ -96,7 +96,7 @@ create_issue() {
 ## Out-of-Scope Observation
 
 **Surfaced by**: $reviewer
-**Phase**: $phase review
+**Phase**: $phase
 **Vote tally**: $vote
 
 ## Description
@@ -129,6 +129,10 @@ BODY_EOF
 flush_item() {
     if [[ -n "$CURRENT_TITLE" ]] && [[ -n "$CURRENT_DESCRIPTION" ]]; then
         create_issue "$CURRENT_TITLE" "$CURRENT_DESCRIPTION" "$CURRENT_REVIEWER" "$CURRENT_VOTE" "$CURRENT_PHASE"
+    elif [[ -n "$CURRENT_TITLE" ]] && [[ -z "$CURRENT_DESCRIPTION" ]]; then
+        # Malformed input: title without description — count as failure
+        ISSUES_FAILED=$((ISSUES_FAILED + 1))
+        echo "SKIPPED: '$CURRENT_TITLE' — missing description" >&2
     fi
     CURRENT_TITLE=""
     CURRENT_DESCRIPTION=""

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -440,7 +440,7 @@ Use the two reviewer archetypes from `${CLAUDE_PLUGIN_ROOT}/skills/shared/review
 
 Additionally, append the following competition context to each reviewer's prompt (both Claude subagents and external reviewers):
 
-> **Competition notice**: Your findings will be voted on by a 3-agent panel (Deep Analysis Reviewer, Codex, Cursor) using YES/NO/EXONERATE. Each finding that receives 2+ YES votes earns you +1 point. Findings with exactly 1 YES earn 0 points. Findings with 0 YES but at least 1 EXONERATE earn 0 points (the panel recognized your concern as legitimate). Findings with 0 YES and 0 EXONERATE cost you -1 point. Focus on high-quality, actionable findings. Concerns that are valid but not actionable in this PR may still be exonerated rather than penalized. Out-of-scope observations (pre-existing issues, items beyond PR scope) can never cost you points — surface them freely.
+> **Competition notice**: Your findings will be voted on by a 3-agent panel (Deep Analysis Reviewer, Codex, Cursor) using YES/NO/EXONERATE. Each finding that receives 2+ YES votes earns you +1 point. Findings with exactly 1 YES earn 0 points. Findings with 0 YES but at least 1 EXONERATE earn 0 points (the panel recognized your concern as legitimate). Findings with 0 YES and 0 EXONERATE cost you -1 point. Focus on high-quality, actionable findings. Concerns that are valid but not actionable in this PR may still be exonerated rather than penalized. Out-of-scope observations use the same scoring as in-scope findings: OOS items that receive 2+ YES votes earn +1 point and will be filed as GitHub issues. OOS items with 0 YES and 0 EXONERATE cost -1 point. OOS items with exactly 1 YES or with 1+ EXONERATE earn 0 points.
 
 ### Collecting External Reviewer Results
 
@@ -460,7 +460,7 @@ If **all reviewers** report no in-scope issues and no out-of-scope observations,
 
 ### Voting Panel (replaces negotiation)
 
-After deduplication, submit both in-scope findings and out-of-scope observations to a 3-agent voting panel per the **Voting Protocol** in `${CLAUDE_PLUGIN_ROOT}/skills/shared/voting-protocol.md`. Include OOS items on the ballot with `[OUT_OF_SCOPE]` prefix per the protocol's OOS section — voters can promote OOS items to in-scope by voting YES. For plan review:
+After deduplication, submit both in-scope findings and out-of-scope observations to a 3-agent voting panel per the **Voting Protocol** in `${CLAUDE_PLUGIN_ROOT}/skills/shared/voting-protocol.md`. Include OOS items on the ballot with `[OUT_OF_SCOPE]` prefix per the protocol's OOS section — voters decide whether each OOS item deserves a GitHub issue (YES = file issue, not implement). For plan review:
 
 - **Voter 1**: Claude Deep Analysis reviewer subagent — fresh Agent tool invocation with the voting prompt. Instruct: `"You are a senior architect and correctness specialist on a voting panel. You will vote YES, NO, or EXONERATE on proposed modifications to an implementation plan. Be scrupulous — only vote YES for findings that are correct, important, and worth revising the plan for. Vote EXONERATE if the concern is legitimate but not worth implementing in this PR. When voting, also consider proportionality: vote EXONERATE (not YES) if the finding's concern is legitimate but the proposed change would introduce more complexity than the issue warrants."`
 - **Voter 2**: Codex — via `run-external-reviewer.sh` with the ballot. If `codex_available` is false, launch a Claude subagent voter instead per the Voting Protocol.
@@ -478,24 +478,34 @@ Launch all available voters **in parallel** (Cursor first, then Codex, then Clau
 
 ### Finalize Plan Review
 
-If any in-scope findings or promoted OOS items were **accepted by vote** (2+ YES votes):
-1. Print them under a `## Plan Review Findings (Voted In)` header with vote counts. Include any promoted OOS items (labelled as `[PROMOTED FROM OUT-OF-SCOPE]`).
-2. Revise the implementation plan to address each accepted finding and promoted OOS item.
+If any in-scope findings were **accepted by vote** (2+ YES votes):
+1. Print them under a `## Plan Review Findings (Voted In)` header with vote counts.
+2. Revise the implementation plan to address each accepted in-scope finding.
 3. Print the revised plan under a `## Revised Implementation Plan` header.
-4. Write the accepted findings to `$DESIGN_TMPDIR/accepted-plan-findings.md` so Step 3.5 (Design Discussion Round 2) has a stable artifact to read. Use the format:
+4. Write the accepted in-scope findings to `$DESIGN_TMPDIR/accepted-plan-findings.md` so Step 3.5 (Design Discussion Round 2) has a stable artifact to read. **Only include in-scope `FINDING_*` items — do not include OOS items.** Use the format:
    ```markdown
    ### FINDING_N: <title>
    - **Concern**: <what was raised>
    - **Resolution**: <how the plan was revised>
    ```
 
-Print any non-promoted OOS items under a `## Out-of-Scope Observations` header for visibility. These are not implemented but are recorded for future attention.
+**OOS items accepted by vote** (2+ YES): These are accepted for GitHub issue filing, NOT for plan revision. **Only when `SESSION_ENV_PATH` is non-empty**: write accepted OOS items to `$(dirname "$SESSION_ENV_PATH")/oos-accepted-design.md` using the format:
+```markdown
+### OOS_N: <short title>
+- **Description**: <full description of the observation>
+- **Reviewer**: <attribution>
+- **Vote tally**: <YES/NO/EXONERATE counts>
+- **Phase**: design
+```
+When `SESSION_ENV_PATH` is empty (standalone invocation), skip the OOS artifact write — there is no parent `/implement` to consume it.
 
-If voting rejects all in-scope findings and no OOS items are promoted, print: `**ℹ Voting panel rejected all findings. Plan unchanged.**` and proceed to Step 3.5 (Design Discussion Round 2) if `auto_mode=false`, or Step 3a (Post-Review Confirmation) if `auto_mode=true`.
+Print any non-accepted OOS items under a `## Out-of-Scope Observations` header for visibility. These are not filed as issues but are recorded for future attention.
+
+If voting rejects all in-scope findings, print: `**ℹ Voting panel rejected all in-scope findings. Plan unchanged.**` (OOS items accepted for issue filing are processed separately by `/implement`.) Proceed to Step 3.5 (Design Discussion Round 2) if `auto_mode=false`, or Step 3a (Post-Review Confirmation) if `auto_mode=true`.
 
 ### Track Rejected Plan Review Findings
 
-For any **in-scope** findings that were **not accepted by vote** (fewer than 2 YES votes — whether rejected or exonerated) during plan review (from any reviewer — Claude subagents, Codex, or Cursor), append each to `$DESIGN_TMPDIR/rejected-findings.md` using this format. **Do not include non-promoted OOS items** — those are reported separately in the "Out-of-Scope Observations" PR body section per `voting-protocol.md`:
+For any **in-scope** findings that were **not accepted by vote** (fewer than 2 YES votes — whether rejected or exonerated) during plan review (from any reviewer — Claude subagents, Codex, or Cursor), append each to `$DESIGN_TMPDIR/rejected-findings.md` using this format. **Do not include OOS items** — those follow a separate pipeline (accepted OOS → GitHub issues via `/implement`, non-accepted OOS → PR body observations):
 
 ```markdown
 ### [Plan Review] <Reviewer Name>

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -584,6 +584,8 @@ Read the OOS artifact files:
 
 **If at least one file has content**:
 
+**Idempotency**: If `$IMPLEMENT_TMPDIR/oos-issues-created.md` already exists (written by a previous Step 9a.1 in this session), skip issue creation entirely — read the existing file to get previously created issue URLs and proceed to Step 9b.
+
 1. Read and parse all accepted OOS items from both files.
 2. Deduplicate across phases: if the same pre-existing issue was surfaced and accepted in both design and review (matching by normalized title similarity), keep one entry noting both phases.
 3. Write the deduplicated items to `$IMPLEMENT_TMPDIR/oos-items.md` as input for the creation script.
@@ -595,9 +597,9 @@ Read the OOS artifact files:
 6. If `ISSUES_FAILED > 0`: Log to `$IMPLEMENT_TMPDIR/execution-issues.md` under `Tool Failures`: `Step 9a.1 — create-oos-issues.sh failed to create <N> of <total> OOS issues.`
 7. Save the issue URLs for embedding in the PR body's "Out-of-Scope Observations" section (already prepared in Step 9a). Update the `$IMPLEMENT_TMPDIR/pr-body.md` file to replace the "Accepted OOS (GitHub issues filed)" placeholder with the actual issue links.
 
-Print: `✅ 9a.1: OOS issues — <ISSUES_CREATED> issues filed`
+8. Write the created issue metadata to `$IMPLEMENT_TMPDIR/oos-issues-created.md` as a sentinel for idempotency. Include the `ISSUES_CREATED`, `ISSUES_FAILED`, and all `ISSUE_N_NUMBER`/`ISSUE_N_URL`/`ISSUE_N_TITLE` lines from the script output.
 
-**Idempotency note**: Step 9a.1 runs before `create-pr.sh` in Step 9b. If the PR already exists (`PR_STATUS` will be determined by `create-pr.sh`), the OOS issues have already been created in a prior run. However, since Step 9a.1 runs before Step 9b determines `PR_STATUS`, there is no `PR_STATUS` available yet. To handle reruns: if `$IMPLEMENT_TMPDIR/oos-issues-created.md` already exists (written by a previous Step 9a.1 in this session), skip issue creation and reuse the existing file.
+Print: `✅ 9a.1: OOS issues — <ISSUES_CREATED> issues filed`
 
 ### 9b — Create PR via script
 

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -47,6 +47,7 @@ Step Name Registry:
 | 7a.r | rebase |
 | 8 | version bump |
 | 8a | changelog |
+| 9a.1 | OOS issues |
 | 9 | create PR |
 | 10 | CI monitor |
 | 11 | slack announce |
@@ -294,7 +295,7 @@ After `/review` returns, follow the **Cross-Skill Health Propagation** procedure
 
 ### Track Rejected Code Review Findings
 
-After the code review completes (whether `/review` in normal mode or the simplified review in quick mode), examine the final output. For any **in-scope** findings that were not accepted (not enough YES votes in normal mode — whether rejected or exonerated — or rejected by the main agent in quick mode), append each to `$IMPLEMENT_TMPDIR/rejected-findings.md` using this format. **Do not include non-promoted OOS items** — those are reported separately in the "Out-of-Scope Observations" PR body section:
+After the code review completes (whether `/review` in normal mode or the simplified review in quick mode), examine the final output. For any **in-scope** findings that were not accepted (not enough YES votes in normal mode — whether rejected or exonerated — or rejected by the main agent in quick mode), append each to `$IMPLEMENT_TMPDIR/rejected-findings.md` using this format. **Do not include OOS items** — those follow a separate pipeline (accepted OOS → GitHub issues via Step 9a.1, non-accepted OOS → PR body observations):
 
 ```markdown
 ### [Code Review] <Reviewer Name>
@@ -522,7 +523,11 @@ Write the PR body to a temp file at `$IMPLEMENT_TMPDIR/pr-body.md`. The PR body 
 
 <details><summary>Out-of-Scope Observations</summary>
 
-<non-promoted out-of-scope observations from both plan review (/design Step 3) and code review (/review Step 3c.1) visible in conversation context above. These are pre-existing issues or concerns beyond the PR's scope that reviewers surfaced for future attention. Copy the non-promoted OOS items as they were listed, including the reviewer attribution and description. If no OOS observations were raised, write "No out-of-scope observations were raised." If the observations are not visible in conversation context, write "Out-of-scope observations not available.">
+**Accepted OOS (GitHub issues filed):**
+<If Step 9a.1 created issues, list each with its issue link: "- #<NUMBER>: <title> (<reviewer attribution>)". If no OOS items were accepted, write "No OOS items were accepted for issue filing.">
+
+**Non-accepted OOS observations:**
+<Non-accepted out-of-scope observations from both plan review (/design Step 3) and code review (/review Step 3c.1) visible in conversation context above. These are pre-existing issues or concerns beyond the PR's scope that reviewers surfaced for future attention. Copy the non-accepted OOS items as they were listed, including the reviewer attribution and description. If no OOS observations were raised, write "No out-of-scope observations were raised." If the observations are not visible in conversation context, write "Out-of-scope observations not available.">
 
 </details>
 
@@ -541,6 +546,7 @@ Write the PR body to a temp file at `$IMPLEMENT_TMPDIR/pr-body.md`. The PR body 
 | Code review findings | <N> accepted, <N> rejected |
 | Warnings logged | <N> |
 | Pre-existing issues noticed | <N> |
+| OOS issues filed | <N> |
 | External reviewers | Cursor: <✅/❌>, Codex: <✅/❌> |
 
 </details>
@@ -562,7 +568,36 @@ Populate Run Statistics from conversation context: count accepted/rejected findi
 - **Code Review Voting Tally (Round 1)**: Write "Quick mode — no voting panel. Main agent reviewed findings from 2 Claude subagents."
 - **Implementation Deviations**: Compare implementation to the inline plan (same as normal mode).
 - **Out-of-Scope Observations**: Write "Quick mode — no out-of-scope observations collected."
-- **Run Statistics**: Set "Plan review findings" to "N/A (quick mode)", "External reviewers" to "N/A (quick mode)". Code review findings should reflect the quick review results.
+- **Run Statistics**: Set "Plan review findings" to "N/A (quick mode)", "External reviewers" to "N/A (quick mode)", "OOS issues filed" to "N/A (quick mode)". Code review findings should reflect the quick review results.
+
+### 9a.1 — Create OOS GitHub Issues
+
+**If `quick_mode=true`**: Print `⏩ 9a.1: OOS issues — skipped (quick mode)` and proceed to Step 9b.
+
+**If `repo_unavailable=true`**: Print `⏩ 9a.1: OOS issues — skipped (repo unavailable)` and proceed to Step 9b. Log to `$IMPLEMENT_TMPDIR/execution-issues.md` under `Warnings`.
+
+Read the OOS artifact files:
+- `$IMPLEMENT_TMPDIR/oos-accepted-design.md` (from `/design` plan review)
+- `$IMPLEMENT_TMPDIR/oos-accepted-review.md` (from `/review` code review)
+
+**If neither file exists or both are empty**: Print `⏩ 9a.1: OOS issues — no accepted OOS items` and proceed to Step 9b.
+
+**If at least one file has content**:
+
+1. Read and parse all accepted OOS items from both files.
+2. Deduplicate across phases: if the same pre-existing issue was surfaced and accepted in both design and review (matching by normalized title similarity), keep one entry noting both phases.
+3. Write the deduplicated items to `$IMPLEMENT_TMPDIR/oos-items.md` as input for the creation script.
+4. Invoke the creation script:
+   ```bash
+   ${CLAUDE_PLUGIN_ROOT}/scripts/create-oos-issues.sh --input-file "$IMPLEMENT_TMPDIR/oos-items.md" --repo $REPO
+   ```
+5. Parse the structured output for `ISSUES_CREATED`, `ISSUES_FAILED`, and per-issue `ISSUE_N_NUMBER`/`ISSUE_N_URL` pairs.
+6. If `ISSUES_FAILED > 0`: Log to `$IMPLEMENT_TMPDIR/execution-issues.md` under `Tool Failures`: `Step 9a.1 — create-oos-issues.sh failed to create <N> of <total> OOS issues.`
+7. Save the issue URLs for embedding in the PR body's "Out-of-Scope Observations" section (already prepared in Step 9a). Update the `$IMPLEMENT_TMPDIR/pr-body.md` file to replace the "Accepted OOS (GitHub issues filed)" placeholder with the actual issue links.
+
+Print: `✅ 9a.1: OOS issues — <ISSUES_CREATED> issues filed`
+
+**Idempotency note**: Step 9a.1 runs before `create-pr.sh` in Step 9b. If the PR already exists (`PR_STATUS` will be determined by `create-pr.sh`), the OOS issues have already been created in a prior run. However, since Step 9a.1 runs before Step 9b determines `PR_STATUS`, there is no `PR_STATUS` available yet. To handle reruns: if `$IMPLEMENT_TMPDIR/oos-issues-created.md` already exists (written by a previous Step 9a.1 in this session), skip issue creation and reuse the existing file.
 
 ### 9b — Create PR via script
 
@@ -904,7 +939,7 @@ Also capture `git diff --cached` as supplementary context showing the full stage
 
 Follow `${CLAUDE_PLUGIN_ROOT}/skills/shared/external-reviewers.md` for launch order (Cursor first, Codex, then Claude subagents), background execution, sentinel polling via `wait-for-reviewers.sh`, and output validation. Use `$IMPLEMENT_TMPDIR/conflict-review/` as the tmpdir for all reviewer output files, sentinel files, and ballot files.
 
-**3d-ii. Collect and deduplicate**: After all reviewers complete, collect their findings. Parse Claude subagent dual-list outputs (in-scope findings + OOS observations). Read and validate external reviewer outputs per `external-reviewers.md`. Merge all findings, deduplicate (same file + same issue = one finding), assign stable sequential IDs (`FINDING_1`, `FINDING_2`, etc.), and write the ballot to `$IMPLEMENT_TMPDIR/conflict-review/ballot.txt` following the ballot format in `voting-protocol.md`.
+**3d-ii. Collect and deduplicate**: After all reviewers complete, collect their findings. Parse Claude subagent dual-list outputs (in-scope findings only — **discard OOS observations** from conflict-review context, as conflict resolution is a narrow validation context not suitable for OOS issue filing). Read and validate external reviewer outputs per `external-reviewers.md`. Merge all in-scope findings, deduplicate (same file + same issue = one finding), assign stable sequential IDs (`FINDING_1`, `FINDING_2`, etc.), and write the ballot to `$IMPLEMENT_TMPDIR/conflict-review/ballot.txt` following the ballot format in `voting-protocol.md`. **Do not include OOS items on the conflict-review ballot.**
 
 **3e. Voting**: Run the voting protocol from `${CLAUDE_PLUGIN_ROOT}/skills/shared/voting-protocol.md` with code review voter composition:
 - **Voter 1**: Claude General Reviewer subagent (fresh Agent invocation)

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -183,7 +183,7 @@ Use the two reviewer archetypes from `${CLAUDE_PLUGIN_ROOT}/skills/shared/review
 
 Additionally, append the following competition context to each reviewer's prompt (both Claude subagents and external reviewers):
 
-> **Competition notice**: Your findings will be voted on by a 3-agent panel (General Reviewer, Codex, Cursor) using YES/NO/EXONERATE. Each finding that receives 2+ YES votes earns you +1 point. Findings with exactly 1 YES earn 0 points. Findings with 0 YES but at least 1 EXONERATE earn 0 points (the panel recognized your concern as legitimate). Findings with 0 YES and 0 EXONERATE cost you -1 point. Focus on high-quality, actionable findings. Concerns that are valid but not actionable in this PR may still be exonerated rather than penalized. Out-of-scope observations (pre-existing issues, items beyond PR scope) can never cost you points — surface them freely.
+> **Competition notice**: Your findings will be voted on by a 3-agent panel (General Reviewer, Codex, Cursor) using YES/NO/EXONERATE. Each finding that receives 2+ YES votes earns you +1 point. Findings with exactly 1 YES earn 0 points. Findings with 0 YES but at least 1 EXONERATE earn 0 points (the panel recognized your concern as legitimate). Findings with 0 YES and 0 EXONERATE cost you -1 point. Focus on high-quality, actionable findings. Concerns that are valid but not actionable in this PR may still be exonerated rather than penalized. Out-of-scope observations use the same scoring as in-scope findings: OOS items that receive 2+ YES votes earn +1 point and will be filed as GitHub issues. OOS items with 0 YES and 0 EXONERATE cost -1 point. OOS items with exactly 1 YES or with 1+ EXONERATE earn 0 points.
 
 ### Collecting External Reviewer Results
 
@@ -231,7 +231,17 @@ Launch all available voters **in parallel** (Cursor first, then Codex, then Clau
 
 **Competition scoring**: Compute and print the **Reviewer Competition Scoreboard** per the Voting Protocol. Note in the scoreboard that scores apply to round 1 only — round 2+ findings are auto-accepted and do not contribute to scores.
 
-**Zero accepted findings**: If voting rejects all findings, print `**ℹ Voting panel rejected all findings. No changes to implement.**` and skip to **Step 4**.
+**Zero accepted in-scope findings**: If voting rejects all in-scope findings, print `**ℹ Voting panel rejected all in-scope findings. No changes to implement.**` (OOS items accepted for issue filing are processed separately by `/implement`.) and skip to **Step 4**.
+
+**OOS items accepted by vote** (2+ YES in round 1): These are accepted for GitHub issue filing, NOT for code implementation. **Only when `SESSION_ENV_PATH` is non-empty**: write accepted OOS items to `$(dirname "$SESSION_ENV_PATH")/oos-accepted-review.md` using the format:
+```markdown
+### OOS_N: <short title>
+- **Description**: <full description of the observation>
+- **Reviewer**: <attribution>
+- **Vote tally**: <YES/NO/EXONERATE counts>
+- **Phase**: review
+```
+When `SESSION_ENV_PATH` is empty (standalone invocation), skip the OOS artifact write.
 
 **Save not-accepted finding IDs**: Record the IDs of findings not accepted by vote in round 1 (whether rejected or exonerated). In rounds 2+, if a Claude-only reviewer re-raises a finding that was not accepted by the round-1 voting panel (same file, same issue), suppress it — do not re-accept a finding the panel already voted down or exonerated.
 
@@ -247,7 +257,7 @@ Print to the user:
 
 ### 3e — Implement Fixes
 
-For each **accepted** finding (voted in during round 1, or all findings in rounds 2+):
+For each **accepted in-scope** finding (`FINDING_*` items only — exclude `OOS_*` items, which are processed separately for issue filing by `/implement`; voted in during round 1, or all findings in rounds 2+):
 
 1. Apply the suggested fix by editing the relevant file.
 2. If the fix involves creating new tests, write them.

--- a/skills/shared/voting-protocol.md
+++ b/skills/shared/voting-protocol.md
@@ -72,6 +72,8 @@ You are a {VOTER_ROLE} participating in a voting panel. You will be presented wi
 
 Be scrupulous — only vote YES for findings that genuinely improve the {REVIEW_CONTEXT}. Use EXONERATE when a concern is valid but not actionable now.
 
+**For items prefixed with `[OUT_OF_SCOPE]`:** These are pre-existing issues beyond this PR's scope. Vote YES if the observation deserves a GitHub issue for future tracking. Vote NO if it is not worth tracking. Vote EXONERATE if the concern is legitimate but not worth filing a GitHub issue. OOS items are never implemented in this PR — YES means "file an issue," not "implement now."
+
 {BALLOT}
 
 For each finding, output exactly one line:
@@ -145,13 +147,13 @@ After voting, print a scoreboard to the session:
 ```
 ## Reviewer Competition Scoreboard
 
-| Reviewer | Findings | Accepted | Neutral (1 YES) | Exonerated (0 YES, 1+ EXON.) | Rejected (0 YES, 0 EXON.) | Score |
-|----------|----------|----------|-----------------|-------------------------------|---------------------------|-------|
-| General              | 3        | 2        | 1               | 0                             | 0                         | +2    |
-| Deep-Analysis        | 2        | 1        | 0               | 1                             | 0                         | +1    |
-| Codex-General        | 1        | 0        | 0               | 0                             | 1                         | -1    |
-| Codex-Deep-Analysis  | 1        | 1        | 0               | 0                             | 0                         | +1    |
-| Cursor               | 2        | 1        | 1               | 0                             | 0                         | +1    |
+| Reviewer | Findings | Accepted | Neutral (1 YES) | Exonerated (0 YES, 1+ EXON.) | Rejected (0 YES, 0 EXON.) | OOS Proposed | OOS Accepted | Score |
+|----------|----------|----------|-----------------|-------------------------------|---------------------------|--------------|--------------|-------|
+| General              | 3        | 2        | 1               | 0                             | 0                         | 1            | 0            | +2    |
+| Deep-Analysis        | 2        | 1        | 0               | 1                             | 0                         | 0            | 0            | +1    |
+| Codex-General        | 1        | 0        | 0               | 0                             | 1                         | 0            | 0            | -1    |
+| Codex-Deep-Analysis  | 1        | 1        | 0               | 0                             | 0                         | 0            | 0            | +1    |
+| Cursor               | 2        | 1        | 1               | 0                             | 0                         | 0            | 0            | +1    |
 
 Note: In future iterations, token allocation will be weighted proportionally
 to reviewer scores — higher-scoring reviewers will receive more tokens.
@@ -172,35 +174,42 @@ OOS_1: [OUT_OF_SCOPE] General — <description of pre-existing issue>
 ### OOS Vote Semantics
 
 For out-of-scope items, the vote meanings are:
-- **YES**: Promote this observation to in-scope — it should be implemented in this PR.
-- **NO**: Keep as observation — not worth addressing now.
-- **EXONERATE**: Legitimate observation worth documenting — keep as observation.
+- **YES**: This observation deserves a GitHub issue for future attention.
+- **NO**: Not worth tracking — the observation is trivial or incorrect.
+- **EXONERATE**: Legitimate observation worth documenting, but not worth filing a GitHub issue.
 
-If an OOS item receives 2+ YES votes, it is **promoted** to in-scope and treated as an accepted finding (implemented/revised). Otherwise it remains an observation.
+If an OOS item receives 2+ YES votes, it is **accepted** and will be filed as a GitHub issue by `/implement`. Otherwise it remains an observation reported in the PR body.
+
+**OOS items are never implemented in the current PR** — accepted OOS items result in issue creation only. This cleanly separates "fix now" (in-scope findings) from "fix later" (OOS observations).
 
 ### OOS Scoring
 
-Out-of-scope items use a **per-item scoring floor of 0**. This floor applies **only to OOS items** — in-scope findings retain normal scoring including -1 for rejected.
+Out-of-scope items use the **same symmetric scoring** as in-scope findings:
 
 | OOS Vote Result | Points | Description |
 |---|---|---|
-| OOS promoted (2+ YES) | +1 | Reviewer surfaced an issue worth fixing now |
-| OOS not promoted | 0 | Reviewer surfaced a useful observation (no penalty) |
+| OOS accepted (2+ YES) | +1 | Reviewer surfaced an issue worth tracking |
+| OOS neutral (exactly 1 YES) | 0 | Insufficient support, but not dismissed |
+| OOS exonerated (0 YES, 1+ EXONERATE) | 0 | Legitimate observation, but not worth an issue |
+| OOS rejected (0 YES, 0 EXONERATE) | -1 | Observation was unanimously dismissed |
 
 ### OOS Scoreboard
 
 The scoreboard includes additional columns for OOS items:
 
 ```
-| Reviewer | ... | OOS Proposed | OOS Promoted | ...
+| Reviewer | ... | OOS Proposed | OOS Accepted | ...
 ```
 
 ### OOS Reporting
 
-Non-promoted OOS items are **not** written to `rejected-findings.md`. They are collected separately and reported in a dedicated `<details><summary>Out-of-Scope Observations</summary>` section in the PR body. This section is populated by `/implement` Step 9a from conversation context.
+OOS items are **not** written to `rejected-findings.md`. They follow a separate pipeline:
+
+- **Accepted OOS items** (2+ YES): Written to an artifact file (`oos-accepted-design.md` or `oos-accepted-review.md`) in `$IMPLEMENT_TMPDIR` during the voting phase. `/implement` Step 9a.1 reads these files, deduplicates across phases, and creates GitHub issues via `scripts/create-oos-issues.sh`.
+- **Non-accepted OOS items**: Collected and reported in a dedicated `<details><summary>Out-of-Scope Observations</summary>` section in the PR body for future reference.
 
 External reviewers (Codex, Cursor) use single-list prompts and do not produce OOS items — their entire output is treated as in-scope findings. Only Claude subagent reviewers (which use the dual-list templates from `reviewer-templates.md`) produce OOS items.
 
 ## Zero Accepted Findings
 
-If voting filters out **all** in-scope findings (every in-scope finding rejected by the panel), print: `**ℹ Voting panel rejected all findings. No changes to implement.**` and skip the implementation/revision step. Proceed directly to the rejected findings report. (OOS items that were not promoted are still collected for reporting.)
+If voting filters out **all** in-scope findings (every in-scope finding rejected by the panel), print: `**ℹ Voting panel rejected all findings. No changes to implement.**` and skip the implementation/revision step. Proceed directly to the rejected findings report. (OOS items accepted for issue filing are processed separately by `/implement` and do not count as implementation work.)

--- a/skills/shared/voting-protocol.md
+++ b/skills/shared/voting-protocol.md
@@ -24,12 +24,14 @@ Include the reviewer attribution (e.g., "General", "Deep-Analysis", "Codex-Gener
 
 ## Voter Output Format
 
-Each voter must output one line per finding:
+Each voter must output one line per ballot item, **using the same ID that appears on the ballot** — `FINDING_N` for in-scope items and `OOS_N` for out-of-scope items:
 
 ```
 FINDING_1: YES — <one-line rationale>
 FINDING_2: NO — <one-line rationale>
 FINDING_3: EXONERATE — <one-line rationale>
+OOS_1: YES — <one-line rationale>
+OOS_2: NO — <one-line rationale>
 ...
 ```
 
@@ -76,14 +78,20 @@ Be scrupulous — only vote YES for findings that genuinely improve the {REVIEW_
 
 {BALLOT}
 
-For each finding, output exactly one line:
+For each ballot item, output exactly one line using the same ID from the ballot (FINDING_N or OOS_N):
 FINDING_N: YES — <one-line rationale>
 or
 FINDING_N: NO — <one-line rationale>
 or
 FINDING_N: EXONERATE — <one-line rationale>
+or
+OOS_N: YES — <one-line rationale>
+or
+OOS_N: NO — <one-line rationale>
+or
+OOS_N: EXONERATE — <one-line rationale>
 
-You must vote on every finding. Do NOT skip any. Do NOT modify files.
+You must vote on every item. Do NOT skip any. Do NOT modify files.
 ```
 
 ## Launching Voters


### PR DESCRIPTION
## Summary
- Replaced OOS promotion with GitHub issue filing — accepted OOS items are filed as issues instead of being implemented in the PR
- Switched OOS scoring from floor-of-0 to symmetric -1/0/+1, matching in-scope finding scoring
- Added `scripts/create-oos-issues.sh` and Step 9a.1 for automated OOS issue creation at PR time

<details><summary>Architecture Diagram</summary>

```mermaid
flowchart TD
    subgraph ReviewPhase["Review Phase (design + review)"]
        R1[Claude Subagents<br/>dual-list output]
        R2[External Reviewers<br/>single-list output]
        R1 -->|In-Scope + OOS| DEDUP[Deduplicate]
        R2 -->|In-Scope only| DEDUP
    end

    subgraph VotingPhase["Voting Panel (3 voters)"]
        DEDUP --> BALLOT[Unified Ballot<br/>FINDING_* + OOS_*]
        BALLOT --> VOTE[3-Agent Vote<br/>YES / NO / EXONERATE]
    end

    subgraph InScopeTrack["In-Scope Track"]
        VOTE -->|FINDING_* 2+ YES| IMPL[Implement in PR]
        VOTE -->|FINDING_* < 2 YES| REJ[Rejected Findings]
    end

    subgraph OOSTrack["OOS Track"]
        VOTE -->|OOS_* 2+ YES| ARTIFACT["Write to<br/>$IMPLEMENT_TMPDIR/<br/>oos-accepted-*.md"]
        VOTE -->|OOS_* < 2 YES| REPORT[PR Body:<br/>Observations List]
    end

    subgraph ImplementStep9["Implement Step 9a.1"]
        ARTIFACT --> READ[Read + Deduplicate<br/>across phases]
        READ --> SCRIPT["create-oos-issues.sh<br/>gh issue create --body-file"]
        SCRIPT --> LINKS[Issue URLs → PR Body]
    end

    subgraph Scoring["Merged Scoreboard"]
        IMPL --> SCORE["+1 per accepted"]
        REJ --> SCORE["-1 per rejected<br/>0 per neutral/exonerated"]
        ARTIFACT --> SCORE2["+1 per OOS accepted"]
        REPORT --> SCORE2["-1/0 per OOS<br/>not accepted"]
        SCORE --> TABLE[Single Merged<br/>Competition Table]
        SCORE2 --> TABLE
    end

    style InScopeTrack fill:#1a3a1a
    style OOSTrack fill:#1a2a3a
    style ImplementStep9 fill:#2a1a3a
```

</details>

<details><summary>Code Flow Diagram</summary>

```mermaid
sequenceDiagram
    participant D as /design
    participant R as /review
    participant I as /implement
    participant GH as GitHub API

    Note over D,R: Phase 1: OOS Collection & Voting

    D->>D: Reviewers produce dual-list output<br/>(In-Scope + OOS)
    D->>D: Voting panel votes on OOS items<br/>(YES=file issue, NO, EXONERATE)
    D->>I: Write oos-accepted-design.md<br/>to $IMPLEMENT_TMPDIR

    R->>R: Reviewers produce dual-list output
    R->>R: Voting panel votes on OOS items
    R->>I: Write oos-accepted-review.md<br/>to $IMPLEMENT_TMPDIR

    Note over I: Phase 2: Issue Filing (Step 9a.1)

    I->>I: Check guards:<br/>quick_mode? repo_unavailable?<br/>sentinel exists?
    I->>I: Read both artifact files
    I->>I: Deduplicate across phases
    I->>I: Write oos-items.md

    I->>GH: create-oos-issues.sh<br/>--input-file --repo
    
    loop For each OOS item
        GH->>GH: gh issue create<br/>--body-file --label
        GH-->>I: ISSUE_N_NUMBER, ISSUE_N_URL
    end

    I->>I: Write sentinel<br/>oos-issues-created.md
    I->>I: Embed issue links<br/>in PR body

    Note over I: Phase 3: PR Creation (Step 9b)

    I->>GH: create-pr.sh<br/>(body includes issue links)
```

</details>

<details><summary>Goal</summary>

- Add OOS voting with GitHub issue filing
  - Replace OOS "promotion to in-scope" with issue filing — accepted OOS items are filed as GitHub issues instead of being implemented in the PR
  - Remove the promotion concept entirely from all skills and documentation
  - Switch OOS scoring from floor-of-0 to symmetric -1/0/+1, matching in-scope finding scoring
  - Create two identical-style competitions running in parallel: one for in-scope findings, one for OOS observations
- Automate OOS issue creation
  - Add `scripts/create-oos-issues.sh` wrapper for `gh issue create` with best-effort error handling
  - Add Step 9a.1 in `/implement` to read OOS artifacts from both `/design` and `/review`, deduplicate, and file issues before PR creation
  - Write accepted OOS items to artifact files in `$IMPLEMENT_TMPDIR` using the `--write-health` cross-tmpdir pattern
- Update vote semantics and voter instructions
  - OOS vote: YES = "file GitHub issue", NO = "not worth tracking", EXONERATE = "legitimate but not worth an issue"
  - Update voter prompt template with OOS-specific instructions and output format examples (OOS_N: YES/NO/EXONERATE)
  - Update competition notice in all skills to reflect symmetric OOS scoring
- Handle edge cases
  - Standalone mode guard (empty SESSION_ENV_PATH)
  - Quick-mode skip, REPO_UNAVAILABLE skip
  - Idempotency sentinel for reruns
  - Conflict-review OOS suppression
  - Label fallback when "out-of-scope" label doesn't exist

</details>

<details><summary>Test plan</summary>

- [ ] Run `/relevant-checks` — verify pre-commit linters and claude-lint pass
- [ ] Verify `scripts/create-oos-issues.sh` is executable (`chmod +x`)
- [ ] Verify `create-oos-issues.sh` is referenced in `skills/implement/SKILL.md` via code-fenced invocation
- [ ] Verify all "promotion" references removed from voting-protocol.md, design/SKILL.md, review/SKILL.md, implement/SKILL.md, point-competition.md, voting-process.md
- [ ] Verify OOS scoring tables show symmetric -1/0/+1 in both voting-protocol.md and point-competition.md
- [ ] Verify competition notice updated in both design/SKILL.md and review/SKILL.md
- [ ] Verify voter output format includes OOS_N examples in voting-protocol.md
- [ ] Run `/implement` on a feature to verify end-to-end OOS issue creation flow

</details>

<details><summary>Final Design</summary>

### Files modified:
1. **`skills/shared/voting-protocol.md`** — Rewrote OOS vote semantics (YES = file issue), removed promotion, symmetric scoring, updated voter prompt template with OOS_N output format, merged scoreboard with OOS Accepted column
2. **`skills/design/SKILL.md`** — Updated competition notice, removed promoted OOS from Finalize Plan Review, added OOS artifact write to $IMPLEMENT_TMPDIR, updated accepted-plan-findings.md scope
3. **`skills/review/SKILL.md`** — Updated competition notice, added OOS artifact write, excluded OOS_* from Step 3e implementation
4. **`skills/implement/SKILL.md`** — Added Step 9a.1 (OOS issue creation with guards, dedup, script invocation, idempotency sentinel), updated PR body OOS section, updated Run Statistics, suppressed conflict-review OOS
5. **`scripts/create-oos-issues.sh`** (NEW) — gh issue create wrapper with --body-file, label fallback, structured KEY=VALUE output, best-effort error handling
6. **`docs/point-competition.md`** — Symmetric OOS scoring, removed floor-of-0 invariant, OOS Issue Filing section
7. **`docs/voting-process.md`** — Updated OOS vote semantics, added OOS path to flow diagram

### Key design decisions:
- OOS artifact persistence: Write to $IMPLEMENT_TMPDIR from child skills via SESSION_ENV_PATH dirname (follows --write-health pattern)
- Issue creation timing: BEFORE create-pr.sh so PR body is complete at creation
- Conflict-review: OOS suppressed (not suitable for issue filing context)

</details>

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `94d3326` (Add quality-improvement instructions: TDD, justification gate, proportionality (#63))
- **Current version**: `2.0.3`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `2.0.4`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH").

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

### [Plan Review] General
**Finding**: Step numbering "9a.1" does not match the existing step naming convention in the implement/SKILL.md Step Name Registry. Sub-steps use letters (7a, 8a), not dot-numbers. The finding suggests renaming to "8b" (post-bump, pre-PR finalization) and adding it to the Step Name Registry table.
**Reason not implemented**: The voting panel returned 1 YES, 1 EXONERATE, and 1 NO (neutral outcome). The step logically belongs within Step 9's PR creation workflow, not in the Step 8 series.

### [Plan Review] Deep-Analysis, Cursor, Codex-General
**Finding**: The cross-phase deduplication strategy is vague ("semantic dedup"). Should define concrete dedup rules.
**Reason not implemented**: All 3 voters EXONERATED. Normalized title matching is sufficient for v1.

### [Plan Review] Deep-Analysis, Codex-Deep
**Finding**: The create-oos-issues.sh script contract is underspecified (exit codes, input format, who deduplicates).
**Reason not implemented**: 1 YES, 2 EXONERATE (neutral). Implementation-level details resolved during coding.

### [Plan Review] General, Deep-Analysis
**Finding**: Quick-mode guard for Step 9a.1.
**Reason not implemented**: 1 YES, 2 EXONERATE (neutral). However, the guard was added to the revised plan regardless.

</details>

<details><summary>Implementation Deviations</summary>

No deviations from the plan.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

### [Code Review] Codex-General, Codex-Deep, Cursor
**Finding**: `scripts/create-oos-issues.sh:107` — The footer text in the auto-generated GitHub issue body hardcodes "received majority YES votes during review." This is incorrect for design-phase OOS items (it should say "during design" or be phase-neutral) and misleading for items deduplicated across both design and review phases. The footer should use phase-neutral language like "accepted by the voting panel."
**Reason not implemented**: The voting panel returned 1 YES and 2 EXONERATE (neutral outcome). While the text is slightly imprecise for design-phase items, the impact is negligible — it's cosmetic text in an auto-generated issue body that doesn't affect functionality.

### [Code Review] Deep-Analysis
**Finding**: `scripts/create-oos-issues.sh:115` — Under `set -euo pipefail`, if `gh issue create` returns an unexpected URL format without trailing digits, `grep -oE '[0-9]+$'` exits 1 and would abort the entire script, violating the "best-effort continues on per-item failure" contract. A `|| true` guard should be added.
**Reason not implemented**: The voting panel returned 1 YES, 1 EXONERATE, and 1 NO (neutral outcome). `gh issue create` reliably returns a canonical URL ending in the issue number.

### [Code Review] General
**Finding**: `scripts/create-oos-issues.sh:90` — ITEM_INDEX is incremented for both successful and failed issue creations, creating gaps in the stdout ISSUE_N_* sequence.
**Reason not implemented**: The voting panel returned 0 YES and 3 NO (rejected). Consumers use ISSUES_CREATED/ISSUES_FAILED counts and parse by key name.

### [Code Review] General
**Finding**: `skills/shared/voting-protocol.md:151-156` — Scoreboard example ambiguous under symmetric scoring.
**Reason not implemented**: 0 YES, 3 EXONERATE (exonerated). Scoring rules are clearly documented in tables.

### [Code Review] General
**Finding**: `skills/implement/SKILL.md:592` — `$REPO` unquoted in script invocation.
**Reason not implemented**: 0 YES, 2 EXONERATE, 1 NO (exonerated). REPO format cannot contain spaces.

### [Code Review] Cursor
**Finding**: `skills/shared/voting-protocol.md:213` — Zero Accepted message wording.
**Reason not implemented**: 0 YES, 2 EXONERATE, 1 NO (exonerated). Contextually clear.

### [Code Review] Deep-Analysis
**Finding**: `skills/shared/voting-protocol.md:130-141` — Competition Scoring section doesn't mention OOS contribution.
**Reason not implemented**: 0 YES, 3 EXONERATE (exonerated). OOS scoring documented separately.

</details>

<details><summary>Plan Review Voting Tally</summary>

| Finding | Deep-Analysis | Cursor | Codex | Result |
|---------|--------------|--------|-------|--------|
| FINDING_1 (competition notice text) | YES | YES | YES | **ACCEPTED** (3/3) |
| FINDING_2 (standalone mode guard) | YES | YES | YES | **ACCEPTED** (3/3) |
| FINDING_3 (conflict-review reference) | YES | YES | YES | **ACCEPTED** (3/3) |
| FINDING_4 (quick-mode guard) | EXONERATE | YES | EXONERATE | Neutral (1/3) |
| FINDING_5 (dedup strategy) | EXONERATE | EXONERATE | EXONERATE | Exonerated (0/3) |
| FINDING_6 (script contract) | EXONERATE | YES | EXONERATE | Neutral (1/3) |
| FINDING_7 (Step 3e exclude OOS) | YES | YES | YES | **ACCEPTED** (3/3) |
| FINDING_8 (accepted-plan-findings.md) | YES | YES | YES | **ACCEPTED** (3/3) |
| FINDING_9 (voter prompt OOS semantics) | YES | YES | YES | **ACCEPTED** (3/3) |
| FINDING_10 (--body-file) | YES | YES | EXONERATE | **ACCEPTED** (2/3) |
| FINDING_11 (REPO_UNAVAILABLE) | YES | YES | YES | **ACCEPTED** (3/3) |
| FINDING_12 (label fallback) | YES | EXONERATE | YES | **ACCEPTED** (2/3) |
| FINDING_13 (idempotency) | EXONERATE | YES | YES | **ACCEPTED** (2/3) |
| FINDING_14 (zero-findings messaging) | EXONERATE | YES | YES | **ACCEPTED** (2/3) |
| FINDING_15 (step numbering) | YES | EXONERATE | NO | Neutral (1/3) |

## Reviewer Competition Scoreboard (Plan Review)

| Reviewer | Findings | Accepted | Neutral (1 YES) | Exonerated (0 YES, 1+ EXON.) | Rejected (0 YES, 0 EXON.) | OOS Proposed | OOS Accepted | Score |
|----------|----------|----------|-----------------|-------------------------------|---------------------------|--------------|--------------|-------|
| General | 5 | 3 | 2 | 0 | 0 | 1 | 0 | +3 |
| Deep-Analysis | 7 | 4 | 2 | 1 | 0 | 2 | 0 | +4 |
| Cursor | 9 | 8 | 0 | 1 | 0 | 0 | 0 | +8 |
| Codex-General | 4 | 3 | 0 | 1 | 0 | 0 | 0 | +3 |
| Codex-Deep | 4 | 3 | 1 | 0 | 0 | 0 | 0 | +3 |

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

| Finding | General | Cursor | Codex | Result |
|---------|---------|--------|-------|--------|
| FINDING_1 (idempotency) | YES | YES | YES | **ACCEPTED** (3/3) |
| FINDING_2 (voter output OOS_N) | YES | YES | YES | **ACCEPTED** (3/3) |
| FINDING_3 (phase text) | YES | EXONERATE | YES | **ACCEPTED** (2/3) |
| FINDING_4 (footer text) | EXONERATE | EXONERATE | YES | Neutral (1/3) |
| FINDING_5 (grep abort) | YES | EXONERATE | NO | Neutral (1/3) |
| FINDING_6 (ITEM_INDEX gaps) | NO | NO | NO | **Rejected** (0/3) |
| FINDING_7 (scoreboard example) | EXONERATE | EXONERATE | EXONERATE | Exonerated |
| FINDING_8 ($REPO quoting) | EXONERATE | EXONERATE | NO | Exonerated |
| FINDING_9 (zero-findings msg) | NO | EXONERATE | EXONERATE | Exonerated |
| FINDING_10 (flush_item drop) | YES | YES | YES | **ACCEPTED** (3/3) |
| FINDING_11 (scoring section) | EXONERATE | EXONERATE | EXONERATE | Exonerated |

## Reviewer Competition Scoreboard (Code Review)

| Reviewer | Findings | Accepted | Neutral (1 YES) | Exonerated (0 YES, 1+ EXON.) | Rejected (0 YES, 0 EXON.) | OOS Proposed | OOS Accepted | Score |
|----------|----------|----------|-----------------|-------------------------------|---------------------------|--------------|--------------|-------|
| General | 4 | 1 | 0 | 2 | 1 | 2 | 0 | -2 |
| Deep-Analysis | 5 | 3 | 1 | 1 | 0 | 2 | 1 | +3 |
| Cursor | 7 | 2 | 1 | 2 | 0 | 1 | 1 | +3 |
| Codex-General | 4 | 2 | 1 | 0 | 0 | 0 | 0 | +2 |
| Codex-Deep | 3 | 2 | 0 | 0 | 0 | 0 | 0 | +2 |

</details>

<details><summary>Out-of-Scope Observations</summary>

**Accepted OOS (GitHub issues filed):**
- #66: create-oos-issues.sh multi-line description support (Deep-Analysis, Cursor)

**Non-accepted OOS observations:**

**Plan Review:**
- **OOS_1** (General, Deep-Analysis): Competition notice text is duplicated across /design SKILL.md and /review SKILL.md with slight wording variations. A longer-term improvement would centralize it in skills/shared/.
- **OOS_2** (Deep-Analysis): Non-accepted OOS items in PR body are sourced from conversation context, which is fragile in long sessions.

**Code Review:**
- **OOS_4** (Cursor): `scripts/create-oos-issues.sh` — `gh issue create` stderr is discarded (2>/dev/null), making failure debugging difficult.
- **OOS_6** (Deep-Analysis): Step Name Registry lists 9a.1 before 9, and 9a is missing from the registry.

</details>

<details><summary>Execution Issues</summary>

No execution issues encountered.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | 11 accepted, 4 rejected |
| Code review rounds | 3 |
| Code review findings | 6 accepted (4 round 1 + 2 round 2), 7 rejected |
| Warnings logged | 0 |
| Pre-existing issues noticed | 0 |
| OOS issues filed | 1 |
| External reviewers | Cursor: ✅, Codex: ✅ |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
