### PR TITLE
Fix /compress-skill wc normalization regression (#311)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.0.1] - 2026-04-23
+
+### Fixed
+
+- `skills/compress-skill/scripts/build-feature-description.sh:153-154` — replaced `tr -d ' '` with `tr -d '[:space:]'` on both the `wc -c` and `wc -l` pipelines. The space-only strip failed to remove BSD `wc` leading/padding whitespace that is not a plain ASCII space on some platforms, letting stray whitespace flow into `TOTAL_BYTES` / `TOTAL_LINES` arithmetic and table cells. Restores the safer normalization the removed `measure-set.sh` previously used. Closes #311.
+
 ## [6.0.0] - 2026-04-23
 
 ### Changed

--- a/skills/compress-skill/scripts/build-feature-description.sh
+++ b/skills/compress-skill/scripts/build-feature-description.sh
@@ -150,8 +150,8 @@ TOTAL_LINES=0
 
 while IFS= read -r -d '' path; do
   [[ -z "$path" ]] && continue
-  bytes=$(wc -c < "$path" | tr -d ' ')
-  lines=$(wc -l < "$path" | tr -d ' ')
+  bytes=$(wc -c < "$path" | tr -d '[:space:]')
+  lines=$(wc -l < "$path" | tr -d '[:space:]')
   TOTAL_BYTES=$((TOTAL_BYTES + bytes))
   TOTAL_LINES=$((TOTAL_LINES + lines))
   # Relativize path under TARGET_DIR for readability in the feature description.


### PR DESCRIPTION
## Summary

- Replaced `tr -d ' '` with `tr -d '[:space:]'` on the `wc -c` and `wc -l` pipelines in `skills/compress-skill/scripts/build-feature-description.sh:153-154` so that BSD-`wc` padding whitespace no longer leaks into `TOTAL_BYTES` / `TOTAL_LINES` arithmetic or table cells. Closes #311.

<details><summary>Architecture Diagram</summary>

Quick mode — architecture diagram skipped.

</details>

<details><summary>Code Flow Diagram</summary>

Quick mode — code flow diagram skipped.

</details>

<details><summary>Goal</summary>

- Restore the safer `wc` whitespace-normalization behavior used by the now-removed `measure-set.sh`.
  - Ensure BSD `wc` (macOS / *BSD) leading/padding whitespace — which is not a plain ASCII space — is stripped.
  - Prevent stray whitespace from being concatenated into `TOTAL_BYTES` / `TOTAL_LINES` arithmetic via `$((...))`.
  - Prevent stray whitespace from surfacing inside the rendered Markdown `| bytes / lines |` table cells in the feature description.
- Keep the scope surgical: touch only the two lines named by issue #311.

</details>

<details><summary>Test plan</summary>

- [x] `/relevant-checks` (pre-commit shellcheck + agent-lint full-repo) passes on the changed file.
- [ ] Exercise `/compress-skill` end-to-end on a skill with multi-line `.md` files and confirm table cells contain no leading/padding whitespace (manual post-merge spot check).

</details>

<details><summary>Final Design</summary>

**Files to modify**: `skills/compress-skill/scripts/build-feature-description.sh` (lines 153-154 only).

**Change**: Replace `tr -d ' '` with `tr -d '[:space:]'` on both the `wc -c` and `wc -l` pipelines.

**Verification**: Run `/relevant-checks` (pre-commit + agent-lint) to ensure shell script lint passes.

</details>

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `594b683` (Make Slack posting in /implement opt-in via --slack flag (#326))
- **Current version**: `6.0.0`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `6.0.1`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH").

**Note**: Initial bump computed on branch-point `0331e8e` (5.2.9) produced 5.2.10. After main advanced to 6.0.0 (#326) during CI wait, the feature branch was rebased and the bump was recomputed against the new base `594b683`, producing 6.0.1.

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

Quick mode — no plan review was conducted.

</details>

<details><summary>Implementation Deviations</summary>

No deviations from the plan.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

All code review suggestions were implemented.

</details>

<details><summary>Plan Review Voting Tally</summary>

Quick mode — no plan review voting.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

Quick mode — no voting panel. Main agent reviewed findings across up to 7 single-reviewer rounds (Cursor → Codex → Claude fallback chain). Round 1 (Cursor) returned `NO_ISSUES_FOUND` for in-scope changes; the loop terminated after one round.

</details>

<details><summary>Out-of-Scope Observations</summary>

**Accepted OOS (GitHub issues filed):**
- #328: /simplify-skill wc normalization regression (Main agent)

**Non-accepted OOS observations:**
Quick mode — no reviewer voting panel. Main-agent OOS items (if any) are auto-filed per policy; see Accepted OOS above.

</details>

<details><summary>Execution Issues</summary>

### Pre-existing Code Issues
- **Step 5**: `skills/simplify-skill/scripts/build-feature-description.sh:134-135` has the same `wc` whitespace-normalization bug that issue #311 fixes in `compress-skill`. Both lines use `tr -d ' '`, which only strips ASCII spaces; BSD `wc` emits padding that is not a plain space on some platforms, leaving stray whitespace concatenated into `SKILL_MD_LINES` / `SKILL_MD_CHARS`. Suggested fix: change `tr -d ' '` to `tr -d '[:space:]'` on both lines (same fix as in `compress-skill`). Out-of-scope for #311 since that issue names only the `compress-skill` script.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | N/A (quick mode) |
| Code review rounds | 1 |
| Code review findings | 0 accepted, 0 rejected |
| Warnings logged | 0 |
| Pre-existing issues noticed | 1 |
| OOS issues filed | 1 created, 0 deduplicated |
| External reviewers | N/A (quick mode) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)

