### PR TITLE
Replace ▶ with 🔶 and add blockquote formatting to step headers

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation with collaborative reviewers (Claude subagents + Codex + Cursor).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.10] - 2026-04-13
+
+### Changed
+
+- Replaced `▶` step start icon with `🔶` (large orange diamond) across all skills for improved visibility
+- Added blockquote wrapping (`>`) to step start lines for color differentiation
+- Updated all inline `Print:` directives to include full `> **🔶 ...**` format for consistency with the shared progress reporting contract
+
 ## [2.0.9] - 2026-04-13
 
 ### Changed

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -23,7 +23,7 @@ The feature to design is described by the remainder of `$ARGUMENTS` after flags 
 
 **Every step MUST print clearly visible breadcrumb status lines** so the user can instantly see where execution is and which parent steps they are inside. Follow the formatting rules in `${CLAUDE_PLUGIN_ROOT}/skills/shared/progress-reporting.md`.
 
-- Print a **start line** when entering a step: e.g., `▶ 1: branch` (standalone) or `▶ 1.1: design plan | branch` (nested from `/implement`)
+- Print a **start line** when entering a step: e.g., `🔶 1: branch` (standalone) or `🔶 1.1: design plan | branch` (nested from `/implement`)
 - Print a **completion line** only when it carries informational payload. Only the final step (Step 5) prints an unconditional completion announcement.
 - When `STEP_NUM_PREFIX` is non-empty, prepend it to step numbers: `{STEP_NUM_PREFIX}{local_step}`. When `STEP_PATH_PREFIX` is non-empty, prepend it to breadcrumb paths: `{STEP_PATH_PREFIX} | {step_short_name}`. **This rule overrides the literal step numbers and names in `Print:` directives and examples throughout this file.** Examples shown below assume standalone mode; when nested, prepend the parent context.
 
@@ -50,7 +50,7 @@ Step Name Registry:
 
 - Use empty string for the `description` parameter on all Bash tool calls.
 - Use terse 3-5 word descriptions for Agent tool calls.
-- Do not produce explanatory prose between tool call outputs — only print: step breadcrumb lines (start `▶`, completion `✅`, skip `⏩`), final completion line (Step 5), all warning/error lines (`**⚠ ...`), structured summaries (voting tallies, scoreboards, round summaries, findings lists, approach synthesis, dialectic resolutions, implementation plans, architecture diagrams), and the compact reviewer status table (see below).
+- Do not produce explanatory prose between tool call outputs — only print: step breadcrumb lines (start `🔶`, completion `✅`, skip `⏩`), final completion line (Step 5), all warning/error lines (`**⚠ ...`), structured summaries (voting tallies, scoreboards, round summaries, findings lists, approach synthesis, dialectic resolutions, implementation plans, architecture diagrams), and the compact reviewer status table (see below).
 
 **Compact reviewer status table**: After launching sketch agents (Step 2a) or plan reviewers (Step 3), maintain a mental tracker of each agent's status. Print a compact table after EACH status change:
 
@@ -110,13 +110,13 @@ Parse the output for `CURRENT_BRANCH`, `IS_MAIN`, `IS_USER_BRANCH`, and `USER_PR
   ${CLAUDE_PLUGIN_ROOT}/scripts/create-branch.sh --branch <USER_PREFIX>/<branch-name>
   ```
 
-- If `IS_USER_BRANCH=true`: Verify the branch name (`CURRENT_BRANCH`) aligns with the requested feature. If it appears unrelated (different feature name, unrelated commits), print a warning: `**⚠ Current branch '<branch-name>' may not match the requested feature. Creating a new branch from main.**` and create a new branch as above. Otherwise, skip branch creation. Print: `▶ 1: branch — using existing: <branch-name>`
+- If `IS_USER_BRANCH=true`: Verify the branch name (`CURRENT_BRANCH`) aligns with the requested feature. If it appears unrelated (different feature name, unrelated commits), print a warning: `**⚠ Current branch '<branch-name>' may not match the requested feature. Creating a new branch from main.**` and create a new branch as above. Otherwise, skip branch creation. Print: `🔶 1: branch — using existing: <branch-name>`
 
 - Otherwise (non-main, non-user branch): Print a warning: `**⚠ Currently on branch '<branch-name>' which doesn't match the expected '<USER_PREFIX>/*' pattern. Creating a new branch from main.**` Then derive a name and create as above.
 
 ## Step 1c — Clarifying Questions
 
-Print: `▶ 1c: questions`
+Print: `🔶 1c: questions`
 
 **If `auto_mode=true`**: Print `⏩ 1c: questions — skipped (auto mode) (<elapsed>)` and proceed to Step 1d.
 
@@ -136,7 +136,7 @@ After the user responds, incorporate their answers into your understanding of th
 
 ## Step 1d — Design Discussion (Round 1)
 
-Print: `▶ 1d: discussion r1`
+Print: `🔶 1d: discussion r1`
 
 **If `auto_mode=true`**: Print `⏩ 1d: discussion r1 — skipped (auto mode) (<elapsed>)` and proceed to Step 2a.
 
@@ -198,7 +198,7 @@ Plus 2 external agents (or Claude replacements):
 4. **Cursor** (if available) — or **Claude (Innovation/Exploration)** replacement: proposes creative alternative approaches, questions assumptions, and suggests unconventional solutions
 5. **Codex** (if available) — or **Claude (Edge-cases/Failure-modes)** replacement: focuses on what can go wrong, boundary conditions, error handling, and failure recovery
 
-Print `▶ 2a: sketches` and proceed to 2a.2.
+Print `🔶 2a: sketches` and proceed to 2a.2.
 
 ### 2a.2 — Launch Sketches in Parallel
 
@@ -285,7 +285,7 @@ Print the synthesis under an `## Approach Synthesis` header. Write the synthesis
 
 ### 2a.5 — Dialectic Resolution of Contested Decisions
 
-Print: `▶ 2a.5: dialectic`
+Print: `🔶 2a.5: dialectic`
 
 Read `$DESIGN_TMPDIR/contested-decisions.md`. If the file contains only `NO_CONTESTED_DECISIONS` (ignoring leading/trailing whitespace and newlines), print `⏩ 2a.5: dialectic — no contested decisions (<elapsed>)` and proceed to Step 2b.
 
@@ -517,7 +517,7 @@ If no findings were rejected, do not create the file yet.
 
 ## Step 3.5 — Design Discussion (Round 2)
 
-Print: `▶ 3.5: discussion r2`
+Print: `🔶 3.5: discussion r2`
 
 **If `auto_mode=true`**: Print `⏩ 3.5: discussion r2 — skipped (auto mode) (<elapsed>)` and proceed to Step 3a.
 
@@ -573,7 +573,7 @@ Print: `✅ 3.5: discussion r2 — <N> decisions resolved (<elapsed>)`
 
 ## Step 3a — Post-Review Confirmation
 
-Print: `▶ 3a: confirmation`
+Print: `🔶 3a: confirmation`
 
 **If `auto_mode=true`**: Print `⏩ 3a: confirmation — skipped (auto mode) (<elapsed>)` and proceed to Step 3b.
 
@@ -585,7 +585,7 @@ Print: `▶ 3a: confirmation`
 
 ## Step 3b — Architecture Diagram
 
-Print: `▶ 3b: arch diagram`
+Print: `🔶 3b: arch diagram`
 
 **This step runs on ALL paths through Step 3** — whether voting produced revisions, rejected all findings, or was skipped entirely because all reviewers reported no issues. It always executes before Step 4.
 

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -23,7 +23,7 @@ The feature to design is described by the remainder of `$ARGUMENTS` after flags 
 
 **Every step MUST print clearly visible breadcrumb status lines** so the user can instantly see where execution is and which parent steps they are inside. Follow the formatting rules in `${CLAUDE_PLUGIN_ROOT}/skills/shared/progress-reporting.md`.
 
-- Print a **start line** when entering a step: e.g., `🔶 1: branch` (standalone) or `🔶 1.1: design plan | branch` (nested from `/implement`)
+- Print a **start line** when entering a step: e.g., `> **🔶 1: branch**` (standalone) or `> **🔶 1.1: design plan | branch**` (nested from `/implement`)
 - Print a **completion line** only when it carries informational payload. Only the final step (Step 5) prints an unconditional completion announcement.
 - When `STEP_NUM_PREFIX` is non-empty, prepend it to step numbers: `{STEP_NUM_PREFIX}{local_step}`. When `STEP_PATH_PREFIX` is non-empty, prepend it to breadcrumb paths: `{STEP_PATH_PREFIX} | {step_short_name}`. **This rule overrides the literal step numbers and names in `Print:` directives and examples throughout this file.** Examples shown below assume standalone mode; when nested, prepend the parent context.
 
@@ -110,13 +110,13 @@ Parse the output for `CURRENT_BRANCH`, `IS_MAIN`, `IS_USER_BRANCH`, and `USER_PR
   ${CLAUDE_PLUGIN_ROOT}/scripts/create-branch.sh --branch <USER_PREFIX>/<branch-name>
   ```
 
-- If `IS_USER_BRANCH=true`: Verify the branch name (`CURRENT_BRANCH`) aligns with the requested feature. If it appears unrelated (different feature name, unrelated commits), print a warning: `**⚠ Current branch '<branch-name>' may not match the requested feature. Creating a new branch from main.**` and create a new branch as above. Otherwise, skip branch creation. Print: `🔶 1: branch — using existing: <branch-name>`
+- If `IS_USER_BRANCH=true`: Verify the branch name (`CURRENT_BRANCH`) aligns with the requested feature. If it appears unrelated (different feature name, unrelated commits), print a warning: `**⚠ Current branch '<branch-name>' may not match the requested feature. Creating a new branch from main.**` and create a new branch as above. Otherwise, skip branch creation. Print: `> **🔶 1: branch — using existing: <branch-name>**`
 
 - Otherwise (non-main, non-user branch): Print a warning: `**⚠ Currently on branch '<branch-name>' which doesn't match the expected '<USER_PREFIX>/*' pattern. Creating a new branch from main.**` Then derive a name and create as above.
 
 ## Step 1c — Clarifying Questions
 
-Print: `🔶 1c: questions`
+Print: `> **🔶 1c: questions**`
 
 **If `auto_mode=true`**: Print `⏩ 1c: questions — skipped (auto mode) (<elapsed>)` and proceed to Step 1d.
 
@@ -136,7 +136,7 @@ After the user responds, incorporate their answers into your understanding of th
 
 ## Step 1d — Design Discussion (Round 1)
 
-Print: `🔶 1d: discussion r1`
+Print: `> **🔶 1d: discussion r1**`
 
 **If `auto_mode=true`**: Print `⏩ 1d: discussion r1 — skipped (auto mode) (<elapsed>)` and proceed to Step 2a.
 
@@ -198,7 +198,7 @@ Plus 2 external agents (or Claude replacements):
 4. **Cursor** (if available) — or **Claude (Innovation/Exploration)** replacement: proposes creative alternative approaches, questions assumptions, and suggests unconventional solutions
 5. **Codex** (if available) — or **Claude (Edge-cases/Failure-modes)** replacement: focuses on what can go wrong, boundary conditions, error handling, and failure recovery
 
-Print `🔶 2a: sketches` and proceed to 2a.2.
+Print `> **🔶 2a: sketches**` and proceed to 2a.2.
 
 ### 2a.2 — Launch Sketches in Parallel
 
@@ -285,7 +285,7 @@ Print the synthesis under an `## Approach Synthesis` header. Write the synthesis
 
 ### 2a.5 — Dialectic Resolution of Contested Decisions
 
-Print: `🔶 2a.5: dialectic`
+Print: `> **🔶 2a.5: dialectic**`
 
 Read `$DESIGN_TMPDIR/contested-decisions.md`. If the file contains only `NO_CONTESTED_DECISIONS` (ignoring leading/trailing whitespace and newlines), print `⏩ 2a.5: dialectic — no contested decisions (<elapsed>)` and proceed to Step 2b.
 
@@ -517,7 +517,7 @@ If no findings were rejected, do not create the file yet.
 
 ## Step 3.5 — Design Discussion (Round 2)
 
-Print: `🔶 3.5: discussion r2`
+Print: `> **🔶 3.5: discussion r2**`
 
 **If `auto_mode=true`**: Print `⏩ 3.5: discussion r2 — skipped (auto mode) (<elapsed>)` and proceed to Step 3a.
 
@@ -573,7 +573,7 @@ Print: `✅ 3.5: discussion r2 — <N> decisions resolved (<elapsed>)`
 
 ## Step 3a — Post-Review Confirmation
 
-Print: `🔶 3a: confirmation`
+Print: `> **🔶 3a: confirmation**`
 
 **If `auto_mode=true`**: Print `⏩ 3a: confirmation — skipped (auto mode) (<elapsed>)` and proceed to Step 3b.
 
@@ -585,7 +585,7 @@ Print: `🔶 3a: confirmation`
 
 ## Step 3b — Architecture Diagram
 
-Print: `🔶 3b: arch diagram`
+Print: `> **🔶 3b: arch diagram**`
 
 **This step runs on ALL paths through Step 3** — whether voting produced revisions, rejected all findings, or was skipped entirely because all reviewers reported no issues. It always executes before Step 4.
 

--- a/skills/fix-issue/SKILL.md
+++ b/skills/fix-issue/SKILL.md
@@ -67,7 +67,7 @@ Only include `--issue "$ISSUE_ARG"` if `ISSUE_ARG` is non-empty (the user provid
 
 Handle exit codes:
 
-- **Exit 0**: Parse `ISSUE_NUMBER` and `ISSUE_TITLE`. Print `▶ 1: fetch issue — found #$ISSUE_NUMBER: $ISSUE_TITLE`
+- **Exit 0**: Parse `ISSUE_NUMBER` and `ISSUE_TITLE`. Print `🔶 1: fetch issue — found #$ISSUE_NUMBER: $ISSUE_TITLE`
 - **Exit 1**: Print `✅ 1: fetch issue — no approved issues found (<elapsed>)`. Skip to Step 9.
 - **Exit 2+**: Parse `ERROR` from stdout. Print `**⚠ 1: fetch issue — error: $ERROR (<elapsed>)**`. Skip to Step 9.
 
@@ -95,7 +95,7 @@ Read `$FIX_ISSUE_TMPDIR/issue-details.txt` to get the full issue content.
 
 ## Step 4 — Triage
 
-Print `▶ 4: triage`
+Print `🔶 4: triage`
 
 Read the issue details from Step 3. Explore the codebase using Read, Grep, and Glob to determine if the issue is still actual — that is, whether it describes a real problem that still needs fixing.
 
@@ -127,7 +127,7 @@ Check for:
 
 ## Step 5 — Classify Complexity
 
-Print `▶ 5: classify`
+Print `🔶 5: classify`
 
 Based on the issue details and codebase exploration from Step 4, classify the issue:
 
@@ -140,7 +140,7 @@ Print `✅ 5: classify — $CLASSIFICATION (<elapsed>)`
 
 ## Step 6 — Implement
 
-Print `▶ 6: implement`
+Print `🔶 6: implement`
 
 Compose the feature description from the issue content: use the issue title as the primary description, with key details from the issue body and comments as context.
 
@@ -155,7 +155,7 @@ If `/implement` fails or bails, print `**⚠ 6: implement — failed. Issue #$IS
 
 ## Step 7 — Close Issue
 
-Print `▶ 7: close issue`
+Print `🔶 7: close issue`
 
 Update the issue body with PR link and close with DONE comment (single call):
 

--- a/skills/fix-issue/SKILL.md
+++ b/skills/fix-issue/SKILL.md
@@ -67,7 +67,7 @@ Only include `--issue "$ISSUE_ARG"` if `ISSUE_ARG` is non-empty (the user provid
 
 Handle exit codes:
 
-- **Exit 0**: Parse `ISSUE_NUMBER` and `ISSUE_TITLE`. Print `🔶 1: fetch issue — found #$ISSUE_NUMBER: $ISSUE_TITLE`
+- **Exit 0**: Parse `ISSUE_NUMBER` and `ISSUE_TITLE`. Print `> **🔶 1: fetch issue — found #$ISSUE_NUMBER: $ISSUE_TITLE**`
 - **Exit 1**: Print `✅ 1: fetch issue — no approved issues found (<elapsed>)`. Skip to Step 9.
 - **Exit 2+**: Parse `ERROR` from stdout. Print `**⚠ 1: fetch issue — error: $ERROR (<elapsed>)**`. Skip to Step 9.
 
@@ -95,7 +95,7 @@ Read `$FIX_ISSUE_TMPDIR/issue-details.txt` to get the full issue content.
 
 ## Step 4 — Triage
 
-Print `🔶 4: triage`
+Print `> **🔶 4: triage**`
 
 Read the issue details from Step 3. Explore the codebase using Read, Grep, and Glob to determine if the issue is still actual — that is, whether it describes a real problem that still needs fixing.
 
@@ -127,7 +127,7 @@ Check for:
 
 ## Step 5 — Classify Complexity
 
-Print `🔶 5: classify`
+Print `> **🔶 5: classify**`
 
 Based on the issue details and codebase exploration from Step 4, classify the issue:
 
@@ -140,7 +140,7 @@ Print `✅ 5: classify — $CLASSIFICATION (<elapsed>)`
 
 ## Step 6 — Implement
 
-Print `🔶 6: implement`
+Print `> **🔶 6: implement**`
 
 Compose the feature description from the issue content: use the issue title as the primary description, with key details from the issue body and comments as context.
 
@@ -155,7 +155,7 @@ If `/implement` fails or bails, print `**⚠ 6: implement — failed. Issue #$IS
 
 ## Step 7 — Close Issue
 
-Print `🔶 7: close issue`
+Print `> **🔶 7: close issue**`
 
 Update the issue body with PR link and close with DONE comment (single call):
 

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -24,7 +24,7 @@ The feature to implement is described by `$ARGUMENTS` after flag stripping.
 
 **Every step MUST print clearly visible breadcrumb status lines** so the user can instantly see where execution is and which parent steps they are inside. Follow the formatting rules in `${CLAUDE_PLUGIN_ROOT}/skills/shared/progress-reporting.md`.
 
-- Print a **start line** when entering a step: e.g., `▶ 2: implementation`
+- Print a **start line** when entering a step: e.g., `🔶 2: implementation`
 - Print a **completion line** only when it carries informational payload. Only the final step (Step 18) prints an unconditional completion announcement.
 - For long-running steps, print **intermediate progress**: e.g., `⏳ 12: CI+merge loop — CI running (2m elapsed), main unchanged`
 
@@ -67,7 +67,7 @@ Step Name Registry:
 - Use terse 3-5 word descriptions for Agent tool calls.
 - Do not produce explanatory prose between tool call outputs — only print the designated output categories below.
 
-**Preserved output (NEVER suppressed, regardless of `debug_mode`):** step breadcrumb lines (start `▶`, completion `✅`, skip `⏩`/`⏭️`) — except the three rebase-skip variants listed in Suppressed output below, final completion line (Step 18), all warning/error lines (`**⚠ ...`), structured summaries (voting tallies, competition scoreboards, round summaries, final summaries/reports), architecture diagrams, code flow diagrams, implementation plans (original and revised), dialectic resolutions, accepted/rejected findings lists, out-of-scope observations, PR body sections.
+**Preserved output (NEVER suppressed, regardless of `debug_mode`):** step breadcrumb lines (start `🔶`, completion `✅`, skip `⏩`/`⏭️`) — except the three rebase-skip variants listed in Suppressed output below, final completion line (Step 18), all warning/error lines (`**⚠ ...`), structured summaries (voting tallies, competition scoreboards, round summaries, final summaries/reports), architecture diagrams, code flow diagrams, implementation plans (original and revised), dialectic resolutions, accepted/rejected findings lists, out-of-scope observations, PR body sections.
 
 **Suppressed output (only when `debug_mode=false`):** explanatory prose describing what will happen next or what just happened, script paths and command descriptions, rationale for decisions between tool calls, per-reviewer individual completion messages (replaced by status table in child skills), rebase-skip messages (the following three specific variants: `⏩ 1.m: design plan | update main — already at latest`, `⏩ 1.r: design plan | rebase — already pushed`, `⏩ 1.r: design plan | rebase — already at latest main`). Note: non-rebase `⏩` skip messages and rebase outcomes in the Rebase+Re-bump Sub-procedure (Steps 10/12) are NOT suppressed — they carry CI-debugging semantics.
 
@@ -283,7 +283,7 @@ Skip `/review`. Instead, run a simplified one-round review:
 6. **One round only** — no re-review loop.
 7. For rejected findings, write them to `$IMPLEMENT_TMPDIR/rejected-findings.md` using the same format as normal mode (see below), so Step 16 and PR body sections work unchanged.
 
-Print: `▶ 5: code review — quick mode (2 Claude subagents, 1 round, no voting)`
+Print: `🔶 5: code review — quick mode (2 Claude subagents, 1 round, no voting)`
 
 ### Normal mode (`quick_mode=false`)
 
@@ -345,7 +345,7 @@ If successful:
 
 ## Step 7a — Code Flow Diagram
 
-Print: `▶ 7a: code flow`
+Print: `🔶 7a: code flow`
 
 **This step runs unconditionally after Step 7** — regardless of whether Steps 6-7 were skipped due to no review changes.
 

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -24,7 +24,7 @@ The feature to implement is described by `$ARGUMENTS` after flag stripping.
 
 **Every step MUST print clearly visible breadcrumb status lines** so the user can instantly see where execution is and which parent steps they are inside. Follow the formatting rules in `${CLAUDE_PLUGIN_ROOT}/skills/shared/progress-reporting.md`.
 
-- Print a **start line** when entering a step: e.g., `🔶 2: implementation`
+- Print a **start line** when entering a step: e.g., `> **🔶 2: implementation**`
 - Print a **completion line** only when it carries informational payload. Only the final step (Step 18) prints an unconditional completion announcement.
 - For long-running steps, print **intermediate progress**: e.g., `⏳ 12: CI+merge loop — CI running (2m elapsed), main unchanged`
 
@@ -283,7 +283,7 @@ Skip `/review`. Instead, run a simplified one-round review:
 6. **One round only** — no re-review loop.
 7. For rejected findings, write them to `$IMPLEMENT_TMPDIR/rejected-findings.md` using the same format as normal mode (see below), so Step 16 and PR body sections work unchanged.
 
-Print: `🔶 5: code review — quick mode (2 Claude subagents, 1 round, no voting)`
+Print: `> **🔶 5: code review — quick mode (2 Claude subagents, 1 round, no voting)**`
 
 ### Normal mode (`quick_mode=false`)
 
@@ -345,7 +345,7 @@ If successful:
 
 ## Step 7a — Code Flow Diagram
 
-Print: `🔶 7a: code flow`
+Print: `> **🔶 7a: code flow**`
 
 **This step runs unconditionally after Step 7** — regardless of whether Steps 6-7 were skipped due to no review changes.
 

--- a/skills/loop-review/SKILL.md
+++ b/skills/loop-review/SKILL.md
@@ -19,7 +19,7 @@ Systematically review the entire codebase by partitioning into slices, reviewing
 
 **Every step MUST print clearly visible breadcrumb status lines** so the user can instantly see where execution is. Follow the formatting rules in `${CLAUDE_PLUGIN_ROOT}/skills/shared/progress-reporting.md`.
 
-- Print a **start line** when entering a step: e.g., `▶ 3: implement/defer — slice: scripts/...`
+- Print a **start line** when entering a step: e.g., `🔶 3: implement/defer — slice: scripts/...`
 - Print a **completion line** when done: e.g., `✅ 3: implement/defer — 3 findings implemented, 1 deferred (5m22s)`
 
 Step Name Registry:
@@ -39,7 +39,7 @@ Step Name Registry:
 
 - Use empty string for the `description` parameter on all Bash tool calls.
 - Use terse 3-5 word descriptions for Agent tool calls.
-- Do not produce explanatory prose between tool call outputs — only print: step breadcrumb lines (start `▶`, completion `✅`, skip `⏩`), all warning/error lines (`**⚠ ...`), structured summaries (slice results, findings lists, deferred items, final report).
+- Do not produce explanatory prose between tool call outputs — only print: step breadcrumb lines (start `🔶`, completion `✅`, skip `⏩`), all warning/error lines (`**⚠ ...`), structured summaries (slice results, findings lists, deferred items, final report).
 
 **Suppressed output (only when `debug_mode=false`):** explanatory prose, script paths, rationale for decisions between tool calls.
 

--- a/skills/loop-review/SKILL.md
+++ b/skills/loop-review/SKILL.md
@@ -19,7 +19,7 @@ Systematically review the entire codebase by partitioning into slices, reviewing
 
 **Every step MUST print clearly visible breadcrumb status lines** so the user can instantly see where execution is. Follow the formatting rules in `${CLAUDE_PLUGIN_ROOT}/skills/shared/progress-reporting.md`.
 
-- Print a **start line** when entering a step: e.g., `🔶 3: implement/defer — slice: scripts/...`
+- Print a **start line** when entering a step: e.g., `> **🔶 3: implement/defer — slice: scripts/...**`
 - Print a **completion line** when done: e.g., `✅ 3: implement/defer — 3 findings implemented, 1 deferred (5m22s)`
 
 Step Name Registry:

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -21,7 +21,7 @@ The research question is described by `RESEARCH_QUESTION` (not raw `$ARGUMENTS`)
 
 **Every step MUST print clearly visible breadcrumb status lines** so the user can instantly see where execution is. Follow the formatting rules in `${CLAUDE_PLUGIN_ROOT}/skills/shared/progress-reporting.md`.
 
-- Print a **start line** when entering a step: e.g., `▶ 1: research`
+- Print a **start line** when entering a step: e.g., `🔶 1: research`
 - Print a **completion line** when done: e.g., `✅ 1: research — synthesis complete, 5 agents (3m12s)`
 
 Step Name Registry:
@@ -39,7 +39,7 @@ Step Name Registry:
 
 - Use empty string for the `description` parameter on all Bash tool calls.
 - Use terse 3-5 word descriptions for Agent tool calls.
-- Do not produce explanatory prose between tool call outputs — only print: step breadcrumb lines (start `▶`, completion `✅`, skip `⏩`), all warning/error lines (`**⚠ ...`), structured summaries (findings, risk assessments, research report sections), and the compact agent status table (see below).
+- Do not produce explanatory prose between tool call outputs — only print: step breadcrumb lines (start `🔶`, completion `✅`, skip `⏩`), all warning/error lines (`**⚠ ...`), structured summaries (findings, risk assessments, research report sections), and the compact agent status table (see below).
 
 **Compact agent status table**: After launching research agents (Step 1) or validation reviewers (Step 2), maintain a mental tracker of each agent's status. Print a compact table after EACH status change:
 
@@ -104,7 +104,7 @@ Plus 2 external agents (or Claude replacements):
 4. **Cursor** (if available) — or **Claude (Alternative Perspectives)** replacement: questions assumptions, explores unconventional angles, and surfaces insights that the other agents might overlook
 5. **Codex** (if available) — or **Claude (Edge-cases/Gaps)** replacement: focuses on what might be missing, edge cases, gaps in the codebase, failure modes, and boundary conditions relevant to the research question
 
-Print `▶ 1: research` and proceed to 1.2.
+Print `🔶 1: research` and proceed to 1.2.
 
 ### 1.2 — Launch Research Perspectives in Parallel
 
@@ -182,7 +182,7 @@ Print: `✅ 1: research — synthesis complete, 5 agents (<elapsed>)`
 
 ## Step 2 — Findings Validation
 
-Print: `▶ 2: validation`
+Print: `🔶 2: validation`
 
 **IMPORTANT: Findings validation MUST ALWAYS run with all available reviewers (2 Claude subagents + 2 Codex instances and Cursor if available). Never skip or abbreviate this step regardless of how straightforward the findings appear. Reviewers validate against the actual codebase state, catching inaccuracies or omissions that the research phase may have missed.**
 
@@ -283,7 +283,7 @@ If all reviewers report no issues, print: `✅ 2: validation — all findings va
 
 ## Step 3 — Final Research Report
 
-Print: `▶ 3: report`
+Print: `🔶 3: report`
 
 Print the final research report under a `## Research Report` header with the following structure:
 

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -21,7 +21,7 @@ The research question is described by `RESEARCH_QUESTION` (not raw `$ARGUMENTS`)
 
 **Every step MUST print clearly visible breadcrumb status lines** so the user can instantly see where execution is. Follow the formatting rules in `${CLAUDE_PLUGIN_ROOT}/skills/shared/progress-reporting.md`.
 
-- Print a **start line** when entering a step: e.g., `🔶 1: research`
+- Print a **start line** when entering a step: e.g., `> **🔶 1: research**`
 - Print a **completion line** when done: e.g., `✅ 1: research — synthesis complete, 5 agents (3m12s)`
 
 Step Name Registry:
@@ -104,7 +104,7 @@ Plus 2 external agents (or Claude replacements):
 4. **Cursor** (if available) — or **Claude (Alternative Perspectives)** replacement: questions assumptions, explores unconventional angles, and surfaces insights that the other agents might overlook
 5. **Codex** (if available) — or **Claude (Edge-cases/Gaps)** replacement: focuses on what might be missing, edge cases, gaps in the codebase, failure modes, and boundary conditions relevant to the research question
 
-Print `🔶 1: research` and proceed to 1.2.
+Print `> **🔶 1: research**` and proceed to 1.2.
 
 ### 1.2 — Launch Research Perspectives in Parallel
 
@@ -182,7 +182,7 @@ Print: `✅ 1: research — synthesis complete, 5 agents (<elapsed>)`
 
 ## Step 2 — Findings Validation
 
-Print: `🔶 2: validation`
+Print: `> **🔶 2: validation**`
 
 **IMPORTANT: Findings validation MUST ALWAYS run with all available reviewers (2 Claude subagents + 2 Codex instances and Cursor if available). Never skip or abbreviate this step regardless of how straightforward the findings appear. Reviewers validate against the actual codebase state, catching inaccuracies or omissions that the research phase may have missed.**
 
@@ -283,7 +283,7 @@ If all reviewers report no issues, print: `✅ 2: validation — all findings va
 
 ## Step 3 — Final Research Report
 
-Print: `🔶 3: report`
+Print: `> **🔶 3: report**`
 
 Print the final research report under a `## Research Report` header with the following structure:
 

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -19,7 +19,7 @@ Review all changes on the current branch (vs `main`) using two specialized Claud
 
 **Every step MUST print clearly visible breadcrumb status lines** so the user can instantly see where execution is and which parent steps they are inside. Follow the formatting rules in `${CLAUDE_PLUGIN_ROOT}/skills/shared/progress-reporting.md`.
 
-- Print a **start line** when entering a step: e.g., `▶ 2: launch reviewers` (standalone) or `▶ 5.2: code review | launch reviewers` (nested from `/implement`)
+- Print a **start line** when entering a step: e.g., `🔶 2: launch reviewers` (standalone) or `🔶 5.2: code review | launch reviewers` (nested from `/implement`)
 - Print a **completion line** only when it carries informational payload. Pure "step complete" announcements without payload are not needed.
 - When `STEP_NUM_PREFIX` is non-empty, prepend it to step numbers. When `STEP_PATH_PREFIX` is non-empty, prepend it to breadcrumb paths. **This rule overrides the literal step numbers and names in `Print:` directives and examples throughout this file.** Examples shown below assume standalone mode; when nested, prepend the parent context.
 
@@ -39,7 +39,7 @@ Step Name Registry:
 
 - Use empty string for the `description` parameter on all Bash tool calls.
 - Use terse 3-5 word descriptions for Agent tool calls.
-- Do not produce explanatory prose between tool call outputs — only print: step breadcrumb lines (start `▶`, completion `✅`, skip `⏩`), all warning/error lines (`**⚠ ...`), structured summaries (voting tallies, scoreboards, round summaries, findings lists, final summary), and the compact reviewer status table (see below).
+- Do not produce explanatory prose between tool call outputs — only print: step breadcrumb lines (start `🔶`, completion `✅`, skip `⏩`), all warning/error lines (`**⚠ ...`), structured summaries (voting tallies, scoreboards, round summaries, findings lists, final summary), and the compact reviewer status table (see below).
 
 **Compact reviewer status table**: After launching all reviewers (Step 2), maintain a mental tracker of each reviewer's status. Print a compact table after EACH status change:
 

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -19,7 +19,7 @@ Review all changes on the current branch (vs `main`) using two specialized Claud
 
 **Every step MUST print clearly visible breadcrumb status lines** so the user can instantly see where execution is and which parent steps they are inside. Follow the formatting rules in `${CLAUDE_PLUGIN_ROOT}/skills/shared/progress-reporting.md`.
 
-- Print a **start line** when entering a step: e.g., `🔶 2: launch reviewers` (standalone) or `🔶 5.2: code review | launch reviewers` (nested from `/implement`)
+- Print a **start line** when entering a step: e.g., `> **🔶 2: launch reviewers**` (standalone) or `> **🔶 5.2: code review | launch reviewers**` (nested from `/implement`)
 - Print a **completion line** only when it carries informational payload. Pure "step complete" announcements without payload are not needed.
 - When `STEP_NUM_PREFIX` is non-empty, prepend it to step numbers. When `STEP_PATH_PREFIX` is non-empty, prepend it to breadcrumb paths. **This rule overrides the literal step numbers and names in `Print:` directives and examples throughout this file.** Examples shown below assume standalone mode; when nested, prepend the parent context.
 

--- a/skills/shared/progress-reporting.md
+++ b/skills/shared/progress-reporting.md
@@ -19,7 +19,7 @@ Every progress line follows:
 
 | Icon | Line type | When to use |
 |------|-----------|-------------|
-| `▶` | Step start | Entering a new step |
+| `🔶` | Step start | Entering a new step |
 | `✅` | Completion | Step completed with informational payload |
 | `⏩` | Sub-step skip | Optimization or workflow-conditional skip (quick mode, no changes, etc.) |
 | `⏭️` | Precondition skip | Entire step skipped due to missing precondition (repo unavailable, Slack not configured, merge not set) |
@@ -32,17 +32,18 @@ Every progress line follows:
 
 ## Step Start Formatting
 
-Step start lines (`▶`) get special visual treatment to make them easy to spot:
+Step start lines (`🔶`) get special visual treatment to make them easy to spot:
 
 1. **Separator line**: Print a line of 80 `━` characters immediately before every step start line.
 2. **Bold text**: Render the entire step start line in bold using `**...**` markdown.
+3. **Blockquote**: Wrap the bold line in a markdown blockquote (`>`) for color differentiation.
 
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-**▶ 2: implementation**
+> **🔶 2: implementation**
 ```
 
-Only `▶` step start lines get the separator and bold treatment. Completion (`✅`), skip (`⏩`/`⏭️`), warning (`⚠`), and other lines do NOT get separators or bold.
+Only `🔶` step start lines get the separator, blockquote, and bold treatment. Completion (`✅`), skip (`⏩`/`⏭️`), warning (`⚠`), and other lines do NOT get separators, blockquotes, or bold.
 
 ## Elapsed Time
 
@@ -52,7 +53,7 @@ Every line that marks the **end** of a step or work item must include elapsed ti
 
 ### Step progress lines
 
-Append the elapsed time in parentheses at the end of the line, using short form. The timer starts when the step logically began (its `▶` start line, or entry into the step if no `▶` line exists).
+Append the elapsed time in parentheses at the end of the line, using short form. The timer starts when the step logically began (its `🔶` start line, or entry into the step if no `🔶` line exists).
 
 ```
 ✅ 2a.5: dialectic — 3 decisions resolved (1m42s)
@@ -110,27 +111,27 @@ When outputting a step:
 Standalone `/design` (no `--step-prefix`):
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-**▶ 2a: sketches**
+> **🔶 2a: sketches**
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-**▶ 2a.5: dialectic**
+> **🔶 2a.5: dialectic**
 ✅ 2a.5: dialectic — 3 decisions resolved (1m42s)
 ```
 
 `/design` called from `/implement` with `--step-prefix "1.::design plan"`:
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-**▶ 1.2a: design plan | sketches**
+> **🔶 1.2a: design plan | sketches**
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-**▶ 1.2a.5: design plan | dialectic**
+> **🔶 1.2a.5: design plan | dialectic**
 ✅ 1.2a.5: design plan | dialectic — 3 decisions resolved (1m42s)
 ```
 
 `/review` called from `/implement` with `--step-prefix "5.::code review"`:
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-**▶ 5.2: code review | launch reviewers**
+> **🔶 5.2: code review | launch reviewers**
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-**▶ 5.3: code review | review cycle**
+> **🔶 5.3: code review | review cycle**
 ```
 
 ## Section headers and structured output


### PR DESCRIPTION
## Summary
- Replaced the small `▶` step start icon with `🔶` (large orange diamond) across all 7 skill files for improved visibility
- Added blockquote wrapping (`>`) to step start lines for color differentiation in the terminal
- Updated all inline `Print:` directives to use the full `> **🔶 ...**` format, ensuring consistency between the shared progress reporting contract and local examples

<details><summary>Architecture Diagram</summary>

Quick mode — architecture diagram skipped.

</details>

<details><summary>Code Flow Diagram</summary>

Quick mode — code flow diagram skipped.

</details>

<details><summary>Goal</summary>

- Make step start section headers uniformly bold, colored, and prefixed with a large visible emoji across all larch skills
  - Replace the small `▶` triangle with `🔶` (large orange diamond) for better visibility
  - Add blockquote formatting (`>`) to step start lines for color differentiation
  - Update all `Print:` directives in SKILL.md files to match the canonical format from the shared progress reporting contract

</details>

<details><summary>Test plan</summary>

- [ ] Verify no `▶` references remain in skills/ directory
- [ ] Run `/relevant-checks` — all linting passes
- [ ] Verify `progress-reporting.md` examples show the new `> **🔶 ...` format
- [ ] Verify all SKILL.md `Print:` directives use `> **🔶 ...**` format
- [ ] Run any skill (e.g., `/implement --quick`) and confirm step start lines render with the new format

</details>

<details><summary>Final Design</summary>

**Files to modify**:
1. `skills/shared/progress-reporting.md` — Change icon taxonomy, step start formatting, and all examples
2. `skills/design/SKILL.md` — Update all `▶` references and `Print:` directives
3. `skills/implement/SKILL.md` — Update all `▶` references and `Print:` directives
4. `skills/review/SKILL.md` — Update all `▶` references and `Print:` directives
5. `skills/research/SKILL.md` — Update all `▶` references and `Print:` directives
6. `skills/loop-review/SKILL.md` — Update all `▶` references and `Print:` directives
7. `skills/fix-issue/SKILL.md` — Update all `▶` references and `Print:` directives

**Approach**:
- Replace `▶` → `🔶` everywhere in the icon taxonomy and all step start references
- Add blockquote rule (#3) to step start formatting section
- Update all examples to show `> **🔶 ...` format
- Update all `Print:` directives and `e.g.` examples to include full `> **🔶 ...**` formatting

</details>

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `96825c2` (Move lock before triage in /fix-issue, reduce Bash calls (#72))
- **Current version**: `2.0.9`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `2.0.10`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH").

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

Quick mode — no plan review was conducted.

</details>

<details><summary>Implementation Deviations</summary>

No deviations from the plan.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

### [Code Review] General Reviewer
**Finding**: `skills/loop-review/SKILL.md` lines 121-125 uses a custom double-separator + `🔍` header format for slice announcements that bypasses the standard step-start pattern from `progress-reporting.md`. The double-separator framing conflicts with the visual contract where separator lines should uniquely signal `🔶` step starts. The reviewer suggested either accepting it as a documented exception or aligning it to use a single preceding separator.
**Reason not implemented**: This is a pre-existing pattern that was not introduced or modified by this PR. The `🔍` slice announcement format serves a different purpose than step-start lines — it announces individual review slices within a step, not new top-level steps. Changing this pattern is out of scope for this PR, which focuses on making step-start headers uniform with `🔶` + blockquote + bold formatting across all skills.

### [Code Review] Deep Analysis Reviewer
**Finding**: `CHANGELOG.md` has no entry for this PR's changes. The reviewer noted that `[2.0.8]` (line 22) still documents the now-superseded `▶` icon, and a new entry should document the replacement with `🔶` and blockquote wrapping.
**Reason not implemented**: The CHANGELOG update is handled automatically by Step 8a of the `/implement` workflow after the version bump in Step 8. The entry will be added as part of the standard version bump process, not manually during implementation.

</details>

<details><summary>Plan Review Voting Tally</summary>

Quick mode — no plan review voting.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

Quick mode — no voting panel. Main agent reviewed findings from 2 Claude subagents.

</details>

<details><summary>Out-of-Scope Observations</summary>

**Accepted OOS (GitHub issues filed):**
No OOS items were accepted for issue filing.

**Non-accepted OOS observations:**
Quick mode — no out-of-scope observations collected.

</details>

<details><summary>Execution Issues</summary>

No execution issues encountered.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | N/A (quick mode) |
| Code review rounds | 1 |
| Code review findings | 1 accepted, 2 rejected |
| Warnings logged | 0 |
| Pre-existing issues noticed | 0 |
| OOS issues filed | N/A (quick mode) |
| External reviewers | N/A (quick mode) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
