### PR TITLE
Remove --auto from /fix-issue's /implement invocations (closes #389)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "6.2.13",
+  "version": "6.2.14",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.2.14] - 2026-04-23
+
+### Changed
+
+- Remove `--auto` from the two `/implement` invocation examples in `skills/fix-issue/SKILL.md` Step 6a (closes #389). Both SIMPLE and HARD delegation paths now invoke `/implement` without `--auto`; all other flags (`--quick` on SIMPLE, `--merge`, `--session-env`, `--issue`, conditional `--slack`/`--debug`) and the `<feature description>` positional arg are unchanged. Surgical two-token prose edit; no behaviour gated on `--auto` elsewhere in `/fix-issue` was affected.
+
 ## [6.2.13] - 2026-04-23
 
 ### Changed

--- a/skills/fix-issue/SKILL.md
+++ b/skills/fix-issue/SKILL.md
@@ -170,8 +170,8 @@ Compose the feature description from the issue content: use the issue title as t
 
 Invoke `/implement` via the Skill tool. Forwarding `--issue $ISSUE_NUMBER` makes `/implement` adopt the queue issue as its tracking issue (Phase 3 Branch 2 adoption), so the two skills converge on the same tracking issue and `/fix-issue` avoids a duplicate tracking-issue on its path:
 
-- **SIMPLE**: `/implement --auto --quick --merge --session-env $FIX_ISSUE_TMPDIR/session-env.sh --issue $ISSUE_NUMBER [--slack if slack_enabled] [--debug if debug_mode] <feature description>`
-- **HARD**: `/implement --auto --merge --session-env $FIX_ISSUE_TMPDIR/session-env.sh --issue $ISSUE_NUMBER [--slack if slack_enabled] [--debug if debug_mode] <feature description>`
+- **SIMPLE**: `/implement --quick --merge --session-env $FIX_ISSUE_TMPDIR/session-env.sh --issue $ISSUE_NUMBER [--slack if slack_enabled] [--debug if debug_mode] <feature description>`
+- **HARD**: `/implement --merge --session-env $FIX_ISSUE_TMPDIR/session-env.sh --issue $ISSUE_NUMBER [--slack if slack_enabled] [--debug if debug_mode] <feature description>`
 
 After `/implement` completes, capture the PR URL and PR number from its output. Save as `PR_URL` and `PR_NUMBER`.
 


### PR DESCRIPTION
## Summary
- Removed `--auto` from the two `/implement` invocation examples in `skills/fix-issue/SKILL.md` Step 6a (both SIMPLE and HARD delegation paths) per issue #389.
- Surgical two-token prose edit; all other flags (`--quick` on SIMPLE, `--merge`, `--session-env`, `--issue`, conditional `--slack`/`--debug`) and the `<feature description>` positional arg are unchanged.
- Version bumped to 6.2.14 (PATCH — documentation edit in a SKILL.md body; no public-surface frontmatter tokens changed).

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] `grep -n -- "--auto" skills/fix-issue/SKILL.md` returns no matches.
- [x] The SIMPLE-path line (173) shows `/implement --quick --merge --session-env …`.
- [x] The HARD-path line (174) shows `/implement --merge --session-env …`.
- [x] `/relevant-checks` (pre-commit on modified files + agent-lint on full repo) passes locally.
- [ ] CI passes on the PR.

</details>

Closes #389

Generated with [Claude Code](https://claude.com/claude-code)
