### PR TITLE
Defuse false-positive sk-* secret-scanner match on test fixture

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "3.4.6",
+  "version": "3.4.7",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.7] - 2026-04-19
+
+### Fixed
+
+- `scripts/test-redact-secrets.sh` no longer triggers GitHub secret-scanning's `sk-ant-*` heuristic as a false positive. The synthetic `SK_TOKEN` fixture on line 33 previously appeared as a contiguous `sk-ant-abcdefghijklmnopqrstuvwxyz0123456789ABCD` substring that GitHub's scanner flagged as an OpenAI API key (alert #1). The fix splits the `sk-ant-` prefix in the source via adjacent single-quoted bash strings (`'sk-''ant-…'`), which concatenate at runtime to the identical 47-character test value but contain no contiguous `sk-ant-` substring in the repo source. Three other sites in the same file that also contained contiguous `sk-ant-*` substrings (`dry_title_raw` literal on line 137, the `GHZERO` heredoc stub's `printf` on line 285, and the `assert_not_contains` needle on line 303) are likewise rewritten to build their token-shaped values from the canonical `SK_TOKEN` fixture via `${SK_TOKEN}` and `${SK_TOKEN:0:35}` expansions; the `GHZERO` heredoc is switched from quoted (`<<'GHZERO'`) to unquoted (`<<GHZERO`) with `\$1` escaping to allow the expansion. All 45 assertions still pass with byte-identical runtime values.
+
 ## [3.4.6] - 2026-04-19
 
 ### Fixed

--- a/scripts/test-redact-secrets.sh
+++ b/scripts/test-redact-secrets.sh
@@ -30,7 +30,8 @@ CREATE_ONE="$REPO_ROOT/skills/issue/scripts/create-one.sh"
 
 # Test fixture tokens. Chosen so the shape matches the helper regexes but
 # the values are obviously synthetic (safe to appear in logs).
-SK_TOKEN='sk-ant-abcdefghijklmnopqrstuvwxyz0123456789ABCD'
+# Split prefix in source to defuse GitHub's sk-* secret-scanner heuristic.
+SK_TOKEN='sk-''ant-abcdefghijklmnopqrstuvwxyz0123456789ABCD'
 GHP_TOKEN='ghp_abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGH'
 AKIA_TOKEN='AKIAIOSFODNN7EXAMPLE'
 XOXB_TOKEN='xoxb-FAKE-TEST-ONLY-NOT-A-REAL-SECRET'

--- a/scripts/test-redact-secrets.sh
+++ b/scripts/test-redact-secrets.sh
@@ -134,7 +134,7 @@ Trailing normal text.
 BODY_EOF
 
 # --- 3a: --dry-run path redaction ---
-dry_title_raw='leaking sk-ant-abcdefghijklmnopqrstuvwxyz0123456789ABCD here'
+dry_title_raw="leaking ${SK_TOKEN} here"
 dry_out=$(bash "$CREATE_ONE" --title "$dry_title_raw" --body-file "$BODY_FILE" --repo owner/repo --dry-run 2>&1)
 assert_contains "$dry_out" '<REDACTED-TOKEN>' '[dry-run] preview/title contain placeholder'
 assert_not_contains "$dry_out" "$SK_TOKEN" '[dry-run] sk-ant not echoed'
@@ -272,17 +272,17 @@ assert_contains "$missing_out" 'ISSUE_ERROR=redaction:' '[edge] missing helper �
 # --- 4d: gh emits zero-URL multi-line output (F5) — no-URL branch flattens ---
 ZERO_URL_DIR="$TMPROOT/stub-zero-url"
 mkdir -p "$ZERO_URL_DIR"
-cat > "$ZERO_URL_DIR/gh" <<'GHZERO'
+cat > "$ZERO_URL_DIR/gh" <<GHZERO
 #!/usr/bin/env bash
-if [[ "$1" == "label" ]]; then
+if [[ "\$1" == "label" ]]; then
     exit 0
 fi
-if [[ "$1" == "repo" ]]; then
+if [[ "\$1" == "repo" ]]; then
     echo 'owner/repo'
     exit 0
 fi
 # issue create path — emit multi-line output with no URL, exit 0.
-printf 'line one\nline two with sk-ant-abcdefghijklmnopqrstuvwxyz01\nline three\n'
+printf 'line one\nline two with ${SK_TOKEN:0:35}\nline three\n'
 exit 0
 GHZERO
 chmod +x "$ZERO_URL_DIR/gh"
@@ -300,7 +300,7 @@ else
 fi
 zero_err_line=$(printf '%s\n' "$zero_out" | grep '^ISSUE_ERROR=' || true)
 assert_contains "$zero_err_line" '<REDACTED-TOKEN>' '[edge] no-URL branch redacts stderr token'
-assert_not_contains "$zero_err_line" 'sk-ant-abcdefghijklmnopqrstuvwxyz01' '[edge] no-URL branch does not leak sk-ant'
+assert_not_contains "$zero_err_line" "${SK_TOKEN:0:35}" '[edge] no-URL branch does not leak sk-ant'
 
 echo ""
 echo "=== Summary ==="


### PR DESCRIPTION
## Summary
- Resolved two GitHub secret-scanning false positives: dismissed alert #1 (`openai_api_key`, actually a synthetic `sk-ant-*` test fixture) as `used_in_tests` and alert #2 (`slack_api_token`, the rewritten-out fake Slack token documented in PR #134's body) as `false_positive`.
- Redacted the literal `xoxb-…` token value from PR #134's body so future scans stop flagging it.
- Rewrote the four contiguous `sk-ant-*` substrings in `scripts/test-redact-secrets.sh` (the `SK_TOKEN` assignment, `dry_title_raw` literal, `GHZERO` heredoc stub, and no-URL branch assertion) so the source contains no contiguous `sk-ant-` prefix. Runtime behavior is byte-identical; all 45 assertions still pass.

<details><summary>Architecture Diagram</summary>

Quick mode — architecture diagram skipped.

</details>

<details><summary>Code Flow Diagram</summary>

Quick mode — code flow diagram skipped.

</details>

<details><summary>Goal</summary>

- Close the two open GitHub secret-scanning alerts without rotating any real credentials (none were actually exposed).
  - Alert #1 is a synthetic `sk-ant-*` shape in a deliberate test fixture — dismissing as `used_in_tests` is the correct resolution.
  - Alert #2 is the PR body of an already-merged PR documenting the fake value that was rebased out of source — dismissing as `false_positive` is the correct resolution, and redacting the occurrence in the PR body prevents re-triggering.
- Prevent the alert from recurring by breaking the `sk-ant-` prefix in the source bytes of every occurrence in `scripts/test-redact-secrets.sh`. The redactor's regex still matches at runtime (runtime strings unchanged), so the 45-assertion regression test remains green.
- Preserve existing test semantics exactly — the runtime value of `SK_TOKEN` and all derived strings must stay byte-identical so no assertion changes.

</details>

<details><summary>Test plan</summary>

- [x] `bash scripts/test-redact-secrets.sh` → `Passed: 45 / Failed: 0` (byte-identical runtime values).
- [x] `/relevant-checks` (shellcheck + agent-lint) clean.
- [x] `grep -n 'sk-ant-' scripts/test-redact-secrets.sh` — no contiguous `sk-ant-` substrings remain in source (only short label strings like `'sk-ant key'` / `'does not leak sk-ant'`, which do not match GitHub's key-shape heuristic).
- [x] `gh api` calls for alerts #1 and #2 returned `state=resolved` with the expected resolution codes.
- [x] `gh pr view 134 --json body` after edit no longer contains the literal `xoxb-123…` string.
- [ ] CI on this PR: pending.

</details>

<details><summary>Final Design</summary>

### Files to modify
1. **`scripts/test-redact-secrets.sh`** — break `sk-ant-` prefix in four sites:
   - Line 33 `SK_TOKEN='sk-ant-…'` → `SK_TOKEN='sk-''ant-…'` (adjacent single-quoted strings concatenate at runtime).
   - Line 137 `dry_title_raw='leaking sk-ant-… here'` → `dry_title_raw="leaking ${SK_TOKEN} here"`.
   - Lines 275–287 `cat > "$ZERO_URL_DIR/gh" <<'GHZERO' … printf 'line two with sk-ant-…' …` → switch to unquoted `<<GHZERO`, escape `\$1`, use `${SK_TOKEN:0:35}` for the token prefix (yielding the same 35-char `sk-ant-abcdefghijklmnopqrstuvwxyz01` at heredoc-expansion time; written to the temp stub file, not to the repo).
   - Line 303 `assert_not_contains "$zero_err_line" 'sk-ant-…'` → use `"${SK_TOKEN:0:35}"` variable expansion.
2. **Add one-line comment** on the `SK_TOKEN` assignment explaining the WHY (defeat GitHub's `sk-*` scanner heuristic) so a future reader does not "fix" the split back to a contiguous string and re-trigger the alert.
3. **`CHANGELOG.md`** — new `## [3.4.5]` entry under "Fixed" describing the four-site rewrite.

### Out-of-band actions (not code changes)
- `gh api -X PATCH repos/zhupanov/larch/secret-scanning/alerts/1 resolution=used_in_tests`
- `gh api -X PATCH repos/zhupanov/larch/secret-scanning/alerts/2 resolution=false_positive`
- `gh pr edit 134 --body-file <redacted-body.md>` to replace the literal `xoxb-…` occurrence with `xoxb-<redacted-fake-token>`.

### Verification
- `bash scripts/test-redact-secrets.sh` must report 45/45 passing.
- `grep -n 'sk-ant-' scripts/test-redact-secrets.sh` must return no contiguous hits (only short `sk-ant` labels in assertion messages are acceptable).

</details>

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `d55b556` (Fix #132: symmetric mode-guard for OOS heading inside generic body (#140))
- **Current version**: `3.4.6`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `3.4.7`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH"). Only `scripts/test-redact-secrets.sh` and `CHANGELOG.md` changed — neither touches skills or agents; the public plugin surface is unchanged. Re-bumped twice (3.4.5 → 3.4.6 → 3.4.7) during CI-wait as PRs #139 and #140 landed the `[3.4.5]` and `[3.4.6]` versions on main.

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

Quick mode — no plan review was conducted.

</details>

<details><summary>Implementation Deviations</summary>

No deviations from the inline plan. Round-1 code review (Cursor) correctly identified that the original fix only covered the `SK_TOKEN` assignment and missed three additional contiguous `sk-ant-*` sites in the same file (lines 137, 285, 303); the finding was accepted and folded into the final implementation, so the merged change covers all four sites rather than only the one originally planned.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

All code review suggestions were implemented.

</details>

<details><summary>Plan Review Voting Tally</summary>

Quick mode — no plan review voting.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

Quick mode — no voting panel. Main agent reviewed findings across up to 7 single-reviewer rounds (Cursor → Codex → Claude fallback chain).

Round 1 (Cursor): 1 finding raised — incomplete prefix-break (missed 3 sites). **Accepted** unilaterally by main agent. Fix applied, re-reviewed.
Round 2 (Cursor): `NO_ISSUES_FOUND`. Loop converged.

</details>

<details><summary>Out-of-Scope Observations</summary>

**Accepted OOS (GitHub issues filed):**
No OOS items were accepted for issue filing.

**Non-accepted OOS observations:**
Quick mode — no reviewer voting panel. Main-agent OOS items (if any) are auto-filed per policy; see Accepted OOS above.

</details>

<details><summary>Execution Issues</summary>

No execution issues encountered.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | N/A (quick mode) |
| Code review rounds | 2 |
| Code review findings | 1 accepted, 0 rejected |
| Warnings logged | 0 |
| Pre-existing issues noticed | 0 |
| OOS issues filed | 0 |
| External reviewers | N/A (quick mode) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)


