### PR TITLE
Improve /alias skill toward grade A (loop-improve-skill iteration 1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "4.3.14",
+  "version": "4.3.15",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/skills/alias/SKILL.md
+++ b/skills/alias/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: alias
-description: "Use when creating shortcut aliases for existing larch skills with preset flags. Generates a project-level skill in .claude/skills/ via /implement delegation that forwards to the target skill, optionally with --merge passthrough."
+description: "Use when creating shortcut aliases (wrappers) for existing larch skills with preset flags. Generates a project-level skill in .claude/skills/ via /implement delegation that forwards to the target skill, optionally with --merge passthrough."
 argument-hint: "[--merge] <alias-name> <target-skill> [preset-flags...]"
 allowed-tools: Bash, Skill
 ---
 
 # Alias Skill
+
+This skill follows the Process pattern: numbered steps, checkpointed delegation, fail-closed verification.
 
 Create a project-level alias skill in `.claude/skills/` that forwards to an existing larch skill with preset flags. Delegates to `/implement --quick --auto` for the full pipeline (implementation, code review, version bump, PR), then verifies the artifact landed on disk.
 
@@ -13,7 +15,15 @@ Example: `/alias i implement --merge` creates `.claude/skills/i/SKILL.md` so tha
 
 Example with merge: `/alias --merge i implement --merge` creates the same alias AND merges the PR after CI passes.
 
-**Anti-halt continuation reminder.** After every child `Skill` tool call (e.g., `/implement`) returns, IMMEDIATELY continue with this skill's NEXT numbered step — do NOT end the turn on the child's cleanup output. The rule is strictly subordinate to any explicit non-sequential control-flow directive in THIS file (e.g., `bail`, `skip to Step N`). A normal sequential `proceed to Step N+1` instruction is the default continuation this rule reinforces, NOT an exception. Every `/relevant-checks` invocation anywhere in this file is covered by this rule. See `${CLAUDE_PLUGIN_ROOT}/skills/shared/subskill-invocation.md` section Anti-halt continuation reminder for the canonical rule.
+## NEVER
+
+1. **NEVER create an alias that targets `/alias`** — no alias-to-alias recursion. **Why:** would multiply indirection and break the flat forwarding contract. Enforced by Step 2 check #5.
+2. **NEVER let an alias name shadow an existing larch skill** — neither in `skills/` (public) nor `.claude/skills/` (dev-only). **Why:** shadowing silently reroutes `/<name>` invocations. Enforced by Step 2 check #2 via dynamic probe.
+3. **NEVER auto-remediate when `VERIFIED=false` in Step 4** — do NOT retry `/implement`, roll back, or delete the PR. **Why:** under `--merge` the PR may already be merged; retry would create a divergent PR. Human judgment required.
+4. **NEVER assume success on `VERIFIED=false` just because `/implement` returned.** **Why:** `/implement` can return cleanly while writing the file to the wrong path, skipping the generator, or failing silently — the sentinel-file gate is the only authoritative signal.
+5. **NEVER parse `--merge` tokens after the first positional argument as flags for `/alias`.** **Why:** `--merge` has a dual role (consumed by `/alias` when before the first positional; passed through to the alias's preset flags otherwise); conflating the two is a silent footgun.
+
+**Anti-halt continuation reminder.** After every child `Skill` tool call (e.g., `/implement`) returns, IMMEDIATELY continue with this skill's NEXT numbered step — do NOT end the turn on the child's cleanup output. The rule is strictly subordinate to any explicit non-sequential control-flow directive in THIS file (e.g., `bail`, `skip to Step N`). A normal sequential `proceed to Step N+1` instruction is the default continuation this rule reinforces, NOT an exception. Every `/relevant-checks` invocation anywhere in this file is covered by this rule. See `${CLAUDE_PLUGIN_ROOT}/skills/shared/subskill-invocation.md` section Anti-halt continuation reminder for the canonical rule. **Do NOT load** that reference for routine invocations — the inline rule above is sufficient. Load it only when debugging a child-Skill halt symptom or when adding a new child-Skill invocation to this file.
 
 ## Step 1 — Parse Arguments
 
@@ -39,47 +49,53 @@ If fewer than 2 positional tokens are provided, print: `**ERROR: Usage: /alias [
 
 All validation uses Bash since `${CLAUDE_PLUGIN_ROOT}` is a shell variable not resolvable in Read/Glob.
 
-1. **Alias name format**: Verify alias name matches `^[a-z][a-z0-9-]*$` (lowercase, alphanumeric + hyphens, must start with a letter).
-   - If invalid, print: `**ERROR: Alias name '<name>' is invalid. Must start with a lowercase letter and contain only lowercase letters, digits, and hyphens.**` and abort.
+| # | Check | Rule | On fail |
+|---|-------|------|---------|
+| 1 | Alias name format | Must match `^[a-z][a-z0-9-]*$` (lowercase, alphanumeric + hyphens, must start with a letter) | `E_ALIAS_NAME` |
+| 2 | Reserved name (dynamic probe) | `${CLAUDE_PLUGIN_ROOT}` must be set; alias name must not collide with any directory under `${CLAUDE_PLUGIN_ROOT}/skills/<alias-name>` OR `${CLAUDE_PLUGIN_ROOT}/.claude/skills/<alias-name>`. See `### Check 2` block below. | `E_PLUGIN_ROOT_UNSET` or `E_SHADOW` |
+| 3 | Target name format | Must match `^[a-z][a-z0-9-]*$` (same format as alias names) | `E_TARGET_NAME` |
+| 4 | Target skill exists | `test -f "${CLAUDE_PLUGIN_ROOT}/skills/<target>/SKILL.md"`; if missing, also run `ls "${CLAUDE_PLUGIN_ROOT}/skills/"` for discoverability | `E_TARGET_MISSING` |
+| 5 | Target is not `alias` | Forbid alias-to-alias recursion | `E_RECURSION` |
+| 6 | Collision check | `test -d ".claude/skills/<alias-name>"` must be false | `E_COLLISION` |
 
-2. **Reserved name check (dynamic probe — shadows any larch skill)**. Fail-closed on unset `${CLAUDE_PLUGIN_ROOT}`, then probe both plugin-tree roots for a directory collision:
-   ```bash
-   if [[ -z "${CLAUDE_PLUGIN_ROOT:-}" ]]; then
-     echo "**ERROR: CLAUDE_PLUGIN_ROOT is unset — cannot probe larch skill tree for reserved-name collision.**"
-     exit 1
-   fi
-   # probe BOTH roots: skills/ (public) and .claude/skills/ (dev-only: bump-version, relevant-checks)
-   if test -d "${CLAUDE_PLUGIN_ROOT}/skills/<alias-name>" \
-     || test -d "${CLAUDE_PLUGIN_ROOT}/.claude/skills/<alias-name>"; then
-     echo "**ERROR: alias name '<alias-name>' shadows an existing larch skill.**"
-     exit 1
-   fi
-   ```
-   One conceptual rule — "alias cannot shadow any larch skill" — replacing the prior static enumeration that was drifting as new skills shipped.
+### Check 2 — reserved-name dynamic probe
 
-3. **Target name format**: Verify target skill name matches `^[a-z][a-z0-9-]*$` (same format as alias names).
-   - If invalid, print: `**ERROR: Target name '<target>' is invalid. Must contain only lowercase letters, digits, and hyphens.**` and abort.
+Fail-closed on unset `${CLAUDE_PLUGIN_ROOT}`, then probe both plugin-tree roots for a directory collision:
 
-4. **Target skill exists**: Verify target skill exists:
-   ```bash
-   test -f "${CLAUDE_PLUGIN_ROOT}/skills/<target>/SKILL.md"
-   ```
-   - If not found, print: `**ERROR: Target skill '<target>' does not exist.**` Then list valid targets:
-     ```bash
-     ls "${CLAUDE_PLUGIN_ROOT}/skills/"
-     ```
-     and abort.
+```bash
+if [[ -z "${CLAUDE_PLUGIN_ROOT:-}" ]]; then
+  echo "**ERROR: CLAUDE_PLUGIN_ROOT is unset — cannot probe larch skill tree for reserved-name collision.**"
+  exit 1
+fi
+# probe BOTH roots: skills/ (public) and .claude/skills/ (dev-only: bump-version, relevant-checks)
+if test -d "${CLAUDE_PLUGIN_ROOT}/skills/<alias-name>" \
+  || test -d "${CLAUDE_PLUGIN_ROOT}/.claude/skills/<alias-name>"; then
+  echo "**ERROR: alias name '<alias-name>' shadows an existing larch skill.**"
+  exit 1
+fi
+```
 
-5. **Target is not "alias"**: Forbid alias-to-alias recursion.
-   - If target is "alias", print: `**ERROR: Cannot create an alias that targets /alias (no alias-to-alias recursion).**` and abort.
+One conceptual rule — "alias cannot shadow any larch skill" — replacing the prior static enumeration that was drifting as new skills shipped.
 
-6. **Collision check**: Verify `.claude/skills/<alias-name>/` does not already exist in the current project:
-   ```bash
-   test -d ".claude/skills/<alias-name>"
-   ```
-   - If it exists, print: `**ERROR: '.claude/skills/<alias-name>/' already exists. Remove it first or choose a different name.**` and abort.
+### Error strings (reference)
+
+| ID | Printed string |
+|----|----------------|
+| `E_ALIAS_NAME` | `**ERROR: Alias name '<name>' is invalid. Must start with a lowercase letter and contain only lowercase letters, digits, and hyphens.**` |
+| `E_PLUGIN_ROOT_UNSET` | `**ERROR: CLAUDE_PLUGIN_ROOT is unset — cannot probe larch skill tree for reserved-name collision.**` |
+| `E_SHADOW` | `**ERROR: alias name '<alias-name>' shadows an existing larch skill.**` |
+| `E_TARGET_NAME` | `**ERROR: Target name '<target>' is invalid. Must contain only lowercase letters, digits, and hyphens.**` |
+| `E_TARGET_MISSING` | `**ERROR: Target skill '<target>' does not exist.**` (then run `ls "${CLAUDE_PLUGIN_ROOT}/skills/"` and abort) |
+| `E_RECURSION` | `**ERROR: Cannot create an alias that targets /alias (no alias-to-alias recursion).**` |
+| `E_COLLISION` | `**ERROR: '.claude/skills/<alias-name>/' already exists. Remove it first or choose a different name.**` |
 
 ## Step 3 — Delegate to /implement
+
+### Before delegating, ask
+
+- **What does `/implement` need to build this deterministically?** `/implement` has no codebase context about `/alias` — it will research and guess unless the feature description cites the generator script path, its required flags, the version source, and the write target. The explicit recipe below supplies all four.
+- **What could make the Step 4 verification silently pass when it shouldn't?** Nothing — the `verify-skill-called.sh --sentinel-file` gate reads a child-produced artifact (`.claude/skills/<alias-name>/SKILL.md`) that the outer orchestrator cannot synthesize. A parent-writable gate would not be load-bearing.
+- **Why no retry on `VERIFIED=false`?** Under `--merge` the PR may already be merged by the time control returns; any automated retry would create a divergent PR. Step 4 surfaces branch-specific diagnostic messages instead, leaving recovery to human judgment.
 
 Construct an explicit feature description for `/implement`. The description MUST cite the generator script path, its required flags, the version source, and the write target so `/implement` has a complete, deterministic build recipe — no codebase research required:
 
@@ -108,7 +124,7 @@ Invoke the Skill tool:
 
 Only include `--merge` in the args if `alias_merge=true`.
 
-> **Continue after child returns.** When `/implement` returns, execute Step 4 — do NOT end the turn. See `${CLAUDE_PLUGIN_ROOT}/skills/shared/subskill-invocation.md` section Anti-halt continuation reminder.
+> **Continue after child returns.** When `/implement` returns, execute Step 4 — do NOT end the turn. See `${CLAUDE_PLUGIN_ROOT}/skills/shared/subskill-invocation.md` section Anti-halt continuation reminder. **Do NOT load** that reference for routine `/implement` returns — load only when adding a new child-Skill invocation to this file or when debugging a halt symptom.
 
 ## Step 4 — Verify
 
@@ -133,3 +149,12 @@ Parse stdout for `VERIFIED=true|false` and `REASON=<token>`.
     **ERROR: /implement returned but .claude/skills/<alias-name>/SKILL.md was not written (REASON=<token>). The PR may have already been merged — do not assume success. Inspect the PR/branch/merged-main manually; a revert or follow-up PR may be required.**
     ```
   Do not attempt auto-remediation — `/implement` has already created (and possibly merged) the PR, so any recovery requires human judgment.
+
+### Authoritative exit states
+
+| State | Condition | Printed string (summary) |
+|-------|-----------|--------------------------|
+| Success | `VERIFIED=true` | `✅ /alias — created .claude/skills/<alias-name>/SKILL.md` |
+| Validation fail | Any Step 2 check fails | one of the `E_*` strings from the Step 2 `Error strings (reference)` table |
+| Verify fail (unmerged) | `VERIFIED=false` AND `alias_merge=false` | `**ERROR: /implement returned but .claude/skills/<alias-name>/SKILL.md was not written (REASON=<token>). DO NOT merge the PR. ...**` (full string above) |
+| Verify fail (merged) | `VERIFIED=false` AND `alias_merge=true` | `**ERROR: /implement returned but .claude/skills/<alias-name>/SKILL.md was not written (REASON=<token>). The PR may have already been merged ...**` (full string above) |


### PR DESCRIPTION
## Summary

- Raise /alias skill toward grade A on /skill-judge's 8 dimensions (iteration 1 of /loop-improve-skill loop, closes part of #266).
- Apply 6 surgical edits to `skills/alias/SKILL.md`: consolidated `## NEVER` block (D3), "Before delegating, ask" framework at top of Step 3 (D2), Step 2 rules table + Check 2 block + error-strings reference (D1, D7), pattern-commitment sentence (D7), authoritative exit-states table at end of Step 4 (D8), "wrapper" synonym in description (D4 free lift).
- Edit 4 (D5 progressive disclosure): ecosystem grep showed sibling orchestrators (`/implement`, `/fix-issue`, `/review`, `/loop-review`, `/research`) universally use plain bold `See ...` pointer style for `skills/shared/subskill-invocation.md`. Took the "Do NOT load" variant: kept the bold `See ...` wording but added a one-line "Do NOT load" marker after each such pointer (lines 29 and 114 post-edit), specifying when the reference IS load-bearing (debugging child-Skill halt / adding new child-Skill invocation).

## Goal

Advance the /alias SKILL.md toward grade A on /skill-judge's 8 dimensions per the loop-improve-skill iteration-1 findings (B, 102/120, non-A on D1/D2/D3/D5/D7/D8).

## Test plan

- [x] `/relevant-checks` passes (changed-file + full-repo agent-lint phases).
- [x] `python3 scripts/lint-skill-invocations.py --root /Users/zhupanov/larch1` passes — Step 3's `Invoke the Skill tool:` imperative line remains on a line containing no backticked `/<cmd>` token followed by `skill`, so the per-invocation regex does not fire.
- [x] No behavior change; `scripts/generate-alias.sh` untouched.
- [x] Version bump applied: PATCH 4.3.14 → 4.3.15.

Tracking issue: #266
