### PR TITLE
Fix #138: pending-heading disambiguation in parse-input.sh

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "3.4.9",
+  "version": "3.4.10",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.10] - 2026-04-19
+
+### Fixed
+
+- `skills/issue/scripts/parse-input.sh` no longer silently swallows an author-intended new item into an in-progress OOS body. When a plain `### <title>` line appears inside an OOS Description that has not yet seen a closing structured field (Reviewer / Vote tally / Phase), the parser now defers the absorb decision via a pending-heading state (`PENDING_HEADING` / `PENDING_BODY`). Resolution happens at the first disambiguating signal: Reviewer/Vote tally/Phase fires → `resolve_pending_foldback` merges pending content back into `CURRENT_BODY` (preserves the #129 `### Notes` subheading-absorption behavior byte-for-byte); `### OOS_N:` line or EOF arrives → `resolve_pending_split` emits the current OOS as MALFORMED with its non-empty body, then emits the pending heading + body as a new generic item. `emit_item` gains a `force_malformed` parameter so a MALFORMED item can carry a populated BODY. `flush_item` clears pending state alongside the other per-item resets. `skills/issue/SKILL.md` line 75 now describes the expanded MALFORMED trigger per unanimous dialectic vote. `test-parse-input.sh` rewrites case 6 from "documented absorb limitation" to the #138 contract and adds three regression locks: case 13 (multi-subheading OOS accumulation before Reviewer), case 14 (EOF split), case 15 (mid-stream `### OOS_N:` split). 83 → 121 assertions, all pass. Closes #138.
+
 ## [3.4.9] - 2026-04-19
 
 ### Fixed

--- a/skills/issue/SKILL.md
+++ b/skills/issue/SKILL.md
@@ -72,7 +72,7 @@ Invoke the parser:
 ${CLAUDE_PLUGIN_ROOT}/skills/issue/scripts/parse-input.sh --input-file "$INPUT_FILE"
 ```
 
-Parse the output for `ITEMS_TOTAL=<N>` and per-item `ITEM_<i>_TITLE`, `ITEM_<i>_BODY` (base64-encoded), optional `ITEM_<i>_REVIEWER`, `ITEM_<i>_PHASE`, `ITEM_<i>_VOTE_TALLY`, and `ITEM_<i>_MALFORMED=true` for items without a description.
+Parse the output for `ITEMS_TOTAL=<N>` and per-item `ITEM_<i>_TITLE`, `ITEM_<i>_BODY` (base64-encoded), optional `ITEM_<i>_REVIEWER`, `ITEM_<i>_PHASE`, `ITEM_<i>_VOTE_TALLY`, and `ITEM_<i>_MALFORMED=true` for items that cannot be emitted cleanly — either a title without a body, or (issue #138) an incomplete OOS item whose body was terminated by an ambiguous boundary heading with no structured-field close. The latter shape emits `ITEM_<i>_BODY` alongside `ITEM_<i>_MALFORMED=true`, but per the rule below malformed items never reach Phase 1/2 or create — the description survives only in stdout / stderr diagnostics.
 
 Parser regression coverage lives in `${CLAUDE_PLUGIN_ROOT}/skills/issue/scripts/test-parse-input.sh` (self-contained; run manually via `bash ${CLAUDE_PLUGIN_ROOT}/skills/issue/scripts/test-parse-input.sh`, and wired into `make lint` via the `test-parse-input` target so the harness runs in CI on every PR).
 

--- a/skills/issue/scripts/parse-input.sh
+++ b/skills/issue/scripts/parse-input.sh
@@ -32,7 +32,15 @@
 #   ITEM_<i>_REVIEWER=<attribution>              (OOS only)
 #   ITEM_<i>_PHASE=<design|review>               (OOS only)
 #   ITEM_<i>_VOTE_TALLY=<counts>                 (OOS only)
-#   ITEM_<i>_MALFORMED=true                      (title without body — will fail)
+#   ITEM_<i>_MALFORMED=true                      (item cannot be emitted cleanly:
+#                                                 either title-without-body, or
+#                                                 an incomplete OOS item whose
+#                                                 body was terminated by an
+#                                                 ambiguous boundary heading
+#                                                 with no structured-field
+#                                                 close — see issue #138. In
+#                                                 the latter case BODY is also
+#                                                 emitted alongside MALFORMED.)
 #
 # The BODY is base64-encoded (single line, no wrapping) so multi-line content
 # does not collide with the one-key-per-line contract.
@@ -63,18 +71,33 @@ fi
 
 # ---------------------------------------------------------------------------
 # Parser state — mirrors create-oos-issues.sh:185-222's flush_item + while loop.
-# Key invariant: an item is emitted only when it has BOTH a title and a body/
-# description. A title alone → ITEM_<i>_MALFORMED=true (the caller / SKILL
-# treats this as an early-failed item that contributes to ISSUES_FAILED).
+# Key invariant: a normally-emitted item has BOTH a title and a body. A title
+# alone → ITEM_<i>_MALFORMED=true. An incomplete OOS item (see issue #138
+# below) is flushed as MALFORMED with its non-empty body via emit_item's
+# `force_malformed` parameter. Both cases feed ISSUES_FAILED in the caller.
 #
 # CURRENT_MODE tracks whether the in-progress item is OOS-shaped or generic-
 # shaped. Structured OOS field branches (`- **Description**:`, `- **Reviewer**:`,
 # `- **Vote tally**:`, `- **Phase**:`) fire only when CURRENT_MODE=oos; in
-# generic items those lines are plain body text. A `### <title>` line inside
-# an OOS item's description body (CURRENT_MODE=oos AND IN_BODY=true) is
-# absorbed as body continuation rather than starting a new item, so OOS
-# descriptions may contain markdown subheadings. `flush_item` resets
+# generic items those lines are plain body text. `flush_item` resets
 # CURRENT_MODE alongside the other per-item state.
+#
+# Pending-heading state (issue #138): PENDING_HEADING + PENDING_BODY defer
+# the absorb-vs-split decision for a plain `### <title>` line that appears
+# inside an OOS Description before any of Reviewer / Vote tally / Phase has
+# fired. The line could be either a body subheading (#129 case 1) or the
+# intended start of a new item (the #138 bug). Which one is resolved by
+# what comes next:
+#   * Any of Reviewer / Vote tally / Phase fires → fold PENDING_HEADING +
+#     PENDING_BODY back into CURRENT_BODY (rule 1 — subheading case).
+#   * A `### OOS_N:` line or EOF arrives → emit current OOS as MALFORMED
+#     with its existing body, then emit the pending pair as a new generic
+#     item (rule 2 — new-item case).
+#   * Another plain `### <title>` line arrives while pending-active → append
+#     to PENDING_BODY; do NOT trigger rule 2. Only `### OOS_N:` or EOF splits
+#     (required so case 13's multi-subheading OOS still absorbs correctly).
+# PENDING_HEADING is non-empty iff the pending state is active; PENDING_BODY
+# accumulates continuation lines while pending-active.
 # ---------------------------------------------------------------------------
 ITEM_INDEX=0
 CURRENT_TITLE=""
@@ -84,6 +107,8 @@ CURRENT_VOTE=""
 CURRENT_PHASE=""
 IN_BODY=false
 CURRENT_MODE=""
+PENDING_HEADING=""
+PENDING_BODY=""
 
 b64() {
     # Portable single-line base64 (no wrapping). macOS `base64` wraps at 76 chars
@@ -101,6 +126,10 @@ emit_item() {
     local reviewer="$3"
     local vote="$4"
     local phase="$5"
+    # force_malformed (6th arg): when "true", emit BODY + MALFORMED=true
+    # together (the issue #138 incomplete-OOS path). Empty / falsy keeps the
+    # legacy behavior: MALFORMED only when body is empty.
+    local force_malformed="${6:-}"
 
     ITEM_INDEX=$((ITEM_INDEX + 1))
 
@@ -123,6 +152,15 @@ emit_item() {
 
     echo "ITEM_${ITEM_INDEX}_TITLE=$title"
     echo "ITEM_${ITEM_INDEX}_BODY=$b64_body"
+    if [[ "$force_malformed" == "true" ]]; then
+        # Issue #138: incomplete OOS flushed mid-stream. Body is non-empty
+        # (has the Description text), but the item is structurally malformed
+        # because Reviewer / Vote tally / Phase never fired before the
+        # ambiguous boundary heading arrived. The caller downstream counts it
+        # under ISSUES_FAILED and does not create a GitHub issue for it — the
+        # description survives only in stdout / stderr diagnostics.
+        echo "ITEM_${ITEM_INDEX}_MALFORMED=true"
+    fi
     if [[ -n "$reviewer" ]]; then
         echo "ITEM_${ITEM_INDEX}_REVIEWER=$reviewer"
     fi
@@ -131,6 +169,79 @@ emit_item() {
     fi
     if [[ -n "$phase" ]]; then
         echo "ITEM_${ITEM_INDEX}_PHASE=$phase"
+    fi
+}
+
+# resolve_pending_foldback — rule 1 resolution (issue #138).
+#
+# Called as the FIRST action of each structured-field branch (Description,
+# Reviewer, Vote tally, Phase) before any BASH_REMATCH usage or state
+# mutation. No-ops when PENDING_HEADING is empty. When pending-active, merges
+# PENDING_HEADING + PENDING_BODY back into CURRENT_BODY (preserving the #129
+# subheading-in-OOS-description behavior), then clears the pending state.
+#
+# Uses the conditional-append pattern so an empty CURRENT_BODY (the #131
+# case 9 shape: empty inline Description) does not acquire a spurious
+# leading newline.
+resolve_pending_foldback() {
+    if [[ -z "$PENDING_HEADING" ]]; then
+        return
+    fi
+    if [[ -n "$CURRENT_BODY" ]]; then
+        CURRENT_BODY+=$'\n'"$PENDING_HEADING"
+    else
+        CURRENT_BODY="$PENDING_HEADING"
+    fi
+    if [[ -n "$PENDING_BODY" ]]; then
+        CURRENT_BODY+=$'\n'"$PENDING_BODY"
+    fi
+    PENDING_HEADING=""
+    PENDING_BODY=""
+}
+
+# resolve_pending_split — rule 2 resolution (issue #138).
+#
+# Called as the FIRST action of the `### OOS_N:` heading branch (as a
+# preamble to the existing #132 mode-guard) and from the terminal flush_item
+# at EOF. No-ops when PENDING_HEADING is empty. When pending-active: emits
+# the current OOS as MALFORMED (preserving its non-empty body), then emits
+# the pending pair as a new generic item with no OOS metadata. After this
+# call, the caller's remaining per-item state (CURRENT_TITLE, CURRENT_BODY,
+# etc.) is reset — safe to start a new item inline.
+resolve_pending_split() {
+    if [[ -z "$PENDING_HEADING" ]]; then
+        return
+    fi
+    # Capture pending state before flush_item clears it.
+    local pending_title_line="$PENDING_HEADING"
+    local pending_body="$PENDING_BODY"
+
+    # Save current item's state, clear pending so flush_item does not re-enter
+    # any pending-aware path, then emit current as MALFORMED.
+    PENDING_HEADING=""
+    PENDING_BODY=""
+    if [[ -n "$CURRENT_TITLE" ]]; then
+        emit_item "$CURRENT_TITLE" "$CURRENT_BODY" "$CURRENT_REVIEWER" \
+            "$CURRENT_VOTE" "$CURRENT_PHASE" "true"
+    fi
+    # Reset per-item state (same fields flush_item clears).
+    CURRENT_TITLE=""
+    CURRENT_BODY=""
+    CURRENT_REVIEWER=""
+    CURRENT_VOTE=""
+    CURRENT_PHASE=""
+    IN_BODY=false
+    CURRENT_MODE=""
+
+    # Extract the pending heading's title from the raw stashed line. Re-match
+    # the raw line against the plain-heading regex to get the title.
+    local pending_title=""
+    if [[ "$pending_title_line" =~ ^\#\#\#[[:space:]]+(.+)$ ]]; then
+        pending_title="${BASH_REMATCH[1]}"
+    fi
+    # Emit pending pair as a generic item (no OOS fields).
+    if [[ -n "$pending_title" ]]; then
+        emit_item "$pending_title" "$pending_body" "" "" "" ""
     fi
 }
 
@@ -145,76 +256,135 @@ flush_item() {
     CURRENT_PHASE=""
     IN_BODY=false
     CURRENT_MODE=""
+    # Issue #138: clear pending state alongside per-item resets so pending
+    # content cannot leak across items. resolve_pending_split (called by the
+    # OOS heading preamble and the terminal EOF path) must run BEFORE
+    # flush_item in those call sites, since flush_item silently drops any
+    # pending state.
+    PENDING_HEADING=""
+    PENDING_BODY=""
 }
 
 # Parse line-by-line. Support both OOS (`### OOS_N: title`) and generic
 # (`### <title>` followed by body text) formats, distinguished by CURRENT_MODE.
-# Both `### ` branches apply a symmetric mode-guard: a heading that falls
-# inside another item's active body is absorbed as body continuation rather
-# than flushing the current item.
+# Three guards coexist, each scoped to a different branch / trigger:
 #
-#   * An `### OOS_N: title` line sets CURRENT_MODE=oos; the four structured
-#     bullets (Description / Reviewer / Vote tally / Phase) are parsed as
-#     metadata only while CURRENT_MODE=oos. In generic items those same
-#     bullets are preserved verbatim as body text. UNLESS we are inside a
-#     generic body (CURRENT_MODE=generic AND IN_BODY=true), in which case the
-#     line is absorbed as body continuation (fix for issue #132 — a generic
-#     item's body may contain the literal string `### OOS_N: ...` as prose).
-#   * A plain `### <title>` line sets CURRENT_MODE=generic — UNLESS we are
-#     inside an OOS description (CURRENT_MODE=oos AND IN_BODY=true), in which
-#     case the line is absorbed as body continuation (so OOS descriptions may
-#     contain subheadings like `### Notes`; fix for bug a in issue #129).
-#   * Well-formed OOS items close their body when a Reviewer / Vote tally /
-#     Phase field fires (all set IN_BODY=false), so a following `### <title>`
-#     correctly starts a new item. An incomplete OOS item that has only a
-#     Description (no trailing structured fields) leaves IN_BODY=true, so a
-#     following `### <title>` is absorbed as continuation — by design. Feed
-#     well-formed OOS inputs (all 4 fields) to terminate the body explicitly.
-#   * flush_item resets CURRENT_MODE so per-item mode does not leak across
-#     items.
+#   * Issue #129: a plain `### <subheading>` line inside an OOS Description
+#     (CURRENT_MODE=oos AND IN_BODY=true) must not flush the OOS — it is a
+#     body subheading (e.g., `### Notes`). Handled by the pending-heading
+#     state below: the line enters PENDING_HEADING on first sight and is
+#     folded back into CURRENT_BODY when the next structured field fires.
+#
+#   * Issue #132: a `### OOS_N: ...` line inside an active generic body
+#     (CURRENT_MODE=generic AND IN_BODY=true with meaningful CURRENT_BODY) is
+#     absorbed as body continuation rather than flushing. Symmetric mode-
+#     guard on the OOS-heading branch, unchanged from PR #140.
+#
+#   * Issue #138: a plain `### <title>` line inside an OOS Description is
+#     ambiguous — it could be a body subheading (#129) or the author's
+#     intended start of a new generic item after an incomplete OOS. The
+#     pending-heading state defers the decision: PENDING_HEADING stashes the
+#     line, PENDING_BODY accumulates subsequent continuation lines (and
+#     additional plain `### <subheading>` lines, so case 13 multi-subheading
+#     still works). Resolution:
+#       - Reviewer / Vote tally / Phase fires (any of these) →
+#         resolve_pending_foldback absorbs pending content into CURRENT_BODY
+#         (rule 1, preserves #129).
+#       - `### OOS_N:` line arrives OR EOF is reached → resolve_pending_split
+#         emits the current OOS as MALFORMED with its body, then emits
+#         PENDING_HEADING + PENDING_BODY as a new generic item (rule 2).
+#       - Another plain `### <title>` arrives while pending-active → append
+#         to PENDING_BODY (does NOT trigger rule 2 — only `### OOS_N:` or
+#         EOF splits).
+#
+# Well-formed OOS items (all 4 fields) close via Phase → IN_BODY=false →
+# a subsequent `### <title>` correctly starts a new item without entering
+# pending state. flush_item resets CURRENT_MODE and pending state alongside
+# the other per-item state. resolve_pending_split runs BEFORE flush_item in
+# split-path call sites since flush_item silently clears pending.
+#
+#   ┌─────────────────────────────┬──────────────────┬───────────────────┐
+#   │ Trigger line                │ Pending-active?  │ Action            │
+#   ├─────────────────────────────┼──────────────────┼───────────────────┤
+#   │ `### OOS_N:` (plain)        │ no               │ flush + new OOS   │
+#   │ `### OOS_N:` (gen body)     │ no               │ absorb (#132)     │
+#   │ `### OOS_N:` (plain)        │ yes              │ split + new OOS   │
+#   │ plain `### <title>` (new)   │ no, mode=oos,    │ start pending     │
+#   │                             │   IN_BODY=true   │                   │
+#   │ plain `### <title>` (new)   │ no, mode!=oos or │ flush + new gen   │
+#   │                             │   IN_BODY=false  │                   │
+#   │ plain `### <title>` (new)   │ yes              │ append to pending │
+#   │ Description / Reviewer /    │ yes              │ fold-back then    │
+#   │   Vote tally / Phase        │                  │   process field   │
+#   │ Description / Reviewer /    │ no               │ process field     │
+#   │   Vote tally / Phase        │                  │                   │
+#   │ continuation (IN_BODY=true) │ yes              │ append to pending │
+#   │ continuation (IN_BODY=true) │ no               │ append to body    │
+#   │ EOF                         │ yes              │ split             │
+#   │ EOF                         │ no               │ flush             │
+#   └─────────────────────────────┴──────────────────┴───────────────────┘
 while IFS= read -r line || [[ -n "$line" ]]; do
     if [[ "$line" =~ ^\#\#\#[[:space:]]+OOS_[0-9]+:[[:space:]]+(.+)$ ]]; then
         # OOS-format heading — or a literal `### OOS_N: ...` line inside a
-        # generic item's body. Inside an active generic body with at least one
-        # meaningful (non-whitespace) body line already accumulated, absorb as
-        # body continuation rather than flushing (fix for issue #132).
-        # Symmetric to the mode-guard on the plain `### <title>` branch below.
-        # The meaningful-body check (`${CURRENT_BODY//[[:space:]]/}` — strip
-        # all whitespace, test non-empty) aligns semantics with the
-        # OOS→generic direction (where IN_BODY=true is set by
-        # `**Description**:`, which also populates CURRENT_BODY with non-
-        # whitespace content): do not absorb when the generic heading had
-        # only blank or whitespace-only lines yet — that malformed case
-        # flushes and lets the OOS line start a new OOS item, matching
-        # pre-#132 behavior for those degenerate inputs. Avoid `=~` here
-        # because it would clobber the outer OOS-heading regex's
-        # BASH_REMATCH[1] capture before the `else` branch reads it.
+        # generic item's body (issue #132 case), or the resolution point for
+        # an active pending-heading state (issue #138 rule 2).
+        #
+        # Priority order:
+        #   1. #132 guard: inside an active generic body with meaningful
+        #      content, absorb as continuation (unchanged from PR #140).
+        #   2. #138 pending-split: if pending is active, emit current OOS as
+        #      MALFORMED + pending pair as generic, then process the OOS_N:
+        #      line as a fresh OOS heading.
+        #   3. Default: flush current item + start a new OOS item.
+        #
+        # The #132 guard clause must run first because a generic body with a
+        # nested `### OOS_42:` is the exact case case 10 locks in, and the
+        # pending-heading state is gated on CURRENT_MODE=oos (so the two
+        # paths are disjoint by mode — but explicit ordering is safer).
+        #
+        # Save BASH_REMATCH[1] into a local before calling
+        # resolve_pending_split (which re-runs `=~` internally and would
+        # otherwise clobber the capture).
         if [[ "$CURRENT_MODE" == "generic" && "$IN_BODY" == true && -n "${CURRENT_BODY//[[:space:]]/}" ]]; then
-            # CURRENT_BODY has at least one non-whitespace character (outer
-            # guard), hence is non-empty — the empty-body branch used by
-            # other append sites is unreachable here.
             CURRENT_BODY+=$'\n'"$line"
         else
-            # OOS body comes from the `**Description**:` field that follows,
-            # not from continuation lines under the heading.
+            new_oos_title="${BASH_REMATCH[1]}"
+            # Rule 2 preamble (issue #138): if pending-active, split before
+            # starting the new OOS item. No-ops when pending is empty.
+            resolve_pending_split
             flush_item
-            CURRENT_TITLE="${BASH_REMATCH[1]}"
+            CURRENT_TITLE="$new_oos_title"
             IN_BODY=false
             CURRENT_MODE="oos"
         fi
     elif [[ "$line" =~ ^\#\#\#[[:space:]]+(.+)$ ]]; then
-        # Generic heading — or a markdown subheading inside an OOS description.
-        # Inside an active OOS body, absorb as body continuation rather than
-        # flushing (fix for bug a in issue #129).
+        # Plain `### <title>` heading. Three paths depending on mode and
+        # pending state:
+        #
+        #   1. CURRENT_MODE=oos AND IN_BODY=true AND pending empty → this is
+        #      the #138 ambiguous case: stash the raw line in PENDING_HEADING
+        #      and keep accumulating via the continuation branch.
+        #   2. CURRENT_MODE=oos AND IN_BODY=true AND pending already active →
+        #      another plain `### <subheading>` arriving while pending-active.
+        #      Per case 13, append to PENDING_BODY (do NOT trigger rule 2).
+        #   3. Otherwise → flush current item and start a new generic item.
         if [[ "$CURRENT_MODE" == "oos" && "$IN_BODY" == true ]]; then
-            if [[ -n "$CURRENT_BODY" ]]; then
-                CURRENT_BODY+=$'\n'"$line"
+            if [[ -z "$PENDING_HEADING" ]]; then
+                # Path 1: first ambiguous heading — start pending state.
+                PENDING_HEADING="$line"
             else
-                CURRENT_BODY="$line"
+                # Path 2: additional heading while pending-active — accumulate.
+                if [[ -n "$PENDING_BODY" ]]; then
+                    PENDING_BODY+=$'\n'"$line"
+                else
+                    PENDING_BODY="$line"
+                fi
             fi
         else
+            # Path 3: normal flush + new generic item.
+            new_title="${BASH_REMATCH[1]}"
             flush_item
-            CURRENT_TITLE="${BASH_REMATCH[1]}"
+            CURRENT_TITLE="$new_title"
             IN_BODY=true
             CURRENT_MODE="generic"
         fi
@@ -223,16 +393,31 @@ while IFS= read -r line || [[ -n "$line" ]]; do
         # lines (e.g. `- **Description**:` alone on its line with `  content` on
         # the next line). IN_BODY=true ensures those continuations are captured
         # by the fallback branch below.
-        CURRENT_BODY="${BASH_REMATCH[1]}"
+        #
+        # Description should not fire while pending-active (no `- **Description**:`
+        # can follow an in-progress OOS item before Reviewer/Vote/Phase closes
+        # it), but resolve_pending_foldback is idempotent — safe to call.
+        # Capture BASH_REMATCH[1] first since resolve_pending_foldback does
+        # not run `=~` itself but the pattern of saving captures before any
+        # helper keeps future edits safe.
+        description_inline="${BASH_REMATCH[1]}"
+        resolve_pending_foldback
+        CURRENT_BODY="$description_inline"
         IN_BODY=true
     elif [[ "$CURRENT_MODE" == "oos" && "$line" =~ ^-[[:space:]]+\*\*Reviewer\*\*:[[:space:]]+(.+)$ ]]; then
-        CURRENT_REVIEWER="${BASH_REMATCH[1]}"
+        reviewer_value="${BASH_REMATCH[1]}"
+        resolve_pending_foldback
+        CURRENT_REVIEWER="$reviewer_value"
         IN_BODY=false
     elif [[ "$CURRENT_MODE" == "oos" && "$line" =~ ^-[[:space:]]+\*\*Vote\ tally\*\*:[[:space:]]+(.+)$ ]]; then
-        CURRENT_VOTE="${BASH_REMATCH[1]}"
+        vote_value="${BASH_REMATCH[1]}"
+        resolve_pending_foldback
+        CURRENT_VOTE="$vote_value"
         IN_BODY=false
     elif [[ "$CURRENT_MODE" == "oos" && "$line" =~ ^-[[:space:]]+\*\*Phase\*\*:[[:space:]]+(.+)$ ]]; then
-        CURRENT_PHASE="${BASH_REMATCH[1]}"
+        phase_value="${BASH_REMATCH[1]}"
+        resolve_pending_foldback
+        CURRENT_PHASE="$phase_value"
         IN_BODY=false
     elif [[ "$IN_BODY" == true ]]; then
         # Continuation line. Preserve blank lines in BOTH modes — multi-paragraph
@@ -243,14 +428,29 @@ while IFS= read -r line || [[ -n "$line" ]]; do
         # here and are preserved as ordinary body text (fix for bug b in #129).
         # This matches the behavior fix applied to the deleted
         # scripts/create-oos-issues.sh (see CHANGELOG 3.3.10).
-        if [[ -n "$CURRENT_BODY" ]]; then
-            CURRENT_BODY+=$'\n'"$line"
+        #
+        # Issue #138: while pending-active, route continuation lines to
+        # PENDING_BODY so they resolve together with the stashed heading.
+        if [[ -n "$PENDING_HEADING" ]]; then
+            if [[ -n "$PENDING_BODY" ]]; then
+                PENDING_BODY+=$'\n'"$line"
+            else
+                PENDING_BODY="$line"
+            fi
         else
-            CURRENT_BODY="$line"
+            if [[ -n "$CURRENT_BODY" ]]; then
+                CURRENT_BODY+=$'\n'"$line"
+            else
+                CURRENT_BODY="$line"
+            fi
         fi
     fi
 done < "$INPUT_FILE"
 
+# EOF rule-2 resolution (issue #138): if a pending-heading state is still
+# active, split the current OOS (MALFORMED) and emit the pending pair as a
+# generic item before the terminal flush_item runs.
+resolve_pending_split
 flush_item
 
 echo "ITEMS_TOTAL=$ITEM_INDEX"

--- a/skills/issue/scripts/test-parse-input.sh
+++ b/skills/issue/scripts/test-parse-input.sh
@@ -193,13 +193,16 @@ assert_eq "case 5 item 2 body" "Generic body text." "$(get_body 2 "$out5")"
 assert_absent "case 5 item 2 has no reviewer" "ITEM_2_REVIEWER" "$out5"
 
 # ---------------------------------------------------------------------------
-# Test case 6 — Documented absorb behavior: incomplete OOS (Description only,
-# no trailing structured fields) followed by a `### ` line. Per design, the
-# trailing `### ` is absorbed as body continuation because IN_BODY=true and
-# CURRENT_MODE=oos. This is a known limitation of the incomplete-OOS shape
-# and is documented in the parser header.
+# Test case 6 — Issue #138: incomplete OOS (Description only, no trailing
+# structured fields) followed by a `### <title>` line and a generic body at
+# EOF. The pending-heading state defers the absorb decision; when EOF arrives
+# without any structured field (Reviewer / Vote tally / Phase) closing the
+# OOS, the current OOS is flushed as MALFORMED (with its non-empty body) and
+# the pending heading + pending body are emitted as a new generic item. This
+# preserves the author's intended second item instead of silently swallowing
+# it into the OOS body (the pre-#138 behavior).
 # ---------------------------------------------------------------------------
-echo "Case 6: incomplete OOS absorbs following ### line (documented behavior)"
+echo "Case 6: incomplete OOS splits cleanly at EOF (issue #138 fix)"
 cat > "$TMPDIR_TEST/case6.md" <<'EOF'
 ### OOS_1: Incomplete OOS
 - **Description**: Short description with no trailing fields.
@@ -207,10 +210,16 @@ cat > "$TMPDIR_TEST/case6.md" <<'EOF'
 Would-be body.
 EOF
 out6=$(run_parser "$TMPDIR_TEST/case6.md")
-assert_eq "case 6 items total" "ITEMS_TOTAL=1" "$(grep '^ITEMS_TOTAL=' <<< "$out6")"
-assert_eq "case 6 title" "Incomplete OOS" "$(get_value ITEM_1_TITLE "$out6")"
-expected6=$'Short description with no trailing fields.\n### Would-be generic item\nWould-be body.'
-assert_eq "case 6 body absorbs the would-be-generic heading + body" "$expected6" "$(get_body 1 "$out6")"
+assert_eq "case 6 items total" "ITEMS_TOTAL=2" "$(grep '^ITEMS_TOTAL=' <<< "$out6")"
+assert_eq "case 6 item 1 title" "Incomplete OOS" "$(get_value ITEM_1_TITLE "$out6")"
+assert_eq "case 6 item 1 malformed" "true" "$(get_value ITEM_1_MALFORMED "$out6")"
+assert_eq "case 6 item 1 body preserves description" "Short description with no trailing fields." "$(get_body 1 "$out6")"
+assert_eq "case 6 item 2 title" "Would-be generic item" "$(get_value ITEM_2_TITLE "$out6")"
+assert_eq "case 6 item 2 body" "Would-be body." "$(get_body 2 "$out6")"
+assert_absent "case 6 item 2 has no reviewer" "ITEM_2_REVIEWER" "$out6"
+assert_absent "case 6 item 2 has no vote tally" "ITEM_2_VOTE_TALLY" "$out6"
+assert_absent "case 6 item 2 has no phase" "ITEM_2_PHASE" "$out6"
+assert_absent "case 6 item 2 not malformed" "ITEM_2_MALFORMED" "$out6"
 
 # ---------------------------------------------------------------------------
 # Test case 7 — Back-to-back generic items. Tests that flush_item correctly
@@ -375,6 +384,105 @@ assert_eq "case 12 item 2 body" "Real OOS description." "$(get_body 2 "$out12")"
 assert_eq "case 12 item 2 reviewer" "Cursor" "$(get_value ITEM_2_REVIEWER "$out12")"
 assert_eq "case 12 item 2 vote tally" "YES=2" "$(get_value ITEM_2_VOTE_TALLY "$out12")"
 assert_eq "case 12 item 2 phase" "design" "$(get_value ITEM_2_PHASE "$out12")"
+
+# ---------------------------------------------------------------------------
+# Test case 13 — Issue #138 regression lock + multi-subheading support:
+# OOS with two sequential `### <subheading>` lines inside its Description,
+# then a full structured-field close. Under the pending-heading scheme, the
+# first `### Subheading 1` starts pending state; `Para 2.` accumulates into
+# PENDING_BODY; `### Subheading 2` arrives while pending-active → it appends
+# to PENDING_BODY (does NOT trigger rule-2 resolution — only `### OOS_N:` or
+# EOF trigger that). `Para 3.` accumulates too. When `- **Reviewer**:` fires,
+# rule-1 fold-back merges PENDING_HEADING + PENDING_BODY back into
+# CURRENT_BODY before the field assignment. Locks in both (a) the #129
+# subheading-absorption fix and (b) multi-subheading accumulation.
+# ---------------------------------------------------------------------------
+echo "Case 13: OOS with multiple subheadings before structured close (issue #138)"
+cat > "$TMPDIR_TEST/case13.md" <<'EOF'
+### OOS_1: Example with multiple subheadings
+- **Description**: Para 1.
+### Subheading 1
+Para 2.
+### Subheading 2
+Para 3.
+- **Reviewer**: Codex
+- **Vote tally**: YES=3, NO=0
+- **Phase**: review
+EOF
+out13=$(run_parser "$TMPDIR_TEST/case13.md")
+assert_eq "case 13 items total" "ITEMS_TOTAL=1" "$(grep '^ITEMS_TOTAL=' <<< "$out13")"
+assert_eq "case 13 title" "Example with multiple subheadings" "$(get_value ITEM_1_TITLE "$out13")"
+expected13=$'Para 1.\n### Subheading 1\nPara 2.\n### Subheading 2\nPara 3.'
+assert_eq "case 13 body absorbs both subheadings and all paragraphs" "$expected13" "$(get_body 1 "$out13")"
+assert_eq "case 13 reviewer" "Codex" "$(get_value ITEM_1_REVIEWER "$out13")"
+assert_eq "case 13 vote tally" "YES=3, NO=0" "$(get_value ITEM_1_VOTE_TALLY "$out13")"
+assert_eq "case 13 phase" "review" "$(get_value ITEM_1_PHASE "$out13")"
+assert_absent "case 13 not malformed" "ITEM_1_MALFORMED" "$out13"
+
+# ---------------------------------------------------------------------------
+# Test case 14 — Issue #138 EOF resolution: incomplete OOS + ambiguous heading
+# + body at EOF with no trailing structured field. Similar to case 6 but
+# checks the EOF resolution path in isolation (no following OOS_N: to force
+# resolution; only EOF). The pending-heading and pending-body both populate;
+# EOF in flush_item emits current OOS as MALFORMED (with its non-empty body)
+# then emits pending pair as a new generic item.
+# ---------------------------------------------------------------------------
+echo "Case 14: incomplete OOS at EOF with pending body (issue #138 EOF path)"
+cat > "$TMPDIR_TEST/case14.md" <<'EOF'
+### OOS_1: Incomplete OOS at EOF
+- **Description**: Only a description.
+### Notes with no closing fields
+Some body text.
+EOF
+out14=$(run_parser "$TMPDIR_TEST/case14.md")
+assert_eq "case 14 items total" "ITEMS_TOTAL=2" "$(grep '^ITEMS_TOTAL=' <<< "$out14")"
+assert_eq "case 14 item 1 title" "Incomplete OOS at EOF" "$(get_value ITEM_1_TITLE "$out14")"
+assert_eq "case 14 item 1 malformed" "true" "$(get_value ITEM_1_MALFORMED "$out14")"
+assert_eq "case 14 item 1 body" "Only a description." "$(get_body 1 "$out14")"
+assert_eq "case 14 item 2 title" "Notes with no closing fields" "$(get_value ITEM_2_TITLE "$out14")"
+assert_eq "case 14 item 2 body" "Some body text." "$(get_body 2 "$out14")"
+assert_absent "case 14 item 2 has no reviewer" "ITEM_2_REVIEWER" "$out14"
+assert_absent "case 14 item 2 has no vote tally" "ITEM_2_VOTE_TALLY" "$out14"
+assert_absent "case 14 item 2 has no phase" "ITEM_2_PHASE" "$out14"
+assert_absent "case 14 item 2 not malformed" "ITEM_2_MALFORMED" "$out14"
+
+# ---------------------------------------------------------------------------
+# Test case 15 — Issue #138 mid-stream OOS_N resolution: incomplete OOS +
+# ambiguous heading + pending body + a new `### OOS_N:` heading + its full
+# structured-field tail. The `### OOS_2:` line arrives while pending-active
+# → rule-2 split fires in the OOS heading branch preamble: flush current
+# OOS_1 as MALFORMED, emit pending pair as generic, then process
+# `### OOS_2:` normally as a new OOS item. Result: three items total —
+# OOS_1 (MALFORMED), a generic item from the pending pair, and a well-formed
+# OOS_2.
+# ---------------------------------------------------------------------------
+echo "Case 15: incomplete OOS + pending generic + next OOS_N (issue #138 mid-stream)"
+cat > "$TMPDIR_TEST/case15.md" <<'EOF'
+### OOS_1: Incomplete first OOS
+- **Description**: Only a description.
+### Notes pending
+Some pending body.
+### OOS_2: Well-formed second OOS
+- **Description**: Second body.
+- **Reviewer**: Cursor
+- **Vote tally**: YES=2
+- **Phase**: design
+EOF
+out15=$(run_parser "$TMPDIR_TEST/case15.md")
+assert_eq "case 15 items total" "ITEMS_TOTAL=3" "$(grep '^ITEMS_TOTAL=' <<< "$out15")"
+assert_eq "case 15 item 1 title" "Incomplete first OOS" "$(get_value ITEM_1_TITLE "$out15")"
+assert_eq "case 15 item 1 malformed" "true" "$(get_value ITEM_1_MALFORMED "$out15")"
+assert_eq "case 15 item 1 body" "Only a description." "$(get_body 1 "$out15")"
+assert_eq "case 15 item 2 title" "Notes pending" "$(get_value ITEM_2_TITLE "$out15")"
+assert_eq "case 15 item 2 body" "Some pending body." "$(get_body 2 "$out15")"
+assert_absent "case 15 item 2 has no reviewer" "ITEM_2_REVIEWER" "$out15"
+assert_absent "case 15 item 2 not malformed" "ITEM_2_MALFORMED" "$out15"
+assert_eq "case 15 item 3 title" "Well-formed second OOS" "$(get_value ITEM_3_TITLE "$out15")"
+assert_eq "case 15 item 3 body" "Second body." "$(get_body 3 "$out15")"
+assert_eq "case 15 item 3 reviewer" "Cursor" "$(get_value ITEM_3_REVIEWER "$out15")"
+assert_eq "case 15 item 3 vote tally" "YES=2" "$(get_value ITEM_3_VOTE_TALLY "$out15")"
+assert_eq "case 15 item 3 phase" "design" "$(get_value ITEM_3_PHASE "$out15")"
+assert_absent "case 15 item 3 not malformed" "ITEM_3_MALFORMED" "$out15"
 
 # ---------------------------------------------------------------------------
 echo ""


### PR DESCRIPTION
## Summary

- Fixed issue #138: `skills/issue/scripts/parse-input.sh` no longer silently swallows an author-intended new item into an in-progress OOS body. A plain `### <title>` line inside an OOS Description is now stashed in a pending-heading state and resolved at the first disambiguating signal — structured field (Reviewer / Vote tally / Phase) folds back (preserves #129 case 1), `### OOS_N:` or EOF splits (emits the incomplete OOS as MALFORMED with body, starts the pending pair as a new generic item).
- Extended `emit_item` with a `force_malformed` parameter so MALFORMED items can carry a populated BODY; added `resolve_pending_foldback` and `resolve_pending_split` helpers; updated `flush_item` to clear pending state.
- Updated `skills/issue/SKILL.md` line 75 to document the expanded MALFORMED trigger (per unanimous 3-0 dialectic vote). Rewrote `test-parse-input.sh` case 6 from the old "documented limitation" contract to the new #138 contract; added three regression locks: case 13 (multi-subheading OOS accumulation), case 14 (EOF split), case 15 (mid-stream `### OOS_N:` split). 83 → 121 assertions, all pass.

<details><summary>Architecture Diagram</summary>

```mermaid
flowchart TD
    Input[Input line] --> Check{Heading type?}

    Check -->|^### OOS_N:| OOSBr[OOS Heading Branch<br/>lines 176-204]
    Check -->|^### title| GenBr[Generic Heading Branch<br/>lines 205-220]
    Check -->|- **Field**:| StructBr[Structured Field Branches<br/>Description/Reviewer/Vote/Phase<br/>lines 221-236]
    Check -->|other| ContBr[Continuation Branch<br/>lines 237-251]

    OOSBr --> ResolveSplit1[resolve_pending_split<br/>NEW preamble]
    GenBr --> ResolveSplit2[resolve_pending_split<br/>if pending already active]
    StructBr --> ResolveFold[resolve_pending_foldback<br/>NEW as first action]
    ContBr --> RouteBody{PENDING_HEADING<br/>non-empty?}

    RouteBody -->|yes| PendingAppend[Append to PENDING_BODY]
    RouteBody -->|no| CurrentAppend[Append to CURRENT_BODY]

    OOSBr -->|after preamble| OOSFlow[Existing #132 mode-guard<br/>flush_item + start new OOS item]
    GenBr -->|after preamble,<br/>if new-pending| StartPending[PENDING_HEADING = line<br/>stay in OOS mode]
    GenBr -->|else| StartGeneric[flush_item<br/>start new generic item]
    StructBr -->|after fold| ExistingStructLogic[Existing field assignment<br/>CURRENT_REVIEWER/VOTE/PHASE]

    State[Parser State] -.-> CURRENT[CURRENT_TITLE<br/>CURRENT_BODY<br/>CURRENT_MODE<br/>IN_BODY]
    State -.-> PENDING[PENDING_HEADING<br/>PENDING_BODY<br/>NEW]

    ResolveFold -.-> PENDING
    ResolveSplit1 -.-> PENDING
    ResolveSplit2 -.-> PENDING
    ResolveFold -.-> CURRENT
    ResolveSplit1 -.-> EmitItem[emit_item with<br/>force_malformed=true<br/>NEW param]
    ResolveSplit2 -.-> EmitItem
    FlushEOF[flush_item at EOF<br/>line 254] --> PendingEOF{PENDING<br/>active?}
    PendingEOF -->|yes| EmitItem
    PendingEOF -->|yes| EmitPending[emit_item<br/>pending pair as generic]
    PendingEOF -->|no| NormalEmit[Normal emit_item]

    classDef new fill:#e1f5fe,stroke:#01579b,stroke-width:2px
    class PENDING,ResolveFold,ResolveSplit1,ResolveSplit2,EmitItem,EmitPending,RouteBody,PendingAppend,PendingEOF,StartPending new
```

</details>

<details><summary>Code Flow Diagram</summary>

```mermaid
sequenceDiagram
    participant Loop as while-read loop
    participant GenBr as Generic ### branch
    participant OOSBr as OOS ### OOS_N: branch
    participant FieldBr as Structured field branches<br/>(Description/Reviewer/Vote/Phase)
    participant ContBr as Continuation branch
    participant Pending as PENDING_HEADING<br/>PENDING_BODY
    participant Fold as resolve_pending_foldback
    participant Split as resolve_pending_split
    participant Emit as emit_item
    participant Flush as flush_item

    Note over Loop: Input: OOS_1 incomplete,<br/>### subheading, body,<br/>then {EOF | ### OOS_2:}

    Loop->>OOSBr: ### OOS_1: title
    OOSBr->>Flush: flush prior item
    Note over OOSBr: CURRENT_MODE=oos<br/>IN_BODY=false

    Loop->>FieldBr: - **Description**: Desc
    FieldBr->>Fold: fold (no-op, pending empty)
    Note over FieldBr: CURRENT_BODY="Desc"<br/>IN_BODY=true

    Loop->>GenBr: ### Subheading (1st)
    Note over GenBr: CURRENT_MODE=oos,<br/>IN_BODY=true, pending empty
    GenBr->>Pending: PENDING_HEADING=line

    Loop->>ContBr: body text
    Note over ContBr: PENDING_HEADING non-empty
    ContBr->>Pending: PENDING_BODY+=line

    Loop->>GenBr: ### Subheading (2nd)
    Note over GenBr: pending already active<br/>(case 13 path)
    GenBr->>Pending: PENDING_BODY+=line

    alt Resolution rule 1: Reviewer/Vote/Phase fires
        Loop->>FieldBr: - **Reviewer**: X
        FieldBr->>Fold: fold back
        Fold->>Pending: merge into CURRENT_BODY,<br/>clear pending
        Note over FieldBr: CURRENT_REVIEWER=X<br/>IN_BODY=false
        Loop->>Flush: EOF flush
        Flush->>Emit: emit normal OOS<br/>(preserves #129 case 1)
    else Resolution rule 2a: ### OOS_N: arrives (case 15)
        Loop->>OOSBr: ### OOS_2: title
        OOSBr->>Split: split preamble
        Split->>Emit: emit OOS_1 MALFORMED+body
        Split->>Emit: emit pending pair as generic
        Split->>Pending: clear state
        OOSBr->>Flush: flush (no-op, already reset)
        Note over OOSBr: start new OOS_2 item
        Loop->>Flush: EOF flush for OOS_2
    else Resolution rule 2b: EOF (case 6, 14)
        Loop->>Split: EOF preamble
        Split->>Emit: emit current OOS MALFORMED+body
        Split->>Emit: emit pending pair as generic
        Split->>Pending: clear state
        Loop->>Flush: terminal flush<br/>(no-op, already reset)
    end
```

</details>

<details><summary>Goal</summary>

- Fix issue #138: `parse-input.sh` absorbs generic `### <title>` lines into in-progress OOS bodies
  - Symptom: when an OOS item has only a Description (no closing Reviewer/Vote tally/Phase), a subsequent `### <title>` line that the author intended as a new generic item is absorbed as body continuation — silently corrupting item boundaries.
  - Opposite-direction counterpart to #132 (which fixed the generic→OOS direction via a symmetric mode-guard on the OOS heading branch).
  - Root cause: the generic `### <title>` branch unconditionally absorbs into `CURRENT_BODY` whenever `CURRENT_MODE=oos && IN_BODY=true`. The parser cannot disambiguate a legitimate OOS body subheading (`### Notes` — #129 case 1) from an intended new item (`### Would-be generic item` — case 6) because both look identical until the following lines are seen.
- Preserve locked regression behavior
  - #129 case 1: `### Notes` inside an OOS Description must still absorb when the OOS eventually closes with Reviewer/Vote tally/Phase (byte-stable body).
  - #132 case 10: nested `### OOS_N: ...` inside a generic body must still absorb (symmetric mode-guard on the OOS-heading branch is not modified).
  - Cases 5, 8: production `/implement` Step 9a.1 shape — back-to-back well-formed OOS items must continue parsing as separate items because Phase closes `IN_BODY=false` before the next heading.
- Lock in new behavior with regression tests
  - Rewrite case 6 from "documented absorb limitation" to the #138 contract (ITEMS_TOTAL=2, first OOS MALFORMED with body, second generic item).
  - Add case 13: multi-subheading OOS must still produce a single well-formed OOS item (regression lock for the #129 fold-back path under the new pending-buffer mechanism).
  - Add case 14: incomplete OOS at EOF with ambiguous heading must split cleanly.
  - Add case 15: incomplete OOS followed by another `### OOS_N:` must split at the mid-stream boundary (three items total).

</details>

<details><summary>Test plan</summary>

- [x] `bash skills/issue/scripts/test-parse-input.sh` passes — 121 assertions (was 83; +38 for new cases 13/14/15 and the rewritten case 6).
- [x] All existing cases 1, 2, 3, 4, 5, 7, 8, 9, 10, 11, 12 unchanged in behavior — verified byte-stable.
- [x] New case 13 verifies multi-subheading OOS still absorbs into a single item when structured fields eventually close.
- [x] New case 14 verifies EOF resolution path emits MALFORMED + split cleanly.
- [x] New case 15 verifies mid-stream `### OOS_N:` resolution emits 3 items.
- [x] `/relevant-checks` passes (shellcheck + agent-lint + markdownlint + agnix).
- [x] `make lint` exercises `test-parse-input` automatically (wired in PR #142 which landed during the design phase).

</details>

<details><summary>Final Design</summary>

**Problem**: `skills/issue/scripts/parse-input.sh:205-220` (generic `### <title>` branch) unconditionally absorbs the heading as `CURRENT_BODY` continuation whenever `CURRENT_MODE=oos && IN_BODY=true`. When the current OOS is incomplete (only Description, missing Reviewer/Vote tally/Phase), the author's intended next item is silently merged into the OOS body.

**Fix**: Introduce a pending-heading state — `PENDING_HEADING` (the raw `### <title>` line) + `PENDING_BODY` (subsequent continuation lines plus any additional plain `### <subheading>` lines). The parser defers the absorb decision until a disambiguating signal arrives:

1. **Rule 1 — fold back** (`- **Reviewer**:` / `- **Vote tally**:` / `- **Phase**:` fires): merge PENDING_HEADING + PENDING_BODY back into CURRENT_BODY via `resolve_pending_foldback` called as the FIRST action of each structured-field branch (before BASH_REMATCH is clobbered or CURRENT_* state mutates). Uses the conditional-append pattern from `parse-input.sh:210-214` / `:246-250` so an empty CURRENT_BODY (the #131 case 9 shape) does not acquire a spurious leading newline.
2. **Rule 2 — split** (`### OOS_N:` heading or EOF arrives): `resolve_pending_split` emits the current OOS as MALFORMED with its non-empty body (via `emit_item`'s new `force_malformed=true` parameter), then emits the pending pair as a new generic item with no OOS metadata. Called as a preamble to the existing OOS heading branch (#132 mode-guard unchanged) and directly before the terminal `flush_item` at EOF.
3. **Accumulation** (plain `### <subheading>` arrives while pending-active): append to PENDING_BODY. Does NOT trigger rule 2 — only `### OOS_N:` or EOF splits. Required so case 13's multi-subheading OOS (`### Subheading 1` + `### Subheading 2` + body + Reviewer) still produces ITEMS_TOTAL=1.

**Files modified**:
1. `skills/issue/scripts/parse-input.sh` (+175 / -39): new pending-heading state, two resolution helpers, extended `emit_item`, extended `flush_item`, updated parse loop + header comments.
2. `skills/issue/scripts/test-parse-input.sh` (+156 / -9): rewritten case 6, new cases 13/14/15.
3. `skills/issue/SKILL.md` (+1 / -1): line 75 wording update to reflect the expanded MALFORMED trigger.

**Edge cases** (all covered by tests):
- Back-to-back complete OOS (case 8): Phase closes IN_BODY=false before the next `### OOS_N:`, so pending state never enters. Byte-stable.
- `### Notes` subheading (case 1): pending accumulates, Reviewer folds back. Byte-stable body.
- Multi-subheading OOS (case 13): pending accumulates two `### <subheading>` lines + paragraphs, Reviewer folds back. ITEMS_TOTAL=1.
- #132 generic body with nested `### OOS_N:` (case 10): `CURRENT_MODE=generic` gates the pending path out; existing #132 mode-guard on OOS heading branch handles it. Byte-stable.
- Empty-inline-Description (#131 case 9): no `### <title>` in body, pending path never enters. Byte-stable.
- EOF with pending-active (case 14): `resolve_pending_split` runs before the terminal `flush_item`.
- Mid-stream `### OOS_N:` with pending-active (case 15): `resolve_pending_split` preamble runs before the existing OOS heading logic.

**Subtle gotchas handled**:
- `BASH_REMATCH` clobbering (the #140 gotcha): each branch that re-runs `=~` captures the needed match into a local variable at branch entry before calling any helper.
- Fold-back newline handling: `resolve_pending_foldback` uses the conditional-append pattern to avoid spurious leading newlines when CURRENT_BODY is empty.
- Pending state leak across items: `flush_item` unconditionally clears `PENDING_HEADING` and `PENDING_BODY` alongside the other per-item resets.

**Acknowledged limitations** (documented in Failure Modes):
- A hand-authored mixed-input shape where an incomplete OOS is immediately followed by a generic item whose first body line is a literal OOS-shaped bullet (e.g., `- **Reviewer**: prose`) will fold back incorrectly because the structured-field matcher gates on `CURRENT_MODE=oos` and pending state does not change the mode. Engineered around would require either regressing #129 case 1 or a much deeper state-machine rewrite; not proportionate for this PR. Production callers (`/implement` Step 9a.1) emit only well-formed OOS, so this path is dead code there.
- MALFORMED items with populated bodies are not filed as GitHub issues by `/issue` batch mode (consistent with prior MALFORMED semantics — they feed `ISSUES_FAILED` only). The incomplete OOS's Description survives only in stdout / stderr diagnostics. SKILL.md line 75 now documents this explicitly.

</details>

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `9ca4025` (Defuse false-positive sk-* secret-scanner match on test fixture (#141))
- **Current version**: `3.4.9`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `3.4.10`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH").

**Main-agent escalation review**: No escalation. Changes are a behavioral bug fix inside `skills/issue/scripts/parse-input.sh` plus aligned test updates and a one-line wording change to `skills/issue/SKILL.md`. No SKILL.md frontmatter changes (`name`, `argument-hint`). The ABI contract is preserved: `ITEM_<i>_MALFORMED=true` was already a documented output key; this PR merely expands the set of input shapes that trigger it (and allows `BODY` to be emitted alongside). Production callers that use the MALFORMED signal for `ISSUES_FAILED` counting are unaffected. The old behavior (silently swallowing a user's intended second item) was the documented-limitation footgun this PR fixes; users who manually fed mixed OOS+generic input would see the bug go away — that is the intended fix, not a regression.

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

### [Plan Review] Codex
**Finding**: FINDING_10 — structured-field discriminator unsound against the generic contract. A pending-active OOS whose next line is a literal `- **Reviewer**: prose` in a would-be-generic body would be folded back incorrectly because the structured-field matcher only gates on `CURRENT_MODE=oos`. Suggested fix: stop feeding lines through OOS structured-field branches while pending-active; buffer them as raw pending body.
**Reason not implemented**: Exonerated by voting panel (YES=1, EXONERATE=2). Rationale: the false-positive fold-back path is narrow and triggers only for a hand-authored mixed-input shape that production callers (/implement Step 9a.1) never emit. The suggested fix (suppressing structured fields during pending-active) would regress #129 case 1 — a well-formed OOS with a `### Notes` subheading followed by Reviewer/Vote tally/Phase would split incorrectly. Documented in Failure Modes #4.

### [Plan Review] Cursor
**Finding**: FINDING_12 — plan does not list a CHANGELOG.md entry; repo practice is to add changelog entries for parser behavior changes.
**Reason not implemented**: Rejected by voting panel (YES=0, NO=2, EXONERATE=1). Rationale: `/implement` Step 8a auto-generates CHANGELOG entries from the PR's Summary bullets when both `CHANGELOG.md` exists and `/bump-version` produced a new version commit. The repo workflow handles this downstream; adding an explicit task to the /design plan would duplicate the automation with no benefit. (In fact, Step 8a fired and the CHANGELOG entry for 3.4.10 was created automatically as part of the bump commit.)

</details>

<details><summary>Implementation Deviations</summary>

- The inline plan listed three files modified (`parse-input.sh`, `test-parse-input.sh`, `SKILL.md`). The implementation also modified `CHANGELOG.md` — that file was updated automatically by `/implement` Step 8a from the Summary bullets, not by the plan explicitly listing it. Not a deviation, just a Step 8a automation outcome.
- Accepted plan-review findings (FINDING_1 through FINDING_9 and FINDING_11) were all implemented as specified. FINDING_10 and FINDING_12 were exonerated/rejected and not implemented.
- OOS_1 (test-parse-input.sh not wired into CI) was accepted during plan review voting. When the feature branch rebased onto `origin/main` before the implementation phase, it pulled in PR #142 which had already wired `test-parse-input` into `make lint` (closing upstream issue #136). The stale OOS artifact was removed from `$IMPLEMENT_TMPDIR/oos-accepted-design.md` at Step 9a.1 to avoid filing a duplicate of an already-closed issue.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

All 5 code-review findings were not accepted by the 3-voter panel. See the Run Statistics section below and the panel vote breakdown:

- FINDING_1 (Cursor): contract-change advisory — REJECTED 0-2-1 (informational, not a code defect).
- FINDING_2 (Cursor): `resolve_pending_split` comment says "called from the terminal flush_item at EOF" but actually called BEFORE flush_item — REJECTED 1-2-0 (wording nit per two of three voters).
- FINDING_3 (Cursor): case 14 test comment says "EOF in flush_item emits..." — REJECTED 1-2-0 (same wording-nit proportionality call).
- FINDING_4 (Codex): pending-active + generic body whose first line is OOS-shaped bullet — EXONERATED 0-1-2 (same substantive concern as plan-FINDING_10, already documented; suggested fix would regress #129 case 1).
- OOS_1 (Claude): missing regression lock for `PENDING_HEADING` set + `PENDING_BODY` empty at split time — NOT FILED 1-0-2 (reasonable coverage gap but tracker-noise; add a test in a future edit instead of filing).

</details>

<details><summary>Plan Review Voting Tally</summary>

**Per-finding breakdown** (voters: Claude Code Reviewer subagent, Cursor, Codex):

| Finding | Claude | Cursor | Codex | Outcome |
|---------|--------|--------|-------|---------|
| FINDING_1 (emit_item MALFORMED+BODY exclusivity) | YES | YES | YES | ACCEPTED 3-0-0 |
| FINDING_2 (continuation branch routing) | YES | YES | NO | ACCEPTED 2-1-0 |
| FINDING_3 (OOS heading branch preamble) | YES | YES | NO | ACCEPTED 2-1-0 |
| FINDING_4 (re-entrant trigger handling) | YES | YES | NO | ACCEPTED 2-1-0 |
| FINDING_5 (rule 2 conflicts with case 13) | YES | YES | YES | ACCEPTED 3-0-0 |
| FINDING_6 (fold-back ordering invariant) | YES | YES | NO | ACCEPTED 2-1-0 |
| FINDING_7 (unconditional newline in fold-back) | YES | YES | YES | ACCEPTED 3-0-0 |
| FINDING_8 (MALFORMED-never-create note) | EXO | YES | YES | ACCEPTED 2-0-1 |
| FINDING_9 (case 13 is regression lock) | EXO | YES | YES | ACCEPTED 2-0-1 |
| FINDING_10 (false-positive fold-back on prose) | EXO | YES | EXO | EXONERATED 1-0-2 |
| FINDING_11 (generic item strips OOS metadata) | EXO | YES | YES | ACCEPTED 2-0-1 |
| FINDING_12 (CHANGELOG.md update) | NO | EXO | NO | REJECTED 0-2-1 |
| OOS_1 (test suite not in CI) | YES | YES | YES | ACCEPTED for filing |

**Reviewer Competition Scoreboard (plan review)**:

| Reviewer | Accepted In-Scope | Exonerated | Rejected | Accepted OOS | Points |
|----------|-------------------|------------|----------|--------------|--------|
| Code (Claude) | 2 | 0 | 0 | 1 | +3 |
| Cursor | 6 | 0 | 1 | 0 | +5 |
| Codex | 3 | 1 | 0 | 1 | +4 |

Dialectic adjudication: 3 contested decisions voted, all with full `voted` disposition. DECISION_1 (deferred-buffer vs. lookahead) won 2-1 THESIS. DECISION_2 (split vs. pure MALFORMED) won 2-1 THESIS. DECISION_3 (parser header only vs. header + SKILL.md) won 0-3 ANTI_THESIS (unanimous for updating both).

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

**Per-finding breakdown** (voters: Claude Code Reviewer subagent, Cursor, Codex):

| Finding | Claude | Cursor | Codex | Outcome |
|---------|--------|--------|-------|---------|
| FINDING_1 (Cursor: contract change intentional) | EXO | NO | NO | REJECTED 0-2-1 |
| FINDING_2 (Cursor: resolve_pending_split comment) | YES | NO | NO | REJECTED 1-2-0 |
| FINDING_3 (Cursor: case 14 test comment) | YES | NO | NO | REJECTED 1-2-0 |
| FINDING_4 (Codex: pending + OOS-shaped generic body) | NO | EXO | EXO | EXONERATED 0-1-2 |
| OOS_1 (Claude: bodyless pending regression test) | YES | EXO | EXO | NOT FILED 1-0-2 |

**Reviewer Competition Scoreboard (code review)**:

| Reviewer | Accepted In-Scope | Exonerated | Rejected | Accepted OOS | Points |
|----------|-------------------|------------|----------|--------------|--------|
| Code (Claude) | 0 | 0 | 0 | 0 | 0 |
| Cursor | 0 | 1 | 0 | 0 | 0 |
| Codex | 0 | 1 | 0 | 0 | 0 |

All reviewers tied at 0. No fixes applied during review.

</details>

<details><summary>Out-of-Scope Observations</summary>

**Accepted OOS (GitHub issues filed):**
No OOS items were filed. The one OOS accepted during plan review (test-parse-input.sh not wired into CI) was resolved upstream by PR #142 (`dbae195`) which landed during the /design phase of this PR; the stale OOS artifact was removed at Step 9a.1 to avoid filing a closed-issue duplicate.

**Non-accepted OOS observations:**
- OOS_1 from code review (Claude): coverage gap for "incomplete OOS + bodyless pending subheading + split" — not filed (voted 1-0-2, panel judged it as tracker-noise relative to "add a regression test when touching tests next").
- FINDING_10 from plan review (Codex): narrow false-positive fold-back when pending-active meets a generic body whose first line is an OOS-shaped bullet. Exonerated; acknowledged in Failure Modes #4 of the plan.

</details>

<details><summary>Execution Issues</summary>

No execution issues encountered.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | 10 accepted, 2 rejected (1 exonerated) |
| Code review rounds | 1 |
| Code review findings | 0 accepted, 4 rejected (1 exonerated) |
| Warnings logged | 0 |
| Pre-existing issues noticed | 0 |
| OOS issues filed | 0 |
| External reviewers | Cursor: ✅, Codex: ✅ |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
