### PR TITLE
Move lock before triage in /fix-issue, reduce Bash calls

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation with collaborative reviewers (Claude subagents + Codex + Cursor).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.9] - 2026-04-13
+
+### Changed
+
+- Moved lock step before triage in `/fix-issue` (Step 2 → before read details and triage) to eliminate race conditions where concurrent runs could claim the same issue during triage
+- Enhanced triage close to include detailed research summary explaining why the issue is no longer material
+- Combined `update-body` + `close` into a single `issue-lifecycle.sh close --pr-url` call, eliminating a consecutive Bash call anti-pattern in Step 7
+- Replaced saved `$SLACK_TOKEN`/`$SLACK_CHANNEL` variables with inline env var expansion to eliminate unnecessary env var resolution Bash call in Step 0
+- Fixed `cmd_update_body` using `exit` instead of `return` for error paths, which would bypass `cmd_close`'s error guard when called as an internal function
+
 ## [2.0.8] - 2026-04-13
 
 ### Changed

--- a/skills/fix-issue/SKILL.md
+++ b/skills/fix-issue/SKILL.md
@@ -26,9 +26,9 @@ Step Name Registry:
 |------|-----------|
 | 0 | setup |
 | 1 | fetch issue |
-| 2 | read details |
-| 3 | triage |
-| 4 | lock |
+| 2 | lock |
+| 3 | read details |
+| 4 | triage |
 | 5 | classify |
 | 6 | implement |
 | 7 | close issue |
@@ -45,7 +45,7 @@ Parse output for `SESSION_TMPDIR`, `SLACK_OK`, `SLACK_MISSING`, `REPO`, `REPO_UN
 
 If `REPO_UNAVAILABLE=true`, print `**⚠ Could not determine repository. GitHub issue access requires a valid repo. Aborting.**` and skip to Step 9.
 
-If `SLACK_OK=true`, resolve `LARCH_SLACK_BOT_TOKEN` and `LARCH_SLACK_CHANNEL_ID` from the environment (or `CLAUDE_PLUGIN_OPTION_SLACK_BOT_TOKEN` / `CLAUDE_PLUGIN_OPTION_SLACK_CHANNEL_ID` fallbacks) and save as `SLACK_TOKEN` and `SLACK_CHANNEL` for Steps 3 and 8. Set `slack_available=true`.
+If `SLACK_OK=true`, set `slack_available=true`. **Do NOT make a separate Bash call to resolve Slack env vars.** When Slack tokens are needed (Steps 4 and 8), use inline shell expansion: `"${LARCH_SLACK_BOT_TOKEN:-$CLAUDE_PLUGIN_OPTION_SLACK_BOT_TOKEN}"` and `"${LARCH_SLACK_CHANNEL_ID:-$CLAUDE_PLUGIN_OPTION_SLACK_CHANNEL_ID}"`.
 
 If `SLACK_OK=false`, print `**⚠ Slack not configured ($SLACK_MISSING). Slack announcements will be skipped.**` Set `slack_available=false`.
 
@@ -71,7 +71,20 @@ Handle exit codes:
 - **Exit 1**: Print `✅ 1: fetch issue — no approved issues found (<elapsed>)`. Skip to Step 9.
 - **Exit 2+**: Parse `ERROR` from stdout. Print `**⚠ 1: fetch issue — error: $ERROR (<elapsed>)**`. Skip to Step 9.
 
-## Step 2 — Read Issue Details
+## Step 2 — Lock Issue
+
+Lock immediately after finding an eligible issue to prevent race conditions with concurrent runs.
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/skills/fix-issue/scripts/issue-lifecycle.sh comment \
+  --issue $ISSUE_NUMBER --body "IN PROGRESS" --lock
+```
+
+Parse output for `LOCK_ACQUIRED`. If `LOCK_ACQUIRED=false`, print `**⚠ 2: lock — failed ($ERROR). Another run may have claimed this issue. (<elapsed>)**` Skip to Step 9.
+
+If `LOCK_ACQUIRED=true`, print `✅ 2: lock — issue #$ISSUE_NUMBER locked (<elapsed>)`.
+
+## Step 3 — Read Issue Details
 
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/skills/fix-issue/scripts/get-issue-details.sh \
@@ -80,11 +93,11 @@ ${CLAUDE_PLUGIN_ROOT}/skills/fix-issue/scripts/get-issue-details.sh \
 
 Read `$FIX_ISSUE_TMPDIR/issue-details.txt` to get the full issue content.
 
-## Step 3 — Triage
+## Step 4 — Triage
 
-Print `▶ 3: triage`
+Print `▶ 4: triage`
 
-Read the issue details from Step 2. Explore the codebase using Read, Grep, and Glob to determine if the issue is still actual — that is, whether it describes a real problem that still needs fixing.
+Read the issue details from Step 3. Explore the codebase using Read, Grep, and Glob to determine if the issue is still actual — that is, whether it describes a real problem that still needs fixing.
 
 Check for:
 
@@ -94,39 +107,29 @@ Check for:
 
 **If the issue is no longer material** (already fixed, invalid, or no longer relevant):
 
-1. Compose a one-sentence explanation of why the issue is no longer material.
-2. Close with comment:
+1. Compose a detailed explanation of why the issue is no longer material. Include a summary of the research performed: which files were checked, what recent commits were examined, and what evidence led to the conclusion. This explanation is written into the issue body so that anyone reviewing the closed issue can understand the rationale without re-investigating.
+2. Close with comment containing the detailed explanation:
    ```bash
    ${CLAUDE_PLUGIN_ROOT}/skills/fix-issue/scripts/issue-lifecycle.sh close \
-     --issue $ISSUE_NUMBER --comment "Closing: <explanation>"
+     --issue $ISSUE_NUMBER --comment "Closing: <detailed explanation with research summary>"
    ```
 3. If `slack_available=true`, post Slack notification:
    ```bash
    ${CLAUDE_PLUGIN_ROOT}/skills/fix-issue/scripts/post-issue-slack.sh \
      --issue $ISSUE_NUMBER --title "$ISSUE_TITLE" \
-     --token "$SLACK_TOKEN" --channel-id "$SLACK_CHANNEL" \
+     --token "${LARCH_SLACK_BOT_TOKEN:-$CLAUDE_PLUGIN_OPTION_SLACK_BOT_TOKEN}" \
+     --channel-id "${LARCH_SLACK_CHANNEL_ID:-$CLAUDE_PLUGIN_OPTION_SLACK_CHANNEL_ID}" \
      --message "Issue #$ISSUE_NUMBER ($ISSUE_TITLE) closed — <one-sentence reason>"
    ```
-4. Print `✅ 3: triage — issue #$ISSUE_NUMBER closed, not material (<elapsed>)`. Skip to Step 9.
+4. Print `✅ 4: triage — issue #$ISSUE_NUMBER closed, not material (<elapsed>)`. Skip to Step 9.
 
-**If the issue is still actual**, print `✅ 3: triage — issue is active, proceeding (<elapsed>)` and continue.
-
-## Step 4 — Lock Issue
-
-```bash
-${CLAUDE_PLUGIN_ROOT}/skills/fix-issue/scripts/issue-lifecycle.sh comment \
-  --issue $ISSUE_NUMBER --body "IN PROGRESS" --lock
-```
-
-Parse output for `LOCK_ACQUIRED`. If `LOCK_ACQUIRED=false`, print `**⚠ 4: lock — failed ($ERROR). Another run may have claimed this issue. (<elapsed>)**` Skip to Step 9.
-
-If `LOCK_ACQUIRED=true`, print `✅ 4: lock — issue #$ISSUE_NUMBER locked (<elapsed>)`.
+**If the issue is still actual**, print `✅ 4: triage — issue is active, proceeding (<elapsed>)` and continue.
 
 ## Step 5 — Classify Complexity
 
 Print `▶ 5: classify`
 
-Based on the issue details and codebase exploration from Step 3, classify the issue:
+Based on the issue details and codebase exploration from Step 4, classify the issue:
 
 - **SIMPLE**: Isolated fix in 2 or fewer files. Obvious solution with no architectural decisions needed. Examples: typo fix, small bug with clear root cause, config change.
 - **HARD**: Everything else. Multi-file changes, new features, architectural decisions, unclear root cause, or any uncertainty.
@@ -154,18 +157,11 @@ If `/implement` fails or bails, print `**⚠ 6: implement — failed. Issue #$IS
 
 Print `▶ 7: close issue`
 
-Update the issue body with PR link (idempotent):
-
-```bash
-${CLAUDE_PLUGIN_ROOT}/skills/fix-issue/scripts/issue-lifecycle.sh update-body \
-  --issue $ISSUE_NUMBER --pr-url "$PR_URL"
-```
-
-Close the issue with DONE comment:
+Update the issue body with PR link and close with DONE comment (single call):
 
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/skills/fix-issue/scripts/issue-lifecycle.sh close \
-  --issue $ISSUE_NUMBER --comment "DONE"
+  --issue $ISSUE_NUMBER --pr-url "$PR_URL" --comment "DONE"
 ```
 
 Print `✅ 7: close issue — #$ISSUE_NUMBER closed (<elapsed>)`
@@ -177,7 +173,8 @@ If `slack_available=false`, print `⏭️ 8: slack announce — skipped (Slack n
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/skills/fix-issue/scripts/post-issue-slack.sh \
   --issue $ISSUE_NUMBER --title "$ISSUE_TITLE" --pr-url "$PR_URL" \
-  --token "$SLACK_TOKEN" --channel-id "$SLACK_CHANNEL"
+  --token "${LARCH_SLACK_BOT_TOKEN:-$CLAUDE_PLUGIN_OPTION_SLACK_BOT_TOKEN}" \
+  --channel-id "${LARCH_SLACK_CHANNEL_ID:-$CLAUDE_PLUGIN_OPTION_SLACK_CHANNEL_ID}"
 ```
 
 If the script exits non-zero, print `**⚠ 8: slack announce — failed. Continuing.**`
@@ -196,5 +193,5 @@ Print `✅ 9: cleanup — fix-issue complete! (<elapsed>)`
 
 ## Known Limitations
 
-- **Stale IN PROGRESS lock**: If the skill crashes after Step 4, the issue remains locked with `IN PROGRESS` as the last comment. Recovery: manually delete the `IN PROGRESS` comment and re-add `GO` to re-enable the issue for automated processing.
-- **Single-runner assumption**: The comment-based locking (Step 4) includes duplicate detection but is not fully atomic. For reliable operation, run one instance of `/fix-issue` at a time per repository.
+- **Stale IN PROGRESS lock**: If the skill crashes after Step 2, the issue remains locked with `IN PROGRESS` as the last comment. Recovery: manually delete the `IN PROGRESS` comment and re-add `GO` to re-enable the issue for automated processing.
+- **Single-runner assumption**: The comment-based locking (Step 2) includes duplicate detection but is not fully atomic. For reliable operation, run one instance of `/fix-issue` at a time per repository.

--- a/skills/fix-issue/scripts/issue-lifecycle.sh
+++ b/skills/fix-issue/scripts/issue-lifecycle.sh
@@ -5,7 +5,7 @@
 #
 # Usage:
 #   issue-lifecycle.sh comment --issue NUMBER --body TEXT [--lock]
-#   issue-lifecycle.sh close   --issue NUMBER [--comment TEXT]
+#   issue-lifecycle.sh close   --issue NUMBER [--comment TEXT] [--pr-url URL]
 #   issue-lifecycle.sh update-body --issue NUMBER --pr-url URL
 #
 # Subcommands:
@@ -13,6 +13,7 @@
 #                With --lock: verify last comment is "GO" before posting,
 #                then re-read to detect concurrent duplicate locks.
 #   close      — Close an issue. Optionally post a comment first.
+#                With --pr-url: update the issue body with the PR link before closing.
 #   update-body — Append a PR link to the issue body (idempotent).
 #
 # Exit codes:
@@ -114,19 +115,29 @@ cmd_comment() {
 # Subcommand: close
 # ---------------------------------------------------------------------------
 cmd_close() {
-    local issue="" comment=""
+    local issue="" comment="" pr_url=""
 
     while [[ $# -gt 0 ]]; do
         case "$1" in
             --issue) issue="${2:?--issue requires a value}"; shift 2 ;;
             --comment) comment="${2:?--comment requires a value}"; shift 2 ;;
+            --pr-url) pr_url="${2:?--pr-url requires a value}"; shift 2 ;;
             *) echo "Unknown option for close: $1" >&2; exit 2 ;;
         esac
     done
 
     if [[ -z "$issue" ]]; then
-        echo "Usage: issue-lifecycle.sh close --issue N [--comment TEXT]" >&2
+        echo "Usage: issue-lifecycle.sh close --issue N [--comment TEXT] [--pr-url URL]" >&2
         exit 2
+    fi
+
+    # Update body with PR link if provided (idempotent)
+    if [[ -n "$pr_url" ]]; then
+        cmd_update_body --issue "$issue" --pr-url "$pr_url" || {
+            echo "CLOSED=false"
+            echo "ERROR=Failed to update issue #$issue body with PR link"
+            exit 1
+        }
     fi
 
     # Post comment first if provided

--- a/skills/fix-issue/scripts/issue-lifecycle.sh
+++ b/skills/fix-issue/scripts/issue-lifecycle.sh
@@ -168,13 +168,13 @@ cmd_update_body() {
         case "$1" in
             --issue) issue="${2:?--issue requires a value}"; shift 2 ;;
             --pr-url) pr_url="${2:?--pr-url requires a value}"; shift 2 ;;
-            *) echo "Unknown option for update-body: $1" >&2; exit 2 ;;
+            *) echo "Unknown option for update-body: $1" >&2; return 2 ;;
         esac
     done
 
     if [[ -z "$issue" ]] || [[ -z "$pr_url" ]]; then
         echo "Usage: issue-lifecycle.sh update-body --issue N --pr-url URL" >&2
-        exit 2
+        return 2
     fi
 
     # Read current body
@@ -182,7 +182,7 @@ cmd_update_body() {
     current_body=$(gh issue view "$issue" --json body --jq '.body // ""' 2>/dev/null) || {
         echo "UPDATED=false"
         echo "ERROR=Failed to read issue #$issue body"
-        exit 1
+        return 1
     }
 
     # Idempotency check: skip if PR URL already present
@@ -200,7 +200,7 @@ cmd_update_body() {
     gh issue edit "$issue" --body "$new_body" >/dev/null 2>&1 || {
         echo "UPDATED=false"
         echo "ERROR=Failed to update issue #$issue body"
-        exit 1
+        return 1
     }
 
     echo "UPDATED=true"


### PR DESCRIPTION
## Summary
- Moved lock step before triage in `/fix-issue` to eliminate race conditions where concurrent runs could claim the same issue during triage
- Enhanced triage close to include detailed research summary and combined consecutive `issue-lifecycle.sh` calls into single invocations
- Fixed `cmd_update_body` error paths using `exit` instead of `return`, which would bypass `cmd_close`'s error guard

<details><summary>Architecture Diagram</summary>

Quick mode — architecture diagram skipped.

</details>

<details><summary>Code Flow Diagram</summary>

Quick mode — code flow diagram skipped.

</details>

<details><summary>Goal</summary>

- Eliminate race condition in `/fix-issue` workflow
  - Move lock (IN PROGRESS comment) to immediately after finding an eligible issue, before triage
  - Ensure no concurrent run can claim the same issue while triage is investigating
- Improve triage close quality
  - Replace one-sentence closing explanation with detailed research summary
  - Include which files were checked, recent commits examined, and evidence for the conclusion
- Eliminate consecutive Bash call anti-pattern
  - Combine Step 7's two `issue-lifecycle.sh` calls (update-body + close) into one via new `--pr-url` flag on `close` subcommand
  - Replace saved `$SLACK_TOKEN`/`$SLACK_CHANNEL` variables with inline env var expansion to eliminate Step 0's env var resolution Bash call

</details>

<details><summary>Test plan</summary>

- [ ] Run `/fix-issue` against an issue with `GO` comment — verify lock happens at Step 2 before triage at Step 4
- [ ] Run `/fix-issue` against an already-fixed issue — verify triage closes it with detailed explanation
- [ ] Verify `issue-lifecycle.sh close --issue N --pr-url URL --comment TEXT` updates body and closes in one call
- [ ] Verify `issue-lifecycle.sh close --issue N --comment TEXT` (without `--pr-url`) still works as before
- [ ] Verify `issue-lifecycle.sh update-body` standalone still works (returns non-zero on error, `set -e` catches it)

</details>

<details><summary>Final Design</summary>

**Files modified:**
1. `skills/fix-issue/SKILL.md` — Reorder steps (lock → Step 2, read details → Step 3, triage → Step 4), eliminate unnecessary env var resolution Bash call in Step 0, enhance triage close with research detail, combine Step 7's two `issue-lifecycle.sh` calls into one via new `--pr-url` flag
2. `skills/fix-issue/scripts/issue-lifecycle.sh` — Add `--pr-url` flag to `close` subcommand so update-body + close happen in one call. Fix `cmd_update_body` to use `return` instead of `exit` so it works correctly when called as an internal function.

</details>

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `39ee36f` (Improve progress reporting visibility and timing (#71))
- **Current version**: `2.0.8`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `2.0.9`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH").

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

Quick mode — no plan review was conducted.

</details>

<details><summary>Implementation Deviations</summary>

One deviation: additionally fixed `cmd_update_body` to use `return` instead of `exit` for error paths, discovered during code review. The `exit` calls would bypass `cmd_close`'s `||` error guard when `cmd_update_body` is called as an internal function. This was not in the original plan but is directly related to the combined `close --pr-url` change.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

### [Code Review] General
**Finding**: In `skills/fix-issue/SKILL.md`, Step 3 (Read Issue Details, line ~87) is missing a `▶ 3: read details` step-start print line. Every other active step (Steps 4-7) has a `▶` start line per the progress-reporting contract. The reviewer suggested adding a `Print ▶ 3: read details` line before the script invocation for consistency.
**Reason not implemented**: This is a pre-existing pattern, not introduced by this PR. The old Step 2 (read details) also had no `▶` print. Steps with simple script calls (fetch, lock, read details) embed their output in completion or exit-code handling lines rather than having separate `▶` start lines. Only steps with significant agent work (triage, classify, implement, close) use explicit `▶` start lines. The asymmetry is intentional.

### [Code Review] General
**Finding**: In `skills/fix-issue/SKILL.md`, Step 4 (triage "not material" path, lines ~108-124), when the issue is closed as not material, the `IN PROGRESS` comment from Step 2 remains on the closed issue. The reviewer noted this creates a confusing comment timeline (IN PROGRESS → Closing: <explanation>) since the issue was never actually worked on, and suggested adding a `delete-comment` subcommand or replacing the comment with `NOT PROCEEDING`.
**Reason not implemented**: The comment timeline (GO → IN PROGRESS → Closing: <detailed explanation>) reads naturally as a chronological narrative — the skill started processing ("IN PROGRESS"), investigated, and determined the issue was not material ("Closing: explanation"). The `IN PROGRESS` comment is accurate — the skill was in progress of evaluating the issue. Adding a delete-comment mechanism or replacement comment introduces disproportionate complexity for a cosmetic concern. The detailed closing explanation makes the resolution clear.

</details>

<details><summary>Plan Review Voting Tally</summary>

Quick mode — no plan review voting.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

Quick mode — no voting panel. Main agent reviewed findings from 2 Claude subagents.

</details>

<details><summary>Out-of-Scope Observations</summary>

Quick mode — no out-of-scope observations collected.

</details>

<details><summary>Execution Issues</summary>

No execution issues encountered.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | N/A (quick mode) |
| Code review rounds | 1 |
| Code review findings | 1 accepted, 2 rejected |
| Warnings logged | 0 |
| Pre-existing issues noticed | 0 |
| OOS issues filed | N/A (quick mode) |
| External reviewers | N/A (quick mode) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
