### PR TITLE
Fix #152: drop duplicate PreToolUse mirror from .claude/settings.json

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "4.0.13",
+  "version": "4.0.14",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -175,29 +175,5 @@
       "/tmp",
       "/var/folders"
     ]
-  },
-  "hooks": {
-    "PreToolUse": [
-      {
-        "matcher": "Edit",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "$PWD/scripts/block-submodule-edit.sh",
-            "timeout": 10
-          }
-        ]
-      },
-      {
-        "matcher": "Write",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "$PWD/scripts/block-submodule-edit.sh",
-            "timeout": 10
-          }
-        ]
-      }
-    ]
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ Plugin ships the entire repo. **Runtime surface**: `skills/`, `agents/`, `hooks/
 
 - Use `/bump-version` to change `.claude-plugin/plugin.json` version — it owns that commit; `Bump version to X.Y.Z` is a reserved commit message.
 - `skills/shared/reviewer-templates.md` is the canonical source for the Code Reviewer archetype. `agents/code-reviewer.md` is generated from it via `scripts/generate-code-reviewer-agent.sh` — do not hand-edit the agent file. Edit the template and run `bash scripts/generate-code-reviewer-agent.sh` to regenerate; the `agent-sync` CI job enforces that the committed agent file matches generator output.
-- Always respect `scripts/block-submodule-edit.sh`. If a hook blocks a write, investigate and resolve the underlying issue.
+- Always respect `scripts/block-submodule-edit.sh`. If a hook blocks a write, investigate and resolve the underlying issue. The guard ships via `hooks/hooks.json` only — `.claude/settings.json` no longer mirrors it, so contributors developing in this repo should load larch as a plugin (`claude --plugin-dir .` or the local marketplace) to pick up the guard.
 - After any change, run `/relevant-checks`.
 - `scripts/redact-secrets.sh` is the outbound secret-scrubbing filter invoked by `skills/issue/scripts/create-one.sh` before `gh issue create`. `scripts/test-redact-secrets.sh` is its regression test, wired into `make lint` via the `test-redact` target. Edit patterns only after reading `SECURITY.md`'s outbound-redaction subsection.
 - `skills/issue/scripts/parse-input.sh` parses `/issue` batch-mode input. `skills/issue/scripts/test-parse-input.sh` is its regression harness, wired into `make lint` via the `test-parse-input` target so parser regressions cannot ship undetected.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.14] - 2026-04-19
+
+### Fixed
+
+- `.claude/settings.json` no longer mirrors the `PreToolUse` submodule-guard registration; `hooks/hooks.json` (with `${CLAUDE_PLUGIN_ROOT}` paths) is now the single source of truth, eliminating possible double-invocation, policy drift between the two copies, and the `$PWD`-vs-anchored path question. Contributors developing in this repo should load larch as a plugin (`claude --plugin-dir .` or the local marketplace) to pick up the guard — `AGENTS.md` carries a one-line note to that effect. Closes #152.
+
 ## [4.0.13] - 2026-04-19
 
 ### Fixed


### PR DESCRIPTION
## Summary
- Dropped the duplicate `PreToolUse` submodule-guard `hooks` block from `.claude/settings.json`; `hooks/hooks.json` (with `${CLAUDE_PLUGIN_ROOT}` paths) is now the single registration.
- Extended the `block-submodule-edit.sh` bullet in `AGENTS.md` with a one-line note that contributors developing in this repo should load larch as a plugin (`claude --plugin-dir .` or the local marketplace) to pick up the guard.
- Closes #152.

<details><summary>Architecture Diagram</summary>

Quick mode — architecture diagram skipped.

</details>

<details><summary>Code Flow Diagram</summary>

Quick mode — code flow diagram skipped.

</details>

<details><summary>Goal</summary>

- Eliminate duplicate `PreToolUse` registration of `block-submodule-edit.sh`
  - Remove the dev-mirror `hooks` key from `.claude/settings.json` (lines 179–202) while preserving `permissions`, `defaultMode`, and `additionalDirectories`
  - Leave `hooks/hooks.json` unchanged as the authoritative registration (including its `SessionStart` entry)
- Close three concrete defects caused by the mirror
  - Possible double-invocation of the guard on every `Edit`/`Write`
  - Policy drift if one registration is updated without the other
  - The dev-mirror used `$PWD` (which can drift after `cd`) instead of an anchored path
- Keep the documentation story coherent
  - Extend `AGENTS.md`'s existing `block-submodule-edit.sh` bullet with a one-line note that the guard ships via `hooks/hooks.json` only and that contributors developing in this repo should load larch as a plugin (`claude --plugin-dir .` or the local marketplace) to pick up the guard
- Success criteria
  - `.claude/settings.json`'s `hooks` block removed; all other keys unchanged
  - `hooks/hooks.json` byte-identical to HEAD
  - `AGENTS.md` carries the one-liner
  - `make lint` passes

</details>

<details><summary>Test plan</summary>

- [x] `make lint` / `/relevant-checks` pass (shellcheck, markdownlint, jq, agent-lint, skill-invocation lint).
- [x] `.claude/settings.json` remains valid JSON after the `hooks` block removal; no other keys changed.
- [x] `hooks/hooks.json` unchanged (byte-identical to HEAD — diff touches only `.claude/settings.json`, `AGENTS.md`, `.claude-plugin/plugin.json`, `CHANGELOG.md`).
- [ ] Manual: load larch as a plugin (`claude --plugin-dir .` or local marketplace) and confirm via `/hooks` inside a Claude Code session that the submodule guard is still listed with a `Plugin` source.

</details>

<details><summary>Final Design</summary>

**Implementation Plan (inline, quick mode)**

Files to modify:
1. `.claude/settings.json` — remove the entire `"hooks"` key at lines 179–202 (and the `,` before it). Keep `permissions`, `defaultMode`, `additionalDirectories` untouched.
2. `AGENTS.md` — extend the existing `block-submodule-edit.sh` bullet in "Editing rules" with a one-line note.

Approach: delete `"hooks": {...}` block from `.claude/settings.json`; trim trailing comma from the preceding block. Append one sentence to the existing `block-submodule-edit.sh` bullet in `AGENTS.md`.

Edge cases: JSON validity (ensure no trailing comma); don't touch any other settings; preserve `hooks/hooks.json` exactly.

Testing strategy: run `make lint` (JSON validity + all configured lints). Grep to confirm `.claude/settings.json` has no remaining `hooks` key. Verify `hooks/hooks.json` byte-identical to HEAD.

Failure modes: accidental corruption of JSON → `make lint` catches; accidental edit to `hooks/hooks.json` → `git diff` spot-check.

</details>

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `771294d` (Add lint for skills with Skill in allowed-tools but no invocation step (#181))
- **Current version**: `4.0.13`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `4.0.14`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH").

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

Quick mode — no plan review was conducted.

</details>

<details><summary>Implementation Deviations</summary>

No deviations from the plan.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

### [Code Review] Cursor (round 1)
**Finding**: `CHANGELOG.md:8-12` — the existing `[4.0.13]` section only documents the shellcheck/`-x` change (#178) and does not also document the #152 duplicate-`PreToolUse`-mirror removal. Cursor asked us to add a second bullet under `[4.0.13] ### Fixed` for #152, pointing to `AGENTS.md` and the plugin-load instruction for local dev.
**Reason not implemented**: `[4.0.13]` is a previously released version; #152 is a new change that belongs in the next version bump, not retroactively in 4.0.13. The `/implement` Step 8 + Step 8a workflow runs after code review: `/bump-version` classifies this change and increments `.claude-plugin/plugin.json` to `4.0.14`, and Step 8a prepends a new `[4.0.14]` section to `CHANGELOG.md` using this PR's Summary bullets (which include #152). Retroactively appending to `[4.0.13]` would misrepresent what shipped in that release and conflict with `/bump-version`'s single-bump-commit invariant.

### [Code Review] Cursor (round 1)
**Finding**: `.claude/settings.json` — the mirror removal means contributors who open this repo in Claude Code without loading larch as a plugin lose automatic `block-submodule-edit` guard protection. Cursor suggested optionally adding a one-sentence note under `README.md` "Install for local development" stating that hook-backed protections (e.g. submodule edit guard) require loading the plugin from this tree, so the point is visible outside `AGENTS.md`.
**Reason not implemented**: Cursor itself labels this "accepted tradeoff". `AGENTS.md`'s "Editing rules" section already carries the one-line note per issue #152's acceptance criteria (the guard ships via `hooks/hooks.json` only; contributors should load larch as a plugin to pick up the guard), and `README.md`'s "Install for local development" section already documents `claude --plugin-dir .` and the local-marketplace install path. Adding a second note about the same property in the README would duplicate content that AGENTS.md already carries and expand the PR scope beyond #152's stated acceptance criteria. If the visibility gap is deemed real, it is better filed as a standalone docs issue rather than folded into this surgical mirror-removal PR.

</details>

<details><summary>Plan Review Voting Tally</summary>

Quick mode — no plan review voting.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

Quick mode — no voting panel. Main agent reviewed findings across up to 7 single-reviewer rounds (Cursor → Codex → Claude fallback chain).

</details>

<details><summary>Out-of-Scope Observations</summary>

**Accepted OOS (GitHub issues filed):**
No OOS items were accepted for issue filing.

**Non-accepted OOS observations:**
Quick mode — no reviewer voting panel. Main-agent OOS items (if any) are auto-filed per policy; see Accepted OOS above.

</details>

<details><summary>Execution Issues</summary>

No execution issues encountered.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | N/A (quick mode) |
| Code review rounds | 1 |
| Code review findings | 0 accepted, 2 rejected |
| Warnings logged | 0 |
| Pre-existing issues noticed | 0 |
| OOS issues filed | 0 |
| External reviewers | N/A (quick mode) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
