### PR TITLE
Rename heading in KARPATHY_CLAUDE.md to match filename

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.2] - 2026-04-18
+
+### Changed
+
+- Renamed the top-level heading in `KARPATHY_CLAUDE.md` from `# CLAUDE.md` to `# KARPATHY_CLAUDE.md` to match the filename.
+
 ## [3.0.1] - 2026-04-18
 
 ### Added

--- a/KARPATHY_CLAUDE.md
+++ b/KARPATHY_CLAUDE.md
@@ -1,4 +1,4 @@
-# CLAUDE.md
+# KARPATHY_CLAUDE.md
 
 Behavioral guidelines to reduce common LLM coding mistakes. Merge with project-specific instructions as needed.
 


### PR DESCRIPTION
## Summary
- Renamed the top-level heading in `KARPATHY_CLAUDE.md` from `# CLAUDE.md` to `# KARPATHY_CLAUDE.md` so the heading matches the filename.

<details><summary>Architecture Diagram</summary>

Quick mode — architecture diagram skipped.

</details>

<details><summary>Code Flow Diagram</summary>

Quick mode — code flow diagram skipped.

</details>

<details><summary>Goal</summary>

- Make the heading of `KARPATHY_CLAUDE.md` self-identifying rather than inheriting the generic `CLAUDE.md` title from the source document.
  - Change the first line from `# CLAUDE.md` to `# KARPATHY_CLAUDE.md`.

</details>

<details><summary>Test plan</summary>

- [x] `pre-commit` + `agent-lint` pass.
- [x] First line of `KARPATHY_CLAUDE.md` reads `# KARPATHY_CLAUDE.md`.

</details>

<details><summary>Final Design</summary>

- **File to modify**: `KARPATHY_CLAUDE.md`
- **Change**: Replace the first line `# CLAUDE.md` with `# KARPATHY_CLAUDE.md`
- **Approach**: Single-line Edit.
- **Edge cases**: None.

</details>

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `76d229b` (Add KARPATHY_CLAUDE.md and include in root CLAUDE.md (#87))
- **Current version**: `3.0.1`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `3.0.2`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH").

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

Quick mode — no plan review was conducted.

</details>

<details><summary>Implementation Deviations</summary>

No deviations from the plan.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

All code review suggestions were implemented.

</details>

<details><summary>Plan Review Voting Tally</summary>

Quick mode — no plan review voting.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

Quick mode — no voting panel. User explicitly requested "No review" for this trivial one-line heading rename.

</details>

<details><summary>Out-of-Scope Observations</summary>

Quick mode — no out-of-scope observations collected.

</details>

<details><summary>Execution Issues</summary>

### CI Issues
- **Step 10**: Initial CI run failed transiently — `agent-lint` hook could not download `agent-lint v2.3.2` binary from GitHub Releases (HTTP 504 gateway timeout). Reran the failed job; CI passed on retry.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | N/A (quick mode) |
| Code review rounds | 0 (user requested no review) |
| Code review findings | 0 accepted, 0 rejected |
| Warnings logged | 0 |
| Pre-existing issues noticed | 0 |
| OOS issues filed | N/A (quick mode) |
| External reviewers | N/A (quick mode) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)

