### PR TITLE
Fix #184: drop fragile --paginate + jq '.[-1]' last-comment pattern

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "4.0.17",
+  "version": "4.0.18",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.18] - 2026-04-19
+
+### Fixed
+
+- `skills/fix-issue/scripts/fetch-eligible-issue.sh` — the GO-sentinel check at two sites (explicit-issue path and auto-pick loop) used `gh api --paginate "repos/…/comments" --jq '.[-1].body // empty' | tail -1`. Because `--jq` runs per page, `.[-1]` returned the last element of each page, not the last of the full history — the `tail -1` was only accidentally correct (pages arrive in order, so the final page's last element coincides with the globally-last comment, but the logic is brittle to any jq/paginate behavior change and `tail -1` also truncates multi-line last comments to their final line). Both sites now use the `gh api --paginate --slurp … | jq -r 'add // [] | .[-1].body // empty'` pattern already used by `prose_open_blockers` at line 135-136 — `--slurp` concatenates all pages into one JSON array-of-arrays, `add // []` flattens to a single array, `.[-1].body` unambiguously addresses the globally-last comment. Closes #184.
+
 ## [4.0.17] - 2026-04-19
 
 ### Fixed

--- a/skills/fix-issue/scripts/fetch-eligible-issue.sh
+++ b/skills/fix-issue/scripts/fetch-eligible-issue.sh
@@ -260,9 +260,14 @@ if [[ -n "$ISSUE_ARG" ]]; then
         exit 2
     fi
 
-    # Verify last comment is GO
-    LAST_COMMENT=$(gh api --paginate "repos/${REPO}/issues/${ISSUE_NUM}/comments" \
-        --jq '.[-1].body // empty' 2>/dev/null | tail -1) || {
+    # Verify last comment is GO.
+    # Using --slurp so `jq` sees a single array-of-arrays and can select the
+    # globally-last comment via `add // [] | .[-1]`. The older `--jq '.[-1].body'`
+    # pattern ran the filter per page and was only accidentally correct because
+    # the last page contains the globally-last comment. See `prose_open_blockers`
+    # above for the canonical reference use of this pattern.
+    LAST_COMMENT=$(gh api --paginate --slurp "repos/${REPO}/issues/${ISSUE_NUM}/comments" 2>/dev/null \
+        | jq -r 'add // [] | .[-1].body // empty') || {
         echo "ELIGIBLE=false"
         echo "ERROR=Failed to fetch comments for issue #$ISSUE_NUM"
         exit 2
@@ -320,9 +325,10 @@ while IFS= read -r issue_row; do
     ISSUE_NUM=$(echo "$issue_row" | jq -r '.number')
     ISSUE_TITLE=$(echo "$issue_row" | jq -r '.title')
 
-    # Get the last comment body (paginated to ensure we see all comments)
-    LAST_COMMENT=$(gh api --paginate "repos/${REPO}/issues/${ISSUE_NUM}/comments" \
-        --jq '.[-1].body // empty' 2>/dev/null | tail -1) || {
+    # Get the globally-last comment body. See the explicit-issue path above for
+    # the rationale on `--slurp` + `add // [] | .[-1]`.
+    LAST_COMMENT=$(gh api --paginate --slurp "repos/${REPO}/issues/${ISSUE_NUM}/comments" 2>/dev/null \
+        | jq -r 'add // [] | .[-1].body // empty') || {
         echo "ELIGIBLE=false"
         echo "ERROR=Failed to fetch comments for issue #$ISSUE_NUM"
         exit 2


### PR DESCRIPTION
## Summary
- Replaced the fragile `gh api --paginate … --jq '.[-1].body // empty' | tail -1` pattern at both GO-sentinel sites in `skills/fix-issue/scripts/fetch-eligible-issue.sh` with the `--slurp | jq 'add // [] | .[-1].body // empty'` pattern already used by `prose_open_blockers`, so the last-comment check unambiguously addresses the globally-last comment instead of relying on accidental page ordering.
- Closes #184.

<details><summary>Architecture Diagram</summary>

Quick mode — architecture diagram skipped.

</details>

<details><summary>Code Flow Diagram</summary>

Quick mode — code flow diagram skipped.

</details>

<details><summary>Goal</summary>

- Remove a latent correctness hazard in `/fix-issue`'s GO-sentinel eligibility check
  - Ensure `.[-1].body` indexes into the concatenated page array, not per-page
  - Drop the `tail -1` crutch that silently truncates multi-line last comments to their last line
  - Align both sentinel sites with the already-correct `prose_open_blockers` pattern at line 135-136
- Keep the fix surgical — no scope creep into dependency checks, parser, or other sentinel logic

</details>

<details><summary>Test plan</summary>

- [x] `bash -n skills/fix-issue/scripts/fetch-eligible-issue.sh` (syntax)
- [x] `/relevant-checks` (shellcheck + agent-lint)
- [ ] End-to-end: next `/fix-issue` invocation after merge exercises both the explicit-issue and auto-pick paths
- [ ] Spot-check an issue whose last comment is multi-line (the `tail -1` truncation bug is eliminated)

</details>

<details><summary>Final Design</summary>

## Implementation Plan

**Files to modify:** `skills/fix-issue/scripts/fetch-eligible-issue.sh` (two sites).

**Current fragile pattern** (lines 264-265, 324-325):
```bash
LAST_COMMENT=$(gh api --paginate "repos/${REPO}/issues/${ISSUE_NUM}/comments" \
    --jq '.[-1].body // empty' 2>/dev/null | tail -1)
```
`--jq` runs per-page, so `.[-1]` returns the last element of each page, not of the concatenated history. `tail -1` then picks whichever page's last-element came out last — accidentally correct because pages arrive in order and the final page contains the globally-last comment, but brittle to any jq/paginate behavior change.

**Replacement** (mirrors the already-correct `prose_open_blockers` at line 135-136):
```bash
LAST_COMMENT=$(gh api --paginate --slurp "repos/${REPO}/issues/${ISSUE_NUM}/comments" 2>/dev/null \
    | jq -r 'add // [] | .[-1].body // empty')
```
`--slurp` concatenates all pages into one JSON array-of-arrays; `add // []` flattens; `.[-1].body` addresses the globally-last comment unambiguously. No `tail -1` needed.

**Edge cases:** empty comment list still emits empty (the `// []` then `// empty` fallbacks); `jq -r` preserves raw-body semantics. The surrounding `|| { echo ERROR; exit 2; }` error handler continues to work — a `gh api` failure yields empty stdin, `add // []` yields `[]`, `.[-1].body // empty` yields empty.

**Failure modes:** `jq` errors on malformed input propagate through `$(...)` to the existing `|| { ... exit 2; }` handler at both sites.

</details>

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `c71c286` (Stricter per-invocation lint for skills declaring Skill in allowed-tools (closes #180) (#187))
- **Current version**: `4.0.17`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `4.0.18`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH").

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

Quick mode — no plan review was conducted.

</details>

<details><summary>Implementation Deviations</summary>

No deviations from the inline plan.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

### [Code Review] Cursor (round 1)
**Finding**: `skills/fix-issue/scripts/fetch-eligible-issue.sh:269-270` and `:330-331` — Cursor flagged the new `gh api --paginate --slurp ... | jq -r 'add // [] | .[-1].body // empty'` pattern as widening the runtime requirement, claiming the old path only needed `gh`'s embedded `--jq` formatter and that piping to system `jq` adds a new hard dependency. Suggested adding an explicit `command -v jq` check at the top of the script and/or documenting `jq` as a prerequisite in the `/fix-issue` docs.
**Reason not implemented**: The premise is incorrect — `jq` is already a hard structural dependency of this script at many prior lines (line 136 in `prose_open_blockers` uses the same `gh api --paginate --slurp ... | jq 'add // []'` pattern; lines 146/153/157/170 process prose-parser output via `jq -r`/`jq length`; lines 232-235 parse `gh issue view` JSON via `jq -r`; lines 304/312/320/321 list and sort issues via `jq`). No reachable code path through this script avoids system `jq`. The GO-sentinel check is therefore not the first jq pipe in any flow. Adding `command -v jq` here would be redundant with the repo's existing `scripts/sessionstart-health.sh` SessionStart hook, which already probes `jq` and `git` on PATH and surfaces an advisory when missing (per AGENTS.md). Documentation updates are outside the scope of the surgical fix requested by issue #184.

</details>

<details><summary>Plan Review Voting Tally</summary>

Quick mode — no plan review voting.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

Quick mode — no voting panel. Main agent reviewed findings across up to 7 single-reviewer rounds (Cursor → Codex → Claude fallback chain).

</details>

<details><summary>Out-of-Scope Observations</summary>

**Accepted OOS (GitHub issues filed):**
No OOS items were accepted for issue filing.

**Non-accepted OOS observations:**
Quick mode — no reviewer voting panel. Main-agent OOS items (if any) are auto-filed per policy; see Accepted OOS above.

</details>

<details><summary>Execution Issues</summary>

No execution issues encountered.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | N/A (quick mode) |
| Code review rounds | 1 |
| Code review findings | 0 accepted, 1 rejected |
| Warnings logged | 0 |
| Pre-existing issues noticed | 0 |
| OOS issues filed | 0 |
| External reviewers | Cursor: ✅, Codex: N/A (quick mode) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
