### PR TITLE
Enable caveman + skill-judge plugins; default caveman full mode

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "4.0.19",
+  "version": "4.0.20",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -175,5 +175,17 @@
       "/tmp",
       "/var/folders"
     ]
+  },
+  "enabledPlugins": {
+    "skill-judge@agent-toolkit": true,
+    "caveman@caveman": true
+  },
+  "extraKnownMarketplaces": {
+    "caveman": {
+      "source": {
+        "source": "github",
+        "repo": "JuliusBrussee/caveman"
+      }
+    }
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.20] - 2026-04-19
+
+### Changed
+
+- `.claude/settings.json` — enable `skill-judge` and `caveman` plugins; register `caveman` marketplace (`github:JuliusBrussee/caveman`).
+- `CLAUDE.md` — set default caveman output mode to `full`.
+
 ## [4.0.19] - 2026-04-19
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,2 +1,4 @@
 @AGENTS.md
 @KARPATHY_CLAUDE.md
+
+All output caveman full.


### PR DESCRIPTION
## Summary

- Enabled `skill-judge` (from `agent-toolkit`) and `caveman` Claude Code plugins in `.claude/settings.json`.
- Registered the `caveman` marketplace (`github:JuliusBrussee/caveman`) under `extraKnownMarketplaces`.
- Set default caveman output mode to `full` via `CLAUDE.md`.

<details><summary>Goal</summary>

- Enable `caveman` ultra-compressed output mode by default for this workspace.
- Enable the `skill-judge` skill evaluator plugin.
- Make the `caveman` marketplace discoverable without requiring per-session setup.

</details>

<details><summary>Test plan</summary>

- [x] `/relevant-checks` passes (shellcheck N/A, markdownlint, JSON validation, agent-lint, skill-invocation lint, AI config lint).
- [ ] New session picks up `caveman` plugin and applies `full` mode from `CLAUDE.md`.

</details>

<details><summary>Version Bump Reasoning</summary>

PATCH — changes limited to `.claude/**` and `CLAUDE.md`; no changes to `skills/**` or `agents/**` public surface.

</details>

<details><summary>Implementation Deviations</summary>

Quick mode with `--auto`; user explicitly requested no review. `/design`, `/review`, and the Step 5 inline reviewer loop were skipped intentionally.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

Quick mode — no code review was conducted (user opted out).

</details>

<details><summary>Plan Review Voting Tally</summary>

Quick mode — no plan review voting.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

Quick mode — no code review voting.

</details>

<details><summary>Out-of-Scope Observations</summary>

**Accepted OOS (GitHub issues filed):**
No OOS items were accepted for issue filing.

**Non-accepted OOS observations:**
Quick mode — no reviewer panel.

</details>

<details><summary>Execution Issues</summary>

No execution issues encountered.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | N/A (quick mode) |
| Code review rounds | 0 (user opted out) |
| Code review findings | N/A |
| Warnings logged | 0 |
| Pre-existing issues noticed | 0 |
| OOS issues filed | 0 |
| External reviewers | N/A (quick mode) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
