### PR TITLE
Fix CI workflow warnings: Node 20 deprecation + agent-lint pedantic input (closes #316)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "6.0.5",
+  "version": "6.0.6",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,11 +18,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.cache/pre-commit
           key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
@@ -42,8 +42,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Install PyYAML
@@ -55,17 +55,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: zhupanov/agent-lint@v2.3.2
         with:
           github-token: ${{ github.token }}
-          args: --pedantic
+          pedantic: true
 
   agnix:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: agent-sh/agnix@v0.17.0
         with:
           target: 'claude-code'
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Regenerate agents/code-reviewer.md and check for drift
         run: |
           bash scripts/generate-code-reviewer-agent.sh --check
@@ -162,7 +162,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Run dialectic smoke test
         # Invokes scripts/dialectic-smoke-test.sh directly; the `make smoke-dialectic`
         # target is equivalent and exists for local developer convenience.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.0.6] - 2026-04-23
+
+### Fixed
+
+- `.github/workflows/ci.yaml` Node.js 20 deprecation and invalid `agent-lint` input (closes #316). Bumped `actions/checkout@v4` → `@v6`, `actions/setup-python@v5` → `@v6`, and `actions/cache@v4` → `@v5` — each major publishes a Node.js 24 entrypoint (runner v2.327.1+, already on `ubuntu-latest`). Replaced the silently-ignored `args: --pedantic` on `zhupanov/agent-lint@v2.3.2` with the documented `pedantic: true` input.
+
 ## [6.0.5] - 2026-04-23
 
 ### Changed


### PR DESCRIPTION
## Summary

- Bumped `actions/checkout@v4` → `@v6`, `actions/setup-python@v5` → `@v6`, and `actions/cache@v4` → `@v5` so every `ci.yaml` job runs on a Node.js 24 entrypoint and the runner-level deprecation warning stops firing.
- Replaced the silently-ignored `args: --pedantic` input on `zhupanov/agent-lint@v2.3.2` with the documented `pedantic: true` input, restoring pedantic mode and removing the "Unexpected input(s)" annotation.
- Closes #316. Only `.github/workflows/ci.yaml` and the version-bump/CHANGELOG files are touched.

## Goal

Eliminate the two classes of workflow-level annotations surfacing on every CI run: (1) Node.js 20 deprecation across six jobs, and (2) invalid `args` input to the `agent-lint` action. A fresh CI run on this PR should produce zero workflow-level annotations from either source.

## Test plan

- [x] `/relevant-checks` passes (pre-commit routes to `actionlint` for the edited workflow; agent-lint full-repo pass is green).
- [ ] CI on this PR runs without "Node.js 20 actions are deprecated" warnings on any of the six jobs (`lint`, `test-harnesses`, `agent-lint`, `agnix`, `agent-sync`, `smoke-dialectic`).
- [ ] CI on this PR runs without the `agent-lint` "Unexpected input(s) 'args'" warning; the `agent-lint` job still runs in pedantic mode.

## Implementation notes

- All three official `actions/*` majors with Node-24 entrypoints are newer than the runner-minimum `v2.327.1` — GitHub-hosted `ubuntu-latest` satisfies that. The release notes for `actions/setup-python@v6.0.0` and `actions/cache@v5.0.0` explicitly call out this requirement; GitHub-hosted runners have carried it for months, so this is a no-op for this repo's runner fleet.
- `zhupanov/agent-lint@v2.3.2`'s `action.yml` defines `pedantic` (default `"false"`, stringified-boolean contract) but has no `args` input, so the previous wiring was silently ignored. The new `pedantic: true` wiring matches the action schema and restores `--pedantic` mode that was intended from the start.
- Kept the existing major-only pin convention for the three bumped official actions (matches the rest of the file; third-party actions like `zhupanov/agent-lint@v2.3.2` and `agent-sh/agnix@v0.17.0` keep their pre-existing patch-level pins).

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `c915bdf` (Switch Cursor default to composer-2 and wrap prompts with /max-mode on (#335))
- **Current version**: `6.0.5`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `6.0.6`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH"). The only functional change is a CI-workflow fix under `.github/workflows/`.

</details>

<details><summary>Quick-mode code review (single reviewer, Cursor)</summary>

Cursor reviewed the diff vs `main` with maximum reasoning effort, walked all five focus areas (code-quality, risk-integration, correctness, architecture, security), and externally verified `zhupanov/agent-lint@v2.3.2`'s `action.yml` — confirming that `pedantic` is the defined input and `args` was never recognized. Result: **NO_ISSUES_FOUND**.

</details>

<details><summary>Execution Issues</summary>

No execution issues.

</details>
