### PR TITLE
Fix drop-bump-commit.sh Guard 4 ALLOWED_TWO sort order (#117)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "3.3.7",
+  "version": "3.3.8",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.8] - 2026-04-18
+
+### Fixed
+
+- `scripts/drop-bump-commit.sh` Guard 4 `ALLOWED_TWO` constant reordered to match `sort`'s ASCII byte ordering (`.claude-plugin/plugin.json` before `CHANGELOG.md`, since `.`=0x2E < `C`=0x43), so the two-file bump+CHANGELOG shape produced by `/implement` Step 8a now matches and the `DROPPED=true` happy path is reachable. Previously the constant's letter-before-dot order meant Guard 4 always rejected two-file bump commits, forcing `/implement`'s Rebase + Re-bump Sub-procedure down the expensive `rebase-push.sh` + Phase 1–4 conflict fallback every time `main` advanced during the CI+merge loop. Also pins the `sort` invocation to `LC_ALL=C` so the documented ASCII-order invariant is enforced rather than assumed, adds a comment on the `ALLOWED_*` constants warning future editors not to "fix" the order back to alphabetical-by-filename, and updates the file header's Guard 4 bullet to state the real contract (`plugin.json`, optionally together with `CHANGELOG.md`). Fixes #117.
+
 ## [3.3.7] - 2026-04-18
 
 ### Changed

--- a/scripts/drop-bump-commit.sh
+++ b/scripts/drop-bump-commit.sh
@@ -7,7 +7,9 @@
 #   1. Working tree is clean (no staged, unstaged, or untracked changes).
 #   2. HEAD subject matches ^Bump version to [0-9]+\.[0-9]+\.[0-9]+$.
 #   3. HEAD~1 exists (branch has at least 2 commits).
-#   4. HEAD touches exactly one file: .claude-plugin/plugin.json.
+#   4. HEAD touches only .claude-plugin/plugin.json, optionally together
+#      with CHANGELOG.md (the two-file amended-bump shape produced by
+#      /implement Step 8a), and nothing else.
 #
 # If any check fails, the script prints DROPPED=false and exits 0 (no-op).
 # A stderr WARN line explains which guard refused the drop, for callers that
@@ -57,8 +59,8 @@ fi
 # Use diff --name-only against HEAD~1. A legitimate bump commit produced by
 # apply-bump.sh stages .claude-plugin/plugin.json. Step 8a of /implement may
 # additionally amend CHANGELOG.md into the same commit. Both are acceptable.
-CHANGED_FILES=$(git diff --name-only HEAD~1 HEAD 2>/dev/null | sort)
-# ALLOWED_* constants must match `sort`'s ASCII byte ordering (LC_COLLATE=C semantics):
+CHANGED_FILES=$(git diff --name-only HEAD~1 HEAD 2>/dev/null | LC_ALL=C sort)
+# ALLOWED_* constants must match `sort`'s ASCII byte ordering (forced above via LC_ALL=C):
 # '.' (0x2E) sorts before 'C' (0x43), so '.claude-plugin/plugin.json' comes before 'CHANGELOG.md'.
 # Do NOT reorder alphabetically by filename — that would break the match against the sorted input.
 ALLOWED_ONE=".claude-plugin/plugin.json"

--- a/scripts/drop-bump-commit.sh
+++ b/scripts/drop-bump-commit.sh
@@ -58,8 +58,11 @@ fi
 # apply-bump.sh stages .claude-plugin/plugin.json. Step 8a of /implement may
 # additionally amend CHANGELOG.md into the same commit. Both are acceptable.
 CHANGED_FILES=$(git diff --name-only HEAD~1 HEAD 2>/dev/null | sort)
+# ALLOWED_* constants must match `sort`'s ASCII byte ordering (LC_COLLATE=C semantics):
+# '.' (0x2E) sorts before 'C' (0x43), so '.claude-plugin/plugin.json' comes before 'CHANGELOG.md'.
+# Do NOT reorder alphabetically by filename — that would break the match against the sorted input.
 ALLOWED_ONE=".claude-plugin/plugin.json"
-ALLOWED_TWO=$'CHANGELOG.md\n.claude-plugin/plugin.json'
+ALLOWED_TWO=$'.claude-plugin/plugin.json\nCHANGELOG.md'
 if [[ "$CHANGED_FILES" != "$ALLOWED_ONE" && "$CHANGED_FILES" != "$ALLOWED_TWO" ]]; then
     echo "WARN: HEAD subject matches bump pattern but commit touches unexpected files (changed: $CHANGED_FILES); refusing to drop" >&2
     echo "DROPPED=false"


### PR DESCRIPTION
## Summary
- Reordered `ALLOWED_TWO` in `scripts/drop-bump-commit.sh` so `.claude-plugin/plugin.json` precedes `CHANGELOG.md`, matching `sort`'s ASCII byte ordering (`.`=0x2E < `C`=0x43). Previously the constant's letter-before-dot order never matched the sorted diff, so Guard 4 always rejected the two-file bump+CHANGELOG shape that `/implement` Step 8a produces — forcing the expensive Phase 1–4 conflict fallback on every rebase. Fixes #117.
- Pinned the `sort` invocation to `LC_ALL=C` so the ASCII-order invariant the new comment documents is actually enforced rather than assumed (raised by Cursor in review round 1).
- Added a comment on the `ALLOWED_*` constants warning future editors not to "fix" the order back to alphabetical-by-filename, and corrected the file-header Guard 4 bullet (stale "exactly one file" wording) to state the real one-or-two-file contract.

<details><summary>Architecture Diagram</summary>

Quick mode — architecture diagram skipped.

</details>

<details><summary>Code Flow Diagram</summary>

Quick mode — code flow diagram skipped.

</details>

<details><summary>Goal</summary>

- Fix drop-bump-commit.sh Guard 4 so it actually drops the stale bump commit before rebase
  - Reorder `ALLOWED_TWO` to match `sort`'s output (`.claude-plugin/plugin.json\nCHANGELOG.md`)
  - Apply Option 1 from issue #117 (smallest-diff fix)
  - Preserve defense-in-depth — all four existing guards unchanged
- Prevent silent regression of the fix by future editors
  - Add an explanatory comment above `ALLOWED_ONE`/`ALLOWED_TWO` noting the ASCII sort rationale
  - Pin `sort` to `LC_ALL=C` so the invariant holds regardless of caller locale
  - Correct the file-header Guard 4 bullet to match the implementation
- Eliminate the expensive Rebase + Re-bump fallback path from the common case
  - Restore the `DROPPED=true` happy path for the two-file bump+CHANGELOG shape
  - Keep `/implement`'s CI+merge loop on the fast rebase path when main advances

</details>

<details><summary>Test plan</summary>

- [x] `bash -n scripts/drop-bump-commit.sh` — syntax clean
- [x] `printf 'CHANGELOG.md\n.claude-plugin/plugin.json\n' | LC_ALL=C sort` emits the new `ALLOWED_TWO` bytes exactly
- [x] `printf '.claude-plugin/plugin.json\nCHANGELOG.md\n' | LC_ALL=C sort` emits the same output (order-independent input → deterministic output)
- [x] `/relevant-checks` passes (shellcheck + agent-lint)
- [ ] Integration: next time `/implement` runs `Rebase + Re-bump Sub-procedure` with a prior bump commit that also touched CHANGELOG.md, `drop-bump-commit.sh` should emit `DROPPED=true` and the rebase should stay on the happy path.

</details>

<details><summary>Final Design</summary>

## Implementation Plan

**Files to modify**: `scripts/drop-bump-commit.sh` (single file)

**Approach**:
- Line 62: Reorder `ALLOWED_TWO` so it reads `$'.claude-plugin/plugin.json\nCHANGELOG.md'` — matching `sort`'s ASCII byte output.
- Add a short comment above the `ALLOWED_*` constants documenting the ASCII-sort rationale (`.`=0x2E < `C`=0x43) so a future editor does not "fix" the order back to alphabetical-by-filename.

**Testing strategy** (prompt/script edit — no TDD): After the change, run `printf '.claude-plugin/plugin.json\nCHANGELOG.md\n' | sort` and confirm output exactly matches the new `ALLOWED_TWO` bytes. Also `bash -n scripts/drop-bump-commit.sh` for syntax, then `/relevant-checks`.

**Failure modes**:
- A user forcing `LC_COLLATE=en_US.UTF-8` with unusual collation could reorder punctuation — mitigated in round-1 review by pinning the `sort` invocation to `LC_ALL=C`.
- If the new constant still fails to match in practice, `drop-bump-commit.sh` will continue to fall through to the existing Warning path — same as today's behavior, no regression.

</details>

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `fc1a76b` (Rewrite dialectic debater prompts and quorum logic (#97) (#121))
- **Current version**: `3.3.7`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `3.3.8`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH").

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

Quick mode — no plan review was conducted.

</details>

<details><summary>Implementation Deviations</summary>

One beneficial deviation from the inline plan, added in response to round-1 code review:
- Plan said "reorder the constant + add a comment". Implementation additionally pins the `sort` invocation to `LC_ALL=C` so the documented ASCII-order invariant actually holds at runtime (not just as a comment), and also fixes a stale file-header bullet that said Guard 4 required "exactly one file" when it actually accepts the two-file bump+CHANGELOG shape. Both were raised as in-scope correctness findings by Cursor in round 1 and accepted.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

All code review suggestions were implemented.

</details>

<details><summary>Plan Review Voting Tally</summary>

Quick mode — no plan review voting.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

Quick mode — no voting panel. Main agent reviewed findings across up to 7 single-reviewer rounds (Cursor → Codex → Claude fallback chain).

</details>

<details><summary>Out-of-Scope Observations</summary>

Quick mode — no out-of-scope observations collected.

</details>

<details><summary>Execution Issues</summary>

No execution issues encountered.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | N/A (quick mode) |
| Code review rounds | 2 (Cursor both rounds) |
| Code review findings | 2 accepted, 0 rejected |
| Warnings logged | 0 |
| Pre-existing issues noticed | 0 |
| OOS issues filed | N/A (quick mode) |
| External reviewers | N/A (quick mode) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
