### PR TITLE
Add /issue skill for GitHub issue creation

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "3.0.7",
+  "version": "3.1.0",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0] - 2026-04-18
+
+### Added
+
+- New `/issue` skill (`skills/issue/SKILL.md`) that creates a GitHub issue in the current repository from a free-form description. With the optional `--go` flag, it additionally posts a final `GO` comment on the new issue so it becomes immediately eligible for `/fix-issue` automation without manual approval. `skills/alias/SKILL.md` now reserves the `issue` name so project-level aliases cannot collide with the shipped skill. README install blurb, Skills summary row, and skills table updated to document `/issue`.
+
 ## [3.0.7] - 2026-04-18
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ claude plugin marketplace add zhupanov/larch
 claude plugin install larch@larch-local
 ```
 
-The first command registers larch's marketplace manifest (`.claude-plugin/marketplace.json`). The second command installs the `larch` plugin into your Claude Code user scope. Once installed, the `/design`, `/implement`, `/review`, `/research`, `/loop-review`, `/fix-issue`, `/alias`, `/im`, and `/imaq` slash commands become available in every Claude Code session.
+The first command registers larch's marketplace manifest (`.claude-plugin/marketplace.json`). The second command installs the `larch` plugin into your Claude Code user scope. Once installed, the `/design`, `/implement`, `/review`, `/research`, `/loop-review`, `/fix-issue`, `/issue`, `/alias`, `/im`, and `/imaq` slash commands become available in every Claude Code session.
 
 To scope the install to a single project instead of the user scope, append `--scope project` to the `install` command.
 
@@ -41,7 +41,7 @@ claude plugin install larch@larch-local
 
 | Component | Description |
 |---|---|
-| Skills | `/design`, `/implement`, `/review`, `/research`, `/loop-review`, `/fix-issue`, `/alias`, `/im`, `/imaq` |
+| Skills | `/design`, `/implement`, `/review`, `/research`, `/loop-review`, `/fix-issue`, `/issue`, `/alias`, `/im`, `/imaq` |
 | Agents | `code-reviewer` (unified archetype covering code quality, risk/integration, correctness, architecture) |
 | PreToolUse hook | `block-submodule-edit.sh` — blocks `Edit`/`Write` on files inside any checked-out git submodule of the consuming project |
 
@@ -120,6 +120,7 @@ Slash commands available in Claude Code sessions. They automate multi-step workf
 | [`/implement`](skills/implement/SKILL.md) | `[--quick] [--auto] [--merge] [--debug] <feature description>` | Full end-to-end feature workflow — design, implement, PR, and Slack announce. `--quick` skips `/design` and uses simplified code review (1 Claude Code Reviewer subagent, 1 round). `--auto` suppresses all interactive question checkpoints. `--merge` additionally runs the CI+rebase+merge loop, :merged: emoji, local branch cleanup, and main verification (without `--merge`, the PR is created and the workflow stops after the initial CI wait, Slack announcement, and reports). `--debug` enables verbose output with detailed tool descriptions and explanatory prose (default is compact output). [(Diagram).](skills/implement/diagram.svg) |
 | [`/loop-review`](skills/loop-review/SKILL.md) | `[--debug] [partition criteria]` | Systematic code review of entire repository by partitioning into slices, reviewing each with 2 Claude Code Reviewer subagent lanes (broad + deep perspectives) + 2 Codex (broad + deep) + Cursor (5 total, if available), implementing improvements via `/implement`, and logging deferred suggestions. Uses the Negotiation Protocol. The optional argument specifies how to partition the codebase (e.g., by directory, by file type). [(Diagram).](skills/loop-review/diagram.svg) |
 | [`/fix-issue`](skills/fix-issue/SKILL.md) | `[--debug] [<number-or-url>]` | Process one approved GitHub issue per invocation. Fetches open issues with a `GO` sentinel comment, triages against the codebase, classifies complexity (SIMPLE/HARD), and delegates to `/implement`. With a number or URL argument, targets a specific issue instead of auto-picking. Single-iteration design — the caller handles repetition. |
+| [`/issue`](skills/issue/SKILL.md) | `[--go] <issue description>` | Create a new GitHub issue in the current repository from a free-form description. With `--go`, also posts a final `GO` comment on the new issue so it becomes immediately eligible for `/fix-issue` automation. |
 | [`/alias`](skills/alias/SKILL.md) | `[--merge] <alias-name> <target-skill> [preset-flags...]` | Create a project-level alias for a larch skill with preset flags. Delegates to `/implement --quick --auto` for the full pipeline (code review, version bump, PR). `--merge` also merges the PR. Example: `/alias i implement --merge` creates `/i` as a shortcut for `/implement --merge`. |
 | [`/relevant-checks`](.claude/skills/relevant-checks/SKILL.md) | *(none)* | Run pre-commit linters (shellcheck, markdownlint, jsonlint, actionlint) scoped to files modified on the current branch. Invoked automatically by `/implement` and `/review` after code changes. **Not part of the plugin surface; each consuming repo provides its own.** |
 

--- a/skills/alias/SKILL.md
+++ b/skills/alias/SKILL.md
@@ -33,7 +33,7 @@ All validation uses Bash since `${CLAUDE_PLUGIN_ROOT}` is a shell variable not r
 1. **Alias name format**: Verify alias name matches `^[a-z][a-z0-9-]*$` (lowercase, alphanumeric + hyphens, must start with a letter).
    - If invalid, print: `**ERROR: Alias name '<name>' is invalid. Must start with a lowercase letter and contain only lowercase letters, digits, and hyphens.**` and abort.
 
-2. **Reserved name check**: Reject if alias name matches any of: `design`, `implement`, `review`, `research`, `loop-review`, `alias`, `relevant-checks`, `bump-version`, `fix-issue`, `im`, `imaq`.
+2. **Reserved name check**: Reject if alias name matches any of: `design`, `implement`, `review`, `research`, `loop-review`, `alias`, `relevant-checks`, `bump-version`, `fix-issue`, `issue`, `im`, `imaq`.
    - If reserved, print: `**ERROR: Cannot create alias '<name>' — this name is reserved (it matches an existing larch or common project-level skill). Choose a different name.**` and abort.
 
 3. **Target name format**: Verify target skill name matches `^[a-z][a-z0-9-]*$` (same format as alias names).

--- a/skills/issue/SKILL.md
+++ b/skills/issue/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: issue
+description: "Use when creating a new GitHub issue from a free-form description. Optional --go flag posts a 'GO' comment on the new issue so it becomes immediately eligible for /fix-issue automation."
+argument-hint: "[--go] <issue description>"
+allowed-tools: Bash
+---
+
+# Issue Skill
+
+Create a new GitHub issue in the current repository from a free-form description. Optionally appends a final comment containing only `GO`, which marks the issue as approved for automated processing by `/fix-issue`.
+
+## Step 1 — Parse Arguments
+
+Parse flags from the start of `$ARGUMENTS` before treating the remainder as the issue description. Stop at the first non-flag token.
+
+- `--go`: Set `go_mode=true`. Default: `go_mode=false`. When `true`, a final comment with the exact body `GO` is posted on the new issue after creation.
+
+After flag stripping, the remainder of `$ARGUMENTS` is the **issue description**. Save it as `DESCRIPTION`.
+
+If `DESCRIPTION` is empty (only flags were provided), print `**ERROR: Usage: /issue [--go] <issue description>**` and abort.
+
+## Step 2 — Derive Title and Body
+
+The **title** is a concise one-line summary derived from `DESCRIPTION`:
+
+- Take `DESCRIPTION` up to the first newline (or the whole string if single-line).
+- Trim leading/trailing whitespace.
+- If the result is longer than 80 characters, truncate at the last word boundary ≤ 80 chars and append `…`.
+- If after trimming the title is empty, abort with `**ERROR: Could not derive a title from the description.**`
+
+The **body** is the full original `DESCRIPTION` verbatim (including any multi-line content).
+
+## Step 3 — Verify Repository Access
+
+```bash
+REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null)
+```
+
+If the command fails or `REPO` is empty, print `**ERROR: Could not determine the current repository. Ensure 'gh' is authenticated and you are inside a GitHub-backed repo.**` and abort.
+
+## Step 4 — Create the Issue
+
+Invoke `gh issue create` with the derived title and full body:
+
+```bash
+gh issue create --title "<title>" --body "<body>"
+```
+
+Pass `<body>` via a heredoc or a temp file if it contains characters that would be awkward to quote inline. Capture stdout — `gh` prints the new issue URL as the last line.
+
+**On failure** (non-zero exit): print `**ERROR: Failed to create issue: <stderr excerpt>**` and abort.
+
+**On success**: Parse the issue number from the URL (format `https://github.com/OWNER/REPO/issues/N`).
+
+Save `ISSUE_URL` and `ISSUE_NUMBER`.
+
+## Step 5 — Post GO Comment (conditional)
+
+Run this step only when `go_mode=true`.
+
+```bash
+gh issue comment "$ISSUE_NUMBER" --body "GO"
+```
+
+- On success: proceed to Step 6 — the final summary will note the GO comment was posted.
+- On failure: print `**⚠ Issue was created but GO comment failed: <stderr excerpt>. You can add 'GO' as a final comment manually to approve it for /fix-issue.**` — still proceed to Step 6 (issue exists and is useful on its own).
+
+## Step 6 — Report
+
+Print a final summary on a single line:
+
+- If `go_mode=true` and the GO comment succeeded: `✅ Created issue #<ISSUE_NUMBER> with GO comment — <ISSUE_URL>`
+- If `go_mode=true` and the GO comment failed: `**⚠ Created issue #<ISSUE_NUMBER> — <ISSUE_URL> (GO comment failed; add it manually to approve for /fix-issue)**`
+- If `go_mode=false`: `✅ Created issue #<ISSUE_NUMBER> — <ISSUE_URL>`

--- a/skills/issue/SKILL.md
+++ b/skills/issue/SKILL.md
@@ -25,7 +25,7 @@ The **title** is a concise one-line summary derived from `DESCRIPTION`:
 
 - Take `DESCRIPTION` up to the first newline (or the whole string if single-line).
 - Trim leading/trailing whitespace.
-- If the result is longer than 80 characters, truncate at the last word boundary ≤ 80 chars and append `…`.
+- If the result is longer than 80 characters: truncate at the last whitespace ≤ 80 chars and append `…`. If the first 80 characters contain no whitespace (e.g., a long token or URL), hard-cut at 80 characters and append `…`.
 - If after trimming the title is empty, abort with `**ERROR: Could not derive a title from the description.**`
 
 The **body** is the full original `DESCRIPTION` verbatim (including any multi-line content).
@@ -40,17 +40,23 @@ If the command fails or `REPO` is empty, print `**ERROR: Could not determine the
 
 ## Step 4 — Create the Issue
 
-Invoke `gh issue create` with the derived title and full body:
+Invoke `gh issue create` with the derived title and full body, targeting the verified repository explicitly so the command matches the repo confirmed in Step 3. Pass the title and body as proper shell variables (double-quoted), not interpolated literals — the user's free-form description may contain `"`, `$`, or backticks that would break naive inlining. For long or multi-line bodies, write the body to a temp file first and read it into a variable, or use a heredoc into a variable:
 
 ```bash
-gh issue create --title "<title>" --body "<body>"
+gh issue create -R "$REPO" --title "$TITLE" --body "$BODY"
 ```
 
-Pass `<body>` via a heredoc or a temp file if it contains characters that would be awkward to quote inline. Capture stdout — `gh` prints the new issue URL as the last line.
+Capture stdout.
 
 **On failure** (non-zero exit): print `**ERROR: Failed to create issue: <stderr excerpt>**` and abort.
 
-**On success**: Parse the issue number from the URL (format `https://github.com/OWNER/REPO/issues/N`).
+**On success**: Extract the issue URL — scan stdout for the last line matching the issue-URL pattern (`.*/issues/[0-9]+$`) rather than assuming a fixed line position. Then resolve the issue number host-agnostically (works for github.com and GitHub Enterprise):
+
+```bash
+ISSUE_NUMBER=$(gh issue view "$ISSUE_URL" --json number --jq '.number')
+```
+
+If this command fails (non-zero exit) or `ISSUE_NUMBER` is empty: the issue was created but its number could not be resolved. Print `**⚠ Issue created at $ISSUE_URL but could not resolve its number: <stderr excerpt>. Skipping --go comment (if requested).**` — then **skip Step 5 entirely** and go to Step 6 with the `go_mode=false` summary variant, using `$ISSUE_URL` as the only identifier.
 
 Save `ISSUE_URL` and `ISSUE_NUMBER`.
 
@@ -59,7 +65,7 @@ Save `ISSUE_URL` and `ISSUE_NUMBER`.
 Run this step only when `go_mode=true`.
 
 ```bash
-gh issue comment "$ISSUE_NUMBER" --body "GO"
+gh issue comment -R "$REPO" "$ISSUE_NUMBER" --body "GO"
 ```
 
 - On success: proceed to Step 6 — the final summary will note the GO comment was posted.


### PR DESCRIPTION
## Summary
- Added a new `/issue` skill (`skills/issue/SKILL.md`) that creates a GitHub issue from a free-form description, with an optional `--go` flag that appends a `GO` comment so the issue is immediately eligible for `/fix-issue` automation.
- Reserved the `issue` name in `/alias` so project-level aliases cannot collide with the shipped skill.
- Updated README install blurb, Skills summary row, and skills table to document `/issue`, and added a 3.1.0 entry to `CHANGELOG.md`.

<details><summary>Architecture Diagram</summary>

Quick mode — architecture diagram skipped.

</details>

<details><summary>Code Flow Diagram</summary>

Quick mode — code flow diagram skipped.

</details>

<details><summary>Goal</summary>

- Create a new `/issue` skill
  - Accept a free-form issue description as the skill argument
  - Create a GitHub issue in the current repository using that description (title derived from the first line; body is the full description)
  - Support an optional `--go` flag
    - When present, append a final comment containing only `GO` on the newly created issue
    - The purpose of the `GO` sentinel is to mark the issue as immediately eligible for `/fix-issue` automation without requiring a human reviewer to add the comment manually
- Success criteria
  - Invoking `/issue <description>` produces a new open issue whose title summarizes the description and whose body is the full description
  - Invoking `/issue --go <description>` additionally leaves `GO` as the final comment on the new issue
  - The new skill is documented in the canonical README skill catalog and does not collide with `/alias`'s reserved-name protection

</details>

<details><summary>Test plan</summary>

- [ ] Run `/issue This is a test issue` in a repo with `gh` authenticated; verify a new open issue is created with "This is a test issue" as both title and body.
- [ ] Run `/issue --go Multi-line\ntest body` (multi-line description); verify the title is the first line (truncated if >80 chars), the body is the full description, and the final comment on the issue is exactly `GO`.
- [ ] Run `/fix-issue <issue-number>` on the issue created with `--go` to confirm the `GO` sentinel is detected and the automation is eligible to proceed.
- [ ] Try `/alias issue <target>` — verify the alias skill now rejects `issue` as a reserved name.
- [ ] Spot-check README Skills table rendering — the `/issue` row appears between `/fix-issue` and `/alias`.

</details>

<details><summary>Final Design</summary>

Inline quick-mode plan (no `/design` phase):

- Create `skills/issue/SKILL.md` as a thin prompt-only skill following the `/alias` pattern (Bash-only `allowed-tools`, no helper scripts).
- Parse `--go` at the head of `$ARGUMENTS`; remainder is the issue description (`DESCRIPTION`). Abort if empty.
- Derive title: first line of `DESCRIPTION`, trimmed, truncated at last whitespace ≤80 chars with `…` suffix; if no whitespace in first 80 chars, hard-cut at 80 + `…`. Body = full `DESCRIPTION`.
- Resolve repo via `gh repo view --json nameWithOwner --jq '.nameWithOwner'`; abort with error if `gh` is unauthenticated or not in a GitHub repo.
- Create issue with `gh issue create -R "$REPO" --title "$TITLE" --body "$BODY"` using proper shell-variable quoting (not literal placeholders). Extract URL by scanning stdout for the last line matching `.*/issues/[0-9]+$`.
- Resolve issue number host-agnostically with `gh issue view "$ISSUE_URL" --json number --jq '.number'` (works on github.com and GitHub Enterprise). If resolution fails, warn, skip the `--go` step, and report with URL-only.
- If `--go` was requested and number resolution succeeded: `gh issue comment -R "$REPO" "$ISSUE_NUMBER" --body "GO"`. On failure, report partial success (issue exists, GO comment missing) rather than aborting.
- README: add `/issue` to the install paragraph, the Skills summary row, and the skills table. `skills/alias/SKILL.md`: add `issue` to the reserved-name list.
- CHANGELOG: new `[3.1.0] - 2026-04-18` entry under `Added`.
- Version bump: MINOR (new skill added) → `3.1.0`.

</details>

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `fbbf648` (Skip /fix-issue candidates blocked by open GitHub dependencies (#105))
- **Current version**: `3.0.7`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: MINOR

- **New version**: `3.1.0`

### MINOR evidence
- Added `skills/issue/SKILL.md`

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

Quick mode — no plan review was conducted.

</details>

<details><summary>Implementation Deviations</summary>

No deviations from the inline plan.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

All code review suggestions were implemented (or subsumed by accepted fixes).

</details>

<details><summary>Plan Review Voting Tally</summary>

Quick mode — no plan review voting.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

Quick mode — no voting panel. Main agent reviewed findings across 4 single-reviewer rounds (Cursor → Codex → Claude fallback chain; Cursor used for all 4 rounds).

- **Round 1** (Cursor): 6 findings raised → 5 accepted + 1 subsumed (fragile stdout parsing → addressed by host-agnostic URL→number resolution via `gh issue view --json`).
- **Round 2** (Cursor): 7 findings raised → 5 acknowledged the round-1 fixes (no-op), 2 new findings accepted (title double-quote safety; explicit failure path when `gh issue view` fails to resolve the issue number).
- **Round 3** (Cursor): 6 findings raised → 5 acknowledged prior fixes (no-op), 1 new finding accepted (`/alias` reserved list now includes `issue`).
- **Round 4** (Cursor): 7 findings raised → all 7 acknowledged previously-applied fixes (no-op). Loop converged; no new changes this round.

</details>

<details><summary>Out-of-Scope Observations</summary>

Quick mode — no out-of-scope observations collected.

</details>

<details><summary>Execution Issues</summary>

No execution issues encountered.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | N/A (quick mode) |
| Code review rounds | 4 |
| Code review findings | 8 accepted (across rounds 1–3), 18 acknowledgements of prior fixes (rounds 2–4), 0 outright rejected |
| Warnings logged | 0 |
| Pre-existing issues noticed | 0 |
| OOS issues filed | N/A (quick mode) |
| External reviewers | Cursor: ✅, Codex: N/A (quick mode) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
