### PR TITLE
Clarify agent setup in README: Claude mandatory, rest optional

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "6.1.6",
+  "version": "6.1.7",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.1.7] - 2026-04-23
+
+### Changed
+
+- `README.md` "Setting Up Claude, Codex, Cursor, etc." section intro rewritten to state explicitly that only `claude` is mandatory; `codex` and `cursor` are optional and are substituted with Claude subagents when missing or unauthenticated (deduplicated with `Prerequisites > Optional integrations` via cross-reference rather than restating). Adds a sentence clarifying that larch is agent-agnostic about authentication — each agent can be set up with either an API key or a subscription plan via web-based login; larch only needs the binary on `PATH` and a successful authenticated session.
+- `README.md` Cursor-subsection `cli-config.json` note trimmed from a multi-sentence paragraph to the single sentence "Note — larch overrides the cli-config.json model for its own Cursor invocations." The `--model` precedence, `LARCH_CURSOR_MODEL` resolution, `composer-2` default, and max-mode prompt injection details are preserved in the `Environment Variables > LARCH_CURSOR_MODEL` section rather than being duplicated in the setup recipe.
+
 ## [6.1.6] - 2026-04-23
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ claude plugin install larch@larch-local
 ```
 
 ### Setting Up Claude, Codex, Cursor, etc.
-- Larch uses Claude, Codex, and Cursor in agent mode.  All of these need to be set up with API keys and properly configured as per instructions below.
-- If either Codex or Cursor is not installed or available, Larch skills default to using Claude instead.
+- **Only `claude` is mandatory.** `codex` and `cursor` are optional — when either binary is missing or fails to authenticate, larch skills substitute Claude subagents automatically. See [Optional integrations](#optional-integrations) for the full fallback semantics.
+- **Larch is agent-agnostic about authentication.** Each agent can be set up either with an **API key** in your shell environment, or with a **subscription plan** via web-based login from the binary itself. Larch does not care which — it only needs the corresponding binary (`claude`, `codex`, `cursor`) to be on your `PATH` and to land in an authenticated session when invoked.
+- The subsections below document one concrete setup recipe per agent (API-key path). If you prefer the subscription-plan path, install the binary and follow its own web-login flow instead — the rest of larch's configuration (settings, model overrides) still applies.
 
 #### Claude
 - Via web UI of your Claude org, create your own API key
@@ -79,7 +80,7 @@ claude plugin install larch@larch-local
   }
 ```
 
-> **Note — larch overrides the cli-config.json model for its own Cursor invocations.** Larch launches Cursor via `cursor agent --model $MODEL …`, where `$MODEL` is resolved by `scripts/reviewer-model-args.sh` from `LARCH_CURSOR_MODEL` (env var) or the plugin userConfig `cursor_model` (exported to subprocesses as `CLAUDE_PLUGIN_OPTION_CURSOR_MODEL`; default: `composer-2`). Cursor's CLI `--model` flag takes precedence over the `modelId` set in `~/.cursor/cli-config.json`, so editing the JSON alone will not change the model larch uses. To pin larch to a specific Cursor model, set `LARCH_CURSOR_MODEL` (or the `cursor_model` userConfig) instead. Larch similarly enforces max-mode at the prompt level (`scripts/cursor-wrap-prompt.sh` prepends `/max-mode on.`), so `"maxMode": true` in the JSON is not required for larch-driven calls — though setting it is harmless. The cli-config.json snippet above is still the recommended setup for Cursor outside larch.
+> **Note — larch overrides the cli-config.json model for its own Cursor invocations.**
 
 ### What the plugin provides
 


### PR DESCRIPTION
## Summary

- Rewrite the intro of `README.md` → "Setting Up Claude, Codex, Cursor, etc." to state explicitly that only `claude` is mandatory, `codex`/`cursor` are optional and are substituted with Claude subagents when missing, and that each agent can authenticate via either API key or a subscription plan (web-based login) — larch only needs the corresponding binary on `PATH` and a successful authenticated session.
- Deduplicate with `Prerequisites > Optional integrations` via cross-reference rather than restating the fallback semantics.
- Trim the Cursor subsection's `cli-config.json` note from a multi-sentence paragraph to its single first sentence; the `--model` precedence details are preserved in the `Environment Variables > LARCH_CURSOR_MODEL` section.

## Goal

Make the "Setting Up" section correctly describe larch's actual flexibility (Claude-only floor, agent-agnostic authentication) instead of the previous "all three need API keys" phrasing, and reduce redundant / out-of-place model-precedence prose in the Cursor recipe.

## Test plan

- [x] `pre-commit run --files README.md CHANGELOG.md .claude-plugin/plugin.json` (via `/relevant-checks`)
- [x] `agent-lint` full-repo scan clean
- [x] Visual confirmation: `grep -n "mandatory\|substituted\|API key\|subscription plan" README.md` shows the intended phrasing only in the new intro; no duplication with the `Prerequisites > Optional integrations` block (lines 177–180)
- [x] Visual confirmation: the trimmed Cursor note at README.md:83 is a single `>` blockquote line; the dropped precedence details are still present in `### LARCH_CURSOR_MODEL` (README.md:373–395)

## Final Design

Two non-adjacent edits to `README.md`:

1. Lines 40–42: replace the two introductory bullets with three bullets that establish (a) Claude-only mandatory, (b) authentication-mode agnosticism, (c) the subsections below are one concrete recipe (API-key path).
2. Line 82: replace the multi-sentence `cli-config.json` blockquote with its first sentence only.

Plus a CHANGELOG entry for v6.1.7 documenting both edits.

<details><summary>Version Bump Reasoning</summary>

Classification: **PATCH** (`6.1.6 → 6.1.7`). No `skills/**` or `agents/**` files modified — public plugin surface unchanged. Docs-only diff defaults to PATCH per policy.

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

_Plan review skipped — `/design` not invoked in quick mode._

</details>

<details><summary>Implementation Deviations</summary>

_None._

</details>

<details><summary>Rejected Code Review Suggestions</summary>

### [Code Review] Cursor (round 1)
**Finding**: README.md:83 — after trimming the Cursor `cli-config.json` blockquote from a multi-sentence paragraph to a single sentence, the reviewer flagged that readers who stop at the Cursor subsection are more likely to miss the "editing JSON alone won't change larch's model" point, since the full explanation now lives only under `### LARCH_CURSOR_MODEL`. Suggested fix: add a second sentence or a link to `LARCH_CURSOR_MODEL` reiterating the model precedence.
**Reason not implemented**: The user explicitly requested this exact trim as part of the task ("It's enough to have just 'Note — larch overrides the cli-config.json model for its own Cursor invocations.'"). Adding text back would contradict the instruction. The `LARCH_CURSOR_MODEL` section (README.md:373–395) still documents `--model` precedence and the `composer-2` default — the information has moved to the canonical Environment Variables section rather than being duplicated in the setup recipe.

</details>

<details><summary>Plan Review Voting Tally</summary>

_Quick mode — no plan review panel._

</details>

<details><summary>Code Review Voting Tally Round 1</summary>

_Quick mode — single reviewer per round, no voting panel. Round 1 used Cursor; 1 finding, 0 accepted, 1 rejected (see above)._

</details>

<details><summary>Out-of-Scope Observations</summary>

_None._

</details>

<details><summary>Accepted OOS</summary>

_None — no out-of-scope observations were accepted this session._

</details>

<details><summary>Execution Issues</summary>

_None logged this session._

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|---|---|
| Mode | `--merge --auto --quick` |
| Commits | 2 (implementation + version bump) |
| Review rounds | 1 (quick mode, Cursor) |
| Accepted findings | 0 |
| Rejected findings | 1 |
| OOS issues filed | 0 |

</details>
