### PR TITLE
Add issue deduplication to OOS issue creation

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation with collaborative reviewers (Claude subagents + Codex + Cursor).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.5] - 2026-04-13
+
+### Changed
+
+- Added deduplication to `create-oos-issues.sh` — fetches open issues before creating new ones and skips creation when a normalized-title match already exists
+- Updated SKILL.md Step 9a.1 to document new `ISSUES_DEDUPLICATED` output field and dedup reporting in PR body
+
 ## [2.0.4] - 2026-04-13
 
 ### Changed

--- a/scripts/create-oos-issues.sh
+++ b/scripts/create-oos-issues.sh
@@ -80,7 +80,7 @@ gh issue list --repo "$REPO" --state open --json title,number,url --limit 500 --
 
 # Normalize a title for comparison: lowercase, strip [OOS] prefix, collapse whitespace, trim
 normalize_title() {
-    echo "$1" | tr '[:upper:]' '[:lower:]' | sed -E 's/^\[oos\]\s*//' | tr -s '[:space:]' ' ' | sed 's/^ *//;s/ *$//'
+    printf '%s\n' "$1" | tr '[:upper:]' '[:lower:]' | sed -E 's/^\[oos\]\s*//' | tr -s '[:space:]' ' ' | sed 's/^ *//;s/ *$//'
 }
 
 # Check if a title is a duplicate of an existing open issue.
@@ -98,12 +98,6 @@ check_duplicate() {
 
         # Exact match after normalization
         if [[ "$new_norm" == "$existing_norm" ]]; then
-            printf '%s\t%s' "$num" "$url"
-            return 0
-        fi
-
-        # Substring containment (either direction)
-        if [[ "$existing_norm" == *"$new_norm"* ]] || [[ "$new_norm" == *"$existing_norm"* ]]; then
             printf '%s\t%s' "$num" "$url"
             return 0
         fi
@@ -175,6 +169,8 @@ BODY_EOF
         echo "ISSUE_${ITEM_INDEX}_NUMBER=$number"
         echo "ISSUE_${ITEM_INDEX}_URL=$issue_url"
         echo "ISSUE_${ITEM_INDEX}_TITLE=$title"
+        # Append to snapshot so later items in this batch detect intra-run duplicates
+        printf '%s\t%s\t[OOS] %s\n' "$number" "$issue_url" "$title" >> "$EXISTING_ISSUES_FILE"
     else
         ISSUES_FAILED=$((ISSUES_FAILED + 1))
         echo "ISSUE_${ITEM_INDEX}_FAILED=true" >&2

--- a/scripts/create-oos-issues.sh
+++ b/scripts/create-oos-issues.sh
@@ -22,9 +22,13 @@
 # Outputs (key=value to stdout):
 #   ISSUES_CREATED=<N>
 #   ISSUES_FAILED=<N>
+#   ISSUES_DEDUPLICATED=<N>
 #   ISSUE_1_NUMBER=<N>
 #   ISSUE_1_URL=<url>
 #   ISSUE_1_TITLE=<title>
+#   ISSUE_1_DUPLICATE=true           (if deduplicated)
+#   ISSUE_1_DUPLICATE_OF_NUMBER=<N>  (existing issue number)
+#   ISSUE_1_DUPLICATE_OF_URL=<url>   (existing issue URL)
 #   ...
 #
 # Exit codes:
@@ -69,10 +73,50 @@ if gh label list --repo "$REPO" --search "out-of-scope" --json name --jq '.[].na
     LABEL_FLAG="--label out-of-scope"
 fi
 
+# Fetch all open issue titles for deduplication (one API call, reused per item)
+EXISTING_ISSUES_FILE=$(mktemp)
+trap 'rm -f "$EXISTING_ISSUES_FILE"' EXIT
+gh issue list --repo "$REPO" --state open --json title,number,url --limit 500 --jq '.[] | "\(.number)\t\(.url)\t\(.title)"' > "$EXISTING_ISSUES_FILE" 2>/dev/null || true
+
+# Normalize a title for comparison: lowercase, strip [OOS] prefix, collapse whitespace, trim
+normalize_title() {
+    echo "$1" | tr '[:upper:]' '[:lower:]' | sed -E 's/^\[oos\]\s*//' | tr -s '[:space:]' ' ' | sed 's/^ *//;s/ *$//'
+}
+
+# Check if a title is a duplicate of an existing open issue.
+# Returns 0 (match found) and prints "NUMBER<tab>URL" of the match, or returns 1 (no match).
+check_duplicate() {
+    local new_title="$1"
+    local new_norm
+    new_norm=$(normalize_title "$new_title")
+    [[ -z "$new_norm" ]] && return 1
+
+    while IFS=$'\t' read -r num url existing_title; do
+        local existing_norm
+        existing_norm=$(normalize_title "$existing_title")
+        [[ -z "$existing_norm" ]] && continue
+
+        # Exact match after normalization
+        if [[ "$new_norm" == "$existing_norm" ]]; then
+            printf '%s\t%s' "$num" "$url"
+            return 0
+        fi
+
+        # Substring containment (either direction)
+        if [[ "$existing_norm" == *"$new_norm"* ]] || [[ "$new_norm" == *"$existing_norm"* ]]; then
+            printf '%s\t%s' "$num" "$url"
+            return 0
+        fi
+    done < "$EXISTING_ISSUES_FILE"
+
+    return 1
+}
+
 # Parse OOS items from the input file
 # Each item starts with "### OOS_" and contains Description, Reviewer, Vote tally, Phase
 ISSUES_CREATED=0
 ISSUES_FAILED=0
+ISSUES_DEDUPLICATED=0
 ITEM_INDEX=0
 CURRENT_TITLE=""
 CURRENT_DESCRIPTION=""
@@ -88,6 +132,20 @@ create_issue() {
     local phase="$5"
 
     ITEM_INDEX=$((ITEM_INDEX + 1))
+
+    # Check for duplicate before creating
+    local dup_info
+    if dup_info=$(check_duplicate "$title"); then
+        local dup_number dup_url
+        dup_number=$(echo "$dup_info" | cut -f1)
+        dup_url=$(echo "$dup_info" | cut -f2)
+        ISSUES_DEDUPLICATED=$((ISSUES_DEDUPLICATED + 1))
+        echo "ISSUE_${ITEM_INDEX}_DUPLICATE=true"
+        echo "ISSUE_${ITEM_INDEX}_DUPLICATE_OF_NUMBER=$dup_number"
+        echo "ISSUE_${ITEM_INDEX}_DUPLICATE_OF_URL=$dup_url"
+        echo "ISSUE_${ITEM_INDEX}_TITLE=$title"
+        return
+    fi
 
     # Write issue body to temp file (avoids shell quoting issues)
     local body_file
@@ -161,3 +219,4 @@ flush_item
 
 echo "ISSUES_CREATED=$ISSUES_CREATED"
 echo "ISSUES_FAILED=$ISSUES_FAILED"
+echo "ISSUES_DEDUPLICATED=$ISSUES_DEDUPLICATED"

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -593,13 +593,13 @@ Read the OOS artifact files:
    ```bash
    ${CLAUDE_PLUGIN_ROOT}/scripts/create-oos-issues.sh --input-file "$IMPLEMENT_TMPDIR/oos-items.md" --repo $REPO
    ```
-5. Parse the structured output for `ISSUES_CREATED`, `ISSUES_FAILED`, and per-issue `ISSUE_N_NUMBER`/`ISSUE_N_URL` pairs.
+5. Parse the structured output for `ISSUES_CREATED`, `ISSUES_FAILED`, `ISSUES_DEDUPLICATED`, and per-issue `ISSUE_N_NUMBER`/`ISSUE_N_URL`/`ISSUE_N_DUPLICATE`/`ISSUE_N_DUPLICATE_OF_NUMBER`/`ISSUE_N_DUPLICATE_OF_URL` pairs.
 6. If `ISSUES_FAILED > 0`: Log to `$IMPLEMENT_TMPDIR/execution-issues.md` under `Tool Failures`: `Step 9a.1 — create-oos-issues.sh failed to create <N> of <total> OOS issues.`
-7. Save the issue URLs for embedding in the PR body's "Out-of-Scope Observations" section (already prepared in Step 9a). Update the `$IMPLEMENT_TMPDIR/pr-body.md` file to replace the "Accepted OOS (GitHub issues filed)" placeholder with the actual issue links.
+7. Save the issue URLs for embedding in the PR body's "Out-of-Scope Observations" section (already prepared in Step 9a). Update the `$IMPLEMENT_TMPDIR/pr-body.md` file to replace the "Accepted OOS (GitHub issues filed)" placeholder with the actual issue links. For deduplicated items, link to the existing issue instead: `"- #<EXISTING_NUMBER>: <title> (deduplicated — already tracked) (<reviewer attribution>)"`.
 
-8. Write the created issue metadata to `$IMPLEMENT_TMPDIR/oos-issues-created.md` as a sentinel for idempotency. Include the `ISSUES_CREATED`, `ISSUES_FAILED`, and all `ISSUE_N_NUMBER`/`ISSUE_N_URL`/`ISSUE_N_TITLE` lines from the script output.
+8. Write the created issue metadata to `$IMPLEMENT_TMPDIR/oos-issues-created.md` as a sentinel for idempotency. Include the `ISSUES_CREATED`, `ISSUES_FAILED`, `ISSUES_DEDUPLICATED`, and all `ISSUE_N_NUMBER`/`ISSUE_N_URL`/`ISSUE_N_TITLE`/`ISSUE_N_DUPLICATE*` lines from the script output.
 
-Print: `✅ 9a.1: OOS issues — <ISSUES_CREATED> issues filed`
+Print: `✅ 9a.1: OOS issues — <ISSUES_CREATED> created, <ISSUES_DEDUPLICATED> deduplicated`
 
 ### 9b — Create PR via script
 


### PR DESCRIPTION
## Summary
- Added deduplication logic to `create-oos-issues.sh` that fetches all open issues before creating new ones and skips creation when a normalized-title match already exists
- Updated SKILL.md Step 9a.1 to document the new `ISSUES_DEDUPLICATED` output field and deduplicated-item reporting in the PR body

<details><summary>Architecture Diagram</summary>

Quick mode — architecture diagram skipped.

</details>

<details><summary>Code Flow Diagram</summary>

Quick mode — code flow diagram skipped.

</details>

<details><summary>Goal</summary>

- Prevent duplicate GitHub issue creation when the `/implement` skill files OOS observations
  - Fetch all open issues in the repo before creating new ones
  - Compare normalized titles (lowercase, strip `[OOS]` prefix, collapse whitespace)
  - Skip creation and report deduplication when a match is found
  - Detect intra-run duplicates by appending newly created issues to the snapshot

</details>

<details><summary>Test plan</summary>

- [ ] Run `create-oos-issues.sh` with an input file containing an OOS item whose title matches an existing open issue — verify it reports `ISSUES_DEDUPLICATED=1` and does not create a duplicate
- [ ] Run with an input file containing a genuinely new OOS item — verify it creates the issue normally
- [ ] Run with an input file containing two items with the same title — verify only the first is created and the second is reported as deduplicated (intra-run dedup)
- [ ] Run with an empty repo (no open issues) — verify all items are created normally
- [ ] Verify shellcheck passes on the modified script

</details>

<details><summary>Final Design</summary>

**Approach**: Add deduplication to `scripts/create-oos-issues.sh`:
1. After verifying repo access, fetch all open issue titles/numbers/URLs via `gh issue list --limit 500`
2. Add `normalize_title()` function: lowercase, strip `[OOS]` prefix, collapse whitespace
3. Add `check_duplicate()` function: exact match after normalization
4. In `create_issue()`, call `check_duplicate()` before `gh issue create`; if match found, skip creation and emit `ISSUE_N_DUPLICATE*` fields
5. After each successful creation, append to snapshot for intra-run dedup
6. Track `ISSUES_DEDUPLICATED` counter alongside `ISSUES_CREATED` and `ISSUES_FAILED`

**Files modified**: `scripts/create-oos-issues.sh`, `skills/implement/SKILL.md`

</details>

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `f8e9cf2` (Add OOS voting, symmetric scoring, and GitHub issue filing (#67))
- **Current version**: `2.0.4`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `2.0.5`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH").

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

Quick mode — no plan review was conducted.

</details>

<details><summary>Implementation Deviations</summary>

No deviations from the plan.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

### [Code Review] General Reviewer
**Finding**: In `scripts/create-oos-issues.sh` line 78, the `trap 'rm -f "$EXISTING_ISSUES_FILE"' EXIT` call would overwrite any prior EXIT trap. The pre-existing pattern for `body_file` uses explicit `rm -f` cleanup inline rather than a trap. If a future edit adds another EXIT trap, one cleanup handler would be silently lost.
**Reason not implemented**: This is the only EXIT trap in the script. The concern is purely theoretical — there is no existing EXIT trap to overwrite, and the trap pattern is idiomatic for temp file cleanup in short-lived scripts. Adding a comment would be over-documenting.

### [Code Review] General Reviewer
**Finding**: In `skills/implement/SKILL.md` line 597, the error log template `failed to create <N> of <total> OOS issues` is now ambiguous because `<total>` could include deduplicated items. The template should explicitly state which counts compose the total.
**Reason not implemented**: This is prompt text consumed by an LLM agent, not executable code. The agent has access to all three counters (`ISSUES_CREATED`, `ISSUES_FAILED`, `ISSUES_DEDUPLICATED`) and can compute the appropriate total from context. Adding verbose disambiguation to the prompt would not improve correctness.

### [Code Review] Deep Analysis Reviewer
**Finding**: In `scripts/create-oos-issues.sh` lines 144-146 vs 180-181, `ISSUE_N_TITLE` is emitted to stdout for deduplicated items but to stderr for failed items. SKILL.md Step 8 says to capture "all `ISSUE_N_TITLE` lines" but the main agent only captures stdout, so failed items' titles are invisible in the sentinel file. The deduplication path makes this asymmetry more prominent.
**Reason not implemented**: This is a pre-existing inconsistency in the failed-item error reporting path that predates this PR. The failed-item path intentionally uses stderr for error signaling. Changing the error reporting contract for failed items is scope creep — the deduplication feature does not worsen the existing behavior for failed items, it only adds a new (correctly stdout-based) path for deduplicated items.

</details>

<details><summary>Plan Review Voting Tally</summary>

Quick mode — no plan review voting.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

Quick mode — no voting panel. Main agent reviewed findings from 2 Claude subagents.

</details>

<details><summary>Out-of-Scope Observations</summary>

Quick mode — no out-of-scope observations collected.

</details>

<details><summary>Execution Issues</summary>

No execution issues encountered.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | N/A (quick mode) |
| Code review rounds | 1 |
| Code review findings | 3 accepted, 3 rejected |
| Warnings logged | 0 |
| Pre-existing issues noticed | 0 |
| OOS issues filed | N/A (quick mode) |
| External reviewers | N/A (quick mode) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
