### PR TITLE
Delete GO comment when locking issue in /fix-issue

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.0.2] - 2026-04-21
+
+### Changed
+
+- `/fix-issue` Step 2 lock now deletes the `GO` comment (instead of leaving it alongside `IN PROGRESS`). `issue-lifecycle.sh comment --lock` captures the GO comment's id + `created_at`, deletes the comment via `DELETE /repos/{owner}/{repo}/issues/comments/{id}`, posts `IN PROGRESS`, and uses the captured timestamp (not a surviving GO anchor) for the concurrent-race duplicate-`IN PROGRESS` post-check. Recovery semantics updated for the crash-between-delete-and-post scenario.
+
 ## [5.0.1] - 2026-04-21
 
 ### Fixed

--- a/skills/fix-issue/SKILL.md
+++ b/skills/fix-issue/SKILL.md
@@ -263,7 +263,7 @@ Print `✅ 9: cleanup — fix-issue complete! (<elapsed>)`
 
 ## Known Limitations
 
-- **Stale IN PROGRESS lock**: If the skill crashes after Step 2, the issue remains locked with `IN PROGRESS` as the last comment. Recovery: manually delete the `IN PROGRESS` comment and re-add `GO` to re-enable the issue for automated processing.
+- **Stale IN PROGRESS lock**: Step 2 deletes the `GO` comment and posts `IN PROGRESS` (so the `GO` sentinel no longer remains after locking). If the skill crashes after Step 2 completes, the issue's last comment is `IN PROGRESS` — recovery: manually delete the `IN PROGRESS` comment and re-add `GO`. If it crashes mid-Step-2 (between deleting `GO` and posting `IN PROGRESS`), the issue has neither sentinel — recovery: manually re-add `GO`.
 - **Single-runner assumption**: The comment-based locking (Step 2) includes duplicate detection but is not fully atomic. For reliable operation, run one instance of `/fix-issue` at a time per repository.
 - **Dependency check degrades silently on API failure**: The blocked-by check (Step 1) treats unreachable or erroring dependency-API responses as "no blockers known" to avoid hard-blocking the automation. If GitHub's issue-dependencies endpoint is returning 5xx or an unexpected payload, a blocked issue could temporarily be eligible. The GO sentinel still applies, so the blast radius is limited to whatever the reviewer intended to allow via `GO`.
 - **Prose-dependency check shares the same fail-open posture**: A parser regression, body/comment fetch failure, or per-reference state lookup failure all degrade to "no prose blockers known" for that candidate. The offline harness (`test-parse-prose-blockers.sh`, run via `make lint`) is the primary guard against parser regressions.

--- a/skills/fix-issue/scripts/issue-lifecycle.sh
+++ b/skills/fix-issue/scripts/issue-lifecycle.sh
@@ -10,8 +10,10 @@
 #
 # Subcommands:
 #   comment    — Post a comment on an issue.
-#                With --lock: verify last comment is "GO" before posting,
-#                then re-read to detect concurrent duplicate locks.
+#                With --lock: verify last comment is "GO", DELETE that GO
+#                comment, then post the new comment (typically "IN PROGRESS").
+#                Re-reads afterward to detect concurrent duplicate locks via
+#                "IN PROGRESS" comments created after the deleted GO timestamp.
 #   close      — Close an issue. Optionally post a comment first.
 #                With --pr-url: update the issue body with the PR link before closing.
 #   update-body — Append a PR link to the issue body (idempotent).
@@ -51,24 +53,46 @@ cmd_comment() {
         exit 2
     fi
 
-    # --lock: verify last comment is still "GO" before posting
+    local go_ts=""
+
+    # --lock: verify last comment is "GO", capture its id + timestamp, then
+    # delete it so the GO sentinel does not remain on the issue after locking.
     if [ "$lock" = true ]; then
-        local last_comment
-        last_comment=$(gh api --paginate "repos/${REPO}/issues/${issue}/comments" \
-            --jq '.[-1].body // empty' 2>/dev/null | tail -1) || {
+        local comments_json
+        comments_json=$(gh api --paginate --slurp "repos/${REPO}/issues/${issue}/comments" 2>/dev/null | jq 'add // []') || {
             echo "LOCK_ACQUIRED=false"
             echo "ERROR=Failed to read comments for lock verification"
             exit 1
         }
 
+        local last_body last_id
+        last_body=$(echo "$comments_json" | jq -r '.[-1].body // empty')
+        last_id=$(echo "$comments_json" | jq -r '.[-1].id // empty')
+        go_ts=$(echo "$comments_json" | jq -r '.[-1].created_at // empty')
+
         local trimmed
-        trimmed=$(echo "$last_comment" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+        trimmed=$(echo "$last_body" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
 
         if [ "$trimmed" != "GO" ]; then
             echo "LOCK_ACQUIRED=false"
             echo "ERROR=Last comment is no longer GO (found: ${trimmed:-empty})"
             exit 1
         fi
+
+        if [[ -z "$last_id" ]] || [[ -z "$go_ts" ]]; then
+            echo "LOCK_ACQUIRED=false"
+            echo "ERROR=Failed to extract GO comment id/timestamp for deletion"
+            exit 1
+        fi
+
+        # Delete the GO comment. The post-check below uses $go_ts (captured
+        # above) as the duplicate-detection sentinel in place of a surviving
+        # GO anchor.
+        gh api -X DELETE "repos/${REPO}/issues/comments/${last_id}" >/dev/null 2>&1 || {
+            echo "LOCK_ACQUIRED=false"
+            echo "ERROR=Failed to delete GO comment on issue #$issue"
+            exit 1
+        }
     fi
 
     # Post the comment
@@ -90,14 +114,12 @@ cmd_comment() {
             exit 1
         }
 
-        # Count IN PROGRESS comments posted after the last GO comment
+        # Count IN PROGRESS comments created strictly after the deleted GO's
+        # timestamp. Two concurrent runners that both raced the pre-check will
+        # see count > 1 here.
         local lock_count
-        lock_count=$(echo "$comments_json" | jq '
-            [to_entries
-             | (map(select(.value.body == "GO")) | last.key // -1) as $last_go
-             | .[]
-             | select(.key > $last_go and .value.body == "IN PROGRESS")
-            ] | length')
+        lock_count=$(echo "$comments_json" | jq --arg ts "$go_ts" '
+            [.[] | select(.body == "IN PROGRESS" and .created_at > $ts)] | length')
 
         if [ "$lock_count" -gt 1 ]; then
             echo "LOCK_ACQUIRED=false"


### PR DESCRIPTION
## Summary
- Changed `/fix-issue` Step 2 lock so that acquiring the lock deletes the `GO` comment instead of leaving it alongside `IN PROGRESS`. End-state of a locked issue is exactly one new sentinel comment: `IN PROGRESS`.
- Rewrote `issue-lifecycle.sh` `cmd_comment --lock` to capture the last comment's id + `created_at`, verify it is `GO`, `DELETE` it via the GitHub API, post `IN PROGRESS`, and run a concurrent-race post-check using the captured timestamp (instead of searching for a surviving `GO` anchor).

<details><summary>Architecture Diagram</summary>

Quick mode — architecture diagram skipped.

</details>

<details><summary>Code Flow Diagram</summary>

Quick mode — code flow diagram skipped.

</details>

<details><summary>Goal</summary>

- Make `/fix-issue`'s Step 2 lock remove the `GO` comment rather than append `IN PROGRESS` next to it, so a locked issue no longer carries a `GO` sentinel.
  - The user explicitly authorized either "replace `GO` contents with `IN PROGRESS`" or "delete `GO` then append `IN PROGRESS`" — end-state requirement is that the `GO` comment is no longer present on the issue after locking.
  - Preserve the concurrent-lock race detection that the current implementation provides via the "IN PROGRESS after last GO" duplicate check.
  - Preserve all pre-existing semantics of Step 2: pre-check that last comment is `GO`, post failure modes (`LOCK_ACQUIRED=false` with `ERROR=` details).

</details>

<details><summary>Test plan</summary>

- [x] `bash -n` parse of `issue-lifecycle.sh`
- [x] `/relevant-checks` (shellcheck, markdownlint, agent-lint, lint-skill-invocations, …) — green
- [ ] Manual verification against a test issue: add `GO`, invoke a `/fix-issue` run, confirm `GO` is deleted and `IN PROGRESS` is the last comment
- [ ] Manual verification of the failed-lock path: pre-seed with `GO` not as last comment; confirm `LOCK_ACQUIRED=false` + no DELETE attempted
- [ ] Manual verification of recovery per updated Known Limitations bullet: crash between DELETE and post → issue has no sentinel; re-add `GO` to re-enable

</details>

<details><summary>Final Design</summary>

`cmd_comment --lock` in `issue-lifecycle.sh`:

1. Single slurped read of issue comments (`gh api --paginate --slurp`); extract `.[-1].body`, `.[-1].id`, `.[-1].created_at` from the canonical `add // []` array.
2. Verify trimmed last body equals `GO`; otherwise emit `LOCK_ACQUIRED=false` + `ERROR=Last comment is no longer GO (…)` and exit 1.
3. Guard that `last_id` and `go_ts` are non-empty; otherwise emit `LOCK_ACQUIRED=false` + `ERROR=Failed to extract GO comment id/timestamp for deletion` and exit 1.
4. `gh api -X DELETE repos/{owner}/{repo}/issues/comments/{last_id}` (stderr redirected to `/dev/null 2>&1`, matching sibling gh calls in the same file).
5. `gh issue comment "$issue" --body "$body"` (unchanged — posts IN PROGRESS).
6. Post-check (unchanged control flow): re-slurp comments, count `IN PROGRESS` comments with `created_at > $go_ts` (captured in step 1). If `>1`, emit `LOCK_ACQUIRED=false` + `ERROR=Duplicate IN PROGRESS detected (<n> found) — concurrent lock race`.

Why delete-then-post rather than edit-in-place: editing the GO comment to "IN PROGRESS" in place would be a single API call, but the duplicate-race post-check would need to count all `IN PROGRESS` comments without a sentinel (GO is gone either way under Option B, but under Option A the edited comment's position is a sentinel of its own). Delete-then-post is simpler and the captured `created_at` provides a clean timestamp sentinel. The two-call overhead is negligible vs. the API call already made to fetch + validate comments.

Known-limitations recovery updated: crash-after-Step-2 is unchanged (last comment is `IN PROGRESS`; delete it and re-add `GO`); crash-mid-Step-2 is new (no sentinel at all; just re-add `GO`).

</details>

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `d3179d0` (Fix unbound CLAUDE_PLUGIN_ROOT in loop-improve-skill driver.sh (closes #288) (#289))
- **Current version**: `5.0.1`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `5.0.2`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH").

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

Quick mode — no plan review was conducted.

</details>

<details><summary>Implementation Deviations</summary>

No deviations from the plan.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

### [Code Review] Cursor (round 1)
**Finding**: `skills/fix-issue/scripts/issue-lifecycle.sh:60-95` (correctness). TOCTOU gap between the `gh api --paginate --slurp` comment snapshot and the subsequent `gh api -X DELETE`: if another comment is posted after the snapshot but before the delete, the DELETE still targets the GO comment by id and succeeds, leaving a mid-thread foreign comment followed by `IN PROGRESS` without a preceding GO anchor. Suggested fix: re-fetch comments immediately before DELETE, confirm `.[-1].id == last_id` and tail body still trims to `GO`; if not, emit `LOCK_ACQUIRED=false` and exit without deleting or posting.
**Reason not implemented**: The window between snapshot and DELETE is sub-second, DELETE targets the GO id explicitly (not by tail position), and the lock still functions correctly: IN PROGRESS becomes the last comment and the timestamp-gated post-check still catches concurrent IN PROGRESS. The only visible effect is a mildly confusing thread where a foreign comment precedes IN PROGRESS with no GO anchor between them — not a correctness bug. The original code had an equivalent TOCTOU (pre-check + blind append) without re-verification. Doubling API calls for this narrow, non-destructive-outcome scenario is disproportionate.

### [Code Review] Cursor (round 1)
**Finding**: `skills/fix-issue/scripts/issue-lifecycle.sh:88-95` (risk-integration). The lock path no longer leaves the `GO` comment in issue history. External consumers that scraped for GO persistence would observe a changed audit trail. Suggested fix: add a CHANGELOG entry and grep internal docs for assumptions about GO persisting after Step 2.
**Reason not implemented**: Step 8a of `/implement` auto-generated a CHANGELOG entry (see v5.0.1). Internal-doc grep was already performed: the only references to GO in `skills/fix-issue` are in `SKILL.md` (updated), `issue-lifecycle.sh` (modified), and `fetch-eligible-issue.sh` which only checks "last comment == GO" for eligibility and is unaffected by post-lock GO deletion.

### [Code Review] Cursor (round 1)
**Finding**: `skills/fix-issue/SKILL.md:266` (code-quality). The "Stale IN PROGRESS lock" bullet title no longer accurately summarizes its content. Suggested fix: rename or split.
**Reason not implemented**: Primary case documented is still "stale IN PROGRESS lock"; the crash-mid-Step-2 case is a sub-bullet, not a separate named limitation. Style nit rather than a clarity defect.

### [Code Review] Cursor (round 1)
**Finding**: `skills/fix-issue/scripts/issue-lifecycle.sh:91-94` (code-quality). `gh api -X DELETE ... >/dev/null 2>&1` hides API error details. Suggested fix: allow stderr through.
**Reason not implemented**: The existing `gh issue comment ... >/dev/null 2>&1` pattern two lines below uses the same stderr suppression; changing only the DELETE call creates inconsistent diagnostic behavior across sibling operations.

### [Code Review] Cursor (round 1)
**Finding**: `skills/fix-issue/scripts/issue-lifecycle.sh:39-134` (risk-integration). No offline test harness exists for `issue-lifecycle.sh`. Suggested fix: add a table-driven test with stub gh/jq fixtures.
**Reason not implemented**: Pre-existing gap not introduced by the current change. The task scope is a specific behavior change, not adding a test harness for the whole script. A stub-gh framework is a separate effort; `make lint` + agent-lint exercised structural correctness.

</details>

<details><summary>Plan Review Voting Tally</summary>

Quick mode — no plan review voting.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

Quick mode — no voting panel. Main agent reviewed findings across up to 7 single-reviewer rounds (Cursor → Codex → Claude fallback chain). Round 1 (Cursor) returned 5 findings; main agent rejected all 5 as disproportionate/out-of-scope/style — loop converged with zero accepted findings.

</details>

<details><summary>Out-of-Scope Observations</summary>

**Accepted OOS (GitHub issues filed):**
No OOS items were accepted for issue filing.

**Non-accepted OOS observations:**
Quick mode — no reviewer voting panel. Main-agent OOS items (if any) are auto-filed per policy; see Accepted OOS above.

</details>

<details><summary>Execution Issues</summary>

No execution issues encountered.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | N/A (quick mode) |
| Code review rounds | 1 |
| Code review findings | 0 accepted, 5 rejected |
| Warnings logged | 0 |
| Pre-existing issues noticed | 0 |
| OOS issues filed | 0 |
| External reviewers | N/A (quick mode) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
