### PR TITLE
Make /loop-improve-skill judge repo-local skill, not plugin-install copy

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/skills/loop-improve-skill/SKILL.md
+++ b/skills/loop-improve-skill/SKILL.md
@@ -42,15 +42,18 @@ Validate:
 
 If invalid, print `**⚠ 1: parse args — invalid or missing <skill-name>. Usage: /loop-improve-skill <skill-name>**` and abort.
 
-Resolve the target skill path. Probe both:
-- `${CLAUDE_PLUGIN_ROOT}/skills/${SKILL_NAME}/SKILL.md` (plugin-public skill)
-- `.claude/skills/${SKILL_NAME}/SKILL.md` (project-local skill, relative to the current working directory)
+Resolve the target skill path. Determine the current repo root via `git rev-parse --show-toplevel`; if that command fails (not a git repo), fall back to `$PWD`. Save as `REPO_ROOT`.
 
-If neither exists, print `**⚠ 1: parse args — no skill found at ${CLAUDE_PLUGIN_ROOT}/skills/${SKILL_NAME}/ or .claude/skills/${SKILL_NAME}/. Aborting.**` and abort.
+Probe in this order (first match wins) and save as an absolute path in `TARGET_SKILL_PATH`:
+1. `${REPO_ROOT}/skills/${SKILL_NAME}/SKILL.md` — plugin-dev mode: the current checkout IS the larch plugin (or another plugin repo).
+2. `${REPO_ROOT}/.claude/skills/${SKILL_NAME}/SKILL.md` — project-local skill defined in the current repo.
+3. `${CLAUDE_PLUGIN_ROOT}/skills/${SKILL_NAME}/SKILL.md` — plugin-installation fallback (read-only source of truth when the current repo is NOT a larch clone).
 
-Save the first matching path as `TARGET_SKILL_PATH` (for diagnostics) and continue.
+**Why repo-local wins**: `/loop-improve-skill` is an iterative loop. Inside it, `/im` modifies the skill file in the current repo. If the probe order preferred the plugin-installation path (e.g., a pristine `larch1` clone) over the current repo (e.g., a working `larch3` clone being mutated by `/im`), every iteration after the first would re-judge the frozen plugin-dir copy instead of the latest modified contents — defeating the purpose of the loop.
 
-Print: `✅ 1: parse args — target /${SKILL_NAME}`
+If none of the three paths exist, print `**⚠ 1: parse args — no skill found. Probed: ${REPO_ROOT}/skills/${SKILL_NAME}/, ${REPO_ROOT}/.claude/skills/${SKILL_NAME}/, ${CLAUDE_PLUGIN_ROOT}/skills/${SKILL_NAME}/. Aborting.**` and abort.
+
+Print: `✅ 1: parse args — target /${SKILL_NAME} at ${TARGET_SKILL_PATH}`
 
 ## Step 2 — Create Tracking GitHub Issue
 
@@ -74,7 +77,15 @@ Print: `> **🔶 3: loop — iteration ${ITER}**`
 
 ### 3.j — Run /skill-judge
 
-Invoke the Skill tool with skill `"skill-judge"` (bare name first). On "no matching skill", retry with `"skill-judge:skill-judge"`. Pass `${SKILL_NAME}` as args. Capture the full response to `$JUDGE_OUT` (a temp file).
+Invoke the Skill tool with skill `"skill-judge"` (bare name first). On "no matching skill", retry with `"skill-judge:skill-judge"`. Pass the following string as args so the judge reads the current on-disk contents from the repo-local path resolved in Step 1 rather than whatever default resolution `/skill-judge` would otherwise perform:
+
+```
+${SKILL_NAME} (absolute SKILL.md path: ${TARGET_SKILL_PATH}) — read the SKILL.md at this exact path before evaluating; do NOT resolve by name against the plugin installation directory. Also evaluate any sibling scripts/ and references/ files under the same skill directory.
+```
+
+The explicit absolute-path directive is load-bearing: `/loop-improve-skill` is an iterative loop where `/im` mutates the skill file between iterations, and subsequent rounds MUST judge the latest modified contents in the current repo (e.g., a `larch3` clone), not the frozen copy in the plugin-installation tree (e.g., `larch1`).
+
+Capture the full response to `$JUDGE_OUT` (a temp file).
 
 > **Continue after child returns.** When `/skill-judge` returns, execute 3.j's post-call step (gh comment) and then 3.d — do NOT end the turn.
 

--- a/skills/loop-improve-skill/SKILL.md
+++ b/skills/loop-improve-skill/SKILL.md
@@ -42,7 +42,7 @@ Validate:
 
 If invalid, print `**⚠ 1: parse args — invalid or missing <skill-name>. Usage: /loop-improve-skill <skill-name>**` and abort.
 
-Resolve the target skill path. Determine the current repo root via `git rev-parse --show-toplevel`; if that command fails (not a git repo), fall back to `$PWD`. Save as `REPO_ROOT`.
+Resolve the target skill path. Determine the current repo root via `REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd -P)`. The `pwd -P` fallback resolves symlinks and guarantees an absolute path even when the process was launched with a relative `$PWD` or inside a symlinked working directory, so `TARGET_SKILL_PATH` below is always a usable absolute path when passed to child skills.
 
 Probe in this order (first match wins) and save as an absolute path in `TARGET_SKILL_PATH`:
 1. `${REPO_ROOT}/skills/${SKILL_NAME}/SKILL.md` — plugin-dev mode: the current checkout IS the larch plugin (or another plugin repo).
@@ -83,7 +83,7 @@ Invoke the Skill tool with skill `"skill-judge"` (bare name first). On "no match
 ${SKILL_NAME} (absolute SKILL.md path: ${TARGET_SKILL_PATH}) — read the SKILL.md at this exact path before evaluating; do NOT resolve by name against the plugin installation directory. Also evaluate any sibling scripts/ and references/ files under the same skill directory.
 ```
 
-The explicit absolute-path directive is load-bearing: `/loop-improve-skill` is an iterative loop where `/im` mutates the skill file between iterations, and subsequent rounds MUST judge the latest modified contents in the current repo (e.g., a `larch3` clone), not the frozen copy in the plugin-installation tree (e.g., `larch1`).
+The explicit absolute-path directive is load-bearing for two reasons: (1) the **probe order** in Step 1 prefers the repo-local copy when one exists (see "Why repo-local wins"); (2) passing that absolute path into `/skill-judge`'s args is what prevents `/skill-judge` from resolving the target by name and falling back to the plugin-installation copy — this matters regardless of which probe matched, because even when only probe 3 (plugin-installation) matched, the judge still reads the exact resolved file rather than re-resolving via a potentially different search path.
 
 Capture the full response to `$JUDGE_OUT` (a temp file).
 
@@ -98,7 +98,7 @@ gh issue comment "${ISSUE_NUM}" --body-file "$JUDGE_COMMENT_FILE"
 
 ### 3.d — Run /design
 
-Invoke the Skill tool with skill `"design"` (bare name first; fallback `"larch:design"`). Pass a prompt asking for an improvement plan for `/${SKILL_NAME}` that addresses the `skill-judge` findings just captured. Capture the full response to `$DESIGN_OUT` via the Skill tool call.
+Invoke the Skill tool with skill `"design"` (bare name first; fallback `"larch:design"`). Pass a prompt asking for an improvement plan for `/${SKILL_NAME}` that addresses the `skill-judge` findings just captured. The prompt should explicitly name `TARGET_SKILL_PATH` as the absolute path of the SKILL.md to modify, so the plan references the file at that resolved path (whichever Step 1 probe matched — repo-local when available, plugin-installation when only probe 3 hit) when `/im` consumes it. This is best-effort guidance to `/design` (and in turn `/im` / `/implement`) — whether `/implement` honors an absolute path in the plan over other resolution heuristics depends on that skill's own behavior. Capture the full response to `$DESIGN_OUT` via the Skill tool call.
 
 > **Continue after child returns.** When `/design` returns, execute the no-plan detector and then either exit the loop or continue to 3.i — do NOT end the turn.
 
@@ -118,7 +118,7 @@ gh issue comment "${ISSUE_NUM}" --body-file "$PLAN_COMMENT_FILE"
 
 ### 3.i — Run /im
 
-Invoke the Skill tool with skill `"im"` (bare name first; fallback `"larch:im"`) via the Skill tool. Pass the full plan text (from `$DESIGN_OUT`) as args so `/im` runs the design + implement + review + version bump + PR + merge pipeline on the plan.
+Invoke the Skill tool with skill `"im"` (bare name first; fallback `"larch:im"`) via the Skill tool. Pass the full plan text (from `$DESIGN_OUT`) as args so `/im` runs the design + implement + review + version bump + PR + merge pipeline on the plan. Because the plan composed in 3.d names `TARGET_SKILL_PATH`, `/im`'s implementation step is likely to edit the file at that resolved path; however, this is soft guidance — the final target is determined by `/implement`'s own path resolution.
 
 > **Continue after child returns.** When `/im` returns, increment the iteration counter and decide whether to loop or exit — do NOT end the turn.
 


### PR DESCRIPTION
## Summary
- Made `/loop-improve-skill` judge the skill file in the current repo rather than the frozen plugin-installation copy, so each loop iteration grades the output of the previous `/im` iteration.
- Inverted Step 1 probe order (repo-local paths now win over plugin-install fallback) and passed the resolved absolute `TARGET_SKILL_PATH` into `/skill-judge`'s args so the judge reads the exact file rather than name-resolving to the plugin tree.

<details><summary>Architecture Diagram</summary>

Quick mode — architecture diagram skipped.

</details>

<details><summary>Code Flow Diagram</summary>

Quick mode — code flow diagram skipped.

</details>

<details><summary>Goal</summary>

- Ensure `/loop-improve-skill <skill>` judges the skill contents that `/im` is actually mutating, not a separate frozen source
  - Motivation: user runs the loop from a working larch clone (e.g., `larch3`) while the plugin-installation tree points at a different clone (e.g., `larch1`). Before this change, Step 1's probe resolved to the plugin-install path first, so every iteration after the first re-judged the stale pristine copy instead of the just-modified working copy.
  - Desired behavior: probe the current repo first (`skills/` and `.claude/skills/`), fall back to the plugin-install tree only when neither repo-local candidate exists (consumer repos that are not larch clones).
  - Pass the resolved absolute path into `/skill-judge` so the judge reads that exact file rather than its own name-based resolution.

</details>

<details><summary>Test plan</summary>

- [x] `/relevant-checks` (pre-commit: markdownlint, agent-lint, skill-invocation lint, agent-config lint) passes
- [x] `scripts/test-anti-halt-banners.sh` still passes — loop-improve-skill's anti-halt banner preserved
- [ ] Manual: next invocation of `/loop-improve-skill <name>` in a working larch clone shows `✅ 1: parse args — target /<name> at <absolute-path-under-cwd>` — confirms probe 1 or 2 won over probe 3
- [ ] Manual: next `/skill-judge` comment in the tracking issue quotes content from the just-edited repo file (not the frozen plugin-install copy)

</details>

<details><summary>Final Design</summary>

Quick-mode inline plan:

**Files to modify**
- `skills/loop-improve-skill/SKILL.md` — prompt-only change.

**Changes**
1. Step 1: resolve `REPO_ROOT` via `git rev-parse --show-toplevel 2>/dev/null || pwd -P` for a guaranteed canonical absolute path.
2. Step 1 probe order (first match wins):
   1. `${REPO_ROOT}/skills/${SKILL_NAME}/SKILL.md` — plugin-dev mode
   2. `${REPO_ROOT}/.claude/skills/${SKILL_NAME}/SKILL.md` — project-local skill
   3. `${CLAUDE_PLUGIN_ROOT}/skills/${SKILL_NAME}/SKILL.md` — plugin-installation fallback
3. Step 3.j (`/skill-judge`): pass `${SKILL_NAME} (absolute SKILL.md path: ${TARGET_SKILL_PATH}) — read the SKILL.md at this exact path before evaluating; do NOT resolve by name against the plugin installation directory. Also evaluate any sibling scripts/ and references/ files under the same skill directory.` as args.
4. Step 3.d (`/design`): prompt explicitly names `TARGET_SKILL_PATH` so the plan references that file (best-effort; final target resolution depends on `/implement`).
5. Step 3.i (`/im`): note that the plan names `TARGET_SKILL_PATH` so `/im`'s implementation step is likely to edit the file at that resolved path.

**Testing**
- `/relevant-checks` (pre-commit lints) on modified SKILL.md.
- Manual verification documented in Test plan.

**Failure modes**
- `$PWD` differs from repo root (user in subdir): `git rev-parse --show-toplevel` still finds the root; `pwd -P` is fallback.
- `/skill-judge` ignores the path hint: reverts to its own resolution, which is the pre-fix behavior — not worse than today.
- Anti-halt banner test regression: banner block left untouched.

</details>

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `c34b778` (Add /loop-improve-skill for iterative skill improvement loops (#203))
- **Current version**: `4.1.0`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `4.1.1`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH").

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

Quick mode — no plan review was conducted.

</details>

<details><summary>Implementation Deviations</summary>

No deviations from the plan.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

(See `## Unimplemented Code Review Suggestions` section in Step 16 output below — copied here for archival.)

Across 7 review rounds, Cursor surfaced a recurring speculative concern about the `/skill-judge` external contract (rounds 1, 2, 3) and about a monorepo sub-directory `.claude/skills/` regression (rounds 5, 7). Both are rejected for the same reason: `/skill-judge` is shipped by a different plugin so contract alignment belongs there, and larch convention places `.claude/skills/` at the repo root (the motivating use case for this fix). Other rejected items: absolute-path disclosure in public issue bodies (pre-existing, out of scope — redaction lives in `scripts/redact-secrets.sh`); `git rev-parse` exit-code specialization (extraordinarily rare failure modes); `larch1`/`larch3` concrete example names (match the user's actual dual-clone scenario — generic placeholders would be less clear); alternative probe-order to make `.claude/skills/` win over `skills/` (the current order serves the motivating plugin-dev use case).

</details>

<details><summary>Plan Review Voting Tally</summary>

Quick mode — no plan review voting.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

Quick mode — no voting panel. Main agent reviewed findings across 7 single-reviewer rounds using Cursor.

</details>

<details><summary>Out-of-Scope Observations</summary>

**Accepted OOS (GitHub issues filed):**
No OOS items were accepted for issue filing.

**Non-accepted OOS observations:**
Quick mode — no reviewer voting panel. Main-agent OOS items (if any) are auto-filed per policy; see Accepted OOS above.

</details>

<details><summary>Execution Issues</summary>

No execution issues encountered.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | N/A (quick mode) |
| Code review rounds | 7 |
| Code review findings | 4 accepted, 10 rejected |
| Warnings logged | 0 |
| Pre-existing issues noticed | 0 |
| OOS issues filed | 0 |
| External reviewers | Cursor: ✅, Codex: N/A (quick mode — Cursor-only loop) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
