### PR TITLE
Split CI lint job: run pre-commit and test harnesses as separate jobs

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,10 @@ permissions:
   contents: read
 
 jobs:
+  # Linters only: pre-commit over all files (shellcheck, markdownlint,
+  # jsonlint, actionlint, agent-lint, agnix, lint-skill-invocations).
+  # Test harnesses run in the separate `test-harnesses` job below so
+  # harness failures and linter failures can be re-run independently.
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -26,8 +30,26 @@ jobs:
             pre-commit-
       - name: Install pre-commit and PyYAML
         run: pip install pre-commit==4.2.0 pyyaml==6.0.2
-      - name: Run all linters
-        run: make lint
+      - name: Run pre-commit linters
+        run: make lint-only
+
+  # Regression harnesses (the 22 `test-*` bash scripts in Makefile). Runs
+  # in parallel with the `lint` job so a harness failure can be diagnosed
+  # and re-run without waiting on pre-commit, and vice versa. PyYAML is
+  # required because test-lint-skill-invocations invokes the python lint
+  # directly (outside the pre-commit venv).
+  test-harnesses:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install PyYAML
+        run: pip install pyyaml==6.0.2
+      - name: Run test harnesses
+        run: make test-harnesses
 
   agent-lint:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.1.1] - 2026-04-21
+
+### Changed
+
+- CI split: `make lint` is now composed of two split targets, `lint-only` (pre-commit over all files) and `test-harnesses` (the 22 `test-*` bash regression harnesses). `.github/workflows/ci.yaml` replaces the single `lint` job with two parallel jobs (`lint` → `make lint-only` and `test-harnesses` → `make test-harnesses`) so harness regressions and linter regressions surface on independent job tiles and can be re-run independently. Local `make lint` behavior is unchanged.
+
 ## [5.1.0] - 2026-04-21
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,17 @@
 # Larch Makefile
 # Thin wrapper around pre-commit. Linter definitions live in .pre-commit-config.yaml.
 
-.PHONY: lint shellcheck markdownlint jsonlint actionlint agent-lint agnix setup test-redact test-parse-input test-parse-prose-blockers test-sessionstart test-audit-edit-write test-block-submodule test-deny-edit-write test-post-scaffold-hints test-render-skill test-verify-skill-called test-check-bump-version test-lint-skill-invocations test-anti-halt test-orchestrator-scope-sync test-design-structure test-implement-rebase-macro test-implement-structure test-subskill-anchors test-loop-improve-skill-driver test-loop-improve-skill-skill-md test-parse-skill-judge-grade test-lib-halt-ledger smoke-dialectic halt-rate-probe
+.PHONY: lint lint-only test-harnesses shellcheck markdownlint jsonlint actionlint agent-lint agnix setup test-redact test-parse-input test-parse-prose-blockers test-sessionstart test-audit-edit-write test-block-submodule test-deny-edit-write test-post-scaffold-hints test-render-skill test-verify-skill-called test-check-bump-version test-lint-skill-invocations test-anti-halt test-orchestrator-scope-sync test-design-structure test-implement-rebase-macro test-implement-structure test-subskill-anchors test-loop-improve-skill-driver test-loop-improve-skill-skill-md test-parse-skill-judge-grade test-lib-halt-ledger smoke-dialectic halt-rate-probe
 
-lint: test-redact test-parse-input test-parse-prose-blockers test-sessionstart test-audit-edit-write test-block-submodule test-deny-edit-write test-post-scaffold-hints test-render-skill test-verify-skill-called test-check-bump-version test-lint-skill-invocations test-anti-halt test-orchestrator-scope-sync test-design-structure test-implement-rebase-macro test-implement-structure test-subskill-anchors test-loop-improve-skill-driver test-loop-improve-skill-skill-md test-parse-skill-judge-grade test-lib-halt-ledger
+# CI splits `lint` into `lint-only` (pre-commit) and `test-harnesses`
+# (regression harnesses). `lint` remains the local-dev convenience target
+# that runs both, defined in terms of the two split targets to prevent drift.
+lint: test-harnesses lint-only
+
+lint-only:
 	pre-commit run --all-files
+
+test-harnesses: test-redact test-parse-input test-parse-prose-blockers test-sessionstart test-audit-edit-write test-block-submodule test-deny-edit-write test-post-scaffold-hints test-render-skill test-verify-skill-called test-check-bump-version test-lint-skill-invocations test-anti-halt test-orchestrator-scope-sync test-design-structure test-implement-rebase-macro test-implement-structure test-subskill-anchors test-loop-improve-skill-driver test-loop-improve-skill-skill-md test-parse-skill-judge-grade test-lib-halt-ledger
 
 test-redact:
 	bash scripts/test-redact-secrets.sh


### PR DESCRIPTION
## Summary

- Split CI's single `lint` job into two parallel jobs — `lint` (pre-commit over all files) and `test-harnesses` (the 22 `test-*` bash regression harnesses) — so harness failures and linter failures are distinct CI tiles that can be re-run independently.
- Introduce `lint-only` and `test-harnesses` as split Makefile targets; redefine `lint` as their union so local `make lint` keeps its current meaning while CI composition and local composition stay drift-free.
- Answer the user's question about the skill-judge-related test (see [Skill-judge test note](#skill-judge-test-note) below) — no LLMs, no tokens spent.

## Goal

Before: a single CI job ran `make lint`, interleaving 22 regression harnesses and `pre-commit run --all-files` in one pass. A single harness regression made the whole job red and forced a rerun of every linter too.

After: two independent jobs run in parallel. A harness failure re-runs only the harness job; a pre-commit failure re-runs only the lint job. Local `make lint` is unchanged.

## Test plan

- [x] `make -n lint-only` → expands to `pre-commit run --all-files` only.
- [x] `make -n test-harnesses` → expands to the 22 `test-*` targets only.
- [x] `make -n lint` → expands to both (via dependency chain).
- [x] `/relevant-checks` clean (pre-commit + `agent-lint --pedantic`).
- [ ] CI observes two parallel job tiles: `lint` and `test-harnesses`.

## Skill-judge test note

The user asked about "the test involving a python script from skill-judge." There is no literal Python script inside a `skill-judge` skill — the only Python script in the repo is `scripts/lint-skill-invocations.py`. Two candidates match the description (either sense), so both are covered below.

### Candidate A — `scripts/test-lint-skill-invocations.sh` (tests the only Python script)

- **What it tests**: `scripts/lint-skill-invocations.py`, a style-guide lint that scans every `skills/*/SKILL.md` and `.claude/skills/*/SKILL.md`. When a SKILL.md declares `Skill` in its `allowed-tools` frontmatter, the lint enforces two rules: (1) the body contains at least one canonical phrase — "Invoke the Skill tool" or "via the Skill tool"; (2) every line that matches the `INVOCATION_LINE_REGEX` (imperative "Invoke `/name`") also contains "via the Skill tool" on the same line. Both rules are byte-exact regex + YAML frontmatter parsing. The harness invokes the Python lint as a black-box subprocess against inline heredoc fixtures under `mktemp -d`.
- **LLM / token use**: none. The Python script is `argparse` + `re` + `PyYAML` only — no network I/O, no model calls. `pyyaml==6.0.2` is the single runtime dep.

### Candidate B — `scripts/test-parse-skill-judge-grade.sh` (the only test whose name contains "skill-judge")

- **What it tests**: `scripts/parse-skill-judge-grade.sh`, a pure-bash parser that reads the `## Dimension Scores` pipe-table from a `/skill-judge` output file and emits per-dimension score/max KVs plus `GRADE_A=true|false`, `PARSE_STATUS=ok|missing_table|missing_file|bad_row|empty_file`, and `OVERALL_GRADE=A|B|C|D|F`. Consumed only by the `/loop-improve-skill` bash driver to drive grade-gated termination. The harness covers 14 fixture cases (per-dim threshold edges for D1 max=20 / D2–D6+D8 max=15 / D7 max=10, the full `PARSE_STATUS` taxonomy, a verbatim `/skill-judge` Step-5 report template for upstream-grammar pinning, and the defensive consistency rule that only rewrites `ok+empty NON_A_DIMS` to `bad_row` while preserving `missing_table` etc.).
- **LLM / token use**: none. Both the parser and the harness are pure bash + `mktemp -d` fixtures. They do not call any `/skill-judge` invocation at test time — the fixtures inline the expected pipe-table format directly.

**Confirmation**: Neither harness spawns `claude`, nor any external LLM CLI, nor any network call. Both are offline regression tests executed in a fresh `mktemp -d` sandbox. Total token cost to run: 0.

## Final Design

### Makefile

- Declared two new phony targets, `lint-only` and `test-harnesses`.
- `lint-only: pre-commit run --all-files` (no prerequisites).
- `test-harnesses: ` + the 22 `test-*` prerequisites (no recipe — pure aggregator).
- `lint: test-harnesses lint-only` (pure aggregator — both targets retain their recipes unchanged).

### CI workflow

- `lint` job: unchanged env (Python 3.12 + pre-commit cache + pyyaml), now runs `make lint-only`.
- New `test-harnesses` job: Python 3.12 + pyyaml install (required by `test-lint-skill-invocations` which invokes the Python lint directly outside the pre-commit venv), runs `make test-harnesses`. Does NOT install pre-commit or use the pre-commit cache — harnesses do not need it.

Both jobs run in parallel (GitHub Actions fan-out).

<details><summary>Version Bump Reasoning</summary>

Classified PATCH by `classify-bump.sh` — no changes under `skills/**` or `agents/**`. Applied `5.1.0 → 5.1.1`.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

### [Code Review] Cursor (round 1)
**Finding**: `Makefile:9` — `lint: test-harnesses lint-only` uses sibling prerequisites. Under `make -j` (parallel make) `test-harnesses` and `lint-only` could run concurrently, whereas the previous single-recipe `lint` rule ran `pre-commit run --all-files` only after every harness prerequisite finished. Reviewer suggested serializing via `lint: lint-only` with `lint-only: test-harnesses` (making `test-harnesses` an order-only prereq of `lint-only`).
**Reason not implemented**: The suggested fix would break the CI split. CI's new `lint` job calls `make lint-only` directly, specifically to exclude the 22 test harnesses; making `lint-only` depend on `test-harnesses` would re-couple them and regress to the previous single-job behavior. The parallel-make concern only applies to a hypothetical `make -j lint` local invocation, which is not a supported pattern in this repo — the Makefile is not designed for parallel builds, and no documentation or CI step uses `make -j`. Both split targets are read-only with respect to tracked files (harnesses use `mktemp -d` scratch directories), so even if a user did force parallel execution, there is no observable shared-state conflict. Under serial `make lint` (the default) the original prerequisite-first ordering is preserved.

</details>

<details><summary>Execution Issues</summary>

None.

</details>

| Metric | Value |
|---|---|
| Mode | `--merge --auto --quick` |
| /design | skipped (quick mode) |
| /review | skipped — inline single-reviewer loop (Cursor, 1 round, no accepted findings) |
| OOS issues filed | 0 |
| Version bump | PATCH — 5.1.0 → 5.1.1 |
