### PR TITLE
Drop Description column from Aliases table in README

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation with collaborative reviewers (Claude subagents + Codex + Cursor).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.2] - 2026-04-15
+
+### Changed
+
+- Dropped the Description column from the Aliases table in README.md for a leaner two-column layout
+
 ## [2.3.1] - 2026-04-15
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -127,10 +127,10 @@ Slash commands available in Claude Code sessions. They automate multi-step workf
 
 Shortcut skills shipped with the plugin. Each alias forwards to an existing skill with preset flags.
 
-| Alias | Equivalent | Description |
-|---|---|---|
-| [`/im`](skills/im/SKILL.md) | `/implement --merge` | Implement a feature and merge the PR after CI passes. |
-| [`/imaq`](skills/imaq/SKILL.md) | `/implement --merge --auto --quick` | Quick autonomous implementation — skips `/design`, uses simplified code review, suppresses interactive questions, and merges after CI. |
+| Alias | Equivalent |
+|---|---|
+| [`/im`](skills/im/SKILL.md) | `/implement --merge` |
+| [`/imaq`](skills/imaq/SKILL.md) | `/implement --merge --auto --quick` |
 
 ## Review Agents
 


### PR DESCRIPTION
## Summary
- Dropped the Description column from the Aliases table in README.md, leaving a leaner two-column (Alias, Equivalent) layout

<details><summary>Architecture Diagram</summary>

Quick mode — architecture diagram skipped.

</details>

<details><summary>Code Flow Diagram</summary>

Quick mode — code flow diagram skipped.

</details>

<details><summary>Goal</summary>

- Remove the third (Description) column from the Aliases table in README.md
  - The descriptions duplicate information already available in each alias's linked SKILL.md file
  - Simplify the table to just Alias and Equivalent columns

</details>

<details><summary>Test plan</summary>

- [x] Verify the Aliases table renders correctly with two columns in GitHub Markdown
- [x] Confirm no other tables or sections in README.md were affected
- [x] Verify the linked SKILL.md paths still exist and contain the description information

</details>

<details><summary>Final Design</summary>

**Inline plan (quick mode):**
- **File**: `README.md` (lines 130–133)
- **Change**: Remove the third column (Description) from the Aliases table — drop `| Description |` from the header, the third `---|` from the separator, and the trailing `| ... |` description cell from each data row
- **Edge cases**: Ensure the table still renders correctly with only 2 columns (Alias, Equivalent)

</details>

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `ba98620` (Add failure diagnostics to health check and reviewer messages (#79))
- **Current version**: `2.3.1`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `2.3.2`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH").

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

Quick mode — no plan review was conducted.

</details>

<details><summary>Implementation Deviations</summary>

No deviations from the plan.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

All code review suggestions were implemented.

</details>

<details><summary>Plan Review Voting Tally</summary>

Quick mode — no plan review voting.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

Quick mode — no voting panel. Main agent reviewed findings from 2 Claude subagents.

</details>

<details><summary>Out-of-Scope Observations</summary>

**Accepted OOS (GitHub issues filed):**
No OOS items were accepted for issue filing.

**Non-accepted OOS observations:**
Quick mode — no out-of-scope observations collected.

</details>

<details><summary>Execution Issues</summary>

No execution issues encountered.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | N/A (quick mode) |
| Code review rounds | 1 |
| Code review findings | 0 accepted, 0 rejected |
| Warnings logged | 0 |
| Pre-existing issues noticed | 0 |
| OOS issues filed | N/A (quick mode) |
| External reviewers | N/A (quick mode) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
