### PR TITLE
Scaffold skill-design-principles.md pointer in render-skill-md.sh (closes #216)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "4.2.5",
+  "version": "4.2.6",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.2.6] - 2026-04-20
+
+### Changed
+
+- `skills/create-skill/scripts/render-skill-md.sh` — emit a single-line pointer to `${CLAUDE_PLUGIN_ROOT}/skills/shared/skill-design-principles.md` at the top of both scaffold body variants (multi-step and minimal), right after the opening TODO HTML comment, so scaffold authors encounter the canonical principles doc at creation time. `skills/create-skill/scripts/test-render-skill-md.sh` — add contract assertion (7) guarding regression and reusing the empty-plugin-token rooted-path guard. Closes #216.
+
 ## [4.2.5] - 2026-04-20
 
 ### Fixed

--- a/skills/create-skill/scripts/render-skill-md.sh
+++ b/skills/create-skill/scripts/render-skill-md.sh
@@ -126,6 +126,8 @@ ${DESCRIPTION}
   Shared scripts (used by two or more skills) should live under ${PLUGIN_TOKEN}/scripts/ instead.
 -->
 
+> **Before editing, read \`${PLUGIN_TOKEN}/skills/shared/skill-design-principles.md\`** — canonical larch skill-design principles (knowledge delta, structure, mechanical rules A/B/C, anti-patterns). Section III overrides general writing-style guidance.
+
 ## Flags
 
 Parse flags from the start of \$ARGUMENTS. Flags may appear in any order; stop at the first non-flag token.
@@ -178,6 +180,8 @@ ${DESCRIPTION}
   Do NOT place raw bash commands in this SKILL.md — wrap every command in a script.
   Shared scripts (used by two or more skills) should live under ${PLUGIN_TOKEN}/scripts/ instead.
 -->
+
+> **Before editing, read \`${PLUGIN_TOKEN}/skills/shared/skill-design-principles.md\`** — canonical larch skill-design principles (knowledge delta, structure, mechanical rules A/B/C, anti-patterns). Section III overrides general writing-style guidance.
 
 ## Sub-skill Invocation
 

--- a/skills/create-skill/scripts/test-render-skill-md.sh
+++ b/skills/create-skill/scripts/test-render-skill-md.sh
@@ -14,7 +14,10 @@
 #       skills/shared/subskill-invocation.md with a NON-EMPTY prefix (guards
 #       against empty ${PLUGIN_TOKEN} expansion silently producing a rooted
 #       "/skills/shared/subskill-invocation.md" pointer that would resolve
-#       to a filesystem root rather than the plugin tree).
+#       to a filesystem root rather than the plugin tree),
+#   (7) the rendered body cites
+#       skills/shared/skill-design-principles.md (closes #216 — the canonical
+#       principles doc must be surfaced to scaffold authors at creation time).
 #
 # Invoked via:  bash skills/create-skill/scripts/test-render-skill-md.sh
 # Wired into:   make lint (via the test-render-skill Makefile target).
@@ -124,6 +127,17 @@ run_case() {
   # scaffold would silently drop the rule for every new orchestrator.
   if ! printf '%s\n' "$content" | grep -Fq 'Anti-halt continuation reminder'; then
     echo "FAIL: rendered file does not mention 'Anti-halt continuation reminder' in the scaffold checklist" >&2
+    echo "--- rendered content ---" >&2
+    printf '%s\n' "$content" >&2
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    return
+  fi
+
+  # Check that the rendered body cites the canonical skill-design-principles
+  # doc (closes #216). Must match PLUGIN_TOKEN + "/skills/shared/skill-design-principles.md"
+  # so an empty --plugin-token cannot silently emit a rooted pointer.
+  if ! printf '%s\n' "$content" | grep -Eq '\$\{CLAUDE_PLUGIN_ROOT\}/skills/shared/skill-design-principles\.md'; then
+    echo "FAIL: rendered file does not cite \${CLAUDE_PLUGIN_ROOT}/skills/shared/skill-design-principles.md" >&2
     echo "--- rendered content ---" >&2
     printf '%s\n' "$content" >&2
     FAIL_COUNT=$((FAIL_COUNT + 1))


### PR DESCRIPTION
## Summary

- Added a single-line pointer to `${CLAUDE_PLUGIN_ROOT}/skills/shared/skill-design-principles.md` into both scaffold variants (multi-step and minimal) emitted by `render-skill-md.sh`, right after the opening TODO HTML comment.
- Extended `test-render-skill-md.sh` with contract assertion (7) guarding that the rendered body cites the canonical principles doc and reusing the empty-plugin-token rooted-path guard.

<details><summary>Architecture Diagram</summary>

Quick mode — architecture diagram skipped.

</details>

<details><summary>Code Flow Diagram</summary>

Quick mode — code flow diagram skipped.

</details>

<details><summary>Goal</summary>

- Close #216 (OOS observation deferred from #206):
  - Surface the canonical `skills/shared/skill-design-principles.md` doc to scaffold authors at creation time.
  - Make regression coverage explicit in the generator path's harness-enforced contract surface.
- Keep the PR minimal-scope and low-risk:
  - Touch only `render-skill-md.sh` and its test harness.
  - Do not restructure the scaffold — only add a pointer line.
  - Do not touch `post-scaffold-hints.sh` (out of scope per issue body).

</details>

<details><summary>Test plan</summary>

- [x] `bash skills/create-skill/scripts/test-render-skill-md.sh` — 3/3 cases pass (multi-step plugin-mode, minimal consumer-mode, empty-plugin-token rejected).
- [x] `/relevant-checks` — pre-commit + agent-lint pass.
- [ ] CI green on PR.

</details>

<details><summary>Final Design</summary>

**Files**:
1. `skills/create-skill/scripts/render-skill-md.sh` — insert pointer line into both `MULTI_STEP_BODY` and `MINIMAL_BODY` heredocs, right after the closing `-->` of the opening TODO comment. Pointer uses `${PLUGIN_TOKEN}` substitution so the rendered body contains the literal `${CLAUDE_PLUGIN_ROOT}` token, matching house style for shared references.
2. `skills/create-skill/scripts/test-render-skill-md.sh` — add assertion (7) that the rendered body cites `${CLAUDE_PLUGIN_ROOT}/skills/shared/skill-design-principles.md` with the same regex shape as the existing `subskill-invocation.md` check (non-empty `${CLAUDE_PLUGIN_ROOT}` prefix guard). Update the header-comment assertion enumeration accordingly.

**Pointer text** (single line, blockquote):

```
> **Before editing, read `${CLAUDE_PLUGIN_ROOT}/skills/shared/skill-design-principles.md`** — canonical larch skill-design principles (knowledge delta, structure, mechanical rules A/B/C, anti-patterns). Section III overrides general writing-style guidance.
```

**Heredoc care**: the `MULTI_STEP_BODY` / `MINIMAL_BODY` heredocs are unquoted, so backticks trigger command substitution unless escaped. Surrounding template lines already use the `\`` escape pattern; the new line follows suit.

**Failure modes**:
- Path typo in pointer — harness assertion (7) catches.
- Heredoc expansion of bare `$` — mitigated, `${PLUGIN_TOKEN}` is a variable on the caller side that expands to the literal `${CLAUDE_PLUGIN_ROOT}` string.
- Harness not exercising both variants — existing `run_case` is already invoked twice (multi-step + minimal); assertion (7) runs inside the shared case body.

</details>

<details><summary>Version Bump Reasoning</summary>

See `bump-version-reasoning.md` (classify-bump.sh output). PATCH — changes are confined to `skills/create-skill/scripts/` (not part of the public plugin surface considered by the classifier).

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

Quick mode — no plan review was conducted.

</details>

<details><summary>Implementation Deviations</summary>

No deviations from the inline plan.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

All code review suggestions were implemented.

</details>

<details><summary>Plan Review Voting Tally</summary>

Quick mode — no plan review voting.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

Quick mode — no voting panel. Main agent reviewed findings across up to 7 single-reviewer rounds (Cursor → Codex → Claude fallback chain). Round 1 reviewer (Cursor) returned `NO_ISSUES_FOUND` — loop exited after one round.

</details>

<details><summary>Out-of-Scope Observations</summary>

**Accepted OOS (GitHub issues filed):**
No OOS items were accepted for issue filing.

**Non-accepted OOS observations:**
Quick mode — no reviewer voting panel. Main-agent OOS items (if any) are auto-filed per policy; see Accepted OOS above.

</details>

<details><summary>Execution Issues</summary>

No execution issues encountered.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | N/A (quick mode) |
| Code review rounds | 1 |
| Code review findings | 0 accepted, 0 rejected |
| Warnings logged | 0 |
| Pre-existing issues noticed | 0 |
| OOS issues filed | 0 |
| External reviewers | N/A (quick mode) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
