### PR TITLE
Fix unbound CLAUDE_PLUGIN_ROOT in loop-improve-skill driver.sh (closes #288)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.0.1] - 2026-04-21
+
+### Fixed
+
+- `skills/loop-improve-skill/scripts/driver.sh`: derive `CLAUDE_PLUGIN_ROOT` from the script's own location when the harness did not export it, so the driver no longer aborts at Step 2 session-setup under `set -u` when invoked as a Skill (closes #288).
+
 ## [5.0.0] - 2026-04-21
 
 ### Changed

--- a/skills/loop-improve-skill/scripts/driver.sh
+++ b/skills/loop-improve-skill/scripts/driver.sh
@@ -45,6 +45,20 @@
 
 set -euo pipefail
 
+# Derive CLAUDE_PLUGIN_ROOT from script location when the harness did not
+# export it. When /loop-improve-skill is invoked as a Skill, Claude Code's
+# harness expands ${CLAUDE_PLUGIN_ROOT} in SKILL.md's Bash template into a
+# literal path before subprocess launch but does NOT export the variable to
+# the Bash environment. Under `set -u`, the first unguarded reference aborts
+# the driver at Step 2 session-setup. Deriving the value from the script's
+# own location keeps driver.sh self-sufficient regardless of invocation mode.
+# Layout: ${CLAUDE_PLUGIN_ROOT}/skills/loop-improve-skill/scripts/driver.sh
+# so the plugin root is three directories up from the script.
+if [[ -z "${CLAUDE_PLUGIN_ROOT:-}" ]]; then
+  CLAUDE_PLUGIN_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd -P)"
+  export CLAUDE_PLUGIN_ROOT
+fi
+
 # --------------------------------------------------------------------------
 # Breadcrumb helpers (match larch progress convention)
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Fix `CLAUDE_PLUGIN_ROOT: unbound variable` abort in `skills/loop-improve-skill/scripts/driver.sh` when `/loop-improve-skill` is invoked as a Skill.
- Root cause: Claude Code's harness expands `${CLAUDE_PLUGIN_ROOT}` in SKILL.md's Bash template into a literal path but does NOT export the variable to the subprocess. Driver runs under `set -u`, so the first unguarded reference (line 152, `session-setup.sh` invocation) aborts Step 2.
- Fix: derive `CLAUDE_PLUGIN_ROOT` from the script's own location (`"$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd -P)"`) immediately after `set -euo pipefail` when the variable is unset.

Closes #288.

## Goal

`/loop-improve-skill` must work end-to-end when invoked as a Skill from Claude Code (not only when invoked via `claude -p --plugin-dir ... /larch:loop-improve-skill`).

## Test plan

- [x] `bash -n skills/loop-improve-skill/scripts/driver.sh` — syntax ok.
- [x] Smoke: `unset CLAUDE_PLUGIN_ROOT && bash skills/loop-improve-skill/scripts/driver.sh <bogus-skill>` from `/tmp` now reaches the skill-probe error (not `line 152: CLAUDE_PLUGIN_ROOT: unbound variable`).
- [x] `/relevant-checks` — shellcheck + agent-lint clean.
- [ ] Re-run the original failing flow from issue #288 (`/larch:loop-improve-skill /create-skill`) without pre-setting `CLAUDE_PLUGIN_ROOT` — should reach Step 2 session-setup successfully.

## Final Design

Single-file edit: insert `CLAUDE_PLUGIN_ROOT` fallback-derivation block at the top of `driver.sh`, after `set -euo pipefail`, before any usage. Keeps any harness-provided value via the `[[ -z "${CLAUDE_PLUGIN_ROOT:-}" ]]` guard. Derivation uses `pwd -P` to canonicalize symlinks.

<details><summary>Version Bump Reasoning</summary>

PATCH. Change is internal to `skills/loop-improve-skill/scripts/driver.sh` (bash script under the skill); no SKILL.md surface change, no flag change, no behavioral incompatibility. Public plugin surface unchanged per classify-bump.sh.

</details>

## Rejected Plan Review Suggestions

None — quick mode, no plan review panel.

## Implementation Deviations

None.

## Rejected Code Review Suggestions

None — Cursor round 1 returned `NO_ISSUES_FOUND`.

## Code Review Voting Tally Round 1

Quick mode — single-reviewer loop (Cursor), no voting panel. Round 1 verdict: NO_ISSUES_FOUND.

## Out-of-Scope Observations

### Accepted OOS (GitHub issues filed)

No OOS items were accepted for issue filing.

## Run Statistics

| Metric | Value |
|--------|-------|
| Mode | `--merge --auto --quick` |
| Review rounds | 1 |
| OOS issues filed | 0 |
| Version bump | 5.0.0 → 5.0.1 (PATCH) |

<details><summary>Execution Issues</summary>

_No execution issues recorded._

</details>
