### PR TITLE
Improve /implement Step 2 prompt with six research-backed edits (#96)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.1] - 2026-04-18
+
+### Changed
+
+- Strengthened `/implement` Step 2 prompt with six research-backed edits to `skills/implement/SKILL.md`: (1) quick-mode inline plan schema at SKILL.md:185 now requires testing strategy and failure modes to match `/design`'s output; (2) new root-cause-discipline bullet in Step 2; (3) new incremental-`/relevant-checks` bullet in Step 2; (4) mode-aware Step 2 lead-in sentence; (5) auto-mode clause at SKILL.md:230 now instructs the agent to log mid-coding interpretations under the "Implementation Deviations" PR-body section; (6) TDD bullet tail now includes a concrete non-TDD verification fallback. Closes #96.
+
 ## [3.3.0] - 2026-04-18
 
 ### Added

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -182,7 +182,7 @@ Skip `/design` entirely. Handle branch creation directly, then produce an inline
 - If `IS_USER_BRANCH=true`: Verify the branch name (`CURRENT_BRANCH`) aligns with the requested feature. If it appears unrelated (different feature name, unrelated commits), print a warning: `**⚠ Current branch '<branch-name>' may not match the requested feature. Creating a new branch from main.**` and create a new branch. Otherwise, use the existing branch.
 - Otherwise (non-main, non-user branch): Print a warning: `**⚠ Currently on branch '<branch-name>' which doesn't match the expected '<USER_PREFIX>/*' pattern. Creating a new branch from main.**` and create a new branch.
 
-**Inline design**: Research the codebase (read relevant files, grep for patterns), then produce a concrete implementation plan under a `## Implementation Plan` header. This plan should include files to modify, approach, and edge cases — the same content `/design` would produce, but without collaborative sketches, plan review, or voting. Print: `⚡ 1: design plan — quick mode, inline plan`
+**Inline design**: Research the codebase (read relevant files, grep for patterns), then produce a concrete implementation plan under a `## Implementation Plan` header. This plan should include: files to modify, approach, edge cases, **testing strategy** (TDD where applicable; otherwise a concrete verification — `/relevant-checks`, grep, dry-run, or manual repro), and **failure modes** (what could go wrong and how we'd detect it). The same content `/design` would produce, but without collaborative sketches, plan review, or voting. Print: `⚡ 1: design plan — quick mode, inline plan`
 
 Proceed to Step 2.
 
@@ -227,14 +227,16 @@ If successful:
 
 ## Step 2 — Implement the Feature
 
-**Opportunistic questions** (`auto_mode=false` only): Before starting edits, if the implementation plan leaves genuinely ambiguous choices (e.g., naming conventions, test strategy, which of two valid approaches to use), batch them into a single `AskUserQuestion` call with 1-4 questions. Only ask when the ambiguity cannot be resolved from the plan, codebase, or CLAUDE.md. When `auto_mode=true`, proceed with best judgment — do not ask. Material answers that change scope or approach should be noted for the "Implementation Deviations" section.
+**Opportunistic questions** (`auto_mode=false` only): Before starting edits, if the implementation plan leaves genuinely ambiguous choices (e.g., naming conventions, test strategy, which of two valid approaches to use), batch them into a single `AskUserQuestion` call with 1-4 questions. Only ask when the ambiguity cannot be resolved from the plan, codebase, or CLAUDE.md. When `auto_mode=true`, proceed with best judgment — do not ask. When a genuine ambiguity is encountered mid-coding, pick the interpretation most consistent with the plan and existing patterns, and record the decision (question + chosen interpretation + one-sentence rationale) under the "Implementation Deviations" PR-body section. Material answers that change scope or approach are logged there as well.
 
-Implement the feature following the (reviewed) plan from the `/design` phase. Follow all guidelines in CLAUDE.md:
+Implement the feature following the plan from Step 1 — the reviewed `/design` plan in normal mode, or the inline `## Implementation Plan` in quick mode. Follow all guidelines in CLAUDE.md:
 - Read existing code before modifying
 - Match existing style and patterns
 - Avoid code duplication — search for reusable code first
 - Don't over-engineer — for each abstraction, helper, or indirection you introduce, ask: is this justified by a concrete current need? If the answer is "it might be useful later," don't add it
-- When the project has test infrastructure (look for: test directories, Makefile test targets, package.json test scripts, or a test framework), prefer test-driven development: write a failing test for the expected behavior first, then implement to make it pass. For changes that are purely configuration, documentation, or prompt-text edits, skip TDD
+- When the project has test infrastructure (look for: test directories, Makefile test targets, package.json test scripts, or a test framework), prefer test-driven development: write a failing test for the expected behavior first, then implement to make it pass. For changes that are purely configuration, documentation, or prompt-text edits, skip TDD — but state one concrete post-change verification: a `/relevant-checks` invocation, a grep confirming no stale references remain, a dry-run command, or a minimal manual repro
+- Address root causes, not symptoms; do not suppress errors or paper over failures.
+- Invoke `/relevant-checks` promptly after each non-trivial logical sub-step, not only at the end of implementation. Step 3 is the final check, not the only one.
 
 ## Step 3 — Relevant Checks (first pass)
 


### PR DESCRIPTION
## Summary
- Strengthened `/implement` Step 2 prompt with six research-backed prompt-text edits to `skills/implement/SKILL.md`: richer quick-mode inline plan schema, root-cause discipline, incremental `/relevant-checks`, mode-aware lead-in, auto-mode mid-coding deviation logging, and non-TDD verification fallback.
- Closes #96.

<details><summary>Architecture Diagram</summary>

Quick mode — architecture diagram skipped.

</details>

<details><summary>Code Flow Diagram</summary>

Quick mode — code flow diagram skipped.

</details>

<details><summary>Goal</summary>

- Close the six genuine gaps identified by `/larch:research` on 2026-04-18 between current `/implement` Step 2 prompt and reputable LLM coding-prompt best practices (Anthropic, Karpathy, Aider, Cline, OpenAI Codex).
  - G1 Root-cause discipline — not covered by CLAUDE.md/AGENTS.md/KARPATHY_CLAUDE.md or Step 2.
  - G2 Quick-mode inline plan schema lighter than `/design`'s — the most load-bearing gap.
  - G3 Incremental verification timing — Step 2 could be read as permitting one end-of-step batch.
  - G4 Auto-mode mid-coding ambiguity logging — only "material user answers" were captured.
  - G5 Step 2 wording was normal-mode-centric ("the (reviewed) plan from /design").
  - Non-TDD verification fallback — best-practice #1 on the non-TDD path.
- Keep additions minimal (~7-8 new lines, ~2 rewritten sentences) to respect Anthropic's explicit anti-bloat guidance.
- Match each suggestion to the exact prescribed text from the issue body, preserving ordering and phrasing so the acceptance criteria are verifiable 1:1.

</details>

<details><summary>Test plan</summary>

- [x] `pre-commit run --files skills/implement/SKILL.md` (markdownlint, agnix) passes.
- [x] `agent-lint` structural lint passes.
- [x] Grep confirms the old lead-in ("following the (reviewed) plan from the `/design` phase") no longer appears.
- [x] Grep confirms each of the six new/rewritten phrases appears.
- [x] Single-reviewer quick-mode code review completes with zero findings accepted.
- [x] `/relevant-checks` passes after the version bump.

</details>

<details><summary>Final Design</summary>

**Files to modify**: `skills/implement/SKILL.md` (single file, two regions: lines 185 and 230-237).

**Approach**: Six surgical text edits, all spelled out verbatim in issue #96:

1. Expand SKILL.md:185 inline-plan paragraph to include testing strategy + failure modes.
2. Append a root-cause bullet to Step 2.
3. Append an incremental-checks bullet to Step 2.
4. Rewrite SKILL.md:232 lead-in sentence to be mode-aware.
5. Rewrite SKILL.md:230 auto-mode clause to log mid-coding deviations.
6. Extend TDD bullet tail at SKILL.md:237 with a concrete non-TDD verification.

**Edge cases**:

- Edit #6 extends the same bullet that edits #2 and #3 append after — apply in order: edit #6 first (modify existing bullet), then #2 and #3 (append new bullets), so `old_string` uniqueness is preserved.
- All `old_string`s must be unique at the moment of the Edit call — verified using large surrounding context.

**Testing strategy**: Prompt-text edit. Run `/relevant-checks` after changes. Grep for the old phrases post-edit to confirm they no longer exist; grep for new phrases to confirm presence.

**Failure modes**: (a) `old_string` non-unique → Edit tool errors, widen context; (b) edit ordering causes text drift → apply in dependency order above; (c) `/relevant-checks` surfaces CI mismatch → fix root cause.

</details>

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `ea032f2` (Add /create-skill skill for scaffolding new larch-style skills (#112))
- **Current version**: `3.3.0`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `3.3.1`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH"). The change is prompt-text only within `skills/implement/SKILL.md`'s body — no frontmatter edits, no `--flag` additions/removals, no skill additions or deletions. Escalation review: no behavioral regression; the six edits only enrich agent guidance. PATCH confirmed.

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

Quick mode — no plan review was conducted.

</details>

<details><summary>Implementation Deviations</summary>

No deviations from the plan. All six edits applied verbatim per issue #96's prescribed text; one intentional deviation-of-phrasing was made in edit #1 to preserve the existing trailing clause "The same content `/design` would produce, but without collaborative sketches, plan review, or voting" on its own sentence (the issue's proposed-change block shows this clause starting a new sentence; this PR preserves that split).

</details>

<details><summary>Rejected Code Review Suggestions</summary>

### [Code Review] Cursor (round 1)
**Finding**: At `skills/implement/SKILL.md:239`, the new bullet ends with "Step 3 is the final check, not the only one." Cursor argued this could be read as "last validation in `/implement`" and thereby mislead the agent about Step 6 (Relevant Checks, second pass). Suggested rewording to something like "Treat Step 3 as the mandated check before the implementation commit (Step 4), not the only time to run checks; Step 6 may run checks again after review-driven edits."
**Reason not implemented**: The text is prescribed verbatim by issue #96's Suggestion 3. The immediately-preceding clause ("not only at the end of implementation") makes it clear that "the end" refers to implementation-phase end, not the entire workflow. Rewording would deviate from the issue-author's spec without evidence that agents misread the current text in practice. The issue explicitly discusses bloat-avoidance; further qualifiers work against that goal.

### [Code Review] Cursor (round 1)
**Finding**: At `skills/implement/SKILL.md:185`, the trailing clause "The same content `/design` would produce, but without collaborative sketches, plan review, or voting" over-claims equivalence: unless `/design` always includes testing strategy and failure modes at the same level, quick-mode's expanded plan is a superset, not a match. Suggested narrowing the claim to "Match `/design`-style planning (files, approach, edge cases), and in quick mode also require explicit testing strategy and failure modes".
**Reason not implemented**: The phrase "The same content `/design` would produce" was preserved verbatim from the original paragraph (pre-existing before this PR). The change only prepends new required fields; it does not introduce the equivalence claim. If the claim is inaccurate, that is a pre-existing documentation issue outside the scope of issue #96, whose acceptance criteria specify exact prescribed text.

### [Code Review] Cursor (round 1)
**Finding**: At `skills/implement/SKILL.md:239`, the new bullet "Invoke `/relevant-checks` promptly after each non-trivial logical sub-step" lacks guardrails and may materially increase skill invocations and context overhead. Suggested adding boundaries — run after each "coherent chunk" or "when touching distinct subsystems", skip redundant re-runs over the same file set.
**Reason not implemented**: The bullet already contains the qualifier "non-trivial logical sub-step", which bounds the frequency to meaningful boundaries. Issue #96 explicitly cites Anthropic's bloat warning and rejects adding more structural qualifiers; the issue also notes that quick-mode verification is inherently best-effort. Adding further sub-clauses would contradict the issue's explicit design rationale.

</details>

<details><summary>Plan Review Voting Tally</summary>

Quick mode — no plan review voting.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

Quick mode — no voting panel. Main agent reviewed findings across up to 7 single-reviewer rounds (Cursor → Codex → Claude fallback chain). Round 1 (Cursor): 3 findings surfaced, 0 accepted, 3 rejected. Loop short-circuited on zero-acceptance per Step 5.6.

</details>

<details><summary>Out-of-Scope Observations</summary>

Quick mode — no out-of-scope observations collected.

</details>

<details><summary>Execution Issues</summary>

No execution issues encountered.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | N/A (quick mode) |
| Code review rounds | 1 |
| Code review findings | 0 accepted, 3 rejected |
| Warnings logged | 0 |
| Pre-existing issues noticed | 0 |
| OOS issues filed | N/A (quick mode) |
| External reviewers | N/A (quick mode) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
