### PR TITLE
Fix OOS Description regex to accept empty inline value (#131)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.4] - 2026-04-19
+
+### Fixed
+
+- `skills/issue/scripts/parse-input.sh` Description bullet regex now accepts an empty inline value. Previously, `^-[[:space:]]+\*\*Description\*\*:[[:space:]]+(.+)$` required non-empty inline content, so a bullet written as `- **Description**:` with body on continuation lines only failed to match, `IN_BODY` never transitioned to `true`, and both the bullet line and all its continuations were silently dropped from `CURRENT_BODY`. The regex is relaxed to `^-[[:space:]]+\*\*Description\*\*:[[:space:]]*(.*)$` — both trailing quantifiers become zero-or-more, so an empty inline value captures as `""`, `IN_BODY` flips to `true`, and the existing fallback branch populates the body from subsequent continuation lines. `test-parse-input.sh` grows a new case 9 that feeds this shape (empty inline + multi-line continuation including a blank line) and asserts the decoded body, tallied vote count, reviewer, phase, and absence of `ITEM_1_MALFORMED`. Header grammar comment updated to document that the inline value may be empty. Closes #131.
+
 ## [3.4.3] - 2026-04-19
 
 ### Fixed

--- a/skills/issue/scripts/parse-input.sh
+++ b/skills/issue/scripts/parse-input.sh
@@ -187,7 +187,11 @@ while IFS= read -r line || [[ -n "$line" ]]; do
             IN_BODY=true
             CURRENT_MODE="generic"
         fi
-    elif [[ "$CURRENT_MODE" == "oos" && "$line" =~ ^-[[:space:]]+\*\*Description\*\*:[[:space:]]+(.+)$ ]]; then
+    elif [[ "$CURRENT_MODE" == "oos" && "$line" =~ ^-[[:space:]]+\*\*Description\*\*:[[:space:]]*(.*)$ ]]; then
+        # Accept empty inline value — the body may come entirely from continuation
+        # lines (e.g. `- **Description**:` alone on its line with `  content` on
+        # the next line). IN_BODY=true ensures those continuations are captured
+        # by the fallback branch below.
         CURRENT_BODY="${BASH_REMATCH[1]}"
         IN_BODY=true
     elif [[ "$CURRENT_MODE" == "oos" && "$line" =~ ^-[[:space:]]+\*\*Reviewer\*\*:[[:space:]]+(.+)$ ]]; then

--- a/skills/issue/scripts/parse-input.sh
+++ b/skills/issue/scripts/parse-input.sh
@@ -16,6 +16,9 @@
 #         - **Vote tally**: <YES/NO/EXONERATE counts>
 #         - **Phase**: design|review
 #
+#       The inline value after `- **Description**:` may be empty — in that
+#       case the body is supplied entirely by the continuation lines.
+#
 #   (2) Generic fallback: for non-OOS callers, accept `### <title>` headings
 #       followed by free-form body. Emits only ITEM_<i>_TITLE / ITEM_<i>_BODY.
 #

--- a/skills/issue/scripts/test-parse-input.sh
+++ b/skills/issue/scripts/test-parse-input.sh
@@ -260,6 +260,36 @@ assert_eq "case 8 item 2 vote tally" "YES=2, NO=1" "$(get_value ITEM_2_VOTE_TALL
 assert_eq "case 8 item 2 phase" "design" "$(get_value ITEM_2_PHASE "$out8")"
 
 # ---------------------------------------------------------------------------
+# Test case 9 — Issue #131: OOS item where `- **Description**:` has no inline
+# value and the body is supplied entirely by continuation lines. Before the
+# fix, the `[[:space:]]+(.+)$` regex required non-empty inline content, so
+# the Description bullet did not match, IN_BODY stayed false, and all
+# continuation lines were silently dropped. With `[[:space:]]*(.*)$` the
+# empty inline value matches, IN_BODY flips to true, and continuations are
+# captured by the fallback branch.
+# ---------------------------------------------------------------------------
+echo "Case 9: OOS item with empty inline Description, body from continuations"
+cat > "$TMPDIR_TEST/case9.md" <<'EOF'
+### OOS_1: Description body from continuations only
+- **Description**:
+  First continuation line.
+
+  Third line after blank.
+- **Reviewer**: Code
+- **Vote tally**: YES=3, NO=0
+- **Phase**: design
+EOF
+out9=$(run_parser "$TMPDIR_TEST/case9.md")
+assert_eq "case 9 items total" "ITEMS_TOTAL=1" "$(grep '^ITEMS_TOTAL=' <<< "$out9")"
+assert_eq "case 9 title" "Description body from continuations only" "$(get_value ITEM_1_TITLE "$out9")"
+assert_eq "case 9 reviewer" "Code" "$(get_value ITEM_1_REVIEWER "$out9")"
+assert_eq "case 9 vote tally" "YES=3, NO=0" "$(get_value ITEM_1_VOTE_TALLY "$out9")"
+assert_eq "case 9 phase" "design" "$(get_value ITEM_1_PHASE "$out9")"
+expected9=$'  First continuation line.\n\n  Third line after blank.'
+assert_eq "case 9 body captures multi-line continuation" "$expected9" "$(get_body 1 "$out9")"
+assert_absent "case 9 not MALFORMED" "ITEM_1_MALFORMED" "$out9"
+
+# ---------------------------------------------------------------------------
 echo ""
 echo "Summary: $PASS_COUNT passed, $FAIL_COUNT failed"
 if [[ "$FAIL_COUNT" -gt 0 ]]; then


### PR DESCRIPTION
## Summary

- Fixed `parse-input.sh` Description-bullet regex to accept an empty inline value, so OOS items written with the body entirely on continuation lines (e.g. `- **Description**:\n  continuation text`) are parsed correctly instead of being silently dropped. Resolves #131.
- Added regression test case 9 in `test-parse-input.sh` covering the empty-inline shape with multi-line continuation body (including a blank line), and updated the top-of-file grammar docstring to note that the inline Description value may be empty.

<details><summary>Architecture Diagram</summary>

Quick mode — architecture diagram skipped.

</details>

<details><summary>Code Flow Diagram</summary>

Quick mode — code flow diagram skipped.

</details>

<details><summary>Goal</summary>

- Fix the silent data-loss bug in `skills/issue/scripts/parse-input.sh` identified as issue #131
  - The OOS Description bullet regex `^-[[:space:]]+\*\*Description\*\*:[[:space:]]+(.+)$` required non-empty inline content
  - When a producer emitted `- **Description**:` with body on continuation lines only (a shape used by some OOS generators), the bullet line failed to match the regex, `IN_BODY` never transitioned to `true`, and all continuation lines were then also silently discarded by the parser
  - Apply the reporter-suggested fix (option a): relax the trailing quantifiers from `+` to `*` so an empty inline value matches, captures empty string, and still sets `IN_BODY=true`
  - Lock the fix against future regressions by adding a case to the existing manual-run regression harness

</details>

<details><summary>Test plan</summary>

- [x] `bash skills/issue/scripts/test-parse-input.sh` — 59 assertions pass (52 preexisting + 7 new for case 9, including vote tally parity assert added after round 3 review)
- [x] Manual reproducer: feed `/tmp/.../oos-empty-inline.md` with `- **Description**:` + continuation-only body into `parse-input.sh` and decode `ITEM_1_BODY` — confirmed captures the continuation text (previously dropped)
- [x] Manual regression: feed an OOS input with inline Description value present — confirmed `ITEM_1_BODY` unchanged from prior behavior
- [x] `/relevant-checks` — shellcheck, agent-lint, pre-commit all green after every round

</details>

<details><summary>Final Design</summary>

### Implementation Plan

**Files to modify**:
- `skills/issue/scripts/parse-input.sh` — single regex change at line 190 (+ header doc note)
- `skills/issue/scripts/test-parse-input.sh` — new regression test case 9

**Approach**: Relax the Description-bullet regex from `^-[[:space:]]+\*\*Description\*\*:[[:space:]]+(.+)$` to `^-[[:space:]]+\*\*Description\*\*:[[:space:]]*(.*)$`. Both trailing quantifiers become zero-or-more:
- `[[:space:]]+` → `[[:space:]]*`: accepts `- **Description**:` with no trailing space
- `(.+)$` → `(.*)$`: captures empty inline value

When the inline value is empty, `CURRENT_BODY` starts as `""` and `IN_BODY` is set to `true`. The existing IN_BODY fallback branch (lines 206–219) then populates `CURRENT_BODY` from subsequent continuation lines — no other code changes required.

**Edge cases**:
- Inline value present (existing happy path): `(.*)$` still matches and captures — behavior unchanged.
- Only trailing whitespace: captures empty string (unchanged net behavior; continuations populate).
- Continuation is a structured field marker (Reviewer/Vote tally/Phase): those elif branches come FIRST in the chain, so they still match and terminate the Description body — unchanged.
- Multiple blank lines immediately after `- **Description**:`: blank lines preserved inside body per existing IN_BODY logic — unchanged.

**Testing strategy**:
1. Craft a minimal OOS input with `- **Description**:` and content only on the next line; verify `ITEM_1_BODY` (base64-decoded) contains the continuation content and the item is not MALFORMED.
2. Run `parse-input.sh` against an existing valid OOS input (inline Description value present) and verify identical output to current behavior — regression check.
3. `/relevant-checks` after each edit.

**Failure modes**:
- Risk: Regex becomes too permissive and matches something unintended. Mitigation: `^-[[:space:]]+\*\*Description\*\*:` is still anchored; the change only relaxes what follows the colon, so non-Description lines cannot newly match.
- Detection: Regression test (#2 above) catches behavior drift on the inline-value path.

</details>

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `09befc7` (Fix parse-input.sh OOS/generic mode conflation (#129) (#133))
- **Current version**: `3.4.3`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `3.4.4`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH"). Main-agent escalation review: none warranted — the regex change is strictly more accepting (previously-rejected input now parses; previously-accepted input behaves identically), which is a behavior-compatible fix.

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

Quick mode — no plan review was conducted.

</details>

<details><summary>Implementation Deviations</summary>

No deviations from the quick-mode inline plan. The plan called for a one-line regex change and a regression test; both were delivered. Round 2 code review accepted a short header-doc addition (explicitly noting that the Description inline value may be empty) and round 3 review accepted a vote-tally parity assertion in case 9 — both minor additions consistent with the plan's spirit rather than scope changes.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

### [Code Review] Cursor (round 3)
**Finding**: In `skills/issue/scripts/test-parse-input.sh` and `skills/issue/scripts/parse-input.sh` (branch state — committed HEAD vs working tree at the time of round 3): the committed HEAD `d9e3a8c` contained only the regex change in `parse-input.sh`, while the new regression test (case 9) in `test-parse-input.sh` and the extra header-doc note in `parse-input.sh` were still unstaged working-tree edits. Cursor flagged that a push of the current single commit alone would ship the behavior change without the new test in git history until a follow-up commit, and suggested amending or squashing so the fix and its regression test share one revision.

**Reason not implemented**: This is an artifact of the /implement workflow's intentional commit topology — Step 4 creates the implementation commit, Steps 5-7 run code review and commit review fixes as a separate "Address code review feedback" commit, and nothing is pushed until Step 9. The two-commit structure is deliberate (it provides a clean code-review audit trail in the squashed PR merge), not a bug. Cursor's underlying concern — that a push could ship the regex change without the regression test — is moot because Step 7 commits the review fixes (including case 9 and the header doc) before any push happens in Step 9. The PR squash-merge then bundles both commits into a single commit on main, so the history ultimately contains the regex and its regression test together.

### [Code Review] Cursor (round 4, finding 1)
**Finding**: Duplicate of round 3 finding 1 — Cursor again observed that the regression test (case 9) and the new header-doc clarification in `skills/issue/scripts/parse-input.sh` were still unstaged at the time of round 4 while the committed HEAD contained only the regex change, and again suggested staging/squashing so fix + tests + doc ship together on the branch.

**Reason not implemented**: Same reason as round 3 rejection — the workflow's two-commit topology (Step 4 implementation commit + Step 7 review-fix commit) is intentional, nothing is pushed until Step 9, and the PR squash-merge bundles both into a single commit on main.

### [Code Review] Cursor (round 4, finding 2)
**Finding**: In `skills/issue/scripts/parse-input.sh:193-197` — the multi-line comment on the Description elif branch (explaining "Accept empty inline value — the body may come entirely from continuation lines..." plus the IN_BODY=true consequence for the fallback branch) largely repeats what the file header states after the new lines 19-20 edit about empty inline values being supplied by continuations. Suggested fix: keep the full explanation in the header and reduce the elif-branch comment to a single short line like "Allow empty capture so continuations populate the body."

**Reason not implemented**: The elif-block comment is not a duplicate of the header grammar doc — it adds implementation-local WHY context that the header does not carry: specifically, the reason for setting `IN_BODY=true` even when the inline capture is empty, and the mechanism by which the fallback branch below collects the continuation text. Per CLAUDE.md's guidance to include comments only when the WHY is non-obvious (and to anchor them to the code they describe rather than a header summary), this comment earns its keep at the call site. Cursor's own round 4 conclusion confirms the finding is style/nit rather than a defect: "If you treat only defects as findings and exclude process/style nits, the substantive technical conclusion is: NO_ISSUES_FOUND." Per Step 5.5, trivial style nits are rejected.

</details>

<details><summary>Plan Review Voting Tally</summary>

Quick mode — no plan review voting.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

Quick mode — no voting panel. Main agent reviewed findings across 4 single-reviewer rounds using Cursor. Round 1: 1 finding accepted (add regression test). Round 2: 2 findings accepted (add header doc note, commit test case — already addressed in working tree). Round 3: 1 finding accepted (vote-tally assertion parity for case 9), 1 rejected (workflow-topology nit). Round 4: 2 rejected (duplicate of round 3 topology nit + comment-duplication style nit; Cursor's own conclusion acknowledged both were process/style rather than defects). Loop terminated at round 4 with zero accepted findings.

</details>

<details><summary>Out-of-Scope Observations</summary>

**Accepted OOS (GitHub issues filed):**
No OOS items were accepted for issue filing.

**Non-accepted OOS observations:**
Quick mode — no reviewer voting panel. Main-agent OOS items (if any) are auto-filed per policy; see Accepted OOS above.

</details>

<details><summary>Execution Issues</summary>

No execution issues encountered.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | N/A (quick mode) |
| Code review rounds | 4 |
| Code review findings | 4 accepted, 3 rejected |
| Warnings logged | 0 |
| Pre-existing issues noticed | 0 |
| OOS issues filed | 0 |
| External reviewers | Cursor: ✅, Codex: N/A (not used this run) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
