### PR TITLE
Add agent-lint v2.2.4 pre-commit hook with --pedantic

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation with collaborative reviewers (Claude subagents + Codex + Cursor).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/.claude/skills/relevant-checks/scripts/run-checks.sh
+++ b/.claude/skills/relevant-checks/scripts/run-checks.sh
@@ -24,7 +24,7 @@ run_post_checks() {
     if command -v agent-lint >/dev/null 2>&1; then
         echo ""
         echo "=== Running agent-lint ==="
-        agent-lint "$REPO_ROOT"
+        agent-lint --pedantic "$REPO_ROOT"
         return $?
     else
         echo ""

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,3 +37,4 @@ jobs:
       - uses: zhupanov/agent-lint@v2
         with:
           github-token: ${{ github.token }}
+          args: --pedantic

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,12 @@ repos:
         language: system
         types: [json]
 
+  - repo: https://github.com/zhupanov/agent-lint
+    rev: v2.2.4
+    hooks:
+      - id: agent-lint
+        args: [--pedantic]
+
   - repo: https://github.com/rhysd/actionlint
     rev: v1.7.7
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.3] - 2026-04-15
+
+### Added
+
+- Added `agent-lint` v2.2.4 as a pre-commit hook with `--pedantic` flag
+- Added `agent-lint` Make target for standalone invocation
+- Aligned `--pedantic` flag across all agent-lint invocations (CI action, `/relevant-checks` post-check)
+
 ## [2.3.2] - 2026-04-15
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Larch Makefile
 # Thin wrapper around pre-commit. Linter definitions live in .pre-commit-config.yaml.
 
-.PHONY: lint shellcheck markdownlint jsonlint actionlint setup
+.PHONY: lint shellcheck markdownlint jsonlint actionlint agent-lint setup
 
 lint:
 	pre-commit run --all-files
@@ -17,6 +17,9 @@ jsonlint:
 
 actionlint:
 	pre-commit run actionlint --all-files
+
+agent-lint:
+	pre-commit run agent-lint --all-files
 
 setup:
 	pre-commit install


### PR DESCRIPTION
## Summary
- Added `agent-lint` v2.2.4 as a pre-commit hook with `--pedantic` flag and a corresponding Makefile target
- Aligned `--pedantic` flag across all agent-lint invocations: CI GitHub Action and `/relevant-checks` post-check script

<details><summary>Architecture Diagram</summary>

Quick mode — architecture diagram skipped.

</details>

<details><summary>Code Flow Diagram</summary>

Quick mode — code flow diagram skipped.

</details>

<details><summary>Goal</summary>

- Add `agent-lint` as a pre-commit hook in `.pre-commit-config.yaml` at version v2.2.4 with `--pedantic` flag
  - Ensure local developers and CI `lint` job both run agent-lint via pre-commit
  - Add standalone `make agent-lint` target for convenience
- Run pre-commit on all files and fix any issues agent-lint surfaces
- Ensure consistency of `--pedantic` flag across all agent-lint invocation paths

</details>

<details><summary>Test plan</summary>

- [x] `pre-commit run --all-files` passes (including new agent-lint hook with `--pedantic`)
- [x] `/relevant-checks` passes on changed files
- [x] `make agent-lint` target works correctly
- [ ] CI `lint` job passes (runs `make lint` which includes new agent-lint hook)
- [ ] CI `agent-lint` job passes with `--pedantic` argument

</details>

<details><summary>Final Design</summary>

1. Add agent-lint hook to `.pre-commit-config.yaml` at `rev: v2.2.4` with `args: [--pedantic]`
2. Add `agent-lint` Make target and `.PHONY` entry
3. Run `pre-commit run --all-files` and fix issues
4. Align `--pedantic` flag in CI action and `run-checks.sh`

</details>

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `bb97704` (Drop Description column from Aliases table in README (#81))
- **Current version**: `2.3.2`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `2.3.3`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH").

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

Quick mode — no plan review was conducted.

</details>

<details><summary>Implementation Deviations</summary>

Code review identified that `--pedantic` should also be applied to the CI GitHub Action (`ci.yaml`) and the `/relevant-checks` post-check script (`run-checks.sh`). Both were updated to maintain consistency across all agent-lint invocation paths.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

All code review suggestions were implemented.

</details>

<details><summary>Plan Review Voting Tally</summary>

Quick mode — no plan review voting.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

Quick mode — no voting panel. Main agent reviewed findings from 2 Claude subagents.

</details>

<details><summary>Out-of-Scope Observations</summary>

Quick mode — no out-of-scope observations collected.

</details>

<details><summary>Execution Issues</summary>

No execution issues encountered.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | N/A (quick mode) |
| Code review rounds | 1 |
| Code review findings | 2 accepted, 0 rejected |
| Warnings logged | 0 |
| Pre-existing issues noticed | 0 |
| OOS issues filed | N/A (quick mode) |
| External reviewers | N/A (quick mode) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
