### PR TITLE
Print tracking-issue URL at end of /loop-improve-skill and /improve-skill

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.0.1] - 2026-04-24
+
+### Changed
+
+- `/loop-improve-skill` and `/improve-skill` now print the tracking-issue URL as the final `✅` breadcrumb so the user gets a clickable link at the end of a run. `driver.sh` emits the URL after the Step 5 close-out comment; `iteration.sh` emits it from the EXIT trap in standalone mode (create OR `--issue <N>` adopt), gated on `OWNS_WORK_DIR=true` and a non-empty `ISSUE_URL`. Loop-mode invocations stay silent so `driver.sh` owns the final URL output.
+- `iteration.sh` hydrates `ISSUE_URL` on the standalone `--issue <N>` adopt path via `gh issue view --json url --jq .url`. Graceful degradation: on `gh` failure `ISSUE_URL` stays empty, a warning is logged to stderr, and the EXIT trap's `-n` gate silently falls through.
+
 ## [7.0.0] - 2026-04-24
 
 ### Changed

--- a/skills/improve-skill/scripts/iteration.md
+++ b/skills/improve-skill/scripts/iteration.md
@@ -58,9 +58,10 @@ Emitted via `trap emit_kv_footer EXIT` — guarantees the footer is present on e
 
 Stdout is reserved for:
 1. Breadcrumb lines via the four helpers — `breadcrumb_done` (`✅`), `breadcrumb_inprogress` (`> **🔶`), `breadcrumb_warn` (`**⚠`), and `breadcrumb_skip` (`⏩`). Only the first three prefixes are matched by the Monitor-tail filter regex on the consumer SKILL.md's live stream (`breadcrumb_skip` is defined for future use and for symmetry with `driver.sh`; skip lines land in the retained log but not on the live Monitor view).
-2. The `### iteration-result` header + 9 KV lines from the EXIT trap.
+2. Final tracking-issue URL breadcrumb, emitted by the EXIT trap in standalone mode only (`OWNS_WORK_DIR=true` AND `ISSUE_URL` non-empty). Precedes the KV footer block. Uses `breadcrumb_done` (`✅` prefix) so Monitor surfaces the URL as the last visible breadcrumb. Loop mode suppresses this line — `driver.sh` holds the URL form and emits it itself at its Step 5.
+3. The `### iteration-result` header + 9 KV lines from the EXIT trap.
 
-All `claude -p` child I/O stays in files under `$WORK_DIR` (via `invoke_claude_p`'s `> "$out_file"` and `2> "$stderr_file"` redirects). No third-party `KEY=value` text leaks onto iteration.sh's own stdout, so the loop driver's awk KV extraction is always unambiguous.
+All `claude -p` child I/O stays in files under `$WORK_DIR` (via `invoke_claude_p`'s `> "$out_file"` and `2> "$stderr_file"` redirects). No third-party `KEY=value` text leaks onto iteration.sh's own stdout, so the loop driver's awk KV extraction is always unambiguous (the KV parser is scoped to post-`### iteration-result` lines, so the URL breadcrumb above it is invisible to the parser).
 
 ## Security invariants
 

--- a/skills/improve-skill/scripts/iteration.sh
+++ b/skills/improve-skill/scripts/iteration.sh
@@ -112,6 +112,11 @@ KV_TOTAL_DEN="N/A"
 KV_ITERATION_TMPDIR=""
 KV_ISSUE_NUM=""
 
+# Captured at Step 3 standalone-create; empty when the loop driver adopts via
+# --issue (driver emits the URL itself at loop end). Initialized here so the
+# EXIT trap's `set -u` safely references it on any early-exit path.
+ISSUE_URL=""
+
 # shellcheck disable=SC2317  # invoked via trap on EXIT — shellcheck cannot see the indirect call
 emit_kv_footer() {
   # Emitted on every exit path (normal + set -e abort). Uses `printf` to
@@ -138,8 +143,15 @@ OWNS_WORK_DIR="false"   # true only in standalone mode (no --work-dir passed)
 # shellcheck disable=SC2317  # invoked via trap on EXIT
 cleanup_on_exit() {
   local rc=$?
-  # Emit KV footer first so parsers see the result even when work-dir
-  # cleanup fails (FINDING_2 guarantee).
+  # Surface the tracking-issue URL in standalone mode so the user sees it at
+  # the very end via Monitor (loop mode suppresses this: driver.sh emits the
+  # URL itself at Step 5, and iteration.sh in loop mode does not hold the
+  # URL form — only the adopted number).
+  if [[ "$OWNS_WORK_DIR" == "true" && -n "$ISSUE_URL" ]]; then
+    breadcrumb_done "tracking issue URL: ${ISSUE_URL}" || true
+  fi
+  # Emit KV footer so parsers see the result even when work-dir cleanup fails
+  # (FINDING_2 guarantee).
   emit_kv_footer || true
   if [[ "$OWNS_WORK_DIR" == "true" && -n "$WORK_DIR" && -d "$WORK_DIR" ]]; then
     if [[ -x "${CLAUDE_PLUGIN_ROOT:-}/scripts/cleanup-tmpdir.sh" ]]; then

--- a/skills/improve-skill/scripts/iteration.sh
+++ b/skills/improve-skill/scripts/iteration.sh
@@ -134,7 +134,8 @@ emit_kv_footer() {
 }
 
 # --------------------------------------------------------------------------
-# Cleanup trap (KV footer first, then work-dir cleanup when owned)
+# Cleanup trap (optional URL breadcrumb, then KV footer, then work-dir
+# cleanup when owned)
 # --------------------------------------------------------------------------
 
 WORK_DIR=""
@@ -365,6 +366,18 @@ KV_ITERATION_TMPDIR="$WORK_DIR"
 
 if [[ -n "$ISSUE_ARG" ]]; then
   ISSUE_NUM="$ISSUE_ARG"
+  # Hydrate ISSUE_URL so the EXIT-trap URL breadcrumb fires on standalone-adopt
+  # runs too. Loop mode (OWNS_WORK_DIR=false) suppresses the trap line and the
+  # driver emits its own URL at loop end, so the hydration is only load-bearing
+  # for standalone-adopt. Graceful degradation: if `gh issue view` fails (stale
+  # issue number, network blip, gh auth lapse), leave ISSUE_URL empty and log
+  # to stderr — the trap's `-n "$ISSUE_URL"` gate falls through silently.
+  if [[ "$OWNS_WORK_DIR" == "true" ]]; then
+    if ! ISSUE_URL="$(gh issue view "$ISSUE_NUM" --json url --jq .url 2>/dev/null)"; then
+      ISSUE_URL=""
+      printf 'iteration.sh: warning: gh issue view #%s failed; final URL breadcrumb suppressed.\n' "${ISSUE_NUM}" >&2
+    fi
+  fi
   breadcrumb_done "3: issue — adopted #${ISSUE_NUM} (via --issue)"
 else
   breadcrumb_inprogress "3: issue — creating tracking issue"

--- a/skills/loop-improve-skill/scripts/driver.sh
+++ b/skills/loop-improve-skill/scripts/driver.sh
@@ -532,6 +532,7 @@ gh issue comment "$ISSUE_NUM" --body-file "$CLOSEOUT_REDACTED" || {
 printf 'done\n' > "$LOOP_TMPDIR/closeout.sentinel"
 
 breadcrumb_done "5: close out — issue #${ISSUE_NUM}, exit: ${EXIT_REASON}"
+breadcrumb_done "5: tracking issue URL: ${ISSUE_URL}"
 
 # --------------------------------------------------------------------------
 # Step 6 — Cleanup (EXIT trap also handles this; explicit call for symmetry)


### PR DESCRIPTION
## Summary
- Added a final `✅ tracking issue URL: ...` breadcrumb at the end of `/loop-improve-skill` (`driver.sh` Step 5) and `/improve-skill` (`iteration.sh` EXIT trap in standalone mode) so the user sees a clickable link to the overarching tracking issue at the end of the run — the URL was previously captured into `$ISSUE_URL` but never echoed.
- Hydrated `ISSUE_URL` on the standalone `--issue <N>` adopt path via `gh issue view --json url --jq .url` so the breadcrumb fires on both create AND adopt paths (previously only the create path had the URL).

<details><summary>Architecture Diagram</summary>

Architecture diagram not available. (Quick-mode `/design` was not invoked for this small change; the Code Flow Diagram below captures the behavioral change.)

</details>

<details><summary>Code Flow Diagram</summary>

```mermaid
flowchart TD
    Start([User invokes /loop-improve-skill<br/>or /improve-skill]) --> Mode{Invocation<br/>mode?}

    Mode -->|"/loop-improve-skill"| Driver[driver.sh]
    Mode -->|"/improve-skill<br/>standalone"| IterStandalone[iteration.sh<br/>OWNS_WORK_DIR=true]

    Driver --> DriverCreate["gh issue create →<br/>ISSUE_URL captured"]
    DriverCreate --> DriverLoop["while ITER ≤ 10:<br/>iteration.sh --issue $ISSUE_NUM<br/>--work-dir $LOOP_TMPDIR<br/>(loop mode: OWNS_WORK_DIR=false)"]
    DriverLoop --> DriverCloseout["Post close-out comment<br/>(Grade History)"]
    DriverCloseout --> DriverPrint1["✅ 5: close out — issue #N, exit: ..."]
    DriverPrint1 --> DriverPrint2["✅ 5: tracking issue URL: $ISSUE_URL<br/>(NEW)"]
    DriverPrint2 --> DriverEnd([cleanup])

    IterStandalone --> IterIssueCheck{"--issue <N><br/>provided?"}
    IterIssueCheck -->|Yes| IterAdopt["ISSUE_NUM = ISSUE_ARG<br/>gh issue view → ISSUE_URL<br/>(NEW hydration)"]
    IterIssueCheck -->|No| IterCreate["gh issue create →<br/>ISSUE_URL captured"]
    IterAdopt --> IterWork[judge → design → im]
    IterCreate --> IterWork
    IterWork --> IterExit[Any exit path<br/>success/failure]
    IterExit --> IterTrap{EXIT trap:<br/>OWNS_WORK_DIR=true<br/>AND ISSUE_URL≠∅?}
    IterTrap -->|Yes| IterTrapURL["✅ tracking issue URL: $ISSUE_URL<br/>(NEW)"]
    IterTrap -->|No loop mode<br/>or gh failure| IterTrapKV
    IterTrapURL --> IterTrapKV["### iteration-result<br/>KV footer"]
    IterTrapKV --> IterEnd([cleanup-tmpdir.sh])

    DriverLoop -.->|"each iteration<br/>(loop mode)"| IterLoopMode[iteration.sh<br/>OWNS_WORK_DIR=false]
    IterLoopMode -.->|trap: gate=false<br/>no URL emitted| IterTrapKV

    style DriverPrint2 fill:#d4edda
    style IterAdopt fill:#d4edda
    style IterTrapURL fill:#d4edda
```

</details>

<details><summary>Test plan</summary>

- [x] `scripts/test-improve-skill-iteration.sh` — passes (62/62)
- [x] `scripts/test-loop-improve-skill-driver.sh` — passes (41/41)
- [x] `scripts/test-loop-improve-skill-skill-md.sh` — passes (12/12)
- [x] `scripts/test-improve-skill-skill-md.sh` — passes (12/12)
- [x] `bash -n` syntax check on both modified scripts
- [x] `/relevant-checks` (pre-commit + agent-lint) — passes
- [x] Halt-rate test's pinned close-out grep pattern (`✅ 5: close out — issue #[0-9]+, exit: .*`) preserved byte-for-byte in driver.sh; new URL breadcrumb is added as a separate line beneath it
- [ ] Manual: run `/improve-skill <skill>` standalone (create path) — confirm `✅ tracking issue URL: <url>` appears as the final breadcrumb
- [ ] Manual: run `/improve-skill --issue <N> <skill>` (adopt path) — confirm the same breadcrumb fires (validates FINDING_5 fix)
- [ ] Manual: run `/loop-improve-skill <skill>` — confirm `✅ 5: tracking issue URL: <url>` appears after the close-out breadcrumb

</details>

Closes #400

Generated with [Claude Code](https://claude.com/claude-code)
