### PR TITLE
Fix #137: capture gh stderr separately on /issue success path

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "3.4.8",
+  "version": "3.4.9",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.9] - 2026-04-19
+
+### Fixed
+
+- `skills/issue/scripts/create-one.sh` no longer merges `gh` stderr into the success-path variable used for URL extraction. Previously `ISSUE_URL=$(gh … 2>&1)` captured both stdout and stderr into one variable, and the downstream `grep -oE 'https?://…/issues/N'` parsed the combined blob; any future stderr line (progress or warning) on success could corrupt the extraction. The fix redirects stderr to a dedicated temp file (`ERR_TMP`) so `ISSUE_URL` holds only stdout on the success branch, and the failure branch reads `ERR_TMP` for the error message still piped through `redact`/flatten/`head -c 500`. `ERR_TMP` is registered in the existing `cleanup()` EXIT trap alongside `BODY_TMP`, so every exit path — including `emit_redaction_failure` on the no-URL branch — removes the stderr temp file, closing a potential durable-disk exposure for token-bearing error text. `scripts/test-redact-secrets.sh` grows a new section 3d case that stubs `gh` to emit a URL on stdout and a warning on stderr, asserting `ISSUE_NUMBER=137` is still extracted and stderr noise does not leak into `ISSUE_URL`. Closes #137.
+
 ## [3.4.8] - 2026-04-19
 
 ### Changed

--- a/scripts/test-redact-secrets.sh
+++ b/scripts/test-redact-secrets.sh
@@ -219,6 +219,33 @@ fail_err_line=$(printf '%s\n' "$fail_out" | grep '^ISSUE_ERROR=' || true)
 assert_contains "$fail_err_line" '<REDACTED-TOKEN>' '[failure] ISSUE_ERROR has placeholder for stderr token'
 assert_not_contains "$fail_err_line" "$SK_TOKEN" '[failure] ISSUE_ERROR does not leak stderr token'
 
+# --- 3d: regression for #137 — gh exits 0 with URL on stdout AND noise on stderr ---
+# Before the fix, ISSUE_URL=$(gh ... 2>&1) merged stderr into the variable used
+# for URL extraction. A warning line on stderr could corrupt the regex match.
+# Post-fix: stderr is captured to a temp file and ignored on the success path,
+# so URL parsing still succeeds.
+STUB_NOISE_DIR="$TMPROOT/stub-success-with-stderr"
+mkdir -p "$STUB_NOISE_DIR"
+cat > "$STUB_NOISE_DIR/gh" <<'GHNOISE'
+#!/usr/bin/env bash
+if [[ "$1" == "label" ]]; then
+    exit 0
+fi
+if [[ "$1" == "repo" ]]; then
+    echo 'owner/repo'
+    exit 0
+fi
+# issue create path — emit a harmless warning on stderr and a valid URL on stdout.
+echo 'warning: experimental feature enabled' >&2
+echo 'https://github.com/owner/repo/issues/137'
+exit 0
+GHNOISE
+chmod +x "$STUB_NOISE_DIR/gh"
+noise_out=$(PATH="$STUB_NOISE_DIR:$PATH" bash "$CREATE_ONE" --title 'plain-title' --body-file "$BODY_FILE" --repo owner/repo 2>&1 || true)
+assert_contains "$noise_out" 'ISSUE_NUMBER=137' '[#137] URL parsed from stdout despite stderr noise'
+assert_contains "$noise_out" 'ISSUE_URL=https://github.com/owner/repo/issues/137' '[#137] ISSUE_URL exact match, no stderr contamination'
+assert_not_contains "$noise_out" 'warning: experimental feature enabled' '[#137] stderr noise not echoed via ISSUE_URL/ISSUE_NUMBER'
+
 echo ""
 echo "=== Section 4: Edge cases ==="
 

--- a/skills/issue/scripts/create-one.sh
+++ b/skills/issue/scripts/create-one.sh
@@ -235,7 +235,12 @@ for L in "${VALID_LABELS[@]+"${VALID_LABELS[@]}"}"; do
     GH_ARGS+=(--label "$L")
 done
 
-if ISSUE_URL=$(gh "${GH_ARGS[@]}" 2>&1); then
+# Capture stdout and stderr separately so a stray stderr line (progress,
+# warning) on the success path cannot corrupt URL extraction below. ERR_TMP
+# holds stderr; ISSUE_URL holds stdout only. Both paths explicitly clean up
+# ERR_TMP before exiting.
+ERR_TMP=$(mktemp)
+if ISSUE_URL=$(gh "${GH_ARGS[@]}" 2>"$ERR_TMP"); then
     # gh issue create emits the URL on stdout. Extract the trailing number.
     # `|| true` keeps the no-URL branch reachable under `set -euo pipefail`
     # when grep finds no match; without it pipefail would abort the script
@@ -248,20 +253,24 @@ if ISSUE_URL=$(gh "${GH_ARGS[@]}" 2>&1); then
         # emitted key=value line honors the one-line-per-record contract.
         REDACTED_OUTPUT=$(redact "$ISSUE_URL") || emit_redaction_failure
         REDACTED_OUTPUT_FLAT=$(echo "$REDACTED_OUTPUT" | tr '\n' ' ' | head -c 500)
+        rm -f "$ERR_TMP"
         echo "ISSUE_FAILED=true"
         echo "ISSUE_ERROR=gh issue create did not emit a URL (output: $REDACTED_OUTPUT_FLAT)"
         exit 2
     fi
     ISSUE_NUM=$(echo "$URL_LINE" | grep -oE '[0-9]+$')
+    rm -f "$ERR_TMP"
     echo "ISSUE_NUMBER=$ISSUE_NUM"
     echo "ISSUE_URL=$URL_LINE"
     echo "ISSUE_TITLE=$FINAL_TITLE"
     exit 0
 else
-    # ISSUE_URL here actually holds stderr content because of 2>&1.
-    # Redact secondary leak surface (tokens in auth-failure messages, request
-    # bodies echoed by the API in 4xx responses) before flattening/echoing.
-    REDACTED_ERR=$(redact "$ISSUE_URL") || emit_redaction_failure
+    # Read stderr from the temp file and redact secondary leak surface
+    # (tokens in auth-failure messages, request bodies echoed by the API in
+    # 4xx responses) before flattening/echoing.
+    ERR_CONTENT=$(cat "$ERR_TMP")
+    rm -f "$ERR_TMP"
+    REDACTED_ERR=$(redact "$ERR_CONTENT") || emit_redaction_failure
     ERR_FLAT=$(echo "$REDACTED_ERR" | tr '\n' ' ' | head -c 500)
     echo "ISSUE_FAILED=true"
     echo "ISSUE_ERROR=$ERR_FLAT"

--- a/skills/issue/scripts/create-one.sh
+++ b/skills/issue/scripts/create-one.sh
@@ -178,10 +178,14 @@ done
 # ---------------------------------------------------------------------------
 BODY_CONTENT=""
 BODY_TMP=""
+ERR_TMP=""
 # shellcheck disable=SC2317  # reachable via EXIT trap; shellcheck can't see indirect invocation
 cleanup() {
     if [[ -n "${BODY_TMP:-}" ]] && [[ -f "$BODY_TMP" ]]; then
         rm -f "$BODY_TMP"
+    fi
+    if [[ -n "${ERR_TMP:-}" ]] && [[ -f "$ERR_TMP" ]]; then
+        rm -f "$ERR_TMP"
     fi
 }
 trap cleanup EXIT
@@ -237,8 +241,9 @@ done
 
 # Capture stdout and stderr separately so a stray stderr line (progress,
 # warning) on the success path cannot corrupt URL extraction below. ERR_TMP
-# holds stderr; ISSUE_URL holds stdout only. Both paths explicitly clean up
-# ERR_TMP before exiting.
+# holds stderr; ISSUE_URL holds stdout only. Cleanup happens via the EXIT
+# trap, so every exit path — including emit_redaction_failure — removes the
+# stderr temp file.
 ERR_TMP=$(mktemp)
 if ISSUE_URL=$(gh "${GH_ARGS[@]}" 2>"$ERR_TMP"); then
     # gh issue create emits the URL on stdout. Extract the trailing number.
@@ -253,13 +258,11 @@ if ISSUE_URL=$(gh "${GH_ARGS[@]}" 2>"$ERR_TMP"); then
         # emitted key=value line honors the one-line-per-record contract.
         REDACTED_OUTPUT=$(redact "$ISSUE_URL") || emit_redaction_failure
         REDACTED_OUTPUT_FLAT=$(echo "$REDACTED_OUTPUT" | tr '\n' ' ' | head -c 500)
-        rm -f "$ERR_TMP"
         echo "ISSUE_FAILED=true"
         echo "ISSUE_ERROR=gh issue create did not emit a URL (output: $REDACTED_OUTPUT_FLAT)"
         exit 2
     fi
     ISSUE_NUM=$(echo "$URL_LINE" | grep -oE '[0-9]+$')
-    rm -f "$ERR_TMP"
     echo "ISSUE_NUMBER=$ISSUE_NUM"
     echo "ISSUE_URL=$URL_LINE"
     echo "ISSUE_TITLE=$FINAL_TITLE"
@@ -269,7 +272,6 @@ else
     # (tokens in auth-failure messages, request bodies echoed by the API in
     # 4xx responses) before flattening/echoing.
     ERR_CONTENT=$(cat "$ERR_TMP")
-    rm -f "$ERR_TMP"
     REDACTED_ERR=$(redact "$ERR_CONTENT") || emit_redaction_failure
     ERR_FLAT=$(echo "$REDACTED_ERR" | tr '\n' ' ' | head -c 500)
     echo "ISSUE_FAILED=true"


### PR DESCRIPTION
## Summary
- Fixed `create-one.sh` on the `/issue` success path: `gh` stdout and stderr are now captured separately, so a stray stderr warning cannot corrupt the URL regex.
- Routed the new `ERR_TMP` stderr temp file through the existing `cleanup()` EXIT trap so every exit path — including `emit_redaction_failure` on the no-URL branch — removes it, closing a potential durable-disk exposure for token-bearing error text.
- Added a regression test in `scripts/test-redact-secrets.sh` (section 3d) that stubs `gh` to emit a URL on stdout plus noise on stderr, asserting URL parsing still succeeds and stderr content does not leak into `ISSUE_URL`.

<details><summary>Architecture Diagram</summary>

Quick mode — architecture diagram skipped.

</details>

<details><summary>Code Flow Diagram</summary>

Quick mode — code flow diagram skipped.

</details>

<details><summary>Goal</summary>

- Fix #137: stop merging `gh` stderr into the variable used for URL extraction on the success path of `skills/issue/scripts/create-one.sh`.
  - Capture stdout into `ISSUE_URL` and stderr into a separate temp file (`ERR_TMP`) so the success-branch URL regex only sees stdout.
  - On the failure branch, read stderr content from `ERR_TMP` into the existing `redact` → flatten → `head -c 500` pipeline.
  - Preserve all existing redaction behavior on both branches.
  - Preserve the no-URL defensive fallback.
  - Clean up the temp file on every exit path.
  - Do not change any other logic in the script.

</details>

<details><summary>Test plan</summary>

- [x] `/relevant-checks` (shellcheck + agent-lint) passes after both commits.
- [x] `bash scripts/test-redact-secrets.sh` — all 48 assertions pass (45 pre-existing + 3 new #137 regression assertions in section 3d).
- [x] `make test-redact` (same harness, via Makefile target exercised in CI) covers the new cases.
- [x] Manual inspection of the diff: stdout-only capture on success branch, stderr-only capture on failure branch, `ERR_TMP` registered in the `cleanup()` EXIT trap.

</details>

<details><summary>Final Design</summary>

**File**: `skills/issue/scripts/create-one.sh:238-269`

Replace `ISSUE_URL=$(gh "${GH_ARGS[@]}" 2>&1)` with a form that captures stdout into `ISSUE_URL` and stderr into a dedicated temp file `ERR_TMP`. Route `ERR_TMP` cleanup through the existing `cleanup()` EXIT trap (already used for `BODY_TMP`) so every exit path — including `emit_redaction_failure` — removes the file. On the success branch, parse only stdout; on the failure branch, `cat "$ERR_TMP"` into the existing `redact`/flatten/head pipeline.

Add a regression test in `scripts/test-redact-secrets.sh` Section 3d that stubs `gh` to exit 0 with a URL on stdout and a warning on stderr, asserting `ISSUE_NUMBER=137` is extracted, `ISSUE_URL` is exact-match, and stderr noise does not appear in output.

</details>

<details><summary>Version Bump Reasoning</summary>

PATCH — changes are in `skills/issue/scripts/create-one.sh` (script under a skill directory, not a public-surface SKILL.md edit) and `scripts/test-redact-secrets.sh` (not on the public surface). No SKILL.md `name:`/`argument-hint:` changes, no added/removed SKILL.md or agent. `classify-bump.sh` defaulted to PATCH; no escalation warranted for a pure bug fix.

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

Quick mode — no plan review was conducted.

</details>

<details><summary>Implementation Deviations</summary>

One intentional deviation from the initial inline plan: instead of explicit `rm -f "$ERR_TMP"` calls on each exit path (as proposed in Step 1's plan), round-1 code review surfaced a genuine leak — `emit_redaction_failure` in the no-URL branch would exit before the explicit `rm`. The fix routes `ERR_TMP` cleanup through the existing `cleanup()` EXIT trap (already used for `BODY_TMP`), which is strictly better: every exit path (including `emit_redaction_failure`) clears the file, and the invariant is centralized rather than scattered. The explicit `rm -f` calls were removed as redundant.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

All code review suggestions were implemented.

</details>

<details><summary>Plan Review Voting Tally</summary>

Quick mode — no plan review voting.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

Quick mode — no voting panel. Main agent reviewed findings across up to 7 single-reviewer rounds (Cursor → Codex → Claude fallback chain). Round 1 (Cursor) raised 5 findings; 4 accepted and implemented (centralized `ERR_TMP` trap cleanup + comment update + regression test for #137); finding 5 (security — durable local exposure) was subsumed by the trap fix. Round 2 (Cursor) findings referenced pre-round-1 HEAD state (Cursor diffed `main...HEAD` against the committed state while the round-1 fixes were in the working tree); both findings were already addressed by the working tree, so the loop converged.

</details>

<details><summary>Out-of-Scope Observations</summary>

**Accepted OOS (GitHub issues filed):**
No OOS items were accepted for issue filing.

**Non-accepted OOS observations:**
Quick mode — no reviewer voting panel. Main-agent OOS items (if any) are auto-filed per policy; see Accepted OOS above.

</details>

<details><summary>Execution Issues</summary>

No execution issues encountered.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | N/A (quick mode) |
| Code review rounds | 2 |
| Code review findings | 4 accepted, 0 rejected (finding 5 subsumed by finding 1's fix; round 2 findings stale against working tree) |
| Warnings logged | 0 |
| Pre-existing issues noticed | 0 |
| OOS issues filed | 0 |
| External reviewers | Cursor: ✅, Codex: N/A (quick mode) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
