### PR TITLE
Fix stale anchor in scripts/git-amend-add.sh:5 header comment (closes #249)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "4.3.12",
+  "version": "4.3.13",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.3.13] - 2026-04-20
+
+### Fixed
+
+- `scripts/git-amend-add.sh` — header comment on line 5 carried a stale "/implement Step 8a + Rebase + Re-bump Sub-procedure step 4a" anchor pointing at the pre-extraction SKILL.md inline home. Appended the parenthetical `(skills/implement/references/rebase-rebump-subprocedure.md)` on the following line, matching the pattern used by the four headers fixed under #235. Closes #249.
+
 ## [4.3.12] - 2026-04-20
 
 ### Fixed

--- a/scripts/git-amend-add.sh
+++ b/scripts/git-amend-add.sh
@@ -3,6 +3,7 @@
 #
 # Wraps `git add <files>` followed by `git commit --amend --no-edit`. Used by
 # /implement Step 8a (CHANGELOG) and the Rebase + Re-bump Sub-procedure step 4a
+# (skills/implement/references/rebase-rebump-subprocedure.md)
 # to fold CHANGELOG.md updates into the preceding bump commit.
 #
 # Usage:


### PR DESCRIPTION
## Summary
- Fixed stale anchor in `scripts/git-amend-add.sh:5` header comment pointing at the pre-extraction SKILL.md inline home of the Rebase + Re-bump Sub-procedure.
- Appended `(skills/implement/references/rebase-rebump-subprocedure.md)` on the following line, matching the pattern used by the four headers fixed under #235.

<details><summary>Architecture Diagram</summary>

Quick mode — architecture diagram skipped.

</details>

<details><summary>Code Flow Diagram</summary>

Quick mode — code flow diagram skipped.

</details>

<details><summary>Goal</summary>

- Fix stale SKILL.md-implicit anchor in `scripts/git-amend-add.sh:5`
  - PR #229 extracted the Rebase + Re-bump Sub-procedure to `skills/implement/references/rebase-rebump-subprocedure.md`
  - Header comment still implicitly refers to the pre-extraction inline home
  - Follow the #235 pattern: append `(skills/implement/references/rebase-rebump-subprocedure.md)` after the step 4a citation
- Close #249

</details>

<details><summary>Test plan</summary>

- [x] `/relevant-checks` passes on the modified file
- [x] Header anchor parses to the extracted sub-procedure reference file

</details>

<details><summary>Final Design</summary>

Single-line edit to `scripts/git-amend-add.sh`: append `# (skills/implement/references/rebase-rebump-subprocedure.md)` on the line immediately after the existing "Rebase + Re-bump Sub-procedure step 4a" citation. Matches the already-merged pattern in `scripts/git-force-push.sh:6`, `scripts/git-sync-local-main.sh:6`, `scripts/check-bump-version.sh:43`.

</details>

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `1056557` (Enrich intra-iteration halt diagnostic at outer Step 4.v (closes #247) (#263))
- **Current version**: `4.3.12`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `4.3.13`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH").

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

Quick mode — no plan review was conducted.

</details>

<details><summary>Implementation Deviations</summary>

No deviations from the plan.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

All code review suggestions were implemented.

</details>

<details><summary>Plan Review Voting Tally</summary>

Quick mode — no plan review voting.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

Quick mode — no voting panel. Main agent reviewed findings across up to 7 single-reviewer rounds (Cursor → Codex → Claude fallback chain).

</details>

<details><summary>Out-of-Scope Observations</summary>

**Accepted OOS (GitHub issues filed):**
No OOS items were accepted for issue filing.

**Non-accepted OOS observations:**
Quick mode — no reviewer voting panel. Main-agent OOS items (if any) are auto-filed per policy; see Accepted OOS above.

</details>

<details><summary>Execution Issues</summary>

No execution issues encountered.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | N/A (quick mode) |
| Code review rounds | 1 |
| Code review findings | 0 accepted, 0 rejected |
| Warnings logged | 0 |
| Pre-existing issues noticed | 0 |
| OOS issues filed | 0 |
| External reviewers | N/A (quick mode) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
