### PR TITLE
Fix stale anchor in scripts/test-check-bump-version.sh body comment (closes #248)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "4.3.7",
+  "version": "4.3.8",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.3.8] - 2026-04-20
+
+### Fixed
+
+- `scripts/test-check-bump-version.sh` — Section 5 body comments cited `skills/implement/SKILL.md Rebase + Re-bump Sub-procedure step 4` (line 383 call-site example) and `SKILL.md step 4 "Pre-check STATUS guard"` (lines 430-431 test rationale), but PR #229 extracted the sub-procedure to `skills/implement/references/rebase-rebump-subprocedure.md`. Replace both with the canonical `rebase-rebump-subprocedure.md step 4` anchor. Prose-only; zero runtime behavior change. Same class of stale anchor as #235 (which targeted 4 script headers) but in a test-script body comment that was deliberately left out of #235's enumerated scope. Closes #248.
+
 ## [4.3.7] - 2026-04-20
 
 ### Changed

--- a/scripts/test-check-bump-version.sh
+++ b/scripts/test-check-bump-version.sh
@@ -427,8 +427,8 @@ assert_stdout_contains "5b post-recovered: COMMITS_AFTER=3 (true count)" "$post_
 # With the coerced BEFORE=0 and true AFTER=3, the numeric check would
 # naturally set VERIFIED=false — but a correct caller skips the comparison
 # because the pre-check STATUS was non-ok. This test documents the raw
-# signals; the SKILL.md step 4 "Pre-check STATUS guard" branches on the
-# pre-check STATUS, not on this post-check's VERIFIED value.
+# signals; the rebase-rebump-subprocedure.md step 4 "Pre-check STATUS guard"
+# branches on the pre-check STATUS, not on this post-check's VERIFIED value.
 assert_stdout_contains "5b post-recovered: script-level VERIFIED reflects naive arithmetic" "$post_out" "VERIFIED=false"
 
 # --- Section 6: argument-error paths -----------------------------------------

--- a/scripts/test-check-bump-version.sh
+++ b/scripts/test-check-bump-version.sh
@@ -380,7 +380,7 @@ assert_stdout_contains "4b: STATUS=git_error" "$out" "STATUS=git_error"
 # Regression guard for the pre-STATUS caller-side trap (surfaced during #172
 # code review). The script does not itself mix pre and post state — each
 # invocation is independent — but the observable signals MUST allow callers
-# (e.g., skills/implement/SKILL.md Rebase + Re-bump Sub-procedure step 4)
+# (e.g., skills/implement/references/rebase-rebump-subprocedure.md step 4)
 # to distinguish:
 #   (a) pre-degraded → COMMITS_BEFORE coerced to 0, STATUS non-ok
 #   (b) post-recovered → COMMITS_AFTER reflects true count N, STATUS=ok


### PR DESCRIPTION
## Summary

- Replaced stale `skills/implement/SKILL.md Rebase + Re-bump Sub-procedure step 4` anchor on `scripts/test-check-bump-version.sh:383` with `skills/implement/references/rebase-rebump-subprocedure.md step 4`.
- Fixed second stale anchor `SKILL.md step 4 "Pre-check STATUS guard"` on `scripts/test-check-bump-version.sh:430-431` surfaced by code review (same class of anchor rot).
- Prose-only comment fix; zero runtime behavior change. Same class as #235 but in a test-script body comment deliberately left out of #235's enumerated scope.

<details><summary>Architecture Diagram</summary>

Quick mode — architecture diagram skipped.

</details>

<details><summary>Code Flow Diagram</summary>

Quick mode — code flow diagram skipped.

</details>

<details><summary>Goal</summary>

- Fix stale anchor in test-script body comment (closes #248)
  - Line 383: sole target named in the issue
  - Lines 430-431: adjacent stale anchor in same Section 5 narrative, surfaced by Cursor review
- Keep anchors canonical after PR #229's extraction of the Rebase + Re-bump Sub-procedure to `skills/implement/references/rebase-rebump-subprocedure.md`

</details>

<details><summary>Test plan</summary>

- [x] `grep -rn 'SKILL\.md.*Rebase \+ Re-bump Sub-procedure step 4'` returns no matches
- [x] `grep -n 'SKILL\.md step 4' scripts/test-check-bump-version.sh` returns no matches
- [x] `/relevant-checks` passes (shellcheck, agent-lint, structural)
- [x] Target file `skills/implement/references/rebase-rebump-subprocedure.md` exists with a "step 4" (Re-bump) section

</details>

<details><summary>Final Design</summary>

- File: `scripts/test-check-bump-version.sh`
- Line 383 change: replace `skills/implement/SKILL.md Rebase + Re-bump Sub-procedure step 4` with `skills/implement/references/rebase-rebump-subprocedure.md step 4`
- Lines 430-431 change (round-1 review fix): replace `SKILL.md step 4 "Pre-check STATUS guard"` with `rebase-rebump-subprocedure.md step 4 "Pre-check STATUS guard"`
- Verification: grep confirms no stale anchors; `/relevant-checks` green

</details>

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `1c72253` (Polish /relevant-checks: description keywords, maintenance rule, drop hook enumeration (#256))
- **Current version**: `4.3.7`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `4.3.8`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH").

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

Quick mode — no plan review was conducted.

</details>

<details><summary>Implementation Deviations</summary>

No deviations from the plan. Round-1 review extended the fix to an adjacent stale anchor on lines 430-431 that fell in the same Section 5 narrative block as the line-383 target — accepted because it was the same class of anchor rot.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

All code review suggestions were implemented.

</details>

<details><summary>Plan Review Voting Tally</summary>

Quick mode — no plan review voting.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

Quick mode — no voting panel. Main agent reviewed findings across up to 7 single-reviewer rounds (Cursor → Codex → Claude fallback chain).

</details>

<details><summary>Out-of-Scope Observations</summary>

**Accepted OOS (GitHub issues filed):**
No OOS items were accepted for issue filing.

**Non-accepted OOS observations:**
Quick mode — no reviewer voting panel. Main-agent OOS items (if any) are auto-filed per policy; see Accepted OOS above.

</details>

<details><summary>Execution Issues</summary>

No execution issues encountered.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | N/A (quick mode) |
| Code review rounds | 2 |
| Code review findings | 1 accepted, 0 rejected |
| Warnings logged | 0 |
| Pre-existing issues noticed | 0 |
| OOS issues filed | 0 |
| External reviewers | N/A (quick mode) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
