### PR TITLE
Preserve blank lines in OOS description accumulation

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "3.3.9",
+  "version": "3.3.10",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.10] - 2026-04-18
+
+### Fixed
+
+- `scripts/create-oos-issues.sh` parser no longer silently drops blank lines inside a multi-line `Description` block. The continuation branch previously guarded on `[[ -n "${line// }" ]]`, which skipped every blank line — so any multi-paragraph OOS description produced by `/design`, `/review`, or (after #118 landed) main-agent dual-write collapsed into a single run-together paragraph in the filed issue body. `IN_DESCRIPTION` is already cleared only by a recognized field marker (`Reviewer:`, `Vote tally:`, `Phase:`) or a new `### OOS_N:` header, so removing the non-blank guard is sufficient to preserve paragraph breaks without capturing structural lines. Fixes #123.
+
 ## [3.3.9] - 2026-04-18
 
 ### Changed

--- a/scripts/create-oos-issues.sh
+++ b/scripts/create-oos-issues.sh
@@ -244,8 +244,10 @@ while IFS= read -r line; do
     elif [[ "$line" =~ ^-\ \*\*Phase\*\*:\ (.+)$ ]]; then
         CURRENT_PHASE="${BASH_REMATCH[1]}"
         IN_DESCRIPTION=false
-    elif [[ "$IN_DESCRIPTION" == true ]] && [[ -n "${line// }" ]]; then
-        # Accumulate non-blank continuation lines for multi-line descriptions
+    elif [[ "$IN_DESCRIPTION" == true ]]; then
+        # Accumulate continuation lines (including blank lines) so paragraph breaks
+        # survive — IN_DESCRIPTION is cleared only by a field marker or a new
+        # ### OOS_N: header, so this branch never captures structural lines.
         CURRENT_DESCRIPTION+=$'\n'"$line"
     fi
 done < "$INPUT_FILE"


### PR DESCRIPTION
## Summary

- Preserved blank lines inside multi-paragraph OOS descriptions by removing the non-blank guard on the description-continuation branch in `scripts/create-oos-issues.sh`.
- Paragraph breaks in `/design`, `/review`, and main-agent-emitted OOS items now survive into the filed GitHub issue body.

<details><summary>Architecture Diagram</summary>

Quick mode — architecture diagram skipped.

</details>

<details><summary>Code Flow Diagram</summary>

Quick mode — code flow diagram skipped.

</details>

<details><summary>Goal</summary>

- Fix `scripts/create-oos-issues.sh` multi-line description accumulation so that blank lines inside a description block are preserved (not silently dropped).
  - Accumulation should only terminate on recognized field markers (`Reviewer:`, `Vote tally:`, `Phase:`) or a new `### OOS_N:` header.
  - The pre-existing `[[ -n "${line// }" ]]` guard on line 218 skipped every blank line and must be removed.
- Preserve paragraph breaks in multi-paragraph OOS descriptions so the filed GitHub issue body is readable.
- Close #123.

</details>

<details><summary>Test plan</summary>

- [x] Ad-hoc repro feeding a three-paragraph OOS block through the parser loop verifies blank lines survive and `Reviewer`/`Vote tally`/`Phase` metadata still parses.
- [x] `/relevant-checks` passes (shellcheck + agent-lint).
- [x] Single-reviewer quick-mode review (Cursor) reports `NO_ISSUES_FOUND`.

</details>

<details><summary>Final Design</summary>

## Implementation Plan

**File**: `scripts/create-oos-issues.sh`

**Approach**: Remove the `[[ -n "${line// }" ]]` non-blank guard in the description-continuation branch. `IN_DESCRIPTION` is only flipped to `false` by a field marker (`Reviewer:`, `Vote tally:`, `Phase:`) or a new `### OOS_N:` header, so removing the guard is safe — structural lines still hit their earlier elif branches and never reach the accumulation branch. `flush_item`'s malformed-input check (`[[ -n "$CURRENT_TITLE" ]] && [[ -z "$CURRENT_DESCRIPTION" ]]`) still guards against OOS entries that somehow end up without any description content.

**Edge cases considered**:
- Trailing blank lines before the next `### OOS_` header: appended, acceptable.
- `CURRENT_DESCRIPTION` starts from the `.+` capture in the Description line, so there is always at least one non-blank leading character before blank-line accumulation begins.

**Testing strategy**:
- No existing shell test harness in the repo.
- Black-box repro feeds a multi-paragraph description through the parser loop and verifies that (a) both later paragraphs appear, (b) at least 2 empty lines exist between paragraphs, (c) `Reviewer`/`Vote tally`/`Phase` still parse correctly.
- Run `/relevant-checks`.

**Failure modes**:
- Shell regex/quoting regression → caught by shellcheck.
- Ugly trailing whitespace in issue bodies → tolerable; structural lines still diverted to metadata fields.

</details>

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `212b08d` (Fix drop-bump-commit.sh Guard 4 ALLOWED_TWO sort order (#117) (#122))
- **Current version**: `3.3.9`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `3.3.10`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH"). The change is a bug fix in `scripts/**`, outside the classification scope.

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

Quick mode — no plan review was conducted.

</details>

<details><summary>Implementation Deviations</summary>

No deviations from the inline plan.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

All code review suggestions were implemented.

</details>

<details><summary>Plan Review Voting Tally</summary>

Quick mode — no plan review voting.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

Quick mode — no voting panel. Main agent reviewed findings across up to 7 single-reviewer rounds (Cursor → Codex → Claude fallback chain). Cursor reported `NO_ISSUES_FOUND` in round 1, so the loop terminated after a single round.

</details>

<details><summary>Out-of-Scope Observations</summary>

Quick mode — no out-of-scope observations collected.

</details>

<details><summary>Execution Issues</summary>

No execution issues encountered.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | N/A (quick mode) |
| Code review rounds | 1 |
| Code review findings | 0 accepted, 0 rejected |
| Warnings logged | 0 |
| Pre-existing issues noticed | 0 |
| OOS issues filed | N/A (quick mode) |
| External reviewers | Cursor: ✅, Codex: N/A (not invoked in single-round quick review) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
