### PR TITLE
Fix stale Rebase + Re-bump Sub-procedure anchors in 4 script headers (closes #235)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "4.3.2",
+  "version": "4.3.3",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.3.3] - 2026-04-20
+
+### Fixed
+
+- `scripts/lib-count-commits.sh`, `scripts/check-bump-version.sh`, `scripts/git-force-push.sh`, `scripts/git-sync-local-main.sh` — header comments cited `skills/implement/SKILL.md` as the inline home of the Rebase + Re-bump Sub-procedure, but PR #229 extracted it to `skills/implement/references/rebase-rebump-subprocedure.md`. Append the reference-file path as a parenthetical anchor adjacent to each existing step-number citation (preserving step numbers 3/4/5 which map 1:1 to the extracted file's numbering). Prose-only; zero runtime behavior change. Also makes `check-bump-version.sh`'s header carry an explicit `step 4` anchor so it matches the `step N (path)` pattern of the other three headers (plan-review FINDING_2, 2 YES / 1 NO). Closes #235.
+
 ## [4.3.1] - 2026-04-20
 
 ### Fixed

--- a/scripts/check-bump-version.sh
+++ b/scripts/check-bump-version.sh
@@ -39,8 +39,9 @@
 #
 # Commit counting uses local `main` if it exists, falling back to `origin/main`
 # if only the remote ref is present. This matches classify-bump.sh's base
-# resolution and ensures the /implement Rebase + Re-bump Sub-procedure's post-
-# verification check works correctly even when the repo has no local `main`
+# resolution and ensures the /implement's Rebase + Re-bump Sub-procedure step 4
+# (skills/implement/references/rebase-rebump-subprocedure.md) post-verification
+# check works correctly even when the repo has no local `main`
 # ref (e.g., some CI clones). Without the fallback, `git rev-list main..HEAD`
 # silently returns 0 and the post-check produces a false VERIFIED=false.
 #

--- a/scripts/git-force-push.sh
+++ b/scripts/git-force-push.sh
@@ -2,7 +2,8 @@
 # git-force-push.sh — Force-push the current branch with lease protection + recovery.
 #
 # Wraps `git push --force-with-lease` with the full recovery logic from
-# /implement's Rebase + Re-bump Sub-procedure step 5:
+# /implement's Rebase + Re-bump Sub-procedure step 5
+# (skills/implement/references/rebase-rebump-subprocedure.md):
 #   - Try `git push --force-with-lease` once.
 #   - On failure: refresh the local tracking ref (`git fetch origin <branch>`),
 #     compare local HEAD vs origin/<branch>. If equal, the push actually landed

--- a/scripts/git-sync-local-main.sh
+++ b/scripts/git-sync-local-main.sh
@@ -2,8 +2,10 @@
 # git-sync-local-main.sh — Fast-forward local `main` ref to `origin/main`.
 #
 # Silent no-op when the local `main` ref does not exist. Used by the
-# Rebase + Re-bump Sub-procedure step 3 so that `classify-bump.sh`'s
-# merge-base computation resolves against the latest remote base.
+# Rebase + Re-bump Sub-procedure step 3
+# (skills/implement/references/rebase-rebump-subprocedure.md) so that
+# `classify-bump.sh`'s merge-base computation resolves against the latest
+# remote base.
 #
 # Never run on `main` itself — `git branch -f` of the current branch fails.
 # /implement's Step 10 and Step 12 rebase loops always run on a feature branch.

--- a/scripts/lib-count-commits.sh
+++ b/scripts/lib-count-commits.sh
@@ -43,8 +43,8 @@
 #   operators' existing grep patterns (see #160 FINDING_7). Consumers MAY
 #   grep `WARN: check-bump-version.sh:` for this condition. The prefix is
 #   intentionally a historical alias — do not rename to `lib-count-commits.sh`
-#   without coordinating consumer updates (e.g., skills/implement/SKILL.md's
-#   Rebase + Re-bump Sub-procedure step 4 notes).
+#   without coordinating consumer updates (e.g., skills/implement/references/
+#   rebase-rebump-subprocedure.md step 4 notes).
 #
 # Scope boundary (distinct from classify-bump.sh):
 #   `.claude/skills/bump-version/scripts/classify-bump.sh` also resolves a


### PR DESCRIPTION
## Summary

- Updated four shell-script header comments (`lib-count-commits.sh`, `check-bump-version.sh`, `git-force-push.sh`, `git-sync-local-main.sh`) to cite `skills/implement/references/rebase-rebump-subprocedure.md` instead of the pre-extraction inline SKILL.md home, preserving step numbers 3/4/5 which still map 1:1 to the extracted reference (closes #235).
- Applied plan-review finding FINDING_2 by making `check-bump-version.sh`'s header carry an explicit `step 4` anchor so it matches the `step N (path)` pattern of the other three headers.

<details><summary>Architecture Diagram</summary>

```mermaid
flowchart LR
  subgraph Canonical[Canonical Spec]
    R[skills/implement/references/rebase-rebump-subprocedure.md<br/>step 3, 4, 4a, 5]
  end
  subgraph Consumers[Script Headers - prose-only]
    S1[scripts/lib-count-commits.sh<br/>step 4 notes]
    S2[scripts/check-bump-version.sh<br/>step 4 post-verification]
    S3[scripts/git-force-push.sh<br/>step 5 push recovery]
    S4[scripts/git-sync-local-main.sh<br/>step 3 local main sync]
  end
  S1 -. cites .-> R
  S2 -. cites .-> R
  S3 -. cites .-> R
  S4 -. cites .-> R
```

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available (prose-only change — no runtime flow distinct from the architecture diagram).

</details>

<details><summary>Goal</summary>

- Fix stale SKILL.md anchors in script header comments surfaced as follow-up from PR #229
  - After PR #229 extracted the Rebase + Re-bump Sub-procedure from `skills/implement/SKILL.md` to `skills/implement/references/rebase-rebump-subprocedure.md`, four shell-script header comments retained pre-extraction citations.
  - Point each header at the new canonical reference file while preserving the step-number anchors (step 3/4/5) that still map cleanly to the extracted file's own numbering.
  - Success criteria: the four named headers now append `(skills/implement/references/rebase-rebump-subprocedure.md)` adjacent to their existing step-number anchors; zero runtime/behavioral change; `/relevant-checks` passes.

</details>

<details><summary>Test plan</summary>

- [x] `/relevant-checks` passes (shellcheck + agent-lint + lint-skill-invocations) on the four edited scripts
- [x] Grep `SKILL\.md.*Rebase|Rebase.*SKILL\.md` in `scripts/` returns only the intentional test-harness literal in `scripts/test-implement-rebase-macro.sh:164` (which asserts the structural contract pinning both locations) plus the two follow-up issues #248 / #249 targets (filed as OOS).
- [x] Manual diff review confirms prose-only edits, no executable-code touches

</details>

<details><summary>Final Design</summary>

**Files modified (exactly 4):**

1. `scripts/lib-count-commits.sh:46-47` — parenthetical now cites `skills/implement/references/rebase-rebump-subprocedure.md step 4 notes`.
2. `scripts/check-bump-version.sh:41-43` — now reads `/implement's Rebase + Re-bump Sub-procedure step 4 (skills/implement/references/rebase-rebump-subprocedure.md) post-verification check`. (Plan-review FINDING_2: explicit `step 4` anchor added for consistency with the other three.)
3. `scripts/git-force-push.sh:4-6` — now reads `/implement's Rebase + Re-bump Sub-procedure step 5 (skills/implement/references/rebase-rebump-subprocedure.md):`.
4. `scripts/git-sync-local-main.sh:4-7` — now reads `Rebase + Re-bump Sub-procedure step 3 (skills/implement/references/rebase-rebump-subprocedure.md)`. Outer `/implement` Step 10/12 references left untouched.

Approach: minimum parenthetical appends adjacent to existing step-number anchors. Zero behavior change. Testing: `/relevant-checks` + grep verification.

</details>

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `5a2211c` (Extract /implement SKILL.md to references/ for progressive disclosure (#229))
- **Current version**: `4.3.2`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `4.3.3`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH").

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

**[Plan Review] Codex + Cursor (FINDING_1)** — Expand PR scope to include `scripts/git-amend-add.sh:4-5` (`Rebase + Re-bump Sub-procedure step 4a` anchor). Unanimously exonerated (0 YES / 3 EXON) — disproportionate to widen #235's explicit 4-file scope mid-PR. Tracked as follow-up #249 per OOS_2 voting result.

**[Plan Review] Cursor (FINDING_3)** — Bake post-edit grep verification into plan. Rejected (1 YES / 1 NO / 1 EXON) — panel viewed as process ceremony; main agent runs grep naturally during review.

</details>

<details><summary>Implementation Deviations</summary>

No deviations from the plan. All four edits landed as specified; FINDING_2 accepted mid-design was incorporated before implementation.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

All code review suggestions were implemented (0 in-scope findings from any reviewer in round 1). The single OOS observation that rose above 2+ YES (`scripts/git-amend-add.sh:5`) was filed as #249 rather than mid-PR scope expansion.

</details>

<details><summary>Plan Review Voting Tally</summary>

| Finding | Claude | Codex | Cursor | YES | Outcome |
|---------|--------|-------|--------|-----|---------|
| FINDING_1 | EXON | EXON | EXON | 0 | rejected (unanimous exonerate) |
| FINDING_2 | NO | YES | YES | 2 | **ACCEPTED** |
| FINDING_3 | NO | YES | EXON | 1 | rejected |
| OOS_1 (test-check-bump-version.sh:383) | YES | YES | YES | 3 | **ACCEPTED — filed as #248** |

**Reviewer Competition Scoreboard (design phase)**

| Reviewer | In-scope accepted | In-scope exonerated | OOS accepted | Score |
|----------|-------------------|---------------------|--------------|-------|
| Code | 0 | 0 | 1 | +1 |
| Codex | 1 (F2) | 1 (F1) | 0 | +1 |
| Cursor | 0 | 1 (F1) | 0 | 0 |

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

| Finding | Claude | Codex | Cursor | YES | Outcome |
|---------|--------|-------|--------|-----|---------|
| OOS_2 (git-amend-add.sh:5) | YES | YES | YES | 3 | **ACCEPTED — filed as #249** |

All 3 reviewers reported 0 in-scope findings on the cumulative branch diff. Only OOS item voted.

**Reviewer Competition Scoreboard (review phase)**

| Reviewer | In-scope accepted | OOS accepted | Score |
|----------|-------------------|--------------|-------|
| Code | 0 | 1 | +1 |
| Codex | 0 | 0 | 0 |
| Cursor | 0 | 0 | 0 |

</details>

<details><summary>Out-of-Scope Observations</summary>

**Accepted OOS (GitHub issues filed):**

- #248: [OOS] scripts/test-check-bump-version.sh:383 inline comment carries stale `skills/implement/SKILL.md Rebase + Re-bump Sub-procedure step 4` anchor (Code)
- #249: [OOS] scripts/git-amend-add.sh:5 header comment carries stale "/implement Step 8a + Rebase + Re-bump Sub-procedure step 4a" anchor pointing at the pre-extraction SKILL.md inline home (Code)

**Non-accepted OOS observations:**

No non-accepted OOS observations — both OOS items reached 3 YES and were filed.

</details>

<details><summary>Execution Issues</summary>

### Warnings
- **Step 7a**: code flow diagram generation skipped — prose-only comment edit has no runtime flow distinct from the architecture diagram already emitted in Step 1 (/design).

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | 1 accepted, 2 rejected |
| Code review rounds | 1 |
| Code review findings | 0 accepted, 0 rejected |
| Warnings logged | 1 |
| Pre-existing issues noticed | 2 (filed as #248, #249) |
| OOS issues filed | 2 created, 0 deduplicated |
| External reviewers | Cursor: ✅, Codex: ✅ |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
