### PR TITLE
Change /imaq argument-hint to <arguments> to match /im

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation with collaborative reviewers (Claude subagents + Codex + Cursor).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.1] - 2026-04-15
+
+### Changed
+
+- Changed `/imaq` `argument-hint` from `<feature-description>` to `<arguments>` to match `/im`, signaling that extra flags are forwarded to `/implement`
+- Fixed `generate-alias.sh` to emit `<arguments>` as the argument-hint for newly generated aliases
+
 ## [2.3.0] - 2026-04-15
 
 ### Changed

--- a/skills/alias/scripts/generate-alias.sh
+++ b/skills/alias/scripts/generate-alias.sh
@@ -61,7 +61,7 @@ HEREDOC_START
 
 echo "name: ${NAME}"
 echo "description: \"${DESC}\""
-echo "argument-hint: \"<feature-description>\""
+echo "argument-hint: \"<arguments>\""
 echo "allowed-tools: Skill"
 
 cat <<'HEREDOC_MID'

--- a/skills/imaq/SKILL.md
+++ b/skills/imaq/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: imaq
 description: "Use when implementing a feature quickly and autonomously with auto-merge. Shortcut for /implement --merge --auto --quick."
-argument-hint: "<feature-description>"
+argument-hint: "<arguments>"
 allowed-tools: Skill
 ---
 


### PR DESCRIPTION
## Summary
- Changed `/imaq` `argument-hint` from `<feature-description>` to `<arguments>` to match `/im`, signaling that extra flags are forwarded to `/implement`
- Fixed `generate-alias.sh` to emit `<arguments>` as the argument-hint for newly generated aliases (root cause fix)

<details><summary>Architecture Diagram</summary>

Quick mode — architecture diagram skipped.

</details>

<details><summary>Code Flow Diagram</summary>

Quick mode — code flow diagram skipped.

</details>

<details><summary>Goal</summary>

- Align `/imaq` argument-hint with `/im` so both signal that arbitrary flags/arguments are accepted and forwarded to `/implement`
  - Change `argument-hint` frontmatter from `<feature-description>` to `<arguments>`
  - Fix the generator (`generate-alias.sh`) so future aliases also use `<arguments>`

</details>

<details><summary>Test plan</summary>

- [x] Verify `skills/imaq/SKILL.md` frontmatter has `argument-hint: "<arguments>"`
- [x] Verify `skills/im/SKILL.md` frontmatter matches (already `<arguments>`)
- [x] Verify `skills/alias/scripts/generate-alias.sh` emits `<arguments>` on line 64
- [x] Run `/relevant-checks` — shellcheck, markdownlint, agent-lint all pass

</details>

<details><summary>Final Design</summary>

**File to modify:** `skills/imaq/SKILL.md`

**Change:** Line 4 — change `argument-hint: "<feature-description>"` to `argument-hint: "<arguments>"`

This is a one-line frontmatter change. The `<arguments>` hint (matching `/im`) signals to users that the skill accepts arbitrary flags/arguments, not just a feature description string. The actual forwarding behavior (`$ARGUMENTS`) is already correct on line 18 — this is purely a hint alignment fix.

**Code review addition:** Also fix `skills/alias/scripts/generate-alias.sh` line 64 to emit `<arguments>` instead of `<feature-description>`, fixing the root cause so future aliases are consistent.

</details>

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `ba98620` (Add failure diagnostics to health check and reviewer messages (#79))
- **Current version**: `2.3.0`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `2.3.1`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH").

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

Quick mode — no plan review was conducted.

</details>

<details><summary>Implementation Deviations</summary>

Code review identified the root cause in `generate-alias.sh` — the generator still hardcoded `<feature-description>`. This was not in the original inline plan but is a necessary fix to prevent regression. Accepted and implemented.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

All code review suggestions were implemented.

</details>

<details><summary>Plan Review Voting Tally</summary>

Quick mode — no plan review voting.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

Quick mode — no voting panel. Main agent reviewed findings from 2 Claude subagents.

</details>

<details><summary>Out-of-Scope Observations</summary>

Quick mode — no out-of-scope observations collected.

</details>

<details><summary>Execution Issues</summary>

No execution issues encountered.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | N/A (quick mode) |
| Code review rounds | 1 |
| Code review findings | 1 accepted, 0 rejected |
| Warnings logged | 0 |
| Pre-existing issues noticed | 0 |
| OOS issues filed | N/A (quick mode) |
| External reviewers | N/A (quick mode) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
