### PR TITLE
Add /loop-improve-skill to setup docs skills inventory (closes #371)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "6.2.4",
+  "version": "6.2.5",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.2.5] - 2026-04-23
+
+### Changed
+
+- Add `/loop-improve-skill` to the skills inventory in `docs/installation-and-setup.md` (closes #371). The skill is shipped at `skills/loop-improve-skill/` and documented in `README.md`, but was omitted from the "What the plugin provides" table when the setup docs were split out in 6fe1262.
+
 ## [6.2.4] - 2026-04-23
 
 ### Changed

--- a/docs/installation-and-setup.md
+++ b/docs/installation-and-setup.md
@@ -82,7 +82,7 @@ claude plugin install larch@larch-local
 
 | Component | Description |
 |---|---|
-| Skills | `/design`, `/implement`, `/review`, `/research`, `/loop-review`, `/fix-issue`, `/issue`, `/alias`, `/create-skill`, `/simplify-skill`, `/compress-skill`, `/im`, `/imaq` |
+| Skills | `/design`, `/implement`, `/review`, `/research`, `/loop-review`, `/loop-improve-skill`, `/fix-issue`, `/issue`, `/alias`, `/create-skill`, `/simplify-skill`, `/compress-skill`, `/im`, `/imaq` |
 | Agents | `code-reviewer` (unified archetype covering code quality, risk/integration, correctness, architecture, security) |
 | PreToolUse hook | `block-submodule-edit.sh` — blocks `Edit`/`Write` on files inside any checked-out git submodule of the consuming project |
 | SessionStart hook | `sessionstart-health.sh` — at session start/resume/clear/compact, probes `jq` and `git` on `PATH`; if either is missing, injects an advisory into session context so the issue is visible before the first `Edit`/`Write`. Non-blocking (always exits 0); silent when both tools are present |


### PR DESCRIPTION
## Summary

- Added `/loop-improve-skill` to the skills inventory in `docs/installation-and-setup.md` (closes #371). The skill is shipped at `skills/loop-improve-skill/` and documented in `README.md`, but was omitted from the "What the plugin provides" table when the setup docs were split out in 6fe1262.

<details><summary>Architecture Diagram</summary>

Quick mode — architecture diagram skipped.

</details>

<details><summary>Code Flow Diagram</summary>

Quick mode — code flow diagram skipped.

</details>

<details><summary>Goal</summary>

- Fix the skills inventory omission surfaced by issue #371
  - Add `/loop-improve-skill` to the table row labeled "Skills" in `docs/installation-and-setup.md`
  - Preserve the existing convention of keeping the two `loop-*` skills adjacent (insert between `/loop-review` and `/fix-issue`)
  - Scope: single-line documentation edit — no structural refactor (the issue's secondary suggestion of a generated inventory is explicitly deferred)

</details>

<details><summary>Test plan</summary>

- [x] `/relevant-checks` passes (pre-commit + agent-lint full repo)
- [x] Cross-check: the updated inventory matches the shipped `skills/` tree (14 skills including `/loop-improve-skill`)
- [x] Single-reviewer quick-mode code review returned `NO_ISSUES_FOUND`

</details>

<details><summary>Final Design</summary>

**File modified**: `docs/installation-and-setup.md` (line 85).

**Change**: Inserted `/loop-improve-skill` into the comma-separated skills list in the "What the plugin provides" table, between `/loop-review` and `/fix-issue`.

**Scope boundary**: Exactly one line. The issue's alternative suggestion (canonical inventory sourced from a single generated point) was considered and explicitly deferred — out of scope for this fix.

</details>

<details><summary>Version Bump Reasoning</summary>

# Version Bump Reasoning

- **Base commit**: `cf70f9a` (Phase 5: rebase-rebump sub-procedure anchor refresh (closes #353) (#372))
- **Current version**: `6.2.4`
- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).

## Result: PATCH

- **New version**: `6.2.5`

### PATCH rationale

No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH").

</details>

<details><summary>Rejected Plan Review Suggestions</summary>

Quick mode — no plan review was conducted.

</details>

<details><summary>Implementation Deviations</summary>

No deviations from the plan.

</details>

<details><summary>Rejected Code Review Suggestions</summary>

All code review suggestions were implemented.

</details>

<details><summary>Plan Review Voting Tally</summary>

Quick mode — no plan review voting.

</details>

<details><summary>Code Review Voting Tally (Round 1)</summary>

Quick mode — no voting panel. Main agent reviewed findings across up to 7 single-reviewer rounds (Cursor → Codex → Claude fallback chain).

</details>

<details><summary>Out-of-Scope Observations</summary>

**Accepted OOS (GitHub issues filed):**
No OOS items were accepted for issue filing.

**Non-accepted OOS observations:**
Quick mode — no reviewer voting panel. Main-agent OOS items (if any) are auto-filed per policy; see Accepted OOS above.

</details>

<details><summary>Execution Issues</summary>

No execution issues encountered.

</details>

<details><summary>Run Statistics</summary>

| Metric | Value |
|--------|-------|
| Plan review findings | N/A (quick mode) |
| Code review rounds | 1 |
| Code review findings | 0 accepted, 0 rejected |
| Warnings logged | 0 |
| Pre-existing issues noticed | 0 |
| OOS issues filed | 0 |
| External reviewers | N/A (quick mode) |

</details>

Generated with [Claude Code](https://claude.com/claude-code)
