### PR TITLE
Improve progress reporting visibility and timing

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation with collaborative reviewers (Claude subagents + Codex + Cursor).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.8] - 2026-04-13
+
+### Changed
+
+- Replaced `▸` step start icon with `▶` (filled, more visible) across all skills
+- Added 80-char `━` separator line and bold formatting for step start lines
+- Expanded elapsed time to all terminal lines: `⏩`, `⏭️`, `❌` (status tables), and step-ending `⚠` — not just `✅`
+- Clarified "step-ending ⚠" definition in progress reporting contract
+
 ## [2.0.7] - 2026-04-13
 
 ### Fixed

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -118,7 +118,7 @@ Parse the output for `CURRENT_BRANCH`, `IS_MAIN`, `IS_USER_BRANCH`, and `USER_PR
 
 Print: `▶ 1c: questions`
 
-**If `auto_mode=true`**: Print `⏩ 1c: questions — skipped (auto mode)` and proceed to Step 1d.
+**If `auto_mode=true`**: Print `⏩ 1c: questions — skipped (auto mode) (<elapsed>)` and proceed to Step 1d.
 
 **If `auto_mode=false`**: Before launching the expensive collaborative sketch phase, use `AskUserQuestion` to clarify any ambiguities in the feature description. This is the highest-value question point — answers here reshape what the sketch agents explore.
 
@@ -138,7 +138,7 @@ After the user responds, incorporate their answers into your understanding of th
 
 Print: `▶ 1d: discussion r1`
 
-**If `auto_mode=true`**: Print `⏩ 1d: discussion r1 — skipped (auto mode)` and proceed to Step 2a.
+**If `auto_mode=true`**: Print `⏩ 1d: discussion r1 — skipped (auto mode) (<elapsed>)` and proceed to Step 2a.
 
 **If `auto_mode=false`**: Before launching the expensive collaborative sketch phase, stress-test the feature's scope and requirements by walking through the decision tree one question at a time. This is a deeper, sequential interrogation that resolves dependencies between decisions — each answer may reshape subsequent questions.
 
@@ -156,7 +156,7 @@ Then walk each branch one question at a time via sequential `AskUserQuestion` ca
 
 ### Short-circuit
 
-If the feature is straightforward with fewer than 2 scope decision branches, print `⏩ 1d: discussion r1 — no scope decisions require discussion` and proceed to Step 2a.
+If the feature is straightforward with fewer than 2 scope decision branches, print `⏩ 1d: discussion r1 — no scope decisions require discussion (<elapsed>)` and proceed to Step 2a.
 
 ### Output
 
@@ -287,7 +287,7 @@ Print the synthesis under an `## Approach Synthesis` header. Write the synthesis
 
 Print: `▶ 2a.5: dialectic`
 
-Read `$DESIGN_TMPDIR/contested-decisions.md`. If the file contains only `NO_CONTESTED_DECISIONS` (ignoring leading/trailing whitespace and newlines), print `⏩ 2a.5: dialectic — no contested decisions` and proceed to Step 2b.
+Read `$DESIGN_TMPDIR/contested-decisions.md`. If the file contains only `NO_CONTESTED_DECISIONS` (ignoring leading/trailing whitespace and newlines), print `⏩ 2a.5: dialectic — no contested decisions (<elapsed>)` and proceed to Step 2b.
 
 Otherwise, read `$DESIGN_TMPDIR/approach-synthesis.txt` — this provides `{SYNTHESIS_TEXT}` for the agent prompts below. Select up to the first 3 decisions from the file (they are already in priority order from Step 2a.4). For each selected decision, launch a **thesis agent** and an **antithesis agent** as Claude subagents via the Agent tool. **All thesis+antithesis pairs across all decisions must be issued in a single Agent fan-out message** (up to 6 Agent tool calls in one message) to maximize parallelism.
 
@@ -519,7 +519,7 @@ If no findings were rejected, do not create the file yet.
 
 Print: `▶ 3.5: discussion r2`
 
-**If `auto_mode=true`**: Print `⏩ 3.5: discussion r2 — skipped (auto mode)` and proceed to Step 3a.
+**If `auto_mode=true`**: Print `⏩ 3.5: discussion r2 — skipped (auto mode) (<elapsed>)` and proceed to Step 3a.
 
 **If `auto_mode=false`**: After the plan has been reviewed and revised, stress-test the remaining design decisions that were either (a) not covered in Round 1, or (b) deemed suboptimal by reviewers, or (c) introduced by the plan itself (decisions that didn't exist at the feature-description stage).
 
@@ -546,7 +546,7 @@ Unlike Round 1, Round 2 MAY ask about architectural decisions and implementation
 
 ### Short-circuit
 
-If all plan decisions are already covered by Round 1, no reviewer findings challenged them, and no decisions from `contested-decisions.md` have a close or inconclusive dialectic resolution, print `⏩ 3.5: discussion r2 — no additional decisions require discussion` and proceed to Step 3a.
+If all plan decisions are already covered by Round 1, no reviewer findings challenged them, and no decisions from `contested-decisions.md` have a close or inconclusive dialectic resolution, print `⏩ 3.5: discussion r2 — no additional decisions require discussion (<elapsed>)` and proceed to Step 3a.
 
 ### Output
 
@@ -575,9 +575,9 @@ Print: `✅ 3.5: discussion r2 — <N> decisions resolved (<elapsed>)`
 
 Print: `▶ 3a: confirmation`
 
-**If `auto_mode=true`**: Print `⏩ 3a: confirmation — skipped (auto mode)` and proceed to Step 3b.
+**If `auto_mode=true`**: Print `⏩ 3a: confirmation — skipped (auto mode) (<elapsed>)` and proceed to Step 3b.
 
-**If the plan was NOT revised** (voting rejected all findings or was skipped, AND Step 3.5 discussion made no changes): Print `⏩ 3a: confirmation — skipped (plan unchanged)` and proceed to Step 3b.
+**If the plan was NOT revised** (voting rejected all findings or was skipped, AND Step 3.5 discussion made no changes): Print `⏩ 3a: confirmation — skipped (plan unchanged) (<elapsed>)` and proceed to Step 3b.
 
 **If `auto_mode=false` AND the plan was revised** (by reviewers or Step 3.5 discussion): Use `AskUserQuestion` to confirm the revised plan addresses the user's original intent. Present a brief summary of what changed and ask the user to approve or reject.
 
@@ -605,7 +605,7 @@ Print the diagram under a `## Architecture Diagram` header with a mermaid code f
 
 **If diagram generation succeeds**, print: `✅ 3b: arch diagram — generated (<elapsed>)`
 
-**If diagram generation fails** (e.g., the feature is too abstract to diagram meaningfully), print: `**⚠ 3b: arch diagram — generation failed, proceeding without diagram**`
+**If diagram generation fails** (e.g., the feature is too abstract to diagram meaningfully), print: `**⚠ 3b: arch diagram — generation failed, proceeding without diagram (<elapsed>)**`
 
 ## Step 4 — Rejected Plan Review Findings Report
 
@@ -634,7 +634,7 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/cleanup-tmpdir.sh --dir "$DESIGN_TMPDIR"
 - `**⚠ Cursor review failed: <reason>**`
 - `**⚠ Cursor sketch timed out / produced empty output**`
 - `**⚠ Codex sketch timed out / produced empty output**`
-- `**⚠ 3b: arch diagram — generation failed, proceeding without diagram**`
+- `**⚠ 3b: arch diagram — generation failed, proceeding without diagram (<elapsed>)**`
 
 If `STEP_NUM_PREFIX` is empty (standalone mode): Print: `✅ 5: cleanup — design complete! (<elapsed>)`
 If `STEP_NUM_PREFIX` is non-empty (orchestrated mode): skip this final print — the parent orchestrator handles overall progress.

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -23,7 +23,7 @@ The feature to design is described by the remainder of `$ARGUMENTS` after flags 
 
 **Every step MUST print clearly visible breadcrumb status lines** so the user can instantly see where execution is and which parent steps they are inside. Follow the formatting rules in `${CLAUDE_PLUGIN_ROOT}/skills/shared/progress-reporting.md`.
 
-- Print a **start line** when entering a step: e.g., `▸ 1: branch` (standalone) or `▸ 1.1: design plan | branch` (nested from `/implement`)
+- Print a **start line** when entering a step: e.g., `▶ 1: branch` (standalone) or `▶ 1.1: design plan | branch` (nested from `/implement`)
 - Print a **completion line** only when it carries informational payload. Only the final step (Step 5) prints an unconditional completion announcement.
 - When `STEP_NUM_PREFIX` is non-empty, prepend it to step numbers: `{STEP_NUM_PREFIX}{local_step}`. When `STEP_PATH_PREFIX` is non-empty, prepend it to breadcrumb paths: `{STEP_PATH_PREFIX} | {step_short_name}`. **This rule overrides the literal step numbers and names in `Print:` directives and examples throughout this file.** Examples shown below assume standalone mode; when nested, prepend the parent context.
 
@@ -50,15 +50,15 @@ Step Name Registry:
 
 - Use empty string for the `description` parameter on all Bash tool calls.
 - Use terse 3-5 word descriptions for Agent tool calls.
-- Do not produce explanatory prose between tool call outputs — only print: step breadcrumb lines (start `▸`, completion `✅`, skip `⏩`), final completion line (Step 5), all warning/error lines (`**⚠ ...`), structured summaries (voting tallies, scoreboards, round summaries, findings lists, approach synthesis, dialectic resolutions, implementation plans, architecture diagrams), and the compact reviewer status table (see below).
+- Do not produce explanatory prose between tool call outputs — only print: step breadcrumb lines (start `▶`, completion `✅`, skip `⏩`), final completion line (Step 5), all warning/error lines (`**⚠ ...`), structured summaries (voting tallies, scoreboards, round summaries, findings lists, approach synthesis, dialectic resolutions, implementation plans, architecture diagrams), and the compact reviewer status table (see below).
 
 **Compact reviewer status table**: After launching sketch agents (Step 2a) or plan reviewers (Step 3), maintain a mental tracker of each agent's status. Print a compact table after EACH status change:
 
 ```
-📊 Reviewers: | General: ✅ 2m31s | Arch: ⏳ | Pragmatic: ✅ 3m5s | Cursor: ❌ | Codex: ⏳ |
+📊 Reviewers: | General: ✅ 2m31s | Arch: ⏳ | Pragmatic: ✅ 3m5s | Cursor: ❌ 8m3s | Codex: ⏳ |
 ```
 
-Icons: ✅ done (with elapsed time since launch), ⏳ pending/in-progress, ❌ failed/timeout, ⊘ skipped (unavailable). This replaces individual per-agent completion messages in non-debug mode. See `${CLAUDE_PLUGIN_ROOT}/skills/shared/progress-reporting.md` for elapsed time format rules.
+Icons: ✅ done (with elapsed time since launch), ⏳ pending/in-progress, ❌ failed/timeout (with elapsed time since launch), ⊘ skipped (unavailable). This replaces individual per-agent completion messages in non-debug mode. See `${CLAUDE_PLUGIN_ROOT}/skills/shared/progress-reporting.md` for elapsed time and step start formatting rules.
 
 **Suppressed output (only when `debug_mode=false`):** explanatory prose, script paths, rationale for decisions between tool calls, per-reviewer individual completion messages.
 
@@ -110,13 +110,13 @@ Parse the output for `CURRENT_BRANCH`, `IS_MAIN`, `IS_USER_BRANCH`, and `USER_PR
   ${CLAUDE_PLUGIN_ROOT}/scripts/create-branch.sh --branch <USER_PREFIX>/<branch-name>
   ```
 
-- If `IS_USER_BRANCH=true`: Verify the branch name (`CURRENT_BRANCH`) aligns with the requested feature. If it appears unrelated (different feature name, unrelated commits), print a warning: `**⚠ Current branch '<branch-name>' may not match the requested feature. Creating a new branch from main.**` and create a new branch as above. Otherwise, skip branch creation. Print: `▸ 1: branch — using existing: <branch-name>`
+- If `IS_USER_BRANCH=true`: Verify the branch name (`CURRENT_BRANCH`) aligns with the requested feature. If it appears unrelated (different feature name, unrelated commits), print a warning: `**⚠ Current branch '<branch-name>' may not match the requested feature. Creating a new branch from main.**` and create a new branch as above. Otherwise, skip branch creation. Print: `▶ 1: branch — using existing: <branch-name>`
 
 - Otherwise (non-main, non-user branch): Print a warning: `**⚠ Currently on branch '<branch-name>' which doesn't match the expected '<USER_PREFIX>/*' pattern. Creating a new branch from main.**` Then derive a name and create as above.
 
 ## Step 1c — Clarifying Questions
 
-Print: `▸ 1c: questions`
+Print: `▶ 1c: questions`
 
 **If `auto_mode=true`**: Print `⏩ 1c: questions — skipped (auto mode)` and proceed to Step 1d.
 
@@ -136,7 +136,7 @@ After the user responds, incorporate their answers into your understanding of th
 
 ## Step 1d — Design Discussion (Round 1)
 
-Print: `▸ 1d: discussion r1`
+Print: `▶ 1d: discussion r1`
 
 **If `auto_mode=true`**: Print `⏩ 1d: discussion r1 — skipped (auto mode)` and proceed to Step 2a.
 
@@ -198,7 +198,7 @@ Plus 2 external agents (or Claude replacements):
 4. **Cursor** (if available) — or **Claude (Innovation/Exploration)** replacement: proposes creative alternative approaches, questions assumptions, and suggests unconventional solutions
 5. **Codex** (if available) — or **Claude (Edge-cases/Failure-modes)** replacement: focuses on what can go wrong, boundary conditions, error handling, and failure recovery
 
-Print `▸ 2a: sketches` and proceed to 2a.2.
+Print `▶ 2a: sketches` and proceed to 2a.2.
 
 ### 2a.2 — Launch Sketches in Parallel
 
@@ -285,7 +285,7 @@ Print the synthesis under an `## Approach Synthesis` header. Write the synthesis
 
 ### 2a.5 — Dialectic Resolution of Contested Decisions
 
-Print: `▸ 2a.5: dialectic`
+Print: `▶ 2a.5: dialectic`
 
 Read `$DESIGN_TMPDIR/contested-decisions.md`. If the file contains only `NO_CONTESTED_DECISIONS` (ignoring leading/trailing whitespace and newlines), print `⏩ 2a.5: dialectic — no contested decisions` and proceed to Step 2b.
 
@@ -517,7 +517,7 @@ If no findings were rejected, do not create the file yet.
 
 ## Step 3.5 — Design Discussion (Round 2)
 
-Print: `▸ 3.5: discussion r2`
+Print: `▶ 3.5: discussion r2`
 
 **If `auto_mode=true`**: Print `⏩ 3.5: discussion r2 — skipped (auto mode)` and proceed to Step 3a.
 
@@ -573,7 +573,7 @@ Print: `✅ 3.5: discussion r2 — <N> decisions resolved (<elapsed>)`
 
 ## Step 3a — Post-Review Confirmation
 
-Print: `▸ 3a: confirmation`
+Print: `▶ 3a: confirmation`
 
 **If `auto_mode=true`**: Print `⏩ 3a: confirmation — skipped (auto mode)` and proceed to Step 3b.
 
@@ -585,7 +585,7 @@ Print: `▸ 3a: confirmation`
 
 ## Step 3b — Architecture Diagram
 
-Print: `▸ 3b: arch diagram`
+Print: `▶ 3b: arch diagram`
 
 **This step runs on ALL paths through Step 3** — whether voting produced revisions, rejected all findings, or was skipped entirely because all reviewers reported no issues. It always executes before Step 4.
 

--- a/skills/fix-issue/SKILL.md
+++ b/skills/fix-issue/SKILL.md
@@ -67,7 +67,7 @@ Only include `--issue "$ISSUE_ARG"` if `ISSUE_ARG` is non-empty (the user provid
 
 Handle exit codes:
 
-- **Exit 0**: Parse `ISSUE_NUMBER` and `ISSUE_TITLE`. Print `▸ 1: fetch issue — found #$ISSUE_NUMBER: $ISSUE_TITLE`
+- **Exit 0**: Parse `ISSUE_NUMBER` and `ISSUE_TITLE`. Print `▶ 1: fetch issue — found #$ISSUE_NUMBER: $ISSUE_TITLE`
 - **Exit 1**: Print `✅ 1: fetch issue — no approved issues found (<elapsed>)`. Skip to Step 9.
 - **Exit 2+**: Parse `ERROR` from stdout. Print `**⚠ 1: fetch issue — error: $ERROR**`. Skip to Step 9.
 
@@ -82,7 +82,7 @@ Read `$FIX_ISSUE_TMPDIR/issue-details.txt` to get the full issue content.
 
 ## Step 3 — Triage
 
-Print `▸ 3: triage`
+Print `▶ 3: triage`
 
 Read the issue details from Step 2. Explore the codebase using Read, Grep, and Glob to determine if the issue is still actual — that is, whether it describes a real problem that still needs fixing.
 
@@ -124,7 +124,7 @@ If `LOCK_ACQUIRED=true`, print `✅ 4: lock — issue #$ISSUE_NUMBER locked (<el
 
 ## Step 5 — Classify Complexity
 
-Print `▸ 5: classify`
+Print `▶ 5: classify`
 
 Based on the issue details and codebase exploration from Step 3, classify the issue:
 
@@ -137,7 +137,7 @@ Print `✅ 5: classify — $CLASSIFICATION (<elapsed>)`
 
 ## Step 6 — Implement
 
-Print `▸ 6: implement`
+Print `▶ 6: implement`
 
 Compose the feature description from the issue content: use the issue title as the primary description, with key details from the issue body and comments as context.
 
@@ -152,7 +152,7 @@ If `/implement` fails or bails, print `**⚠ 6: implement — failed. Issue #$IS
 
 ## Step 7 — Close Issue
 
-Print `▸ 7: close issue`
+Print `▶ 7: close issue`
 
 Update the issue body with PR link (idempotent):
 
@@ -172,7 +172,7 @@ Print `✅ 7: close issue — #$ISSUE_NUMBER closed (<elapsed>)`
 
 ## Step 8 — Slack Announce
 
-If `slack_available=false`, print `⏭️ 8: slack announce — skipped (Slack not configured)` and proceed to Step 9.
+If `slack_available=false`, print `⏭️ 8: slack announce — skipped (Slack not configured) (<elapsed>)` and proceed to Step 9.
 
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/skills/fix-issue/scripts/post-issue-slack.sh \

--- a/skills/fix-issue/SKILL.md
+++ b/skills/fix-issue/SKILL.md
@@ -69,7 +69,7 @@ Handle exit codes:
 
 - **Exit 0**: Parse `ISSUE_NUMBER` and `ISSUE_TITLE`. Print `▶ 1: fetch issue — found #$ISSUE_NUMBER: $ISSUE_TITLE`
 - **Exit 1**: Print `✅ 1: fetch issue — no approved issues found (<elapsed>)`. Skip to Step 9.
-- **Exit 2+**: Parse `ERROR` from stdout. Print `**⚠ 1: fetch issue — error: $ERROR**`. Skip to Step 9.
+- **Exit 2+**: Parse `ERROR` from stdout. Print `**⚠ 1: fetch issue — error: $ERROR (<elapsed>)**`. Skip to Step 9.
 
 ## Step 2 — Read Issue Details
 
@@ -118,7 +118,7 @@ ${CLAUDE_PLUGIN_ROOT}/skills/fix-issue/scripts/issue-lifecycle.sh comment \
   --issue $ISSUE_NUMBER --body "IN PROGRESS" --lock
 ```
 
-Parse output for `LOCK_ACQUIRED`. If `LOCK_ACQUIRED=false`, print `**⚠ 4: lock — failed ($ERROR). Another run may have claimed this issue.**` Skip to Step 9.
+Parse output for `LOCK_ACQUIRED`. If `LOCK_ACQUIRED=false`, print `**⚠ 4: lock — failed ($ERROR). Another run may have claimed this issue. (<elapsed>)**` Skip to Step 9.
 
 If `LOCK_ACQUIRED=true`, print `✅ 4: lock — issue #$ISSUE_NUMBER locked (<elapsed>)`.
 
@@ -148,7 +148,7 @@ Invoke `/implement` via the Skill tool:
 
 After `/implement` completes, capture the PR URL and PR number from its output. Save as `PR_URL` and `PR_NUMBER`.
 
-If `/implement` fails or bails, print `**⚠ 6: implement — failed. Issue #$ISSUE_NUMBER remains locked with IN PROGRESS.**` Skip to Step 9. The IN PROGRESS comment serves as an indicator that manual intervention is needed.
+If `/implement` fails or bails, print `**⚠ 6: implement — failed. Issue #$ISSUE_NUMBER remains locked with IN PROGRESS. (<elapsed>)**` Skip to Step 9. The IN PROGRESS comment serves as an indicator that manual intervention is needed.
 
 ## Step 7 — Close Issue
 

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -24,7 +24,7 @@ The feature to implement is described by `$ARGUMENTS` after flag stripping.
 
 **Every step MUST print clearly visible breadcrumb status lines** so the user can instantly see where execution is and which parent steps they are inside. Follow the formatting rules in `${CLAUDE_PLUGIN_ROOT}/skills/shared/progress-reporting.md`.
 
-- Print a **start line** when entering a step: e.g., `▸ 2: implementation`
+- Print a **start line** when entering a step: e.g., `▶ 2: implementation`
 - Print a **completion line** only when it carries informational payload. Only the final step (Step 18) prints an unconditional completion announcement.
 - For long-running steps, print **intermediate progress**: e.g., `⏳ 12: CI+merge loop — CI running (2m elapsed), main unchanged`
 
@@ -67,7 +67,7 @@ Step Name Registry:
 - Use terse 3-5 word descriptions for Agent tool calls.
 - Do not produce explanatory prose between tool call outputs — only print the designated output categories below.
 
-**Preserved output (NEVER suppressed, regardless of `debug_mode`):** step breadcrumb lines (start `▸`, completion `✅`, skip `⏩`/`⏭️`) — except the three rebase-skip variants listed in Suppressed output below, final completion line (Step 18), all warning/error lines (`**⚠ ...`), structured summaries (voting tallies, competition scoreboards, round summaries, final summaries/reports), architecture diagrams, code flow diagrams, implementation plans (original and revised), dialectic resolutions, accepted/rejected findings lists, out-of-scope observations, PR body sections.
+**Preserved output (NEVER suppressed, regardless of `debug_mode`):** step breadcrumb lines (start `▶`, completion `✅`, skip `⏩`/`⏭️`) — except the three rebase-skip variants listed in Suppressed output below, final completion line (Step 18), all warning/error lines (`**⚠ ...`), structured summaries (voting tallies, competition scoreboards, round summaries, final summaries/reports), architecture diagrams, code flow diagrams, implementation plans (original and revised), dialectic resolutions, accepted/rejected findings lists, out-of-scope observations, PR body sections.
 
 **Suppressed output (only when `debug_mode=false`):** explanatory prose describing what will happen next or what just happened, script paths and command descriptions, rationale for decisions between tool calls, per-reviewer individual completion messages (replaced by status table in child skills), rebase-skip messages (the following three specific variants: `⏩ 1.m: design plan | update main — already at latest`, `⏩ 1.r: design plan | rebase — already pushed`, `⏩ 1.r: design plan | rebase — already at latest main`). Note: non-rebase `⏩` skip messages and rebase outcomes in the Rebase+Re-bump Sub-procedure (Steps 10/12) are NOT suppressed — they carry CI-debugging semantics.
 
@@ -283,7 +283,7 @@ Skip `/review`. Instead, run a simplified one-round review:
 6. **One round only** — no re-review loop.
 7. For rejected findings, write them to `$IMPLEMENT_TMPDIR/rejected-findings.md` using the same format as normal mode (see below), so Step 16 and PR body sections work unchanged.
 
-Print: `▸ 5: code review — quick mode (2 Claude subagents, 1 round, no voting)`
+Print: `▶ 5: code review — quick mode (2 Claude subagents, 1 round, no voting)`
 
 ### Normal mode (`quick_mode=false`)
 
@@ -311,7 +311,7 @@ After the code review completes (whether `/review` in normal mode or the simplif
 ${CLAUDE_PLUGIN_ROOT}/skills/implement/scripts/check-review-changes.sh
 ```
 
-Parse the output for `FILES_CHANGED`. If `FILES_CHANGED=false`, print: `⏩ 6: checks (2) — skipped, no review changes` and skip Steps 6 and 7 (but NOT Step 7a — the Code Flow Diagram step runs unconditionally).
+Parse the output for `FILES_CHANGED`. If `FILES_CHANGED=false`, print: `⏩ 6: checks (2) — skipped, no review changes (<elapsed>)` and skip Steps 6 and 7 (but NOT Step 7a — the Code Flow Diagram step runs unconditionally).
 
 If files **did change**, invoke `/relevant-checks` to ensure review fixes didn't introduce new issues. If checks fail, diagnose and fix, then re-invoke `/relevant-checks`.
 
@@ -345,11 +345,11 @@ If successful:
 
 ## Step 7a — Code Flow Diagram
 
-Print: `▸ 7a: code flow`
+Print: `▶ 7a: code flow`
 
 **This step runs unconditionally after Step 7** — regardless of whether Steps 6-7 were skipped due to no review changes.
 
-**If `quick_mode=true`**: Print `⏩ 7a: code flow — skipped (quick mode)` and proceed to Step 8.
+**If `quick_mode=true`**: Print `⏩ 7a: code flow — skipped (quick mode) (<elapsed>)` and proceed to Step 8.
 
 **If `quick_mode=false`**: Generate a mermaid Code Flow Diagram based on the actual committed implementation. The diagram should focus on **runtime behavior** — function call sequences, data flow, or control flow through the implemented code paths. Do NOT duplicate the Architecture Diagram's structural/component view.
 
@@ -413,8 +413,8 @@ Parse the output for `HAS_BUMP` and `COMMITS_BEFORE`.
 ## Step 8a — CHANGELOG Update
 
 **Conditional**: Skip Step 8a entirely and proceed to Step 9 if either condition is true:
-- `CHANGELOG.md` does not exist in the project root (check via the Read tool — if Read returns an error, the file does not exist). Print `⏩ 8a: changelog — skipped (no CHANGELOG.md)`
-- Step 8 was skipped (`HAS_BUMP=false`). Print `⏩ 8a: changelog — skipped (no version bump)`
+- `CHANGELOG.md` does not exist in the project root (check via the Read tool — if Read returns an error, the file does not exist). Print `⏩ 8a: changelog — skipped (no CHANGELOG.md) (<elapsed>)`
+- Step 8 was skipped (`HAS_BUMP=false`). Print `⏩ 8a: changelog — skipped (no version bump) (<elapsed>)`
 
 **If `CHANGELOG.md` exists AND Step 8 produced a version bump**:
 
@@ -572,15 +572,15 @@ Populate Run Statistics from conversation context: count accepted/rejected findi
 
 ### 9a.1 — Create OOS GitHub Issues
 
-**If `quick_mode=true`**: Print `⏩ 9a.1: OOS issues — skipped (quick mode)` and proceed to Step 9b.
+**If `quick_mode=true`**: Print `⏩ 9a.1: OOS issues — skipped (quick mode) (<elapsed>)` and proceed to Step 9b.
 
-**If `repo_unavailable=true`**: Print `⏩ 9a.1: OOS issues — skipped (repo unavailable)` and proceed to Step 9b. Log to `$IMPLEMENT_TMPDIR/execution-issues.md` under `Warnings`.
+**If `repo_unavailable=true`**: Print `⏩ 9a.1: OOS issues — skipped (repo unavailable) (<elapsed>)` and proceed to Step 9b. Log to `$IMPLEMENT_TMPDIR/execution-issues.md` under `Warnings`.
 
 Read the OOS artifact files:
 - `$IMPLEMENT_TMPDIR/oos-accepted-design.md` (from `/design` plan review)
 - `$IMPLEMENT_TMPDIR/oos-accepted-review.md` (from `/review` code review)
 
-**If neither file exists or both are empty**: Print `⏩ 9a.1: OOS issues — no accepted OOS items` and proceed to Step 9b.
+**If neither file exists or both are empty**: Print `⏩ 9a.1: OOS issues — no accepted OOS items (<elapsed>)` and proceed to Step 9b.
 
 **If at least one file has content**:
 
@@ -745,7 +745,7 @@ Phase 4 enters the sub-procedure AFTER `rebase-push.sh --continue` has already p
 
 ## Step 10 — CI Monitor (initial wait for green)
 
-**If `repo_unavailable=true`**: Print `⏭️ 10: CI monitor — skipped (repo unavailable)` and proceed to Step 11.
+**If `repo_unavailable=true`**: Print `⏭️ 10: CI monitor — skipped (repo unavailable) (<elapsed>)` and proceed to Step 11.
 
 Wait for CI to go green so the Slack announcement (Step 11) links to a PR with passing CI. This step does **NOT merge** — Step 12 is the merge-aware loop that handles main advancement and merging.
 
@@ -790,9 +790,9 @@ After handling any non-terminal/non-rebase action (e.g., `evaluate_failure`), **
 
 ## Step 11 — Post Slack Announcement
 
-**If `slack_available=false`**: Print `⏭️ 11: slack announce — skipped (Slack not configured)` Set `SLACK_TS` to empty and proceed to the post-execution PR body refresh below.
+**If `slack_available=false`**: Print `⏭️ 11: slack announce — skipped (Slack not configured) (<elapsed>)` Set `SLACK_TS` to empty and proceed to the post-execution PR body refresh below.
 
-**If `PR_STATUS=existing`**: Print `⏭️ 11: slack announce — skipped (PR already existed, run post-pr-announce.sh manually)` Set `SLACK_TS` to empty and proceed to the post-execution PR body refresh below.
+**If `PR_STATUS=existing`**: Print `⏭️ 11: slack announce — skipped (PR already existed, run post-pr-announce.sh manually) (<elapsed>)` Set `SLACK_TS` to empty and proceed to the post-execution PR body refresh below.
 
 **Otherwise** (`slack_available=true` and `PR_STATUS=created`):
 
@@ -830,9 +830,9 @@ If `execution-issues.md` does not exist or is empty, skip this refresh.
 
 ## Step 12 — CI + Rebase + Merge Loop
 
-**If `merge=false`**: Print `⏭️ 12: CI+merge loop — skipped (--merge not set)` and skip to Step 16.
+**If `merge=false`**: Print `⏭️ 12: CI+merge loop — skipped (--merge not set) (<elapsed>)` and skip to Step 16.
 
-**If `repo_unavailable=true`**: Print `⏭️ 12: CI+merge loop — skipped (repo unavailable)` and skip to Step 16.
+**If `repo_unavailable=true`**: Print `⏭️ 12: CI+merge loop — skipped (repo unavailable) (<elapsed>)` and skip to Step 16.
 
 Monitor CI and the main branch **in parallel**. The key optimization: don't wait for CI to finish before checking if main has advanced.
 
@@ -1021,7 +1021,7 @@ When bailing out:
 
 **If `merge=false`**: Skip this step.
 
-**If `slack_available=false`**: Print `⏭️ 13: merged emoji — skipped (Slack not configured)` and proceed to Step 14.
+**If `slack_available=false`**: Print `⏭️ 13: merged emoji — skipped (Slack not configured) (<elapsed>)` and proceed to Step 14.
 
 **Only if the PR was successfully merged in Step 12b or force-merged externally** (not bailed in 12d).
 
@@ -1037,7 +1037,7 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/post-merged-emoji.sh --slack-ts "$SLACK_TS"
 
 ## Step 14 — Local Cleanup
 
-**If `merge=false`**: Print `⏭️ 14: local cleanup — skipped (--merge not set), still on $BRANCH_NAME` and skip to Step 16.
+**If `merge=false`**: Print `⏭️ 14: local cleanup — skipped (--merge not set), still on $BRANCH_NAME (<elapsed>)` and skip to Step 16.
 
 **If the PR was successfully merged (Step 12b or force-merged externally)**:
 

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -367,7 +367,7 @@ Print the diagram under a `## Code Flow Diagram` header with a mermaid code fenc
 
 **If diagram generation succeeds**, print: `✅ 7a: code flow — diagram generated (<elapsed>)`
 
-**If diagram generation fails** (e.g., the implementation is too abstract to diagram meaningfully), print: `**⚠ 7a: code flow — generation failed, proceeding without diagram**` Log this warning to `$IMPLEMENT_TMPDIR/execution-issues.md` under the `Warnings` category.
+**If diagram generation fails** (e.g., the implementation is too abstract to diagram meaningfully), print: `**⚠ 7a: code flow — generation failed, proceeding without diagram (<elapsed>)**` Log this warning to `$IMPLEMENT_TMPDIR/execution-issues.md` under the `Warnings` category.
 
 ### Rebase onto latest main (before version bump)
 
@@ -782,7 +782,7 @@ Parse the output for: `ACTION`, `CI_STATUS`, `BEHIND_COUNT`, `FAILED_RUN_ID`, `B
      1. **Transient failure** (runner provisioning, Docker pull rate limit, "hosted runner lost communication", etc.): If `transient_retries < 2`, run `${CLAUDE_PLUGIN_ROOT}/scripts/sleep-seconds.sh 60`, then run `${CLAUDE_PLUGIN_ROOT}/scripts/ci-rerun-failed.sh --run-id <FAILED_RUN_ID> --repo $REPO`. Parse output for `RERUN_SUBMITTED` and `ERROR`. If `RERUN_SUBMITTED=false`, print the `ERROR` and treat as a real CI failure (fall through to diagnosis). Otherwise increment `transient_retries`, re-invoke `ci-wait.sh`. If `transient_retries >= 2`, treat as real failure.
      2. **Real CI failure**: Run `${CLAUDE_PLUGIN_ROOT}/scripts/gh-run-logs.sh --run-id <FAILED_RUN_ID> --repo $REPO`. Diagnose the issue, fix it, run `/relevant-checks`, stage and commit using `${CLAUDE_PLUGIN_ROOT}/scripts/git-commit.sh -m "Fix CI failure" <fixed-files>`, push. Increment `fix_attempts`. Re-invoke `ci-wait.sh`.
 
-   - **`ACTION=bail`**: Print `BAIL_REASON`. Print `**⚠ 10: CI monitor — bailed, PR may have failing CI**` and proceed to Step 11.
+   - **`ACTION=bail`**: Print `BAIL_REASON`. Print `**⚠ 10: CI monitor — bailed, PR may have failing CI (<elapsed>)**` and proceed to Step 11.
 
 **Execution issues**: Log any CI failures, transient retries, or bail events to `$IMPLEMENT_TMPDIR/execution-issues.md` under the `CI Issues` category.
 
@@ -1047,13 +1047,13 @@ Switch back to main, pull the merged changes, and delete the development branch:
 ${CLAUDE_PLUGIN_ROOT}/scripts/local-cleanup.sh --branch "$BRANCH_NAME"
 ```
 
-Parse the output for `CLEANUP_SUCCESS`, `CURRENT_BRANCH`, and `BRANCH_DELETED`. If `CLEANUP_SUCCESS=true`, print: `✅ 14: local cleanup — switched to main, deleted $BRANCH_NAME (<elapsed>)`. If `CLEANUP_SUCCESS=false`, print: `**⚠ 14: local cleanup — partially failed, branch: <CURRENT_BRANCH>, deleted: <BRANCH_DELETED>**`
+Parse the output for `CLEANUP_SUCCESS`, `CURRENT_BRANCH`, and `BRANCH_DELETED`. If `CLEANUP_SUCCESS=true`, print: `✅ 14: local cleanup — switched to main, deleted $BRANCH_NAME (<elapsed>)`. If `CLEANUP_SUCCESS=false`, print: `**⚠ 14: local cleanup — partially failed, branch: <CURRENT_BRANCH>, deleted: <BRANCH_DELETED> (<elapsed>)**`
 
 **If Step 12 bailed out (PR was NOT merged)**:
 
 Do NOT switch branches or delete the local branch. The user will need the branch to continue manually.
 
-Print: `⚠ 14: local cleanup — skipped (PR not merged), still on $BRANCH_NAME`
+Print: `**⚠ 14: local cleanup — skipped (PR not merged), still on $BRANCH_NAME (<elapsed>)**`
 
 `$BRANCH_NAME` is the variable captured at the end of Step 1 (after branch resolution by `/design` or quick-mode branch creation).
 
@@ -1072,7 +1072,7 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/verify-main.sh --expected-title "<PR_TITLE> (#<PR_
 Parse the output for `VERIFIED`, `COMMIT_HASH`, and `COMMIT_MESSAGE`. Print the result:
 
 - If `VERIFIED=true`: `✅ 15: verify main — at <COMMIT_HASH> "<COMMIT_MESSAGE>" (<elapsed>)`
-- If `VERIFIED=false`: `**⚠ 15: verify main — unexpected HEAD: <COMMIT_HASH> "<COMMIT_MESSAGE>". Expected: "<PR_TITLE> (#<PR_NUMBER>)"**`
+- If `VERIFIED=false`: `**⚠ 15: verify main — unexpected HEAD: <COMMIT_HASH> "<COMMIT_MESSAGE>". Expected: "<PR_TITLE> (#<PR_NUMBER>)" (<elapsed>)**`
 
 ## Step 16 — Rejected Code Review Findings Report
 

--- a/skills/loop-review/SKILL.md
+++ b/skills/loop-review/SKILL.md
@@ -19,7 +19,7 @@ Systematically review the entire codebase by partitioning into slices, reviewing
 
 **Every step MUST print clearly visible breadcrumb status lines** so the user can instantly see where execution is. Follow the formatting rules in `${CLAUDE_PLUGIN_ROOT}/skills/shared/progress-reporting.md`.
 
-- Print a **start line** when entering a step: e.g., `▸ 3: implement/defer — slice: scripts/...`
+- Print a **start line** when entering a step: e.g., `▶ 3: implement/defer — slice: scripts/...`
 - Print a **completion line** when done: e.g., `✅ 3: implement/defer — 3 findings implemented, 1 deferred (5m22s)`
 
 Step Name Registry:
@@ -39,7 +39,7 @@ Step Name Registry:
 
 - Use empty string for the `description` parameter on all Bash tool calls.
 - Use terse 3-5 word descriptions for Agent tool calls.
-- Do not produce explanatory prose between tool call outputs — only print: step breadcrumb lines (start `▸`, completion `✅`, skip `⏩`), all warning/error lines (`**⚠ ...`), structured summaries (slice results, findings lists, deferred items, final report).
+- Do not produce explanatory prose between tool call outputs — only print: step breadcrumb lines (start `▶`, completion `✅`, skip `⏩`), all warning/error lines (`**⚠ ...`), structured summaries (slice results, findings lists, deferred items, final report).
 
 **Suppressed output (only when `debug_mode=false`):** explanatory prose, script paths, rationale for decisions between tool calls.
 

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -21,7 +21,7 @@ The research question is described by `RESEARCH_QUESTION` (not raw `$ARGUMENTS`)
 
 **Every step MUST print clearly visible breadcrumb status lines** so the user can instantly see where execution is. Follow the formatting rules in `${CLAUDE_PLUGIN_ROOT}/skills/shared/progress-reporting.md`.
 
-- Print a **start line** when entering a step: e.g., `▸ 1: research`
+- Print a **start line** when entering a step: e.g., `▶ 1: research`
 - Print a **completion line** when done: e.g., `✅ 1: research — synthesis complete, 5 agents (3m12s)`
 
 Step Name Registry:
@@ -39,15 +39,15 @@ Step Name Registry:
 
 - Use empty string for the `description` parameter on all Bash tool calls.
 - Use terse 3-5 word descriptions for Agent tool calls.
-- Do not produce explanatory prose between tool call outputs — only print: step breadcrumb lines (start `▸`, completion `✅`, skip `⏩`), all warning/error lines (`**⚠ ...`), structured summaries (findings, risk assessments, research report sections), and the compact agent status table (see below).
+- Do not produce explanatory prose between tool call outputs — only print: step breadcrumb lines (start `▶`, completion `✅`, skip `⏩`), all warning/error lines (`**⚠ ...`), structured summaries (findings, risk assessments, research report sections), and the compact agent status table (see below).
 
 **Compact agent status table**: After launching research agents (Step 1) or validation reviewers (Step 2), maintain a mental tracker of each agent's status. Print a compact table after EACH status change:
 
 ```
-📊 Agents: | General: ✅ 2m31s | Domain: ⏳ | Contrarian: ✅ 3m5s | Cursor: ❌ | Codex: ⏳ |
+📊 Agents: | General: ✅ 2m31s | Domain: ⏳ | Contrarian: ✅ 3m5s | Cursor: ❌ 8m3s | Codex: ⏳ |
 ```
 
-Icons: ✅ done (with elapsed time since launch), ⏳ pending/in-progress, ❌ failed/timeout, ⊘ skipped (unavailable). This replaces individual per-agent completion messages in non-debug mode. See `${CLAUDE_PLUGIN_ROOT}/skills/shared/progress-reporting.md` for elapsed time format rules.
+Icons: ✅ done (with elapsed time since launch), ⏳ pending/in-progress, ❌ failed/timeout (with elapsed time since launch), ⊘ skipped (unavailable). This replaces individual per-agent completion messages in non-debug mode. See `${CLAUDE_PLUGIN_ROOT}/skills/shared/progress-reporting.md` for elapsed time and step start formatting rules.
 
 **Suppressed output (only when `debug_mode=false`):** explanatory prose, script paths, rationale for decisions between tool calls, per-agent individual completion messages.
 
@@ -104,7 +104,7 @@ Plus 2 external agents (or Claude replacements):
 4. **Cursor** (if available) — or **Claude (Alternative Perspectives)** replacement: questions assumptions, explores unconventional angles, and surfaces insights that the other agents might overlook
 5. **Codex** (if available) — or **Claude (Edge-cases/Gaps)** replacement: focuses on what might be missing, edge cases, gaps in the codebase, failure modes, and boundary conditions relevant to the research question
 
-Print `▸ 1: research` and proceed to 1.2.
+Print `▶ 1: research` and proceed to 1.2.
 
 ### 1.2 — Launch Research Perspectives in Parallel
 
@@ -182,7 +182,7 @@ Print: `✅ 1: research — synthesis complete, 5 agents (<elapsed>)`
 
 ## Step 2 — Findings Validation
 
-Print: `▸ 2: validation`
+Print: `▶ 2: validation`
 
 **IMPORTANT: Findings validation MUST ALWAYS run with all available reviewers (2 Claude subagents + 2 Codex instances and Cursor if available). Never skip or abbreviate this step regardless of how straightforward the findings appear. Reviewers validate against the actual codebase state, catching inaccuracies or omissions that the research phase may have missed.**
 
@@ -283,7 +283,7 @@ If all reviewers report no issues, print: `✅ 2: validation — all findings va
 
 ## Step 3 — Final Research Report
 
-Print: `▸ 3: report`
+Print: `▶ 3: report`
 
 Print the final research report under a `## Research Report` header with the following structure:
 

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -19,7 +19,7 @@ Review all changes on the current branch (vs `main`) using two specialized Claud
 
 **Every step MUST print clearly visible breadcrumb status lines** so the user can instantly see where execution is and which parent steps they are inside. Follow the formatting rules in `${CLAUDE_PLUGIN_ROOT}/skills/shared/progress-reporting.md`.
 
-- Print a **start line** when entering a step: e.g., `▸ 2: launch reviewers` (standalone) or `▸ 5.2: code review | launch reviewers` (nested from `/implement`)
+- Print a **start line** when entering a step: e.g., `▶ 2: launch reviewers` (standalone) or `▶ 5.2: code review | launch reviewers` (nested from `/implement`)
 - Print a **completion line** only when it carries informational payload. Pure "step complete" announcements without payload are not needed.
 - When `STEP_NUM_PREFIX` is non-empty, prepend it to step numbers. When `STEP_PATH_PREFIX` is non-empty, prepend it to breadcrumb paths. **This rule overrides the literal step numbers and names in `Print:` directives and examples throughout this file.** Examples shown below assume standalone mode; when nested, prepend the parent context.
 
@@ -39,15 +39,15 @@ Step Name Registry:
 
 - Use empty string for the `description` parameter on all Bash tool calls.
 - Use terse 3-5 word descriptions for Agent tool calls.
-- Do not produce explanatory prose between tool call outputs — only print: step breadcrumb lines (start `▸`, completion `✅`, skip `⏩`), all warning/error lines (`**⚠ ...`), structured summaries (voting tallies, scoreboards, round summaries, findings lists, final summary), and the compact reviewer status table (see below).
+- Do not produce explanatory prose between tool call outputs — only print: step breadcrumb lines (start `▶`, completion `✅`, skip `⏩`), all warning/error lines (`**⚠ ...`), structured summaries (voting tallies, scoreboards, round summaries, findings lists, final summary), and the compact reviewer status table (see below).
 
 **Compact reviewer status table**: After launching all reviewers (Step 2), maintain a mental tracker of each reviewer's status. Print a compact table after EACH status change:
 
 ```
-📊 Reviewers: | General: ✅ 2m31s | Deep: ⏳ | Codex-G: ✅ 4m12s | Codex-D: ❌ | Cursor: ⏳ |
+📊 Reviewers: | General: ✅ 2m31s | Deep: ⏳ | Codex-G: ✅ 4m12s | Codex-D: ❌ 8m3s | Cursor: ⏳ |
 ```
 
-Icons: ✅ done (with elapsed time since launch), ⏳ pending/in-progress, ❌ failed/timeout, ⊘ skipped (unavailable). See `${CLAUDE_PLUGIN_ROOT}/skills/shared/progress-reporting.md` for elapsed time format rules.
+Icons: ✅ done (with elapsed time since launch), ⏳ pending/in-progress, ❌ failed/timeout (with elapsed time since launch), ⊘ skipped (unavailable). See `${CLAUDE_PLUGIN_ROOT}/skills/shared/progress-reporting.md` for elapsed time and step start formatting rules.
 
 **Status table updates**: (1) Print initial table after launching all reviewers (all ⏳ or ⊘). (2) Update after each Claude subagent returns (adding elapsed time to its ✅). (3) Update after `wait-for-reviewers.sh` returns (all external reviewers resolved).
 

--- a/skills/shared/progress-reporting.md
+++ b/skills/shared/progress-reporting.md
@@ -48,6 +48,8 @@ Only `▶` step start lines get the separator and bold treatment. Completion (`�
 
 Every line that marks the **end** of a step or work item must include elapsed time — whether it completed successfully, was skipped, failed, or timed out. This applies to: `✅`, `⏩`, `⏭️`, and step-ending `⚠` lines.
 
+**Step-ending `⚠`** means any `⚠` that contains a step-number prefix (e.g., `⚠ 7a: ...`, `⚠ 14: ...`). Unnumbered bail lines (e.g., `⚠ Rebase onto main failed. Bailing to cleanup.`) do not require elapsed time.
+
 ### Step progress lines
 
 Append the elapsed time in parentheses at the end of the line, using short form. The timer starts when the step logically began (its `▶` start line, or entry into the step if no `▶` line exists).

--- a/skills/shared/progress-reporting.md
+++ b/skills/shared/progress-reporting.md
@@ -19,7 +19,7 @@ Every progress line follows:
 
 | Icon | Line type | When to use |
 |------|-----------|-------------|
-| `▸` | Step start | Entering a new step |
+| `▶` | Step start | Entering a new step |
 | `✅` | Completion | Step completed with informational payload |
 | `⏩` | Sub-step skip | Optimization or workflow-conditional skip (quick mode, no changes, etc.) |
 | `⏭️` | Precondition skip | Entire step skipped due to missing precondition (repo unavailable, Slack not configured, merge not set) |
@@ -30,28 +30,44 @@ Every progress line follows:
 
 **Semantic distinction**: `⏩` and `⏭️` are intentionally separate. `⏩` indicates a lightweight skip within the normal flow; `⏭️` indicates a precondition failure that causes an entire major step to be bypassed.
 
+## Step Start Formatting
+
+Step start lines (`▶`) get special visual treatment to make them easy to spot:
+
+1. **Separator line**: Print a line of 80 `━` characters immediately before every step start line.
+2. **Bold text**: Render the entire step start line in bold using `**...**` markdown.
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+**▶ 2: implementation**
+```
+
+Only `▶` step start lines get the separator and bold treatment. Completion (`✅`), skip (`⏩`/`⏭️`), warning (`⚠`), and other lines do NOT get separators or bold.
+
 ## Elapsed Time
 
-Every `✅` indicator — whether in a step completion line or a compact status table — must include the elapsed time for that work item.
+Every line that marks the **end** of a step or work item must include elapsed time — whether it completed successfully, was skipped, failed, or timed out. This applies to: `✅`, `⏩`, `⏭️`, and step-ending `⚠` lines.
 
-### `✅` completion lines
+### Step progress lines
 
-Append the elapsed time in parentheses at the end of the line, using short form. The timer starts when the corresponding `▸` start line was printed (or when the step logically began if no `▸` line exists).
+Append the elapsed time in parentheses at the end of the line, using short form. The timer starts when the step logically began (its `▶` start line, or entry into the step if no `▶` line exists).
 
 ```
 ✅ 2a.5: dialectic — 3 decisions resolved (1m42s)
-✅ 8a: changelog — updated for v2.1.0 (4s)
+⏩ 6: checks (2) — skipped, no review changes (1s)
+⏭️ 12: CI+merge loop — skipped (--merge not set) (0s)
+⚠ 7a: code flow — generation failed, proceeding without diagram (12s)
 ```
 
 ### Compact status tables (`📊` lines)
 
-For reviewer/agent status tables, include elapsed time immediately after each `✅`. The timer for each entry starts when that agent/reviewer was launched.
+For reviewer/agent status tables, include elapsed time immediately after each `✅` and `❌`. The timer for each entry starts when that agent/reviewer was launched.
 
 ```
-📊 Reviewers: | General: ✅ 2m31s | Deep: ⏳ | Codex-G: ✅ 4m12s | Codex-D: ❌ | Cursor: ⏳ |
+📊 Reviewers: | General: ✅ 2m31s | Deep: ⏳ | Codex-G: ✅ 4m12s | Codex-D: ❌ 8m3s | Cursor: ⏳ |
 ```
 
-Other status icons (`⏳`, `❌`, `⊘`) do not include timing.
+`⏳` (in-progress) and `⊘` (skipped/unavailable) do not include timing.
 
 ### Time format
 
@@ -91,22 +107,28 @@ When outputting a step:
 
 Standalone `/design` (no `--step-prefix`):
 ```
-▸ 2a: sketches
-▸ 2a.5: dialectic
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+**▶ 2a: sketches**
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+**▶ 2a.5: dialectic**
 ✅ 2a.5: dialectic — 3 decisions resolved (1m42s)
 ```
 
 `/design` called from `/implement` with `--step-prefix "1.::design plan"`:
 ```
-▸ 1.2a: design plan | sketches
-▸ 1.2a.5: design plan | dialectic
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+**▶ 1.2a: design plan | sketches**
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+**▶ 1.2a.5: design plan | dialectic**
 ✅ 1.2a.5: design plan | dialectic — 3 decisions resolved (1m42s)
 ```
 
 `/review` called from `/implement` with `--step-prefix "5.::code review"`:
 ```
-▸ 5.2: code review | launch reviewers
-▸ 5.3: code review | review cycle
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+**▶ 5.2: code review | launch reviewers**
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+**▶ 5.3: code review | review cycle**
 ```
 
 ## Section headers and structured output


### PR DESCRIPTION
## Summary
- Replaced `▸` step start icon with `▶` (filled, more visible) and added 80-char `━` separator line + bold formatting for step start headers
- Expanded elapsed time reporting to ALL terminal lines (`⏩`, `⏭️`, `❌`, step-ending `⚠`) — not just `✅`
- Clarified "step-ending ⚠" definition in progress reporting contract

<details><summary>Architecture Diagram</summary>

Quick mode — architecture diagram skipped.

</details>

<details><summary>Code Flow Diagram</summary>

Quick mode — code flow diagram skipped.

</details>

<details><summary>Goal</summary>

- Make step start headers visually distinctive and easy to spot
  - Replace small gray `▸` triangle with filled `▶` icon
  - Add 80-char `━` separator line above each step start
  - Render step start lines in bold (`**...**`)
- Report elapsed time on ALL end-of-step lines, not just successful completions
  - Add `(<elapsed>)` to `⏩` skip lines
  - Add `(<elapsed>)` to `⏭️` precondition skip lines
  - Add elapsed time to `❌` entries in compact status tables
  - Add `(<elapsed>)` to step-ending `⚠` warning lines
- Clarify contract definition of "step-ending ⚠" vs mid-step warnings

</details>

<details><summary>Test plan</summary>

- [ ] Verify no `▸` remains anywhere in `skills/` directory
- [ ] Verify `progress-reporting.md` has new "Step Start Formatting" section with separator + bold rules
- [ ] Verify elapsed time section covers `⏩`, `⏭️`, `❌`, and step-ending `⚠`
- [ ] Verify all 3 status table examples show `❌` with timing
- [ ] Run `/relevant-checks` to confirm linting passes
- [ ] Run a skill and verify new formatting appears

</details>

<details><summary>Final Design</summary>

**Inline implementation plan (quick mode)**:

1. Update `skills/shared/progress-reporting.md`:
   - Replace `▸` with `▶` in icon taxonomy
   - Add "Step Start Formatting" section (separator + bold)
   - Expand "Elapsed Time" section to cover all terminal icons
   - Add `❌` timing to status table section
   - Clarify "step-ending ⚠" definition
2. Replace `▸` → `▶` across all 6 SKILL.md files (replace_all)
3. Update status table examples with `❌` timing
4. Update visible `⏩`/`⏭️` Print directives with `(<elapsed>)` in implement/SKILL.md
5. Update step-ending `⚠` lines with `(<elapsed>)` in implement, design, fix-issue

</details>

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `00d629d` (Add elapsed time to all completion indicators (#69))
- **Current version**: `2.0.7`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `2.0.8`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH").

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

Quick mode — no plan review was conducted.

</details>

<details><summary>Implementation Deviations</summary>

Code review identified additional step-ending lines needing elapsed time that the inline plan missed:
- 8 `⏩` skip lines in design/SKILL.md
- Step-ending `⚠` lines in design, implement, and fix-issue SKILL.md
- Clarification of "step-ending ⚠" definition added to contract

</details>

<details><summary>Rejected Code Review Suggestions</summary>

All code review suggestions were implemented.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

Quick mode — no voting panel. Main agent reviewed findings from 2 Claude subagents.

</details>

<details><summary>Out-of-Scope Observations</summary>

**Accepted OOS (GitHub issues filed):**
No OOS items were accepted for issue filing.

**Non-accepted OOS observations:**
Quick mode — no out-of-scope observations collected.

</details>

<details><summary>Execution Issues</summary>

No execution issues encountered.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | N/A (quick mode) |
| Code review rounds | 1 |
| Code review findings | 5 accepted, 0 rejected |
| Warnings logged | 0 |
| Pre-existing issues noticed | 0 |
| OOS issues filed | N/A (quick mode) |
| External reviewers | N/A (quick mode) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
