### PR TITLE
Compress /create-skill SKILL.md prose (minor filler removal)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "6.1.7",
+  "version": "6.1.8",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.1.8] - 2026-04-23
+
+### Changed
+
+- `skills/create-skill/SKILL.md` prose compressed via Strunk & White filler removal. Two sentence-level tweaks on line 10 drop "if you want to" and sentential "it is" from the `--merge` explicit-pass note. Net saving: 19 bytes (0.11% of file); 0 line-count delta. `scripts/parse-args.md` unchanged — every paragraph is already at or below the ~10% per-paragraph compression threshold, so meaning-preservation beats marginal compression. Zero structural changes: YAML frontmatter, fenced code blocks, headings, link targets, table structure, file paths, numeric values, flag names all byte-identical.
+
 ## [6.1.7] - 2026-04-23
 
 ### Changed

--- a/skills/create-skill/SKILL.md
+++ b/skills/create-skill/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools: Bash, Skill
 
 # Create Skill
 
-Scaffold a new larch-style skill and delegate to `/im --quick --auto` for the full pipeline (implementation, code review, version bump, PR, auto-merge). `/im` is larch's `/implement --merge` alias — auto-merge is now the default for scaffolded skills. Pass `--merge` if you want to be explicit (it is a backward-compat no-op since `/im` already merges).
+Scaffold a new larch-style skill and delegate to `/im --quick --auto` for the full pipeline (implementation, code review, version bump, PR, auto-merge). `/im` is larch's `/implement --merge` alias — auto-merge is now the default for scaffolded skills. Pass `--merge` to be explicit (a backward-compat no-op since `/im` already merges).
 
 Example: `/create-skill foo "Use when doing X"` creates `.claude/skills/foo/SKILL.md` in the consumer repo. With `--plugin`, creates `skills/foo/SKILL.md` inside the larch plugin repo.
 
@@ -135,7 +135,7 @@ MUST read ${CLAUDE_PLUGIN_ROOT}/skills/shared/skill-design-principles.md (full f
   C. No consecutive Bash-tool calls per step — combine multi-action steps into one coordinator .sh that invokes the individual scripts internally.
 ```
 
-Print: `**Create-skill /<NAME> (<plugin-dev|consumer>, <minimal|multi-step>) — delegating to /im --quick --auto [--debug] [--slack]**` (omit each optional flag if its corresponding variable is `false`). `/im` auto-merges; `--merge` on `/create-skill` is a backward-compat no-op and is not forwarded.
+Print: `**Create-skill /<NAME> (<plugin-dev|consumer>, <minimal|multi-step>) — delegating to /im --quick --auto [--debug] [--slack]**` (omit each optional flag if its corresponding variable is `false`). `/im` auto-merges; `--merge` on `/create-skill` is a backward-compat no-op and not forwarded.
 
 Invoke the Skill tool:
 - Try skill: `"im"` first (bare name). If no skill matches, try skill: `"larch:im"` (fully-qualified plugin name).

--- a/skills/create-skill/SKILL.md
+++ b/skills/create-skill/SKILL.md
@@ -135,7 +135,7 @@ MUST read ${CLAUDE_PLUGIN_ROOT}/skills/shared/skill-design-principles.md (full f
   C. No consecutive Bash-tool calls per step — combine multi-action steps into one coordinator .sh that invokes the individual scripts internally.
 ```
 
-Print: `**Create-skill /<NAME> (<plugin-dev|consumer>, <minimal|multi-step>) — delegating to /im --quick --auto [--debug] [--slack]**` (omit each optional flag if its corresponding variable is `false`). `/im` auto-merges; `--merge` on `/create-skill` is a backward-compat no-op and not forwarded.
+Print: `**Create-skill /<NAME> (<plugin-dev|consumer>, <minimal|multi-step>) — delegating to /im --quick --auto [--debug] [--slack]**` (omit each optional flag if its corresponding variable is `false`). `/im` auto-merges; `--merge` on `/create-skill` is a backward-compat no-op and is not forwarded.
 
 Invoke the Skill tool:
 - Try skill: `"im"` first (bare name). If no skill matches, try skill: `"larch:im"` (fully-qualified plugin name).


### PR DESCRIPTION
## Summary

- Compress `/create-skill` SKILL.md prose by applying Strunk & White filler-removal to one sentence on line 10 — drops "if you want to" and sentential "it is" from the `--merge` explicit-pass note. No other prose changes cleared the ~10% per-paragraph threshold.
- `scripts/parse-args.md` unchanged: every paragraph is already at or below the compression threshold.
- Zero structural changes — YAML frontmatter, fenced code blocks, headings, link targets, table structure, file paths, numeric values, and flag names remain byte-identical.

## Goal

Behavior-preserving prose compression of `/create-skill` per `/compress-skill`. Meaning preservation beats compression — when every paragraph falls at or below the ~10% threshold, the style guide explicitly allows a near-zero delta.

## Test plan

- [x] `/relevant-checks` passes (pre-commit + `agent-lint`)
- [x] Structural spot-check: YAML frontmatter byte-identical; no fenced-block content altered; headings unchanged; link targets unchanged
- [x] Step 3 `/im` feature-description template (lines 121–136) — inside a fenced block, untouched

## Token budget

| File (relative to /Users/zhupanov/larch5/skills/create-skill) | Before (bytes / lines) | After (bytes / lines) | Delta (bytes / lines) |
|----------------------------------|------------------------|------------------------|------------------------|
| SKILL.md | 13628 / 144 | 13610 / 144 | -18 / 0 |
| scripts/parse-args.md | 2889 / 29 | 2889 / 29 | 0 / 0 |
| **Total** | 16517 / 173 | 16499 / 173 | **-18 / 0** |

**Near-zero compression, justified**: Both files are mature and previously-compressed. Applying Strunk & White's "Omit needless words" sentence by sentence, the only candidates that cleanly preserve meaning are:

- Line 10 sentence 3 — cut "if you want to" (canonical S&W filler) and sentential "it is" (canonical S&W construction). Sentence-level saving: 18 chars (17.8% on the sentence); paragraph-level: 5.1%. Applied.
- Line 138 second sentence — elide the second "is" in "… no-op and is not forwarded". Tried, reverted after Round 1 reviewer correctly flagged the elliptical coordination (noun phrase + passive participle) as awkward and ambiguous for agent-facing docs.
- Line 144 — "will execute" → "executes" and convert the verb list to present plural. Tried, reverted because the plural-present forms ("runs", "commits", "reviews", "bumps", "creates", "merges") added more characters than "will" saved (net +2 bytes).

Every other paragraph I considered — including the long anti-pattern bullets (56–63), the Design Mindset bullets (48–52), the `MANDATORY — READ ENTIRE FILE` block (67), and all of `parse-args.md` — had its best candidate rewrite fall below the ~10% per-paragraph threshold. Per the style guide ("under ~10% is not worth the drift risk — keep the original"), I preserved the original wording. This is the "acceptable when every paragraph was already at or below the ~10% threshold" case the style guide explicitly calls out.

## Rejected Code Review Suggestions

No rejected findings — the single review finding (Round 1) was accepted and reverted edit 2.

## Code Review Voting Tally (Round 1)

Quick mode: single reviewer (Cursor), no voting panel.

| Finding | Reviewer | Action |
|---------|----------|--------|
| Line 138 awkward elliptical coordination ("no-op and not forwarded") | Cursor | Accepted → reverted edit 2 (restored "and is not forwarded") |

Round 2 flagged the same issue (review runs against `main...HEAD`, which excluded my uncommitted fix); the reviewer itself noted the working-tree edit already addressed it. No new edits needed — loop converged.

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `1c49d50` (Normalize /implement anti-halt banner to canonical wording (closes #346) (#355))
- **Current version**: `6.1.7`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `6.1.8`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH").

</details>

<details><summary>Execution Issues</summary>

No execution issues.

</details>

## Run Statistics

| Metric | Value |
|--------|-------|
| Mode | quick (single reviewer, inline plan) |
| Review rounds | 2 (1 finding accepted, loop converged) |
| Version bump | 6.1.7 → 6.1.8 (PATCH) |
| OOS issues filed | 0 |
| Files changed | 2 (SKILL.md -18 bytes, CHANGELOG.md +entry) |
