### PR TITLE
Add SessionStart health-check hook (jq/git preflight) (#153)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ Plugin ships the entire repo. **Runtime surface**: `skills/`, `agents/`, `hooks/
 - After any change, run `/relevant-checks`.
 - `scripts/redact-secrets.sh` is the outbound secret-scrubbing filter invoked by `skills/issue/scripts/create-one.sh` before `gh issue create`. `scripts/test-redact-secrets.sh` is its regression test, wired into `make lint` via the `test-redact` target. Edit patterns only after reading `SECURITY.md`'s outbound-redaction subsection.
 - `skills/issue/scripts/parse-input.sh` parses `/issue` batch-mode input. `skills/issue/scripts/test-parse-input.sh` is its regression harness, wired into `make lint` via the `test-parse-input` target so parser regressions cannot ship undetected.
+- `${CLAUDE_PLUGIN_ROOT}/scripts/sessionstart-health.sh` is the SessionStart preflight hook that probes `jq` and `git` on `PATH` at session start and injects an advisory into session context when either is missing. `${CLAUDE_PLUGIN_ROOT}/scripts/test-sessionstart-health.sh` is its regression test, wired into `make lint` via the `test-sessionstart` target (run manually via `bash ${CLAUDE_PLUGIN_ROOT}/scripts/test-sessionstart-health.sh`). The hook MUST always exit 0 (SessionStart is non-blocking by spec) and the `additionalContext` string MUST remain fixed ASCII literals — see the invariant comment in the script.
 - Public `skills/*/SKILL.md` use `${CLAUDE_PLUGIN_ROOT}/…`; dev-only `.claude/skills/*/SKILL.md` use `$PWD/…`.
 - Update `SECURITY.md` when security-relevant behavior changes.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.1] - 2026-04-19
+
+### Added
+
+- New `SessionStart` hook `scripts/sessionstart-health.sh` probes `jq` and `git` on `PATH` at session start/resume/clear/compact and injects a spec-compliant `hookSpecificOutput.additionalContext` advisory when either is missing. Non-blocking (always exits 0) and silent on the happy path — converts the existing reactive-block-at-first-edit pattern in `scripts/block-submodule-edit.sh` into a proactive session-start advisory. JSON is emitted via `printf` only (no `jq` dependency inside the hook) so the warning reaches Claude's session context even when `jq` itself is missing. Regression test `scripts/test-sessionstart-health.sh` covers 4 cases (both present, jq missing, git missing, both missing) using a stub-only PATH via `env -i PATH="$STUB_DIR" "$BASH_BIN"` for strict isolation. Wired into `make lint` via the new `test-sessionstart` target. README.md feature matrix updated; AGENTS.md editing rules updated with the fixed-ASCII-literal invariant. Closes #153.
+
 ## [4.0.0] - 2026-04-19
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 # Larch Makefile
 # Thin wrapper around pre-commit. Linter definitions live in .pre-commit-config.yaml.
 
-.PHONY: lint shellcheck markdownlint jsonlint actionlint agent-lint agnix setup test-redact test-parse-input smoke-dialectic
+.PHONY: lint shellcheck markdownlint jsonlint actionlint agent-lint agnix setup test-redact test-parse-input test-sessionstart smoke-dialectic
 
-lint: test-redact test-parse-input
+lint: test-redact test-parse-input test-sessionstart
 	pre-commit run --all-files
 
 test-redact:
@@ -11,6 +11,9 @@ test-redact:
 
 test-parse-input:
 	bash skills/issue/scripts/test-parse-input.sh
+
+test-sessionstart:
+	bash scripts/test-sessionstart-health.sh
 
 smoke-dialectic:
 	bash scripts/dialectic-smoke-test.sh

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ claude plugin install larch@larch-local
 | Skills | `/design`, `/implement`, `/review`, `/research`, `/loop-review`, `/fix-issue`, `/issue`, `/alias`, `/create-skill`, `/im`, `/imaq` |
 | Agents | `code-reviewer` (unified archetype covering code quality, risk/integration, correctness, architecture, security) |
 | PreToolUse hook | `block-submodule-edit.sh` — blocks `Edit`/`Write` on files inside any checked-out git submodule of the consuming project |
+| SessionStart hook | `sessionstart-health.sh` — at session start/resume/clear/compact, probes `jq` and `git` on `PATH`; if either is missing, injects an advisory into session context so the issue is visible before the first `Edit`/`Write`. Non-blocking (always exits 0); silent when both tools are present |
 
 ### `/relevant-checks` — required consumer dependency
 

--- a/agent-lint.toml
+++ b/agent-lint.toml
@@ -7,3 +7,13 @@ suppress = [
   "desc-body-misalign",
   "terminology-inconsistent",
 ]
+
+# scripts/test-sessionstart-health.sh is the regression test for the
+# SessionStart hook (scripts/sessionstart-health.sh). It is a plugin-level
+# infrastructure test — not owned by any SKILL.md — and is invoked via
+# `make lint` (test-sessionstart target). Agent-lint's dead-script rule
+# only recognizes structured references from SKILL.md/hooks.json/ci.yaml,
+# so we exclude the test path explicitly.
+exclude = [
+  "scripts/test-sessionstart-health.sh",
+]

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -21,6 +21,18 @@
           }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/sessionstart-health.sh",
+            "timeout": 5
+          }
+        ]
+      }
     ]
   }
 }

--- a/scripts/sessionstart-health.sh
+++ b/scripts/sessionstart-health.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# sessionstart-health.sh — SessionStart hook that probes required CLI tools
+# (jq, git) at session start and emits a spec-compliant advisory to Claude's
+# session context when any are missing.
+#
+# INVARIANT: the additionalContext string MUST be composed only from fixed
+# ASCII literals chosen from a small predetermined set — never interpolate
+# runtime-derived variables (paths, version strings, locale-dependent text,
+# command output, environment values) into this JSON. Hand-crafted JSON is
+# only safe because the message body has no `"` / `\` / control characters.
+# If dynamic fragments are ever needed, switch to a structured JSON emitter
+# (e.g., `jq -n --arg ctx "$MSG" '...'`) and remove this invariant.
+#
+# SessionStart is non-blocking by spec: the script ALWAYS exits 0. A failing
+# probe produces advisory JSON on stdout; a healthy environment produces
+# nothing. The hook does not read stdin.
+
+set -euo pipefail
+LC_ALL=C
+
+# Collect missing-tool fragments in a single string. Guarded `if ! command -v`
+# is -e-safe because the `if` consumes the non-zero exit.
+MSG=""
+if ! command -v jq >/dev/null 2>&1; then
+    MSG="larch hook preflight: jq not on PATH (install: brew install jq / apt install jq). Claude Code JSON parsing and several larch scripts depend on jq."
+fi
+if ! command -v git >/dev/null 2>&1; then
+    if [[ -n "$MSG" ]]; then
+        MSG="$MSG "
+    fi
+    MSG="${MSG}larch hook preflight: git not on PATH. The submodule-edit guard and most larch scripts depend on git."
+fi
+
+if [[ -n "$MSG" ]]; then
+    # Hand-crafted single-line JSON. The two fixed-literal message strings
+    # above contain no `"` / `\` / control characters, so no escaping is
+    # required. If the INVARIANT above is ever violated, this line becomes
+    # unsafe.
+    printf '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"%s"}}\n' "$MSG"
+fi
+
+exit 0

--- a/scripts/test-sessionstart-health.sh
+++ b/scripts/test-sessionstart-health.sh
@@ -3,9 +3,10 @@
 #
 # Four cases, each run with a controlled PATH that contains only stub scripts
 # for the tools we want "present" in that case — no real /usr/bin/jq or
-# /usr/bin/git leaks in. The script-under-test is invoked via absolute
-# /bin/bash so its `#!/usr/bin/env bash` shebang never triggers PATH lookup
-# for bash itself.
+# /usr/bin/git leaks in. The script-under-test is invoked via an absolute
+# bash path (resolved once before `env -i` from the ambient PATH, so this
+# works on Nix-style layouts where bash is not at /bin/bash) so its
+# `#!/usr/bin/env bash` shebang never triggers PATH lookup for bash itself.
 #
 #   Case 1: jq + git both present        → exit 0, empty stdout
 #   Case 2: jq missing, git present      → exit 0, JSON mentions jq
@@ -30,6 +31,14 @@ fi
 
 if ! command -v jq >/dev/null 2>&1; then
     echo "FAIL: harness jq not on PATH; cannot validate JSON output" >&2
+    exit 1
+fi
+
+# Resolve bash from ambient PATH once, before env -i scrubs the environment.
+# This lets the harness run on Nix-style layouts where bash is not at /bin/bash.
+BASH_BIN=$(command -v bash)
+if [[ -z "$BASH_BIN" || ! -x "$BASH_BIN" ]]; then
+    echo "FAIL: could not resolve bash on ambient PATH" >&2
     exit 1
 fi
 
@@ -106,15 +115,15 @@ build_stub_dir() {
     done
 }
 
-# Run the script under test with a stub-only PATH. Absolute /bin/bash bypasses
-# the shebang's PATH-lookup of `env` and `bash`, so the only executables the
-# script can see are the stubs in $stub_dir.
+# Run the script under test with a stub-only PATH. The pre-resolved $BASH_BIN
+# bypasses the shebang's PATH-lookup of `env` and `bash`, so the only
+# executables the script can see are the stubs in $stub_dir.
 run_under_stubs() {
     local stub_dir="$1"
     local out_file="$2"
     local err_file="$3"
     local rc=0
-    env -i PATH="$stub_dir" /bin/bash "$SCRIPT" < /dev/null > "$out_file" 2> "$err_file" || rc=$?
+    env -i PATH="$stub_dir" "$BASH_BIN" "$SCRIPT" < /dev/null > "$out_file" 2> "$err_file" || rc=$?
     printf '%s\n' "$rc"
 }
 

--- a/scripts/test-sessionstart-health.sh
+++ b/scripts/test-sessionstart-health.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+# test-sessionstart-health.sh — Regression test for scripts/sessionstart-health.sh.
+#
+# Four cases, each run with a controlled PATH that contains only stub scripts
+# for the tools we want "present" in that case — no real /usr/bin/jq or
+# /usr/bin/git leaks in. The script-under-test is invoked via absolute
+# /bin/bash so its `#!/usr/bin/env bash` shebang never triggers PATH lookup
+# for bash itself.
+#
+#   Case 1: jq + git both present        → exit 0, empty stdout
+#   Case 2: jq missing, git present      → exit 0, JSON mentions jq
+#   Case 3: jq present, git missing      → exit 0, JSON mentions git
+#   Case 4: both missing                 → exit 0, JSON mentions both
+#
+# JSON validation uses the harness's own jq (from the outer PATH), not the
+# stubs visible to the script-under-test.
+#
+# Usage:  bash scripts/test-sessionstart-health.sh
+# Exit codes:  0 on success, 1 on first failure.
+
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+SCRIPT="$REPO_ROOT/scripts/sessionstart-health.sh"
+
+if [[ ! -x "$SCRIPT" ]]; then
+    echo "FAIL: $SCRIPT does not exist or is not executable" >&2
+    exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "FAIL: harness jq not on PATH; cannot validate JSON output" >&2
+    exit 1
+fi
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+PASS=0
+FAIL=0
+FAILED_TESTS=()
+
+assert_eq() {
+    local got="$1" expected="$2" label="$3"
+    if [[ "$got" == "$expected" ]]; then
+        PASS=$((PASS + 1))
+        echo "  ok: $label"
+    else
+        FAIL=$((FAIL + 1))
+        FAILED_TESTS+=("$label (got '$got', expected '$expected')")
+        echo "  FAIL: $label" >&2
+        echo "       got:      '$got'" >&2
+        echo "       expected: '$expected'" >&2
+    fi
+}
+
+assert_empty() {
+    local got="$1" label="$2"
+    if [[ -z "$got" ]]; then
+        PASS=$((PASS + 1))
+        echo "  ok: $label (stdout empty)"
+    else
+        FAIL=$((FAIL + 1))
+        FAILED_TESTS+=("$label (stdout non-empty)")
+        echo "  FAIL: $label" >&2
+        echo "       got: '$got'" >&2
+    fi
+}
+
+assert_contains() {
+    local haystack="$1" needle="$2" label="$3"
+    if [[ "$haystack" == *"$needle"* ]]; then
+        PASS=$((PASS + 1))
+        echo "  ok: $label (contains '$needle')"
+    else
+        FAIL=$((FAIL + 1))
+        FAILED_TESTS+=("$label (missing '$needle')")
+        echo "  FAIL: $label (missing '$needle')" >&2
+        echo "       haystack: '$haystack'" >&2
+    fi
+}
+
+assert_not_contains() {
+    local haystack="$1" needle="$2" label="$3"
+    if [[ "$haystack" != *"$needle"* ]]; then
+        PASS=$((PASS + 1))
+        echo "  ok: $label (does not contain '$needle')"
+    else
+        FAIL=$((FAIL + 1))
+        FAILED_TESTS+=("$label (leaked '$needle')")
+        echo "  FAIL: $label (leaked '$needle')" >&2
+    fi
+}
+
+# Build a stub bin directory. Stubs are minimal: they just exit 0. The point
+# is that `command -v <tool>` returns zero when the stub is present and
+# non-zero when it is absent.
+build_stub_dir() {
+    local dir="$1"
+    shift
+    rm -rf "$dir"
+    mkdir -p "$dir"
+    for tool in "$@"; do
+        printf '#!/bin/sh\nexit 0\n' > "$dir/$tool"
+        chmod +x "$dir/$tool"
+    done
+}
+
+# Run the script under test with a stub-only PATH. Absolute /bin/bash bypasses
+# the shebang's PATH-lookup of `env` and `bash`, so the only executables the
+# script can see are the stubs in $stub_dir.
+run_under_stubs() {
+    local stub_dir="$1"
+    local out_file="$2"
+    local err_file="$3"
+    local rc=0
+    env -i PATH="$stub_dir" /bin/bash "$SCRIPT" < /dev/null > "$out_file" 2> "$err_file" || rc=$?
+    printf '%s\n' "$rc"
+}
+
+echo "=== Case 1: jq + git both present ==="
+build_stub_dir "$tmp/c1_bin" jq git
+rc=$(run_under_stubs "$tmp/c1_bin" "$tmp/c1.out" "$tmp/c1.err")
+assert_eq "$rc" "0" "case 1: exit code 0"
+stdout=$(cat "$tmp/c1.out")
+assert_empty "$stdout" "case 1: stdout empty"
+
+echo "=== Case 2: jq missing, git present ==="
+build_stub_dir "$tmp/c2_bin" git
+rc=$(run_under_stubs "$tmp/c2_bin" "$tmp/c2.out" "$tmp/c2.err")
+assert_eq "$rc" "0" "case 2: exit code 0"
+stdout=$(cat "$tmp/c2.out")
+# Must be valid JSON and a single line.
+lines=$(printf '%s' "$stdout" | wc -l | tr -d ' ')
+assert_eq "$lines" "0" "case 2: exactly one line of stdout (no trailing newline counted by wc -l)"
+# Validate JSON structure via harness jq.
+if ! printf '%s' "$stdout" | jq -e . >/dev/null 2>&1; then
+    FAIL=$((FAIL + 1))
+    FAILED_TESTS+=("case 2: stdout is not valid JSON")
+    echo "  FAIL: case 2: stdout is not valid JSON" >&2
+    echo "       stdout: '$stdout'" >&2
+else
+    PASS=$((PASS + 1))
+    echo "  ok: case 2: stdout is valid JSON"
+fi
+hook_event=$(printf '%s' "$stdout" | jq -r '.hookSpecificOutput.hookEventName // empty')
+assert_eq "$hook_event" "SessionStart" "case 2: hookEventName"
+ctx=$(printf '%s' "$stdout" | jq -r '.hookSpecificOutput.additionalContext // empty')
+assert_contains "$ctx" "jq" "case 2: additionalContext mentions jq"
+assert_not_contains "$ctx" "git not on PATH" "case 2: additionalContext does not mention git (git is present)"
+
+echo "=== Case 3: jq present, git missing ==="
+build_stub_dir "$tmp/c3_bin" jq
+rc=$(run_under_stubs "$tmp/c3_bin" "$tmp/c3.out" "$tmp/c3.err")
+assert_eq "$rc" "0" "case 3: exit code 0"
+stdout=$(cat "$tmp/c3.out")
+lines=$(printf '%s' "$stdout" | wc -l | tr -d ' ')
+assert_eq "$lines" "0" "case 3: exactly one line of stdout"
+if ! printf '%s' "$stdout" | jq -e . >/dev/null 2>&1; then
+    FAIL=$((FAIL + 1))
+    FAILED_TESTS+=("case 3: stdout is not valid JSON")
+    echo "  FAIL: case 3: stdout is not valid JSON" >&2
+    echo "       stdout: '$stdout'" >&2
+else
+    PASS=$((PASS + 1))
+    echo "  ok: case 3: stdout is valid JSON"
+fi
+hook_event=$(printf '%s' "$stdout" | jq -r '.hookSpecificOutput.hookEventName // empty')
+assert_eq "$hook_event" "SessionStart" "case 3: hookEventName"
+ctx=$(printf '%s' "$stdout" | jq -r '.hookSpecificOutput.additionalContext // empty')
+assert_contains "$ctx" "git" "case 3: additionalContext mentions git"
+assert_not_contains "$ctx" "jq not on PATH" "case 3: additionalContext does not mention jq (jq is present)"
+
+echo "=== Case 4: both missing ==="
+build_stub_dir "$tmp/c4_bin"
+rc=$(run_under_stubs "$tmp/c4_bin" "$tmp/c4.out" "$tmp/c4.err")
+assert_eq "$rc" "0" "case 4: exit code 0"
+stdout=$(cat "$tmp/c4.out")
+lines=$(printf '%s' "$stdout" | wc -l | tr -d ' ')
+assert_eq "$lines" "0" "case 4: exactly one line of stdout"
+if ! printf '%s' "$stdout" | jq -e . >/dev/null 2>&1; then
+    FAIL=$((FAIL + 1))
+    FAILED_TESTS+=("case 4: stdout is not valid JSON")
+    echo "  FAIL: case 4: stdout is not valid JSON" >&2
+    echo "       stdout: '$stdout'" >&2
+else
+    PASS=$((PASS + 1))
+    echo "  ok: case 4: stdout is valid JSON"
+fi
+hook_event=$(printf '%s' "$stdout" | jq -r '.hookSpecificOutput.hookEventName // empty')
+assert_eq "$hook_event" "SessionStart" "case 4: hookEventName"
+ctx=$(printf '%s' "$stdout" | jq -r '.hookSpecificOutput.additionalContext // empty')
+assert_contains "$ctx" "jq" "case 4: additionalContext mentions jq"
+assert_contains "$ctx" "git" "case 4: additionalContext mentions git"
+
+echo
+echo "=== Summary ==="
+echo "  passed: $PASS"
+echo "  failed: $FAIL"
+if [[ $FAIL -gt 0 ]]; then
+    echo >&2
+    echo "Failed tests:" >&2
+    for t in "${FAILED_TESTS[@]}"; do
+        echo "  - $t" >&2
+    done
+    exit 1
+fi
+
+echo "all tests passed"
+exit 0


### PR DESCRIPTION
## Summary

- Added a new `SessionStart` hook (`scripts/sessionstart-health.sh`) that proactively warns when `jq` or `git` is missing from PATH at session start — converting the existing reactive block-at-first-edit pattern in `block-submodule-edit.sh` into a proactive session-start advisory. Closes #153.
- Hook emits a spec-compliant `hookSpecificOutput.additionalContext` JSON via `printf` only (no `jq` dependency inside the hook itself), always exits 0, and stays silent on the happy path.
- Added regression test `scripts/test-sessionstart-health.sh` with strict PATH isolation (stub-only PATH + pre-resolved `$BASH_BIN`); wired into `make lint` via a new `test-sessionstart` target.

<details><summary>Architecture Diagram</summary>

```mermaid
graph TD
    A[Claude Code session starts/resumes/clears/compacts] -->|fires SessionStart event| B[hooks/hooks.json]
    B -->|matcher: startup\|resume\|clear\|compact| C[scripts/sessionstart-health.sh]
    C -->|command -v jq| D{jq on PATH?}
    C -->|command -v git| E{git on PATH?}
    D -->|missing| F[append jq warning to context]
    E -->|missing| F
    D -->|present| G[no append]
    E -->|present| G
    F --> H[printf single-line JSON to stdout]
    G --> I{any tool missing?}
    I -->|no| J[silent: empty stdout]
    I -->|yes| H
    H --> K[exit 0]
    J --> K
    K --> L[Claude session context receives additionalContext]

    M[make lint] -->|prerequisite| N[test-sessionstart target]
    N --> O[scripts/test-sessionstart-health.sh]
    O -->|env -i PATH=stub BASH_BIN SCRIPT| C
    O -->|jq . over captured stdout| P[assert JSON shape + exit 0]

    subgraph "Runtime (plugin)"
      B
      C
      L
    end
    subgraph "CI/dev validation"
      M
      N
      O
      P
    end
```

</details>

<details><summary>Code Flow Diagram</summary>

```mermaid
sequenceDiagram
    participant CC as Claude Code Session
    participant HOOK as hooks/hooks.json dispatcher
    participant SH as scripts/sessionstart-health.sh
    participant PATH as PATH probes (command -v)
    participant STDOUT as stdout / session context

    CC->>HOOK: fire SessionStart event<br/>(startup|resume|clear|compact)
    HOOK->>SH: match event → exec script<br/>(timeout: 5s)
    activate SH
    SH->>SH: set -euo pipefail; LC_ALL=C
    SH->>SH: MSG=""

    SH->>PATH: command -v jq
    alt jq missing
        PATH-->>SH: exit 1
        SH->>SH: MSG="larch hook preflight: jq not on PATH ..."
    else jq present
        PATH-->>SH: exit 0
        SH->>SH: (no append)
    end

    SH->>PATH: command -v git
    alt git missing
        PATH-->>SH: exit 1
        SH->>SH: append/init "... git not on PATH ..."
    else git present
        PATH-->>SH: exit 0
        SH->>SH: (no append)
    end

    alt MSG non-empty
        SH->>STDOUT: printf single-line JSON<br/>hookSpecificOutput.additionalContext
    else MSG empty
        SH->>STDOUT: (silent — no output)
    end
    SH-->>HOOK: exit 0 (always)
    deactivate SH

    HOOK-->>CC: inject additionalContext into session context<br/>(only when JSON emitted)

    Note over CC: subsequent Edit/Write tool calls<br/>see the advisory BEFORE<br/>block-submodule-edit.sh's<br/>reactive jq-missing failure
```

</details>

<details><summary>Goal</summary>

- Provide a proactive signal to users that their environment is missing `jq` or `git` before they attempt the first Edit/Write, rather than discovering it reactively when `scripts/block-submodule-edit.sh:25-27` fails closed mid-session.
- Keep the hook non-invasive: always exits 0 (SessionStart is non-blocking by spec) and stays silent when both tools are present, so users with healthy environments see no overhead.
- Align with existing test-harness patterns in the repo (`test-redact-secrets.sh`, `test-parse-input.sh`) for consistency and reviewer familiarity.
- Document the new runtime surface in README.md's "What the plugin provides" feature matrix.

</details>

<details><summary>Test plan</summary>

- [x] `scripts/test-sessionstart-health.sh` passes all 20 assertions across 4 cases (both present, jq missing, git missing, both missing).
- [x] `make lint` passes end-to-end (shellcheck + markdownlint + jsonlint + agent-lint + agnix + all test targets including new test-sessionstart).
- [x] `/relevant-checks` passes after implementation and after code-review fix.
- [ ] Manual post-merge smoke: start a fresh Claude Code session with `jq` temporarily hidden via PATH manipulation and verify the advisory surfaces in session context.

</details>

<details><summary>Final Design</summary>

Core design (unchanged from Step 2b):
- Single new standalone `scripts/sessionstart-health.sh` (not routed through `session-setup.sh`/`preflight.sh`).
- Registered in `hooks/hooks.json` under `SessionStart` with matcher `"startup|resume|clear|compact"` and 5s timeout, using `${CLAUDE_PLUGIN_ROOT}/scripts/sessionstart-health.sh`.
- Always exit 0; silent on happy path.
- Regression test under `scripts/test-sessionstart-health.sh` with PATH bin-wrapper trick, wired into `make lint` via new `test-sessionstart` target.

Dialectic resolution (binding for this PR): **printf-only JSON emission on all paths — no jq dependency inside the hook.** Overturned the issue's literal "jq-first" spec 2-1 (Claude and Cursor voted for printf-only, Codex voted for jq-first). The resolution is strictly better for UX: even when jq is missing, the advisory JSON still reaches Claude's session context via stdout (rather than degrading to stderr).

Plan-review-voted-in revisions (5 findings accepted, all implemented):
- FINDING_1: PATH isolation uses stub-only PATH via `env -i PATH="$STUB_DIR"` + explicit bash invocation (avoids leaking real `/usr/bin/jq`/`git` into "missing" test cases).
- FINDING_2: Added README.md row for the new SessionStart hook.
- FINDING_3: Matcher values `startup|resume|clear|compact` confirmed against the Anthropic hooks spec during plan review.
- FINDING_4: Added explicit invariant comment in the hook script header about additionalContext being fixed ASCII literals.
- FINDING_5: Added `/relevant-checks` as an explicit testing-strategy step alongside `make lint`.

</details>

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `f17634d` (Switch /loop-review to file GitHub issues via /issue (closes #148) (#163))
- **Current version**: `4.0.0`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `4.0.1`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH"). The changes in this PR touch only `scripts/`, `hooks/`, `README.md`, `AGENTS.md`, `Makefile`, `agent-lint.toml`, and `CHANGELOG.md` — all outside the `skills/**` / `agents/**` public surface that drives MAJOR/MINOR classification. No escalation needed: the new SessionStart hook is additive, non-blocking, and invisible on the happy path.

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

### [Plan Review] Cursor (FINDING_6)
**Finding**: Plugin-registered SessionStart hooks may not reliably surface `additionalContext`; suggested recording minimum Claude Code version, release-note caveat, debug-log success criteria.
**Reason not implemented**: 0 YES, 2 EXONERATE, 1 NO — concern is plausible but unverified; proposed mitigation is disproportionate. Manual post-merge smoke will surface the issue if real.

### [Plan Review] Cursor (FINDING_7)
**Finding**: `additionalContext` message should explicitly disclose scope (only probes jq/git, not gh).
**Reason not implemented**: 1 YES, 1 EXONERATE, 1 NO — below threshold. The hook only emits on failure and names the specific missing tool; no reasonable consumer would infer "all prerequisites satisfied" from an advisory that only ever states what's wrong.

</details>

<details><summary>Implementation Deviations</summary>

No deviations from the plan. All 5 accepted plan-review findings (1, 2, 3, 4, 5) were incorporated before implementation started. The dialectic resolution (printf-only JSON emission) overturned the issue's literal `jq -cn` directive and is explicitly called out in the script header comment.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

### [Code Review] Code (Claude Code Reviewer)
**Finding**: `hooks/hooks.json:27` — the SessionStart matcher `"startup|resume|clear|compact"` uses pipe-separated alternation, a pattern not previously used by this codebase (existing PreToolUse hooks use literal tool-name matchers like `"Edit"` and `"Write"`). If the Claude Code runtime interprets the `matcher` field as a literal string for SessionStart rather than supporting alternation, the hook would never fire and the entire feature would be silently inoperative.
**Reason not implemented**: Unanimously rejected (0 YES, 0 EXONERATE). Both Cursor and Codex verified against the current Anthropic Claude Code hooks reference that SessionStart matchers are documented to accept pipe-separated exact strings with values `startup` / `resume` / `clear` / `compact`. The configuration in this PR is spec-compliant.

### [Code Review] Cursor (round 1)
**Finding**: `scripts/test-sessionstart-health.sh:18-19` header comment says "Exit codes: 0 on success, 1 on first failure" — but the harness runs all four cases and only exits 1 after the full summary.
**Reason not implemented**: Voted 1 YES, 1 EXONERATE (Cursor itself), 1 NO — below the 2-YES threshold. The misleading comment has no functional impact.

### [Code Review] Cursor (round 1)
**Finding**: `scripts/test-sessionstart-health.sh:133-135` — the `wc -l == 0` assertion's comment about "no trailing newline counted by `wc -l`" is misleading; the real reason is command-substitution newline stripping.
**Reason not implemented**: 1 YES, 0 EXONERATE, 2 NO — below threshold. A wording nit with no functional impact.

### [Code Review] Cursor (round 1)
**Finding**: `AGENTS.md:17` should mention `make test-sessionstart` as the conventional local entry point.
**Reason not implemented**: Unanimously rejected (0 YES, 0 EXONERATE). All three voters agreed the existing description of the make target wiring is adequate.

</details>

<details><summary>Plan Review Voting Tally</summary>

| Finding | Claude | Cursor | Codex | Result |
|---------|--------|--------|-------|--------|
| FINDING_1 PATH isolation | YES | YES | YES | ✅ 3 YES |
| FINDING_2 README update | YES | YES | YES | ✅ 3 YES |
| FINDING_3 matcher spec verify | NO | YES | YES | ✅ 2 YES |
| FINDING_4 invariant comment | EXONERATE | YES | YES | ✅ 2 YES |
| FINDING_5 /relevant-checks | YES | YES | YES | ✅ 3 YES |
| FINDING_6 plugin SessionStart viability | NO | EXONERATE | EXONERATE | ❌ 0 YES |
| FINDING_7 scope messaging | EXONERATE | YES | NO | ❌ 1 YES |

**Reviewer Competition Scoreboard (plan review)**
| Reviewer | Score |
|----------|-------|
| Code | +4 |
| Cursor | +3 |
| Codex | +3 |

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

| Finding | Claude | Cursor | Codex | Result |
|---------|--------|--------|-------|--------|
| FINDING_1 matcher semantics | NO | NO | NO | ❌ rejected unanimously |
| FINDING_2 test header wording | YES | EXONERATE | NO | ❌ 1 YES |
| FINDING_3 wc -l comment | NO | YES | NO | ❌ 1 YES |
| FINDING_4 AGENTS.md make mention | NO | NO | NO | ❌ rejected unanimously |
| FINDING_5 portable bash path | EXONERATE | YES | YES | ✅ 2 YES |
| OOS_1 Slack scripts portability | NO | NO | YES | ❌ 1 YES |

**Reviewer Competition Scoreboard (code review, round 1)**
| Reviewer | Score |
|----------|-------|
| Code | -1 |
| Cursor | -1 |
| Codex | +1 |

</details>

<details><summary>Out-of-Scope Observations</summary>

**Accepted OOS (GitHub issues filed):**
No OOS items were accepted for issue filing.

**Non-accepted OOS observations:**
- **Cursor (code review)**: Pre-existing agent-lint config and Claude product behavior (matcher semantics, hook merge order, schema drift) not directly validatable by this diff. Not filed.
- **Codex (code review)**: `scripts/add-slack-emoji.sh` and `scripts/post-slack-message.sh` have the same `/bin/bash` portability limitation as the fixed test file. Voted 1 YES (Codex), 2 NO — not filed. The concern is legitimate but low-impact (these scripts run on macOS developer workstations where `/bin/bash` is always present).

</details>

<details><summary>Execution Issues</summary>

### Warnings
- **Step 3 (/relevant-checks, first pass)**: `agent-lint` reported the new `scripts/test-sessionstart-health.sh` as a "dead script" (no structured invocation reference found). Agent-lint recognizes references only from SKILL.md/hooks.json/ci.yaml — `make lint` invocation + AGENTS.md reference don't satisfy the rule. Resolved by adding an explicit `exclude = ["scripts/test-sessionstart-health.sh"]` entry to `agent-lint.toml` with a documented rationale. The test is exercised by CI via `make lint`.

### Tool Failures
- **Step 1 (`/review` gather context)**: The gather-branch-context script initially picked up stale local `main`, including an unrelated commit (`f17634d`) from an already-merged upstream PR in the diff. Resolved by running `git-sync-local-main.sh` to fast-forward local `main` to `origin/main`, then re-running the gather. Root cause: `rebase-push.sh --no-push` rebases onto `origin/main` but does not update the local `main` ref; the gather script defaults to local `main` as BASE.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | 5 accepted, 2 rejected |
| Code review rounds | 2 |
| Code review findings | 1 accepted, 4 rejected in-scope, 1 rejected OOS |
| Warnings logged | 1 |
| Pre-existing issues noticed | 1 (Slack scripts `/bin/bash`) |
| OOS issues filed | 0 |
| External reviewers | Cursor: ✅, Codex: ✅ |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
