### PR TITLE
Add elapsed time to all completion indicators

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation with collaborative reviewers (Claude subagents + Codex + Cursor).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.6] - 2026-04-13
+
+### Changed
+
+- Added elapsed time reporting to all `✅` completion indicators — step completion lines show `(<elapsed>)` and compact status tables show timing after each `✅`
+- Defined elapsed time format rules in `skills/shared/progress-reporting.md` (central contract)
+- Updated all `Print:` directives across all 7 skills to include `(<elapsed>)` placeholders
+
 ## [2.0.5] - 2026-04-13
 
 ### Changed

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -58,7 +58,7 @@ Step Name Registry:
 📊 Reviewers: | General: ✅ 2m31s | Arch: ⏳ | Pragmatic: ✅ 3m5s | Cursor: ❌ | Codex: ⏳ |
 ```
 
-Icons: ✅ done (with elapsed time), ⏳ pending/in-progress, ❌ failed/timeout, ⊘ skipped (unavailable). This replaces individual per-agent completion messages in non-debug mode. See `${CLAUDE_PLUGIN_ROOT}/skills/shared/progress-reporting.md` for elapsed time format rules.
+Icons: ✅ done (with elapsed time since launch), ⏳ pending/in-progress, ❌ failed/timeout, ⊘ skipped (unavailable). This replaces individual per-agent completion messages in non-debug mode. See `${CLAUDE_PLUGIN_ROOT}/skills/shared/progress-reporting.md` for elapsed time format rules.
 
 **Suppressed output (only when `debug_mode=false`):** explanatory prose, script paths, rationale for decisions between tool calls, per-reviewer individual completion messages.
 
@@ -130,7 +130,7 @@ Consider asking about:
 **Guidelines**:
 - Only ask questions when there is genuine ambiguity — do NOT ask trivially answerable questions or re-confirm what is already clear.
 - Batch questions into a single `AskUserQuestion` call with 1-4 questions rather than multiple sequential calls.
-- If the feature description is clear and unambiguous, print `✅ 1c: questions — no clarifying questions needed` and proceed to Step 1d.
+- If the feature description is clear and unambiguous, print `✅ 1c: questions — no clarifying questions needed (<elapsed>)` and proceed to Step 1d.
 
 After the user responds, incorporate their answers into your understanding of the feature for all subsequent steps.
 
@@ -179,7 +179,7 @@ At most **7 `AskUserQuestion` calls** in this step. If more than 7 decision bran
 
 If the user gives a terse or non-responsive answer (e.g., "I don't know", "your recommendation is fine", "sure"), accept the recommended answer and move on without re-asking.
 
-Print: `✅ 1d: discussion r1 — <N> decisions resolved`
+Print: `✅ 1d: discussion r1 — <N> decisions resolved (<elapsed>)`
 
 ## Step 2a — Collaborative Approach Sketches
 
@@ -339,7 +339,7 @@ Print resolutions under a `## Dialectic Resolutions` header.
 
 **Scope**: Dialectic resolutions are **binding for Step 2b plan generation only**. They may be superseded later by accepted Step 3 review findings. The finalized plan (after Step 3 review) remains the sole canonical output.
 
-Print: `✅ 2a.5: dialectic — <N> decisions resolved` (where N is the count of decisions that passed the quorum rule).
+Print: `✅ 2a.5: dialectic — <N> decisions resolved (<elapsed>)` (where N is the count of decisions that passed the quorum rule).
 
 ## Step 2b — Design the Implementation Plan
 
@@ -569,7 +569,7 @@ At most **7 `AskUserQuestion` calls** in this step. If more than 7 decision bran
 
 If the user gives a terse or non-responsive answer, accept the recommended answer and move on without re-asking.
 
-Print: `✅ 3.5: discussion r2 — <N> decisions resolved`
+Print: `✅ 3.5: discussion r2 — <N> decisions resolved (<elapsed>)`
 
 ## Step 3a — Post-Review Confirmation
 
@@ -603,7 +603,7 @@ Print the diagram under a `## Architecture Diagram` header with a mermaid code f
 ```
 ```
 
-**If diagram generation succeeds**, print: `✅ 3b: arch diagram — generated`
+**If diagram generation succeeds**, print: `✅ 3b: arch diagram — generated (<elapsed>)`
 
 **If diagram generation fails** (e.g., the feature is too abstract to diagram meaningfully), print: `**⚠ 3b: arch diagram — generation failed, proceeding without diagram**`
 
@@ -613,7 +613,7 @@ Print any rejected plan review findings:
 
 1. Check if `$DESIGN_TMPDIR/rejected-findings.md` exists and is non-empty.
 2. If it has content, print it under a `## Unimplemented Plan Review Suggestions` header, formatted clearly with the reviewer name, the suggestion, and the reason for each.
-3. If the file doesn't exist or is empty, print: `✅ 4: rejected findings — all suggestions implemented`
+3. If the file doesn't exist or is empty, print: `✅ 4: rejected findings — all suggestions implemented (<elapsed>)`
 
 ## Step 5 — Cleanup and Final Warnings
 
@@ -636,5 +636,5 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/cleanup-tmpdir.sh --dir "$DESIGN_TMPDIR"
 - `**⚠ Codex sketch timed out / produced empty output**`
 - `**⚠ 3b: arch diagram — generation failed, proceeding without diagram**`
 
-If `STEP_NUM_PREFIX` is empty (standalone mode): Print: `✅ 5: cleanup — design complete!`
+If `STEP_NUM_PREFIX` is empty (standalone mode): Print: `✅ 5: cleanup — design complete! (<elapsed>)`
 If `STEP_NUM_PREFIX` is non-empty (orchestrated mode): skip this final print — the parent orchestrator handles overall progress.

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -55,10 +55,10 @@ Step Name Registry:
 **Compact reviewer status table**: After launching sketch agents (Step 2a) or plan reviewers (Step 3), maintain a mental tracker of each agent's status. Print a compact table after EACH status change:
 
 ```
-📊 Reviewers: | General: ✅ | Arch: ⏳ | Pragmatic: ✅ | Cursor: ❌ | Codex: ⏳ |
+📊 Reviewers: | General: ✅ 2m31s | Arch: ⏳ | Pragmatic: ✅ 3m5s | Cursor: ❌ | Codex: ⏳ |
 ```
 
-Icons: ✅ done, ⏳ pending/in-progress, ❌ failed/timeout, ⊘ skipped (unavailable). This replaces individual per-agent completion messages in non-debug mode.
+Icons: ✅ done (with elapsed time), ⏳ pending/in-progress, ❌ failed/timeout, ⊘ skipped (unavailable). This replaces individual per-agent completion messages in non-debug mode. See `${CLAUDE_PLUGIN_ROOT}/skills/shared/progress-reporting.md` for elapsed time format rules.
 
 **Suppressed output (only when `debug_mode=false`):** explanatory prose, script paths, rationale for decisions between tool calls, per-reviewer individual completion messages.
 

--- a/skills/fix-issue/SKILL.md
+++ b/skills/fix-issue/SKILL.md
@@ -68,7 +68,7 @@ Only include `--issue "$ISSUE_ARG"` if `ISSUE_ARG` is non-empty (the user provid
 Handle exit codes:
 
 - **Exit 0**: Parse `ISSUE_NUMBER` and `ISSUE_TITLE`. Print `▸ 1: fetch issue — found #$ISSUE_NUMBER: $ISSUE_TITLE`
-- **Exit 1**: Print `✅ 1: fetch issue — no approved issues found`. Skip to Step 9.
+- **Exit 1**: Print `✅ 1: fetch issue — no approved issues found (<elapsed>)`. Skip to Step 9.
 - **Exit 2+**: Parse `ERROR` from stdout. Print `**⚠ 1: fetch issue — error: $ERROR**`. Skip to Step 9.
 
 ## Step 2 — Read Issue Details
@@ -107,9 +107,9 @@ Check for:
      --token "$SLACK_TOKEN" --channel-id "$SLACK_CHANNEL" \
      --message "Issue #$ISSUE_NUMBER ($ISSUE_TITLE) closed — <one-sentence reason>"
    ```
-4. Print `✅ 3: triage — issue #$ISSUE_NUMBER closed (not material)`. Skip to Step 9.
+4. Print `✅ 3: triage — issue #$ISSUE_NUMBER closed, not material (<elapsed>)`. Skip to Step 9.
 
-**If the issue is still actual**, print `✅ 3: triage — issue is active, proceeding` and continue.
+**If the issue is still actual**, print `✅ 3: triage — issue is active, proceeding (<elapsed>)` and continue.
 
 ## Step 4 — Lock Issue
 
@@ -120,7 +120,7 @@ ${CLAUDE_PLUGIN_ROOT}/skills/fix-issue/scripts/issue-lifecycle.sh comment \
 
 Parse output for `LOCK_ACQUIRED`. If `LOCK_ACQUIRED=false`, print `**⚠ 4: lock — failed ($ERROR). Another run may have claimed this issue.**` Skip to Step 9.
 
-If `LOCK_ACQUIRED=true`, print `✅ 4: lock — issue #$ISSUE_NUMBER locked`.
+If `LOCK_ACQUIRED=true`, print `✅ 4: lock — issue #$ISSUE_NUMBER locked (<elapsed>)`.
 
 ## Step 5 — Classify Complexity
 
@@ -133,7 +133,7 @@ Based on the issue details and codebase exploration from Step 3, classify the is
 
 **Default to HARD when uncertain.** A HARD classification uses the full `/design` + `/review` pipeline, which is safer for non-trivial changes.
 
-Print `✅ 5: classify — $CLASSIFICATION`
+Print `✅ 5: classify — $CLASSIFICATION (<elapsed>)`
 
 ## Step 6 — Implement
 
@@ -168,7 +168,7 @@ ${CLAUDE_PLUGIN_ROOT}/skills/fix-issue/scripts/issue-lifecycle.sh close \
   --issue $ISSUE_NUMBER --comment "DONE"
 ```
 
-Print `✅ 7: close issue — #$ISSUE_NUMBER closed`
+Print `✅ 7: close issue — #$ISSUE_NUMBER closed (<elapsed>)`
 
 ## Step 8 — Slack Announce
 
@@ -182,7 +182,7 @@ ${CLAUDE_PLUGIN_ROOT}/skills/fix-issue/scripts/post-issue-slack.sh \
 
 If the script exits non-zero, print `**⚠ 8: slack announce — failed. Continuing.**`
 
-Print `✅ 8: slack announce — posted`
+Print `✅ 8: slack announce — posted (<elapsed>)`
 
 ## Step 9 — Cleanup
 
@@ -192,7 +192,7 @@ Print `✅ 8: slack announce — posted`
 ${CLAUDE_PLUGIN_ROOT}/scripts/cleanup-tmpdir.sh --dir "$FIX_ISSUE_TMPDIR"
 ```
 
-Print `✅ 9: cleanup — fix-issue complete!`
+Print `✅ 9: cleanup — fix-issue complete! (<elapsed>)`
 
 ## Known Limitations
 

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -170,7 +170,7 @@ If the script exits non-zero, print: `**⚠ Failed to ensure local main is fresh
 
 If successful:
 - If stdout contains `SKIPPED_ALREADY_FRESH=true`: if `debug_mode=true`, print: `⏩ 1.m: design plan | update main — already at latest` Otherwise, silently continue.
-- Otherwise, print: `✅ 1.m: design plan | update main — rebased onto latest origin/main`
+- Otherwise, print: `✅ 1.m: design plan | update main — rebased onto latest origin/main (<elapsed>)`
 
 ### Quick mode (`quick_mode=true`)
 
@@ -222,7 +222,7 @@ If the script exits non-zero, print: `**⚠ Rebase onto main failed. Bailing to 
 If successful:
 - If stdout contains `SKIPPED_ALREADY_PUSHED=true`: if `debug_mode=true`, print: `⏩ 1.r: design plan | rebase — already pushed` Otherwise, silently continue.
 - If stdout contains `SKIPPED_ALREADY_FRESH=true`: if `debug_mode=true`, print: `⏩ 1.r: design plan | rebase — already at latest main` Otherwise, silently continue.
-- Otherwise, print: `✅ 1.r: design plan | rebase — rebased onto latest main`
+- Otherwise, print: `✅ 1.r: design plan | rebase — rebased onto latest main (<elapsed>)`
 
 ## Step 2 — Implement the Feature
 
@@ -263,7 +263,7 @@ If the script exits non-zero, print: `**⚠ Rebase onto main failed. Bailing to 
 If successful:
 - If stdout contains `SKIPPED_ALREADY_PUSHED=true`: if `debug_mode=true`, print: `⏩ 4.r: commit (impl) | rebase — already pushed` Otherwise, silently continue.
 - If stdout contains `SKIPPED_ALREADY_FRESH=true`: if `debug_mode=true`, print: `⏩ 4.r: commit (impl) | rebase — already at latest main` Otherwise, silently continue.
-- Otherwise, print: `✅ 4.r: commit (impl) | rebase — rebased onto latest main`
+- Otherwise, print: `✅ 4.r: commit (impl) | rebase — rebased onto latest main (<elapsed>)`
 
 ## Step 5 — Code Review
 
@@ -341,7 +341,7 @@ If the script exits non-zero, print: `**⚠ Rebase onto main failed. Bailing to 
 If successful:
 - If stdout contains `SKIPPED_ALREADY_PUSHED=true`: if `debug_mode=true`, print: `⏩ 7.r: commit (review) | rebase — already pushed` Otherwise, silently continue.
 - If stdout contains `SKIPPED_ALREADY_FRESH=true`: if `debug_mode=true`, print: `⏩ 7.r: commit (review) | rebase — already at latest main` Otherwise, silently continue.
-- Otherwise, print: `✅ 7.r: commit (review) | rebase — rebased onto latest main`
+- Otherwise, print: `✅ 7.r: commit (review) | rebase — rebased onto latest main (<elapsed>)`
 
 ## Step 7a — Code Flow Diagram
 
@@ -365,7 +365,7 @@ Print the diagram under a `## Code Flow Diagram` header with a mermaid code fenc
 ```
 ```
 
-**If diagram generation succeeds**, print: `✅ 7a: code flow — diagram generated`
+**If diagram generation succeeds**, print: `✅ 7a: code flow — diagram generated (<elapsed>)`
 
 **If diagram generation fails** (e.g., the implementation is too abstract to diagram meaningfully), print: `**⚠ 7a: code flow — generation failed, proceeding without diagram**` Log this warning to `$IMPLEMENT_TMPDIR/execution-issues.md` under the `Warnings` category.
 
@@ -385,7 +385,7 @@ If the script exits non-zero, print: `**⚠ Rebase onto main failed. Bailing to 
 If successful:
 - If stdout contains `SKIPPED_ALREADY_PUSHED=true`: if `debug_mode=true`, print: `⏩ 7a.r: code flow | rebase — already pushed` Otherwise, silently continue.
 - If stdout contains `SKIPPED_ALREADY_FRESH=true`: if `debug_mode=true`, print: `⏩ 7a.r: code flow | rebase — already at latest main` Otherwise, silently continue.
-- Otherwise, print: `✅ 7a.r: code flow | rebase — rebased onto latest main`
+- Otherwise, print: `✅ 7a.r: code flow | rebase — rebased onto latest main (<elapsed>)`
 
 ## Step 8 — Version Bump
 
@@ -443,7 +443,7 @@ Parse the output for `HAS_BUMP` and `COMMITS_BEFORE`.
 
    This keeps the bump commit as the single HEAD commit containing both the version bump and the changelog update.
 
-Print: `✅ 8a: changelog — updated for v<NEW_VERSION>`
+Print: `✅ 8a: changelog — updated for v<NEW_VERSION> (<elapsed>)`
 
 ## Step 9 — Create PR
 
@@ -599,7 +599,7 @@ Read the OOS artifact files:
 
 8. Write the created issue metadata to `$IMPLEMENT_TMPDIR/oos-issues-created.md` as a sentinel for idempotency. Include the `ISSUES_CREATED`, `ISSUES_FAILED`, `ISSUES_DEDUPLICATED`, and all `ISSUE_N_NUMBER`/`ISSUE_N_URL`/`ISSUE_N_TITLE`/`ISSUE_N_DUPLICATE*` lines from the script output.
 
-Print: `✅ 9a.1: OOS issues — <ISSUES_CREATED> created, <ISSUES_DEDUPLICATED> deduplicated`
+Print: `✅ 9a.1: OOS issues — <ISSUES_CREATED> created, <ISSUES_DEDUPLICATED> deduplicated (<elapsed>)`
 
 ### 9b — Create PR via script
 
@@ -770,9 +770,9 @@ Parse the output for: `ACTION`, `CI_STATUS`, `BEHIND_COUNT`, `FAILED_RUN_ID`, `B
 
 **Execute the action** returned by `ci-wait.sh`:
 
-   - **`ACTION=merge`**: CI passed and branch is up-to-date. Print `✅ 10: CI monitor — CI passed!` and proceed to Step 11. **Do NOT merge here** — Step 12 handles merging.
+   - **`ACTION=merge`**: CI passed and branch is up-to-date. Print `✅ 10: CI monitor — CI passed! (<elapsed>)` and proceed to Step 11. **Do NOT merge here** — Step 12 handles merging.
 
-   - **`ACTION=already_merged`**: PR was merged externally during CI wait. Print `✅ 10: CI monitor — PR merged externally` and proceed to Step 11. (Step 12 will detect `already_merged` again and skip the merge loop.)
+   - **`ACTION=already_merged`**: PR was merged externally during CI wait. Print `✅ 10: CI monitor — PR merged externally (<elapsed>)` and proceed to Step 11. (Step 12 will detect `already_merged` again and skip the merge loop.)
 
    - **`ACTION=rebase`**: Main advanced. Invoke the **Rebase + Re-bump Sub-procedure** (defined before this step) with `rebase_already_done=false`, `caller_kind=step10_rebase`. The sub-procedure handles drop-before-rebase, rebase, fast-forward local main, re-bump via `/bump-version`, push with recovery, and PR body refresh. On sub-procedure success, counter updates and `ci-wait.sh` re-invocation happen inside the sub-procedure's step 7. On sub-procedure failure (rebase conflict, re-bump failure, or push failure), the sub-procedure logs a warning and breaks out of Step 10 to Step 11 — it does NOT bail to 12d (Step 12 will re-run the sub-procedure under strict semantics).
 
@@ -861,9 +861,9 @@ Parse the output for: `ACTION`, `CI_STATUS`, `BEHIND_COUNT`, `FAILED_RUN_ID`, `B
 
    - **`ACTION=rebase`**: Print a context-specific message based on `CI_STATUS`: if `CI_STATUS=pass`, print `🔃 12: CI+merge loop — CI passed, main advanced, rebasing + re-bumping`; if `CI_STATUS=pending`, print `🔃 12: CI+merge loop — main advanced, rebasing + re-bumping` → invoke the **Rebase + Re-bump Sub-procedure** (defined before Step 10) with `rebase_already_done=false`, `caller_kind=step12_rebase`. The sub-procedure handles drop-before-rebase, rebase (with Phase 1–4 fallback on conflict), fast-forward local main, `/bump-version`, push with recovery, and PR body refresh. On successful return, counter updates (`rebase_count`, `iteration`, `transient_retries` reset) and `ci-wait.sh` re-invocation happen inside the sub-procedure's step 7. On hard failure, the sub-procedure bails to 12d directly.
 
-   - **`ACTION=merge`**: Print `✅ 12: CI+merge loop — CI passed, main up-to-date, merging!` → proceed to **12b**.
+   - **`ACTION=merge`**: Print `✅ 12: CI+merge loop — CI passed, main up-to-date, merging! (<elapsed>)` → proceed to **12b**.
 
-   - **`ACTION=already_merged`**: Print `✅ PR was force-merged externally — skipping CI wait and merge.` → skip **12b** (no merge needed) and proceed directly to Step 13. The PR counts as successfully merged for Steps 13–15.
+   - **`ACTION=already_merged`**: Print `✅ PR was force-merged externally — skipping CI wait and merge. (<elapsed>)` → skip **12b** (no merge needed) and proceed directly to Step 13. The PR counts as successfully merged for Steps 13–15.
 
    - **`ACTION=rebase_then_evaluate`**: Invoke the **Rebase + Re-bump Sub-procedure** with `rebase_already_done=false`, `caller_kind=step12_rebase_then_evaluate`. On successful return (counter updates already done inside the sub-procedure), **fall through to 12c** to evaluate the CI failure. Do NOT re-invoke `ci-wait.sh` from the caller — the sub-procedure's `caller_kind=step12_rebase_then_evaluate` branch skips the re-invocation for this path. On hard failure, the sub-procedure bails to 12d.
 
@@ -976,8 +976,8 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/merge-pr.sh --pr <PR-NUMBER> --repo $REPO
 
 Parse the output for `MERGE_RESULT` and `ERROR`. Handle each result:
 
-- **`MERGE_RESULT=merged`**: Print `✅ 12: CI+merge loop — PR #<NUMBER> merged!` and continue.
-- **`MERGE_RESULT=admin_merged`**: Print `**⚠ Merged with --admin (review overridden).** ✅ 12: CI+merge loop — PR #<NUMBER> merged!` and continue.
+- **`MERGE_RESULT=merged`**: Print `✅ 12: CI+merge loop — PR #<NUMBER> merged! (<elapsed>)` and continue.
+- **`MERGE_RESULT=admin_merged`**: Print `**⚠ Merged with --admin (review overridden).** ✅ 12: CI+merge loop — PR #<NUMBER> merged! (<elapsed>)` and continue.
 - **`MERGE_RESULT=main_advanced`**: Go back to **12a** (the next iteration will detect the branch is behind and rebase).
 - **`MERGE_RESULT=ci_not_ready`**: Go back to **12a** (CI may need more time or a rerun).
 - **`MERGE_RESULT=admin_failed`**: Bail out (Step 12d) with the `ERROR` message.
@@ -1047,7 +1047,7 @@ Switch back to main, pull the merged changes, and delete the development branch:
 ${CLAUDE_PLUGIN_ROOT}/scripts/local-cleanup.sh --branch "$BRANCH_NAME"
 ```
 
-Parse the output for `CLEANUP_SUCCESS`, `CURRENT_BRANCH`, and `BRANCH_DELETED`. If `CLEANUP_SUCCESS=true`, print: `✅ 14: local cleanup — switched to main, deleted $BRANCH_NAME`. If `CLEANUP_SUCCESS=false`, print: `**⚠ 14: local cleanup — partially failed, branch: <CURRENT_BRANCH>, deleted: <BRANCH_DELETED>**`
+Parse the output for `CLEANUP_SUCCESS`, `CURRENT_BRANCH`, and `BRANCH_DELETED`. If `CLEANUP_SUCCESS=true`, print: `✅ 14: local cleanup — switched to main, deleted $BRANCH_NAME (<elapsed>)`. If `CLEANUP_SUCCESS=false`, print: `**⚠ 14: local cleanup — partially failed, branch: <CURRENT_BRANCH>, deleted: <BRANCH_DELETED>**`
 
 **If Step 12 bailed out (PR was NOT merged)**:
 
@@ -1071,7 +1071,7 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/verify-main.sh --expected-title "<PR_TITLE> (#<PR_
 
 Parse the output for `VERIFIED`, `COMMIT_HASH`, and `COMMIT_MESSAGE`. Print the result:
 
-- If `VERIFIED=true`: `✅ 15: verify main — at <COMMIT_HASH> "<COMMIT_MESSAGE>"`
+- If `VERIFIED=true`: `✅ 15: verify main — at <COMMIT_HASH> "<COMMIT_MESSAGE>" (<elapsed>)`
 - If `VERIFIED=false`: `**⚠ 15: verify main — unexpected HEAD: <COMMIT_HASH> "<COMMIT_MESSAGE>". Expected: "<PR_TITLE> (#<PR_NUMBER>)"**`
 
 ## Step 16 — Rejected Code Review Findings Report
@@ -1080,17 +1080,17 @@ Print a report of all code review suggestions that were **not** implemented.
 
 1. Check if `$IMPLEMENT_TMPDIR/rejected-findings.md` exists and is non-empty.
 2. If it has content, print it under a `## Unimplemented Code Review Suggestions` header, formatted clearly with the reviewer name, the suggestion, and the reason for each.
-3. If the file doesn't exist or is empty, print: `✅ 16: rejected findings — all suggestions implemented`
+3. If the file doesn't exist or is empty, print: `✅ 16: rejected findings — all suggestions implemented (<elapsed>)`
 
 ## Step 17 — Final Report
 
-**If `quick_mode=true`**: Print: `✅ 17: final report — quick mode (/design skipped, 2 subagent review)`
+**If `quick_mode=true`**: Print: `✅ 17: final report — quick mode, /design skipped, 2 subagent review (<elapsed>)`
 
 **If `quick_mode=false`**: Print a summary noting that:
 - Plan review findings were reported by the `/design` phase (visible in conversation above)
 - Code review findings were reported by the `/review` phase (visible in conversation above)
 
-If both phases reported all suggestions implemented, print: `✅ 17: final report — all suggestions implemented (plan + code review)`
+If both phases reported all suggestions implemented, print: `✅ 17: final report — all suggestions implemented, plan + code review (<elapsed>)`
 
 ## Step 18 — Cleanup and Final Warnings
 
@@ -1106,4 +1106,4 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/cleanup-tmpdir.sh --dir "$IMPLEMENT_TMPDIR"
 
 If `merge=false`, remind: `**Note: --merge was not set. PR was created but not merged. Merge manually when ready.**`
 
-Print: `✅ 18: cleanup — implement complete!`
+Print: `✅ 18: cleanup — implement complete! (<elapsed>)`

--- a/skills/loop-review/SKILL.md
+++ b/skills/loop-review/SKILL.md
@@ -20,7 +20,7 @@ Systematically review the entire codebase by partitioning into slices, reviewing
 **Every step MUST print clearly visible breadcrumb status lines** so the user can instantly see where execution is. Follow the formatting rules in `${CLAUDE_PLUGIN_ROOT}/skills/shared/progress-reporting.md`.
 
 - Print a **start line** when entering a step: e.g., `▸ 3: implement/defer — slice: scripts/...`
-- Print a **completion line** when done: e.g., `✅ 3: implement/defer — 3 findings implemented, 1 deferred`
+- Print a **completion line** when done: e.g., `✅ 3: implement/defer — 3 findings implemented, 1 deferred (5m22s)`
 
 Step Name Registry:
 | Step | Short Name |
@@ -237,7 +237,7 @@ Print the classification: `📋 Slice N: X findings (Y to implement, Z to defer)
 
 ### 3e — Zero findings
 
-If all reviewers found nothing: `✅ Slice N: <name> — Clean`. Continue to next slice.
+If all reviewers found nothing: `✅ Slice N: <name> — Clean (<elapsed>)`. Continue to next slice.
 
 ### 3f — All findings deferred
 

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -22,7 +22,7 @@ The research question is described by `RESEARCH_QUESTION` (not raw `$ARGUMENTS`)
 **Every step MUST print clearly visible breadcrumb status lines** so the user can instantly see where execution is. Follow the formatting rules in `${CLAUDE_PLUGIN_ROOT}/skills/shared/progress-reporting.md`.
 
 - Print a **start line** when entering a step: e.g., `▸ 1: research`
-- Print a **completion line** when done: e.g., `✅ 1: research — synthesis complete (5 agents)`
+- Print a **completion line** when done: e.g., `✅ 1: research — synthesis complete, 5 agents (3m12s)`
 
 Step Name Registry:
 | Step | Short Name |
@@ -85,7 +85,7 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/git-branch-info.sh
 
 Parse the output for `HEAD_SHA` and `CURRENT_BRANCH`. If `CURRENT_BRANCH` is empty (detached HEAD), use `"(detached HEAD)"` in the report.
 
-Print: `✅ 0: setup — researching on branch <CURRENT_BRANCH> at <HEAD_SHA>`
+Print: `✅ 0: setup — researching on branch <CURRENT_BRANCH> at <HEAD_SHA> (<elapsed>)`
 
 ## Step 1 — Collaborative Research Perspectives
 
@@ -178,7 +178,7 @@ Print the synthesis under a `## Research Synthesis` header. Write the synthesis 
 - The branch and commit being researched
 - The synthesized findings
 
-Print: `✅ 1: research — synthesis complete (5 agents)`
+Print: `✅ 1: research — synthesis complete, 5 agents (<elapsed>)`
 
 ## Step 2 — Findings Validation
 
@@ -279,7 +279,7 @@ If any findings were accepted (from Claude subagents, Codex, or Cursor):
 2. Revise the research synthesis to incorporate corrections and additions.
 3. Print the revised synthesis under a `## Revised Research Findings` header.
 
-If all reviewers report no issues, print: `✅ 2: validation — all findings validated, no corrections needed`
+If all reviewers report no issues, print: `✅ 2: validation — all findings validated, no corrections needed (<elapsed>)`
 
 ## Step 3 — Final Research Report
 
@@ -316,7 +316,7 @@ Print the final research report under a `## Research Report` header with the fol
 
 If risk assessment, difficulty estimate, or feasibility verdict are not applicable to the nature of the research question (e.g., a pure "how does X work?" question), mark them as **N/A** with a brief explanation.
 
-Print: `✅ 3: report — complete`
+Print: `✅ 3: report — complete (<elapsed>)`
 
 ## Step 4 — Cleanup and Final Warnings
 
@@ -332,4 +332,4 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/cleanup-tmpdir.sh --dir "$RESEARCH_TMPDIR"
 - `**⚠ Cursor research timed out / produced empty output**`
 - `**⚠ Codex research timed out / produced empty output**`
 
-Print: `✅ 4: cleanup — research complete!`
+Print: `✅ 4: cleanup — research complete! (<elapsed>)`

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -44,10 +44,10 @@ Step Name Registry:
 **Compact agent status table**: After launching research agents (Step 1) or validation reviewers (Step 2), maintain a mental tracker of each agent's status. Print a compact table after EACH status change:
 
 ```
-📊 Agents: | General: ✅ | Domain: ⏳ | Contrarian: ✅ | Cursor: ❌ | Codex: ⏳ |
+📊 Agents: | General: ✅ 2m31s | Domain: ⏳ | Contrarian: ✅ 3m5s | Cursor: ❌ | Codex: ⏳ |
 ```
 
-Icons: ✅ done, ⏳ pending/in-progress, ❌ failed/timeout, ⊘ skipped (unavailable). This replaces individual per-agent completion messages in non-debug mode.
+Icons: ✅ done (with elapsed time since launch), ⏳ pending/in-progress, ❌ failed/timeout, ⊘ skipped (unavailable). This replaces individual per-agent completion messages in non-debug mode. See `${CLAUDE_PLUGIN_ROOT}/skills/shared/progress-reporting.md` for elapsed time format rules.
 
 **Suppressed output (only when `debug_mode=false`):** explanatory prose, script paths, rationale for decisions between tool calls, per-agent individual completion messages.
 

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -44,12 +44,12 @@ Step Name Registry:
 **Compact reviewer status table**: After launching all reviewers (Step 2), maintain a mental tracker of each reviewer's status. Print a compact table after EACH status change:
 
 ```
-📊 Reviewers: | General: ✅ | Deep: ⏳ | Codex-G: ✅ | Codex-D: ❌ | Cursor: ⏳ |
+📊 Reviewers: | General: ✅ 2m31s | Deep: ⏳ | Codex-G: ✅ 4m12s | Codex-D: ❌ | Cursor: ⏳ |
 ```
 
-Icons: ✅ done, ⏳ pending/in-progress, ❌ failed/timeout, ⊘ skipped (unavailable).
+Icons: ✅ done (with elapsed time since launch), ⏳ pending/in-progress, ❌ failed/timeout, ⊘ skipped (unavailable). See `${CLAUDE_PLUGIN_ROOT}/skills/shared/progress-reporting.md` for elapsed time format rules.
 
-**Timing**: (1) Print initial table after launching all reviewers (all ⏳ or ⊘). (2) Update after each Claude subagent returns. (3) Update after `wait-for-reviewers.sh` returns (all external reviewers resolved).
+**Status table updates**: (1) Print initial table after launching all reviewers (all ⏳ or ⊘). (2) Update after each Claude subagent returns (adding elapsed time to its ✅). (3) Update after `wait-for-reviewers.sh` returns (all external reviewers resolved).
 
 This replaces individual per-reviewer completion messages in non-debug mode. Do NOT print individual "Reviewer X completed" or "Reviewer X returned N findings" lines.
 

--- a/skills/shared/progress-reporting.md
+++ b/skills/shared/progress-reporting.md
@@ -30,6 +30,38 @@ Every progress line follows:
 
 **Semantic distinction**: `⏩` and `⏭️` are intentionally separate. `⏩` indicates a lightweight skip within the normal flow; `⏭️` indicates a precondition failure that causes an entire major step to be bypassed.
 
+## Elapsed Time
+
+Every `✅` indicator — whether in a step completion line or a compact status table — must include the elapsed time for that work item.
+
+### `✅` completion lines
+
+Append the elapsed time in parentheses at the end of the line, using short form. The timer starts when the corresponding `▸` start line was printed (or when the step logically began if no `▸` line exists).
+
+```
+✅ 2a.5: dialectic — 3 decisions resolved (1m42s)
+✅ 8a: changelog — updated for v2.1.0 (4s)
+```
+
+### Compact status tables (`📊` lines)
+
+For reviewer/agent status tables, include elapsed time immediately after each `✅`. The timer for each entry starts when that agent/reviewer was launched.
+
+```
+📊 Reviewers: | General: ✅ 2m31s | Deep: ⏳ | Codex-G: ✅ 4m12s | Codex-D: ❌ | Cursor: ⏳ |
+```
+
+Other status icons (`⏳`, `❌`, `⊘`) do not include timing.
+
+### Time format
+
+Use the shortest representation:
+- Under 1 minute: `45s`
+- 1–59 minutes: `2m31s`
+- 1+ hours: `1h3m`
+
+Omit zero components: use `2m` not `2m0s`, use `1h` not `1h0m`.
+
 ## `--step-prefix` Encoding
 
 When a parent skill invokes a child skill (e.g., `/implement` → `/design`), it passes step context via `--step-prefix` using this encoding:
@@ -61,14 +93,14 @@ Standalone `/design` (no `--step-prefix`):
 ```
 ▸ 2a: sketches
 ▸ 2a.5: dialectic
-✅ 2a.5: dialectic — 3 decisions resolved
+✅ 2a.5: dialectic — 3 decisions resolved (1m42s)
 ```
 
 `/design` called from `/implement` with `--step-prefix "1.::design plan"`:
 ```
 ▸ 1.2a: design plan | sketches
 ▸ 1.2a.5: design plan | dialectic
-✅ 1.2a.5: design plan | dialectic — 3 decisions resolved
+✅ 1.2a.5: design plan | dialectic — 3 decisions resolved (1m42s)
 ```
 
 `/review` called from `/implement` with `--step-prefix "5.::code review"`:

--- a/skills/shared/progress-reporting.md
+++ b/skills/shared/progress-reporting.md
@@ -58,7 +58,7 @@ Other status icons (`⏳`, `❌`, `⊘`) do not include timing.
 Use the shortest representation:
 - Under 1 minute: `45s`
 - 1–59 minutes: `2m31s`
-- 1+ hours: `1h3m`
+- 1+ hours: `1h3m` (seconds are always omitted in the hours tier)
 
 Omit zero components: use `2m` not `2m0s`, use `1h` not `1h0m`.
 


### PR DESCRIPTION
## Summary
- Added elapsed time reporting to all `✅` completion indicators across all 7 skills
- Defined centralized elapsed time format rules in `skills/shared/progress-reporting.md`
- Updated compact reviewer/agent status tables and all `Print:` directives to include `(<elapsed>)` placeholders

<details><summary>Architecture Diagram</summary>

Quick mode — architecture diagram skipped.

</details>

<details><summary>Code Flow Diagram</summary>

Quick mode — code flow diagram skipped.

</details>

<details><summary>Goal</summary>

- Add elapsed time to every completion indicator across all larch skills
  - Step completion lines (`✅ N: step — payload`) append `(<elapsed>)` at the end
  - Compact status tables (`📊 Reviewers: | General: ✅ |`) include time after each `✅`
- Define the timing convention centrally in `skills/shared/progress-reporting.md` so all skills inherit the rule
- Ensure consistency by updating all `Print:` directives in all SKILL.md files

</details>

<details><summary>Test plan</summary>

- [ ] Verify `skills/shared/progress-reporting.md` has the new "Elapsed Time" section with format rules
- [ ] Verify all 3 status table examples (design, review, research) show timing after `✅`
- [ ] Verify all `Print:` directives with `✅` across all 7 skills include `(<elapsed>)`
- [ ] Run `/relevant-checks` to confirm linting passes
- [ ] Run a skill (e.g., `/research`) and verify elapsed times appear in output

</details>

<details><summary>Final Design</summary>

**Inline implementation plan (quick mode)**:

1. Add "Elapsed Time" section to `skills/shared/progress-reporting.md` defining:
   - `✅` completion lines append `(<elapsed>)` at end
   - Status tables include time after each `✅`
   - Time format: shortest form (`45s`, `2m31s`, `1h3m`)
2. Update status table examples in `design/SKILL.md`, `review/SKILL.md`, `research/SKILL.md`
3. Update all `Print:` directives with `✅` across all 7 SKILL.md files

</details>

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `f8e9cf2` (Add OOS voting, symmetric scoring, and GitHub issue filing (#67))
- **Current version**: `2.0.5`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `2.0.6`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH").

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

Quick mode — no plan review was conducted.

</details>

<details><summary>Implementation Deviations</summary>

The original plan called for updating only 4 files (the shared contract + 3 status table examples). Code review identified that all `Print:` directives across all 7 skills needed `(<elapsed>)` placeholders too, which was implemented in the review fixes commit.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

### [Code Review] General Reviewer
**Finding**: `skills/research/SKILL.md` status table example uses agent labels ("Domain", "Contrarian") that don't match the actual agents in this skill (General Research, Architecture/Patterns, Risk/Feasibility).
**Reason not implemented**: This is a pre-existing issue in the status table example labels, not introduced by this PR. The labels were already "Domain" and "Contrarian" before this change. Fixing pre-existing label mismatches is out of scope for this elapsed-time feature.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

Quick mode — no voting panel. Main agent reviewed findings from 2 Claude subagents.

</details>

<details><summary>Out-of-Scope Observations</summary>

**Accepted OOS (GitHub issues filed):**
No OOS items were accepted for issue filing.

**Non-accepted OOS observations:**
Quick mode — no out-of-scope observations collected.

</details>

<details><summary>Execution Issues</summary>

No execution issues encountered.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | N/A (quick mode) |
| Code review rounds | 1 |
| Code review findings | 3 accepted, 1 rejected |
| Warnings logged | 0 |
| Pre-existing issues noticed | 1 |
| OOS issues filed | N/A (quick mode) |
| External reviewers | N/A (quick mode) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
