### PR TITLE
Remove --limit 100 cap in /fix-issue auto-pick mode

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "3.3.3",
+  "version": "3.3.4",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.4] - 2026-04-18
+
+### Fixed
+
+- `/fix-issue` auto-pick mode no longer silently caps candidate scanning at the first 100 open issues. `skills/fix-issue/scripts/fetch-eligible-issue.sh` now calls `gh api --paginate repos/{owner}/{repo}/issues?state=open&per_page=100`, filtering PRs out with `select(.pull_request == null)` and slurping the JSONL stream with `jq -s` before the oldest-first sort. Matches the pagination pattern already used by `open_blockers` and the comment fetchers in the same file. Fixes #110.
+
 ## [3.3.3] - 2026-04-18
 
 ### Fixed

--- a/skills/fix-issue/scripts/fetch-eligible-issue.sh
+++ b/skills/fix-issue/scripts/fetch-eligible-issue.sh
@@ -169,15 +169,23 @@ fi
 
 # ---------------------------------------------------------------------------
 # Auto-pick mode (no --issue): scan open issues oldest-first
+#
+# Use `gh api --paginate` so there is no fixed cap — `gh issue list --limit N`
+# has no "unlimited" sentinel (0 and -1 are rejected), and a hardcoded ceiling
+# silently starves older issues once a repo exceeds it. The REST issues
+# endpoint returns PRs alongside issues; filter them with
+# `select(.pull_request == null)` since `gh issue list` does this implicitly.
 # ---------------------------------------------------------------------------
-ISSUES_JSON=$(gh issue list --state open --json number,title --limit 100 2>/dev/null) || {
+ISSUES_JSONL=$(gh api --paginate "repos/${REPO}/issues?state=open&per_page=100" \
+    --jq '.[] | select(.pull_request == null) | {number, title}' 2>/dev/null) || {
     echo "ELIGIBLE=false"
     echo "ERROR=Failed to list issues"
     exit 2
 }
 
-# Sort by number ascending (oldest first) and iterate
-SORTED=$(echo "$ISSUES_JSON" | jq -c 'sort_by(.number) | .[]')
+# Sort by number ascending (oldest first) and iterate. `-s` slurps the JSONL
+# stream emitted by `--jq '.[]'` into an array so we can sort it.
+SORTED=$(echo "$ISSUES_JSONL" | jq -s -c 'sort_by(.number) | .[]')
 
 if [ -z "$SORTED" ]; then
     echo "ELIGIBLE=false"


### PR DESCRIPTION
## Summary
- Removed the hardcoded `--limit 100` cap in `skills/fix-issue/scripts/fetch-eligible-issue.sh` auto-pick mode, which silently starved older eligible issues once a repo exceeded 100 open issues.
- Switched to `gh api --paginate repos/{owner}/{repo}/issues?state=open&per_page=100` (matching the pagination pattern already used by `open_blockers` and the comment fetchers), with `select(.pull_request == null)` to filter out PRs and `jq -s` to slurp the JSONL stream for sorting.
- Fixes #110.

<details><summary>Architecture Diagram</summary>

Quick mode — architecture diagram skipped.

</details>

<details><summary>Code Flow Diagram</summary>

Quick mode — code flow diagram skipped.

</details>

<details><summary>Goal</summary>

- Remove the hardcoded 100-issue ceiling in `fetch-eligible-issue.sh` auto-pick mode
  - Starvation bug: once a repo exceeds 100 open issues, older eligible issues with `GO` + no blockers would never be considered
  - Reporter (issue #110 follow-up comment) explicitly directed "Get rid of the cap entirely — there should never be huge numbers of open issues, especially eligible ones"
- Use `gh`'s API pagination primitives rather than adding a new abstraction
  - `gh issue list --limit` has no "unlimited" sentinel (0 and -1 are rejected by `gh` 2.76.0)
  - Match the pagination pattern already used by `open_blockers` and the comment fetchers in the same file

</details>

<details><summary>Test plan</summary>

- [x] `shellcheck` via `/relevant-checks` passes on the modified script
- [x] `agent-lint` passes
- [ ] Manual verification: invoke `/fix-issue` in auto-pick mode against a repo with >100 open issues to confirm older eligible issues are now picked up (deferred — no such test repo is in scope here)

</details>

<details><summary>Final Design</summary>

**File:** `skills/fix-issue/scripts/fetch-eligible-issue.sh` (auto-pick mode, lines 170-184)

**Approach:** Replace `gh issue list --state open --json number,title --limit 100` with `gh api --paginate "repos/${REPO}/issues?state=open&per_page=100"`, matching the pagination pattern already used by `open_blockers` earlier in the same file. Filter out PRs via `select(.pull_request == null)` since the REST issues endpoint returns both issues and PRs (unlike `gh issue list`, which filters implicitly). Reshape from per-page arrays to JSONL via `--jq '.[] | {number, title}'`, then slurp and sort via `jq -s -c 'sort_by(.number) | .[]'` to preserve the existing oldest-first scan order.

**Edge cases:**
- PRs included by the REST endpoint → filtered via `.pull_request == null`
- Empty repo (no open issues) → existing `if [ -z "$SORTED" ]` branch handles it
- `per_page=100` minimizes API round trips while pagination removes the hard cap

</details>

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Current version**: `3.3.3`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `3.3.4`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. The only changed file is `skills/fix-issue/scripts/fetch-eligible-issue.sh` — an internal script, not a SKILL.md or agent file. No `name:` or `argument-hint:` frontmatter fields changed, no skills/agents added or removed. Defaulting to PATCH per policy ("every PR must bump at least PATCH").

(Re-bumped twice during Step 12's CI+merge loop: 3.3.1→3.3.2 collided with PR #114 which merged first, giving us 3.3.3; then 3.3.3 collided with a docs PR which also merged first, giving us the final 3.3.4.)

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

Quick mode — no plan review was conducted.

</details>

<details><summary>Implementation Deviations</summary>

No deviations from the inline quick-mode plan. Implementation exactly matches the sketch in the `Final Design` section above.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

### [Code Review] Cursor (round 1)
**Finding**: `skills/fix-issue/scripts/fetch-eligible-issue.sh:179-188` (risk-integration) — Auto-pick now loads all open issues (paginated) into `ISSUES_JSONL` before sorting. On repos with a very large open-issue backlog, this increases REST page count, wall time, memory for the shell variable, and exposure to GitHub rate limits compared to the previous hard cap of 100. Cursor suggested documenting this under Known Limitations and/or CHANGELOG, and/or adding an optional ceiling via an environment variable (e.g., max issues or max pages) while keeping unlimited as the default.
**Reason not implemented**: The user's explicit directive on issue #110 was "Get rid of the cap entirely -- there should never be humoungous number of open issues, especially eligible ones." Adding back a configurable ceiling would directly contradict that directive. Documenting "unbounded scan" as a limitation is also contrary to the user's stated mental model (huge open-issue backlogs should not occur in practice). The practical footprint is small: `gh api --paginate` with `per_page=100` fetches 100 issues per round trip, and each issue's comment fetch (the subsequent paginated API call inside the loop) dominates wall time for any eligible issue anyway. If a repo ever does accumulate enough open issues to cause real problems, that is itself a signal worth surfacing rather than silently hiding behind a cap.

### [Code Review] Cursor (round 1)
**Finding**: `CHANGELOG.md` (risk-integration) — Not updated on this branch; this is a user-visible behavior change for auto-pick when a repo has more than 100 open issues (different candidate ordering and higher API usage). Cursor suggested adding a short CHANGELOG.md bullet so consumers know auto-pick is no longer implicitly capped at 100.
**Reason not implemented**: CHANGELOG.md updates are produced automatically by `/implement` Step 8a, which amends the version-bump commit with a new `## [X.Y.Z] - YYYY-MM-DD` section based on the PR's Summary bullets. The reviewer has no visibility into this downstream step. Adding a CHANGELOG entry manually in this commit would conflict with Step 8a's auto-generated entry. (Step 8a in fact ran on this branch and the CHANGELOG now contains the 3.3.2 entry.)

</details>

<details><summary>Plan Review Voting Tally</summary>

Quick mode — no plan review voting.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

Quick mode — no voting panel. Main agent reviewed findings across up to 7 single-reviewer rounds (Cursor → Codex → Claude fallback chain).

</details>

<details><summary>Out-of-Scope Observations</summary>

Quick mode — no out-of-scope observations collected.

</details>

<details><summary>Execution Issues</summary>

No execution issues encountered.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | N/A (quick mode) |
| Code review rounds | 1 |
| Code review findings | 0 accepted, 2 rejected |
| Warnings logged | 0 |
| Pre-existing issues noticed | 0 |
| OOS issues filed | N/A (quick mode) |
| External reviewers | N/A (quick mode) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
