### PR TITLE
Fix SIGPIPE 141 in classify-bump.sh extract_frontmatter on large SKILL.md (closes #240)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/.claude/skills/bump-version/scripts/classify-bump.sh
+++ b/.claude/skills/bump-version/scripts/classify-bump.sh
@@ -158,8 +158,12 @@ while IFS=$'\t' read -r status old new_or_blank; do
           '
         }
 
-        OLD_FRONTMATTER=$(printf '%s\n' "$OLD_FILE" | extract_frontmatter)
-        NEW_FRONTMATTER=$(printf '%s\n' "$NEW_FILE" | extract_frontmatter)
+        # Use herestring instead of `printf | awk` because awk's `exit` on the
+        # closing `---` line causes SIGPIPE back to `printf` for large files;
+        # with `set -euo pipefail` the whole script would abort with exit 141.
+        # Herestrings don't create an intermediate pipe sensitive to SIGPIPE.
+        OLD_FRONTMATTER=$(extract_frontmatter <<< "$OLD_FILE")
+        NEW_FRONTMATTER=$(extract_frontmatter <<< "$NEW_FILE")
 
         # name: frontmatter field (scoped to frontmatter block only).
         OLD_NAME=$(printf '%s\n' "$OLD_FRONTMATTER" | awk '/^name: / { sub(/^name: */, ""); print; exit }')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.3.1] - 2026-04-20
+
+### Fixed
+
+- `.claude/skills/bump-version/scripts/classify-bump.sh` — fix silent SIGPIPE 141 abort on large SKILL.md files. The `extract_frontmatter` awk function exits after matching the closing `---` frontmatter delimiter; `printf '%s\n' "$FILE" | extract_frontmatter` then receives SIGPIPE while still writing hundreds of KB on large files. Under `set -euo pipefail` the pipefail-propagated 141 silently aborted the whole script with no stdout and no stderr, causing `/implement` Step 8 to misclassify the bump. Replaces the pipe with a herestring (`extract_frontmatter <<< "$FILE"`) so awk reads from stdin without an intermediate writer that can be SIGPIPE-killed; awk function body unchanged. The four subsequent `printf | awk` extractions for `OLD_NAME`/`NEW_NAME`/`OLD_ARG_HINT`/`NEW_ARG_HINT` operate on already-extracted small frontmatter blocks (well under the 64KB pipe buffer) and do not trigger the bug — left as-is. Closes #240.
+
 ## [4.3.0] - 2026-04-20
 
 ### Added


### PR DESCRIPTION
## Summary
- Fixed silent SIGPIPE 141 abort in `.claude/skills/bump-version/scripts/classify-bump.sh` `extract_frontmatter` on large SKILL.md files by replacing the `printf | awk` pipe with a herestring.

<details><summary>Architecture Diagram</summary>

Quick mode — architecture diagram skipped.

</details>

<details><summary>Code Flow Diagram</summary>

Quick mode — code flow diagram skipped.

</details>

<details><summary>Goal</summary>

- Eliminate silent failure mode in `/implement` Step 8 bump classification.
  - `classify-bump.sh` aborts with exit 141 when piping large SKILL.md content (e.g., the current `skills/implement/SKILL.md` at ~1000+ lines) into `extract_frontmatter`.
  - `awk` exits after matching the closing `---` frontmatter delimiter; `printf` then receives SIGPIPE while still writing the rest of the file; under `set -euo pipefail` the pipefail-propagated 141 aborts the whole script with no stdout and no stderr.
  - The caller (`/implement` Step 8) sees no `KEY=VALUE` output and misclassifies the bump.
- Apply the issue's option (a): use `extract_frontmatter <<< "$FILE"` so awk reads from stdin without an intermediate writer process that can be SIGPIPE-killed.
- Keep awk function body unchanged.
- Leave the subsequent `printf | awk` calls for `OLD_NAME`/`NEW_NAME`/`OLD_ARG_HINT`/`NEW_ARG_HINT` unchanged — those operate on already-extracted small frontmatter blocks (well under the 64KB pipe buffer) and do not trigger the bug.
- Closes #240.

</details>

<details><summary>Test plan</summary>

- [x] `/relevant-checks` passes (shellcheck on the modified script).
- [x] Manual repro: `printf '%s\n' "$BIG" | extract_frontmatter` exits 141 on a 260KB synthetic input under `set -o pipefail`; same input via `extract_frontmatter <<< "$BIG"` exits 0 with the correct frontmatter output.
- [x] `/bump-version` ran successfully against the modified file (Step 8 produced PATCH bump as expected).

</details>

<details><summary>Final Design</summary>

**File**: `.claude/skills/bump-version/scripts/classify-bump.sh`

**Problem**: `printf '%s\n' "$OLD_FILE" | extract_frontmatter` pipes large SKILL.md content into awk; awk `exit` after closing `---` causes SIGPIPE → `pipefail` → exit 141.

**Fix** (option a from issue): Replace pipe with herestring. awk reads stdin by default; herestrings don't propagate SIGPIPE because there is no separate writer process.

**Edit**: lines 161-162 — `printf '%s\n' "$OLD_FILE" | extract_frontmatter` → `extract_frontmatter <<< "$OLD_FILE"` (same for NEW). Function body unchanged. Added a 4-line comment explaining the SIGPIPE/pipefail/141 mechanism.

**Verify**: (1) existing manual repro now exits 0 with correct output; (2) `/relevant-checks` shellcheck passes; (3) `/bump-version` ran successfully on this branch (the modified script classified its own bump).

</details>

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `d7df2b4` (Fix /loop-improve-skill halt: split outer + /loop-improve-skill-iter with mechanical gate (#231) (#243))
- **Current version**: `4.3.0`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `4.3.1`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH").

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

Quick mode — no plan review was conducted.

</details>

<details><summary>Implementation Deviations</summary>

No deviations from the plan.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

### [Code Review] Cursor (round 1)
**Finding**: `.claude/skills/bump-version/scripts/classify-bump.sh:165-166, 176-177`. The same `printf '%s\n' "$OLD_FRONTMATTER" | awk '/^name: / { ...; exit }'` pattern remains for `OLD_NAME`/`NEW_NAME`/`OLD_ARG_HINT`/`NEW_ARG_HINT` extraction. Reviewer suggests applying the herestring fix to these four extractions for symmetry.
**Reason not implemented**: The user explicitly excluded these from scope in issue #240's filing prompt: "Keep the subsequent `printf | awk` calls for OLD_NAME/NEW_NAME/OLD_ARG_HINT/NEW_ARG_HINT etc. unchanged — those operate on already-extracted small frontmatter blocks and do not trigger the bug." Frontmatter blocks are bounded between two `---` delimiters and are at most a few dozen lines (typically <2KB), well under the 64KB pipe buffer — `printf` writes the whole frontmatter in a single syscall and exits before `awk` closes the read end, so no SIGPIPE is possible. The bug only triggers on full-file body traversal where `printf` is still writing hundreds of KB after `awk` exits. Expanding scope would be a speculative refactor unrelated to the user-described failure mode.

### [Code Review] Cursor (round 1)
**Finding**: `.claude/skills/bump-version/scripts/classify-bump.sh:161-164`. The new comment says herestrings "don't create an intermediate pipe sensitive to SIGPIPE." Reviewer argues the more accurate framing is that herestrings avoid the separate `printf` process whose SIGPIPE pipefail-propagates to 141.
**Reason not implemented**: Subjective wording preference. The current comment is technically correct (bash uses a small anonymous file descriptor for `<<<` and the writer is bash itself, not a separate killable process). Both framings convey the same operational truth — that the failure mode does not occur with herestrings. Disproportionate fix for marginal clarity gain in a comment that already names the SIGPIPE/141/pipefail mechanism.

### [Code Review] Cursor (round 1)
**Finding**: No regression test wired to `make lint` for `classify-bump.sh` SIGPIPE/141 behavior — a future regression to `printf | awk` could slip in unnoticed. Reviewer suggests adding a fixture-driven shell test.
**Reason not implemented**: Scope creep beyond the bug fix described in #240. Adding a regression harness for a dev-only `.claude/skills/` script is forward-looking work, not part of the user's explicit fix instructions. The fix itself was empirically verified against a 260KB synthetic file (exit 0 with herestring vs. exit 141 with `printf | awk`). A standalone test harness for the dev-only bump-version skill is a separable improvement that can be filed independently if the maintainer chooses.

</details>

<details><summary>Plan Review Voting Tally</summary>

Quick mode — no plan review voting.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

Quick mode — no voting panel. Main agent reviewed findings across up to 7 single-reviewer rounds (Cursor → Codex → Claude fallback chain).

</details>

<details><summary>Out-of-Scope Observations</summary>

**Accepted OOS (GitHub issues filed):**
No OOS items were accepted for issue filing.

**Non-accepted OOS observations:**
Quick mode — no reviewer voting panel. Main-agent OOS items (if any) are auto-filed per policy; see Accepted OOS above.

</details>

<details><summary>Execution Issues</summary>

No execution issues encountered.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | N/A (quick mode) |
| Code review rounds | 1 |
| Code review findings | 0 accepted, 3 rejected |
| Warnings logged | 0 |
| Pre-existing issues noticed | 0 |
| OOS issues filed | 0 |
| External reviewers | N/A (quick mode) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
