### PR TITLE
Make /implement --quick use Cursor → Codex → Claude with 5 re-review rounds

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.4] - 2026-04-18
+
+### Changed
+
+- `/implement --quick` code review now uses a single-reviewer loop with the Cursor → Codex → Claude Code Reviewer subagent fallback chain, re-reviewing up to 5 rounds when a round's fixes introduce significant changes. Previously, quick mode ran a single Claude subagent for one round with no re-review. The fallback chain re-evaluates per round so runtime timeouts cascade to the next tier. Step 0 now explicitly sets the `cursor_available`/`codex_available` mental flags consumed by the new Step 5 selection logic.
+
 ## [3.0.3] - 2026-04-18
 
 ### Fixed

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -13,7 +13,7 @@ The feature to implement is described by `$ARGUMENTS` after flag stripping.
 
 **Flags**: Parse flags from the start of `$ARGUMENTS` before treating the remainder as the feature description. Flags may appear in any order; stop at the first non-flag token. After stripping all flags, save the remainder as `FEATURE_DESCRIPTION` — use this (not raw `$ARGUMENTS`) whenever the human-readable feature description is needed (e.g., PR body, design invocation, commit messages). **All boolean flags default to `false`. Only set a flag to `true` when its `--flag` token is explicitly present in the arguments. Flags are independent — the presence of one flag must not influence the default value of any other flag.**
 
-- `--quick`: Set a mental flag `quick_mode=true`. Default: `quick_mode=false`. When `quick_mode=true`: Step 1 skips `/design` (this skill creates the branch and an inline plan directly), Step 5 skips `/review` (a simplified one-round review with 1 Claude Code Reviewer subagent only — no external reviewers, no voting panel), and Step 7a skips the Code Flow Diagram. All other steps (CI wait, Slack, cleanup) run normally. The `--merge` opt-in is independent of `--quick`.
+- `--quick`: Set a mental flag `quick_mode=true`. Default: `quick_mode=false`. When `quick_mode=true`: Step 1 skips `/design` (this skill creates the branch and an inline plan directly), Step 5 skips `/review` (a single-reviewer loop of up to 5 rounds using the Cursor → Codex → Claude Code Reviewer subagent fallback chain — no voting panel), and Step 7a skips the Code Flow Diagram. All other steps (CI wait, Slack, cleanup) run normally. The `--merge` opt-in is independent of `--quick`.
 - `--auto`: Set a mental flag `auto_mode=true`. Default: `auto_mode=false`. When `auto_mode=true`: (a) forward `--auto` to `/design` invocation in Step 1, suppressing `/design`'s interactive question checkpoints; (b) suppress this skill's own opportunistic questions in Step 2; (c) in Step 12, when merge conflicts require user input for uncertain resolutions, suppress `AskUserQuestion` and use best-effort resolution instead (bailing if confidence is too low). When `--quick` is also set and `/design` is skipped, `--auto` still suppresses Step 2 questions.
 - `--merge`: Set a mental flag `merge=true`. Default: `merge=false`. When `merge=true`, Steps 12–15 run (CI+rebase+merge loop, :merged: emoji, local cleanup, and main verification). When `merge=false`, these steps are skipped — the PR is created and the workflow stops after the initial CI wait, Slack announcement, rejected findings report, final report, and temp cleanup.
 - `--no-merge`: **Deprecated** — recognized for backward compatibility but treated as a no-op (the new default already skips merge steps). When this flag is encountered, print: `**ℹ '--no-merge' is now the default and no longer needed; the flag is recognized as a no-op for backward compatibility.**`
@@ -269,21 +269,75 @@ If successful:
 
 ### Quick mode (`quick_mode=true`)
 
-Skip `/review`. Instead, run a simplified one-round review:
+Print: `> **🔶 5: code review — quick mode (single reviewer, Cursor → Codex → Claude fallback, up to 5 rounds)**`
 
-1. Gather the diff using the context script:
-   ```bash
-   ${CLAUDE_PLUGIN_ROOT}/scripts/gather-branch-context.sh --output-dir "$IMPLEMENT_TMPDIR"
-   ```
-   Parse the output for `DIFF_FILE`, `FILE_LIST_FILE`, and `COMMIT_LOG_FILE`. Read these files to get the full diff, file list, and commit log.
-2. Launch **1 Claude Code Reviewer subagent** (subagent_type: `code-reviewer`) using the unified reviewer archetype from `${CLAUDE_PLUGIN_ROOT}/skills/shared/reviewer-templates.md` with these variable bindings: `{REVIEW_TARGET}` = `"code changes"`, `{CONTEXT_BLOCK}` = the commit log + file list + full diff, `{OUTPUT_INSTRUCTION}` = `"File path and line number(s)"` + `"What the issue is"` + `"Suggested fix"`. **No Codex, no Cursor, no external reviewers. No competition notice** (there is no voting panel in quick mode).
-3. Collect findings from the Code Reviewer subagent.
-4. **Main agent decides**: Evaluate each finding and unilaterally accept or reject it. No voting panel. Accept findings that identify genuine bugs, logic errors, or important improvements. Reject trivial style nits or speculative concerns. Also reject findings whose proposed fix would introduce more complexity than the issue warrants (disproportionate fix).
-5. Implement accepted fixes. Run `/relevant-checks` if files changed.
-6. **One round only** — no re-review loop.
-7. For rejected findings, write them to `$IMPLEMENT_TMPDIR/rejected-findings.md` using the same format as normal mode (see below), so Step 16 and PR body sections work unchanged.
+Skip `/review`. Instead, run a single-reviewer loop with up to **5 rounds** of review + fix. There is no voting panel — one reviewer per round, main agent unilaterally accepts/rejects each finding.
 
-Print: `> **🔶 5: code review — quick mode (1 Claude Code Reviewer subagent, 1 round, no voting)**`
+**Reviewer selection**: At the start of each round, pick ONE reviewer from the following priority chain (re-evaluated each round so runtime failures cascade to the next tier per the **Runtime Timeout Fallback** procedure in `${CLAUDE_PLUGIN_ROOT}/skills/shared/external-reviewers.md`):
+
+1. **Cursor** if `cursor_available=true`
+2. Else **Codex** if `codex_available=true`
+3. Else **Claude Code Reviewer subagent** (subagent_type: `code-reviewer`)
+
+Track `round_num` starting at 1. For each round:
+
+**5.1 — Gather context**:
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/scripts/gather-branch-context.sh --output-dir "$IMPLEMENT_TMPDIR"
+```
+
+Parse the output for `DIFF_FILE`, `FILE_LIST_FILE`, and `COMMIT_LOG_FILE`. Read these files to get the current cumulative diff (main...HEAD), file list, and commit log.
+
+**5.2 — Select the round's reviewer** per the priority chain above. Print: `⏳ 5: code review — round $round_num using <Cursor|Codex|Claude>`
+
+**5.3 — Launch the selected reviewer**:
+
+- **Cursor** — invoke via the shared monitored wrapper (Cursor has full repo access — no need to inline the diff):
+  ```bash
+  ${CLAUDE_PLUGIN_ROOT}/scripts/run-external-reviewer.sh --tool cursor --output "$IMPLEMENT_TMPDIR/quick-review-round${round_num}.txt" --timeout 1800 --capture-stdout -- \
+    cursor agent -p --force --trust $("${CLAUDE_PLUGIN_ROOT}/scripts/reviewer-model-args.sh" --tool cursor --with-effort) --workspace "$PWD" \
+      "Review all code changes on the current branch vs main. Run git diff main...HEAD to see changes and git log main...HEAD --oneline for commits. For each changed file, read the full file for context. Walk four focus areas: (1) Code Quality: bugs, logic, reuse, tests, backward compat, style. (2) Risk/Integration: breaking changes, side effects, thread safety, deployment risks, regressions, CI. (3) Correctness: logic errors, off-by-one, nil handling, type mismatches, races, error paths. (4) Architecture: separation of concerns, contract boundaries, invariants, semantic boundaries. Tag each finding with its focus area. Return numbered findings with focus-area tag, file:line, issue, and suggested fix. If NO issues, output exactly NO_ISSUES_FOUND. Do NOT modify files. Work at your maximum reasoning effort level."
+  ```
+  Use `run_in_background: true` and `timeout: 1860000`. Then collect via:
+  ```bash
+  ${CLAUDE_PLUGIN_ROOT}/scripts/collect-reviewer-results.sh --timeout 1860 [--write-health "${SESSION_ENV_PATH}.health"] "$IMPLEMENT_TMPDIR/quick-review-round${round_num}.txt"
+  ```
+  Include `--write-health` only if `SESSION_ENV_PATH` is non-empty.
+
+- **Codex** — same pattern (no `--capture-stdout` — Codex uses its own output flag):
+  ```bash
+  ${CLAUDE_PLUGIN_ROOT}/scripts/run-external-reviewer.sh --tool codex --output "$IMPLEMENT_TMPDIR/quick-review-round${round_num}.txt" --timeout 1800 -- \
+    codex exec --full-auto -C "$PWD" $("${CLAUDE_PLUGIN_ROOT}/scripts/reviewer-model-args.sh" --tool codex --with-effort) \
+      --output-last-message "$IMPLEMENT_TMPDIR/quick-review-round${round_num}.txt" \
+      "Review all code changes on the current branch vs main. Run git diff main...HEAD to see changes and git log main...HEAD --oneline for commits. For each changed file, read the full file for context. Walk four focus areas: (1) Code Quality: bugs, logic, reuse, tests, backward compat, style. (2) Risk/Integration: breaking changes, side effects, thread safety, deployment risks, regressions, CI. (3) Correctness: logic errors, off-by-one, nil handling, type mismatches, races, error paths. (4) Architecture: separation of concerns, contract boundaries, invariants, semantic boundaries. Tag each finding with its focus area. Return numbered findings with focus-area tag, file:line, issue, and suggested fix. If NO issues, output exactly NO_ISSUES_FOUND. Do NOT modify files. Work at your maximum reasoning effort level."
+  ```
+  Collect via the same `collect-reviewer-results.sh` call.
+
+- **Claude Code Reviewer subagent** — launch via the Agent tool (subagent_type: `code-reviewer`) using the unified reviewer archetype from `${CLAUDE_PLUGIN_ROOT}/skills/shared/reviewer-templates.md` with: `{REVIEW_TARGET}` = `"code changes"`, `{CONTEXT_BLOCK}` = the commit log + file list + full diff, `{OUTPUT_INSTRUCTION}` = `"File path and line number(s)"` + `"What the issue is"` + `"Suggested fix"`. **No competition notice** (no voting panel).
+
+**5.3.a — Runtime failure handling** (Cursor/Codex only): If `collect-reviewer-results.sh` reports `STATUS` not `OK`, follow the **Runtime Timeout Fallback** procedure in `external-reviewers.md`: flip the corresponding `cursor_available` / `codex_available` flag to `false` for the remainder of the session, log to `$IMPLEMENT_TMPDIR/execution-issues.md` under `External Reviewer Issues`, and **retry this round** (jump back to 5.2 to re-select the reviewer). Do NOT increment `round_num` — a failed external reviewer is not a counted round.
+
+**5.4 — Check for no findings**: If the reviewer reports no findings (`NO_ISSUES_FOUND`, "No issues found.", or a Claude subagent dual-list output with zero in-scope findings), the loop is done — proceed to Step 6. Claude subagent OOS observations are discarded in quick mode (Step 9a.1 is skipped in quick mode).
+
+**5.5 — Main agent evaluates findings**: For each reviewer finding, unilaterally accept or reject:
+- **Accept** findings that identify genuine bugs, logic errors, security issues, or clearly important improvements.
+- **Reject** trivial style nits, subjective preferences, or speculative concerns.
+- **Reject** findings whose proposed fix would introduce more complexity than the issue warrants (disproportionate fix).
+
+Append rejected findings to `$IMPLEMENT_TMPDIR/rejected-findings.md` using the standard format (see "Track Rejected Code Review Findings" below). Use the round number and reviewer tool in the reviewer name field (e.g., `[Code Review] Cursor (round 2)`).
+
+**5.6 — Short-circuit if no accepted findings**: If zero findings were accepted in this round, no fixes will be applied — no significant changes will be made. The loop is done — proceed to Step 6.
+
+**5.7 — Implement accepted fixes**: Edit the affected files. Then invoke `/relevant-checks`. If checks fail, diagnose and fix, then re-invoke `/relevant-checks` until clean.
+
+**5.8 — Re-review gate**: If `/relevant-checks` reported no files modified in this round (accepted findings turned out to be no-ops after re-reading code), the loop is done — proceed to Step 6. Otherwise, significant changes were made: increment `round_num`. If `round_num <= 5`, loop back to 5.1. If `round_num > 5`, print:
+
+```
+**⚠ 5: code review — quick mode hit 5-round cap without converging. Remaining findings from the last round are listed above. Proceeding.**
+```
+
+Log to `$IMPLEMENT_TMPDIR/execution-issues.md` under `Warnings`: `Step 5 — quick-mode review loop did not converge after 5 rounds.` Then proceed to Step 6.
 
 ### Normal mode (`quick_mode=false`)
 
@@ -566,7 +620,7 @@ Populate Run Statistics from conversation context: count accepted/rejected findi
 - **Version Bump Reasoning**: Populate from `$BUMP_REASONING_FILE` (the absolute path parsed from `classify-bump.sh`'s `REASONING_FILE=<path>` stdout line in Step 8, identical to normal mode) if it exists and is non-empty, otherwise the standard fallback text from the normal-mode template.
 - **Rejected Plan Review Suggestions**: Write "Quick mode — no plan review was conducted."
 - **Plan Review Voting Tally**: Write "Quick mode — no plan review voting."
-- **Code Review Voting Tally (Round 1)**: Write "Quick mode — no voting panel. Main agent reviewed findings from 1 Claude Code Reviewer subagent."
+- **Code Review Voting Tally (Round 1)**: Write "Quick mode — no voting panel. Main agent reviewed findings across up to 5 single-reviewer rounds (Cursor → Codex → Claude fallback chain)."
 - **Implementation Deviations**: Compare implementation to the inline plan (same as normal mode).
 - **Out-of-Scope Observations**: Write "Quick mode — no out-of-scope observations collected."
 - **Run Statistics**: Set "Plan review findings" to "N/A (quick mode)", "External reviewers" to "N/A (quick mode)", "OOS issues filed" to "N/A (quick mode)". Code review findings should reflect the quick review results.
@@ -1076,7 +1130,7 @@ Print a report of all code review suggestions that were **not** implemented.
 
 ## Step 17 — Final Report
 
-**If `quick_mode=true`**: Print: `✅ 17: final report — quick mode, /design skipped, 1 subagent review (<elapsed>)`
+**If `quick_mode=true`**: Print: `✅ 17: final report — quick mode, /design skipped, single-reviewer loop (<elapsed>)`
 
 **If `quick_mode=false`**: Print a summary noting that:
 - Plan review findings were reported by the `/design` phase (visible in conversation above)
@@ -1092,7 +1146,7 @@ Remove the session temp directory and all files within it:
 ${CLAUDE_PLUGIN_ROOT}/scripts/cleanup-tmpdir.sh --dir "$IMPLEMENT_TMPDIR"
 ```
 
-**Repeat any external reviewer warnings** from earlier in the workflow (from `/design` or `/review` phases) so they are visible at the end. **If `quick_mode=true`**, there are no external reviewer warnings to repeat (no external reviewers were used). For example:
+**Repeat any external reviewer warnings** from earlier in the workflow (from `/design` or `/review` phases, or from Step 5 runtime-fallback flips in quick mode). For example:
 - `**⚠ Codex not available: <reason>**`
 - `**⚠ Cursor review failed: <reason>**`
 

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -101,6 +101,7 @@ Parse the output for `SESSION_TMPDIR`, `SLACK_OK`, `SLACK_MISSING`, `REPO`, `REP
 - `IMPLEMENT_TMPDIR` = `SESSION_TMPDIR`
 - If `SLACK_OK=false`, print: `**⚠ Slack is not fully configured (<SLACK_MISSING> not set). Slack announcement (Step 11) and :merged: emoji (Step 13) will be skipped.**` Set a mental flag `slack_available=false`.
 - If `REPO_UNAVAILABLE=true`, print `**⚠ Could not determine repository name. CI monitoring (Steps 10, 12) and merge (Step 12b) will be skipped.**` Set a mental flag `repo_unavailable=true`.
+- Set mental flag `codex_available` from the probe output per the **Binary Check and Health Probe** mapping in `${CLAUDE_PLUGIN_ROOT}/skills/shared/external-reviewers.md`: `codex_available=true` only if both `CODEX_AVAILABLE=true` and `CODEX_HEALTHY=true`; otherwise `codex_available=false`. Same logic for `cursor_available`. These flags are used by Step 5 quick-mode reviewer selection and flip to `false` at runtime when a reviewer times out (per the Runtime Timeout Fallback procedure).
 - If `CODEX_AVAILABLE=false`: print `**⚠ Codex not available (binary not found). Proceeding without Codex reviewer.**`
 - Else if `CODEX_HEALTHY=false`: print `**⚠ Codex installed but not responding (health check failed). Using Claude replacement.**`
 - Same for Cursor. Only check `*_HEALTHY` when `*_AVAILABLE=true`.
@@ -331,7 +332,7 @@ Append rejected findings to `$IMPLEMENT_TMPDIR/rejected-findings.md` using the s
 
 **5.7 — Implement accepted fixes**: Edit the affected files. Then invoke `/relevant-checks`. If checks fail, diagnose and fix, then re-invoke `/relevant-checks` until clean.
 
-**5.8 — Re-review gate**: If `/relevant-checks` reported no files modified in this round (accepted findings turned out to be no-ops after re-reading code), the loop is done — proceed to Step 6. Otherwise, significant changes were made: increment `round_num`. If `round_num <= 5`, loop back to 5.1. If `round_num > 5`, print:
+**5.8 — Re-review gate**: Observable signal is whether Step 5.7 actually edited any files in the working tree — the main agent knows this from its own Edit/Write tool usage during this round. If Step 5.7 made no file edits (accepted findings turned out to be no-ops after re-reading code), the loop is done — proceed to Step 6. Otherwise, significant changes were made: increment `round_num`. If `round_num <= 5`, loop back to 5.1. If `round_num > 5`, print:
 
 ```
 **⚠ 5: code review — quick mode hit 5-round cap without converging. Remaining findings from the last round are listed above. Proceeding.**


### PR DESCRIPTION
## Summary
- Rewrote `/implement --quick` code review (Step 5) to use a single-reviewer loop with the Cursor → Codex → Claude Code Reviewer subagent fallback chain, re-evaluating the chain each round so runtime timeouts cascade to the next tier.
- Added a 5-round re-review gate: if a round's accepted fixes actually edit files, the loop re-reviews the updated diff; otherwise it short-circuits.
- Added explicit initialization of `cursor_available`/`codex_available` mental flags in Step 0 so the new Step 5 selection logic has an authoritative source.

<details><summary>Architecture Diagram</summary>

Quick mode — architecture diagram skipped.

</details>

<details><summary>Code Flow Diagram</summary>

Quick mode — code flow diagram skipped.

</details>

<details><summary>Goal</summary>

- Make `/implement --quick`'s single-reviewer step prefer stronger external reviewers over Claude
  - Use Cursor when available
  - Fall back to Codex if Cursor is unavailable
  - Fall back to a Claude Code Reviewer subagent only when both externals are unavailable
- Allow re-review after significant changes so quick mode can converge on a fix set
  - If a round's accepted fixes produced file edits, re-review the updated diff
  - Cap the loop at 5 rounds total to prevent runaway review loops
- Keep quick mode's "no voting panel" property — one reviewer per round, main agent unilaterally accepts or rejects findings
- Handle runtime failure gracefully: a Cursor/Codex timeout flips `*_available=false` and the next round automatically picks the next tier

</details>

<details><summary>Test plan</summary>

- [ ] Run `/implement --merge --auto --quick <some feature>` end-to-end on a throwaway branch and verify Step 5 selects Cursor as the round-1 reviewer and prints the new breadcrumb (`5: code review — round 1 using Cursor`).
- [ ] Simulate a Cursor timeout (e.g., block network) and confirm the next round falls back to Codex per the runtime-timeout cascade.
- [ ] Simulate both externals down and confirm the Claude Code Reviewer subagent is used.
- [ ] Verify the 5-round cap triggers the warning and proceeds to Step 6 (no bail).
- [ ] Verify rejected findings are appended to `rejected-findings.md` with the round number in the reviewer-name field (e.g., `[Code Review] Cursor (round 2)`).

</details>

<details><summary>Final Design</summary>

Rewrite the Quick-mode block of Step 5 in `skills/implement/SKILL.md` (lines 270-286 of the pre-change file) with:

1. **Tiered reviewer selection** evaluated at the start of each round:
   - Cursor if `cursor_available=true`
   - Else Codex if `codex_available=true`
   - Else Claude Code Reviewer subagent

2. **Round loop** (`round_num` starts at 1, cap 5):
   - 5.1 Gather context via `gather-branch-context.sh`
   - 5.2 Select reviewer + print round breadcrumb
   - 5.3 Launch the selected reviewer (Cursor/Codex via `run-external-reviewer.sh` + `collect-reviewer-results.sh`; Claude via Agent tool with `code-reviewer` subagent)
   - 5.3.a Runtime failure handling for externals: flip `*_available=false`, log to `execution-issues.md`, retry round (don't count it)
   - 5.4 Exit if no findings
   - 5.5 Main agent accepts/rejects each finding
   - 5.6 Exit if zero accepted findings
   - 5.7 Implement accepted fixes, run `/relevant-checks`
   - 5.8 Re-review gate based on whether Step 5.7 made file edits; increment `round_num`; loop or cap

3. **Step 0** explicitly initializes `cursor_available` and `codex_available` per the Binary Check and Health Probe mapping so Step 5 has an authoritative flag source (previously implicit).

4. **Consistency touch-ups** for quick-mode cross-references:
   - `--quick` flag description (line 16)
   - Code Review Voting Tally quick-mode guidance (line 568)
   - Step 17 final report quick-mode message (line 1089)
   - Step 18 external-reviewer warnings guard (line 1105)

No scripts were added or modified — existing infrastructure (`run-external-reviewer.sh`, `collect-reviewer-results.sh`, `gather-branch-context.sh`, `external-reviewers.md`) is reused.

</details>

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `f14e31c` (Rename heading in KARPATHY_CLAUDE.md to match filename (#88))
- **Current version**: `3.0.3`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `3.0.4`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH").

### Main-agent escalation review

Reviewed the diff for behavioral changes. The change is prompt-text-only and alters internal behavior of `/implement --quick`'s Step 5 (reviewer selection + re-review loop). The `--quick` flag's semantics ("quick mode") are preserved — it still skips `/design`, skips voting, and skips the code flow diagram. The only observable difference for callers is that quick mode now runs a stronger external reviewer and may iterate up to 5 rounds instead of 1. This is a behavioral enhancement, not a backward-incompatible change: no API, flag, or skill surface was removed. No escalation.

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

Quick mode — no plan review was conducted.

</details>

<details><summary>Implementation Deviations</summary>

No deviations from the inline plan. The implementation landed the planned rewrite of Step 5's quick-mode block and the 4 cross-references, and additionally added the `cursor_available`/`codex_available` mental-flag initialization in Step 0 in response to accepted round-1 review Finding 5 (a genuine pre-existing gap surfaced by the new code's reliance on those flags).

</details>

<details><summary>Rejected Code Review Suggestions</summary>

### [Code Review] Cursor (round 1)
**Finding**: `skills/implement/SKILL.md:979-984` — Phase 3c (Conflict Resolution Procedure) says per-file conflict context blocks are sufficient and no additional staged-diff capture is required, while Phase 3d defines `{CONTEXT_BLOCK}` as "the per-file conflict context blocks from 3c + supplementary staged diff". The reviewer flagged this as a contract ambiguity: include `git diff --cached` or not?
**Reason not implemented**: Out of scope for this change. Phase 3c/3d are part of the Conflict Resolution Procedure in Step 12, which was not modified by this PR. The PR scope is limited to rewriting the Quick-mode block of Step 5 (`/implement --quick` review behavior) plus 4 quick-mode cross-references. Pre-existing contract ambiguities in unrelated sections are not addressed here — they should be filed as a separate cleanup task. Addressing this now would violate the surgical-change principle in CLAUDE.md (KARPATHY_CLAUDE.md §3: "Don't refactor things that aren't broken. Every changed line should trace directly to the user's request.").

### [Code Review] Cursor (round 1)
**Finding**: `scripts/git-sync-local-main.sh:34-43` — if local `main` exists but `origin/main` is missing (no remote, wrong remote name, or ref never fetched), `REMOTE_MAIN` is empty, the `already_current` check fails, and `git branch -f main origin/main` can fail under `set -e`, aborting the Rebase + Re-bump sub-procedure. Suggested fix: require `git rev-parse --verify origin/main` before `git branch -f` and emit `RESULT=no_origin_main` or document the precondition.
**Reason not implemented**: Out of scope for this change. `scripts/git-sync-local-main.sh` was introduced in commit `b4ef83c` (PR #89 — "Wrap direct bash commands in /implement"), which is already merged to `origin/main` but not yet fast-forwarded to local `main` in this working tree. Cursor's diff of `main...HEAD` included that previously-merged commit and surfaced findings from it. This PR's scope is quick-mode review behavior; touching an unrelated script from another PR would mix concerns and inflate the change surface.

### [Code Review] Cursor (round 1)
**Finding**: `.claude/skills/bump-version/scripts/classify-bump.sh:62-64` — when `IMPLEMENT_TMPDIR` is unset, the reasoning log defaults to `${TMPDIR:-/tmp}/bump-version-reasoning.md`. Parallel `/bump-version` or `/implement` runs (or a stale file on disk) can clobber or mis-attribute reasoning content for PR bodies. Suggested fix: use a unique path (e.g. `mktemp` or `$$`/`$RANDOM` in basename) and still emit `REASONING_FILE=...` on stdout.
**Reason not implemented**: Out of scope for this change. The fallback path was introduced in commit `b4ef83c` (PR #89), not this PR. The finding itself is legitimate (clobbering under parallel runs is a real risk), but addressing it here would mix concerns. Filing as a separate follow-up is more appropriate.

### [Code Review] Cursor (round 1)
**Finding**: `skills/implement/SKILL.md:930-931` — Phase 1 §2 (Conflict Resolution Procedure) tells the agent to treat missing stages as uncertain "when the conflict type requires that stage" but does not spell out which git patterns imply which stages (e.g., when only stages 2+3 exist vs 1+2+3). This invites inconsistent classification between runs. Suggested fix: add a short table or a pointer to git documentation clarifying stage semantics.
**Reason not implemented**: Out of scope for this change. Phase 1 of the Conflict Resolution Procedure is in Step 12 and was not modified by this PR. The phrasing pre-dates this change.

### [Code Review] Cursor (round 1)
**Finding**: `CHANGELOG.md:12` / `classify-bump.sh:58-61` — moving the default reasoning log out of `$PWD/.git/` fixes permission prompts but changes the on-disk contract for any out-of-band automation that still looked for `.git/bump-version-reasoning.md`. Suggested fix: mention migration in `README.md` if external integrations are documented there.
**Reason not implemented**: Out of scope for this change. The behavior change was made in commit `b4ef83c` (PR #89), already merged. The CHANGELOG entry is already noted. Additional migration documentation is a concern for that PR's review cycle, not this one.

### [Code Review] Cursor (round 2)
**Finding**: `skills/implement/SKILL.md:320-321` — Step 5.3.a defines structured runtime recovery (retry round, log to execution-issues, flip `*_available` flag) only for Cursor/Codex collection failures. If the Claude Code Reviewer subagent path fails (tool error, token limit, malformed output), there is no parallel retry/degrade/bail rule. Suggested fix: add an explicit rule for Claude subagent failures (e.g., retry once, then log to `execution-issues.md` and bail or fall back to a simpler single-shot review), aligned with `external-reviewers.md` tone.
**Reason not implemented**: Disproportionate fix — the symmetry the reviewer requests is an asymmetric case. External reviewers (Cursor, Codex) require wrapper scripts, sentinel files, and timeout machinery because they run as background processes outside Claude's control; that machinery is what 5.3.a's recovery hooks into. The Claude Code Reviewer subagent runs via the Agent tool, which is an in-context synchronous tool call — any failure is returned to the main agent directly as a tool result and handled in the normal conversational flow (e.g., the main agent can retry the Agent call, diagnose, or proceed). Adding an explicit retry/bail spec for the Claude path would duplicate default Agent-tool semantics into the skill prompt, inflating the spec without changing actual behavior. Crucially, `/review` (the canonical multi-reviewer skill) also does not define explicit retry/degrade/bail for its Claude subagent reviewers — the absence is deliberate, not an oversight. Matching `/review`'s convention keeps `/implement --quick` behavior consistent and avoids divergent spec style for the same underlying primitive.

</details>

<details><summary>Plan Review Voting Tally</summary>

Quick mode — no plan review voting.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

Quick mode — no voting panel. Main agent reviewed findings across 2 single-reviewer rounds using Cursor.

- **Round 1 (Cursor)**: 7 findings raised. 2 accepted (Findings 2, 5). 5 rejected as out-of-scope (Findings 1, 3, 4, 6, 7 — references to pre-existing code from a previously merged commit).
- **Round 2 (Cursor)**: 4 findings raised. 0 accepted. 3 duplicates of round-1 OOS rejections; 1 new finding (Finding 4, asymmetric Claude-subagent retry rule) rejected as a disproportionate fix.

Loop exited via Step 5.6 (zero accepted findings in round 2).

</details>

<details><summary>Out-of-Scope Observations</summary>

Quick mode — no out-of-scope observations collected.

</details>

<details><summary>Execution Issues</summary>

### CI Issues
- **Step 10**: Two consecutive transient 504 errors during CI environment setup. First: `HTTP Error 504: Gateway Time-out` while pre-commit installed `shellcheck-py` (downloading shellcheck binary). Second: `curl: (22) The requested URL returned error: 504` while pre-commit's `agent-lint` hook downloaded its binary from GitHub releases. Both were resolved by `ci-rerun-failed.sh`; third run (after 60s sleep each time) succeeded. No code changes were required. transient_retries reached 2 before CI went green.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | N/A (quick mode) |
| Code review rounds | 2 |
| Code review findings | 2 accepted, 6 rejected |
| Warnings logged | 0 |
| Pre-existing issues noticed | 5 (surfaced by Cursor against previously merged commit; documented in Rejected Code Review Suggestions) |
| OOS issues filed | N/A (quick mode) |
| External reviewers | Cursor: ✅, Codex: N/A (not needed — Cursor healthy both rounds) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)

