### PR TITLE
Fix /loop-improve-skill iteration-1 early-exit failure modes

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.2.5] - 2026-04-20
+
+### Fixed
+
+- `/loop-improve-skill` — prevent silent exit after iteration 1 on minor `/skill-judge` findings or self-judged token/context budget pressure (closes #214). Expanded top banner with an **Anti-self-curtailment** clause enumerating the four authoritative exits. Strengthened Step 3.d's `/design` prompt with three contract clauses requiring a plan for minor/nit findings, forbidding budget-based self-curtailment, and forbidding no-plan sentinels when findings exist. Tightened the no-plan sentinel detector so a first-line sentinel match is terminal only when no structured plan marker (`^#{1,6}\s`, `^[1-9]\d?\.\s`, `^[-*+]\s`) follows — the 5 sentinel strings remain byte-identical. Added a one-shot rescue re-invocation of `/design --auto` when the first response is non-empty, non-sentinel, non-refusal prose with no plan shape; replacement semantics ensure at most one plan comment per iteration. Added explicit Step 3.d ordering invariant and a dedicated `EXIT_REASON` for the `/design` refusal/error exit.
+
 ## [4.2.4] - 2026-04-20
 
 ### Changed

--- a/skills/loop-improve-skill/SKILL.md
+++ b/skills/loop-improve-skill/SKILL.md
@@ -13,6 +13,8 @@ Example: `/loop-improve-skill design` or `/loop-improve-skill /design`.
 
 **Anti-halt continuation reminder.** After every child `Skill` tool call (`/skill-judge`, `/design`, `/im`) returns, IMMEDIATELY continue with this skill's NEXT numbered sub-step — do NOT end the turn on the child's cleanup output. The rule is strictly subordinate to any explicit non-sequential control-flow directive in THIS file (e.g., loop exit on "no plan", `max iterations reached`). A normal sequential continuation is the default this rule reinforces, NOT an exception. See `${CLAUDE_PLUGIN_ROOT}/skills/shared/subskill-invocation.md` section Anti-halt continuation reminder for the canonical rule.
 
+**Anti-self-curtailment.** Token/context budget is NOT a valid loop exit condition. The loop driver and its children MUST NOT end iteration based on their own judgment about token usage, context size, or perceived budget pressure. Only these four authoritative exits end the loop: (1) `ITER > 10` (max iterations); (2) `$DESIGN_OUT` is empty; (3) the tightened no-plan sentinel detector fires (see Step 3.d — sentinel match on the first non-blank line AND no structured plan marker follows); (4) `/design` returns an explicit refusal or error. If any child self-curtails citing tokens/budget and returns prose without plan shape, treat that output as ambiguous and route it through the Step 3.d rescue path — do NOT exit the loop on self-judged budget grounds.
+
 ## Arguments
 
 `$ARGUMENTS` is a single positional token: `<skill-name>`.
@@ -75,6 +77,8 @@ Initialize `ITER=1`. Loop while `ITER <= 10`:
 
 Print: `> **🔶 3: loop — iteration ${ITER}**`
 
+**Loop-exit reminder.** The only authoritative exits are the four enumerated in the top-of-file Anti-self-curtailment banner. Token/context budget is NOT one of them. Proceed to the next iteration regardless of perceived token pressure; only the four defined exits may end the loop.
+
 ### 3.j — Run /skill-judge
 
 Invoke the Skill tool with skill `"skill-judge"` (bare name first). On "no matching skill", retry with `"skill-judge:skill-judge"`. Pass the following string as args so the judge reads the current on-disk contents from the repo-local path resolved in Step 1 rather than whatever default resolution `/skill-judge` would otherwise perform:
@@ -98,14 +102,51 @@ gh issue comment "${ISSUE_NUM}" --body-file "$JUDGE_COMMENT_FILE"
 
 ### 3.d — Run /design
 
-Invoke the Skill tool with skill `"design"` (bare name first; fallback `"larch:design"`). Pass a prompt asking for an improvement plan for `/${SKILL_NAME}` that addresses the `skill-judge` findings just captured. The prompt should explicitly name `TARGET_SKILL_PATH` as the absolute path of the SKILL.md to modify, so the plan references the file at that resolved path (whichever Step 1 probe matched — repo-local when available, plugin-installation when only probe 3 hit) when `/im` consumes it. This is best-effort guidance to `/design` (and in turn `/im` / `/implement`) — whether `/implement` honors an absolute path in the plan over other resolution heuristics depends on that skill's own behavior. Capture the full response to `$DESIGN_OUT` via the Skill tool call.
+Invoke the Skill tool with skill `"design"` (bare name first; fallback `"larch:design"`). Pass a prompt asking for an improvement plan for `/${SKILL_NAME}` that addresses the `skill-judge` findings just captured. The prompt MUST include these three contract clauses verbatim so `/design` produces a plan even for minor findings and never self-curtails on budget:
 
-> **Continue after child returns.** When `/design` returns, execute the no-plan detector and then either exit the loop or continue to 3.i — do NOT end the turn.
+- `/design` MUST produce a concrete, implementable plan for ANY actionable `/skill-judge` finding — including findings classified "minor", "nit", or cosmetic. Treat "minor" as "small plan", not as "no plan".
+- `/design` MUST NOT self-curtail citing token/context budget. Under any perceived pressure, narrow scope to the single highest-leverage finding and emit a compressed micro-plan that still conforms to the standard `/design` plan schema (`## Implementation Plan` with `Files to modify/create`, `Approach`, `Edge cases`, `Failure modes`, `Testing strategy`) — never emit a no-plan sentinel on budget grounds.
+- `/design` MUST NOT emit any of the no-plan sentinel phrases (`no plan`, `no improvements`, `nothing to improve`, `already optimal`, `skill is already high quality`) when `/skill-judge` surfaced any actionable finding. Sentinels are reserved for the genuine case where no improvement is warranted.
 
-**No-plan detection.** Exit the loop cleanly if any of:
+The prompt should also explicitly name `TARGET_SKILL_PATH` as the absolute path of the SKILL.md to modify, so the plan references the file at that resolved path (whichever Step 1 probe matched — repo-local when available, plugin-installation when only probe 3 hit) when `/im` consumes it. This is best-effort guidance to `/design` (and in turn `/im` / `/implement`) — whether `/implement` honors an absolute path in the plan over other resolution heuristics depends on that skill's own behavior. Capture the full response to `$DESIGN_OUT` via the Skill tool call.
+
+> **Continue after child returns.** When `/design` returns, run the tightened no-plan detector below, then the rescue path (when applicable), and then either post the plan and continue to 3.i or exit the loop — do NOT end the turn. **Token/context budget is NOT a valid exit condition**; only the four authoritative exits in the top-of-file Anti-self-curtailment banner end the loop.
+
+**No-plan detection (tightened).** Exit the loop cleanly if any of:
+
 - `$DESIGN_OUT` is empty.
-- The first non-blank line of `$DESIGN_OUT`, trimmed and case-folded, matches one of these exact sentinels: `no plan`, `no improvements`, `nothing to improve`, `already optimal`, `skill is already high quality`. Match the whole trimmed line only — do NOT substring-search the body (a legitimate plan may mention any of these phrases in prose).
-- `/design` returned an explicit refusal or error.
+- The first non-blank line of `$DESIGN_OUT`, trimmed and case-folded, matches one of these exact sentinels: `no plan`, `no improvements`, `nothing to improve`, `already optimal`, `skill is already high quality`, **AND** no structured plan marker appears on any subsequent line of `$DESIGN_OUT`. Match the sentinels against the whole trimmed first non-blank line only — do NOT substring-search the body (a legitimate plan may mention any of these phrases in prose). A **structured plan marker** is any line matching one of these anchored regexes (line-start only — do NOT match mid-line occurrences):
+  - `^#{1,6}\s` — markdown heading (1-6 leading `#` followed by whitespace).
+  - `^[1-9]\d?\.\s` — numbered list counter from 1 through 99, then `.` and whitespace. This deliberately excludes 3+ digit prefixes so calendar-year-prefixed prose (a 4-digit year followed by `.` and a roadmap blurb) does NOT count as a plan marker.
+  - `^[-*+]\s` — bulleted list item (`-`, `*`, or `+` followed by whitespace).
+
+  If ANY line after the sentinel-matching first line matches one of the marker regexes, the sentinel match does NOT fire; `$DESIGN_OUT` is treated as a legitimate plan (proceed past the rescue-and-detector block to the "Otherwise, post the plan" block below).
+- `/design` returned an explicit refusal or error (a structured error response from the Skill tool, or a prose response whose entire body clearly says `/design` could not run — distinct from a plan that merely lacks content).
+
+**Rescue re-invocation of /design (at most one per iteration).** When the tightened no-plan detector does NOT fire but `$DESIGN_OUT` appears ambiguous or budget-curtailed, run a single rescue `/design` call before accepting or exiting. Rescue triggers when ALL four conditions hold:
+
+- `$DESIGN_OUT` is non-empty.
+- The tightened sentinel check above did NOT fire.
+- `/design` did NOT return an explicit refusal or error.
+- `$DESIGN_OUT` contains NO structured plan markers anywhere — none of the three anchored regexes (`^#{1,6}\s`, `^[1-9]\d?\.\s`, `^[-*+]\s`) matches any line.
+
+That is: prose-only output with no plan shape — the characteristic pattern when `/design` self-curtailed, returned a budget excuse, or emitted a weak non-sentinel reply.
+
+When rescue fires, re-invoke the Skill tool with skill `"design"` (bare name first; fallback `"larch:design"`) and pass args `--quick --auto <rescue prompt>`. `--quick` skips `/design`'s expensive 5-agent sketch phase and 3-reviewer voting panel so rescue stays cheap; `--auto` suppresses `/design`'s interactive `AskUserQuestion` checkpoints so rescue runs fully autonomously. The rescue prompt MUST require `/design`'s standard plan schema (a top-level `## Implementation Plan` section with the headings `Files to modify/create`, `Approach`, `Edge cases`, `Failure modes`, `Testing strategy`), focused exclusively on the single highest-leverage `/skill-judge` finding from this iteration, and MUST forbid preamble prose, budget excuses, and all no-plan sentinels. Capture the rescue response and OVERWRITE `$DESIGN_OUT` with it.
+
+Re-run the tightened no-plan detector on the (new) `$DESIGN_OUT`. If it fires this time, exit the loop per the detector rules above. Do NOT chain a second rescue — at most one rescue per iteration. If the four rescue conditions did not hold in the first place, skip the rescue entirely.
+
+**Ordering invariant for Step 3.d.** Within a single iteration, these actions occur in exactly this order, with no exceptions:
+
+1. Invoke `/design` via the Skill tool (the first call).
+2. Run the tightened no-plan detector on `$DESIGN_OUT`.
+3. If the four rescue conditions hold, invoke `/design --quick --auto` via the Skill tool (the rescue call) and OVERWRITE `$DESIGN_OUT` with the rescue output.
+4. Re-run the tightened no-plan detector on the (now-overwritten) `$DESIGN_OUT`.
+5. If the detector fired (in step 2 for the original, or in step 4 for the rescue), proceed to the no-plan exit below.
+6. Otherwise, post exactly ONE plan comment (the `gh issue comment` block below) using the final `$DESIGN_OUT` (the rescue output if rescue ran, else the original).
+7. Continue to 3.i with the same final `$DESIGN_OUT`.
+
+At most one `gh issue comment` plan-body post is made per iteration — never post both the original and the rescue output.
 
 On no-plan exit, set `EXIT_REASON="no plan at iteration ${ITER}"` and proceed directly to Step 4 — Step 4 posts the single summary comment; do not post a separate "no plan materialized" comment here.
 

--- a/skills/loop-improve-skill/SKILL.md
+++ b/skills/loop-improve-skill/SKILL.md
@@ -105,7 +105,7 @@ gh issue comment "${ISSUE_NUM}" --body-file "$JUDGE_COMMENT_FILE"
 Invoke the Skill tool with skill `"design"` (bare name first; fallback `"larch:design"`). Pass a prompt asking for an improvement plan for `/${SKILL_NAME}` that addresses the `skill-judge` findings just captured. The prompt MUST include these three contract clauses verbatim so `/design` produces a plan even for minor findings and never self-curtails on budget:
 
 - `/design` MUST produce a concrete, implementable plan for ANY actionable `/skill-judge` finding — including findings classified "minor", "nit", or cosmetic. Treat "minor" as "small plan", not as "no plan".
-- `/design` MUST NOT self-curtail citing token/context budget. Under any perceived pressure, narrow scope to the single highest-leverage finding and emit a compressed micro-plan that still conforms to the standard `/design` plan schema (`## Implementation Plan` with `Files to modify/create`, `Approach`, `Edge cases`, `Failure modes`, `Testing strategy`) — never emit a no-plan sentinel on budget grounds.
+- `/design` MUST NOT self-curtail citing token/context budget. Under any perceived pressure, narrow scope to the single highest-leverage finding and emit a compressed micro-plan that still conforms to the standard `/design` plan schema (`## Implementation Plan` with `Files to modify/create`, `Approach`, `Edge cases`, `Testing strategy`, and `Failure modes` when the change is non-trivial per `/design`'s own rules) — never emit a no-plan sentinel on budget grounds.
 - `/design` MUST NOT emit any of the no-plan sentinel phrases (`no plan`, `no improvements`, `nothing to improve`, `already optimal`, `skill is already high quality`) when `/skill-judge` surfaced any actionable finding. Sentinels are reserved for the genuine case where no improvement is warranted.
 
 The prompt should also explicitly name `TARGET_SKILL_PATH` as the absolute path of the SKILL.md to modify, so the plan references the file at that resolved path (whichever Step 1 probe matched — repo-local when available, plugin-installation when only probe 3 hit) when `/im` consumes it. This is best-effort guidance to `/design` (and in turn `/im` / `/implement`) — whether `/implement` honors an absolute path in the plan over other resolution heuristics depends on that skill's own behavior. Capture the full response to `$DESIGN_OUT` via the Skill tool call.
@@ -132,7 +132,7 @@ The prompt should also explicitly name `TARGET_SKILL_PATH` as the absolute path 
 
 That is: prose-only output with no plan shape — the characteristic pattern when `/design` self-curtailed, returned a budget excuse, or emitted a weak non-sentinel reply.
 
-When rescue fires, re-invoke the Skill tool with skill `"design"` (bare name first; fallback `"larch:design"`) and pass args `--quick --auto <rescue prompt>`. `--quick` skips `/design`'s expensive 5-agent sketch phase and 3-reviewer voting panel so rescue stays cheap; `--auto` suppresses `/design`'s interactive `AskUserQuestion` checkpoints so rescue runs fully autonomously. The rescue prompt MUST require `/design`'s standard plan schema (a top-level `## Implementation Plan` section with the headings `Files to modify/create`, `Approach`, `Edge cases`, `Failure modes`, `Testing strategy`), focused exclusively on the single highest-leverage `/skill-judge` finding from this iteration, and MUST forbid preamble prose, budget excuses, and all no-plan sentinels. Capture the rescue response and OVERWRITE `$DESIGN_OUT` with it.
+When rescue fires, re-invoke the Skill tool with skill `"design"` (bare name first; fallback `"larch:design"`) and pass args `--auto <rescue prompt>`. `--auto` suppresses `/design`'s interactive `AskUserQuestion` checkpoints so rescue runs fully autonomously. (`/design` does not currently expose a "cheap" or "skip-sketches" flag of its own, so the rescue runs the full `/design` pipeline — the cost is accepted as proportionate to the alternative of the loop exiting silently after iteration 1; the rescue cap of 1 per iteration bounds total blast radius.) The rescue prompt MUST require `/design`'s standard plan schema (a top-level `## Implementation Plan` section with the headings `Files to modify/create`, `Approach`, `Edge cases`, `Testing strategy`, and `Failure modes` when applicable per `/design`'s own rules), focused exclusively on the single highest-leverage `/skill-judge` finding from this iteration, and MUST forbid preamble prose, budget excuses, and all no-plan sentinels. Capture the rescue response and OVERWRITE `$DESIGN_OUT` with it.
 
 Re-run the tightened no-plan detector on the (new) `$DESIGN_OUT`. If it fires this time, exit the loop per the detector rules above. Do NOT chain a second rescue — at most one rescue per iteration. If the four rescue conditions did not hold in the first place, skip the rescue entirely.
 
@@ -140,7 +140,7 @@ Re-run the tightened no-plan detector on the (new) `$DESIGN_OUT`. If it fires th
 
 1. Invoke `/design` via the Skill tool (the first call).
 2. Run the tightened no-plan detector on `$DESIGN_OUT`.
-3. If the four rescue conditions hold, invoke `/design --quick --auto` via the Skill tool (the rescue call) and OVERWRITE `$DESIGN_OUT` with the rescue output.
+3. If the four rescue conditions hold, invoke `/design --auto` via the Skill tool (the rescue call) and OVERWRITE `$DESIGN_OUT` with the rescue output.
 4. Re-run the tightened no-plan detector on the (now-overwritten) `$DESIGN_OUT`.
 5. If the detector fired (in step 2 for the original, or in step 4 for the rescue), proceed to the no-plan exit below.
 6. Otherwise, post exactly ONE plan comment (the `gh issue comment` block below) using the final `$DESIGN_OUT` (the rescue output if rescue ran, else the original).
@@ -148,7 +148,12 @@ Re-run the tightened no-plan detector on the (new) `$DESIGN_OUT`. If it fires th
 
 At most one `gh issue comment` plan-body post is made per iteration — never post both the original and the rescue output.
 
-On no-plan exit, set `EXIT_REASON="no plan at iteration ${ITER}"` and proceed directly to Step 4 — Step 4 posts the single summary comment; do not post a separate "no plan materialized" comment here.
+On no-plan exit, set `EXIT_REASON` and proceed directly to Step 4 — Step 4 posts the single summary comment; do not post a separate "no plan materialized" comment here. The `EXIT_REASON` wording depends on which of the four authoritative exits fired:
+
+- Empty `$DESIGN_OUT` or sentinel match (tightened): `EXIT_REASON="no plan at iteration ${ITER}"`.
+- `/design` returned an explicit refusal or error: `EXIT_REASON="/design refusal or error at iteration ${ITER}"`.
+
+(The fourth exit — `ITER > 10` — is handled in 3.next, not here.)
 
 Otherwise, post the plan to the issue:
 


### PR DESCRIPTION
## Summary

- Fixed two iteration-1 early-exit failure modes in `/loop-improve-skill` (closes #214): loop no longer exits when `/skill-judge` findings are minor/nit, and no longer honors self-judged token/context-budget curtailment.
- Added an Anti-self-curtailment banner enumerating the 4 authoritative exit conditions, tightened the no-plan sentinel detector to require a "pure sentinel shape" (no structured plan markers follow), and added a one-shot `/design --auto` rescue path for ambiguous/budget-curtailed responses.
- Version bump: PATCH → 4.2.4.

<details><summary>Architecture Diagram</summary>

```mermaid
graph TD
    A[loop-improve-skill] --> B[Top banner: Anti-halt + Anti-self-curtailment]
    A --> C[Step 3 loop]
    C --> D[3.j: /skill-judge]
    C --> E[3.d: /design + tightened detector + rescue]
    E --> E1[Contract clauses: plan for minor; no self-curtail; no sentinel-on-findings]
    E --> E2[Tightened detector: sentinel + no plan markers follow]
    E --> E3[Rescue: /design --auto once, standard schema, cap 1/iter]
    E --> E4[Ordering invariant: 1 plan comment/iter]
    C --> F[3.i: /im]
    C --> G[3.next: ITER++]
    G -->|≤10| C
    G -->|>10| H[Step 4: close out]
    E -->|exit conditions| H
```

</details>

<details><summary>Code Flow Diagram</summary>

```mermaid
sequenceDiagram
    participant L as loop-improve-skill
    participant J as /skill-judge
    participant D as /design
    participant DR as /design rescue (--auto)
    participant I as /im
    participant GH as GitHub issue

    Note over L: ITER=1; max=10
    loop ITER ≤ 10
        L->>J: invoke with TARGET_SKILL_PATH
        J-->>L: judgment
        L->>GH: post judgment comment
        L->>D: invoke with 3 contract clauses
        D-->>L: $DESIGN_OUT
        alt $DESIGN_OUT empty OR sentinel+no markers OR refusal/error
            L-->>L: break loop (EXIT_REASON set)
        else non-empty AND no sentinel AND no refusal AND no markers
            L->>DR: invoke --auto (one-shot, standard schema)
            DR-->>L: overwrite $DESIGN_OUT
            L->>L: re-run tightened detector
            alt detector fires on rescue
                L-->>L: break loop
            else rescue OK
                L->>GH: post ONE plan comment (rescue)
                L->>I: invoke with rescue plan
            end
        else plan with markers
            L->>GH: post ONE plan comment (original)
            L->>I: invoke with plan
        end
        L->>L: ITER++
    end
    L->>GH: post final summary
```

</details>

<details><summary>Goal</summary>

- Stop `/loop-improve-skill` from silently terminating after the first iteration in two observed failure modes reported in issue #214:
  - `/skill-judge` surfaces only "minor"/"nit" findings → `/design` returns a no-plan sentinel → loop exits.
  - `/design` or the loop driver self-curtails citing token/context budget → loop exits.
- Require `/design` to produce a plan for ANY actionable `/skill-judge` finding, including minor/nit/cosmetic.
- Forbid the loop and its children from using self-judged token/context budget as an exit condition.
- Preserve the existing 5-sentinel list byte-identical; only refine the matching rule.
- Keep max-iteration cap at 10.
- Edit only `skills/loop-improve-skill/SKILL.md`; do not modify `/skill-judge` or `/design` scoring thresholds.
- Close issue #214 when the PR merges.

</details>

<details><summary>Test plan</summary>

- [x] `bash scripts/test-anti-halt-banners.sh` — banner + micro-reminder contract tokens still present.
- [x] `make lint` (via `/relevant-checks`) — markdownlint, agent-lint, lint-skill-invocations, agent-lint all pass on the changed SKILL.md.
- [x] Grep verification: all 5 no-plan sentinel strings appear byte-identical at the detector line.
- [x] Manual diff review: tightened matcher regexes anchored line-start; rescue conditions conjunct; ordering invariant explicit.
- [ ] Runtime: next `/loop-improve-skill` invocation on a skill with minor-only findings should produce a plan and iterate (not exit at iter 1). Validate on first post-merge use.

</details>

<details><summary>Final Design</summary>

See the **Revised Implementation Plan** in the `/design` phase output visible in conversation context above. Four orchestrator-layer changes in `skills/loop-improve-skill/SKILL.md`:

1. **Strengthened Step 3.d prompt to `/design`** — three contract clauses requiring a plan for any actionable finding (including minor/nit), forbidding self-curtailment, forbidding no-plan sentinels when findings exist.
2. **Tightened no-plan sentinel detector** (DECISION_2 binding, dialectic 3-0): first-line sentinel match is terminal only when no structured plan marker (`^#{1,6}\s` heading, `^[1-9]\d?\.\s` numbered step 1-99, `^[-*+]\s` bullet) follows anywhere in `$DESIGN_OUT`. Sentinel strings preserved byte-identical.
3. **Rescue re-invocation of `/design --auto`** (DECISION_1 binding, dialectic 2-1): on prose-only output with no plan shape (non-empty + no sentinel + no refusal + no markers), re-invoke `/design --auto` once with a standard-schema prompt; overwrite `$DESIGN_OUT`; re-run detector; cap 1/iteration. Replacement semantics ensure at most one plan comment is posted to the tracking issue per iteration.
4. **Anti-self-curtailment banner + per-call micro-reminders** — new top-of-file Anti-self-curtailment clause enumerating the 4 authoritative exits, plus a loop-exit micro-reminder at the Step 3 preamble. Preserves `**Anti-halt continuation reminder.**` and `Continue after child returns` contract tokens.

Round-1 review fixes applied: removed the non-existent `--quick` flag from the rescue call (consensus across Claude + Cursor + Codex), added an explicit `EXIT_REASON` for the refusal/error exit path, and made `Failure modes` optional in the rescue prompt schema (aligned with `/design`'s own rule).

</details>

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `fc7a29b` (Factor /create-skill Principles into skills/shared/skill-design-principles.md (#218))
- **Current version**: `4.2.4`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `4.2.5`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH").

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

Three plan-phase findings were exonerated rather than implemented:

- **F5 (Cursor, code-quality)** — Add a regression harness for 5-sentinel byte-identity. Exonerate: grep check already planned; new harness scope creep for prose-only edit.
- **F6 (Cursor, risk-integration)** — Rescue may supersede a marginal-but-acceptable first plan. Exonerate: rescue triggers only when NO plan markers present; a marginal-but-acceptable plan contains structured markers by definition and would never trigger rescue.
- **F7 (Codex, correctness)** — Fundamental detector redesign to use positive `## Implementation Plan` header. Exonerate: constraint-violating (sentinel list must be preserved); scope creep.

</details>

<details><summary>Implementation Deviations</summary>

None. The revised implementation plan was followed exactly. Round-1 code review findings (F1/F2/F8) were applied on top of the plan and are part of the final diff.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

See `$IMPLEMENT_TMPDIR/rejected-findings.md` (embedded below). Five code-review findings and one OOS observation were exonerated:

- Cursor (round 1, code-quality) — "verbatim" clauses should be a literal fenced block. Exonerate: clauses already precise; stylistic only.
- Cursor (round 1, correctness) — Marker regex `^#{1,6}\s` requires space after `#`; malformed markdown would miss. Exonerate: CommonMark-compliant plans include the space; rescue path is the fallback.
- Cursor (round 1, correctness) — "Explicit refusal or error" is prose-judged; ambiguous. Exonerate: distinction already documented between structured error and empty plan; F2 fix addresses observable-state concern.
- Cursor (round 1, architecture) — Tension between "always produce plan" contract and `/design`'s "NEVER skip Step 2a". Exonerate: clauses target output shape, not `/design`'s internal steps — no contract mismatch.
- Codex (round 1, correctness) — Tightened detector is too broad (any later marker bypasses exit). Exonerate: direct counterpart of DECISION_2's dialectic-resolved tighten direction (3-0 vote). Schema-level detection is DECISION_7 variant exonerated in plan review for same constraint reason.
- Claude (round 1, OOS asymmetric) — Add `test-anti-halt-banners.sh` assertion for new Anti-self-curtailment banner. Legitimate follow-up; not blocking for this PR.

</details>

<details><summary>Plan Review Voting Tally</summary>

Plan review ran in orchestrator mode — the 3-reviewer panel surfaced 10 findings total. 7 accepted, 3 exonerated. Competition (notional, not formally tallied due to orchestrator-run):
- Claude Code Reviewer subagent: +2 (F1 rescue `--auto` required, F2 banner exit-count inconsistency).
- Cursor: +3 (F2 duplicate, F3 regex year false-positive, F4 ordering invariant).
- Codex: +3 (F8 rescue full-/design expensive → use `--quick` (later reversed in code review), F9 schema mismatch, F10 placement of micro-reminder).

Dialectic resolutions (binding for Step 2b):
- **DECISION_1** (rescue retry): ANTI_THESIS wins 2-1 (Cursor + Codex judges). Plan adopted rescue path.
- **DECISION_2** (tighten sentinel match): THESIS wins 3-0. Plan adopted the tightened matcher.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

Round 1 code review ran with all 3 reviewers (Claude Code Reviewer subagent + Codex + Cursor). Findings and outcomes (orchestrator-judged equivalent voting):

| Finding | Reviewer(s) | Outcome | Rationale |
|---|---|---|---|
| F1 — `--quick` is not a `/design` flag | Code + Codex + Cursor | ACCEPT (3 YES) | All three reviewers confirmed — cross-skill contract mismatch; rescue call would silently no-op |
| F2 — No `EXIT_REASON` on refusal/error path | Code | ACCEPT (1 strong YES) | Clear bug; uninformative/misleading summary comment on that branch |
| F8 — `Failure modes` hardcoded | Codex | ACCEPT (1 YES) | `/design` allows omitting for cosmetic work |
| F3 — "verbatim" clause wording | Cursor | EXONERATE | Legitimate; not blocking |
| F4 — Marker regex edge case | Cursor | EXONERATE | Low-probability; rescue path is fallback |
| F5 — Refusal/error ambiguity | Cursor | EXONERATE | Already documented; F2 addresses observable side |
| F6 — Contract tension with /design anti-patterns | Cursor | EXONERATE | No actual mismatch — clauses target output, not internal steps |
| F7 — Tightened detector too broad | Codex | EXONERATE | Constraint-violating alternative; out of scope |

Round 2 (Claude-only on cumulative diff): no findings. Converged.

Reviewer Competition Scoreboard (round 1, in-scope only):
- **Code**: +2 (F1, F2 accepted)
- **Codex**: +2 (F1, F8 accepted; F7 exonerated = 0)
- **Cursor**: +1 (F1 accepted; F3/F4/F5/F6 all exonerated = 0 each)

</details>

<details><summary>Out-of-Scope Observations</summary>

**Accepted OOS (GitHub issues filed):**
No OOS items were accepted for issue filing.

**Non-accepted OOS observations:**
- **Claude (code review, round 1)** — Add `test-anti-halt-banners.sh` assertion for the new `**Anti-self-curtailment.**` banner and declare it as a contract token in `AGENTS.md` or `skills/shared/subskill-invocation.md`. Without mechanical coverage, future edits could silently drift the banner text. Classified as OOS nit — legitimate follow-up, not blocking for this PR.

</details>

<details><summary>Execution Issues</summary>

### Tool Failures
- **Step 8**: Encountered a stray zero-byte untracked file named `**🔶` in the repo root. Likely created by an agent's shell glitch (unquoted emoji/markdown token used in a redirect). Removed before applying version bump; no content loss. Worth investigating the origin to prevent recurrence in background-command or heredoc contexts.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | 7 accepted, 3 exonerated |
| Code review rounds | 2 |
| Code review findings | 3 accepted, 6 exonerated (5 in-scope + 1 OOS) |
| Warnings logged | 0 |
| Pre-existing issues noticed | 0 |
| OOS issues filed | 0 |
| External reviewers | Cursor: ✅, Codex: ✅ |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
