### PR TITLE
Fix /simplify-skill wc normalization to strip all whitespace (closes #328)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.1.2] - 2026-04-23
+
+### Fixed
+
+- `skills/simplify-skill/scripts/build-feature-description.sh:134-135` now strips all whitespace from `wc -l` / `wc -c` output via `tr -d '[:space:]'` instead of only ASCII spaces. BSD `wc` pads its numeric output with whitespace that is not a plain space, so the previous `tr -d ' '` left stray characters concatenated into `SKILL_MD_LINES` / `SKILL_MD_CHARS`. Identical fix to the one already applied to `skills/compress-skill/scripts/build-feature-description.sh` for issue #311. Closes #328.
+
 ## [6.1.1] - 2026-04-23
 
 ### Added

--- a/skills/simplify-skill/scripts/build-feature-description.sh
+++ b/skills/simplify-skill/scripts/build-feature-description.sh
@@ -131,8 +131,8 @@ done
 FEATURE_FILE="$(mktemp -t simplify-skill-feature.XXXXXX)"
 
 # Count lines for the Token budget baseline the feature description pins.
-SKILL_MD_LINES=$(wc -l < "$TARGET_SKILL_MD" | tr -d ' ')
-SKILL_MD_CHARS=$(wc -c < "$TARGET_SKILL_MD" | tr -d ' ')
+SKILL_MD_LINES=$(wc -l < "$TARGET_SKILL_MD" | tr -d '[:space:]')
+SKILL_MD_CHARS=$(wc -c < "$TARGET_SKILL_MD" | tr -d '[:space:]')
 
 # Build the included-files prose block (one per line, indented).
 INCLUDED_PROSE=""


### PR DESCRIPTION
## Summary

- Fixed `wc` output normalization in `skills/simplify-skill/scripts/build-feature-description.sh:134-135` so `SKILL_MD_LINES` / `SKILL_MD_CHARS` are pure digits on BSD `wc` (closes #328).
- Applied the same `tr -d '[:space:]'` treatment that issue #311 already applied to the compress-skill variant, so the two parallel scripts stay consistent.

<details><summary>Architecture Diagram</summary>

Quick mode — architecture diagram skipped.

</details>

<details><summary>Code Flow Diagram</summary>

Quick mode — code flow diagram skipped.

</details>

<details><summary>Goal</summary>

- Stop BSD `wc` padding whitespace from leaking into the feature description generated by `/simplify-skill`.
  - Root cause: `tr -d ' '` only strips U+0020; BSD `wc` pads its numeric output with additional whitespace (leading spaces plus possible tabs) that the previous filter left intact.
  - Fix posture: change both `tr -d ' '` filters to `tr -d '[:space:]'`, identical to the fix applied to `skills/compress-skill/scripts/build-feature-description.sh` for issue #311.
- Keep the two parallel helper scripts in `skills/simplify-skill/scripts/` and `skills/compress-skill/scripts/` aligned so the same regression cannot silently diverge again.
- Success criteria: `SKILL_MD_LINES` / `SKILL_MD_CHARS` are pure digits on all supported `wc` implementations; no other behavioral change.

</details>

<details><summary>Test plan</summary>

- [x] `/relevant-checks` (shellcheck + agent-lint) — passed.
- [x] Grep sweep confirmed no `wc ... | tr -d ' '` remains under `skills/simplify-skill/`.
- [x] Cross-checked `skills/compress-skill/scripts/build-feature-description.sh:160-161` uses the same `[:space:]` form.
- [ ] CI (agent-lint, plugin-validate, test-harnesses, shellcheck) — to be verified on PR.

</details>

<details><summary>Final Design</summary>

Two-line edit in `skills/simplify-skill/scripts/build-feature-description.sh`:

- Line 134: `wc -l < "$TARGET_SKILL_MD" | tr -d ' '` → `wc -l < "$TARGET_SKILL_MD" | tr -d '[:space:]'`
- Line 135: `wc -c < "$TARGET_SKILL_MD" | tr -d ' '` → `wc -c < "$TARGET_SKILL_MD" | tr -d '[:space:]'`

Behavior-preserving on GNU `wc` (which emits no leading whitespace and where `tr -d ' '` had nothing to strip) and correct on BSD `wc` (where the previous filter left padding whitespace concatenated into `SKILL_MD_LINES` / `SKILL_MD_CHARS`).

</details>

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `6e35b7b` (Pin pr-body-template.md marker literals in test-implement-structure.sh (closes #323) (#341))
- **Current version**: `6.1.1`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `6.1.2`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH").

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

Quick mode — no plan review was conducted.

</details>

<details><summary>Implementation Deviations</summary>

No deviations from the plan.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

All code review suggestions were implemented.

</details>

<details><summary>Plan Review Voting Tally</summary>

Quick mode — no plan review voting.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

Quick mode — no voting panel. Main agent reviewed findings across up to 7 single-reviewer rounds (Cursor → Codex → Claude fallback chain). Round 1 (Cursor) returned `NO_ISSUES_FOUND`, so the loop exited after one round with zero accepted and zero rejected findings.

</details>

<details><summary>Out-of-Scope Observations</summary>

**Accepted OOS (GitHub issues filed):**
No OOS items were accepted for issue filing.

**Non-accepted OOS observations:**
Quick mode — no reviewer voting panel. Main-agent OOS items (if any) are auto-filed per policy; see Accepted OOS above.

</details>

<details><summary>Execution Issues</summary>

No execution issues encountered.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | N/A (quick mode) |
| Code review rounds | 1 |
| Code review findings | 0 accepted, 0 rejected |
| Warnings logged | 0 |
| Pre-existing issues noticed | 0 |
| OOS issues filed | 0 |
| External reviewers | N/A (quick mode) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)

