### PR TITLE
Drop stale harness count from ci.yaml comment (closes #319)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "6.0.9",
+  "version": "6.0.10",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Run pre-commit linters
         run: make lint-only
 
-  # Regression harnesses (the 22 `test-*` bash scripts in Makefile). Runs
+  # Regression harnesses (the `test-*` bash scripts in Makefile). Runs
   # in parallel with the `lint` job so a harness failure can be diagnosed
   # and re-run without waiting on pre-commit, and vice versa. PyYAML is
   # required because test-lint-skill-invocations invokes the python lint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.0.10] - 2026-04-23
+
+### Changed
+
+- `.github/workflows/ci.yaml:36` comment no longer asserts a hardcoded harness count: the literal string `the 22 test-*` was replaced with `the test-*` so the phrase reads "the `test-*` bash scripts in Makefile". The count was already stale (the target lists 25+) and would keep drifting every time a harness is added; CI still runs `make test-harnesses`, the authoritative list. Cosmetic, no behavioral effect. Closes #319.
+
 ## [6.0.9] - 2026-04-23
 
 ### Changed


### PR DESCRIPTION
## Summary

- Dropped the stale hardcoded "22" count from the `test-harnesses` job comment in `.github/workflows/ci.yaml:36` — comment now reads "the `test-*` bash scripts in Makefile" instead of "the 22 `test-*` bash scripts in Makefile". Closes #319.

<details><summary>Architecture Diagram</summary>

Quick mode — architecture diagram skipped.

</details>

<details><summary>Code Flow Diagram</summary>

Quick mode — code flow diagram skipped.

</details>

<details><summary>Goal</summary>

- Fix the stale harness-count claim in `.github/workflows/ci.yaml:36`
  - Prior comment asserted "the 22 `test-*` bash scripts in Makefile", but the Makefile's `test-harnesses` target already lists 25+ such scripts.
  - Stale count misled contributors who count harnesses manually.
  - Preferred fix (per issue #319): drop the count entirely rather than bump to the current count, so the comment cannot rot every time a harness is added.
- Preserve CI behavior unchanged
  - Comment is cosmetic; `make test-harnesses` remains the authoritative list.

</details>

<details><summary>Test plan</summary>

- [x] `grep -n "test-\*" .github/workflows/ci.yaml` shows only the updated comment (no remaining "22" count).
- [x] `/relevant-checks` (pre-commit + agent-lint) passes.
- [x] Cursor code review returns `NO_ISSUES_FOUND`.
- [ ] CI `test-harnesses` job still runs (unchanged from before).

</details>

<details><summary>Final Design</summary>

Single-character edit to a YAML comment at `.github/workflows/ci.yaml:36`. Change `the 22 \`test-*\` bash scripts in Makefile` → `the \`test-*\` bash scripts in Makefile`. No code or behavior changes.

</details>

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `74010a2` (Harden test-review-structure.sh with line-scoped callsite pins (closes #318) (#340))
- **Current version**: `6.0.9`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `6.0.10`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH").

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

Quick mode — no plan review was conducted.

</details>

<details><summary>Implementation Deviations</summary>

No deviations from the plan.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

All code review suggestions were implemented.

</details>

<details><summary>Plan Review Voting Tally</summary>

Quick mode — no plan review voting.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

Quick mode — no voting panel. Main agent reviewed findings across up to 7 single-reviewer rounds (Cursor → Codex → Claude fallback chain).

</details>

<details><summary>Out-of-Scope Observations</summary>

**Accepted OOS (GitHub issues filed):**
No OOS items were accepted for issue filing.

**Non-accepted OOS observations:**
Quick mode — no reviewer voting panel. Main-agent OOS items (if any) are auto-filed per policy; see Accepted OOS above.

</details>

<details><summary>Execution Issues</summary>

### CI Issues
- **Step 10**: First CI run failed on markdownlint MD038 ("Spaces inside code span elements") at CHANGELOG.md:12. Root cause: my CHANGELOG entry used escaped backticks inside backtick-quoted spans, which markdownlint parsed as broken code spans. Rewrote the entry to avoid the nested escapes and amended the bump commit. Fixed.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | N/A (quick mode) |
| Code review rounds | 1 |
| Code review findings | 0 accepted, 0 rejected |
| Warnings logged | 0 |
| Pre-existing issues noticed | 0 |
| OOS issues filed | 0 |
| External reviewers | N/A (quick mode) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)





