### PR TITLE
Remove stale 'All output caveman full.' instruction from CLAUDE.md

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.1.2] - 2026-04-21
+
+### Removed
+
+- `CLAUDE.md`: delete the stale `All output caveman full.` instruction. The caveman plugin was uninstalled, so the directive no longer matches any available plugin and was incorrectly forcing caveman-style output in every session.
+
 ## [5.1.1] - 2026-04-21
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,2 @@
 @AGENTS.md
 @KARPATHY_CLAUDE.md
-
-All output caveman full.


### PR DESCRIPTION
## Summary

- Delete the stale `All output caveman full.` instruction from `CLAUDE.md`. The caveman plugin was uninstalled, so the directive no longer corresponds to any plugin and was incorrectly forcing caveman-style output in every session.
- CHANGELOG entry under `[5.1.2] - Removed`.

## Goal

Stop `CLAUDE.md` from forcing a style directive that points at a plugin which is no longer installed.

## Test plan

- [x] `grep -n -i caveman /Users/zhupanov/larch5/CLAUDE.md` returns no matches
- [x] `/relevant-checks` passes (changed-file pre-commit + full-repo agent-lint)
- [x] Quick-mode Cursor review: `NO_ISSUES_FOUND`

## Final Design

Two-line deletion in `CLAUDE.md`: remove `All output caveman full.` plus the blank line above it. Both `@AGENTS.md` and `@KARPATHY_CLAUDE.md` imports preserved. No runtime-surface impact (CLAUDE.md is supplementary, not in `skills/**`/`agents/**`/`hooks/**`/`scripts/**`/`.claude-plugin/**`).

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `062da56` (Split CI lint job: run pre-commit and test harnesses as separate jobs (#298))
- **Current version**: `5.1.1`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `5.1.2`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH").

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

None — quick mode skipped `/design`.

</details>

<details><summary>Implementation Deviations</summary>

None.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

None — Cursor returned `NO_ISSUES_FOUND` in round 1.

</details>

<details><summary>Plan Review Voting Tally</summary>

N/A — quick mode.

</details>

<details><summary>Code Review Voting Tally Round 1</summary>

N/A — quick mode uses single-reviewer loop (Cursor), no voting panel.

</details>

<details><summary>Out-of-Scope Observations</summary>

### Accepted OOS (GitHub issues filed)

No OOS items were accepted for issue filing.

### Non-accepted OOS

None.

</details>

<details><summary>Execution Issues</summary>

None.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|---|---|
| Mode | quick + merge + auto |
| Design phase | skipped (quick mode) |
| Code review rounds | 1 |
| Reviewer | Cursor |
| OOS issues filed | 0 |
| Version bump | 5.1.1 → 5.1.2 (PATCH) |

</details>
