### PR TITLE
Fix #166: resolve file_path symlinks before submodule classification

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "4.0.6",
+  "version": "4.0.7",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.7] - 2026-04-19
+
+### Fixed
+
+- `scripts/block-submodule-edit.sh` now resolves `tool_input.file_path` through any symlink chain before repo classification, closing the bypass where a symlink in the superproject pointing into a submodule was allowed (the hook previously canonicalized only the containing directory via `pwd -P` and never resolved the `file_path` itself). Implementation is a bounded-depth (40-hop) pure-bash `readlink` loop inserted after `REPO_ROOT` canonicalization and before the ancestor walk — non-symlink inputs pass through unchanged, so all prior allow / deny behavior is preserved. macOS ships without `readlink -f` / `realpath` so the loop avoids them; relative readlink targets are rebased against the link's own directory. Fail-closed via the existing `block()` helper on depth-cap exhaustion (possible cycle), `readlink` failure, or empty target. `scripts/test-block-submodule-edit.sh` gains three strict regression cases: case 11 (absolute symlink into submodule → deny), case 12 (self-referential symlink cycle → deny via depth cap), case 13 (relative symlink into submodule → deny, exercises the `$(dirname "$resolved")/$target` rebasing branch); the top-of-file fixture comment block lists the three new symlinks. Closes #166.
+
 ## [4.0.6] - 2026-04-19
 
 ### Added

--- a/scripts/block-submodule-edit.sh
+++ b/scripts/block-submodule-edit.sh
@@ -70,6 +70,35 @@ REPO_ROOT=$(cd "$REPO_ROOT" 2>/dev/null && pwd -P) || {
   exit 0
 }
 
+# --- Resolve file_path through any symlink chain ---
+# macOS has no readlink -f / realpath by default; use a pure-bash loop.
+# Bounded depth (40) doubles as a cycle detector (fail-closed on exhaustion).
+# Relative readlink targets are rebased against the link's own directory
+# (follows each hop; does not perform full lexical `..` normalization — the
+# kernel resolves `..` at lstat time, and PROBE_DIR is canonicalized below).
+# Placed after REPO_ROOT so non-git callers still fail-open (issue #166).
+# Only activates when the path is itself a symlink; non-symlink inputs pass
+# through unchanged.
+resolved="$FILE_PATH"
+max_depth=40
+depth=0
+while [[ -L "$resolved" ]]; do
+  if (( depth >= max_depth )); then
+    block "submodule edit guard: symlink resolution exceeded $max_depth hops (possible cycle), blocking as precaution"
+  fi
+  target=$(readlink "$resolved" 2>/dev/null) \
+    || block "submodule edit guard: readlink failed on '$resolved', blocking as precaution"
+  [[ -n "$target" ]] \
+    || block "submodule edit guard: readlink returned empty target for '$resolved', blocking as precaution"
+  if [[ "$target" == /* ]]; then
+    resolved="$target"
+  else
+    resolved="$(dirname "$resolved")/$target"
+  fi
+  depth=$((depth + 1))
+done
+FILE_PATH="$resolved"
+
 # --- Find the nearest existing ancestor of the target path ---
 # Handles Write to a new file in a new subdirectory inside a submodule.
 PROBE_PATH="$FILE_PATH"

--- a/scripts/test-block-submodule-edit.sh
+++ b/scripts/test-block-submodule-edit.sh
@@ -14,7 +14,10 @@
 #   $TMPROOT/super      — superproject
 #     sub/              — submodule (added via `git submodule add file://...`)
 #     nested/           — standalone nested repo, NOT registered as a submodule
-#     symlink-file      — symlink → super/README.md
+#     symlink-file      — symlink → super/README.md (case 6)
+#     outside-link      — symlink → sub/any.txt, absolute target (case 11)
+#     cycle-link        — symlink → itself, self-referential cycle (case 12)
+#     relative-link     — symlink → sub/any.txt, relative target (case 13)
 #   $TMPROOT/nonrepo    — ordinary directory outside any git repo
 #
 # Deny channel: the hook always exits 0 and emits Anthropic's hookSpecificOutput
@@ -198,6 +201,15 @@ git -C "$NESTED" commit -m 'nested' >/dev/null
 # asserts the hook allows it (target canonicalizes into the superproject).
 ln -s "$SUPER/README.md" "$SUPER/symlink-file"
 
+# Symlinks exercising the symlink-resolution loop added for issue #166.
+# Case 11: absolute symlink into the submodule — must now deny.
+# Case 12: self-referential cycle — must deny via the bounded-depth branch.
+# Case 13: relative symlink into the submodule — exercises the
+#          `$(dirname "$resolved")/$target` rebasing branch.
+ln -s "$SUB/any.txt" "$SUPER/outside-link"
+ln -s "$SUPER/cycle-link" "$SUPER/cycle-link"
+ln -s "sub/any.txt" "$SUPER/relative-link"
+
 # Non-repo directory outside any git repo. Case 9 runs the hook from here.
 mkdir -p "$NONREPO"
 
@@ -355,6 +367,38 @@ echo "=== 10: Fail-closed — non-absolute file_path ==="
 run_hook "$SUPER" '{"tool_input":{"file_path":"relative/path.txt"}}'
 assert_eq "[case 10] exit code" 0 "$RC"
 assert_deny_json "$HOOK_STDOUT" "absolute" "[case 10]"
+
+# --- Case 11: Deny — absolute symlink in superproject pointing into submodule (issue #166) ---
+# Without the symlink-resolution loop, the hook classified outside-link's
+# dirname ($SUPER) as the repo and allowed the edit, bypassing the submodule
+# guard. The loop resolves outside-link → $SUB/any.txt before the ancestor
+# walk; classification then correctly lands in the submodule. Strict, not
+# tri-state.
+echo ""
+echo "=== 11: Deny symlink into submodule (absolute target, issue #166) ==="
+run_hook "$SUPER" "$(json_payload "$SUPER/outside-link")"
+assert_eq "[case 11] exit code" 0 "$RC"
+assert_deny_json "$HOOK_STDOUT" "submodule" "[case 11]"
+
+# --- Case 12: Deny — self-referential symlink cycle (fail-closed depth cap) --
+# Exercises the new bounded-depth branch (max_depth=40 hops). The deny reason
+# contains "symlink" so assert_deny_json matches only that branch.
+echo ""
+echo "=== 12: Deny self-referential symlink cycle (fail-closed depth cap) ==="
+run_hook "$SUPER" "$(json_payload "$SUPER/cycle-link")"
+assert_eq "[case 12] exit code" 0 "$RC"
+assert_deny_json "$HOOK_STDOUT" "symlink" "[case 12]"
+
+# --- Case 13: Deny — relative symlink into submodule (relative-rebase branch) ---
+# Exercises `$(dirname "$resolved")/$target` — the trickiest branch of the
+# resolution loop. relative-link → sub/any.txt (relative target) must be
+# rebased against $SUPER (the link's own directory) to $SUPER/sub/any.txt,
+# which lands in the submodule.
+echo ""
+echo "=== 13: Deny symlink into submodule (relative target, issue #166) ==="
+run_hook "$SUPER" "$(json_payload "$SUPER/relative-link")"
+assert_eq "[case 13] exit code" 0 "$RC"
+assert_deny_json "$HOOK_STDOUT" "submodule" "[case 13]"
 
 # --- Summary --------------------------------------------------------------
 echo ""


### PR DESCRIPTION
## Summary
- Closed the symlink-based bypass in `scripts/block-submodule-edit.sh` (issue #166): the hook previously canonicalized only the containing directory via `pwd -P`, so a symlink in the superproject pointing into a submodule was classified as a superproject edit and allowed.
- Added a bounded-depth (40 hops) pure-bash `readlink` resolution loop after `REPO_ROOT` canonicalization and before the ancestor walk; fail-closed on depth cap, `readlink` failure, or empty target. Non-symlink inputs flow through unchanged.
- Added three strict regression cases (11/12/13) to `scripts/test-block-submodule-edit.sh` covering absolute, cyclic, and relative symlink variants.

<details><summary>Architecture Diagram</summary>

```mermaid
flowchart TD
    Start([Edit/Write tool input]) --> StdinJQ{Read stdin via jq<br/>parse file_path}
    StdinJQ -->|missing or empty| Exit0a([exit 0 — allow])
    StdinJQ -->|not absolute| BlockAbs[block: not absolute]
    StdinJQ -->|absolute| RepoRoot{git rev-parse --show-toplevel<br/>from cwd}
    RepoRoot -->|empty — not in repo| Exit0b([exit 0 — fail-open])
    RepoRoot -->|non-empty| CanonRoot[REPO_ROOT = pwd -P]

    CanonRoot --> NewLoop[/"NEW: Symlink resolution loop<br/>while [[ -L resolved ]]<br/>• bounded depth 40<br/>• relative target rebased via dirname<br/>• block on cap / readlink fail / empty target"/]
    NewLoop -->|chain exceeded 40 hops| BlockCycle[block: cycle / depth cap]
    NewLoop -->|readlink failed or empty target| BlockReadlink[block: readlink error]
    NewLoop -->|resolved to non-symlink| Walk[Ancestor walk<br/>while not exist: dirname]

    Walk --> ProbeDir[PROBE_DIR = dirname if file<br/>else PROBE_PATH]
    ProbeDir --> CanonDir[PROBE_DIR = cd && pwd -P]
    CanonDir --> FileRepo{git -C PROBE_DIR<br/>rev-parse --show-toplevel}
    FileRepo -->|empty — not in repo| Exit0c([exit 0 — allow])
    FileRepo -->|same as REPO_ROOT| Exit0d([exit 0 — allow])
    FileRepo -->|different| SuperProject{show-superproject<br/>-working-tree}
    SuperProject -->|empty — nested non-submodule| Exit0e([exit 0 — allow])
    SuperProject -->|matches REPO_ROOT| BlockSub[block: submodule edit]

    style NewLoop fill:#fff3cd,stroke:#ff9800,stroke-width:2px
    style BlockCycle fill:#f8d7da
    style BlockReadlink fill:#f8d7da
    style BlockSub fill:#f8d7da
    style BlockAbs fill:#f8d7da
```

</details>

<details><summary>Code Flow Diagram</summary>

```mermaid
sequenceDiagram
    participant Caller as Edit/Write call
    participant Hook as block-submodule-edit.sh
    participant Loop as Symlink resolve loop
    participant Walk as Ancestor walk
    participant Git as git rev-parse

    Caller->>Hook: stdin = {"tool_input":{"file_path": P}}
    Hook->>Hook: jq check → require absolute path
    Hook->>Git: git rev-parse (from cwd)
    Git-->>Hook: REPO_ROOT or empty
    alt REPO_ROOT empty
        Hook-->>Caller: exit 0 (fail-open, non-git)
    else REPO_ROOT set
        Hook->>Hook: cd+pwd -P canonicalize REPO_ROOT
        Note over Loop: NEW (issue #166)
        Hook->>Loop: resolved = FILE_PATH
        loop while [[ -L "$resolved" ]]  (bound=40)
            Loop->>Loop: check depth < 40 else block()
            Loop->>Loop: target = readlink (empty/err → block)
            alt target absolute
                Loop->>Loop: resolved = target
            else target relative
                Loop->>Loop: resolved = dirname(resolved)/target
            end
            Loop->>Loop: depth++
        end
        Loop->>Hook: FILE_PATH = resolved
        Hook->>Walk: ancestor walk dirname until -e
        Walk->>Walk: PROBE_DIR = cd+pwd -P
        Walk->>Git: git -C PROBE_DIR rev-parse
        Git-->>Walk: FILE_REPO_ROOT
        alt FILE_REPO_ROOT empty OR == REPO_ROOT
            Walk-->>Caller: exit 0 (allow)
        else different repo
            Walk->>Git: show-superproject-working-tree
            alt no superproject OR != REPO_ROOT
                Walk-->>Caller: exit 0 (allow, nested repo)
            else superproject == REPO_ROOT
                Walk-->>Caller: block() → exit 0 + deny JSON
            end
        end
    end
```

</details>

<details><summary>Goal</summary>

- Close the symlink-based bypass reported in issue #166: a symlink in the superproject pointing into a submodule must be blocked, not allowed.
- Preserve the hook's documented contracts:
  - Fail-open when the caller cwd is outside any git repo.
  - Allow symlinks that resolve into the superproject (case 6).
  - Allow edits inside nested non-submodule repos (case 5).
  - Byte-identical behavior for non-symlink paths (cases 1–10).
- Preserve the hook's fail-closed posture for security-sensitive ambiguity:
  - Depth-cap exhaustion (possible cycle) → block.
  - `readlink` failure → block.
  - Empty `readlink` target → block.
- Remain portable: no dependency on `readlink -f`, `realpath`, or `greadlink` (macOS default bash 3.2 + BSD userland).
- Keep the scope surgical: only `scripts/block-submodule-edit.sh` + its regression harness change. `AGENTS.md` contract is unchanged.
- Add strict regression coverage for the three distinct resolver branches:
  - Absolute symlink target (case 11).
  - Self-referential cycle (case 12).
  - Relative symlink target (case 13).

</details>

<details><summary>Test plan</summary>

- [x] `bash scripts/test-block-submodule-edit.sh` — all 43 hard assertions pass; 1 known-fail (case 3, tracked by #150, unrelated).
- [x] `/relevant-checks` — shellcheck + agent-lint pass.
- [x] Existing cases 1–10 unchanged (behavior-preservation verified by passing assertions).
- [x] Case 6 (symlink into superproject) still allows (pre-existing test continues to pass).
- [x] Case 11 (absolute symlink into submodule) denies with reason containing "submodule".
- [x] Case 12 (self-referential cycle) denies with reason containing "symlink".
- [x] Case 13 (relative symlink into submodule) denies with reason containing "submodule".
- [x] CI `make lint` wiring unchanged — cases append to the same harness script wired via the existing `test-block-submodule` target.

</details>

<details><summary>Final Design</summary>

**Files modified**:
1. `scripts/block-submodule-edit.sh` — inserted an inline pure-bash symlink resolution loop immediately after `REPO_ROOT` canonicalization (line 71) and before `PROBE_PATH="$FILE_PATH"` (line 75 in the pre-patch file).
2. `scripts/test-block-submodule-edit.sh` — updated the top-of-file fixture comment; added fixture-bootstrap lines for the three new symlinks; added cases 11, 12, 13.

**No other files**. `AGENTS.md` contract ("deny submodule edits") is unchanged; this closes a gap in enforcement.

**Approach** (final, post-review):

```bash
# --- Resolve file_path through any symlink chain ---
resolved="$FILE_PATH"
max_depth=40
depth=0
while [[ -L "$resolved" ]]; do
  if (( depth >= max_depth )); then
    block "submodule edit guard: symlink resolution exceeded $max_depth hops (possible cycle), blocking as precaution"
  fi
  target=$(readlink "$resolved" 2>/dev/null) \
    || block "submodule edit guard: readlink failed on '$resolved', blocking as precaution"
  [[ -n "$target" ]] \
    || block "submodule edit guard: readlink returned empty target for '$resolved', blocking as precaution"
  if [[ "$target" == /* ]]; then
    resolved="$target"
  else
    resolved="$(dirname "$resolved")/$target"
  fi
  depth=$((depth + 1))
done
FILE_PATH="$resolved"
```

**Placement rationale**: After `REPO_ROOT` canonicalization preserves the hook's fail-open-for-non-git contract (a cycle in a non-git context still falls through to the early-exit at line 66).

**Edge cases**:
- Absolute readlink target → replaces `resolved` outright.
- Relative target → rebased against `dirname "$resolved"` (the link's own directory). Follows each hop; does not perform full lexical `..` normalization — the kernel resolves `..` at `lstat` time, and `PROBE_DIR` is canonicalized via `cd ... && pwd -P` for downstream comparisons.
- Depth cap / `readlink` failure / empty target → `block()` fail-closed with precise reason.
- Broken symlink (target doesn't exist) → loop terminates when `-L` becomes false; non-existent path flows into ancestor walk like any other new-file path.
- Non-symlink input → `-L` false immediately; `FILE_PATH` unchanged. Byte-identical for cases 1–10.
- Non-git caller → early-exit at line 66 runs before the loop (per placement); loop only executes for callers in a git repo.
- Case 6 symlink-to-superproject → resolves into superproject; classification allows.

**Failure modes**:
1. Bash 3.2 portability on macOS — all constructs (`[[ -L ]]`, `readlink`, `dirname`, `(( ))`, `== /*`) are 3.2-safe.
2. Whitespace-in-paths — quoted assignments and quoted `dirname` args handle correctly.
3. Symlink TOCTOU — same class as existing `pwd -P` / `git rev-parse` calls; not in scope.

**Testing strategy**: TDD via case 11 first, then 12/13; existing cases 1–10 guard behavior preservation.

</details>

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `1f51765` (Document Skill(name) vs Skill(plugin:name) permissions convention (closes #161) (#170))
- **Current version**: `4.0.6`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `4.0.7`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH").

**Escalation review**: diff only touches `scripts/**`; no public-surface behavior change. PATCH stands.

**Note**: Bumped 4.0.5 → 4.0.6 initially; rebased onto latest main after #170 landed as 4.0.6, re-bumped to 4.0.7.

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

**FINDING_4** (Codex, architecture — 3 EXONERATE): Fail-closed on cycle widens the hook's documented contract beyond "block only true submodules"; Codex suggested falling back to ancestor-walk classification on resolution exhaustion. Not implemented because the concern is legitimate but the proposed fix substantially complicates the resolution loop with its own correctness risks (which path to re-classify?), the user's original spec explicitly requested fail-closed on cycle, and fail-closed is the defensible guard-hook posture. Follow-up issue can revisit if real-world complaints surface.

**FINDING_6** (Code, correctness — 3 EXONERATE): Relative-target rebasing does not collapse `..` segments; theoretically accumulated path could approach PATH_MAX. Not implemented because the design already fail-closes on `readlink` ENAMETOOLONG, and a pure-bash `..`-collapser would be more code than the entire loop it augments for a scenario with no concrete reproducer.

**FINDING_7** (Cursor, code-quality — 2 NO 1 EXONERATE): CHANGELOG.md historically described the harness as "covering 11 cases"; adding cases 11–13 creates narrative drift. Rejected: CHANGELOG.md is historical release documentation; the new 4.0.6 entry describes the expanded coverage.

</details>

<details><summary>Implementation Deviations</summary>

None. Implementation matches the revised plan exactly — all four accepted plan-review findings (FINDING_1 insertion point, FINDING_2 empty-target guard, FINDING_3 relative-hop case 13, FINDING_5 softened wording) were incorporated before coding began.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

All code review reviewers returned zero in-scope findings (Cursor: NO_ISSUES_FOUND; Codex: NO_ISSUES_FOUND; Claude Code Reviewer: zero in-scope). Two OOS nits from the Claude Code Reviewer — both pre-existing and not introduced by this PR, not worth filing as issues:
- `scripts/block-submodule-edit.sh:19` — `set -uo pipefail` (without `-e`) lacks an inline comment explaining the intentional omission. Pre-existing.
- `scripts/test-block-submodule-edit.sh:209` — new symlinks target `$SUB/any.txt` which does not exist in the submodule fixture; works because the ancestor walk handles non-existent targets (same pattern as pre-existing case 2). Pre-existing naming convention.

</details>

<details><summary>Plan Review Voting Tally</summary>

| Finding | Cursor | Codex | Code | Tally | Outcome |
|---------|--------|-------|------|-------|---------|
| FINDING_1: Move insertion after REPO_ROOT canonicalization | YES | YES | YES | 3Y | ACCEPTED |
| FINDING_2: Empty-target defensive check | YES | YES | NO  | 2Y 1N | ACCEPTED |
| FINDING_3: Relative-hop regression test | YES | YES | YES | 3Y | ACCEPTED |
| FINDING_4: Cycle deny widens contract (fallback to ancestor-walk) | EXON | EXON | EXON | 3E | Exonerated |
| FINDING_5: Soften "realpath -P semantics" wording | YES | YES | YES | 3Y | ACCEPTED |
| FINDING_6: PATH_MAX `..` normalization | EXON | EXON | EXON | 3E | Exonerated |
| FINDING_7: CHANGELOG drift | EXON | NO | NO | 2N 1E | Rejected |
| OOS_1: Document `-e` semantics for dangling symlinks | YES | NO | NO | 1Y 2N | Rejected |

**Reviewer Competition Scoreboard (plan review)**

| Reviewer | Accepted | Rejected (-1) | Exonerated (0) | Net |
|----------|----------|---------------|----------------|-----|
| Cursor   | F1, F2, F5 | — | F7 | **+3** |
| Codex    | F3 | — | F4 | **+1** |
| Code     | — | — | F6 | **0** |

(F1 had 3 co-proposers; credited to Cursor in the scoreboard column.)

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

No findings were raised — voting was not needed. All 3 reviewers returned zero in-scope findings:
- Code (Claude): 0 in-scope, 2 OOS pre-existing nits
- Codex: NO_ISSUES_FOUND
- Cursor: NO_ISSUES_FOUND

**Reviewer Competition Scoreboard (code review, round 1)**: all reviewers at Net 0 — no competition signal since nothing was voted on.

</details>

<details><summary>Dialectic Resolutions</summary>

Two decisions from the sketch-phase synthesis were contested and sent to dialectic adjudication (3-judge panel).

**DECISION_1 — helper function vs inline loop**: Inline the loop. Voted ANTI_THESIS 2-1 (Codex and Claude judges favored inline for a single-use linear preprocessor; Cursor favored helper for auditability). Inline with a block-scoped comment documents intent without adding call indirection.

**DECISION_2 — add symlink-cycle regression test**: Add case 12. Voted THESIS 3-0 (unanimous). The bounded-depth + cycle-detection branch is security-critical new logic that case 11 cannot exercise; the fixture is a one-liner.

</details>

<details><summary>Out-of-Scope Observations</summary>

**Accepted OOS (GitHub issues filed):**
No OOS items were accepted for issue filing.

**Non-accepted OOS observations:**
- **OOS_1 (Code, plan review)**: Document `-e` semantics in the ancestor walk at `scripts/block-submodule-edit.sh:75` (which follows symlinks and treats dangling symlinks as absent). After this PR's resolution loop lands, dangling symlinks are handled before the ancestor walk; the residual clarity gap does not rise to an issue-tracker entry. Voting: 1 YES (Cursor) / 2 NO (Codex, Code).
- **Code (code review OOS nits, both pre-existing)**: (a) `scripts/block-submodule-edit.sh:19` lacks an inline comment explaining why `-e` is intentionally omitted from `set -uo pipefail`; (b) `scripts/test-block-submodule-edit.sh:209` new symlinks target `$SUB/any.txt` which doesn't exist in the fixture (pre-existing pattern inherited from case 2).

</details>

<details><summary>Execution Issues</summary>

No execution issues encountered.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | 4 accepted, 3 rejected/exonerated |
| Code review rounds | 1 |
| Code review findings | 0 accepted, 0 rejected |
| Warnings logged | 0 |
| Pre-existing issues noticed | 2 (both OOS nits, not filed) |
| OOS issues filed | 0 |
| External reviewers | Cursor: ✅, Codex: ✅ |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
