### PR TITLE
Clear residual agnix linter warnings (closes #317)

### DIFF
--- a/.agnix.toml
+++ b/.agnix.toml
@@ -3,6 +3,26 @@
 
 tools = ["claude-code"]
 
+# Exclude paths from validation. An explicit 'exclude' replaces agnix's
+# defaults (node_modules/**, .git/**, target/**), so we list them here
+# alongside the repo-specific additions.
+# - tests/fixtures/** — intentionally skeletal fixture skills used by the
+#   halt-rate harness (see tests/fixtures/loop-halt-rate/SKILL.md). They
+#   are designed to be graded below-A; AS-010 "missing Use when... trigger"
+#   is expected and must NOT be fixed on the fixture itself.
+exclude = [
+  "node_modules/**",
+  ".git/**",
+  "target/**",
+  "tests/fixtures/**",
+]
+
+# Pin versions so version-dependent rules (VER-001 family) evaluate against
+# a known baseline rather than drifting with agnix defaults. This repo IS
+# the larch Claude Code plugin, so we target the Claude Code 2.1 series.
+[tool_versions]
+claude_code = "2.1.0"
+
 [rules]
 disabled_rules = [
   # File-length rules — larch skills are intentionally long (orchestration prompts)
@@ -14,4 +34,5 @@ disabled_rules = [
   "CC-SK-008",  # 'Agent' is a valid Claude Code tool not yet in agnix's known-tool list
   "XP-003",     # Hard-coded .claude/ paths are correct — this IS a Claude Code plugin repo
   "CC-SK-007",  # Unrestricted Bash is intentional — all larch skills need full shell access
+  "XP-SK-001",  # 'argument-hint' is a Claude Code-supported field; every use in this repo is intentional because this IS a Claude Code plugin
 ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "6.0.6",
+  "version": "6.0.7",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ Plugin ships the entire repo. **Runtime surface**: `skills/`, `agents/`, `hooks/
 ## Editing rules
 
 - Use `/bump-version` to change `.claude-plugin/plugin.json` version — it owns that commit; `Bump version to X.Y.Z` is a reserved commit message.
-- Always respect `scripts/block-submodule-edit.sh`. If a hook blocks a write, investigate and resolve the underlying issue. The guard ships via `hooks/hooks.json` only — `.claude/settings.json` no longer mirrors it, so contributors developing in this repo should load larch as a plugin (`claude --plugin-dir .` or the local marketplace) to pick up the guard.
+- Always respect `scripts/block-submodule-edit.sh`. If a hook blocks a write, investigate and resolve the underlying issue. The guard ships via `hooks/hooks.json` only — `.claude/settings.json` no longer mirrors it, so contributors developing in this repo must load larch as a plugin (`claude --plugin-dir .` or the local marketplace) to pick up the guard.
 - After any change, run `/relevant-checks`.
 - Public `skills/*/SKILL.md` use `${CLAUDE_PLUGIN_ROOT}/…`; dev-only `.claude/skills/*/SKILL.md` use `$PWD/…`.
 - Update `SECURITY.md` when security-relevant behavior changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.0.7] - 2026-04-23
+
+### Changed
+
+- `.agnix.toml` cleared four residual CI warnings with no behavioral change to any skill (closes #317). Added `XP-SK-001` to `disabled_rules` with a comment explaining that `argument-hint` is a Claude Code-supported field and intentional across every skill here. Added a top-level `exclude` list that preserves agnix's defaults (`node_modules/**`, `.git/**`, `target/**`) and adds `tests/fixtures/**` so deliberately-skeletal halt-rate fixtures (e.g. `tests/fixtures/loop-halt-rate/SKILL.md`) no longer trigger `AS-010`. Added a `[tool_versions]` section pinning `claude_code = "2.1.0"` to satisfy `VER-001`. `AGENTS.md` tightened `contributors developing in this repo should load larch as a plugin …` to `must` to clear `PE-003` in the critical "Editing rules" section.
+
 ## [6.0.6] - 2026-04-23
 
 ### Fixed


### PR DESCRIPTION
## Summary

- `.agnix.toml`: adds `XP-SK-001` to `disabled_rules` (argument-hint is a Claude Code-supported field and intentional here), adds top-level `exclude` that preserves agnix's defaults and adds `tests/fixtures/**` (halt-rate fixtures are deliberately skeletal), and adds `[tool_versions]` pinning `claude_code = "2.1.0"` to satisfy `VER-001`.
- `AGENTS.md`: tightens `contributors developing in this repo should load larch as a plugin …` to `must` to clear `PE-003` in the critical "Editing rules" section.
- Verified with `agnix .` → "No issues found"; closes #317.

## Goal

Clear the four residual agnix linter warnings (`XP-SK-001`, `VER-001`, `AS-010`, `PE-003`) from the latest CI run without changing the behavior of any shipped skill — edits are limited to `.agnix.toml` and `AGENTS.md` per the issue's acceptance criteria.

## Test plan

- [x] `agnix .` reports no warnings (verified locally — "No issues found").
- [x] `/relevant-checks` passes (pre-commit + agent-lint).
- [ ] CI's `agnix` job is green on the PR.
- [ ] CI's `agent-lint`, `shellcheck`, `markdownlint`, `jsonlint`, `actionlint`, and `lint-skill-invocations` jobs remain green.

## Final Design

**.agnix.toml**
- `XP-SK-001` appended to `disabled_rules` (rationale comment records that `argument-hint` is a Claude Code-supported field, so every occurrence in this repo is intentional because this IS a Claude Code plugin).
- New top-level `exclude` list: `node_modules/**`, `.git/**`, `target/**` (agnix's defaults, preserved because an explicit `exclude` replaces them), plus `tests/fixtures/**` with a comment pointing at the halt-rate-harness rationale.
- New `[tool_versions]` table with `claude_code = "2.1.0"` — the 2.1 series is what the plugin currently targets; pinning silences `VER-001` and gives version-dependent rules a known baseline rather than drifting with agnix defaults.

**AGENTS.md**
- Single-word edit at line 12: `should load larch as a plugin` → `must load larch as a plugin`. The "Editing rules" section is classified critical by agnix, so `PE-003` flagged the weak "should"; the guidance is already firm in intent (without loading larch as a plugin the `block-submodule-edit.sh` guard doesn't run), so "must" is accurate.

## Version Bump Reasoning

<details><summary>Version Bump Reasoning</summary>

- **Base commit**: `ceb9ff3` (Fix CI workflow warnings: Node 20 deprecation + agent-lint pedantic input (closes #316) (#336))
- **Current version**: `6.0.6`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

**Result: PATCH → 6.0.7**

No MAJOR or MINOR evidence found in the public plugin surface. This PR only edits `.agnix.toml` and `AGENTS.md` (neither under `skills/**` or `agents/**`); defaulting to PATCH per policy ("every PR must bump at least PATCH").

</details>

## Rejected Plan Review Suggestions

None — quick mode skips `/design`.

## Implementation Deviations

None.

## Rejected Code Review Suggestions

None — Cursor reviewer (quick-mode round 1) reported `NO_ISSUES_FOUND`.

## Plan Review Voting Tally

N/A — quick mode skips `/design`.

## Code Review Voting Tally Round 1

N/A — quick mode uses a single-reviewer loop, not a voting panel. Round 1 reviewer: Cursor; result: `NO_ISSUES_FOUND`.

## Out-of-Scope Observations

None.

## Accepted OOS

None.

<details><summary>Execution Issues</summary>

None recorded this run.

</details>

## Run Statistics

| Metric | Value |
|--------|-------|
| Mode | quick |
| Review rounds | 1 |
| OOS issues filed | 0 |
| Files changed | 3 (`.agnix.toml`, `AGENTS.md`, `CHANGELOG.md`) + `.claude-plugin/plugin.json` (version bump) |
| Commits on branch | 2 (implementation + version bump) |

