### PR TITLE
Enable shellcheck source-following in pre-commit (closes #178)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "4.0.12",
+  "version": "4.0.13",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,7 @@ repos:
     rev: v0.10.0.1
     hooks:
       - id: shellcheck
+        args: [-x]
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.44.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.13] - 2026-04-19
+
+### Fixed
+
+- `.pre-commit-config.yaml`'s `shellcheck` hook gains `args: [-x]` so pre-commit instructs shellcheck to follow `source` directives, eliminating the SC1091 false-positive that fired when `/relevant-checks` (via `pre-commit run --files <subset>`) scoped shellcheck to consumers of `scripts/lib-count-commits.sh` (`scripts/check-bump-version.sh`, `scripts/verify-skill-called.sh`) without also including the library itself. CI's `make lint` (via `pre-commit run --all-files`) was unaffected because all files were always present. With `-x`, the file-subset path now matches the all-files behavior on source-following. Reproduces on unmodified main via `pre-commit run shellcheck --files scripts/check-bump-version.sh`. Closes #178.
+
 ## [4.0.12] - 2026-04-19
 
 ### Added


### PR DESCRIPTION
## Summary
- Added `args: [-x]` to the shellcheck hook in `.pre-commit-config.yaml` so pre-commit instructs shellcheck to follow `source` directives, matching CI's `pre-commit run --all-files` behavior.
- Eliminated the SC1091 false-positive that fired from `/relevant-checks` whenever the changed-file subset excluded `scripts/lib-count-commits.sh` but included a consumer (`scripts/check-bump-version.sh` or `scripts/verify-skill-called.sh`).
- Closes #178.

<details><summary>Architecture Diagram</summary>

Quick mode — architecture diagram skipped.

</details>

<details><summary>Code Flow Diagram</summary>

Quick mode — code flow diagram skipped.

</details>

<details><summary>Goal</summary>

- Eliminate SC1091 false-positive noise from `/relevant-checks` runs
  - Ensure file-subset shellcheck invocations follow the `# shellcheck source=` directive the same way all-files CI invocations do
  - Avoid diff-time triage burden on every PR touching `scripts/check-bump-version.sh` or `scripts/verify-skill-called.sh`
- Preserve parity between local `/relevant-checks`, `make lint`, and CI
  - No change to `make lint` semantics — the all-files run was already clean
  - Keep the fix minimal and surgical (single-line pre-commit config edit, per issue #178's preferred option (a))
- Close #178

</details>

<details><summary>Test plan</summary>

- [x] Reproduced SC1091 on unmodified main: `pre-commit run shellcheck --files scripts/check-bump-version.sh` → fails
- [x] After the fix, the same command passes
- [x] `pre-commit run shellcheck --files scripts/verify-skill-called.sh` → passes
- [x] `pre-commit run shellcheck --all-files` → passes (no new SC1091s surfaced by `-x` in other scripts)
- [x] `/relevant-checks` on the modified file — passes

</details>

<details><summary>Final Design</summary>

**Files to modify**: `.pre-commit-config.yaml` (single file).

**Change**: Add `args: [-x]` to the shellcheck hook entry so `pre-commit` instructs shellcheck to follow `source` directives the same way `shellcheck -x` does on the CLI.

**Why**: `scripts/check-bump-version.sh` and `scripts/verify-skill-called.sh` both `source` the shared library `scripts/lib-count-commits.sh` with a `# shellcheck source=scripts/lib-count-commits.sh` directive. Without `-x`, shellcheck refuses to follow the directive when the library isn't passed on the command line and emits SC1091, which surfaces as a hook failure. `make lint` runs `pre-commit run --all-files`, so the library is always included in the file list and SC1091 never fires in CI. The `/relevant-checks` skill runs `pre-commit run --files <subset>` on just the changed files — when the subset excludes the library (the common case for any PR touching only consumers), pre-commit cannot follow the source and fails.

**Testing strategy**: reproduce the failure before the fix; apply the fix; confirm the same command passes; run `make lint`/`all-files` shellcheck to confirm no regressions; run `/relevant-checks` to exercise the file-subset path that originally triggered the false positive.

**Edge cases**:
- `-x` follows all `source` directives globally, which could unmask new SC1091s in *other* scripts. Verified by running `pre-commit run shellcheck --all-files` post-fix — passed.
- `-x` may emit new warnings if a sourced file itself has shellcheck issues. `lib-count-commits.sh` is pre-existing and `make lint` already passes on it.

**Failure modes**:
- `args: [-x]` syntax wrong for pre-commit: verified by inspecting pre-commit's shellcheck-py mirror — `args` is the standard pre-commit hook field, forwarded to the underlying executable. Confirmed by re-running pre-commit after the change.

</details>

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `771294d` (Add lint for skills with Skill in allowed-tools but no invocation step (#181))
- **Current version**: `4.0.12`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `4.0.13`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH").

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

Quick mode — no plan review was conducted.

</details>

<details><summary>Implementation Deviations</summary>

No deviations from the plan.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

All code review suggestions were implemented.

</details>

<details><summary>Plan Review Voting Tally</summary>

Quick mode — no plan review voting.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

Quick mode — no voting panel. Main agent reviewed findings across up to 7 single-reviewer rounds (Cursor → Codex → Claude fallback chain).

</details>

<details><summary>Out-of-Scope Observations</summary>

**Accepted OOS (GitHub issues filed):**
No OOS items were accepted for issue filing.

**Non-accepted OOS observations:**
Quick mode — no reviewer voting panel. Main-agent OOS items (if any) are auto-filed per policy; see Accepted OOS above.

</details>

<details><summary>Execution Issues</summary>

No execution issues encountered.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | N/A (quick mode) |
| Code review rounds | 1 |
| Code review findings | 0 accepted, 0 rejected |
| Warnings logged | 0 |
| Pre-existing issues noticed | 0 |
| OOS issues filed | 0 |
| External reviewers | N/A (quick mode) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
