### PR TITLE
Compress two prose paragraphs in implement SKILL.md (-101 bytes)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "5.2.1",
+  "version": "5.2.2",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.2.2] - 2026-04-21
+
+### Changed
+
+- Two prose paragraphs in `skills/implement/SKILL.md` compressed via Strunk & White rewrites (omit-needless-words). Affects the Cross-Skill Health Propagation trailer sentence and the `oos-accepted-main-agent.md` create-on-missing paragraph. Structure, code references, modals, and technical content preserved verbatim; -101 bytes, no line-count change.
+
 ## [5.2.1] - 2026-04-21
 
 ### Changed

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -177,7 +177,7 @@ After each child skill returns (`/design` in Step 1, `/review` in Step 5), check
 1. Read the current values from `$IMPLEMENT_TMPDIR/session-env.sh` (parse `SLACK_OK`, `SLACK_MISSING`, `REPO`, `REPO_UNAVAILABLE` line-by-line, same safe parsing as `session-setup.sh` — do NOT source the file)
 2. Re-write the file using `write-session-env.sh` with those preserved values plus the updated health flags
 
-This ensures runtime timeouts propagate across skill boundaries within the `/implement` flow without clobbering existing Slack/repo state.
+Runtime timeouts then propagate across skill boundaries without clobbering existing Slack/repo state.
 
 ## Execution Issues Tracking
 
@@ -268,7 +268,7 @@ The Description field is forwarded verbatim into a public GitHub issue body by `
 - **Phase**: implement
 ```
 
-If `oos-accepted-main-agent.md` does not yet exist, create it with the new entry. If `repo_unavailable=true`, still append to the file (Step 9a.1 will skip filing) — note that `$IMPLEMENT_TMPDIR` is removed at Step 18 cleanup, so the only persistent audit trail in the repo-unavailable case is the corresponding `Pre-existing Code Issues` entry in `execution-issues.md` that gets written into the PR body's `<details><summary>Execution Issues</summary>` block. The PR body's "Accepted OOS (GitHub issues filed)" subsection will explicitly say "Skipped — repo unavailable" in this case (see Step 9a.1's `repo_unavailable=true` branch).
+If `oos-accepted-main-agent.md` does not exist, create it with the new entry. If `repo_unavailable=true`, still append (Step 9a.1 will skip filing) — `$IMPLEMENT_TMPDIR` is removed at Step 18 cleanup, so the only persistent audit trail in the repo-unavailable case is the `Pre-existing Code Issues` entry in `execution-issues.md` that gets written into the PR body's `<details><summary>Execution Issues</summary>` block. The PR body's "Accepted OOS (GitHub issues filed)" subsection will say "Skipped — repo unavailable" (see Step 9a.1's `repo_unavailable=true` branch).
 
 ## Step 1 — Ensure Design Plan Exists
 


### PR DESCRIPTION
## Summary

- Compressed two prose paragraphs in `skills/implement/SKILL.md` via Strunk & White rewrites (omit needless words), preserving every structural element, code reference, modal, and technical identifier.
- Net delta: -101 bytes, 0 lines. Affected paragraphs: the Cross-Skill Health Propagation trailer sentence and the `oos-accepted-main-agent.md` create-on-missing paragraph.

<details><summary>Architecture Diagram</summary>

Quick mode — architecture diagram skipped.

</details>

<details><summary>Code Flow Diagram</summary>

Quick mode — code flow diagram skipped.

</details>

<details><summary>Goal</summary>

- Apply `/compress-skill` to `/implement`.
  - Scan SKILL.md and its transitive `.md` reference set for paragraphs where Strunk & White rewrites would shorten text by ≥10% without drift risk.
  - Preserve every structural element verbatim: YAML frontmatter, fenced code blocks, inline code, HTML comments, heading text, link targets, list markers, table cell structure, file paths, numeric values, identifiers, and load-bearing modals (MUST / SHOULD / NEVER).
- Commit and push a PR with the compression result per the user's explicit request to skip reviews.

</details>

<details><summary>Test plan</summary>

- [x] `/compress-skill /implement` ran end-to-end; before/after delta report emitted.
- [x] Five files in the transitive `.md` set were scanned; no fenced code block, heading, or citation was modified.
- [x] Two prose rewrites applied; three reference files left unchanged (either byte-preserving contracts or lean enough to fall under the 10% threshold rule).
- [x] `git diff` confirms only prose changes (2 insertions, 2 deletions in SKILL.md).
- [ ] CI green on the resulting PR.

</details>

<details><summary>Final Design</summary>

## Implementation Plan

Files to modify:
- `skills/implement/SKILL.md` — two localized prose rewrites.

Approach: no coding required — the `/compress-skill` invocation already produced the correct minimal diff. The `/imaq` follow-up simply commits, bumps the version, and opens the PR.

Edge cases addressed by the compressor itself:
- Fenced blocks, headings, citations, paths, and modals were mechanically preserved.
- Paragraphs not shortened by ≥10% were left alone.
- Reference files marked "byte-preserving extraction from SKILL.md Lxxx–Lxxx" were skipped entirely (would break the contract invariant).

Testing strategy: a `grep` confirming no fenced-block or heading drift, plus a `git diff --stat` showing only SKILL.md changes. CI will run the harness-level structural checks.

Failure modes: the only drift risk is semantic meaning; the two chosen rewrites are both in sentences that are pure narrative glue (no modals, no enum literals, no citations), so semantic regression risk is minimal.

</details>

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `57ef0c1` (Add /compress-skill: rewrite skill prose applying Strunk & White, preserving structure (#302))
- **Current version**: `5.2.1`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `5.2.2`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH").

### Escalation-only review

Main-agent reviewed the diff for behavioral changes relative to a skill's original intent. The two edits are pure narrative-prose omit-needless-words rewrites in paragraphs containing no modals, no enum literals, no path citations, and no contract tokens. No behavioral change. No escalation.

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

Quick mode — no plan review was conducted.

</details>

<details><summary>Implementation Deviations</summary>

Per user's explicit instruction "skipping reviews, commit and push PR with the above changes", Step 3 (first `/relevant-checks`), Step 5 (quick-mode single-reviewer loop), Step 6 (second `/relevant-checks`), and Step 7 (review-fix commit) were skipped. Rationale: the change is two prose-only rewrites already produced and verified by `/compress-skill`, and the user owns the judgment call to bypass review. This user override deviates from `skills/implement/SKILL.md`'s NEVER list rule #4 ("NEVER skip the `/review` step regardless of the nature of changes") and is logged here for auditability.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

Quick mode — no voting panel. Main agent reviewed findings across up to 7 single-reviewer rounds (Cursor → Codex → Claude fallback chain). All review was skipped at user request; no rejected suggestions to list.

</details>

<details><summary>Plan Review Voting Tally</summary>

Quick mode — no plan review voting.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

Quick mode — no voting panel. Main agent reviewed findings across up to 7 single-reviewer rounds (Cursor → Codex → Claude fallback chain). Review skipped at user request.

</details>

<details><summary>Out-of-Scope Observations</summary>

**Accepted OOS (GitHub issues filed):**
No OOS items were accepted for issue filing.

**Non-accepted OOS observations:**
Quick mode — no reviewer voting panel. Main-agent OOS items (if any) are auto-filed per policy; see Accepted OOS above.

</details>

<details><summary>Execution Issues</summary>

### Warnings
- **Step 3, 5, 6, 7**: Skipped per user's explicit "skipping reviews" instruction. See Implementation Deviations.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | N/A (quick mode) |
| Code review rounds | 0 (skipped per user) |
| Code review findings | 0 accepted, 0 rejected |
| Warnings logged | 1 |
| Pre-existing issues noticed | 0 |
| OOS issues filed | 0 |
| External reviewers | N/A (quick mode) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
