### PR TITLE
Phase 2 dialectic: external Cursor/Codex bucketing, cap 5, mechanical fallback

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "3.3.10",
+  "version": "3.3.11",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.11] - 2026-04-18
+
+### Changed
+
+- `/design` Step 2a.5 (dialectic debate) now runs each contested decision's thesis+antithesis on **external Cursor or Codex** instead of the previous Claude Agent-tool subagent fan-out (`skills/design/SKILL.md`). Cap raised from 3 to 5 (`min(5, |contested-decisions|)`); deterministic per-decision bucketing assigns odd-indexed decisions (1, 3, 5) to Cursor and even-indexed (2, 4) to Codex, with both sides of each decision sharing the assigned tool. When the assigned tool is unavailable, the bucket is **skipped entirely** and the Step 2a.4 synthesis decision stands — Claude subagents are never substituted into the dialectic debate path (intentional divergence from the repo-wide replacement-first fallback architecture; see `skills/shared/voting-protocol.md` and Step 3 fallbacks). Option B for the unhealthy-status cascade: dialectic-scoped shadow flags (`dialectic_codex_available`, `dialectic_cursor_available`) snapshot the orchestrator-wide `*_available` at entry; orchestrator-wide flags are never mutated, and the dialectic `collect-reviewer-results.sh` call uses `--write-health /dev/null` so Step 3 plan-review panel integrity is preserved by construction. Per-decision rendered prompts are written to files under `$DESIGN_TMPDIR` and referenced by path in the launch prompt (mirrors the voting-protocol pattern, avoids `cat`-based shell patterns that trigger Claude Code permission prompts). The quorum rule now has a mandatory STATUS pre-check that immediately fails any decision where either side returned `STATUS != OK` from the collector, preventing one-sided binding resolutions from partial-launch cases. Phase 1's tagged-output prompt template bodies, debate quorum rule, winner-selection rule, and `dialectic-resolutions.md` schema are preserved byte-for-byte. `docs/collaborative-sketches.md` is updated with the new cap (3→5), tool-routing description, and a new "Dialectic debate" row in the "Fallback Behavior by Phase" table that documents the no-Claude-substitution rule. Closes #98.
+
 ## [3.3.10] - 2026-04-18
 
 ### Fixed

--- a/docs/collaborative-sketches.md
+++ b/docs/collaborative-sketches.md
@@ -36,6 +36,7 @@ The handling of unavailable external tools differs across workflow phases:
 | **Plan review** (`/design`) | Claude Code Reviewer subagent fallbacks — always 3 reviewers |
 | **Code review** (`/review`) | Claude Code Reviewer subagent fallbacks — always 3 reviewers |
 | **Voting** | Claude replacement voters used — always 3 voters. 3 voters: 2+ YES to accept; 2 voters: unanimous YES; <2 voters: voting skipped, all findings accepted |
+| **Dialectic debate** (`/design`) | **No Claude substitution** — when the assigned external tool (Cursor for odd-indexed decisions, Codex for even-indexed) is unavailable, that decision's bucket is skipped entirely and the Step 2a.4 synthesis decision stands. Intentional divergence from the rules above; see Step 2a.5 in `skills/design/SKILL.md` |
 
 ## How It Works
 
@@ -117,7 +118,7 @@ For each contested decision (up to 5, prioritized by impact):
 1. A **thesis agent** defends the approach chosen by the synthesis, arguing why it's the right call given the codebase and requirements
 2. An **antithesis agent** attacks that choice, arguing for the strongest alternative, poking at hidden assumptions, and surfacing risks the synthesis glossed over
 
-Both agents run in parallel and produce 1-2 focused paragraphs. A **quorum rule** requires both sides to produce substantive output before a binding resolution is written — if either side fails, the debate falls back to the original synthesis decision.
+Both agents run in parallel and produce 1-2 focused paragraphs. A **quorum rule** requires both sides to report `STATUS=OK` from the collector and produce substantive structured output before a binding resolution is written — if either side's status check or content check fails, the debate falls back to the original synthesis decision.
 
 The orchestrator then writes a resolution for each contested point that must explicitly address the antithesis arguments. It can still pick the original choice, but now it must justify against the strongest counterargument.
 

--- a/docs/collaborative-sketches.md
+++ b/docs/collaborative-sketches.md
@@ -61,7 +61,7 @@ flowchart TD
 
     SYNTHESIS --> CHECK{Contested\ndecisions?}
     CHECK -->|None| PLAN[Full implementation plan]
-    CHECK -->|1-3 found| DIALECTIC
+    CHECK -->|1-5 found| DIALECTIC
 
     subgraph DIALECTIC["Dialectic Debate (/design only)"]
         direction LR
@@ -96,7 +96,7 @@ flowchart TD
    - Notes **Innovation/Exploration** alternatives sourced from Codex slot 1 that are worth preserving as options
    - Lists contested decisions in a structured format for the dialectic debate phase
 
-4. **Dialectic debate** (`/design` only) — If the synthesis identifies contested decisions (points where sketches genuinely diverged), the top 2-3 are submitted to structured thesis/antithesis debates. For each contested decision, a thesis agent defends the synthesis choice and an antithesis agent argues for the strongest alternative. Both run in parallel with codebase access. The orchestrator then writes binding resolutions that must explicitly address the antithesis arguments. This step is skipped when all sketches agree. See [Dialectic Debate](#dialectic-debate-design-only) below for details.
+4. **Dialectic debate** (`/design` only) — If the synthesis identifies contested decisions (points where sketches genuinely diverged), up to 5 (in priority order) are submitted to structured thesis/antithesis debates run on Cursor and Codex via deterministic per-decision bucketing. For each contested decision, a thesis agent defends the synthesis choice and an antithesis agent argues for the strongest alternative. Both run in parallel with codebase access. The orchestrator then writes binding resolutions that must explicitly address the antithesis arguments. This step is skipped when all sketches agree. See [Dialectic Debate](#dialectic-debate-design-only) below for details.
 
 5. **Full plan** — The synthesis and any dialectic resolutions inform the complete implementation plan, which is then submitted to the 3-reviewer panel (1 Claude Code Reviewer subagent + 1 Codex + 1 Cursor) for validation.
 
@@ -112,7 +112,7 @@ The dialectic debate runs only when the synthesis in Step 2a.4 identifies genuin
 
 ### How It Works
 
-For each contested decision (up to 3, prioritized by impact):
+For each contested decision (up to 5, prioritized by impact):
 
 1. A **thesis agent** defends the approach chosen by the synthesis, arguing why it's the right call given the codebase and requirements
 2. An **antithesis agent** attacks that choice, arguing for the strongest alternative, poking at hidden assumptions, and surfacing risks the synthesis glossed over

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -349,7 +349,7 @@ Otherwise, read `$DESIGN_TMPDIR/approach-synthesis.txt` — this provides `{SYNT
    - Cursor buckets write to `$DESIGN_TMPDIR/debate-<n>-cursor-thesis.txt` and `…-cursor-antithesis.txt`.
    - Codex buckets write to `$DESIGN_TMPDIR/debate-<n>-codex-thesis.txt` and `…-codex-antithesis.txt`.
 
-   Each Cursor launch (use `run_in_background: true` and `timeout: 1860000`):
+   Each Cursor launch (use `run_in_background: true` and `timeout: 1860000`). Pass a short bootstrap prompt that references the per-decision prompt file by path; the tool reads the file via its own filesystem access. This mirrors the voting pattern below ("Read the ballot from $DESIGN_TMPDIR/ballot.txt") and avoids `$(cat ...)` in the launch shell — which would trigger Claude Code permission prompts that break autonomous execution:
    ```bash
    ${CLAUDE_PLUGIN_ROOT}/scripts/run-external-reviewer.sh --tool cursor \
      --output "$DESIGN_TMPDIR/debate-<n>-cursor-<thesis|antithesis>.txt" \
@@ -357,10 +357,10 @@ Otherwise, read `$DESIGN_TMPDIR/approach-synthesis.txt` — this provides `{SYNT
      cursor agent -p --force --trust \
        $("${CLAUDE_PLUGIN_ROOT}/scripts/reviewer-model-args.sh" --tool cursor --with-effort) \
        --workspace "$PWD" \
-       "$(cat "$DESIGN_TMPDIR/debate-<n>-<thesis|antithesis>-prompt.txt") Work at your maximum reasoning effort level."
+       "Read the dialectic-debate task description from $DESIGN_TMPDIR/debate-<n>-<thesis|antithesis>-prompt.txt and follow it exactly to produce the structured tagged output it requests. Work at your maximum reasoning effort level."
    ```
 
-   Each Codex launch (use `run_in_background: true` and `timeout: 1860000`):
+   Each Codex launch (use `run_in_background: true` and `timeout: 1860000`). Same file-path-reference pattern:
    ```bash
    ${CLAUDE_PLUGIN_ROOT}/scripts/run-external-reviewer.sh --tool codex \
      --output "$DESIGN_TMPDIR/debate-<n>-codex-<thesis|antithesis>.txt" \
@@ -368,7 +368,7 @@ Otherwise, read `$DESIGN_TMPDIR/approach-synthesis.txt` — this provides `{SYNT
      codex exec --full-auto -C "$PWD" \
        $("${CLAUDE_PLUGIN_ROOT}/scripts/reviewer-model-args.sh" --tool codex --with-effort) \
        --output-last-message "$DESIGN_TMPDIR/debate-<n>-codex-<thesis|antithesis>.txt" \
-       "$(cat "$DESIGN_TMPDIR/debate-<n>-<thesis|antithesis>-prompt.txt") Work at your maximum reasoning effort level."
+       "Read the dialectic-debate task description from $DESIGN_TMPDIR/debate-<n>-<thesis|antithesis>-prompt.txt and follow it exactly to produce the structured tagged output it requests. Work at your maximum reasoning effort level."
    ```
 
    The trailing `Work at your maximum reasoning effort level.` is appended at the bash-launch level (NOT in the templated prompt body) because `${CLAUDE_PLUGIN_ROOT}/scripts/reviewer-model-args.sh --with-effort` is documented as a no-op for Cursor (Cursor has no dedicated reasoning-effort flag — the convention is the prompt-level suffix). Codex receives the same suffix for symmetry.
@@ -381,7 +381,7 @@ Otherwise, read `$DESIGN_TMPDIR/approach-synthesis.txt` — this provides `{SYNT
    ```
    `--write-health /dev/null` ensures both the read path (collect-reviewer-results.sh checks `-f "$WRITE_HEALTH"`, which is false for character devices like `/dev/null`) and the write path (explicit `!= "/dev/null"` guard) skip — the dialectic phase NEVER updates the cross-skill `${SESSION_ENV_PATH}.health` file. Block on this call (do NOT use `run_in_background`).
 
-9. **Per-bucket runtime failure handling**. For any reviewer with `STATUS != OK`, print `**⚠ <Tool> dialectic debate (decision <n>, <thesis|antithesis>) failed: <FAILURE_REASON>. Bucket truncated; synthesis decision stands.**` Do NOT flip any flag. The "debate quorum rule" below already routes failed buckets to the synthesis-fallback path because the missing/failed side fails the substantive-output / role-vs-RECOMMEND consistency check.
+9. **Per-bucket runtime failure handling**. For any reviewer with `STATUS != OK`, print `**⚠ <Tool> dialectic debate (decision <n>, <thesis|antithesis>) failed: <FAILURE_REASON>. Bucket truncated; synthesis decision stands.**` Do NOT flip any flag. The mandatory STATUS pre-check at the top of the "debate quorum rule" below catches the partial-launch case (thesis or antithesis non-OK → decision immediately fails quorum → synthesis decision stands).
 
 The thesis/antithesis prompt template bodies below are byte-identical to Phase 1. Only the delivery channel (external CLI via `run-external-reviewer.sh` rather than the Agent tool) and the call-site effort suffix change.
 
@@ -454,7 +454,11 @@ These tags are prompt-level delimiters, not a sanitization boundary — they red
 </debater_decision>
 ```
 
-**After all external debaters return** (read each output file for which the collector reported `STATUS=OK`), apply the **debate quorum rule** for each decision. A side passes quorum only when every check below is satisfied; otherwise the orchestrator does NOT write a binding resolution for that decision. The check is a conjunct — the pre-existing "substantive output" requirement is retained alongside the new structural gates:
+**After all external debaters return**, apply the **debate quorum rule** to each decision **whose bucket was launched** (decisions skipped in step 4 or skipped by the zero-externals guardrail in step 5 have no output files; their synthesis decisions already stand and need no quorum check).
+
+**Per-decision STATUS pre-check** (mandatory, applied before the per-side checks below): for each launched decision, if the collector did not report `STATUS=OK` for BOTH the thesis and the antithesis output files, the decision immediately fails quorum — do NOT apply the per-side checks below; the synthesis decision stands for that point and no binding resolution is written. This guards the partial-launch case where one side completed but its sibling failed (e.g., thesis OK + antithesis TIMED_OUT): the orchestrator must NOT write a one-sided resolution from the lone surviving file, since adversarial debate requires both sides.
+
+For each surviving decision (both sides `STATUS=OK`), read each side's file via the file path from the collector's `REVIEWER_FILE` field (which may point at a `*-retry.txt` if a retry recovered an empty output) — do NOT read directly from the launch path, as that would miss content recovered by retry. A side passes quorum only when every check below is satisfied; otherwise the orchestrator does NOT write a binding resolution for that decision. The check is a conjunct — the pre-existing "substantive output" requirement is retained alongside the new structural gates:
 
 - **Substantive output**: non-empty output with at least one full sentence of substantive content per required tag body.
 - **All 5 tags present**: `<claim>`, `<evidence>`, `<strongest_concession>`, `<counter_to_opposition>`, `<risk_if_wrong>`.

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -318,7 +318,72 @@ Print: `> **🔶 2a.5: dialectic**`
 
 Read `$DESIGN_TMPDIR/contested-decisions.md`. If the file contains only `NO_CONTESTED_DECISIONS` (ignoring leading/trailing whitespace and newlines), print `⏩ 2a.5: dialectic — no contested decisions (<elapsed>)` and proceed to Step 2b.
 
-Otherwise, read `$DESIGN_TMPDIR/approach-synthesis.txt` — this provides `{SYNTHESIS_TEXT}` for the agent prompts below. Select up to the first 3 decisions from the file (they are already in priority order from Step 2a.4). For each selected decision, launch a **thesis agent** and an **antithesis agent** as Claude subagents via the Agent tool. **All thesis+antithesis pairs across all decisions must be issued in a single Agent fan-out message** (up to 6 Agent tool calls in one message) to maximize parallelism.
+**Intentional divergence from the repo-wide replacement-first fallback architecture**. This phase deliberately diverges from the "Voter Composition" rule in `${CLAUDE_PLUGIN_ROOT}/skills/shared/voting-protocol.md` and from the Cursor/Codex fallback rules in the "Step 3 — Plan Review" section below: when an assigned external tool is unavailable, the bucket is **skipped entirely** — Claude subagents are NEVER substituted into the dialectic debate path. Likewise, the "Runtime Timeout Fallback" procedure in `${CLAUDE_PLUGIN_ROOT}/skills/shared/external-reviewers.md` flips orchestrator-wide `*_available` for all subsequent session steps; in this phase, runtime failures affect ONLY this phase's bookkeeping and never mutate the orchestrator-wide flags. Do NOT "fix" this carve-out back to global-flip + Claude-replacement behavior — see GitHub issue #98 for the rationale.
+
+Otherwise, read `$DESIGN_TMPDIR/approach-synthesis.txt` — this provides `{SYNTHESIS_TEXT}` for the prompt templates below. Then apply the following protocol:
+
+1. **Cap = `min(5, |contested-decisions|)`** — select that many decisions from the file (they are already in priority order from Step 2a.4).
+
+2. **Initialize dialectic-scoped shadow flags** at the top of this step:
+   - `dialectic_codex_available = codex_available` (snapshot at entry)
+   - `dialectic_cursor_available = cursor_available` (snapshot at entry)
+   The orchestrator-wide `codex_available` / `cursor_available` flags are NEVER mutated during this step. This preserves Step 3's plan-review panel integrity by construction (Option B).
+
+3. **Deterministic per-decision bucket assignment** (1-based indexing):
+   - Decision 1, 3, 5 → **Cursor** bucket (uses `dialectic_cursor_available`).
+   - Decision 2, 4 → **Codex** bucket (uses `dialectic_codex_available`).
+   - Both thesis and antithesis for a single decision use the same tool (bucket homogeneity).
+
+4. **Per-bucket pre-launch availability check**. For each selected decision, check the assigned tool's `dialectic_*_available` flag:
+   - If `false`: print `**⚠ <Tool> unavailable — dialectic skipped for bucket <N> decisions (indices: <comma-list>). Step 2a.4 synthesis decisions stand.**`, skip that decision, and continue. Do NOT fall back to a Claude Agent-tool subagent. Do NOT reassign the decision to the surviving tool. Do NOT abort this step.
+   - If `true`: queue both the thesis and antithesis launch for that decision.
+
+5. **Zero-externals guardrail**. If after iterating all selected decisions, zero buckets are queued, print no further launches, do NOT call `collect-reviewer-results.sh` at all, and proceed to the completion line. `dialectic-resolutions.md` is not created — Step 2b reads it conditionally and tolerates absence.
+
+6. **Per-decision prompt-file rendering**. For each queued decision, render the thesis and antithesis prompts (the templates below) with `{FEATURE_DESCRIPTION}`, `{SYNTHESIS_TEXT}`, `{DECISION_BLOCK}`, `{CHOSEN}`, `{ALTERNATIVE}`, `{TENSION}`, `{AFFECTED_FILES}` substituted, and use the **Write tool** (not heredoc/cat) to write each rendered prompt to its own file:
+   - `$DESIGN_TMPDIR/debate-<n>-thesis-prompt.txt`
+   - `$DESIGN_TMPDIR/debate-<n>-antithesis-prompt.txt`
+   File-based prompt delivery eliminates shell-quoting hazards from synthesis/decision content that may contain `"`, `$()`, backticks, or newlines.
+
+7. **Parallel launch** — issue all queued launches in a **single Bash message** (up to 10 background calls: 5 decisions × 2 sides). Per-decision output filenames embed the assigned tool name so the collector's basename heuristic correctly attributes results:
+   - Cursor buckets write to `$DESIGN_TMPDIR/debate-<n>-cursor-thesis.txt` and `…-cursor-antithesis.txt`.
+   - Codex buckets write to `$DESIGN_TMPDIR/debate-<n>-codex-thesis.txt` and `…-codex-antithesis.txt`.
+
+   Each Cursor launch (use `run_in_background: true` and `timeout: 1860000`):
+   ```bash
+   ${CLAUDE_PLUGIN_ROOT}/scripts/run-external-reviewer.sh --tool cursor \
+     --output "$DESIGN_TMPDIR/debate-<n>-cursor-<thesis|antithesis>.txt" \
+     --timeout 1800 --capture-stdout -- \
+     cursor agent -p --force --trust \
+       $("${CLAUDE_PLUGIN_ROOT}/scripts/reviewer-model-args.sh" --tool cursor --with-effort) \
+       --workspace "$PWD" \
+       "$(cat "$DESIGN_TMPDIR/debate-<n>-<thesis|antithesis>-prompt.txt") Work at your maximum reasoning effort level."
+   ```
+
+   Each Codex launch (use `run_in_background: true` and `timeout: 1860000`):
+   ```bash
+   ${CLAUDE_PLUGIN_ROOT}/scripts/run-external-reviewer.sh --tool codex \
+     --output "$DESIGN_TMPDIR/debate-<n>-codex-<thesis|antithesis>.txt" \
+     --timeout 1800 -- \
+     codex exec --full-auto -C "$PWD" \
+       $("${CLAUDE_PLUGIN_ROOT}/scripts/reviewer-model-args.sh" --tool codex --with-effort) \
+       --output-last-message "$DESIGN_TMPDIR/debate-<n>-codex-<thesis|antithesis>.txt" \
+       "$(cat "$DESIGN_TMPDIR/debate-<n>-<thesis|antithesis>-prompt.txt") Work at your maximum reasoning effort level."
+   ```
+
+   The trailing `Work at your maximum reasoning effort level.` is appended at the bash-launch level (NOT in the templated prompt body) because `${CLAUDE_PLUGIN_ROOT}/scripts/reviewer-model-args.sh --with-effort` is documented as a no-op for Cursor (Cursor has no dedicated reasoning-effort flag — the convention is the prompt-level suffix). Codex receives the same suffix for symmetry.
+
+8. **Collect** with health bookkeeping disabled (Option B enforcement):
+   ```bash
+   ${CLAUDE_PLUGIN_ROOT}/scripts/collect-reviewer-results.sh --timeout 1860 \
+     --write-health /dev/null \
+     <each launched output path>
+   ```
+   `--write-health /dev/null` ensures both the read path (collect-reviewer-results.sh checks `-f "$WRITE_HEALTH"`, which is false for character devices like `/dev/null`) and the write path (explicit `!= "/dev/null"` guard) skip — the dialectic phase NEVER updates the cross-skill `${SESSION_ENV_PATH}.health` file. Block on this call (do NOT use `run_in_background`).
+
+9. **Per-bucket runtime failure handling**. For any reviewer with `STATUS != OK`, print `**⚠ <Tool> dialectic debate (decision <n>, <thesis|antithesis>) failed: <FAILURE_REASON>. Bucket truncated; synthesis decision stands.**` Do NOT flip any flag. The "debate quorum rule" below already routes failed buckets to the synthesis-fallback path because the missing/failed side fails the substantive-output / role-vs-RECOMMEND consistency check.
+
+The thesis/antithesis prompt template bodies below are byte-identical to Phase 1. Only the delivery channel (external CLI via `run-external-reviewer.sh` rather than the Agent tool) and the call-site effort suffix change.
 
 **Thesis agent prompt template**:
 ```
@@ -389,7 +454,7 @@ These tags are prompt-level delimiters, not a sanitization boundary — they red
 </debater_decision>
 ```
 
-**After all agents return**, apply the **debate quorum rule** for each decision. A side passes quorum only when every check below is satisfied; otherwise the orchestrator does NOT write a binding resolution for that decision. The check is a conjunct — the pre-existing "substantive output" requirement is retained alongside the new structural gates:
+**After all external debaters return** (read each output file for which the collector reported `STATUS=OK`), apply the **debate quorum rule** for each decision. A side passes quorum only when every check below is satisfied; otherwise the orchestrator does NOT write a binding resolution for that decision. The check is a conjunct — the pre-existing "substantive output" requirement is retained alongside the new structural gates:
 
 - **Substantive output**: non-empty output with at least one full sentence of substantive content per required tag body.
 - **All 5 tags present**: `<claim>`, `<evidence>`, `<strongest_concession>`, `<counter_to_opposition>`, `<risk_if_wrong>`.


### PR DESCRIPTION
## Summary

- Replaced the Claude Agent-tool subagent fan-out in `/design` Step 2a.5 with external Cursor + Codex tools and raised the contested-decision cap from 3 to 5, so dialectic debates are sourced from a different model family than the orchestrator (model diversity in adversarial debate per Liang et al. 2023 MAD).
- Implemented mechanical "no Claude debaters" enforcement: when the bucket's assigned external tool is unavailable, the bucket is **skipped entirely** and the Step 2a.4 synthesis decision stands — Claude subagents are never substituted into the dialectic debate path. This is an intentional divergence from the repo-wide replacement-first fallback architecture.
- Added Option B for the unhealthy-status cascade: dialectic-scoped shadow flags initialized from orchestrator-wide `*_available` at entry; orchestrator-wide flags are never mutated and the dialectic `collect-reviewer-results.sh` call uses `--write-health /dev/null`, so Step 3 plan-review panel integrity is preserved by construction. Closes #98.

<details><summary>Architecture Diagram</summary>

```mermaid
flowchart TD
    subgraph SYNTH[Step 2a.4 - Synthesis]
        CD[contested-decisions.md\n1-N decisions, priority order]
    end

    CD --> CAP[Cap = min 5 of N]
    CAP --> SHADOW[Initialize shadow flags\ndialectic_codex_available\ndialectic_cursor_available\nfrom orchestrator-wide flags]

    SHADOW --> ITER[Iterate decisions 1..min 5,N]

    ITER --> BUCKET{Decision index parity}
    BUCKET -->|Odd 1,3,5| CHECKCURSOR{dialectic_cursor_available?}
    BUCKET -->|Even 2,4| CHECKCODEX{dialectic_codex_available?}

    CHECKCURSOR -->|false| SKIPCURSOR[Print skip warning\nNo launch\nSynthesis stands]
    CHECKCURSOR -->|true| RENDERCURSOR[Render thesis-prompt.txt\nRender antithesis-prompt.txt]

    CHECKCODEX -->|false| SKIPCODEX[Print skip warning\nNo launch\nSynthesis stands]
    CHECKCODEX -->|true| RENDERCODEX[Render thesis-prompt.txt\nRender antithesis-prompt.txt]

    RENDERCURSOR --> QUEUECURSOR[Queue Cursor launches]
    RENDERCODEX --> QUEUECODEX[Queue Codex launches]

    QUEUECURSOR --> ALLLAUNCH{Any launches queued?}
    QUEUECODEX --> ALLLAUNCH

    ALLLAUNCH -->|No| SKIPCOLLECT[Zero-externals guardrail:\nskip collect call entirely]
    ALLLAUNCH -->|Yes| PARALLEL[Single Bash message:\nrun-external-reviewer.sh\nfor each queued thesis+antithesis\nbackground, timeout 1800s]

    PARALLEL --> COLLECT[collect-reviewer-results.sh\n--write-health /dev/null\ntimeout 1860s, blocking]

    COLLECT --> PERBUCKET[For each result:\nSTATUS != OK -> print failure]

    PERBUCKET --> QUORUM[Quorum rule\nUNCHANGED from Phase 1:\nall 5 tags, RECOMMEND token,\nrole consistency,\nfile:line citation]

    QUORUM --> WINNER[Winner-selection rule\nUNCHANGED from Phase 1]

    WINNER --> WRITEDR[Write dialectic-resolutions.md\nschema UNCHANGED]
    SKIPCOLLECT --> COMPLETION[Completion line:\nN decisions resolved\nN = quorum passes]
    WRITEDR --> COMPLETION

    SKIPCURSOR -.-> ITER
    SKIPCODEX -.-> ITER

    COMPLETION --> STEP2B[Proceed to Step 2b\nOrchestrator-wide *_available\nNEVER mutated]

    style SHADOW fill:#5a3a2e,color:#fff
    style SKIPCURSOR fill:#6e1a4a,color:#fff
    style SKIPCODEX fill:#6e1a4a,color:#fff
    style SKIPCOLLECT fill:#6e1a4a,color:#fff
    style RENDERCURSOR fill:#1a4a6e,color:#fff
    style RENDERCODEX fill:#4a3a6e,color:#fff
    style QUORUM fill:#2d5a27,color:#fff
    style WINNER fill:#2d5a27,color:#fff
```

</details>

<details><summary>Code Flow Diagram</summary>

```mermaid
sequenceDiagram
    participant Orch as Orchestrator
    participant CD as contested-decisions.md
    participant Cursor as Cursor (per bucket)
    participant Codex as Codex (per bucket)
    participant Files as $DESIGN_TMPDIR/*
    participant Coll as collect-reviewer-results.sh
    participant DR as dialectic-resolutions.md

    Orch->>CD: read priority-ordered list
    Note over Orch: cap = min(5, N)
    Note over Orch: snapshot dialectic_codex_available<br/>= codex_available<br/>and dialectic_cursor_available<br/>= cursor_available

    loop for each tool with assigned decisions
        alt dialectic_*_available = false
            Orch->>Orch: print skip warning<br/>(skip all tool's decisions)
        else available
            loop for each decision in tool's bucket
                Orch->>Files: Write debate-N-{thesis,antithesis}-prompt.txt<br/>(rendered with FEATURE/SYNTHESIS/DECISION)
                Orch->>Cursor: queue launch (odd N) — pass file PATH only
                Orch->>Codex: queue launch (even N) — pass file PATH only
            end
        end
    end

    alt zero buckets queued (zero-externals guardrail)
        Orch->>Orch: print "0 decisions resolved"<br/>skip collect call entirely
    else >=1 bucket queued
        par Cursor and Codex run in parallel (single Bash msg)
            Cursor->>Files: read prompt file → produce thesis/antithesis output
            Cursor->>Files: write debate-N-cursor-{thesis,antithesis}.txt
        and
            Codex->>Files: read prompt file → produce thesis/antithesis output
            Codex->>Files: write debate-N-codex-{thesis,antithesis}.txt
        end

        Orch->>Coll: collect-reviewer-results.sh<br/>--write-health /dev/null<br/>--timeout 1860 <paths>
        Coll-->>Orch: per-file STATUS, REVIEWER_FILE<br/>(may point at -retry.txt)

        loop runtime failure for any STATUS != OK
            Orch->>Orch: print failure warning<br/>(do NOT flip orchestrator-wide flag)
        end

        loop per launched decision
            alt either side STATUS != OK
                Orch->>Orch: STATUS pre-check fails<br/>synthesis stands<br/>NO binding resolution
            else both sides STATUS = OK
                Orch->>Files: read REVIEWER_FILE for thesis + antithesis
                Orch->>Orch: apply quorum rule<br/>(5 tags, RECOMMEND token,<br/>role consistency, citation)
                alt either side fails any check
                    Orch->>Orch: synthesis stands
                else both sides pass
                    Orch->>Orch: winner selection
                    Orch->>DR: write binding resolution
                end
            end
        end
    end

    Note over Orch: orchestrator-wide *_available NEVER mutated<br/>Step 3 sees Step 0's original values
    Orch->>Orch: print "N decisions resolved"<br/>(N = quorum passes)
```

</details>

<details><summary>Goal</summary>

- Implement Phase 2 of the dialectic debate overhaul (issue #98)
  - Source dialectic debaters from a different model family than the orchestrator to address single-model-family debate-quality degradation (Liang et al. 2023 MAD)
  - Raise contested-decision cap from 3 → 5 because the 5-lane sketch synthesis surfaces more contested points than the previous cap could adjudicate
- Use the existing repo machinery (`scripts/run-external-reviewer.sh`, `scripts/collect-reviewer-results.sh`, `scripts/reviewer-model-args.sh --with-effort`) verbatim — no new debate-runner framework
  - Deterministic per-decision bucketing: odd-indexed decisions to Cursor, even-indexed to Codex; both sides of a single decision share the same tool
  - Per-decision output paths in `$DESIGN_TMPDIR`, collected with the same wait/timeout pattern plan review uses
- Enforce "no Claude debaters" mechanically, not via prompt-only guidance
  - When the assigned tool is unavailable, the bucket is skipped entirely and the synthesis decision stands
  - Runtime timeout = bucket truncation, never Claude substitution
  - Never reassign decisions to the surviving tool (would double load and could saturate rate limits)
  - Never abort 2a.5 (synthesis fallback is valid)
- Preserve Step 3 plan-review panel integrity (Option B)
  - Dialectic-scoped shadow flags so dialectic-phase availability state never mutates the orchestrator-wide `*_available`
  - Dialectic `collect-reviewer-results.sh` does not write to the cross-skill health file
- Preserve Phase 1 contracts byte-for-byte
  - Thesis/antithesis tagged-output prompt template bodies unchanged
  - Debate quorum rule, winner-selection rule, and `dialectic-resolutions.md` schema unchanged
- Keep the diff surface minimal
  - Only `skills/design/SKILL.md` and `docs/collaborative-sketches.md` (3 surgical lines) — issue #98's "Out of scope: Phase 4 docs/diagrams/automation" is honored

</details>

<details><summary>Test plan</summary>

- [x] `/relevant-checks` passes after every commit (markdown + agent-lint clean)
- [x] grep `skills/design/SKILL.md` 2a.5 block: zero "Agent tool" / "subagent" matches in any launch path (only in prohibition language and the divergence callout)
- [x] grep 2a.5 block: `min(5,` present (cap rule)
- [x] grep 2a.5 block: `--write-health /dev/null` present (Option B enforcement)
- [x] grep 2a.5 block: `${CLAUDE_PLUGIN_ROOT}/scripts/` prefix present on all 3 script invocations
- [x] grep 2a.5 block: `Work at your maximum reasoning effort level.` present in both Cursor and Codex bash launches
- [x] grep 2a.5 block: file-path-reference launch pattern (`Read the dialectic-debate task description from $DESIGN_TMPDIR/...`) instead of `$(cat ...)`
- [x] STATUS pre-check present in quorum-rule preamble (catches partial-launch case)
- [x] grep `docs/collaborative-sketches.md`: zero remaining instances of `1-3 found`, `top 2-3`, `up to 3, prioritized`; new `1-5 found` and `up to 5, prioritized by impact` present
- [x] `docs/collaborative-sketches.md` "Fallback Behavior by Phase" table includes Dialectic row
- [ ] Manual smoke test (issue acceptance criteria): run `/design --auto` on a synthetic feature with 5 contested decisions; verify both buckets launch, outputs land in `debate-<n>-{cursor,codex}-{thesis,antithesis}.txt`, and `dialectic-resolutions.md` is produced with valid schema
- [ ] Manual failure test (issue acceptance criteria): force `cursor_available=false` (or `codex_available=false`); confirm bucket skip + warning + no Claude substitution + synthesis stands

</details>

<details><summary>Final Design</summary>

### Files to modify

- **`skills/design/SKILL.md`** Step 2a.5 (lines ~315-422): rewrite the introduction + launch protocol; KEEP the thesis/antithesis prompt **template bodies** byte-for-byte (FINDING_3 effort suffix is appended at launch level, not in the template); KEEP the quorum-rule, winner-selection, dialectic-resolutions.md schema, and completion-line sections byte-for-byte.
- **`docs/collaborative-sketches.md`** lines 64, 99, 115: surgical 3-line edit so the doc no longer makes false cap-3 / "top 2-3" / "1-3 found" claims after this PR raises the cap to 5 (FINDING_4).

No script changes.

### Approach (Step 2a.5 rewrite, in order)

1. **Header + intentional-divergence callout** at the top of 2a.5. Names this phase as a deliberate exception to the "Replacement-First" pattern in `skills/shared/voting-protocol.md` and the Cursor/Codex fallback sections of Step 3 below. Cross-references `skills/shared/external-reviewers.md` "Runtime Timeout Fallback".
2. **Read `contested-decisions.md`** with the existing NO_CONTESTED_DECISIONS short-circuit (unchanged).
3. **Cap = `min(5, |contested-decisions|)`**.
4. **Initialize scoped shadow flags** (`dialectic_codex_available` = `codex_available`, `dialectic_cursor_available` = `cursor_available`). Orchestrator-wide flags NEVER mutated.
5. **Bucket assignment**: Decision 1, 3, 5 → Cursor; Decision 2, 4 → Codex. Both sides of a decision share the tool.
6. **Per-bucket pre-launch availability check + skip semantics**: skip bucket if assigned `dialectic_*_available=false`; do NOT fall back to Claude, do NOT reassign, do NOT abort.
7. **Zero-externals guardrail**: if zero buckets queued, skip the collect call entirely.
8. **Per-decision prompt-file rendering**: write rendered thesis/antithesis prompts to `$DESIGN_TMPDIR/debate-<n>-{thesis,antithesis}-prompt.txt`.
9. **Parallel launch**: single Bash message; per-decision output paths embed the tool name; bash launches pass a short bootstrap prompt referencing the prompt file path (mirrors voting protocol's pattern, avoids Claude Code permission prompts on `cat`).
10. **Collect with `--write-health /dev/null`** (Option B enforcement; both `-f` read-path and explicit `!= "/dev/null"` write-path guards reject `/dev/null`).
11. **Per-bucket runtime failure handling**: print warning; do NOT flip any flag; quorum rule's STATUS pre-check (below) catches the partial-launch case.
12. **Quorum rule STATUS pre-check**: if either side has `STATUS != OK`, decision immediately fails quorum and synthesis stands. Otherwise apply the byte-identical Phase 1 quorum + winner-selection rules to the file paths from collector's `REVIEWER_FILE` (handles `*-retry.txt` from collector's retry-once-on-empty path).
13. **Completion line** unchanged: `✅ 2a.5: dialectic — <N> decisions resolved (<elapsed>)` where N = quorum passes (NOT launched buckets).
14. **No final restore** — orchestrator-wide flags never mutated; Step 3 sees Step 0's original values.

### Approach (`docs/collaborative-sketches.md` minimal edit)

- Line 64: `CHECK -->|1-3 found| DIALECTIC` → `CHECK -->|1-5 found| DIALECTIC`
- Line 99: "the top 2-3 are submitted" → "up to 5 (in priority order) are submitted to structured thesis/antithesis debates run on Cursor and Codex via deterministic per-decision bucketing"
- Line 115: "(up to 3, prioritized by impact):" → "(up to 5, prioritized by impact):"
- New row added to "Fallback Behavior by Phase" table documenting the Dialectic phase's "no Claude substitution" behavior (round-1 review FINDING_2).

</details>

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `212b08d` (Fix drop-bump-commit.sh Guard 4 ALLOWED_TWO sort order (#117) (#122))
- **Current version**: `3.3.10`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `3.3.11`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH"). Behavioral change is a deliberate quality improvement (model diversity in adversarial debate); the `dialectic-resolutions.md` schema, the SKILL's `argument-hint`, and the `name:` are all preserved byte-for-byte, so no API/signature surface changed for callers.

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

### [Plan Review] Cursor (FINDING_5)
**Finding**: Cursor proposed adding an explicit, sharper cross-link inside `skills/design/SKILL.md` Step 2a.5 that names the Runtime Timeout Fallback procedure in `skills/shared/external-reviewers.md` as NOT applying to dialectic shadow flags. Specifically: a sentence saying "external-reviewers.md flips `*_available` for all subsequent session steps; in this phase, runtime failures flip ONLY the dialectic-scoped flags, never the orchestrator-wide ones. Do not 'fix' this back to global flip behavior." The concern is that without this sharpness, a future editor "harmonizing" the two locations could re-introduce the global flip, defeating Option B's whole purpose.
**Reason not implemented**: 1 YES (Cursor's own self-vote) + 1 EXONERATE (Code) + 1 NO (Codex) = below 2-YES threshold. The Code reviewer noted that the plan already has both shadow-flags AND a prominent INTENTIONAL-DIVERGENCE callout with cross-references and explicit prohibitions. Codex noted that the carve-out is already explicit in steps 4 and 10, so adding a stronger warning is redundant. The intent is already mechanically enforced by the shadow flags plus the explicit prohibitions.

### [Plan Review] Cursor (FINDING_7)
**Finding**: Cursor proposed omitting `--write-health` entirely from the dialectic `collect-reviewer-results.sh` call instead of passing `--write-health /dev/null`. The argument was that `/dev/null` satisfies the script's `-f` test on the read path, causing a benign-but-wrong-abstraction read pass; omitting the flag entirely would skip both read and write cleanly via the `-n "$WRITE_HEALTH"` short-circuit.
**Reason not implemented**: 1 YES (Cursor self-vote) + 1 EXONERATE (Code) + 1 NO (Codex) = below 2-YES threshold. Codex correctly identified that the finding rests on incorrect shell semantics: `[[ -f /dev/null ]]` returns FALSE on macOS/Linux because `/dev/null` is a character device, not a regular file, so the `-f` test already excludes `/dev/null` from the read path. Both `--write-health /dev/null` and omitting the flag entirely produce identical behavior.

</details>

<details><summary>Implementation Deviations</summary>

No deviations from the plan. The 6 fixes applied across review rounds (4 round-1 voted, 1 round-2 STATUS pre-check, 1 round-3 doc summary clarification) are review-driven additions to the plan, not deviations from it.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

### [Code Review] Cursor (FINDING_4)
**Finding**: Cursor proposed adding an explicit completion-line statement to the zero-externals guardrail (Step 5 of the new 2a.5 protocol). Specifically: when no buckets are queued, the guardrail should print `✅ 2a.5: dialectic — 0 decisions resolved (<elapsed>)` and proceed to Step 2b. The concern was that "proceed to the completion line" leaves N=0 implicit, which an LLM orchestrator could interpret ambiguously.
**Reason not implemented**: 1 YES (Cursor self-vote) + 2 EXONERATE (Code, Cursor) + 1 NO (Codex) → below 2-YES threshold. The completion-line format `✅ 2a.5: dialectic — <N> decisions resolved (<elapsed>)` is defined later in the same SKILL.md section with the explicit note that N is the count of decisions that passed the quorum rule. When zero buckets are launched, N=0 is the only coherent value (no quorum passes possible without launches). Spelling this out adds documentation noise without preventing a real failure mode.

### [Code Review] Cursor (FINDING_5)
**Finding**: Cursor proposed restructuring step 4's per-decision availability check to a per-tool check that emits a single warning per unavailable tool (listing all skipped indices), rather than the current per-decision check that would emit one warning per skipped decision. The argument was that the tool's availability flag does not change between decisions in a single batch, so checking per-decision is wasteful.
**Reason not implemented**: 1 YES (Cursor self-vote) + 1 EXONERATE (Code) + 2 NO (Codex, Cursor in vote) → below 2-YES threshold. The per-decision check is semantically correct (the flag is stable across the batch but the check is correct either way). Restructuring to per-tool checking with summary warnings adds implementation complexity disproportionate to the cosmetic difference in warning granularity.

### [Code Review] Cursor (FINDING_7)
**Finding**: Cursor proposed inlining the dialectic-divergence rationale into the SKILL.md callout (rather than relying on the GitHub issue #98 link). The deeper rationale (single-model debate degrades quality per Liang et al. 2023 MAD; cap-3 leaves contested points unadjudicated; external tools provide model diversity) lives only in the issue body; if the issue is closed, renamed, or moved, on-repo maintainers lose the why.
**Reason not implemented**: 0 YES + 3 EXONERATE → unanimous EXONERATE, below 2-YES threshold. All three voters agreed the GitHub issue link is adequate context for this PR; inlining the rationale is nice-to-have but adds prose to an already-dense divergence callout.

### [Code Review] Codex (FINDING_8)
**Finding**: Codex proposed handling the cascade where skipped dialectic buckets bypass Step 3.5 discussion. Step 3.5's "Still contested" criterion looks at decisions where the dialectic resolution was "close or inconclusive" — skipped decisions have no resolution at all, so Step 3.5 might silently skip them. Suggested fix: write an explicit "skipped/unresolved" record to dialectic-resolutions.md for each skipped decision, OR teach Step 3.5 to treat missing dialectic output for a contested decision as still-contested.
**Reason not implemented**: 1 YES (Code) + 1 EXONERATE (Cursor) + 1 NO (Codex self-vote) → below 2-YES threshold. Step 3.5 is auto-mode-skipped (`auto_mode=true` is the path /implement uses by default), so the gap only matters for interactive `/design` runs — a corner case. The fix would require touching Step 3.5's text or the dialectic-resolutions.md format, expanding the PR scope. Issue #98's "Out of scope: Phase 4" boundary covers this kind of cross-step propagation cleanup.

</details>

<details><summary>Plan Review Voting Tally</summary>

### Per-finding vote breakdown

| Finding | Code | Cursor | Codex | YES | Result |
|---|---|---|---|---|---|
| FINDING_1 (parallel-launch vs shadow-flag-flip inconsistency) | YES | YES | YES | 3 | ✅ Accepted |
| FINDING_2 (`${CLAUDE_PLUGIN_ROOT}/scripts/` prefix on script invocations) | YES | YES | YES | 3 | ✅ Accepted |
| FINDING_3 (Cursor effort suffix at launch-level) | YES | YES | YES | 3 | ✅ Accepted |
| FINDING_4 (docs/collaborative-sketches.md cap-3 stale lines) | YES | YES | YES | 3 | ✅ Accepted |
| FINDING_5 (sharper cross-link to external-reviewers.md) | EXONERATE | YES | NO | 1 | ❌ Rejected |
| FINDING_6 (stale/fragile line references in plan; use section anchors) | YES | YES | YES | 3 | ✅ Accepted |
| FINDING_7 (`--write-health /dev/null` vs omit flag) | EXONERATE | YES | NO | 1 | ❌ Rejected |
| FINDING_8 (shell-injection from substitution → file-based prompts) | YES | YES | YES | 3 | ✅ Accepted |

### Reviewer Competition Scoreboard

| Reviewer | Findings raised (count) | Net points |
|---|---|---|
| Code | F1 (shared), F2 (shared) | +2 |
| Cursor | F1 (shared), F2 (shared), F5, F6, F7, F8 | +4 |
| Codex | F1 (shared), F3, F4 | +3 |

Total: 8 findings voted, 6 accepted, 2 rejected.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

### Per-finding vote breakdown

| Finding | Code | Cursor | Codex | YES | Result |
|---|---|---|---|---|---|
| FINDING_1 (`$(cat ...)` pattern reintroduces permission-prompt friction) | YES | YES | YES | 3 | ✅ Accepted |
| FINDING_2 (Dialectic row missing from Fallback Behavior by Phase table) | YES | YES | EXONERATE | 2 | ✅ Accepted |
| FINDING_3 (Quorum read-path should use REVIEWER_FILE for retry-rename) | YES | YES | YES | 3 | ✅ Accepted |
| FINDING_4 (Zero-externals completion line / N=0 not explicit) | EXONERATE | EXONERATE | NO | 0 | ❌ Rejected |
| FINDING_5 (Per-decision vs per-tool availability check naming) | EXONERATE | NO | NO | 0 | ❌ Rejected |
| FINDING_6 (Quorum scope — only queued decisions) | YES | YES | NO | 2 | ✅ Accepted |
| FINDING_7 (Inline rationale, not just issue link) | EXONERATE | EXONERATE | EXONERATE | 0 | ❌ Rejected |
| FINDING_8 (Skipped buckets bypass Step 3.5) | YES | EXONERATE | NO | 1 | ❌ Rejected |

### Reviewer Competition Scoreboard (round 1 only — round 2+ findings auto-accepted)

| Reviewer | Findings raised (count) | Net points |
|---|---|---|
| Code | F1 (shared), F2 (shared) | +2 |
| Cursor | F1 (shared), F2 (shared), F3, F4, F5, F6, F7 | +4 |
| Codex | F1 (shared), F8 | +1 |

Total: 8 findings voted in round 1, 4 accepted. Rounds 2 and 3 each surfaced 1 additional Claude-only finding (auto-accepted): round 2 added a STATUS pre-check to the quorum rule (correctness fix for partial-launch case); round 3 updated the doc summary at `docs/collaborative-sketches.md:121` to mention the STATUS gate. Round 4 converged with NO_ISSUES_FOUND.

</details>

<details><summary>Out-of-Scope Observations</summary>

**Accepted OOS (GitHub issues filed):**
No OOS items were accepted for issue filing.

**Non-accepted OOS observations:**
No out-of-scope observations were raised by either plan review or code review.

</details>

<details><summary>Execution Issues</summary>

No execution issues encountered.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | 6 accepted, 2 rejected |
| Code review rounds | 4 (3 productive + 1 convergence) |
| Code review findings | 6 accepted (4 round-1 voted + 1 round-2 + 1 round-3), 4 rejected |
| Warnings logged | 0 |
| Pre-existing issues noticed | 0 |
| OOS issues filed | 0 |
| External reviewers | Cursor: ✅, Codex: ✅ |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
