### PR TITLE
Fix work_dir temp dir leak in truncate_body under set -e

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "6.1.10",
+  "version": "6.1.11",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.1.11] - 2026-04-23
+
+### Fixed
+
+- `scripts/tracking-issue-write.sh` `truncate_body` no longer leaks its `work_dir` (from `mktemp -d`) when an `awk` call fails mid-function under `set -e` (closes #360). The function body is now a subshell (`truncate_body() ( … )`) and installs `trap "rm -rf '$work_dir'" EXIT` immediately after `mktemp -d`, so cleanup is structurally scoped to the function's own subshell and fires on every exit path — not only the trailing success-path `rm -rf` that the previous code relied on. The subshell-body form also makes the cleanup contract robust to future refactors: callers no longer have to preserve the implicit "always invoke via `$(…)`" invariant for the EXIT trap to stay scoped. The misleading header comment claiming the caller's EXIT trap covered `work_dir` transitively is rewritten to reflect the new ownership (each per-subcommand EXIT trap only names `BODY_TMP`/`ERR_TMP`/`JSON_TMP`, never `work_dir`). Pure resource-management fix — no change to stdout contract, redaction ordering, truncation algorithm, or anchor skeleton preservation; `scripts/test-tracking-issue-write.sh`'s 43 assertions pass unchanged.
+
 ## [6.1.10] - 2026-04-23
 
 ### Added

--- a/scripts/tracking-issue-write.sh
+++ b/scripts/tracking-issue-write.sh
@@ -154,19 +154,29 @@ emit_gh_failure() {
 # Implementation: the new-interior content can contain newlines, which
 # awk -v cannot accept. For each section we write the replacement
 # interior to a per-section temp file and have awk splice it in via
-# getline. A single work_dir (mktemp -d) holds these temps. Every call
-# site invokes truncate_body via command substitution
-# ($(truncate_body "$BODY_CONTENT")), so the EXIT trap below is scoped
-# to the command-substitution subshell and fires on both normal return
-# AND a set -e abort from any awk failure mid-function — guaranteeing
-# cleanup without relying on the caller's own EXIT trap (which is
-# installed later and only names BODY_TMP/ERR_TMP/JSON_TMP, not
-# work_dir).
-truncate_body() {
+# getline. A single work_dir (mktemp -d) holds these temps. The
+# function body uses a subshell `( … )` rather than a brace group so
+# the EXIT trap below is structurally scoped to the function's own
+# subshell — it cannot clobber the caller's EXIT trap regardless of
+# how the function is invoked. The trap fires whenever this subshell
+# exits (normal return, explicit exit, or propagated failure),
+# guaranteeing work_dir cleanup without relying on the caller's own
+# EXIT trap (which is installed later and only names
+# BODY_TMP/ERR_TMP/JSON_TMP, not work_dir). Note: Bash 3.2's errexit
+# behavior inside nested subshells is known to be inconsistent for
+# some inner-command failure patterns — the cleanup guarantee here
+# rests on subshell exit, not on errexit specifically triggering.
+truncate_body() (
     local body="$1"
     local slug interior new_interior open_marker close_marker
     local work_dir
     work_dir=$(mktemp -d)
+    # Expand $work_dir at trap-install time (double-quoted outer + single-
+    # quoted path inside): work_dir is `local`, so by the time the EXIT
+    # trap fires the local binding is gone. Single-quoting the whole trap
+    # body (or using double quotes around the inner path) would see an
+    # empty variable at EXIT and leak the real directory. The disable
+    # below turns off the SC2064 lint that flags this exact pattern.
     # shellcheck disable=SC2064
     trap "rm -rf '$work_dir'" EXIT
 
@@ -250,7 +260,7 @@ truncate_body() {
     fi
 
     printf '%s' "$body"
-}
+)
 
 # list_anchor_comments <issue-number> <repo> — prints tab-separated
 # "id<TAB>first-line-of-body" lines (one per comment) to stdout, order

--- a/scripts/tracking-issue-write.sh
+++ b/scripts/tracking-issue-write.sh
@@ -154,14 +154,21 @@ emit_gh_failure() {
 # Implementation: the new-interior content can contain newlines, which
 # awk -v cannot accept. For each section we write the replacement
 # interior to a per-section temp file and have awk splice it in via
-# getline. A single TRUNCATE_WORK_DIR holds these temps; the caller's
-# EXIT trap covers cleanup transitively (all writes live under the
-# same per-subcommand tmp that's already trapped).
+# getline. A single work_dir (mktemp -d) holds these temps. Every call
+# site invokes truncate_body via command substitution
+# ($(truncate_body "$BODY_CONTENT")), so the EXIT trap below is scoped
+# to the command-substitution subshell and fires on both normal return
+# AND a set -e abort from any awk failure mid-function — guaranteeing
+# cleanup without relying on the caller's own EXIT trap (which is
+# installed later and only names BODY_TMP/ERR_TMP/JSON_TMP, not
+# work_dir).
 truncate_body() {
     local body="$1"
     local slug interior new_interior open_marker close_marker
     local work_dir
     work_dir=$(mktemp -d)
+    # shellcheck disable=SC2064
+    trap "rm -rf '$work_dir'" EXIT
 
     # Pass 1: per-section cap
     for slug in "${SECTION_MARKERS[@]}"; do
@@ -242,7 +249,6 @@ truncate_body() {
         done
     fi
 
-    rm -rf "$work_dir"
     printf '%s' "$body"
 }
 


### PR DESCRIPTION
## Summary

- Fixed a `work_dir` temp-directory leak in `scripts/tracking-issue-write.sh`'s `truncate_body` that could accumulate under `/tmp` whenever an `awk` pipeline failed mid-function under `set -e` (closes #360).
- Converted `truncate_body` to a subshell-body function (`truncate_body() ( … )`) so its EXIT-trap-based cleanup is structurally scoped to the function's own subshell rather than relying on the implicit "callers always invoke via `$(…)`" contract.
- Rewrote the misleading header comment that claimed the caller's EXIT trap covered `work_dir` cleanup transitively — it only named `BODY_TMP`/`ERR_TMP`/`JSON_TMP`.

<details><summary>Architecture Diagram</summary>

Quick mode — architecture diagram skipped.

</details>

<details><summary>Code Flow Diagram</summary>

Quick mode — code flow diagram skipped.

</details>

<details><summary>Goal</summary>

- Fix the resource leak documented in issue #360
  - `truncate_body` creates `work_dir=$(mktemp -d)` at the top of the function and removed it only via a trailing explicit `rm -rf` at the success-path end
  - Each caller's EXIT trap (`create-issue` / `append-comment` / `upsert-anchor`) cleans up `BODY_TMP` / `ERR_TMP` / `JSON_TMP` by name but does NOT know about `work_dir`
  - Under `set -e`, any failing `awk` in `truncate_body` aborted the shell before the trailing `rm -rf` fired, so `work_dir` leaked under `/tmp` and accumulated across long-running CI sandboxes
- Make the cleanup contract robust against future refactors
  - Don't rely on the implicit "every call site uses `$(truncate_body "$BODY_CONTENT")`" invariant
  - Ensure the EXIT trap can never clobber the caller's own EXIT trap
- Preserve all existing behavior: stdout contract, redaction ordering, two-pass truncation algorithm, anchor-skeleton preservation, seven assertion categories of the existing regression harness

</details>

<details><summary>Test plan</summary>

- [x] `/relevant-checks` passes (shellcheck + agent-lint)
- [x] `scripts/test-tracking-issue-write.sh` — all 43 assertions pass unchanged (no behavioral regression)
- [x] Manual sanity check: `local` works inside a `name() ( … )` subshell-body function on GNU bash 3.2.57 (the script's stated target)
- [ ] CI green

</details>

<details><summary>Final Design</summary>

**File touched:** `scripts/tracking-issue-write.sh` (single file).

**Approach:**
1. Convert `truncate_body` function body from `{ … }` to `( … )` so the body runs in its own subshell regardless of how callers invoke it. This makes the EXIT trap structurally scoped to the function — future callers that don't use `$(…)` still get correct cleanup.
2. Install `trap "rm -rf '$work_dir'" EXIT` immediately after `work_dir=$(mktemp -d)`. The double-quoted trap body with a single-quoted inner path bakes the expanded `work_dir` value at trap-install time — required because `work_dir` is declared `local` and the binding is gone by the time EXIT fires.
3. Remove the redundant trailing `rm -rf "$work_dir"` — the trap is now the single owner of cleanup.
4. Rewrite the misleading header comment to describe the new subshell-scoped ownership model and note Bash 3.2's known errexit-in-nested-subshells inconsistency (the cleanup guarantee rests on subshell exit, not on errexit triggering specifically).
5. Add an inline comment next to the `# shellcheck disable=SC2064` line explaining why the path must be baked at trap-install time (prevents a future "simplification" to single-quoted `'rm -rf "$work_dir"'` which would silently break because `local work_dir` is unset at EXIT time).

**Verification:** `/relevant-checks` (pre-commit + agent-lint) + `scripts/test-tracking-issue-write.sh` (43 assertions).

</details>

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `2b233c6` (Phase 1: tracking-issue foundation helpers (umbrella #348) (#361))
- **Current version**: `6.1.10`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `6.1.11`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH").

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

Quick mode — no plan review was conducted.

</details>

<details><summary>Implementation Deviations</summary>

No deviations from the plan. The subshell-body form and the SC2064 rationale comment were added in response to code review findings (rounds 2–3) — both refinements strengthen the fix rather than deviating from it.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

### [Code Review] Cursor (round 2)
**Finding**: `scripts/tracking-issue-write.sh:171` — the `trap "rm -rf '$work_dir'" EXIT` line breaks in the edge case where `work_dir` contains a single quote (which could only happen if `TMPDIR` pointed at a directory with an apostrophe in its name). Suggested hardening: use `printf -v _wd %q` or a file-descriptor-based cleanup wrapper.
**Reason not implemented**: The reviewer themselves noted that this is "usually not worth changing for typical `mktemp` paths." `mktemp -d` produces alphanumeric suffixes and `TMPDIR` is a trusted shell variable under the user's control — the attack surface is the user's own environment, which has far more direct ways to disrupt their own script. Hardening is disproportionate for this minor resource-management fix and would obscure the intent of the single-line trap. Flagged as a non-issue by the same reviewer in round 3's NO_ISSUES_FOUND verdict.

</details>

<details><summary>Plan Review Voting Tally</summary>

Quick mode — no plan review voting.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

Quick mode — no voting panel. Main agent reviewed findings across up to 7 single-reviewer rounds (Cursor → Codex → Claude fallback chain).

Rounds run: 4 (converged on NO_ISSUES_FOUND in round 4).

| Round | Reviewer | Findings | Accepted | Rejected |
|-------|----------|----------|----------|----------|
| 1     | Cursor   | 1        | 1        | 0        |
| 2     | Cursor   | 2        | 1        | 1        |
| 3     | Cursor   | 2        | 1        | 1 (already addressed) |
| 4     | Cursor   | 0 (NO_ISSUES_FOUND) | — | — |

</details>

<details><summary>Out-of-Scope Observations</summary>

**Accepted OOS (GitHub issues filed):**
No OOS items were accepted for issue filing.

**Non-accepted OOS observations:**
Quick mode — no reviewer voting panel. Main-agent OOS items (if any) are auto-filed per policy; see Accepted OOS above.

</details>

<details><summary>Execution Issues</summary>

No execution issues encountered.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | N/A (quick mode) |
| Code review rounds | 4 |
| Code review findings | 3 accepted, 1 rejected |
| Warnings logged | 0 |
| Pre-existing issues noticed | 0 |
| OOS issues filed | 0 |
| External reviewers | N/A (quick mode) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
