### PR TITLE
Skip /fix-issue candidates blocked by open GitHub dependencies

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.7] - 2026-04-18
+
+### Changed
+
+- `/fix-issue` now skips candidates with currently-open blocking dependencies. After an issue passes the `GO` sentinel check, `fetch-eligible-issue.sh` queries GitHub's native issue-dependencies API (`repos/{owner}/{repo}/issues/{N}/dependencies/blocked_by`); if any blocker is still in the `open` state, auto-pick mode continues scanning and explicit `--issue` mode reports ineligible with the blocker list. The dependency lookup uses `gh api --paginate --jq` so results across multiple pages are merged correctly. API errors (404 on repos without the feature, 5xx, transient gh failures) degrade silently to the prior GO-only behavior so dependency-API availability never hard-blocks the automation; the degradation is documented under the skill's Known Limitations.
+
 ## [3.0.6] - 2026-04-18
 
 ### Changed

--- a/skills/fix-issue/SKILL.md
+++ b/skills/fix-issue/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools: Bash, Read, Grep, Glob, Skill
 
 # Fix Issue
 
-Process one approved GitHub issue per invocation. Fetches open issues with a `GO` sentinel comment, triages against the codebase, classifies complexity, and delegates to `/implement`.
+Process one approved GitHub issue per invocation. Fetches open issues with a `GO` sentinel comment, skips any whose GitHub issue-dependencies list includes an open blocker, triages the remaining candidate against the codebase, classifies complexity, and delegates to `/implement`.
 
 **Single-iteration design**: Each invocation handles at most one issue, then exits. The caller (cron, `/loop`, or manual invocation) is responsible for repeated execution.
 
@@ -65,6 +65,8 @@ ${CLAUDE_PLUGIN_ROOT}/skills/fix-issue/scripts/fetch-eligible-issue.sh ["$ISSUE_
 ```
 
 Only include `"$ISSUE_ARG"` as a positional argument if `ISSUE_ARG` is non-empty (the user provided an issue number/URL via positional argument or the deprecated `--issue` flag).
+
+Candidates are required to be open, have `GO` as their last comment, not be locked by a prior `IN PROGRESS` comment, and **have no currently-open blocking dependencies** (per GitHub's native issue-dependencies feature, queried via `repos/{owner}/{repo}/issues/{N}/dependencies/blocked_by`). An issue whose listed blockers are all closed is eligible; an issue with even one open blocker is skipped in auto-pick mode and reported as ineligible in explicit `--issue` mode. If the dependencies endpoint is unavailable (e.g., 404, transient gh failure), the check degrades to the pre-existing GO-only behavior so API availability never hard-blocks the automation.
 
 Handle exit codes:
 

--- a/skills/fix-issue/SKILL.md
+++ b/skills/fix-issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fix-issue
-description: "Use when fixing open GitHub issues. Processes one approved issue per invocation: triages, classifies complexity, and delegates to /implement."
+description: "Use when fixing open GitHub issues. Processes one approved issue per invocation: skips issues blocked by open dependencies, triages, classifies complexity, and delegates to /implement."
 argument-hint: "[--debug] [--issue <number-or-url>] [<number-or-url>]"
 allowed-tools: Bash, Read, Grep, Glob, Skill
 ---
@@ -15,7 +15,7 @@ Process one approved GitHub issue per invocation. Fetches open issues with a `GO
 
 - `--debug`: Set `debug_mode=true`. Forward `--debug` to `/implement` in Step 6. Default: `debug_mode=false`.
 - `--issue <number-or-url>`: **Deprecated** — recognized for backward compatibility. Prefer passing the issue number or URL as a positional argument (e.g., `/fix-issue 42`). When this flag is encountered, print: `**ℹ '--issue' is deprecated; pass the issue number or URL as a positional argument instead (e.g., /fix-issue 42).**`
-- **Positional argument** (after flag stripping): If any non-flag text remains in `$ARGUMENTS` after stripping `--debug` and `--issue`, treat it as the issue number or URL. Set `ISSUE_ARG` to this value. When set, Step 1 targets this specific issue instead of scanning for the oldest eligible one. Accepts a bare issue number (e.g., `42`) or a full GitHub issue URL (e.g., `https://github.com/owner/repo/issues/42`). The issue must be open and have `GO` as its last comment. Default: empty (auto-pick mode). If both `--issue` and a positional argument are provided, print: `**⚠ Both --issue and a positional argument were provided. Using the positional argument.**` and use the positional argument.
+- **Positional argument** (after flag stripping): If any non-flag text remains in `$ARGUMENTS` after stripping `--debug` and `--issue`, treat it as the issue number or URL. Set `ISSUE_ARG` to this value. When set, Step 1 targets this specific issue instead of scanning for the oldest eligible one. Accepts a bare issue number (e.g., `42`) or a full GitHub issue URL (e.g., `https://github.com/owner/repo/issues/42`). The issue must be open, have `GO` as its last comment, and have no currently-open blocking dependencies (see Step 1 for the degradation note when the dependency endpoint is unavailable). Default: empty (auto-pick mode). If both `--issue` and a positional argument are provided, print: `**⚠ Both --issue and a positional argument were provided. Using the positional argument.**` and use the positional argument.
 
 ## Progress Reporting
 
@@ -198,3 +198,4 @@ Print `✅ 9: cleanup — fix-issue complete! (<elapsed>)`
 
 - **Stale IN PROGRESS lock**: If the skill crashes after Step 2, the issue remains locked with `IN PROGRESS` as the last comment. Recovery: manually delete the `IN PROGRESS` comment and re-add `GO` to re-enable the issue for automated processing.
 - **Single-runner assumption**: The comment-based locking (Step 2) includes duplicate detection but is not fully atomic. For reliable operation, run one instance of `/fix-issue` at a time per repository.
+- **Dependency check degrades silently on API failure**: The blocked-by check (Step 1) treats unreachable or erroring dependency-API responses as "no blockers known" to avoid hard-blocking the automation. If GitHub's issue-dependencies endpoint is returning 5xx or an unexpected payload, a blocked issue could temporarily be eligible. The GO sentinel still applies, so the blast radius is limited to whatever the reviewer intended to allow via `GO`.

--- a/skills/fix-issue/scripts/fetch-eligible-issue.sh
+++ b/skills/fix-issue/scripts/fetch-eligible-issue.sh
@@ -2,11 +2,13 @@
 # fetch-eligible-issue.sh — Find an eligible issue approved for automated work.
 #
 # Without --issue: lists open issues, checks each for the "GO" sentinel as
-# the last comment, excludes issues locked with "IN PROGRESS", and emits
-# the first match (oldest first).
+# the last comment, excludes issues locked with "IN PROGRESS", excludes
+# issues blocked by other open issues (via GitHub's native issue dependencies),
+# and emits the first match (oldest first).
 #
 # With --issue: targets a specific issue (by number or GitHub URL), verifies
-# it is open and has "GO" as the last comment.
+# it is open, has "GO" as the last comment, and has no currently-open
+# blocking dependencies.
 #
 # Usage:
 #   fetch-eligible-issue.sh [<number-or-url>]
@@ -62,6 +64,28 @@ REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null) || {
     echo "ELIGIBLE=false"
     echo "ERROR=Failed to resolve repository name"
     exit 2
+}
+
+# ---------------------------------------------------------------------------
+# open_blockers <issue-number>
+#
+# Queries GitHub's native issue-dependencies API and prints a space-separated
+# list of open blocker issue numbers (e.g., "42 57") on stdout. Empty output
+# means no open blockers — the issue may proceed.
+#
+# API errors (404 on repos without the dependencies feature, transient gh
+# failures) are treated as "no blockers known": the function prints nothing
+# and returns 0. Rationale: do not let dependency-API availability become a
+# hard gate on the automation — if the feature isn't used or is unreachable,
+# fall back to pre-existing behavior (GO sentinel alone).
+# ---------------------------------------------------------------------------
+open_blockers() {
+    local num="$1"
+    local json
+    json=$(gh api --paginate "repos/${REPO}/issues/${num}/dependencies/blocked_by" 2>/dev/null) || return 0
+    [ -z "$json" ] && return 0
+    # Keep only entries in the OPEN state; extract issue numbers on one line.
+    echo "$json" | jq -r '[.[] | select(.state == "open") | .number] | join(" ")' 2>/dev/null || true
 }
 
 # ---------------------------------------------------------------------------
@@ -124,6 +148,15 @@ if [[ -n "$ISSUE_ARG" ]]; then
         exit 2
     fi
 
+    BLOCKERS=$(open_blockers "$ISSUE_NUM")
+    if [ -n "$BLOCKERS" ]; then
+        # Format as comma-separated #N list for the error message
+        FORMATTED=$(echo "$BLOCKERS" | tr ' ' '\n' | sed 's/^/#/' | paste -sd ',' -)
+        echo "ELIGIBLE=false"
+        echo "ERROR=Issue #$ISSUE_NUM is blocked by open dependencies: $FORMATTED"
+        exit 2
+    fi
+
     echo "ELIGIBLE=true"
     echo "ISSUE_NUMBER=$ISSUE_NUM"
     echo "ISSUE_TITLE=$ISSUE_TITLE"
@@ -169,6 +202,13 @@ while IFS= read -r issue_row; do
 
     # Check if last comment is exactly GO (case-sensitive)
     if [ "$TRIMMED" = "GO" ]; then
+        BLOCKERS=$(open_blockers "$ISSUE_NUM")
+        if [ -n "$BLOCKERS" ]; then
+            # Blocked by at least one open dependency — log on stderr and keep scanning.
+            FORMATTED=$(echo "$BLOCKERS" | tr ' ' '\n' | sed 's/^/#/' | paste -sd ',' -)
+            echo "Skipping issue #$ISSUE_NUM: blocked by open dependencies ($FORMATTED)" >&2
+            continue
+        fi
         echo "ELIGIBLE=true"
         echo "ISSUE_NUMBER=$ISSUE_NUM"
         echo "ISSUE_TITLE=$ISSUE_TITLE"

--- a/skills/fix-issue/scripts/fetch-eligible-issue.sh
+++ b/skills/fix-issue/scripts/fetch-eligible-issue.sh
@@ -81,11 +81,15 @@ REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null) || {
 # ---------------------------------------------------------------------------
 open_blockers() {
     local num="$1"
-    local json
-    json=$(gh api --paginate "repos/${REPO}/issues/${num}/dependencies/blocked_by" 2>/dev/null) || return 0
-    [ -z "$json" ] && return 0
-    # Keep only entries in the OPEN state; extract issue numbers on one line.
-    echo "$json" | jq -r '[.[] | select(.state == "open") | .number] | join(" ")' 2>/dev/null || true
+    local nums
+    # Use --paginate with --jq so the filter runs per page and outputs are concatenated
+    # (one number per line). Using --paginate without --jq returns one JSON array per
+    # page as separate documents, and `jq '.[] ...'` only consumes the first — missing
+    # blockers beyond the default page size.
+    nums=$(gh api --paginate "repos/${REPO}/issues/${num}/dependencies/blocked_by" \
+        --jq '.[] | select(.state == "open") | .number' 2>/dev/null) || return 0
+    # Collapse newline-separated numbers into a single space-separated line, trimming trailing whitespace.
+    echo "$nums" | tr '\n' ' ' | sed 's/[[:space:]]*$//'
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Added a dependency-aware eligibility check to `/fix-issue` so candidates whose GitHub native blocked-by list still contains open issues are skipped.
- Applied in both auto-pick (continues scanning) and explicit `--issue` (reports ineligible with blocker list) modes; degrades silently to prior GO-only behavior when the dependencies endpoint is unreachable.
- Documented the new skip condition and the intentional API-degradation fallback under the skill's Known Limitations.

<details><summary>Architecture Diagram</summary>

Quick mode — architecture diagram skipped.

</details>

<details><summary>Code Flow Diagram</summary>

Quick mode — code flow diagram skipped.

</details>

<details><summary>Goal</summary>

- Prevent `/fix-issue` from picking up issues that cannot actually be worked on yet
  - An issue that depends on another still-open issue is not ready to implement
  - Picking such an issue wastes a `/implement` invocation and can produce a PR that conflicts with the in-flight prerequisite
- Use GitHub's native issue-dependencies feature as the authoritative signal
  - Structured, reliable, does not rely on free-text pattern matching
  - When the feature is not used on a repo (empty list) or the endpoint is unavailable, behavior is unchanged from before
- Preserve existing automation guarantees
  - The `GO` sentinel and `IN PROGRESS` lock semantics remain the primary gates
  - The dependency check never hard-blocks the pipeline on API availability

</details>

<details><summary>Test plan</summary>

- [ ] Issue with no blocked_by entries: eligible as before (verified via live probe against issues #99, #101)
- [ ] Issue with a closed blocker: eligible
- [ ] Issue with at least one open blocker: auto-pick skips and logs to stderr; explicit `--issue` returns exit 2 with formatted blocker list in ERROR
- [ ] `gh api` 404 or transient failure: script continues as if no blockers (graceful degradation)
- [ ] Pagination: `--paginate --jq` emits one blocker number per line across pages and is collapsed to a space-separated list

</details>

<details><summary>Final Design</summary>

**Change**: In `skills/fix-issue/scripts/fetch-eligible-issue.sh`, add an `open_blockers()` helper that queries `repos/{REPO}/issues/{N}/dependencies/blocked_by` with `--paginate --jq '.[] | select(.state == "open") | .number'` and collapses newline-separated output to a single space-separated string of open blocker issue numbers. Call this helper after the GO check succeeds in both auto-pick and explicit-issue modes. Auto-pick logs the skip to stderr and continues to the next candidate; explicit mode returns `ELIGIBLE=false` with `ERROR=Issue #N is blocked by open dependencies: #A,#B` and exits 2. API errors, empty responses, and jq failures are all treated as "no blockers known" so the check degrades gracefully.

**Files modified**:
- `skills/fix-issue/scripts/fetch-eligible-issue.sh` — new helper + two call sites + updated header comment
- `skills/fix-issue/SKILL.md` — YAML `description`, positional-argument contract at line 18, Step 1 narrative, and a new Known Limitations bullet

</details>

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `142e4fe` (Refactor /research to 3+3 lane composition (#95))
- **Current version**: `3.0.6`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `3.0.7`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH").

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

Quick mode — no plan review was conducted.

</details>

<details><summary>Implementation Deviations</summary>

No deviations from the inline plan. Round 3 of code review surfaced a correctness bug in the initial implementation (pagination of `gh api` without `--slurp` / `--jq` would silently drop blockers on later pages), which was fixed before commit.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

### [Code Review] Cursor (round 1)
**Finding**: CHANGELOG.md:9–12 — the `[3.0.6]` entry only documents the code-reviewer / reviewer-template tuning and does not mention `/fix-issue` dependency skipping. Suggested adding a bullet under `### Changed` describing the new behavior.
**Reason not implemented**: Out of scope. The `[3.0.6]` CHANGELOG entry belongs to commit `2c5cc03` (upstream `Tune code-reviewer prompt…`), which landed on `main` between branch creation and rebase. My feature branch's local `main` ref is stale vs `origin/main`, so the `main...HEAD` diff shown to Cursor spuriously includes that commit. My change does not touch CHANGELOG.md. The `/implement` Step 8a CHANGELOG update runs after `/bump-version`, at which point a dedicated CHANGELOG entry for the new version will be created — that entry will correctly describe the dependency-skip feature. (Confirmed: the `[3.0.7]` entry added in Step 8a documents this PR's behavior.)

### [Code Review] Cursor (round 1)
**Finding**: agents/code-reviewer.md:49–52 vs skills/shared/reviewer-templates.md:78–82 — Architecture checklist diverges; template's Contract Boundaries and Invariants bullets include parenthetical examples that the agent file omits. Suggested syncing the two files per the AGENTS.md contract.
**Reason not implemented**: Out of scope. The reviewer-templates / code-reviewer changes originate from upstream commit `2c5cc03` (`Tune code-reviewer prompt…`) that landed on `main` after branch creation. My feature branch's local `main` is stale, making the diff spuriously include that commit. My commit only edits `skills/fix-issue/**`. Fixing drift introduced by a prior commit is not this PR's concern.

### [Code Review] Cursor (round 1)
**Finding**: agents/code-reviewer.md:75 vs skills/shared/reviewer-templates.md:105 — priority list item 5 uses different phrasing ("Walk all four focus areas" vs "Walk the four focus areas above"). Suggested unifying wording.
**Reason not implemented**: Out of scope — same root cause as the prior two findings: upstream commit `2c5cc03` landed on `main` and is spuriously attributed to this PR via stale local-main diff. Not introduced by my change.

### [Code Review] Cursor (round 1)
**Finding**: agents/code-reviewer.md:107–111 / skills/shared/reviewer-templates.md:137–141 — In-Scope Findings definition ("issues that should be fixed in this PR") pairs oddly with the Latent severity tag. Suggested clarifying placement or redefining the category.
**Reason not implemented**: Out of scope — reviewer-template semantics originate in upstream commit `2c5cc03` and are not part of this PR's change set. The dependency-skip feature is orthogonal.

### [Code Review] Cursor (round 1)
**Finding**: fetch-eligible-issue.sh:88 — `select(.state == "open")` is case-sensitive; speculated that GitHub could return different casing or synonyms.
**Reason not implemented**: GitHub's REST API schema for issue state is documented as lowercase `open` / `closed`. Adding `ascii_downcase` normalization would be speculative hardening for a scenario that does not occur in the documented contract. Per project guidelines ("Don't add validation for scenarios that can't happen. Trust framework guarantees"), this is rejected as a premature defensive measure.

### [Code Review] Cursor (round 1, partial)
**Finding**: fetch-eligible-issue.sh:82–88 — suggested (a) emitting a one-line stderr warning when `gh api` fails or `jq` returns non-zero, OR (b) documenting the degradation in Known Limitations.
**Reason not implemented (stderr-warning portion only)**: The Known Limitations documentation portion of this finding WAS implemented (see SKILL.md Known Limitations). The stderr-warning portion was not implemented because adding per-invocation logging for an already-documented graceful-degradation behavior would add noise during routine cron/loop execution where the degradation is the design, not a surprise. Documentation is the proportionate fix; runtime logging would be scope creep.

### [Code Review] Cursor (round 2)
**Finding**: fetch-eligible-issue.sh:82–88 — reiterated that `open_blockers` treats any `gh api` failure (including 403, rate limiting, stale `gh` pagination quirks) as "no blockers," which can yield false negatives. Suggested a one-line stderr warning and/or documenting 403/rate-limit explicitly alongside 404 in Known Limitations.
**Reason not implemented**: The Known Limitations entry added in round 1 already uses the generic phrasing "unreachable or erroring dependency-API responses," which covers 403, rate limits, and other non-404 errors without being a maintenance burden. Expanding it to enumerate specific HTTP status codes would be documentation churn with no practical benefit. The stderr-log portion remains rejected for the same scope-creep reason as round 1 — it would produce per-invocation noise in cron/loop runs where the graceful degradation is the documented design, not an anomaly.

### [Code Review] Cursor (round 2)
**Finding**: fetch-eligible-issue.sh:154–157 and :207–208 — the `tr/sed/paste` blocker-list formatting chain is duplicated across the two call sites. Suggested extracting a `format_blocker_list` helper.
**Reason not implemented**: The duplicated code is a single one-line transformation appearing twice in a short file. Per CLAUDE.md's "Three similar lines is better than a premature abstraction" and the project's "Simplicity First" guideline, extracting a helper for two adjacent one-liners would be over-engineering. The two call sites are visually proximate and easy to keep in sync manually.

### [Code Review] Cursor (round 2)
**Finding**: fetch-eligible-issue.sh — no automated tests or fixtures exist for the new dependency filtering paths, degradation semantics, or message formats. Suggested adding lightweight tests with mocked `gh`/`jq` or recorded JSON if a repo pattern exists.
**Reason not implemented**: The repository has no shell-script test infrastructure. Its `Makefile` wraps `pre-commit` (shellcheck, markdownlint, jsonlint, actionlint, agent-lint, agnix) — linting only, no unit-test framework, no fixtures directory, no test runner for shell scripts. Introducing a one-off test harness for this single script would create an orphan pattern inconsistent with the rest of the repo. CLAUDE.md explicitly forbids this: "Don't design for hypothetical future requirements." If a test pattern is added repo-wide later, these paths can be backfilled then.

### [Code Review] Cursor (round 2)
**Finding**: fetch-eligible-issue.sh auto-pick loop (lines ~205–210) — for each `GO`-tagged issue the script makes an additional dependencies/blocked_by API request, producing N extra calls per run when many GO issues are blocked. Suggested mitigations: higher `per_page`, in-run caching, or operational documentation.
**Reason not implemented**: The cost is bounded by the count of open issues with `GO` as the last comment, which is small in practice (GO issues are hand-approved one at a time). The proposed mitigations are speculative — no evidence of rate-limit impact has been observed. Per project guidelines on premature optimization, the minimal correct implementation ships as-is; mitigations can be added if/when operational data shows a real problem.

</details>

<details><summary>Plan Review Voting Tally</summary>

Quick mode — no plan review voting.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

Quick mode — no voting panel. Main agent reviewed findings across up to 5 single-reviewer rounds (Cursor → Codex → Claude fallback chain).

Summary of rounds run:
- Round 1 — Cursor — 7 findings (2 accepted: YAML description polish, Known Limitations bullet; 5 rejected: 4 out-of-scope due to stale local-main diff, 1 speculative state-casing hardening)
- Round 2 — Cursor — 5 findings (1 accepted: SKILL.md positional-argument bullet polish; 4 rejected: stderr-logging scope creep, premature extraction, no test infrastructure, premature optimization)
- Round 3 — Cursor — 1 finding (accepted: genuine pagination correctness bug — `gh api --paginate` without `--jq` only yields the first page; fixed by switching to `--paginate --jq` per-page streaming)
- Round 4 — Cursor — NO_ISSUES_FOUND; loop converged

</details>

<details><summary>Out-of-Scope Observations</summary>

Quick mode — no out-of-scope observations collected.

</details>

<details><summary>Execution Issues</summary>

No execution issues encountered.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | N/A (quick mode) |
| Code review rounds | 4 (converged at round 4 with NO_ISSUES_FOUND) |
| Code review findings | 3 accepted, 10 rejected (across rounds 1–3) |
| Warnings logged | 0 |
| Pre-existing issues noticed | 0 (the apparent in-PR drift in code-reviewer.md / reviewer-templates.md is from a prior upstream commit in the diff, not a pre-existing issue) |
| OOS issues filed | N/A (quick mode) |
| External reviewers | Cursor: ✅, Codex: ✅ (both healthy; Cursor was used for all 4 rounds via the quick-mode priority chain) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
