### PR TITLE
Switch block-submodule-edit.sh deny channel to hookSpecificOutput JSON (closes #151)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.4] - 2026-04-19
+
+### Changed
+
+- `scripts/block-submodule-edit.sh` deny channel now uses Anthropic's documented `hookSpecificOutput` JSON shape (`hookEventName=PreToolUse`, `permissionDecision=deny`, `permissionDecisionReason=<why>`) emitted on stdout with exit 0, replacing the prior exit-2 + stdout-reason behavior that directly contradicted the PreToolUse spec (where exit 2 routes stderr, not stdout, to Claude). `block()` is hardened with a static-JSON fallback for rare `jq` runtime failures so a broken `jq` never degrades to exit 0 + empty stdout (which the runtime interprets as allow, silently weakening the submodule-edit policy). The `jq` availability probe moves ahead of every `block()` call and emits a hardcoded deny JSON literal on the missing-`jq` path. `scripts/test-block-submodule-edit.sh` gains an `assert_deny_json` helper (with an empty-needle guard) and rewrites every deny-case assertion to parse stdout with `jq` and check all three fields; case 3's tri-state fingerprint is updated to match the new contract; case-7 mini-bin comments are rewritten to reflect the jq-first probe ordering. Closes #151.
+
 ## [4.0.3] - 2026-04-19
 
 ### Added

--- a/scripts/block-submodule-edit.sh
+++ b/scripts/block-submodule-edit.sh
@@ -19,6 +19,9 @@
 set -uo pipefail
 
 # See: https://docs.anthropic.com/en/docs/claude-code/hooks
+# If jq fails at runtime (broken install, I/O error, etc.), emit a static deny
+# JSON fallback so a failed jq never degrades to exit 0 + empty stdout, which
+# the runtime would interpret as allow — weakening the submodule-edit policy.
 block() {
   jq -cn --arg reason "$1" '{
     hookSpecificOutput: {
@@ -26,7 +29,7 @@ block() {
       permissionDecision: "deny",
       permissionDecisionReason: $reason
     }
-  }'
+  }' || printf '%s\n' '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"submodule edit guard: deny (jq runtime failure)"}}'
   exit 0
 }
 

--- a/scripts/block-submodule-edit.sh
+++ b/scripts/block-submodule-edit.sh
@@ -3,8 +3,10 @@
 # of the current superproject.
 #
 # Stdin: JSON with tool_input.file_path (absolute path)
-# Exit 0: allow the operation
-# Exit 2: block the operation (stdout is the reason shown to Claude)
+# Always exits 0. To block, emits Anthropic's documented PreToolUse deny shape
+# on stdout: {"hookSpecificOutput":{"hookEventName":"PreToolUse",
+# "permissionDecision":"deny","permissionDecisionReason":"<why>"}}.
+# To allow, emits no output. See Anthropic's Hooks reference for the spec.
 #
 # Behavior:
 # - Fails CLOSED on stdin / JSON parse failure
@@ -16,18 +18,30 @@
 
 set -uo pipefail
 
+# See: https://docs.anthropic.com/en/docs/claude-code/hooks
 block() {
-  printf '%s\n' "$1"
-  exit 2
+  jq -cn --arg reason "$1" '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: $reason
+    }
+  }'
+  exit 0
 }
+
+# jq is required to produce the deny JSON via block(). Check it first so every
+# block() call below can assume jq is available. For the missing-jq case, emit
+# a static JSON literal directly (no jq needed for a fixed string).
+if ! command -v jq >/dev/null 2>&1; then
+  printf '%s\n' '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"submodule edit guard: jq is required but not installed; install jq and retry"}}'
+  exit 0
+fi
 
 # --- Read stdin ---
 INPUT=$(cat) || block "submodule edit guard: failed to read stdin, blocking as precaution"
 
 # --- Extract file_path from JSON ---
-if ! command -v jq >/dev/null 2>&1; then
-  block "submodule edit guard: jq is required but not installed; install jq and retry"
-fi
 FILE_PATH=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null) \
   || block "submodule edit guard: failed to parse tool input, blocking as precaution"
 

--- a/scripts/test-block-submodule-edit.sh
+++ b/scripts/test-block-submodule-edit.sh
@@ -4,7 +4,10 @@
 # Black-box contract test of the PreToolUse hook via stdin JSON + controlled
 # cwd/PATH. Each case synthesizes a payload of shape
 #   {"tool_input":{"file_path":"<abs>"}}
-# pipes it to the hook, and asserts on exit code + stable stdout substrings.
+# pipes it to the hook, and asserts on exit code plus the deny channel shape:
+# deny cases expect exit 0 + parseable hookSpecificOutput JSON (hookEventName,
+# permissionDecision, permissionDecisionReason) via assert_deny_json; allow
+# cases expect exit 0 + empty stdout.
 #
 # Fixture (built once at top):
 #   $TMPROOT/bare.git   — local bare repo used as submodule origin
@@ -113,6 +116,15 @@ assert_empty() {
 # PATH (case 7) — PATH override is scoped to the hook subprocess.
 assert_deny_json() {
     local stdout="$1" expected_reason="$2" label_prefix="$3"
+    # Guard against caller bugs: assert_contains with an empty needle is
+    # vacuously true in bash, so an empty expected_reason would silently skip
+    # the reason check. Fail loudly instead.
+    if [[ -z "$expected_reason" ]]; then
+        FAIL=$((FAIL + 1))
+        FAILED_TESTS+=("$label_prefix assert_deny_json called with empty expected_reason")
+        echo "  FAIL: $label_prefix assert_deny_json called with empty expected_reason" >&2
+        return
+    fi
     local event_name decision reason
     event_name=$(printf '%s' "$stdout" | jq -r '.hookSpecificOutput.hookEventName // empty' 2>/dev/null || true)
     decision=$(printf '%s' "$stdout" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null || true)
@@ -243,7 +255,7 @@ elif (( legacy_match )); then
 else
     FAIL=$((FAIL + 1))
     FAILED_TESTS+=("[case 3] bypass — unexpected state: RC=$RC, stdout=$(printf %q "$HOOK_STDOUT")")
-    echo "  HARD FAIL: [case 3] bypass — neither post-fix (2,\"submodule\") nor legacy (0,\"\") fingerprint matched; RC=$RC, stdout=$(printf %q "$HOOK_STDOUT")" >&2
+    echo "  HARD FAIL: [case 3] bypass — neither post-fix (0, deny JSON with reason containing \"submodule\") nor legacy (0, empty stdout) fingerprint matched; RC=$RC, stdout=$(printf %q "$HOOK_STDOUT")" >&2
 fi
 
 # --- Case 4: Deny — new file in new subdir under submodule (ancestor walk) -
@@ -273,10 +285,11 @@ assert_empty "$HOOK_STDOUT" "[case 6] stdout empty"
 # Build a minimal bin dir with symlinks to the external commands the hook
 # needs to start and exercise the missing-jq branch:
 #   - `bash` (the shebang's `env bash` must resolve the interpreter on PATH)
-#   - `cat` (the hook's first operation is `INPUT=$(cat)`, before the jq gate)
-#   - `git` / `dirname` (not exercised when jq is absent — the hook blocks at
-#     the jq check — but included so the mini-bin stays realistic should the
-#     hook's pre-jq prologue grow in a future refactor).
+#   - `cat` / `git` / `dirname` (not exercised when jq is absent — the hook's
+#     jq probe now runs before any stdin read or git lookup, so the missing-jq
+#     branch emits a static deny JSON and exits before reaching them — but
+#     included so the mini-bin stays realistic should the pre-jq prologue grow
+#     in a future refactor).
 # `jq` is deliberately omitted. The preflight below confirms `jq` is not
 # resolvable under the restricted PATH, so case 7 exercises the intended
 # missing-jq branch and not a different fail-closed path.
@@ -285,8 +298,10 @@ echo "=== 7: Fail-closed — missing jq ==="
 MINI_BIN="$TMPROOT/mini-bin"
 mkdir -p "$MINI_BIN"
 # The hook's shebang `#!/usr/bin/env bash` needs `env` to find `bash` on PATH.
-# Include all external commands the hook can reach before the jq gate, plus
-# the shell interpreter env resolves for the shebang.
+# The hook's jq probe now runs first and the missing-jq branch exits before
+# any other external command. The tools below (cat/git/dirname) are therefore
+# unreachable on today's missing-jq path and kept only to keep the mini-bin
+# realistic if the pre-jq prologue grows in a future refactor.
 for tool in bash cat git dirname; do
     real=$(command -v "$tool" 2>/dev/null || true)
     if [[ -z "$real" ]]; then

--- a/scripts/test-block-submodule-edit.sh
+++ b/scripts/test-block-submodule-edit.sh
@@ -14,10 +14,16 @@
 #     symlink-file      — symlink → super/README.md
 #   $TMPROOT/nonrepo    — ordinary directory outside any git repo
 #
-# Bypass case (#3) uses tri-state fingerprint matching: post-fix (exit 2 +
-# stdout contains "submodule") → PASS; legacy-buggy (exit 0 + empty stdout) →
-# KNOWN-FAIL, increments EXPECTED_FAIL (non-fatal); anything else → HARD FAIL.
-# When issue #150 lands and removes the bypass, the case auto-flips to PASS.
+# Deny channel: the hook always exits 0 and emits Anthropic's hookSpecificOutput
+# JSON deny shape on stdout when blocking. Assertions use assert_deny_json to
+# parse stdout with jq and check the three fields (hookEventName,
+# permissionDecision, permissionDecisionReason).
+#
+# Bypass case (#3) uses tri-state fingerprint matching: post-fix (exit 0 +
+# parseable deny JSON whose reason mentions "submodule") → PASS; legacy-buggy
+# (exit 0 + empty stdout) → KNOWN-FAIL, increments EXPECTED_FAIL (non-fatal);
+# anything else → HARD FAIL. When issue #150 lands and removes the bypass,
+# the case auto-flips to PASS.
 #
 # Scope note: NotebookEdit and Bash-mediated mutations are outside the current
 # hook matcher's scope (PreToolUse on Edit/Write only) — no assertion here.
@@ -96,6 +102,24 @@ assert_empty() {
         FAILED_TESTS+=("$label (expected empty, got $(printf '%q' "${haystack:0:200}"))")
         echo "  FAIL: $label (expected empty, got $(printf '%q' "${haystack:0:200}"))" >&2
     fi
+}
+
+# assert_deny_json <stdout> <expected-reason-substring> <label-prefix>
+# Parses stdout as JSON and asserts Anthropic's PreToolUse deny shape:
+#   .hookSpecificOutput.hookEventName == "PreToolUse"
+#   .hookSpecificOutput.permissionDecision == "deny"
+#   .hookSpecificOutput.permissionDecisionReason contains <expected-reason-substring>
+# The harness still has jq on PATH even when the hook was run under a restricted
+# PATH (case 7) — PATH override is scoped to the hook subprocess.
+assert_deny_json() {
+    local stdout="$1" expected_reason="$2" label_prefix="$3"
+    local event_name decision reason
+    event_name=$(printf '%s' "$stdout" | jq -r '.hookSpecificOutput.hookEventName // empty' 2>/dev/null || true)
+    decision=$(printf '%s' "$stdout" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null || true)
+    reason=$(printf '%s' "$stdout" | jq -r '.hookSpecificOutput.permissionDecisionReason // empty' 2>/dev/null || true)
+    assert_eq "$label_prefix hookEventName" "PreToolUse" "$event_name"
+    assert_eq "$label_prefix permissionDecision" "deny" "$decision"
+    assert_contains "$reason" "$expected_reason" "$label_prefix permissionDecisionReason mentions $expected_reason"
 }
 
 # run_hook <cwd> <stdin_bytes> [<path_override>]
@@ -186,20 +210,25 @@ assert_empty "$HOOK_STDOUT" "[case 1] stdout empty"
 echo ""
 echo "=== 2: Deny submodule file ==="
 run_hook "$SUPER" "$(json_payload "$SUB/any.txt")"
-assert_eq "[case 2] exit code" 2 "$RC"
-assert_contains "$HOOK_STDOUT" "submodule" "[case 2] stdout mentions submodule"
-assert_contains "$HOOK_STDOUT" "sub" "[case 2] stdout names submodule path"
+assert_eq "[case 2] exit code" 0 "$RC"
+assert_deny_json "$HOOK_STDOUT" "submodule" "[case 2]"
+# Submodule path name also surfaces in the reason — verify via a jq read.
+case2_reason=$(printf '%s' "$HOOK_STDOUT" | jq -r '.hookSpecificOutput.permissionDecisionReason // empty' 2>/dev/null || true)
+assert_contains "$case2_reason" "sub" "[case 2] reason names submodule path"
 
 # --- Case 3: Bypass (known-failing until #150) — cwd inside submodule ------
-# Tri-state fingerprint: post-fix (RC=2, stdout contains "submodule") → PASS.
-# Legacy-buggy (RC=0, empty stdout) → KNOWN-FAIL, non-fatal, EXPECTED_FAIL++.
-# Anything else → HARD FAIL. Auto-flips to PASS when #150 lands correctly.
+# Tri-state fingerprint: post-fix (RC=0, parseable deny JSON whose reason
+# mentions "submodule") → PASS. Legacy-buggy (RC=0, empty stdout) → KNOWN-FAIL,
+# non-fatal, EXPECTED_FAIL++. Anything else → HARD FAIL. Auto-flips to PASS
+# when #150 lands correctly.
 echo ""
 echo "=== 3: Bypass — cwd inside submodule (known-failing until #150) ==="
 run_hook "$SUB" "$(json_payload "$SUB/any.txt")"
 post_fix_match=0
 legacy_match=0
-if [[ $RC -eq 2 && "$HOOK_STDOUT" == *"submodule"* ]]; then
+case3_reason=$(printf '%s' "$HOOK_STDOUT" | jq -r '.hookSpecificOutput.permissionDecisionReason // empty' 2>/dev/null || true)
+case3_decision=$(printf '%s' "$HOOK_STDOUT" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null || true)
+if [[ $RC -eq 0 && "$case3_decision" == "deny" && "$case3_reason" == *"submodule"* ]]; then
     post_fix_match=1
 fi
 if [[ $RC -eq 0 && -z "$HOOK_STDOUT" ]]; then
@@ -221,8 +250,8 @@ fi
 echo ""
 echo "=== 4: Deny new file under submodule (ancestor walk) ==="
 run_hook "$SUPER" "$(json_payload "$SUB/does/not/exist/x.txt")"
-assert_eq "[case 4] exit code" 2 "$RC"
-assert_contains "$HOOK_STDOUT" "submodule" "[case 4] stdout mentions submodule"
+assert_eq "[case 4] exit code" 0 "$RC"
+assert_deny_json "$HOOK_STDOUT" "submodule" "[case 4]"
 
 # --- Case 5: Allow — nested non-submodule repo -----------------------------
 # Nested repo has a .git but no submodule pointer; the hook's
@@ -273,8 +302,8 @@ if (( mini_bin_ok )); then
         echo "  SKIP: [case 7] jq still resolvable under restricted PATH (unexpected shell builtin?)" >&2
     else
         run_hook "$SUPER" "$(json_payload "$SUPER/README.md")" "$MINI_BIN"
-        assert_eq "[case 7] exit code" 2 "$RC"
-        assert_contains "$HOOK_STDOUT" "jq" "[case 7] stdout mentions jq"
+        assert_eq "[case 7] exit code" 0 "$RC"
+        assert_deny_json "$HOOK_STDOUT" "jq" "[case 7]"
     fi
 fi
 
@@ -282,9 +311,9 @@ fi
 echo ""
 echo "=== 8: Fail-closed — bad JSON stdin ==="
 run_hook "$SUPER" "this is not json at all"
-assert_eq "[case 8] exit code" 2 "$RC"
-# Parser failure message includes "blocking as precaution"; substring check.
-assert_contains "$HOOK_STDOUT" "blocking" "[case 8] stdout indicates fail-closed"
+assert_eq "[case 8] exit code" 0 "$RC"
+# Parser failure reason includes "blocking as precaution"; substring check.
+assert_deny_json "$HOOK_STDOUT" "blocking" "[case 8]"
 
 # --- Case 9: Fail-open — cwd outside any git repo --------------------------
 # Hook's `git rev-parse --show-toplevel` returns empty when the *caller* is
@@ -309,8 +338,8 @@ assert_empty "$HOOK_STDOUT" "[case 9b] stdout empty"
 echo ""
 echo "=== 10: Fail-closed — non-absolute file_path ==="
 run_hook "$SUPER" '{"tool_input":{"file_path":"relative/path.txt"}}'
-assert_eq "[case 10] exit code" 2 "$RC"
-assert_contains "$HOOK_STDOUT" "absolute" "[case 10] stdout mentions non-absolute path"
+assert_eq "[case 10] exit code" 0 "$RC"
+assert_deny_json "$HOOK_STDOUT" "absolute" "[case 10]"
 
 # --- Summary --------------------------------------------------------------
 echo ""


### PR DESCRIPTION
## Summary

- Switched `scripts/block-submodule-edit.sh` deny channel from the spec-violating "exit 2 + stdout reason" shape to Anthropic's documented `hookSpecificOutput` JSON deny shape on stdout with exit 0, aligning with the PreToolUse contract where exit 2 routes stderr (not stdout) to Claude.
- Hardened `block()` with a static-JSON fallback for rare `jq` runtime failures and moved the `jq` availability probe ahead of every `block()` call; updated the regression harness to parse stdout with `jq` and assert all three deny-JSON fields.

<details><summary>Architecture Diagram</summary>

Quick mode — architecture diagram skipped.

</details>

<details><summary>Code Flow Diagram</summary>

Quick mode — code flow diagram skipped.

</details>

<details><summary>Goal</summary>

- Align `scripts/block-submodule-edit.sh`'s deny channel with Anthropic's documented PreToolUse hook contract
  - Replace spec-violating "exit 2 + stdout reason" emit with `hookSpecificOutput` JSON on stdout + exit 0
  - Include all three required fields: `hookEventName=PreToolUse`, `permissionDecision=deny`, `permissionDecisionReason=<why>`
  - Add `# See: <Anthropic docs URL>` doc-pointer comment near `block()`
  - Update the script header to document the new contract
- Preserve deny behavior at every call site (no logic change — only the channel changes)
  - jq missing → deny
  - stdin parse failure → deny
  - non-absolute `file_path` → deny
  - submodule deny (the core policy) → deny
  - canonicalization ancestor failures → still fail-open per existing policy
- Extend the regression harness so it asserts the new contract rather than the old one
  - Deny cases assert: exit 0 + parseable JSON with correct `hookEventName`, `permissionDecision`, `permissionDecisionReason` substring
  - Allow cases continue asserting exit 0 + empty stdout
  - Case 3's tri-state bypass fingerprint auto-distinguishes post-fix JSON from legacy empty stdout
- Acceptance: `make lint` passes (including the `test-block-submodule` regression target)
- Closes #151

</details>

<details><summary>Test plan</summary>

- [x] `bash scripts/test-block-submodule-edit.sh` — 31 hard assertions pass, 1 known-fail for #150
- [x] `/relevant-checks` — shellcheck + agent-lint clean
- [x] CI passes

</details>

<details><summary>Final Design</summary>

**Files modified**:
1. `scripts/block-submodule-edit.sh` — rewrote `block()` to emit `hookSpecificOutput` JSON via `jq -cn --arg reason`; added static-JSON fallback on jq runtime failure; moved jq availability probe ahead of every `block()` call with a hardcoded JSON literal for the missing-jq path; updated header comment to describe the new contract; added `# See:` doc-pointer.
2. `scripts/test-block-submodule-edit.sh` — added `assert_deny_json` helper with empty-needle guard; rewrote deny-case assertions (cases 2, 3, 4, 7, 8, 10) to check exit 0 + parseable JSON with three fields; preserved allow-case assertions unchanged; updated case 3's tri-state fingerprint and HARD FAIL message; rewrote case-7 mini-bin comments to reflect jq-first probe ordering.

**Approach rationale**: Moving the `jq` check ahead of `block()` is required because `block()` now depends on `jq`. For the missing-jq path we emit a hardcoded JSON literal (no escaping concerns — the reason string is a fixed compile-time constant). For the rare case where jq passes the initial probe but fails inside `block()`, the `|| printf` fallback emits a static deny JSON so a broken jq never degrades to exit 0 + empty stdout (which the runtime would interpret as allow, silently weakening the submodule policy).

**Edge cases**: Case 7 (missing jq) still exercises the jq-missing path because the test harness's restricted PATH only affects the hook subprocess — the harness itself retains jq to validate the deny JSON the hook emits.

</details>

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `a6f0d3e` (Add regression harness for scripts/block-submodule-edit.sh (closes #149) (#167))
- **Current version**: `4.0.3`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `4.0.4`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH").

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

Quick mode — no plan review was conducted.

</details>

<details><summary>Implementation Deviations</summary>

The implementation followed the inline plan precisely. Two small additions emerged during code review (round 1 and round 2):
1. `block()` gained a `|| printf` fallback for rare jq runtime failures (round 1 finding 1).
2. `assert_deny_json` gained an empty-needle guard (round 2 finding 4).

Both are defensive hardening beyond the original plan scope; neither changed the contract or the test-pass expectation.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

### [Code Review] Cursor (round 1)
**Finding**: scripts/block-submodule-edit.sh:5-9 (behavioral contract) — Deny is no longer signaled by non-zero exit and plain-text stdout; it is exit 0 plus Anthropic's JSON shape. Anything outside this repo that assumed `exit 2` + message text will mis-handle results until updated. Suggested: call this out in release/consumer notes and adjust any local wrappers or CI that branched on exit code 2.
**Reason not implemented**: This behavior change is the entire point of the issue (#151). The hook is consumed only by the Claude Code PreToolUse runtime, whose spec documents both the exit-2-stderr shape and the hookSpecificOutput JSON shape as valid deny channels. No local wrappers or CI in this repo branch on the hook's exit code — the only caller is the runtime itself via `hooks/hooks.json`. A release note would describe a non-event from every consumer's perspective. The commit message already explains the rationale for anyone inspecting git history.

### [Code Review] Cursor (round 3) — CHANGELOG callout
**Finding**: scripts/block-submodule-edit.sh (behavior) — Deny is no longer signaled by non-zero exit + plaintext stdout; it is exit 0 + hookSpecificOutput JSON. The branch diff touches only the two scripts; there is no CHANGELOG / README note for consumers who may have wrapped this hook and keyed off exit code 2 or non-JSON stdout.
**Reason not implemented**: `/implement` Step 8a automatically updates `CHANGELOG.md` with the PR's Summary bullets, and the Summary captures the channel change. A bespoke hand-written note would duplicate the auto-generated entry. The only consumer of this hook in the repo is Claude Code itself via `hooks/hooks.json`, and Claude Code's runtime supports both deny channels per Anthropic's spec. External wrappers outside this repo do not exist for the submodule-edit hook — it is a repo-internal guard.

### [Code Review] Cursor (round 3) — static-fallback drops real reason
**Finding**: scripts/block-submodule-edit.sh:26-32 — If jq passes the initial probe but fails inside `block()`, the `|| printf` path emits a fixed `permissionDecisionReason` and drops the real `$1` reason (e.g. the submodule path). Deny stays fail-closed; operability and debugging degrade.
**Reason not implemented**: The reviewer themselves note "Accept as documented limitation, or add a tiny note in the static fallback string" and "a heavier fix is shell-level JSON escaping for `$1` when jq fails (usually not worth the complexity)." The fail-closed static reason `"submodule edit guard: deny (jq runtime failure)"` already signals the failure mode explicitly — an operator sees the exact class of bug to investigate. Escaping `$1` as JSON in pure shell (quotes, backslashes, control chars) correctly is non-trivial and purpose-defeating: we fell back specifically because the JSON generator failed. The rare jq-runtime-failure branch is acceptable as-is.

### [Code Review] Cursor (round 3) — factor static deny JSON helper
**Finding**: scripts/block-submodule-edit.sh:32 and :40 — The static deny JSON schema appears twice (runtime jq failure inside `block()`, and missing-jq prologue). Future field renames need two edits, inviting drift.
**Reason not implemented**: The natural abstraction for reason-parameterized deny JSON already exists — `block()` itself — but cannot be used in either static-fallback context (the whole point is that jq is unavailable or broken). A pure-shell helper for an uncompiled static string is effectively a literal constant with marginal indirection savings. The two occurrences live adjacent to each other in the same file (inside `block()` and inside the jq-missing gate), making drift easy to catch on any future rename. The cost/benefit of extracting a helper is negative for two occurrences of an immutable literal.

### [Code Review] Cursor (round 2)
**Finding**: scripts/test-block-submodule-edit.sh case 3 post-fix fingerprint (around lines 229–231 at review time) — The "post-fix" match in the tri-state check verifies `permissionDecision == "deny"` and the reason contains "submodule" but does NOT verify `hookEventName == "PreToolUse"` like `assert_deny_json` does. A malformed or partial stdout could theoretically satisfy the looser check. Suggested: reuse `assert_deny_json` (or a shared predicate) for case 3 when it flips to a hard assertion after #150 lands.
**Reason not implemented**: Case 3 is a tri-state fingerprint (post-fix / legacy-buggy / hard-fail) whose structure depends on an OR of discrete predicates and `EXPECTED_FAIL++` accounting — it cannot directly reuse `assert_deny_json`, which increments `PASS`/`FAIL` unconditionally. Adding an extra `hookEventName == "PreToolUse"` condition to the post-fix predicate is a no-op in practice: every piece of deny output in this codebase comes from a single `jq -cn` generator (or a single static JSON literal for the missing-jq branch), both of which always populate hookEventName. A "malformed but decision-valid" stdout is therefore not a real scenario. The reviewer themselves flag this as "unlikely in practice." When #150 lands and case 3 flips to a hard assertion, `assert_deny_json` will be the right tool at that point — filing that as future work rather than pre-emptively complicating the tri-state now.

</details>

<details><summary>Plan Review Voting Tally</summary>

Quick mode — no plan review voting.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

Quick mode — no voting panel. Main agent reviewed findings across up to 7 single-reviewer rounds (Cursor → Codex → Claude fallback chain).

</details>

<details><summary>Out-of-Scope Observations</summary>

**Accepted OOS (GitHub issues filed):**
No OOS items were accepted for issue filing.

**Non-accepted OOS observations:**
Quick mode — no reviewer voting panel. Main-agent OOS items (if any) are auto-filed per policy; see Accepted OOS above.

</details>

<details><summary>Execution Issues</summary>

No execution issues encountered.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | N/A (quick mode) |
| Code review rounds | 4 (3 with findings, round 4 clean) |
| Code review findings | 4 accepted, 5 rejected |
| Warnings logged | 0 |
| Pre-existing issues noticed | 0 |
| OOS issues filed | 0 |
| External reviewers | N/A (quick mode) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
