### PR TITLE
Add failure diagnostics to health check and reviewer messages

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation with collaborative reviewers (Claude subagents + Codex + Cursor).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.0] - 2026-04-15
+
+### Changed
+
+- Added `.diag` diagnostic files to `run-external-reviewer.sh` for timeout, failure, and empty output cases
+- Health check failure banners in `session-setup.sh` now include the specific cause of failure
+- `collect-reviewer-results.sh` emits `FAILURE_REASON` field explaining why each non-OK reviewer failed
+- Updated `external-reviewers.md` and `voting-protocol.md` to instruct including failure reasons in all user-facing messages
+
 ## [2.2.0] - 2026-04-15
 
 ### Added

--- a/scripts/check-reviewers.sh
+++ b/scripts/check-reviewers.sh
@@ -117,6 +117,8 @@ if [[ "$PROBE" == "true" ]]; then
                 # Verify output is non-empty
                 if [[ -s "$PROBE_DIR/codex-probe.txt" ]]; then
                     CODEX_HEALTHY="true"
+                elif [[ -f "$PROBE_DIR/codex-probe.txt.diag" ]]; then
+                    CODEX_PROBE_ERROR=$(cat "$PROBE_DIR/codex-probe.txt.diag")
                 else
                     CODEX_PROBE_ERROR="Probe exited successfully but produced no output"
                 fi
@@ -140,6 +142,8 @@ if [[ "$PROBE" == "true" ]]; then
             if [[ "$CURSOR_EXIT" == "0" ]]; then
                 if [[ -s "$PROBE_DIR/cursor-probe.txt" ]]; then
                     CURSOR_HEALTHY="true"
+                elif [[ -f "$PROBE_DIR/cursor-probe.txt.diag" ]]; then
+                    CURSOR_PROBE_ERROR=$(cat "$PROBE_DIR/cursor-probe.txt.diag")
                 else
                     CURSOR_PROBE_ERROR="Probe exited successfully but produced no output"
                 fi
@@ -172,7 +176,7 @@ if [[ "$PROBE" == "true" ]]; then
         RETRY_SENTINELS=()
 
         if [[ "$RETRY_CODEX" == "true" ]]; then
-            rm -f "$PROBE_DIR/codex-probe.txt" "$PROBE_DIR/codex-probe.txt.done" "$PROBE_DIR/codex-probe.txt.meta"
+            rm -f "$PROBE_DIR/codex-probe.txt" "$PROBE_DIR/codex-probe.txt.done" "$PROBE_DIR/codex-probe.txt.meta" "$PROBE_DIR/codex-probe.txt.diag"
             CODEX_MODEL_ARGS=$("$SCRIPT_DIR/reviewer-model-args.sh" --tool codex)
             # shellcheck disable=SC2086
             "$SCRIPT_DIR/run-external-reviewer.sh" \
@@ -187,7 +191,7 @@ if [[ "$PROBE" == "true" ]]; then
         fi
 
         if [[ "$RETRY_CURSOR" == "true" ]]; then
-            rm -f "$PROBE_DIR/cursor-probe.txt" "$PROBE_DIR/cursor-probe.txt.done" "$PROBE_DIR/cursor-probe.txt.meta"
+            rm -f "$PROBE_DIR/cursor-probe.txt" "$PROBE_DIR/cursor-probe.txt.done" "$PROBE_DIR/cursor-probe.txt.meta" "$PROBE_DIR/cursor-probe.txt.diag"
             CURSOR_MODEL_ARGS=$("$SCRIPT_DIR/reviewer-model-args.sh" --tool cursor)
             # shellcheck disable=SC2086
             "$SCRIPT_DIR/run-external-reviewer.sh" \

--- a/scripts/check-reviewers.sh
+++ b/scripts/check-reviewers.sh
@@ -106,6 +106,9 @@ if [[ "$PROBE" == "true" ]]; then
             >"$PROBE_DIR/wait.log" 2>&1 || true
     fi
 
+    CODEX_PROBE_ERROR=""
+    CURSOR_PROBE_ERROR=""
+
     # Check codex probe result (skip if probe was not launched)
     if [[ "$CODEX_AVAILABLE" == "true" && "$SKIP_CODEX_PROBE" == "false" ]]; then
         if [[ -f "$PROBE_DIR/codex-probe.txt.done" ]]; then
@@ -114,8 +117,19 @@ if [[ "$PROBE" == "true" ]]; then
                 # Verify output is non-empty
                 if [[ -s "$PROBE_DIR/codex-probe.txt" ]]; then
                     CODEX_HEALTHY="true"
+                else
+                    CODEX_PROBE_ERROR="Probe exited successfully but produced no output"
+                fi
+            else
+                # Read .diag file if available, fall back to exit code
+                if [[ -f "$PROBE_DIR/codex-probe.txt.diag" ]]; then
+                    CODEX_PROBE_ERROR=$(cat "$PROBE_DIR/codex-probe.txt.diag")
+                else
+                    CODEX_PROBE_ERROR="Probe failed with exit code $CODEX_EXIT"
                 fi
             fi
+        else
+            CODEX_PROBE_ERROR="Probe process did not complete (sentinel file missing — possible crash or system kill)"
         fi
     fi
 
@@ -126,8 +140,18 @@ if [[ "$PROBE" == "true" ]]; then
             if [[ "$CURSOR_EXIT" == "0" ]]; then
                 if [[ -s "$PROBE_DIR/cursor-probe.txt" ]]; then
                     CURSOR_HEALTHY="true"
+                else
+                    CURSOR_PROBE_ERROR="Probe exited successfully but produced no output"
+                fi
+            else
+                if [[ -f "$PROBE_DIR/cursor-probe.txt.diag" ]]; then
+                    CURSOR_PROBE_ERROR=$(cat "$PROBE_DIR/cursor-probe.txt.diag")
+                else
+                    CURSOR_PROBE_ERROR="Probe failed with exit code $CURSOR_EXIT"
                 fi
             fi
+        else
+            CURSOR_PROBE_ERROR="Probe process did not complete (sentinel file missing — possible crash or system kill)"
         fi
     fi
 
@@ -188,7 +212,19 @@ if [[ "$PROBE" == "true" ]]; then
                 CODEX_EXIT=$(cat "$PROBE_DIR/codex-probe.txt.done")
                 if [[ "$CODEX_EXIT" == "0" && -s "$PROBE_DIR/codex-probe.txt" ]]; then
                     CODEX_HEALTHY="true"
+                    CODEX_PROBE_ERROR=""  # retry succeeded, clear error
+                else
+                    # Update error with retry failure info
+                    if [[ -f "$PROBE_DIR/codex-probe.txt.diag" ]]; then
+                        CODEX_PROBE_ERROR="Retry also failed: $(cat "$PROBE_DIR/codex-probe.txt.diag")"
+                    elif [[ "$CODEX_EXIT" == "0" ]]; then
+                        CODEX_PROBE_ERROR="Retry also produced no output"
+                    else
+                        CODEX_PROBE_ERROR="Retry also failed with exit code $CODEX_EXIT"
+                    fi
                 fi
+            else
+                CODEX_PROBE_ERROR="Retry process did not complete (sentinel file missing)"
             fi
         fi
 
@@ -198,7 +234,18 @@ if [[ "$PROBE" == "true" ]]; then
                 CURSOR_EXIT=$(cat "$PROBE_DIR/cursor-probe.txt.done")
                 if [[ "$CURSOR_EXIT" == "0" && -s "$PROBE_DIR/cursor-probe.txt" ]]; then
                     CURSOR_HEALTHY="true"
+                    CURSOR_PROBE_ERROR=""  # retry succeeded, clear error
+                else
+                    if [[ -f "$PROBE_DIR/cursor-probe.txt.diag" ]]; then
+                        CURSOR_PROBE_ERROR="Retry also failed: $(cat "$PROBE_DIR/cursor-probe.txt.diag")"
+                    elif [[ "$CURSOR_EXIT" == "0" ]]; then
+                        CURSOR_PROBE_ERROR="Retry also produced no output"
+                    else
+                        CURSOR_PROBE_ERROR="Retry also failed with exit code $CURSOR_EXIT"
+                    fi
                 fi
+            else
+                CURSOR_PROBE_ERROR="Retry process did not complete (sentinel file missing)"
             fi
         fi
     fi
@@ -208,9 +255,15 @@ if [[ "$PROBE" == "true" ]]; then
     # misleading *_HEALTHY=false into session-env.
     if [[ "$CODEX_AVAILABLE" == "true" ]]; then
         echo "CODEX_HEALTHY=$CODEX_HEALTHY"
+        if [[ -n "$CODEX_PROBE_ERROR" ]]; then
+            echo "CODEX_PROBE_ERROR=$CODEX_PROBE_ERROR"
+        fi
     fi
     if [[ "$CURSOR_AVAILABLE" == "true" ]]; then
         echo "CURSOR_HEALTHY=$CURSOR_HEALTHY"
+        if [[ -n "$CURSOR_PROBE_ERROR" ]]; then
+            echo "CURSOR_PROBE_ERROR=$CURSOR_PROBE_ERROR"
+        fi
     fi
 
 fi

--- a/scripts/collect-reviewer-results.sh
+++ b/scripts/collect-reviewer-results.sh
@@ -319,7 +319,14 @@ if [[ ${#RETRY_FILES[@]} -gt 0 ]]; then
                 else
                     # Retry also failed — NOW mark tool unhealthy
                     set_tool_unhealthy "$TOOL"
-                    RETRY_REASON=$(build_failure_reason "$RETRY_OUTPUT" "EMPTY_OUTPUT" "$RETRY_EXIT")
+                    if [[ "$RETRY_EXIT" == "124" ]]; then
+                        RETRY_STATUS="TIMED_OUT"
+                    elif [[ "$RETRY_EXIT" != "0" ]]; then
+                        RETRY_STATUS="FAILED"
+                    else
+                        RETRY_STATUS="EMPTY_OUTPUT"
+                    fi
+                    RETRY_REASON=$(build_failure_reason "$RETRY_OUTPUT" "$RETRY_STATUS" "$RETRY_EXIT")
                     RESULTS[IDX]="REVIEWER_FILE=$ORIG_OUTPUT|TOOL=$TOOL|STATUS=EMPTY_OUTPUT|EXIT_CODE=0|HEALTHY=false|FAILURE_REASON=Retry also failed: $RETRY_REASON"
                 fi
             else

--- a/scripts/collect-reviewer-results.sh
+++ b/scripts/collect-reviewer-results.sh
@@ -29,6 +29,7 @@
 #   STATUS=<OK|TIMED_OUT|FAILED|EMPTY_OUTPUT|SENTINEL_TIMEOUT>
 #   EXIT_CODE=<N>
 #   HEALTHY=<true|false>
+#   FAILURE_REASON=<explanation>  (non-empty when STATUS != OK; explains the cause of failure)
 #
 # Exit codes:
 #   0 — normal completion (results are informational, not errors)
@@ -137,6 +138,28 @@ is_timed_out() {
     echo "$TIMED_OUT_SENTINELS" | grep -qxF "$needle"
 }
 
+# --- Helper: build failure reason from .diag file or status ---
+build_failure_reason() {
+    local output_file="$1"
+    local status="$2"
+    local exit_code="$3"
+    local diag_file="${output_file}.diag"
+
+    if [[ -f "$diag_file" ]]; then
+        cat "$diag_file"
+        return
+    fi
+
+    # Fallback: construct reason from status and exit code
+    case "$status" in
+        SENTINEL_TIMEOUT) echo "Process did not complete (sentinel file missing — possible crash or system kill)" ;;
+        TIMED_OUT)        echo "Process timed out (exit code 124)" ;;
+        FAILED)           echo "Process failed with exit code $exit_code" ;;
+        EMPTY_OUTPUT)     echo "Process exited successfully but produced no output" ;;
+        *)                echo "Unknown failure (status=$status, exit_code=$exit_code)" ;;
+    esac
+}
+
 # --- 2. Validate each output and collect results ---
 RETRY_FILES=()
 RETRY_INDICES=()
@@ -151,6 +174,7 @@ for i in "${!OUTPUT_FILES[@]}"; do
     STATUS="OK"
     EXIT_CODE="0"
     HEALTHY="true"
+    FAILURE_REASON=""
 
     # F1 fix: strip .done suffix to match wait-for-reviewers.sh output format
     SENTINEL_BASE=$(basename "$SENTINEL" .done)
@@ -159,19 +183,23 @@ for i in "${!OUTPUT_FILES[@]}"; do
         STATUS="SENTINEL_TIMEOUT"
         EXIT_CODE="124"
         HEALTHY="false"
+        FAILURE_REASON=$(build_failure_reason "$OUTPUT" "$STATUS" "$EXIT_CODE")
     elif [[ -f "$SENTINEL" ]]; then
         EXIT_CODE=$(cat "$SENTINEL" 2>/dev/null || echo "99")
         if [[ "$EXIT_CODE" == "124" ]]; then
             STATUS="TIMED_OUT"
             HEALTHY="false"
+            FAILURE_REASON=$(build_failure_reason "$OUTPUT" "$STATUS" "$EXIT_CODE")
         elif [[ "$EXIT_CODE" != "0" ]]; then
             STATUS="FAILED"
             HEALTHY="false"
+            FAILURE_REASON=$(build_failure_reason "$OUTPUT" "$STATUS" "$EXIT_CODE")
         elif [[ ! -s "$OUTPUT" ]]; then
             # F4 fix: empty output is a retry candidate, NOT an immediate health failure.
             # Health is only set to false after retry also fails (see section 3 below).
             STATUS="EMPTY_OUTPUT"
             HEALTHY="true"  # tentative — will be set false if retry fails
+            FAILURE_REASON=$(build_failure_reason "$OUTPUT" "$STATUS" "$EXIT_CODE")
             # Queue for retry if .meta exists
             if [[ -f "$META" ]]; then
                 # Parse META_TIMEOUT for retry wait calculation
@@ -193,6 +221,7 @@ for i in "${!OUTPUT_FILES[@]}"; do
         STATUS="SENTINEL_TIMEOUT"
         EXIT_CODE="124"
         HEALTHY="false"
+        FAILURE_REASON=$(build_failure_reason "$OUTPUT" "$STATUS" "$EXIT_CODE")
     fi
 
     # Monotonic health: if this tool was already marked unhealthy, keep it
@@ -203,7 +232,7 @@ for i in "${!OUTPUT_FILES[@]}"; do
         set_tool_unhealthy "$TOOL"
     fi
 
-    RESULTS+=("REVIEWER_FILE=$OUTPUT|TOOL=$TOOL|STATUS=$STATUS|EXIT_CODE=$EXIT_CODE|HEALTHY=$HEALTHY")
+    RESULTS+=("REVIEWER_FILE=$OUTPUT|TOOL=$TOOL|STATUS=$STATUS|EXIT_CODE=$EXIT_CODE|HEALTHY=$HEALTHY|FAILURE_REASON=$FAILURE_REASON")
 done
 
 # --- 3. Retry empty outputs using .meta files ---
@@ -286,16 +315,17 @@ if [[ ${#RETRY_FILES[@]} -gt 0 ]]; then
                     if [[ "$(get_tool_healthy "$TOOL")" == "false" ]]; then
                         HEALTHY="false"
                     fi
-                    RESULTS[IDX]="REVIEWER_FILE=$RETRY_OUTPUT|TOOL=$TOOL|STATUS=OK|EXIT_CODE=0|HEALTHY=$HEALTHY"
+                    RESULTS[IDX]="REVIEWER_FILE=$RETRY_OUTPUT|TOOL=$TOOL|STATUS=OK|EXIT_CODE=0|HEALTHY=$HEALTHY|FAILURE_REASON="
                 else
                     # Retry also failed — NOW mark tool unhealthy
                     set_tool_unhealthy "$TOOL"
-                    RESULTS[IDX]="REVIEWER_FILE=$ORIG_OUTPUT|TOOL=$TOOL|STATUS=EMPTY_OUTPUT|EXIT_CODE=0|HEALTHY=false"
+                    RETRY_REASON=$(build_failure_reason "$RETRY_OUTPUT" "EMPTY_OUTPUT" "$RETRY_EXIT")
+                    RESULTS[IDX]="REVIEWER_FILE=$ORIG_OUTPUT|TOOL=$TOOL|STATUS=EMPTY_OUTPUT|EXIT_CODE=0|HEALTHY=false|FAILURE_REASON=Retry also failed: $RETRY_REASON"
                 fi
             else
                 # Retry sentinel never appeared — mark unhealthy
                 set_tool_unhealthy "$TOOL"
-                RESULTS[IDX]="REVIEWER_FILE=$ORIG_OUTPUT|TOOL=$TOOL|STATUS=EMPTY_OUTPUT|EXIT_CODE=0|HEALTHY=false"
+                RESULTS[IDX]="REVIEWER_FILE=$ORIG_OUTPUT|TOOL=$TOOL|STATUS=EMPTY_OUTPUT|EXIT_CODE=0|HEALTHY=false|FAILURE_REASON=Retry process did not complete (sentinel file missing)"
             fi
         done
     fi

--- a/scripts/run-external-reviewer.sh
+++ b/scripts/run-external-reviewer.sh
@@ -58,8 +58,8 @@ if [[ $# -eq 0 ]]; then
     usage; exit 1
 fi
 
-# Clear stale output, sentinel, and metadata files
-rm -f "$OUTPUT_FILE" "${OUTPUT_FILE}.done" "${OUTPUT_FILE}.meta"
+# Clear stale output, sentinel, metadata, and diagnostic files
+rm -f "$OUTPUT_FILE" "${OUTPUT_FILE}.done" "${OUTPUT_FILE}.meta" "${OUTPUT_FILE}.diag"
 
 # Write sentinel file on ANY exit — the reliable completion signal for callers.
 # Callers poll for <output-file>.done instead of waiting for runtime notifications.
@@ -130,7 +130,7 @@ if [ "$EXIT_CODE" -ne 0 ]; then
         echo "--- ${TOOL_NAME} output (last 5 lines) ---"
         tail -5 "$OUTPUT_FILE"
         echo "--- end ---"
-        DIAG_DETAIL=" Last output: $(tail -1 "$OUTPUT_FILE" | head -c 200)"
+        DIAG_DETAIL=" Last output: $(tail -1 "$OUTPUT_FILE" | head -c 200 | tr '|' ' ')"
     fi
     # Write diagnostic file for callers
     echo "Failed with exit code ${EXIT_CODE} after ${SECONDS}s. Output size: ${OUTPUT_SIZE} bytes.${DIAG_DETAIL}" > "${OUTPUT_FILE}.diag"

--- a/scripts/run-external-reviewer.sh
+++ b/scripts/run-external-reviewer.sh
@@ -102,6 +102,8 @@ while kill -0 "$PID" 2>/dev/null; do
             OUTPUT_SIZE=$(wc -c < "$OUTPUT_FILE" | tr -d ' ')
         fi
         echo "❌ ${TOOL_NAME} review: TIMED OUT (exit code 124, ${SECONDS}s elapsed, output ${OUTPUT_SIZE} bytes)"
+        # Write diagnostic file for callers
+        echo "Timed out after ${SECONDS}s (limit: ${TIMEOUT_SECONDS}s). Process was killed after exceeding the timeout. Output size: ${OUTPUT_SIZE} bytes." > "${OUTPUT_FILE}.diag"
         EXIT_CODE=124
         exit "$EXIT_CODE"
     fi
@@ -123,14 +125,20 @@ fi
 
 if [ "$EXIT_CODE" -ne 0 ]; then
     echo "❌ ${TOOL_NAME} review: FAILED (exit code ${EXIT_CODE}, ${SECONDS}s elapsed, output ${OUTPUT_SIZE} bytes)"
+    DIAG_DETAIL=""
     if [ "$OUTPUT_SIZE" -gt 0 ]; then
         echo "--- ${TOOL_NAME} output (last 5 lines) ---"
         tail -5 "$OUTPUT_FILE"
         echo "--- end ---"
+        DIAG_DETAIL=" Last output: $(tail -1 "$OUTPUT_FILE" | head -c 200)"
     fi
+    # Write diagnostic file for callers
+    echo "Failed with exit code ${EXIT_CODE} after ${SECONDS}s. Output size: ${OUTPUT_SIZE} bytes.${DIAG_DETAIL}" > "${OUTPUT_FILE}.diag"
 elif [ "$OUTPUT_SIZE" -eq 0 ]; then
     echo "⚠ ${TOOL_NAME} review: completed but OUTPUT IS EMPTY (exit code 0, ${SECONDS}s elapsed)"
     echo "This typically means ${TOOL_NAME} exited without producing findings."
+    # Write diagnostic file for callers
+    echo "Process exited successfully (code 0) after ${SECONDS}s but produced no output. This typically means the tool started but did not generate a response." > "${OUTPUT_FILE}.diag"
 else
     echo "✓ ${TOOL_NAME} review: completed (exit code 0, ${SECONDS}s elapsed, output ${OUTPUT_SIZE} bytes)"
 fi

--- a/scripts/session-setup.sh
+++ b/scripts/session-setup.sh
@@ -38,6 +38,8 @@
 #   CURSOR_AVAILABLE=true|false Output when --check-reviewers
 #   CODEX_HEALTHY=true|false    Output when --check-reviewers, or passthrough from --caller-env
 #   CURSOR_HEALTHY=true|false   Output when --check-reviewers, or passthrough from --caller-env
+#   CODEX_PROBE_ERROR=<reason>  Output when --check-reviewers and CODEX_HEALTHY=false (explains why)
+#   CURSOR_PROBE_ERROR=<reason> Output when --check-reviewers and CURSOR_HEALTHY=false (explains why)
 #
 # On preflight failure, outputs PREFLIGHT_ERROR=<message> and exits non-zero.
 #
@@ -283,13 +285,17 @@ if [[ "$CHECK_REVIEWERS" == "true" ]]; then
     PROBED_CURSOR_AVAILABLE=""
     PROBED_CODEX_HEALTHY=""
     PROBED_CURSOR_HEALTHY=""
+    PROBED_CODEX_PROBE_ERROR=""
+    PROBED_CURSOR_PROBE_ERROR=""
     while IFS='=' read -r key value || [[ -n "$key" ]]; do
         [[ -z "$key" || "$key" =~ ^# ]] && continue
         case "$key" in
-            CODEX_AVAILABLE)  PROBED_CODEX_AVAILABLE="$value" ;;
-            CURSOR_AVAILABLE) PROBED_CURSOR_AVAILABLE="$value" ;;
-            CODEX_HEALTHY)    PROBED_CODEX_HEALTHY="$value" ;;
-            CURSOR_HEALTHY)   PROBED_CURSOR_HEALTHY="$value" ;;
+            CODEX_AVAILABLE)   PROBED_CODEX_AVAILABLE="$value" ;;
+            CURSOR_AVAILABLE)  PROBED_CURSOR_AVAILABLE="$value" ;;
+            CODEX_HEALTHY)     PROBED_CODEX_HEALTHY="$value" ;;
+            CURSOR_HEALTHY)    PROBED_CURSOR_HEALTHY="$value" ;;
+            CODEX_PROBE_ERROR) PROBED_CODEX_PROBE_ERROR="$value" ;;
+            CURSOR_PROBE_ERROR) PROBED_CURSOR_PROBE_ERROR="$value" ;;
         esac
     done <<< "$REVIEWER_OUTPUT"
 
@@ -297,6 +303,8 @@ if [[ "$CHECK_REVIEWERS" == "true" ]]; then
     [[ -n "$PROBED_CURSOR_AVAILABLE" ]] && echo "CURSOR_AVAILABLE=$PROBED_CURSOR_AVAILABLE"
     [[ -n "$PROBED_CODEX_HEALTHY" ]] && echo "CODEX_HEALTHY=$PROBED_CODEX_HEALTHY"
     [[ -n "$PROBED_CURSOR_HEALTHY" ]] && echo "CURSOR_HEALTHY=$PROBED_CURSOR_HEALTHY"
+    [[ -n "$PROBED_CODEX_PROBE_ERROR" ]] && echo "CODEX_PROBE_ERROR=$PROBED_CODEX_PROBE_ERROR"
+    [[ -n "$PROBED_CURSOR_PROBE_ERROR" ]] && echo "CURSOR_PROBE_ERROR=$PROBED_CURSOR_PROBE_ERROR"
 
     # Emit prominent banners to stderr for failed health checks (must be here,
     # not in check-reviewers.sh, because session-setup captures its stdout+stderr
@@ -305,7 +313,11 @@ if [[ "$CHECK_REVIEWERS" == "true" ]]; then
           && "$SKIP_CODEX_PROBE" == "false" ]]; then
         echo "═══════════════════════════════════════════════════════════" >&2
         echo "  ⚠  CODEX HEALTH CHECK FAILED — not responding" >&2
-        echo "     Codex binary found but health probe timed out or errored." >&2
+        if [[ -n "$PROBED_CODEX_PROBE_ERROR" ]]; then
+            echo "     Cause: $PROBED_CODEX_PROBE_ERROR" >&2
+        else
+            echo "     Codex binary found but health probe timed out or errored." >&2
+        fi
         echo "     Will use Claude replacement for this session." >&2
         echo "═══════════════════════════════════════════════════════════" >&2
     fi
@@ -313,7 +325,11 @@ if [[ "$CHECK_REVIEWERS" == "true" ]]; then
           && "$SKIP_CURSOR_PROBE" == "false" ]]; then
         echo "═══════════════════════════════════════════════════════════" >&2
         echo "  ⚠  CURSOR HEALTH CHECK FAILED — not responding" >&2
-        echo "     Cursor binary found but health probe timed out or errored." >&2
+        if [[ -n "$PROBED_CURSOR_PROBE_ERROR" ]]; then
+            echo "     Cause: $PROBED_CURSOR_PROBE_ERROR" >&2
+        else
+            echo "     Cursor binary found but health probe timed out or errored." >&2
+        fi
         echo "     Will use Claude replacement for this session." >&2
         echo "═══════════════════════════════════════════════════════════" >&2
     fi

--- a/skills/shared/external-reviewers.md
+++ b/skills/shared/external-reviewers.md
@@ -65,7 +65,7 @@ FAILURE_REASON=<explanation>
 
 Parse each reviewer's `STATUS`, `REVIEWER_FILE`, and `FAILURE_REASON`:
 - `STATUS=OK`: Read the output file — it is non-empty and validated. `FAILURE_REASON` is empty.
-- Any other status: The reviewer failed. `FAILURE_REASON` explains why (e.g., "Timed out after 1800s (limit: 1800s). Process was killed after exceeding the timeout." or "Failed with exit code 1 after 5s. Last output: error message here"). Follow the **Runtime Timeout Fallback** procedure below, including `FAILURE_REASON` in the message.
+- Any other status: The reviewer failed. `FAILURE_REASON` explains why (e.g., "Timed out after 1800s (limit: 1800s). Process was killed after exceeding the timeout." or "Failed with exit code 1 after 5s. Last output: error message here"). Follow the **Runtime Timeout Fallback** procedure above, including `FAILURE_REASON` in the message.
 
 **Important**: Do NOT read output files before calling `collect-reviewer-results.sh`. Cursor buffers all stdout until exit — its output file is empty until the process finishes. The collection script handles all sentinel polling and validation internally.
 

--- a/skills/shared/external-reviewers.md
+++ b/skills/shared/external-reviewers.md
@@ -18,9 +18,9 @@ The `--check-reviewers` flag runs `check-reviewers.sh --probe` internally and em
 
 Set mental flags `codex_available` and `cursor_available` based on the output:
 - If `CODEX_AVAILABLE=false`: `codex_available=false`. Print: `**⚠ Codex not available (binary not found). Proceeding without Codex reviewer.**`
-- Else if `CODEX_HEALTHY=false`: `codex_available=false`. Print: `**⚠ Codex installed but not responding (health check failed). Using Claude replacement.**`
+- Else if `CODEX_HEALTHY=false`: `codex_available=false`. Print: `**⚠ Codex installed but not responding (health check failed: <CODEX_PROBE_ERROR>). Using Claude replacement.**` where `<CODEX_PROBE_ERROR>` is the `CODEX_PROBE_ERROR` value from `session-setup.sh` output (if available; omit the parenthetical detail if not present).
 - Else: `codex_available=true`
-- Same logic for Cursor.
+- Same logic for Cursor (using `CURSOR_PROBE_ERROR`).
 
 **Note**: `*_AVAILABLE` is a pure install-state signal (binary exists on PATH). `*_HEALTHY` indicates whether the tool actually responded to a trivial prompt within the 60-second probe timeout. Callers must combine both to determine runtime usability.
 
@@ -33,7 +33,9 @@ When processing reviewer results (after `wait-for-reviewers.sh` returns), check 
 - Output is empty/invalid after the retry-once procedure (per "Validating External Reviewer Output" below)
 - `wait-for-reviewers.sh` reports `TIMEOUT` for the reviewer (sentinel never appeared — wrapper killed externally)
 
-Print: `**⚠ <Reviewer> timed out — using Claude replacement for remainder of session.**`
+Print: `**⚠ <Reviewer> failed — <FAILURE_REASON>. Using Claude replacement for remainder of session.**`
+
+Where `<FAILURE_REASON>` is the `FAILURE_REASON` value from `collect-reviewer-results.sh` output (or from the `.diag` file if collecting results manually). Always include the reason so the user can diagnose the root cause (e.g., timeout duration, exit code, last error output).
 
 This is a mental flag flip within the current skill invocation. For cross-skill propagation within `/implement`, child skills write a structured health status file — see the `/implement` SKILL.md for details.
 
@@ -58,11 +60,12 @@ TOOL=<codex|cursor|unknown>
 STATUS=<OK|TIMED_OUT|FAILED|EMPTY_OUTPUT|SENTINEL_TIMEOUT>
 EXIT_CODE=<N>
 HEALTHY=<true|false>
+FAILURE_REASON=<explanation>
 ```
 
-Parse each reviewer's `STATUS` and `REVIEWER_FILE`:
-- `STATUS=OK`: Read the output file — it is non-empty and validated.
-- Any other status: The reviewer failed. Follow the **Runtime Timeout Fallback** procedure below.
+Parse each reviewer's `STATUS`, `REVIEWER_FILE`, and `FAILURE_REASON`:
+- `STATUS=OK`: Read the output file — it is non-empty and validated. `FAILURE_REASON` is empty.
+- Any other status: The reviewer failed. `FAILURE_REASON` explains why (e.g., "Timed out after 1800s (limit: 1800s). Process was killed after exceeding the timeout." or "Failed with exit code 1 after 5s. Last output: error message here"). Follow the **Runtime Timeout Fallback** procedure below, including `FAILURE_REASON` in the message.
 
 **Important**: Do NOT read output files before calling `collect-reviewer-results.sh`. Cursor buffers all stdout until exit — its output file is empty until the process finishes. The collection script handles all sentinel polling and validation internally.
 

--- a/skills/shared/voting-protocol.md
+++ b/skills/shared/voting-protocol.md
@@ -135,6 +135,8 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/wait-for-reviewers.sh --timeout 1260 \
 
 Use `timeout: 1260000` on the Bash tool call. **Do NOT** set `run_in_background: true` — this call must block. Note: voter output files use the `-vote-` infix to avoid collision with reviewer output files (`-plan-output` or `-output`).
 
+**Collecting voter results**: Use `collect-reviewer-results.sh` to validate external voter outputs (same as for reviewer outputs). Parse `STATUS` and `FAILURE_REASON` for each voter. If a voter fails (`STATUS != OK`), print: `**⚠ <Voter> voter failed — <FAILURE_REASON>. Proceeding with <N> voters (<remaining voter names>).**` Always include the `FAILURE_REASON` so the user can see why the voter failed (e.g., timeout, crash, empty output). Reduce the eligible voter count accordingly and apply the threshold rules above.
+
 ## Competition Scoring
 
 After tallying votes, compute a score for each **original reviewer** (not voters):


### PR DESCRIPTION
## Summary
- Added `.diag` diagnostic files to `run-external-reviewer.sh` that capture one-line failure reasons on timeout, failure, or empty output
- Surfaced diagnostics through the full reporting chain: `check-reviewers.sh` emits `*_PROBE_ERROR`, `session-setup.sh` includes them in banners, `collect-reviewer-results.sh` emits `FAILURE_REASON`
- Updated `external-reviewers.md` and `voting-protocol.md` templates to instruct including failure reasons in all user-facing messages

<details><summary>Architecture Diagram</summary>

Quick mode — architecture diagram skipped.

</details>

<details><summary>Code Flow Diagram</summary>

Quick mode — code flow diagram skipped.

</details>

<details><summary>Goal</summary>

- Add clear explanation of failure cause whenever a health check or reviewer/voter fails
  - Health check probes: show timeout duration, exit code, or empty output details in the banner
  - Reviewer failures: include `FAILURE_REASON` in all runtime timeout fallback messages
  - Voter failures: include `FAILURE_REASON` when reporting degraded voter panel
- Ensure no failure message path exists without an accompanying explanation of the root cause

</details>

<details><summary>Test plan</summary>

- [ ] Verify health check failure banner includes cause when Codex/Cursor probe times out
- [ ] Verify `collect-reviewer-results.sh` output includes `FAILURE_REASON` for non-OK reviewers
- [ ] Verify `.diag` files are written on timeout, failure, and empty output paths
- [ ] Verify stale `.diag` files are cleaned up on retry
- [ ] Verify pipe characters in reviewer output don't corrupt the pipe-delimited format
- [ ] Run `/relevant-checks` — shellcheck, markdownlint, agent-lint all pass

</details>

<details><summary>Final Design</summary>

**Implementation Plan (quick mode)**:
1. `run-external-reviewer.sh` — write `${OUTPUT_FILE}.diag` with one-line failure reason on timeout, failure, or empty output
2. `check-reviewers.sh` — read `.diag` files, emit `CODEX_PROBE_ERROR`/`CURSOR_PROBE_ERROR` keys
3. `session-setup.sh` — parse `*_PROBE_ERROR` keys, include in health check banners
4. `collect-reviewer-results.sh` — add `build_failure_reason()` helper, emit `FAILURE_REASON` per reviewer
5. `external-reviewers.md` — update failure message templates to reference `FAILURE_REASON`
6. `voting-protocol.md` — add voter failure message instruction with `FAILURE_REASON`

</details>

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `e54a9ba` (Add /imaq alias for /implement --merge --auto --quick (#77))
- **Current version**: `2.2.0`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: MINOR

- **New version**: `2.3.0`

### MINOR evidence
- Added `skills/im/SKILL.md`
- Added `skills/imaq/SKILL.md`

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

Quick mode — no plan review was conducted.

</details>

<details><summary>Implementation Deviations</summary>

No deviations from the plan.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

All code review suggestions were implemented.

</details>

<details><summary>Plan Review Voting Tally</summary>

Quick mode — no plan review voting.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

Quick mode — no voting panel. Main agent reviewed findings from 2 Claude subagents.

</details>

<details><summary>Out-of-Scope Observations</summary>

Quick mode — no out-of-scope observations collected.

</details>

<details><summary>Execution Issues</summary>

No execution issues encountered.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | N/A (quick mode) |
| Code review rounds | 1 |
| Code review findings | 5 accepted, 0 rejected |
| Warnings logged | 0 |
| Pre-existing issues noticed | 0 |
| OOS issues filed | N/A (quick mode) |
| External reviewers | N/A (quick mode) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
