### PR TITLE
Fix /issue Step 6 malformed summary when issue number unresolved

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.2] - 2026-04-18
+
+### Fixed
+
+- `/issue` Step 6 now emits a dedicated URL-only success line (`✅ Created issue — <ISSUE_URL>`) when `gh issue view` fails to resolve the new issue's number. Previously the resolution-failure path routed to Step 6 with only `$ISSUE_URL` available, but all three existing variants embedded `#<ISSUE_NUMBER>` and produced a malformed `✅ Created issue # — <URL>` line. Step 4's cross-reference is updated to point at the new variant.
+
 ## [3.3.1] - 2026-04-18
 
 ### Changed

--- a/skills/issue/SKILL.md
+++ b/skills/issue/SKILL.md
@@ -56,7 +56,7 @@ Capture stdout.
 ISSUE_NUMBER=$(gh issue view "$ISSUE_URL" --json number --jq '.number')
 ```
 
-If this command fails (non-zero exit) or `ISSUE_NUMBER` is empty: the issue was created but its number could not be resolved. Print `**⚠ Issue created at $ISSUE_URL but could not resolve its number: <stderr excerpt>. Skipping --go comment (if requested).**` — then **skip Step 5 entirely** and go to Step 6 with the `go_mode=false` summary variant, using `$ISSUE_URL` as the only identifier.
+If this command fails (non-zero exit) or `ISSUE_NUMBER` is empty: the issue was created but its number could not be resolved. Print `**⚠ Issue created at $ISSUE_URL but could not resolve its number: <stderr excerpt>. Skipping --go comment (if requested).**` — then **skip Step 5 entirely** and go to Step 6 with the URL-only summary variant, using `$ISSUE_URL` as the only identifier.
 
 Save `ISSUE_URL` and `ISSUE_NUMBER`.
 
@@ -75,6 +75,7 @@ gh issue comment -R "$REPO" "$ISSUE_NUMBER" --body "GO"
 
 Print a final summary on a single line:
 
+- If `ISSUE_NUMBER` is empty (Step 4 resolution-failure path): `✅ Created issue — <ISSUE_URL>`
 - If `go_mode=true` and the GO comment succeeded: `✅ Created issue #<ISSUE_NUMBER> with GO comment — <ISSUE_URL>`
 - If `go_mode=true` and the GO comment failed: `**⚠ Created issue #<ISSUE_NUMBER> — <ISSUE_URL> (GO comment failed; add it manually to approve for /fix-issue)**`
 - If `go_mode=false`: `✅ Created issue #<ISSUE_NUMBER> — <ISSUE_URL>`


### PR DESCRIPTION
## Summary

- Fixed `/issue` Step 6 to emit a well-formed URL-only success line (`✅ Created issue — <ISSUE_URL>`) when `gh issue view` cannot resolve the new issue's number.
- Updated Step 4's cross-reference to name the new URL-only variant instead of routing to the mismatched `go_mode=false` variant.
- Resolves #109.

<details><summary>Architecture Diagram</summary>

Quick mode — architecture diagram skipped.

</details>

<details><summary>Code Flow Diagram</summary>

Quick mode — code flow diagram skipped.

</details>

<details><summary>Goal</summary>

- Fix a latent bug in the `/issue` skill documented at `skills/issue/SKILL.md`
  - Step 4's resolution-failure recovery path routes to Step 6 with only `$ISSUE_URL` available
  - All three existing Step 6 variants embed `#<ISSUE_NUMBER>`, so an empty number produces `✅ Created issue # — <URL>`
  - Add a dedicated URL-only summary variant for this path
  - Update Step 4's cross-reference so it names the new variant

</details>

<details><summary>Test plan</summary>

- [ ] Read `skills/issue/SKILL.md` Step 4 and confirm the cross-reference now says "URL-only summary variant".
- [ ] Read `skills/issue/SKILL.md` Step 6 and confirm the first bullet is the empty-`ISSUE_NUMBER` URL-only variant.
- [ ] Confirm the three pre-existing summary variants (with/without `--go`, failed GO comment) are unchanged.

</details>

<details><summary>Final Design</summary>

Single-file edit to `skills/issue/SKILL.md`:

1. Step 6 (prepend a new bullet): `If ISSUE_NUMBER is empty (Step 4 resolution-failure path): ✅ Created issue — <ISSUE_URL>`
2. Step 4 (line 59): replace "go to Step 6 with the `go_mode=false` summary variant" with "go to Step 6 with the URL-only summary variant".

No other files touched.

</details>

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `8bda7ed` (Improve /implement Step 2 prompt with six research-backed edits (#96) (#113))
- **Current version**: `3.3.1`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `3.3.2`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH").

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

Quick mode — no plan review was conducted.

</details>

<details><summary>Implementation Deviations</summary>

No deviations from the inline plan.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

All code review suggestions were implemented.

</details>

<details><summary>Plan Review Voting Tally</summary>

Quick mode — no plan review voting.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

Quick mode — no voting panel. Main agent reviewed findings across up to 7 single-reviewer rounds (Cursor → Codex → Claude fallback chain). Round 1 used Cursor and returned `NO_ISSUES_FOUND`; loop exited after one round.

</details>

<details><summary>Out-of-Scope Observations</summary>

Quick mode — no out-of-scope observations collected.

</details>

<details><summary>Execution Issues</summary>

### CI Issues
- **Step 10**: Rebase onto latest main exited 1 (conflict) with `--no-push`; rebase was aborted. Deferring to Step 12's full Conflict Resolution Procedure (Phase 1–4).

### Warnings
- **Step 10**: drop-bump-commit.sh reported DROPPED=false before rebase; HEAD was a bump commit amended with CHANGELOG.md (touches .claude-plugin/plugin.json + CHANGELOG.md). Re-bump still ran but branch history may temporarily contain two bump commits and the rebase may encounter a plugin.json conflict routed through Phase 1–3.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | N/A (quick mode) |
| Code review rounds | 1 |
| Code review findings | 0 accepted, 0 rejected |
| Warnings logged | 0 |
| Pre-existing issues noticed | 0 |
| OOS issues filed | N/A (quick mode) |
| External reviewers | N/A (quick mode) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
