### PR TITLE
Add multi-line description support to OOS issue creation (#66)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation with collaborative reviewers (Claude subagents + Codex + Cursor).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.7] - 2026-04-13
+
+### Fixed
+
+- Fixed multi-line description truncation in `scripts/create-oos-issues.sh` — the parser now accumulates continuation lines between `- **Description**:` and the next structured field, preserving full multi-line descriptions in filed GitHub issues
+
 ## [2.0.6] - 2026-04-13
 
 ### Changed

--- a/scripts/create-oos-issues.sh
+++ b/scripts/create-oos-issues.sh
@@ -195,6 +195,7 @@ flush_item() {
     CURRENT_REVIEWER=""
     CURRENT_VOTE=""
     CURRENT_PHASE=""
+    IN_DESCRIPTION=false
 }
 
 while IFS= read -r line; do
@@ -214,8 +215,8 @@ while IFS= read -r line; do
     elif [[ "$line" =~ ^-\ \*\*Phase\*\*:\ (.+)$ ]]; then
         CURRENT_PHASE="${BASH_REMATCH[1]}"
         IN_DESCRIPTION=false
-    elif [[ "$IN_DESCRIPTION" == true ]]; then
-        # Accumulate continuation lines for multi-line descriptions
+    elif [[ "$IN_DESCRIPTION" == true ]] && [[ -n "${line// }" ]]; then
+        # Accumulate non-blank continuation lines for multi-line descriptions
         CURRENT_DESCRIPTION+=$'\n'"$line"
     fi
 done < "$INPUT_FILE"

--- a/scripts/create-oos-issues.sh
+++ b/scripts/create-oos-issues.sh
@@ -14,7 +14,8 @@
 #
 # Input file format (one or more blocks):
 #   ### OOS_N: <short title>
-#   - **Description**: <full description>
+#   - **Description**: <full description, may span multiple lines>
+#     <continuation lines are appended until the next field>
 #   - **Reviewer**: <attribution>
 #   - **Vote tally**: <YES/NO/EXONERATE counts>
 #   - **Phase**: design|review
@@ -117,6 +118,7 @@ CURRENT_DESCRIPTION=""
 CURRENT_REVIEWER=""
 CURRENT_VOTE=""
 CURRENT_PHASE=""
+IN_DESCRIPTION=false
 
 create_issue() {
     local title="$1"
@@ -199,14 +201,22 @@ while IFS= read -r line; do
     if [[ "$line" =~ ^###\ OOS_[0-9]+:\ (.+)$ ]]; then
         flush_item
         CURRENT_TITLE="${BASH_REMATCH[1]}"
+        IN_DESCRIPTION=false
     elif [[ "$line" =~ ^-\ \*\*Description\*\*:\ (.+)$ ]]; then
         CURRENT_DESCRIPTION="${BASH_REMATCH[1]}"
+        IN_DESCRIPTION=true
     elif [[ "$line" =~ ^-\ \*\*Reviewer\*\*:\ (.+)$ ]]; then
         CURRENT_REVIEWER="${BASH_REMATCH[1]}"
+        IN_DESCRIPTION=false
     elif [[ "$line" =~ ^-\ \*\*Vote\ tally\*\*:\ (.+)$ ]]; then
         CURRENT_VOTE="${BASH_REMATCH[1]}"
+        IN_DESCRIPTION=false
     elif [[ "$line" =~ ^-\ \*\*Phase\*\*:\ (.+)$ ]]; then
         CURRENT_PHASE="${BASH_REMATCH[1]}"
+        IN_DESCRIPTION=false
+    elif [[ "$IN_DESCRIPTION" == true ]]; then
+        # Accumulate continuation lines for multi-line descriptions
+        CURRENT_DESCRIPTION+=$'\n'"$line"
     fi
 done < "$INPUT_FILE"
 


### PR DESCRIPTION
## Summary
- Fixed multi-line description truncation in `scripts/create-oos-issues.sh` — the line-by-line parser now accumulates continuation lines between the `- **Description**:` field and the next structured field
- Added `IN_DESCRIPTION` state variable to the parser loop with proper reset in `flush_item` and blank-line filtering to prevent spurious whitespace in issue bodies

<details><summary>Architecture Diagram</summary>

Quick mode — architecture diagram skipped.

</details>

<details><summary>Code Flow Diagram</summary>

Quick mode — code flow diagram skipped.

</details>

<details><summary>Goal</summary>

- Fix multi-line description support in `scripts/create-oos-issues.sh` (fixes #66)
  - The line-by-line parser only captured the first line after `- **Description**:` via a single-line regex
  - Continuation lines of multi-line descriptions were silently dropped, losing detail in filed GitHub issue bodies
  - Add state tracking to accumulate all lines between the Description field and the next structured field (Reviewer, Vote tally, Phase) or the next OOS header

</details>

<details><summary>Test plan</summary>

- [ ] Create a test input file with single-line descriptions — verify existing behavior preserved
- [ ] Create a test input file with multi-line descriptions — verify all continuation lines are captured in the GitHub issue body
- [ ] Create a test input file with blank lines between description continuation and next field — verify blank lines are not included in the description
- [ ] Verify `flush_item` properly resets `IN_DESCRIPTION` between OOS items

</details>

<details><summary>Final Design</summary>

**File**: `scripts/create-oos-issues.sh`

**Approach**: Add a state variable `IN_DESCRIPTION` to track when we're inside a multi-line description block. Continuation lines (lines not matching any structured field pattern or OOS header) are appended to `CURRENT_DESCRIPTION` with newline separators when `IN_DESCRIPTION=true`. Blank lines are filtered out to prevent spurious whitespace.

**Changes**:
1. Added `IN_DESCRIPTION=false` to the variable init block and `flush_item`
2. Set `IN_DESCRIPTION=true` when matching `- **Description**:`
3. Set `IN_DESCRIPTION=false` on all other field/header matches
4. Added `else` clause to append non-blank continuation lines when `IN_DESCRIPTION=true`
5. Updated input format comment to document multi-line support

</details>

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `00d629d` (Add elapsed time to all completion indicators (#69))
- **Current version**: `2.0.6`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `2.0.7`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH").

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

Quick mode — no plan review was conducted.

</details>

<details><summary>Implementation Deviations</summary>

No deviations from the plan.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

### [Code Review] Deep-Analysis
**Finding**: In `scripts/create-oos-issues.sh`, the upstream OOS artifact format contract in `skills/review/SKILL.md` (line 239) and `skills/design/SKILL.md` (line 495) specifies `- **Description**: <full description of the observation>` as a single-line field. The parser now supports multi-line descriptions via continuation lines, but neither SKILL.md updates the writing instructions to indicate that LLMs may produce multi-line descriptions. This means the parser supports a format that no upstream writer currently produces, creating an inconsistency in the reader/writer contract.
**Reason not implemented**: The issue (#66) specifically requests parser-side support for multi-line descriptions. The parser should be defensive and handle multi-line input regardless of what writers currently produce. Updating the writer prompts in SKILL.md files is a separate concern — the LLM writers may naturally produce multi-line descriptions even without explicit instructions, and the parser must handle that gracefully. Additionally, modifying SKILL.md prompt instructions could have unintended effects on LLM behavior and belongs in a separate change.

</details>

<details><summary>Plan Review Voting Tally</summary>

Quick mode — no plan review voting.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

Quick mode — no voting panel. Main agent reviewed findings from 2 Claude subagents.

</details>

<details><summary>Out-of-Scope Observations</summary>

Quick mode — no out-of-scope observations collected.

</details>

<details><summary>Execution Issues</summary>

No execution issues encountered.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | N/A (quick mode) |
| Code review rounds | 1 |
| Code review findings | 2 accepted, 1 rejected |
| Warnings logged | 0 |
| Pre-existing issues noticed | 0 |
| OOS issues filed | N/A (quick mode) |
| External reviewers | N/A (quick mode) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
