### PR TITLE
Raise /implement quick-mode code-review cap from 5 to 7 rounds

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.1] - 2026-04-18
+
+### Changed
+
+- Raised the `/implement --quick` single-reviewer code-review loop cap from 5 rounds to 7. The quick-mode re-review gate (`skills/implement/SKILL.md` Step 5.8) now loops while `round_num <= 7` and prints the non-convergence warning when `round_num > 7`; the `--quick` flag description, Step 5 header, body, warning copy, execution-issues log text, and the quick-mode PR-body guidance for the Code Review Voting Tally are updated in lockstep. Reviews that previously exhausted the cap with unresolved findings now have two additional iterations to converge before the warning is emitted. `/review`'s independent normal-mode 5-round cap is unchanged.
+
 ## [3.1.0] - 2026-04-18
 
 ### Added

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -13,7 +13,7 @@ The feature to implement is described by `$ARGUMENTS` after flag stripping.
 
 **Flags**: Parse flags from the start of `$ARGUMENTS` before treating the remainder as the feature description. Flags may appear in any order; stop at the first non-flag token. After stripping all flags, save the remainder as `FEATURE_DESCRIPTION` — use this (not raw `$ARGUMENTS`) whenever the human-readable feature description is needed (e.g., PR body, design invocation, commit messages). **All boolean flags default to `false`. Only set a flag to `true` when its `--flag` token is explicitly present in the arguments. Flags are independent — the presence of one flag must not influence the default value of any other flag.**
 
-- `--quick`: Set a mental flag `quick_mode=true`. Default: `quick_mode=false`. When `quick_mode=true`: Step 1 skips `/design` (this skill creates the branch and an inline plan directly), Step 5 skips `/review` (a single-reviewer loop of up to 5 rounds using the Cursor → Codex → Claude Code Reviewer subagent fallback chain — no voting panel), and Step 7a skips the Code Flow Diagram. All other steps (CI wait, Slack, cleanup) run normally. The `--merge` opt-in is independent of `--quick`.
+- `--quick`: Set a mental flag `quick_mode=true`. Default: `quick_mode=false`. When `quick_mode=true`: Step 1 skips `/design` (this skill creates the branch and an inline plan directly), Step 5 skips `/review` (a single-reviewer loop of up to 7 rounds using the Cursor → Codex → Claude Code Reviewer subagent fallback chain — no voting panel), and Step 7a skips the Code Flow Diagram. All other steps (CI wait, Slack, cleanup) run normally. The `--merge` opt-in is independent of `--quick`.
 - `--auto`: Set a mental flag `auto_mode=true`. Default: `auto_mode=false`. When `auto_mode=true`: (a) forward `--auto` to `/design` invocation in Step 1, suppressing `/design`'s interactive question checkpoints; (b) suppress this skill's own opportunistic questions in Step 2; (c) in Step 12, when merge conflicts require user input for uncertain resolutions, suppress `AskUserQuestion` and use best-effort resolution instead (bailing if confidence is too low). When `--quick` is also set and `/design` is skipped, `--auto` still suppresses Step 2 questions.
 - `--merge`: Set a mental flag `merge=true`. Default: `merge=false`. When `merge=true`, Steps 12–15 run (CI+rebase+merge loop, :merged: emoji, local cleanup, and main verification). When `merge=false`, these steps are skipped — the PR is created and the workflow stops after the initial CI wait, Slack announcement, rejected findings report, final report, and temp cleanup.
 - `--no-merge`: **Deprecated** — recognized for backward compatibility but treated as a no-op (the new default already skips merge steps). When this flag is encountered, print: `**ℹ '--no-merge' is now the default and no longer needed; the flag is recognized as a no-op for backward compatibility.**`
@@ -270,9 +270,9 @@ If successful:
 
 ### Quick mode (`quick_mode=true`)
 
-Print: `> **🔶 5: code review — quick mode (single reviewer, Cursor → Codex → Claude fallback, up to 5 rounds)**`
+Print: `> **🔶 5: code review — quick mode (single reviewer, Cursor → Codex → Claude fallback, up to 7 rounds)**`
 
-Skip `/review`. Instead, run a single-reviewer loop with up to **5 rounds** of review + fix. There is no voting panel — one reviewer per round, main agent unilaterally accepts/rejects each finding.
+Skip `/review`. Instead, run a single-reviewer loop with up to **7 rounds** of review + fix. There is no voting panel — one reviewer per round, main agent unilaterally accepts/rejects each finding.
 
 **Reviewer selection**: At the start of each round, pick ONE reviewer from the following priority chain (re-evaluated each round so runtime failures cascade to the next tier per the **Runtime Timeout Fallback** procedure in `${CLAUDE_PLUGIN_ROOT}/skills/shared/external-reviewers.md`):
 
@@ -332,13 +332,13 @@ Append rejected findings to `$IMPLEMENT_TMPDIR/rejected-findings.md` using the s
 
 **5.7 — Implement accepted fixes**: Edit the affected files. Then invoke `/relevant-checks`. If checks fail, diagnose and fix, then re-invoke `/relevant-checks` until clean.
 
-**5.8 — Re-review gate**: Observable signal is whether Step 5.7 actually edited any files in the working tree — the main agent knows this from its own Edit/Write tool usage during this round. If Step 5.7 made no file edits (accepted findings turned out to be no-ops after re-reading code), the loop is done — proceed to Step 6. Otherwise, significant changes were made: increment `round_num`. If `round_num <= 5`, loop back to 5.1. If `round_num > 5`, print:
+**5.8 — Re-review gate**: Observable signal is whether Step 5.7 actually edited any files in the working tree — the main agent knows this from its own Edit/Write tool usage during this round. If Step 5.7 made no file edits (accepted findings turned out to be no-ops after re-reading code), the loop is done — proceed to Step 6. Otherwise, significant changes were made: increment `round_num`. If `round_num <= 7`, loop back to 5.1. If `round_num > 7`, print:
 
 ```
-**⚠ 5: code review — quick mode hit 5-round cap without converging. Remaining findings from the last round are listed above. Proceeding.**
+**⚠ 5: code review — quick mode hit 7-round cap without converging. Remaining findings from the last round are listed above. Proceeding.**
 ```
 
-Log to `$IMPLEMENT_TMPDIR/execution-issues.md` under `Warnings`: `Step 5 — quick-mode review loop did not converge after 5 rounds.` Then proceed to Step 6.
+Log to `$IMPLEMENT_TMPDIR/execution-issues.md` under `Warnings`: `Step 5 — quick-mode review loop did not converge after 7 rounds.` Then proceed to Step 6.
 
 ### Normal mode (`quick_mode=false`)
 
@@ -621,7 +621,7 @@ Populate Run Statistics from conversation context: count accepted/rejected findi
 - **Version Bump Reasoning**: Populate from `$BUMP_REASONING_FILE` (the absolute path parsed from `classify-bump.sh`'s `REASONING_FILE=<path>` stdout line in Step 8, identical to normal mode) if it exists and is non-empty, otherwise the standard fallback text from the normal-mode template.
 - **Rejected Plan Review Suggestions**: Write "Quick mode — no plan review was conducted."
 - **Plan Review Voting Tally**: Write "Quick mode — no plan review voting."
-- **Code Review Voting Tally (Round 1)**: Write "Quick mode — no voting panel. Main agent reviewed findings across up to 5 single-reviewer rounds (Cursor → Codex → Claude fallback chain)."
+- **Code Review Voting Tally (Round 1)**: Write "Quick mode — no voting panel. Main agent reviewed findings across up to 7 single-reviewer rounds (Cursor → Codex → Claude fallback chain)."
 - **Implementation Deviations**: Compare implementation to the inline plan (same as normal mode).
 - **Out-of-Scope Observations**: Write "Quick mode — no out-of-scope observations collected."
 - **Run Statistics**: Set "Plan review findings" to "N/A (quick mode)", "External reviewers" to "N/A (quick mode)", "OOS issues filed" to "N/A (quick mode)". Code review findings should reflect the quick review results.


### PR DESCRIPTION
## Summary
- Raised the `/implement --quick` single-reviewer code-review loop cap from 5 rounds to 7, giving reviews that previously exhausted the cap two extra iterations to converge before the non-convergence warning is emitted.
- Updated all seven 5-round references in `skills/implement/SKILL.md` (flag doc, Step 5 header, Step 5 body, Step 5.8 gate, warning copy, execution-issues log text, and quick-mode PR-body guidance) in lockstep so the advertised cap and the actual gate stay in sync.
- Added a 3.1.1 `CHANGELOG.md` entry noting the cap change and explicitly calling out that `/review`'s independent normal-mode 5-round cap is unchanged.

<details><summary>Architecture Diagram</summary>

Quick mode — architecture diagram skipped.

</details>

<details><summary>Code Flow Diagram</summary>

Quick mode — code flow diagram skipped.

</details>

<details><summary>Goal</summary>

- Raise the `/implement` quick-mode code-review round cap from 5 to 7
  - Give reviews that hit the 5-round cap with unresolved findings additional iterations to converge before the warning is emitted
  - Keep all user-visible and internal references to the cap in sync (advertised cap in the `--quick` flag description, Step 5 quick-mode banner, Step 5 body narrative, Step 5.8 gate condition, warning copy, execution-issues log line, quick-mode PR body guidance)
  - Do NOT touch `/review`'s independent normal-mode 5-round cap — the user asked only about `/implement`

</details>

<details><summary>Test plan</summary>

- [ ] Grep `skills/implement/SKILL.md` for `5 round`, `5-round`, `<= 5`, `> 5` — verify no residual references to the old cap remain for the quick-mode loop.
- [ ] Grep `skills/implement/SKILL.md` for `7 round`, `7-round`, `<= 7`, `> 7` — verify exactly the seven expected occurrences are present (1× flag doc, 1× Step 5 header, 1× Step 5 body, 2× Step 5.8 gate condition, 1× warning copy, 1× execution-issues log text, 1× quick-mode PR body guidance).
- [ ] Invoke `/implement --quick <feature>` on a small toy change and confirm the Step 5 banner prints "up to 7 rounds".
- [ ] Construct a scenario that forces >5 rounds (e.g., reviewers intentionally keep finding new issues) and verify the loop now terminates at round 7, not round 5, and that the warning references 7.
- [ ] Confirm `/implement` normal mode and `/review` standalone still run with their original 5-round cap (should be unchanged — only `skills/implement/SKILL.md` was modified).

</details>

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `9ff39db` (Add /issue skill for GitHub issue creation (#107))
- **Current version**: `3.1.0`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `3.1.1`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH").

**Escalation review**: The change raises an internal iteration cap on the `/implement --quick` single-reviewer loop from 5 to 7. No SKILL.md `name:` field or `argument-hint:` tokens changed, no SKILL.md files were added/deleted/renamed, and no agents were touched. The behavioral delta is strictly permissive — any invocation that converged in ≤5 rounds still converges identically; only invocations that previously hit the cap see two extra iterations before the warning. This is a backward-compatible refinement, not a breaking change. PATCH is correct; no escalation applied.

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

Quick mode — no plan review was conducted.

</details>

<details><summary>Implementation Deviations</summary>

No deviations from the inline plan.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

All code review suggestions were implemented (or naturally addressed by the standard `/implement` flow).

</details>

<details><summary>Plan Review Voting Tally</summary>

Quick mode — no plan review voting.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

Quick mode — no voting panel. Main agent reviewed findings across 1 single-reviewer round (Cursor).

- **Round 1** (Cursor): 1 finding raised. The reviewer flagged that the existing `CHANGELOG.md:36` entry (for 3.0.4) describing quick mode as "up to 5 rounds" would become inconsistent with current behavior after this change. The reviewer explicitly suggested adding a new release-line entry for this change rather than rewriting the historical sentence — which is exactly what Step 8a does automatically. No edit needed in Step 5; the 3.1.1 CHANGELOG entry added in Step 8a satisfies the reviewer's suggestion.

Loop converged after 1 round (zero file edits made during review).

</details>

<details><summary>Out-of-Scope Observations</summary>

Quick mode — no out-of-scope observations collected.

</details>

<details><summary>Execution Issues</summary>

No execution issues encountered.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | N/A (quick mode) |
| Code review rounds | 1 |
| Code review findings | 0 accepted (for in-round edits), 0 rejected, 1 naturally handled by Step 8a |
| Warnings logged | 0 |
| Pre-existing issues noticed | 0 |
| OOS issues filed | N/A (quick mode) |
| External reviewers | Cursor: ✅, Codex: N/A (quick mode) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
