### PR TITLE
Align bump-version SKILL.md Output contract with slim PR body (closes #364)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/.claude/skills/bump-version/SKILL.md
+++ b/.claude/skills/bump-version/SKILL.md
@@ -78,7 +78,7 @@ $PWD/.claude/skills/bump-version/scripts/apply-bump.sh --new-version <NEW_VERSIO
 
 ## Output contract
 
-The reasoning log at `${IMPLEMENT_TMPDIR:-${TMPDIR:-/tmp}}/bump-version-reasoning.md` is read by `/implement` Step 9a and embedded into the PR body under `<details><summary>Version Bump Reasoning</summary>`. The absolute path is also emitted on stdout by `classify-bump.sh` as `REASONING_FILE=<path>` — callers should prefer that structured output over reconstructing the path from env vars.
+The reasoning log at `${IMPLEMENT_TMPDIR:-${TMPDIR:-/tmp}}/bump-version-reasoning.md` is read by `/implement` Step 8 as the source content for the `version-bump-reasoning` anchor-section fragment (written to `$IMPLEMENT_TMPDIR/anchor-sections/version-bump-reasoning.md` and upserted into the tracking issue's anchor comment via `tracking-issue-write.sh upsert-anchor`). The slim PR body template (`skills/implement/references/pr-body-template.md`) no longer contains a `<details><summary>Version Bump Reasoning</summary>` block — the anchor comment is the canonical audit surface. The absolute path of the reasoning log is also emitted on stdout by `classify-bump.sh` as `REASONING_FILE=<path>` — callers should prefer that structured output over reconstructing the path from env vars.
 
 ## Exit codes
 - `classify-bump.sh` — 0 on success (including `BUMP_TYPE=NONE`), non-zero on parse/validation failure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.2.1] - 2026-04-23
+
+### Changed
+
+- `.claude/skills/bump-version/SKILL.md` Output contract aligned with the slim PR body that Phase 3 of umbrella #348 shipped (closes #364). The section no longer claims the reasoning log is embedded into the PR body under `<details><summary>Version Bump Reasoning</summary>` — that block does not exist in the post-Phase-3 PR body template. It now states that `/implement` Step 8 reads the reasoning log as source content for the `version-bump-reasoning` anchor-section fragment, which is upserted into the tracking issue's anchor comment via `tracking-issue-write.sh upsert-anchor` and is the canonical audit surface. The `classify-bump.sh REASONING_FILE=<path>` stdout guidance is unchanged.
+
 ## [6.2.0] - 2026-04-23
 
 ### Added


### PR DESCRIPTION
## Summary

- Aligned `.claude/skills/bump-version/SKILL.md` Output contract with the slim PR body shipped by Phase 3 of umbrella #348 — the section no longer claims the reasoning log is embedded into the PR body under a `<details><summary>Version Bump Reasoning</summary>` block (which was dropped from `pr-body-template.md` in Phase 3); it now states that `/implement` Step 8 reads the log as the source for the `version-bump-reasoning` anchor-section fragment upserted into the tracking issue's anchor comment via `tracking-issue-write.sh upsert-anchor`.
- Added a CHANGELOG entry for v6.2.1 documenting the doc correction.

<details><summary>Architecture Diagram</summary>

Quick mode — architecture diagram skipped.

</details>

<details><summary>Code Flow Diagram</summary>

Quick mode — code flow diagram skipped.

</details>

<details><summary>Goal</summary>

- Correct a stale claim in `.claude/skills/bump-version/SKILL.md` about where the bump reasoning log lands:
  - Remove the assertion that the reasoning log is read in Step 9a and embedded in the PR body under `<details><summary>Version Bump Reasoning</summary>` (the block no longer exists in the Phase 3 slim PR body).
  - State the actual post-Phase-3 transport: `/implement` Step 8 consumes the log as source content for the `version-bump-reasoning` anchor-section fragment, which is written to `$IMPLEMENT_TMPDIR/anchor-sections/version-bump-reasoning.md` and upserted into the tracking issue's anchor comment via `tracking-issue-write.sh upsert-anchor`.
  - Preserve the unchanged `classify-bump.sh REASONING_FILE=<path>` stdout guidance so callers keep preferring structured output over env-var path reconstruction.
- Limit scope strictly to `.claude/skills/bump-version/SKILL.md` plus the CHANGELOG entry for the version bump. The Phase-5-transient-gap note at `skills/implement/SKILL.md:613` is out of scope for this fix.
- Close #364.

</details>

<details><summary>Test plan</summary>

- [x] `/relevant-checks` passes (changed-file phase + full-repo agent-lint phase).
- [x] Quick-mode code review round 1 (Cursor) returns `NO_ISSUES_FOUND`.
- [x] `check-bump-version.sh --mode post` reports `VERIFIED=true`, `STATUS=ok`, `COMMITS_AFTER=2` / `EXPECTED=2`.
- [x] CI green on the PR before auto-merge.

</details>

<details><summary>Final Design</summary>

**File to modify**: `.claude/skills/bump-version/SKILL.md`

**Change**: Replace the paragraph that is the body of the `## Output contract` section with text describing the anchor-comment transport per Phase 3 of #348.

**Current text (stale)**: "The reasoning log at `${IMPLEMENT_TMPDIR:-${TMPDIR:-/tmp}}/bump-version-reasoning.md` is read by `/implement` Step 9a and embedded into the PR body under `<details><summary>Version Bump Reasoning</summary>`. The absolute path is also emitted on stdout by `classify-bump.sh` as `REASONING_FILE=<path>` — callers should prefer that structured output over reconstructing the path from env vars."

**Replacement**: "The reasoning log at `${IMPLEMENT_TMPDIR:-${TMPDIR:-/tmp}}/bump-version-reasoning.md` is read by `/implement` Step 8 as the source content for the `version-bump-reasoning` anchor-section fragment (written to `$IMPLEMENT_TMPDIR/anchor-sections/version-bump-reasoning.md` and upserted into the tracking issue's anchor comment via `tracking-issue-write.sh upsert-anchor`). The slim PR body template (`skills/implement/references/pr-body-template.md`) no longer contains a `<details><summary>Version Bump Reasoning</summary>` block — the anchor comment is the canonical audit surface. The absolute path of the reasoning log is also emitted on stdout by `classify-bump.sh` as `REASONING_FILE=<path>` — callers should prefer that structured output over reconstructing the path from env vars."

**Verification**: `/relevant-checks` (Step 3). Grep confirms line 81 was the only stale PR-body reference inside `.claude/skills/bump-version/`.

**Out of scope**: `skills/implement/SKILL.md:613` (the "Transient gap until Phase 5" note) — per the issue scope.

</details>

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `d027c6e` (Phase 3: /implement --issue flag + anchor lifecycle + slim PR body (#348) (#365))
- **Current version**: `6.2.0`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `6.2.1`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH"). The only changed file on the public surface is `.claude/skills/bump-version/SKILL.md`, which is under `.claude/**` — dev-only surface per `AGENTS.md` and the bump-version skill's own Classification rules, so it does not contribute to MAJOR/MINOR.

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

Quick mode — no plan review was conducted.

</details>

<details><summary>Implementation Deviations</summary>

No deviations from the plan.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

All code review suggestions were implemented.

</details>

<details><summary>Plan Review Voting Tally</summary>

Quick mode — no plan review voting.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

Quick mode — no voting panel. Main agent reviewed findings across up to 7 single-reviewer rounds (Cursor → Codex → Claude fallback chain). Round 1 (Cursor) returned `NO_ISSUES_FOUND`; the loop exited after round 1 with zero accepted findings.

</details>

<details><summary>Out-of-Scope Observations</summary>

**Accepted OOS (GitHub issues filed):**
No OOS items were accepted for issue filing.

**Non-accepted OOS observations:**
Quick mode — no reviewer voting panel. Main-agent OOS items (if any) are auto-filed per policy; see Accepted OOS above.

</details>

<details><summary>Execution Issues</summary>

No execution issues encountered.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | N/A (quick mode) |
| Code review rounds | 1 |
| Code review findings | 0 accepted, 0 rejected |
| Warnings logged | 0 |
| Pre-existing issues noticed | 0 |
| OOS issues filed | 0 |
| External reviewers | N/A (quick mode) |

</details>

Closes #364

Generated with [Claude Code](https://claude.com/claude-code)
