### PR TITLE
Wire test-parse-input.sh into make lint (closes #136)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "3.4.7",
+  "version": "3.4.8",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ Plugin ships the entire repo. **Runtime surface**: `skills/`, `agents/`, `hooks/
 - Always respect `scripts/block-submodule-edit.sh`. If a hook blocks a write, investigate and resolve the underlying issue.
 - After any change, run `/relevant-checks`.
 - `scripts/redact-secrets.sh` is the outbound secret-scrubbing filter invoked by `skills/issue/scripts/create-one.sh` before `gh issue create`. `scripts/test-redact-secrets.sh` is its regression test, wired into `make lint` via the `test-redact` target. Edit patterns only after reading `SECURITY.md`'s outbound-redaction subsection.
+- `skills/issue/scripts/parse-input.sh` parses `/issue` batch-mode input. `skills/issue/scripts/test-parse-input.sh` is its regression harness, wired into `make lint` via the `test-parse-input` target so parser regressions cannot ship undetected.
 - Public `skills/*/SKILL.md` use `${CLAUDE_PLUGIN_ROOT}/…`; dev-only `.claude/skills/*/SKILL.md` use `$PWD/…`.
 - Update `SECURITY.md` when security-relevant behavior changes.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.8] - 2026-04-19
+
+### Changed
+
+- `skills/issue/scripts/test-parse-input.sh` is now wired into `make lint` via a new `test-parse-input` Makefile target, mirroring the existing `test-redact` target for `scripts/test-redact-secrets.sh`. The 83-assertion parser regression harness runs on every PR through the existing `lint` CI job in `.github/workflows/ci.yaml`, closing the gap where regressions in `skills/issue/scripts/parse-input.sh` could previously ship undetected. Documentation updated in `skills/issue/SKILL.md`, `AGENTS.md`, and the script header. Closes #136.
+
 ## [3.4.7] - 2026-04-19
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,16 @@
 # Larch Makefile
 # Thin wrapper around pre-commit. Linter definitions live in .pre-commit-config.yaml.
 
-.PHONY: lint shellcheck markdownlint jsonlint actionlint agent-lint agnix setup test-redact smoke-dialectic
+.PHONY: lint shellcheck markdownlint jsonlint actionlint agent-lint agnix setup test-redact test-parse-input smoke-dialectic
 
-lint: test-redact
+lint: test-redact test-parse-input
 	pre-commit run --all-files
 
 test-redact:
 	bash scripts/test-redact-secrets.sh
+
+test-parse-input:
+	bash skills/issue/scripts/test-parse-input.sh
 
 smoke-dialectic:
 	bash scripts/dialectic-smoke-test.sh

--- a/skills/issue/SKILL.md
+++ b/skills/issue/SKILL.md
@@ -74,7 +74,7 @@ ${CLAUDE_PLUGIN_ROOT}/skills/issue/scripts/parse-input.sh --input-file "$INPUT_F
 
 Parse the output for `ITEMS_TOTAL=<N>` and per-item `ITEM_<i>_TITLE`, `ITEM_<i>_BODY` (base64-encoded), optional `ITEM_<i>_REVIEWER`, `ITEM_<i>_PHASE`, `ITEM_<i>_VOTE_TALLY`, and `ITEM_<i>_MALFORMED=true` for items without a description.
 
-Parser regression coverage lives in `${CLAUDE_PLUGIN_ROOT}/skills/issue/scripts/test-parse-input.sh` (self-contained; run manually via `bash ${CLAUDE_PLUGIN_ROOT}/skills/issue/scripts/test-parse-input.sh` — not wired into automated CI).
+Parser regression coverage lives in `${CLAUDE_PLUGIN_ROOT}/skills/issue/scripts/test-parse-input.sh` (self-contained; run manually via `bash ${CLAUDE_PLUGIN_ROOT}/skills/issue/scripts/test-parse-input.sh`, and wired into `make lint` via the `test-parse-input` target so the harness runs in CI on every PR).
 
 Malformed items are pre-counted into the final `ISSUES_FAILED` — they never reach Phase 1/2 or create. For each malformed item, emit on stdout at the end of the run:
 - `ISSUE_<i>_FAILED=true`

--- a/skills/issue/scripts/test-parse-input.sh
+++ b/skills/issue/scripts/test-parse-input.sh
@@ -6,8 +6,9 @@
 # empty inline value), the Issue #132 bug (nested `### OOS_N:` inside a
 # generic body should be absorbed, not flushed), and baseline and boundary
 # cases including the #132-review-surfaced bodyless-generic + nested-OOS edge
-# case. Not wired into any automated test runner; shellcheck (via pre-commit)
-# lints this file automatically. Run manually:
+# case. Wired into `make lint` via the `test-parse-input` target so the harness
+# runs in CI on every PR; shellcheck (via pre-commit) lints this file
+# automatically. Run manually:
 #
 #   bash skills/issue/scripts/test-parse-input.sh
 #


### PR DESCRIPTION
## Summary
- Added a `test-parse-input` Makefile target that runs `bash skills/issue/scripts/test-parse-input.sh`, and wired it as a prerequisite of `lint` alongside `test-redact`.
- Closed the gap where parser regressions in `skills/issue/scripts/parse-input.sh` could ship undetected — the 83-assertion harness now runs on every PR via the existing `make lint` CI job.
- Updated `skills/issue/SKILL.md`, `AGENTS.md`, and the script header to reflect the new wiring.

<details><summary>Architecture Diagram</summary>

Quick mode — architecture diagram skipped.

</details>

<details><summary>Code Flow Diagram</summary>

Quick mode — code flow diagram skipped.

</details>

<details><summary>Goal</summary>

- Wire `skills/issue/scripts/test-parse-input.sh` into automated CI so `/issue` parser regressions cannot ship undetected.
  - Mirror the existing `test-redact` pattern already used for `scripts/test-redact-secrets.sh`:
    - Add a `test-parse-input` Makefile target that runs `bash skills/issue/scripts/test-parse-input.sh`.
    - Add `test-parse-input` as a prerequisite of the `lint` target (alongside `test-redact`).
    - Add `test-parse-input` to the `.PHONY` declaration.
  - Rely on the existing `lint` CI job in `.github/workflows/ci.yaml` — no workflow edits required.
- Update documentation to reflect the new wiring.
  - Replace the "not wired into automated CI" caveat on `skills/issue/SKILL.md` line 77.
  - Add a parallel entry to `AGENTS.md` alongside the `test-redact-secrets.sh` mention.
  - Update the header comment in `skills/issue/scripts/test-parse-input.sh`.
- Close #136.

</details>

<details><summary>Test plan</summary>

- [x] `make test-parse-input` — 83 assertions passed.
- [x] `/relevant-checks` — shellcheck, markdownlint, agent-lint all pass.
- [ ] CI `lint` job exercises the new target on the PR.

</details>

<details><summary>Final Design</summary>

**Files modified:**
1. `Makefile` — added `test-parse-input` target; added to `lint` prerequisites (alongside `test-redact`); added to `.PHONY`.
2. `skills/issue/SKILL.md` line 77 — replaced the "not wired into automated CI" caveat with text stating the test is wired into `make lint` via the `test-parse-input` target.
3. `AGENTS.md` line 15 — added a parallel sentence noting `test-parse-input.sh` is wired into `make lint` alongside `test-redact-secrets.sh`.
4. `skills/issue/scripts/test-parse-input.sh` header comment — updated to reflect the new wiring.

**Approach**: Mirror the exact `test-redact` pattern already in the Makefile. The existing `lint` CI job in `.github/workflows/ci.yaml` runs `make lint`, so adding `test-parse-input` as a prerequisite of `lint` is sufficient to exercise the harness in CI — no workflow edits required.

**Testing strategy**: Verified `make test-parse-input` runs the 83-assertion harness locally before committing. `/relevant-checks` linted Makefile + Markdown + shell edits.

**Failure modes**: Makefile tab/space errors caught locally; parser regressions caught by CI going forward.

</details>

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `9ca4025` (Defuse false-positive sk-* secret-scanner match on test fixture (#141))
- **Current version**: `3.4.7`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `3.4.8`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH").

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

Quick mode — no plan review was conducted.

</details>

<details><summary>Implementation Deviations</summary>

No deviations from the plan.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

All code review suggestions were implemented.

</details>

<details><summary>Plan Review Voting Tally</summary>

Quick mode — no plan review voting.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

Quick mode — no voting panel. Main agent reviewed findings across up to 7 single-reviewer rounds (Cursor → Codex → Claude fallback chain). Round 1 reviewer: Cursor — `NO_ISSUES_FOUND`. Loop exited after round 1.

</details>

<details><summary>Out-of-Scope Observations</summary>

**Accepted OOS (GitHub issues filed):**
No OOS items were accepted for issue filing.

**Non-accepted OOS observations:**
Quick mode — no reviewer voting panel. Main-agent OOS items (if any) are auto-filed per policy; see Accepted OOS above.

</details>

<details><summary>Execution Issues</summary>

No execution issues encountered.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | N/A (quick mode) |
| Code review rounds | 1 |
| Code review findings | 0 accepted, 0 rejected |
| Warnings logged | 0 |
| Pre-existing issues noticed | 0 |
| OOS issues filed | 0 |
| External reviewers | N/A (quick mode) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
