### PR TITLE
Branch /fix-issue on PR vs. non-PR issue intent

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "4.0.18",
+  "version": "4.0.19",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.19] - 2026-04-19
+
+### Changed
+
+- `skills/fix-issue/SKILL.md` — Step 5 now classifies each eligible issue along two independent dimensions: **intent** (PR-producing vs. non-PR task) and, only when `INTENT=PR`, complexity (SIMPLE vs. HARD). Step 6 branches on intent: `PR` delegates to `/implement` as before; `NON_PR` follows the issue's instructions inline using Read/Grep/Glob/Bash and `/issue` (batch mode for multi-issue output, with the `--input-file` markdown written under `$FIX_ISSUE_TMPDIR` — never inside the working tree). Steps 7 and 8 mirror the branching: `NON_PR` closes with a `WORK_SUMMARY` comment (no PR URL, no body update) and announces on Slack via the pre-existing `--message` free-form path. Default to `PR` when uncertain preserves pre-existing behavior for any issue where the intent is ambiguous. Step 4 triage gains an explicit guidance bullet that for investigation/review-only issues, "still relevant" means the **task** is still meaningful rather than "the referenced bug is still in code".
+
 ## [4.0.18] - 2026-04-19
 
 ### Fixed

--- a/skills/fix-issue/SKILL.md
+++ b/skills/fix-issue/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: fix-issue
-description: "Use when fixing open GitHub issues. Processes one approved issue per invocation: skips issues blocked by open dependencies, triages, classifies complexity, and delegates to /implement."
+description: "Use when fixing open GitHub issues. Processes one approved issue per invocation: skips blocked, triages, classifies intent, then either delegates to /implement or follows the issue's instructions inline for research/review tasks."
 argument-hint: "[--debug] [--issue <number-or-url>] [<number-or-url>]"
 allowed-tools: Bash, Read, Grep, Glob, Skill
 ---
 
 # Fix Issue
 
-Process one approved GitHub issue per invocation. Fetches open issues with a `GO` sentinel comment, skips any whose GitHub issue-dependencies list includes an open blocker, triages the remaining candidate against the codebase, classifies complexity, and delegates to `/implement`.
+Process one approved GitHub issue per invocation. Fetches open issues with a `GO` sentinel comment, skips any whose GitHub issue-dependencies list includes an open blocker, triages the remaining candidate against the codebase, classifies **intent** (PR-producing vs. non-PR task) and (for PR work) **complexity**, and either delegates to `/implement` or executes the issue's instructions inline. Non-PR tasks — e.g., "research topic X and summarize findings as issues", "code-review module Y and file issues for each problem" — are followed without `/implement`; any output issues are created via `/issue` and the source issue is closed with a work summary instead of a PR link.
 
 **Single-iteration design**: Each invocation handles at most one issue, then exits. The caller (cron, `/loop`, or manual invocation) is responsible for repeated execution.
 
@@ -33,7 +33,7 @@ Step Name Registry:
 | 3 | read details |
 | 4 | triage |
 | 5 | classify |
-| 6 | implement |
+| 6 | execute |
 | 7 | close issue |
 | 8 | slack announce |
 | 9 | cleanup |
@@ -130,22 +130,37 @@ Check for:
 
 **If the issue is still actual**, print `✅ 4: triage — issue is active, proceeding (<elapsed>)` and continue.
 
-## Step 5 — Classify Complexity
+## Step 5 — Classify Intent and Complexity
 
 Print `> **🔶 5: classify**`
 
-Based on the issue details and codebase exploration from Step 4, classify the issue:
+Based on the issue details and codebase exploration from Step 4, determine two independent dimensions:
+
+### Intent — does this issue prescribe work that should produce a pull request?
+
+- **PR**: The issue prescribes a code change — bug fix, refactor, new feature, documentation edit, prompt/skill edit, config change, test addition, etc. — whose natural output is a pull request against the current repository.
+- **NON_PR**: The issue prescribes an investigative or review task whose natural output is something other than a PR: new GitHub issues summarizing research findings, new GitHub issues flagging code-review problems, a written report, or similar. Typical signals: the issue body contains phrases like "research and summarize", "investigate and report", "code-review this module and file issues", "do not create a PR", or otherwise makes clear that the deliverable is issues/reports rather than code changes.
+
+**Default to `PR` when uncertain.** The `PR` path is the pre-existing behavior; misclassifying a borderline `NON_PR` as `PR` is recoverable (`/implement`'s `/review` phase surfaces the mismatch) while misclassifying a `PR` as `NON_PR` could silently skip real work.
+
+### Complexity (only evaluated when `INTENT=PR`)
 
 - **SIMPLE**: Isolated fix in 2 or fewer files. Obvious solution with no architectural decisions needed. Examples: typo fix, small bug with clear root cause, config change.
 - **HARD**: Everything else. Multi-file changes, new features, architectural decisions, unclear root cause, or any uncertainty.
 
 **Default to HARD when uncertain.** A HARD classification uses the full `/design` + `/review` pipeline, which is safer for non-trivial changes.
 
-Print `✅ 5: classify — $CLASSIFICATION (<elapsed>)`
+When `INTENT=NON_PR`, complexity is not meaningful — leave `COMPLEXITY` unset and skip the SIMPLE/HARD determination.
 
-## Step 6 — Implement
+Print `✅ 5: classify — INTENT=$INTENT [COMPLEXITY=$COMPLEXITY] (<elapsed>)` (omit the `COMPLEXITY=` segment when `INTENT=NON_PR`).
 
-Print `> **🔶 6: implement**`
+## Step 6 — Execute
+
+Print `> **🔶 6: execute**`
+
+Branch on `INTENT` from Step 5.
+
+### 6a — `INTENT=PR` path (delegate to `/implement`)
 
 Compose the feature description from the issue content: use the issue title as the primary description, with key details from the issue body and comments as context.
 
@@ -158,17 +173,46 @@ Invoke `/implement` via the Skill tool:
 
 After `/implement` completes, capture the PR URL and PR number from its output. Save as `PR_URL` and `PR_NUMBER`.
 
-If `/implement` fails or bails, print `**⚠ 6: implement — failed. Issue #$ISSUE_NUMBER remains locked with IN PROGRESS. (<elapsed>)**` Skip to Step 9. The IN PROGRESS comment serves as an indicator that manual intervention is needed.
+If `/implement` fails or bails, print `**⚠ 6: execute — /implement failed. Issue #$ISSUE_NUMBER remains locked with IN PROGRESS. (<elapsed>)**` Skip to Step 9. The IN PROGRESS comment serves as an indicator that manual intervention is needed.
+
+### 6b — `INTENT=NON_PR` path (follow instructions inline)
+
+Read the issue details from Step 3 and execute the instructions directly using Read, Grep, Glob, and Bash. Do NOT call `/implement`. Do NOT modify files in the working tree — `NON_PR` tasks deliver their output as new GitHub issues, a written summary comment, or both.
+
+Common `NON_PR` patterns:
+
+- **Research task** — investigate the requested topic in-codebase via Read/Grep/Glob; when the scope warrants a collaborative read-only research panel, invoke `/research` via the Skill tool. Create one or more summary issues via `/issue` (invoked via the Skill tool) if the issue body requests it.
+- **Code-review task** — examine the requested area and file one issue per problem found. Invoke `/issue` via the Skill tool in batch mode (`--input-file` with a markdown file listing the findings) to file all findings in a single pass with semantic duplicate detection.
+- **Other investigative or planning tasks** — follow the body's instructions literally; when ambiguous, prefer the interpretation that produces actionable output (issues, documented findings) over the interpretation that produces code changes.
+
+> **Continue after child returns.** When any child Skill (`/issue`, `/research`, ...) returns, execute the NEXT step of this skill — do NOT end the turn. See `${CLAUDE_PLUGIN_ROOT}/skills/shared/subskill-invocation.md` section Anti-halt continuation reminder.
+
+As work proceeds, maintain a running `WORK_SUMMARY` — a concise markdown summary of what was done and the output artifacts (links to any issues created, key findings, etc.). This summary becomes the closing comment in Step 7 and the Slack message in Step 8. Keep `PR_URL` and `PR_NUMBER` unset on this path.
+
+If the work cannot be completed (e.g., `/issue` fails repeatedly, the issue's instructions are infeasible, or required external access is unavailable), print `**⚠ 6: execute — non-PR task failed. Issue #$ISSUE_NUMBER remains locked with IN PROGRESS. (<elapsed>)**` and skip to Step 9. The IN PROGRESS comment serves as an indicator that manual intervention is needed — same recovery semantics as the `/implement` failure path.
 
 ## Step 7 — Close Issue
 
 Print `> **🔶 7: close issue**`
 
-Update the issue body with PR link and close with DONE comment (single call):
+Branch on `INTENT`.
+
+### 7a — `INTENT=PR`
+
+Update the issue body with the PR link and close with a DONE comment (single call):
 
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/skills/fix-issue/scripts/issue-lifecycle.sh close \
   --issue $ISSUE_NUMBER --pr-url "$PR_URL" --comment "DONE"
+```
+
+### 7b — `INTENT=NON_PR`
+
+Close the issue with `WORK_SUMMARY` as the closing comment (no `--pr-url`, no body update):
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/skills/fix-issue/scripts/issue-lifecycle.sh close \
+  --issue $ISSUE_NUMBER --comment "$WORK_SUMMARY"
 ```
 
 Print `✅ 7: close issue — #$ISSUE_NUMBER closed (<elapsed>)`
@@ -177,12 +221,30 @@ Print `✅ 7: close issue — #$ISSUE_NUMBER closed (<elapsed>)`
 
 If `slack_available=false`, print `⏭️ 8: slack announce — skipped (Slack not configured) (<elapsed>)` and proceed to Step 9.
 
+Branch on `INTENT`.
+
+### 8a — `INTENT=PR`
+
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/skills/fix-issue/scripts/post-issue-slack.sh \
   --issue $ISSUE_NUMBER --title "$ISSUE_TITLE" --pr-url "$PR_URL" \
   --token "${LARCH_SLACK_BOT_TOKEN:-$CLAUDE_PLUGIN_OPTION_SLACK_BOT_TOKEN}" \
   --channel-id "${LARCH_SLACK_CHANNEL_ID:-$CLAUDE_PLUGIN_OPTION_SLACK_CHANNEL_ID}"
 ```
+
+### 8b — `INTENT=NON_PR`
+
+Post a free-form Slack message summarizing the non-PR work (no PR URL). Compose the `--message` value from `WORK_SUMMARY` — a one-sentence summary is ideal (e.g., "research complete, filed #123 and #124" or "code review complete, filed 5 issues"):
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/skills/fix-issue/scripts/post-issue-slack.sh \
+  --issue $ISSUE_NUMBER --title "$ISSUE_TITLE" \
+  --token "${LARCH_SLACK_BOT_TOKEN:-$CLAUDE_PLUGIN_OPTION_SLACK_BOT_TOKEN}" \
+  --channel-id "${LARCH_SLACK_CHANNEL_ID:-$CLAUDE_PLUGIN_OPTION_SLACK_CHANNEL_ID}" \
+  --message "Issue #$ISSUE_NUMBER ($ISSUE_TITLE) closed — <one-sentence summary from WORK_SUMMARY>"
+```
+
+### After the branch
 
 If the script exits non-zero, print `**⚠ 8: slack announce — failed. Continuing.**`
 

--- a/skills/fix-issue/SKILL.md
+++ b/skills/fix-issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fix-issue
-description: "Use when fixing open GitHub issues. Processes one approved issue per invocation: skips blocked, triages, classifies intent, then either delegates to /implement or follows the issue's instructions inline for research/review tasks."
+description: "Use when fixing open GitHub issues. Processes one approved issue per invocation: skips issues with open blockers, triages, classifies intent, then either delegates to /implement or follows the issue's instructions inline for research/review tasks."
 argument-hint: "[--debug] [--issue <number-or-url>] [<number-or-url>]"
 allowed-tools: Bash, Read, Grep, Glob, Skill
 ---
@@ -109,6 +109,7 @@ Check for:
 - Has the issue already been fixed by recent commits?
 - Is the code/feature the issue references still present?
 - Is the issue a valid bug/feature request, or was it filed in error?
+- For investigation/review-only issues (whose deliverable is research findings or new issues rather than code changes): is the **task itself** still relevant — are the targets, scope, and constraints it describes still meaningful — rather than "is the referenced bug still in code"?
 
 **If the issue is no longer material** (already fixed, invalid, or no longer relevant):
 
@@ -182,7 +183,7 @@ Read the issue details from Step 3 and execute the instructions directly using R
 Common `NON_PR` patterns:
 
 - **Research task** — investigate the requested topic in-codebase via Read/Grep/Glob; when the scope warrants a collaborative read-only research panel, invoke `/research` via the Skill tool. Create one or more summary issues via `/issue` (invoked via the Skill tool) if the issue body requests it.
-- **Code-review task** — examine the requested area and file one issue per problem found. Invoke `/issue` via the Skill tool in batch mode (`--input-file` with a markdown file listing the findings) to file all findings in a single pass with semantic duplicate detection.
+- **Code-review task** — examine the requested area and file one issue per problem found. Invoke `/issue` via the Skill tool in batch mode (`--input-file` with a markdown file listing the findings) to file all findings in a single pass with semantic duplicate detection. Write the `--input-file` markdown to a path under `$FIX_ISSUE_TMPDIR` (never inside the repository working tree) so the "no working-tree edits" rule above holds.
 - **Other investigative or planning tasks** — follow the body's instructions literally; when ambiguous, prefer the interpretation that produces actionable output (issues, documented findings) over the interpretation that produces code changes.
 
 > **Continue after child returns.** When any child Skill (`/issue`, `/research`, ...) returns, execute the NEXT step of this skill — do NOT end the turn. See `${CLAUDE_PLUGIN_ROOT}/skills/shared/subskill-invocation.md` section Anti-halt continuation reminder.


### PR DESCRIPTION
## Summary

- Branched `/fix-issue` Step 6 on a new `INTENT` classification (`PR` vs `NON_PR`), so issues whose deliverable is research/review/issue-filing no longer incorrectly delegate to `/implement`.
- Mirrored the branching into Step 7 (close with `WORK_SUMMARY` instead of PR URL) and Step 8 (Slack `--message` path) on the `NON_PR` side; preserved the existing `/implement` delegation as the default when intent is uncertain.
- Documented guardrails for the `NON_PR` path: no working-tree edits, `/issue --input-file` markdown must live under `$FIX_ISSUE_TMPDIR`, and Step 4 triage now explicitly handles investigation/review-only issues.

<details><summary>Architecture Diagram</summary>

Quick mode — architecture diagram skipped.

</details>

<details><summary>Code Flow Diagram</summary>

Quick mode — code flow diagram skipped.

</details>

<details><summary>Goal</summary>

- Make `/fix-issue` honor the deliverable prescribed by each issue
  - Keep current delegation to `/implement` for issues whose natural output is a pull request (bug fixes, refactors, new features, docs edits, config changes, test additions)
  - Add a new inline execution path for issues whose natural output is something other than a PR:
    - Research tasks that produce summary issues
    - Code-review sweeps that produce one issue per problem found
    - Other investigative/planning tasks whose deliverable is issues/reports, not code
- Preserve backward compatibility so ambiguous issues default to the pre-existing PR path
- Keep the existing lock/triage/complexity/Slack-degradation infrastructure unchanged

</details>

<details><summary>Test plan</summary>

- [x] `/relevant-checks` passes (pre-commit + agent-lint + lint-skill-invocations)
- [x] `description:` frontmatter ≤ 250 chars after edits
- [x] Anti-halt banner preserved in `skills/fix-issue/SKILL.md`; micro-reminder present in both Step 6 branches
- [ ] On a real PR-producing issue: `/fix-issue <N>` still delegates to `/implement` and produces a PR
- [ ] On a real research/review issue: `/fix-issue <N>` executes inline, files any output issues via `/issue`, closes source with work-summary comment (no PR URL), Slack announcement omits PR link

</details>

<details><summary>Final Design</summary>

Files modified: `skills/fix-issue/SKILL.md` (prompt-only change; no script or code changes).

Structural changes to the skill spec:

1. **Step 5 renamed** from "Classify Complexity" to "Classify Intent and Complexity". Produces two dimensions:
   - `INTENT` ∈ {`PR`, `NON_PR`}, defaulting to `PR` when uncertain
   - `COMPLEXITY` ∈ {`SIMPLE`, `HARD`}, only evaluated when `INTENT=PR`; defaults to `HARD` when uncertain (unchanged)
2. **Step 6 renamed** from "Implement" to "Execute", with two sub-paths:
   - **6a (`INTENT=PR`)**: existing flow — invoke `/implement` via the Skill tool with `--auto --merge` plus `--quick` when `COMPLEXITY=SIMPLE`
   - **6b (`INTENT=NON_PR`)**: follow the issue's instructions inline with Read/Grep/Glob/Bash; invoke `/issue` via the Skill tool for output issues (batch mode, `--input-file` markdown written under `$FIX_ISSUE_TMPDIR`); invoke `/research` via the Skill tool when scope warrants a collaborative read-only panel; maintain a `WORK_SUMMARY` as the close comment; keep `PR_URL` and `PR_NUMBER` unset
3. **Step 7 branches** on `INTENT`: `PR` closes with `--pr-url $PR_URL --comment DONE`; `NON_PR` closes with `--comment $WORK_SUMMARY` (no body update)
4. **Step 8 branches** on `INTENT`: `PR` uses the existing `--pr-url` Slack path; `NON_PR` uses the pre-existing `--message` free-form Slack path (the same pattern Step 4 "not material" already uses)
5. **Step 4 triage** gains one bullet: for investigation/review-only issues, "still relevant" means the **task** is still meaningful (scope/targets/constraints) rather than "the referenced bug is still in code"
6. **Frontmatter**: `description` updated to mention both paths while staying ≤ 250 chars

No script changes, no `allowed-tools` change (`Bash, Read, Grep, Glob, Skill` already covers both paths), no hook change. The existing anti-halt banner is preserved verbatim; each Step 6 branch carries its own "Continue after child returns" micro-reminder.

Invariants preserved:
- Step 2 lock semantics unchanged
- Step 4 "not material" close path unchanged
- Failure-to-complete in Step 6 (either branch) leaves the issue locked with `IN PROGRESS` — same manual-recovery story as before
- Slack degradation (`slack_available=false` → skip Step 8) unchanged on both branches

</details>

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `8355ca7` (Fix #184: drop fragile --paginate + jq '.[-1]' last-comment pattern (#188))
- **Current version**: `4.0.18`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `4.0.19`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH").

### Main-agent caveat review

The diff touches `skills/fix-issue/SKILL.md` only and adds a new backward-compatible branch (`INTENT=NON_PR`). Default-to-`PR` preserves pre-existing behavior for any issue that used to trigger `/implement`. No `name:` change, no `--flag` removal, no delete/rename. No MAJOR/MINOR escalation warranted; PATCH stands.

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

Quick mode — no plan review was conducted.

</details>

<details><summary>Implementation Deviations</summary>

No deviations from the inline plan. All 4 sections (Step 5 rewrite, Step 6 branching, Step 7 branching, Step 8 branching) were applied exactly as designed, plus two small refinements accepted from code review (Step 4 bullet for investigation-only issues, explicit `$FIX_ISSUE_TMPDIR` guidance for `/issue --input-file`, description clarity fix).

</details>

<details><summary>Rejected Code Review Suggestions</summary>

### [Code Review] Cursor (round 1)
**Finding**: `skills/fix-issue/SKILL.md` Step 7b around lines 209–216. The documented pattern `issue-lifecycle.sh close --issue $ISSUE_NUMBER --comment "$WORK_SUMMARY"` embeds the closing summary as a shell-argument string. The reviewer flagged that large summaries, embedded double quotes, or shell-sensitive characters could make that inline invocation brittle when an agent pastes a literal command. Suggested fix: note that for long/complex summaries the runner should write `WORK_SUMMARY` to a file under `$FIX_ISSUE_TMPDIR` and use a `--comment-file` flag, or extend `issue-lifecycle.sh` with such a flag so there is one supported path.
**Reason not implemented**: The existing Step 4 "not material" close path in the very same file already uses the identical pattern `issue-lifecycle.sh close --issue $ISSUE_NUMBER --comment "Closing: <detailed explanation with research summary>"` with zero reported problems in production use. The orchestrating agent composes the final shell command at runtime and can select a heredoc / `$'...'` escape / tempfile approach on its own when the payload warrants it — this is the same flexibility the Step 4 path relies on. Introducing a new `--comment-file` flag on `issue-lifecycle.sh` is scope creep for this PR (which changes only the SKILL.md) and would create an asymmetry between the two close paths. The underlying shell-escaping concern is real but pre-existing and orthogonal to the intent-branching change; it belongs in a dedicated refactor if we want one canonical mechanism.

</details>

<details><summary>Plan Review Voting Tally</summary>

Quick mode — no plan review voting.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

Quick mode — no voting panel. Main agent reviewed findings across up to 7 single-reviewer rounds (Cursor → Codex → Claude fallback chain).

Round 1 reviewer: Cursor. 4 findings surfaced; 3 accepted and implemented (Step 4 triage bullet, `$FIX_ISSUE_TMPDIR` note on `/issue --input-file`, description clarity fix), 1 rejected (see Rejected Code Review Suggestions). Round 2 was not needed — the re-review gate short-circuited because no additional findings emerged after the single-round fixes landed.

</details>

<details><summary>Out-of-Scope Observations</summary>

**Accepted OOS (GitHub issues filed):**
No OOS items were accepted for issue filing.

**Non-accepted OOS observations:**
Quick mode — no reviewer voting panel. Main-agent OOS items (if any) are auto-filed per policy; see Accepted OOS above.

</details>

<details><summary>Execution Issues</summary>

No execution issues encountered.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | N/A (quick mode) |
| Code review rounds | 1 |
| Code review findings | 3 accepted, 1 rejected |
| Warnings logged | 0 |
| Pre-existing issues noticed | 0 |
| OOS issues filed | 0 |
| External reviewers | N/A (quick mode) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
