### PR TITLE
Fix test-implement-structure.sh regex to catch dotted substep back-refs (closes #253)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "4.3.8",
+  "version": "4.3.9",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.3.9] - 2026-04-20
+
+### Fixed
+
+- `scripts/test-implement-structure.sh` — assertion (9) regex `see Step [0-9]+[a-z.]* (below|above)` could not consume a digit after the `a.` segment, so dotted substep back-references like `see Step 9a.1 below` or `see Step 3c.2 above` evaded the guard (`/implement` already uses dotted substep numbering). Broaden the step-number token to `[0-9][0-9a-z.]*` so bare digits, letter-suffix forms, and dotted substep forms are all caught; the narrow guard (direction word required) is preserved. Closes #253.
+
 ## [4.3.8] - 2026-04-20
 
 ### Fixed

--- a/scripts/test-implement-structure.sh
+++ b/scripts/test-implement-structure.sh
@@ -160,6 +160,9 @@ done
 #     Pattern is narrow: requires both a step number AND a direction word (below|above).
 #     Permits legitimate cross-refs like 'see Step 8' with no direction word.
 #     Case-insensitive: catches sentence-initial 'See Step 8 below' variants.
+#     The step-number token is `[0-9][0-9a-z.]*` so bare digits (`8`), letter-suffix
+#     forms (`9a`), and dotted substep forms (`9a.1`, `3c.2`) are all caught — matching
+#     /implement's dotted substep numbering (closes #253).
 #     Scans every *.md under references/ (not just the four expected refs) so new
 #     reference files added in the future are covered automatically — the contract
 #     documented in the header and AGENTS.md says "references/*.md" generally.
@@ -172,7 +175,7 @@ shopt -u nullglob
 
 match_files=""
 for ref_path in "${ref_files[@]}"; do
-  if grep -qiE 'see Step [0-9]+[a-z.]* (below|above)' "$ref_path"; then
+  if grep -qiE 'see Step [0-9][0-9a-z.]* (below|above)' "$ref_path"; then
     match_files="$match_files $(basename "$ref_path")"
   fi
 done


### PR DESCRIPTION
## Summary

- Broaden `scripts/test-implement-structure.sh` assertion (9) regex to catch dotted substep back-references (e.g. `see Step 9a.1 below`, `see Step 3c.2 above`) that were evading the old guard.
- Update the step-number token from `[0-9]+[a-z.]*` to `[0-9][0-9a-z.]*` so bare digits, letter-suffix forms, and dotted substep forms are all caught; the narrow guard (direction word required) is preserved.

Closes #253.

## Goal

Fix the coverage gap in the progressive-disclosure guard that scans `skills/implement/references/*.md` for forbidden `see Step N <below|above>` back-references. `/implement` already uses dotted substep numbering (e.g. Step 9a.1), so real forbidden references could slip past the harness.

## Test plan

- `bash scripts/test-implement-structure.sh` — still passes on the current tree (no dotted back-refs present today).
- Regex unit spot-checks performed:
  - `see Step 9a.1 below` — OLD: miss (gap), NEW: match (fix).
  - `see Step 3c.2 above` — NEW: match.
  - `see Step 8 below` — NEW: match (regression preserved).
  - `see Step 8 for context.` — NEW: no match (narrow guard preserved — no direction word, no match).

## Final Design

Single-file edit in `scripts/test-implement-structure.sh`:
- Line 175 ERE: `see Step [0-9]+[a-z.]* (below|above)` → `see Step [0-9][0-9a-z.]* (below|above)`.
- Comment block (lines ~158-165) extended with one sentence explicitly covering dotted substep forms and citing #253.

No other files changed. This script IS the harness for the `references/*.md` invariant — no separate meta-harness exists or is needed.

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `1c72253` (Polish /relevant-checks: description keywords, maintenance rule, drop hook enumeration (#256))
- **Current version**: `4.3.8`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `4.3.9`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH").

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

None — quick mode skips `/design`.

</details>

<details><summary>Implementation Deviations</summary>

None.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

None — Cursor review returned `NO_ISSUES_FOUND` in round 1.

</details>

<details><summary>Out-of-Scope Observations</summary>

### Accepted OOS (GitHub issues filed)

No OOS items were accepted for issue filing.

### Non-accepted OOS

- **Cursor (code review, round 1)** — `(below|above)` is not word-boundary anchored, so in theory a phrase like `see Step 8 below-grade` could match. Pre-existing behavior (predates this diff), noted as non-blocking. Not filed: the matched corpus is controlled internal docs in `skills/implement/references/*.md` where such constructions do not occur, and tightening the anchor has near-zero upside for non-trivial regex complication.

</details>

<details><summary>Execution Issues</summary>

</details>

## Run Statistics

| Metric | Value |
|---|---|
| Mode | `--merge --auto --quick` |
| Design phase | skipped (quick mode) |
| Code review rounds | 1 (Cursor, NO_ISSUES_FOUND) |
| OOS issues filed | 0 |
| Version bump | PATCH (4.3.8 → 4.3.9, re-bumped after rebase) |

