### PR TITLE
Ignore .agents/ and skills-lock.json

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "4.0.20",
+  "version": "4.0.21",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ __pycache__/
 *.pyc
 .claude/settings.local.json
 .claude/hook-audit.log
+.agents/
+skills-lock.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.21] - 2026-04-19
+
+### Changed
+
+- `.gitignore` — ignore `.agents/` and `skills-lock.json`.
+
 ## [4.0.20] - 2026-04-19
 
 ### Changed


### PR DESCRIPTION
## Summary
- Ignored `.agents/` and `skills-lock.json` in `.gitignore` so these auto-generated/plugin-local files stay untracked.

<details><summary>Architecture Diagram</summary>

Quick mode — architecture diagram skipped.

</details>

<details><summary>Code Flow Diagram</summary>

Quick mode — code flow diagram skipped.

</details>

<details><summary>Goal</summary>

- Add `.agents/` directory and `skills-lock.json` file to `.gitignore`.
  - Prevent accidental commits of locally-generated agent state.
  - Prevent accidental commits of plugin skill lockfile.

</details>

<details><summary>Test plan</summary>

- [x] `git status` on a worktree containing `.agents/` or `skills-lock.json` shows no untracked entries for those paths.
- [x] `/relevant-checks` passes.

</details>

<details><summary>Final Design</summary>

Append `.agents/` and `skills-lock.json` to `/Users/zhupanov/larch1/.gitignore`.

</details>

<details><summary>Version Bump Reasoning</summary>

PATCH — `.gitignore` edit only; no `skills/**` or `agents/**` changes.

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

Quick mode — no plan review was conducted.

</details>

<details><summary>Implementation Deviations</summary>

No deviations from the plan.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

No code review was performed per explicit user request ("skipping all reviews").

</details>

<details><summary>Plan Review Voting Tally</summary>

Quick mode — no plan review voting.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

Quick mode — code review skipped per user request.

</details>

<details><summary>Out-of-Scope Observations</summary>

**Accepted OOS (GitHub issues filed):**
No OOS items were accepted for issue filing.

**Non-accepted OOS observations:**
Quick mode — no reviewer voting panel. No OOS observations recorded.

</details>

<details><summary>Execution Issues</summary>

### Warnings
- **Step 5**: Code review skipped per explicit user request ("skipping all reviews"). Trivial 2-line .gitignore addition; no review performed.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | N/A (quick mode) |
| Code review rounds | 0 (skipped per user request) |
| Code review findings | 0 accepted, 0 rejected |
| Warnings logged | 1 |
| Pre-existing issues noticed | 0 |
| OOS issues filed | 0 |
| External reviewers | N/A (quick mode) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
