### PR TITLE
Add KARPATHY_CLAUDE.md and include in root CLAUDE.md

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.1] - 2026-04-18
+
+### Added
+
+- `KARPATHY_CLAUDE.md` at repo root — verbatim copy of Andrej Karpathy's coding guidelines (Think Before Coding, Simplicity First, Surgical Changes, Goal-Driven Execution).
+- `@KARPATHY_CLAUDE.md` include added to root `CLAUDE.md` after the existing `@AGENTS.md` include, loading the guidelines into developer context when working inside this repo.
+
 ## [3.0.0] - 2026-04-18
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,2 @@
 @AGENTS.md
+@KARPATHY_CLAUDE.md

--- a/KARPATHY_CLAUDE.md
+++ b/KARPATHY_CLAUDE.md
@@ -1,0 +1,65 @@
+# CLAUDE.md
+
+Behavioral guidelines to reduce common LLM coding mistakes. Merge with project-specific instructions as needed.
+
+**Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
+
+## 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+---
+
+**These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.


### PR DESCRIPTION
## Summary
- Added `KARPATHY_CLAUDE.md` at the repo root as a verbatim copy of Andrej Karpathy's published coding guidelines.
- Wired `@KARPATHY_CLAUDE.md` into root `CLAUDE.md` (after the existing `@AGENTS.md` include) so the guidelines load into developer context when working inside this repo.

<details><summary>Architecture Diagram</summary>

Quick mode — architecture diagram skipped.

</details>

<details><summary>Code Flow Diagram</summary>

Quick mode — code flow diagram skipped.

</details>

<details><summary>Goal</summary>

- Bring Andrej Karpathy's coding-guideline CLAUDE.md into this repo as a supplementary developer-context include.
  - Fetch the upstream file at `https://github.com/multica-ai/andrej-karpathy-skills/blob/main/CLAUDE.md` verbatim.
  - Store the copy at repo root as `KARPATHY_CLAUDE.md`.
- Make the guidelines take effect during local development on this repo.
  - Add `@KARPATHY_CLAUDE.md` to `CLAUDE.md`, placed immediately after the existing `@AGENTS.md` include, so Claude Code loads it alongside project instructions.

</details>

<details><summary>Test plan</summary>

- [x] `KARPATHY_CLAUDE.md` content matches upstream byte-for-byte.
- [x] `CLAUDE.md` contains both `@AGENTS.md` and `@KARPATHY_CLAUDE.md` in that order.
- [x] `/relevant-checks` passes (markdownlint, agnix, agent-lint).
- [x] Version bumped to 3.0.1 (PATCH — dev-context change only, no public plugin surface modified).
- [x] CHANGELOG entry added for 3.0.1.

</details>

<details><summary>Final Design</summary>

### Files

1. `KARPATHY_CLAUDE.md` (new) — verbatim copy of `https://raw.githubusercontent.com/multica-ai/andrej-karpathy-skills/main/CLAUDE.md`.
2. `CLAUDE.md` — add `@KARPATHY_CLAUDE.md` as the second include line after `@AGENTS.md`.

### Approach

- Fetch via raw URL to preserve content verbatim (avoid HTML-rendering artifacts).
- Write content unmodified to `KARPATHY_CLAUDE.md`.
- Append the new include to `CLAUDE.md`.

### Edge cases

- Content preserved verbatim — upstream updates can be pulled cleanly.
- `CLAUDE.md` include placement after `@AGENTS.md` matches the user-specified ordering.

</details>

<details><summary>Version Bump Reasoning</summary>

PATCH bump (3.0.0 → 3.0.1). Only developer-context files (`CLAUDE.md`, new `KARPATHY_CLAUDE.md`) changed; no changes to `skills/**` or `agents/**` public plugin surface. No escalation warranted.

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

Quick mode — no plan review was conducted.

</details>

<details><summary>Implementation Deviations</summary>

No deviations from the plan.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

### [Code Review] Claude Code Reviewer
**Finding**: In `KARPATHY_CLAUDE.md` line 1, the H1 heading `# CLAUDE.md` is an upstream artifact. When `@KARPATHY_CLAUDE.md` is expanded by Claude Code's CLAUDE.md-include mechanism, the `# CLAUDE.md` heading appears mid-document inside the already-loaded CLAUDE.md context and is misleading. Reviewer suggested either framing the include with a wrapper comment in CLAUDE.md, or renaming the heading in KARPATHY_CLAUDE.md to `# Karpathy Coding Guidelines`.
**Reason not implemented**: The user's explicit instruction was to "copy" the upstream file to `KARPATHY_CLAUDE.md` — a verbatim copy. Modifying the H1 heading would break the verbatim-copy contract, and the heading mismatch is cosmetic inside injected context (Claude Code parses `@`-includes as plain markdown, not as nested CLAUDE.md metadata). Upstream updates to the file can be pulled cleanly only if we keep it verbatim.

### [Code Review] Claude Code Reviewer
**Finding**: Reviewer expressed concern that placing `KARPATHY_CLAUDE.md` at the repo root will ship it to every plugin consumer via the `@KARPATHY_CLAUDE.md` include in `CLAUDE.md`, causing these behavioral guidelines to be injected into all consumers' Claude Code sessions. Suggested moving the file under `.claude/` if the inclusion is dev-only, or documenting the consumer impact in AGENTS.md.
**Reason not implemented**: Per `AGENTS.md` ("Repository layout"), the plugin's runtime surface is explicitly `skills/`, `agents/`, `hooks/`, `scripts/`, `.claude-plugin/`. Root-level `CLAUDE.md` and its `@`-includes are NOT in the runtime surface — they are developer-context files, loaded by Claude Code only when operating inside the larch repo, not when consumers install the plugin. The reviewer's concern assumes CLAUDE.md is shipped as plugin runtime, which contradicts AGENTS.md.

### [Code Review] Claude Code Reviewer
**Finding**: No CHANGELOG.md entry was added for this commit. Repo convention has a CHANGELOG entry per substantive change.
**Reason not implemented**: CHANGELOG updates are handled automatically by Step 8a of the `/implement` skill after the version bump in Step 8. Adding an entry manually now would duplicate or conflict with Step 8a's automatic update. (This has since been added in Step 8a — entry for 3.0.1 is in CHANGELOG.md.)

</details>

<details><summary>Plan Review Voting Tally</summary>

Quick mode — no plan review voting.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

Quick mode — no voting panel. Main agent reviewed findings from 1 Claude Code Reviewer subagent.

</details>

<details><summary>Out-of-Scope Observations</summary>

Quick mode — no out-of-scope observations collected.

</details>

<details><summary>Execution Issues</summary>

No execution issues encountered.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | N/A (quick mode) |
| Code review rounds | 1 |
| Code review findings | 0 accepted, 3 rejected |
| Warnings logged | 0 |
| Pre-existing issues noticed | 0 |
| OOS issues filed | N/A (quick mode) |
| External reviewers | N/A (quick mode) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
