### PR TITLE
Add [IN PROGRESS]/[DONE]/[STALLED] tracking-issue title-prefix lifecycle

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.0.4",
+  "version": "7.0.5",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.0.5] - 2026-04-24
+
+### Added
+
+- Tracking-issue title-prefix lifecycle: `/implement`, `/improve-skill`, and `/loop-improve-skill` now create their tracking issues with `[IN PROGRESS]` in the title, rename to `[DONE]` on successful completion (right before merge for `/implement`; pre-closeout for `/loop-improve-skill`; both success exits for `/improve-skill`), and rename to `[STALLED]` on bail / failure paths. `/fix-issue` excludes issues whose titles start with any managed prefix from both auto-pick and explicit-issue selection, so tracking issues never appear as fix-issue candidates. New `tracking-issue-write.sh rename --issue N --state in-progress|done|stalled` subcommand is the single idempotent mutator (strip-exactly-one-then-prepend, redact parity with `create-issue`, char-oriented 256 truncation). Bash drivers (`iteration.sh`, `driver.sh`) install an EXIT trap with footer-first ordering so the KV footer contract is preserved even when the best-effort stall rename fails.
+
 ## [7.0.4] - 2026-04-24
 
 ### Changed

--- a/scripts/test-tracking-issue-write.sh
+++ b/scripts/test-tracking-issue-write.sh
@@ -474,6 +474,111 @@ else
 fi
 
 echo ""
+echo "=== (j) rename subcommand — idempotency, strip-exactly-one, redaction ==="
+
+# Stub gh for rename scenarios. Reads the mock title from $MOCK_TITLE_FILE
+# (set by each test case). Captures `gh issue edit --title <T>` into
+# $EDIT_CAPTURE. Also tracks whether an edit call was made via
+# $EDIT_CALLED_FILE.
+build_stub_rename() {
+    local stub_dir="$1"
+    mkdir -p "$stub_dir"
+    cat > "$stub_dir/gh" <<'GHSTUB'
+#!/usr/bin/env bash
+if [[ "$1" == "repo" ]] && [[ "$2" == "view" ]]; then
+    echo 'owner/repo'
+    exit 0
+fi
+if [[ "$1" == "issue" ]] && [[ "$2" == "view" ]]; then
+    # Return the mock title verbatim (no JSON wrapper; --jq .title would
+    # have extracted the field, but the stub just emits the raw value).
+    cat "$MOCK_TITLE_FILE"
+    exit 0
+fi
+if [[ "$1" == "issue" ]] && [[ "$2" == "edit" ]]; then
+    touch "$EDIT_CALLED_FILE"
+    for ((i=1; i<=$#; i++)); do
+        if [[ "${!i}" == "--title" ]]; then
+            next=$((i + 1))
+            printf '%s' "${!next}" > "$EDIT_CAPTURE"
+        fi
+    done
+    exit 0
+fi
+exit 0
+GHSTUB
+    chmod +x "$stub_dir/gh"
+}
+
+STUB_J="$TMPROOT/stub-j"
+build_stub_rename "$STUB_J"
+MOCK_TITLE_FILE="$TMPROOT/mock-title.txt"
+EDIT_CAPTURE="$TMPROOT/edit-capture.txt"
+EDIT_CALLED_FILE="$TMPROOT/edit-called.marker"
+export MOCK_TITLE_FILE EDIT_CAPTURE EDIT_CALLED_FILE
+
+# (j1) base rename: no prefix → prepends [IN PROGRESS]
+rm -f "$EDIT_CAPTURE" "$EDIT_CALLED_FILE"
+printf '%s' 'My feature work' > "$MOCK_TITLE_FILE"
+out_j1=$(PATH="$STUB_J:$PATH" bash "$WRITE" rename --issue 42 --state in-progress --repo owner/repo 2>&1)
+assert_contains "$out_j1" 'RENAMED=true' '(j1) base rename emits RENAMED=true'
+assert_contains "$out_j1" 'NEW_TITLE=[IN PROGRESS] My feature work' '(j1) base rename NEW_TITLE correct'
+if [[ -f "$EDIT_CAPTURE" ]]; then
+    cap_j1=$(cat "$EDIT_CAPTURE")
+    assert_equal "$cap_j1" '[IN PROGRESS] My feature work' '(j1) gh issue edit received prefixed title'
+fi
+
+# (j2) transition rename: [IN PROGRESS] → [DONE]
+rm -f "$EDIT_CAPTURE" "$EDIT_CALLED_FILE"
+printf '%s' '[IN PROGRESS] My feature work' > "$MOCK_TITLE_FILE"
+out_j2=$(PATH="$STUB_J:$PATH" bash "$WRITE" rename --issue 42 --state 'done' --repo owner/repo 2>&1)
+assert_contains "$out_j2" 'RENAMED=true' '(j2) transition rename emits RENAMED=true'
+assert_contains "$out_j2" 'NEW_TITLE=[DONE] My feature work' '(j2) transition rename NEW_TITLE correct'
+if [[ -f "$EDIT_CAPTURE" ]]; then
+    cap_j2=$(cat "$EDIT_CAPTURE")
+    assert_equal "$cap_j2" '[DONE] My feature work' '(j2) gh issue edit received transitioned title'
+fi
+
+# (j3) idempotent no-op: already [DONE] → rename to done → RENAMED=false, no edit call
+rm -f "$EDIT_CAPTURE" "$EDIT_CALLED_FILE"
+printf '%s' '[DONE] My feature work' > "$MOCK_TITLE_FILE"
+out_j3=$(PATH="$STUB_J:$PATH" bash "$WRITE" rename --issue 42 --state 'done' --repo owner/repo 2>&1)
+assert_contains "$out_j3" 'RENAMED=false' '(j3) idempotent no-op emits RENAMED=false'
+if [[ -f "$EDIT_CALLED_FILE" ]]; then
+    FAIL=$((FAIL + 1))
+    FAILED_TESTS+=("(j3) gh issue edit was called despite idempotent no-op")
+    echo "  FAIL: (j3) gh issue edit was called despite idempotent no-op" >&2
+else
+    PASS=$((PASS + 1))
+    echo "  ok: (j3) gh issue edit was NOT called (idempotent no-op)"
+fi
+
+# (j4) strip exactly one: [IN PROGRESS] [DONE] Foo → rename to stalled → [STALLED] [DONE] Foo
+# Stacked residue is preserved — helper does not heal corruption.
+rm -f "$EDIT_CAPTURE" "$EDIT_CALLED_FILE"
+printf '%s' '[IN PROGRESS] [DONE] Foo' > "$MOCK_TITLE_FILE"
+out_j4=$(PATH="$STUB_J:$PATH" bash "$WRITE" rename --issue 42 --state stalled --repo owner/repo 2>&1)
+assert_contains "$out_j4" 'RENAMED=true' '(j4) strip-exactly-one emits RENAMED=true'
+assert_contains "$out_j4" 'NEW_TITLE=[STALLED] [DONE] Foo' '(j4) strip-exactly-one preserves stacked residue'
+
+# (j5) redact pipeline applied to new title
+rm -f "$EDIT_CAPTURE" "$EDIT_CALLED_FILE"
+printf 'Work on %s handler' "$SK_TOKEN" > "$MOCK_TITLE_FILE"
+out_j5=$(PATH="$STUB_J:$PATH" bash "$WRITE" rename --issue 42 --state in-progress --repo owner/repo 2>&1)
+assert_contains "$out_j5" 'RENAMED=true' '(j5) redact-applied rename emits RENAMED=true'
+assert_not_contains "$out_j5" "$SK_TOKEN" '(j5) stdout does not leak sk-ant token'
+if [[ -f "$EDIT_CAPTURE" ]]; then
+    cap_j5=$(cat "$EDIT_CAPTURE")
+    assert_contains "$cap_j5" '<REDACTED-TOKEN>' '(j5) outbound title contains <REDACTED-TOKEN>'
+    assert_not_contains "$cap_j5" "$SK_TOKEN" '(j5) outbound title does NOT leak sk-ant'
+fi
+
+# (j6) invalid --state → FAILED=true exit 1
+out_j6=$(PATH="$STUB_J:$PATH" bash "$WRITE" rename --issue 42 --state bogus --repo owner/repo 2>&1 || true)
+assert_contains "$out_j6" 'FAILED=true' '(j6) invalid --state emits FAILED=true'
+assert_contains "$out_j6" 'ERROR=invalid --state' '(j6) invalid --state emits ERROR=invalid --state'
+
+echo ""
 echo "=== Summary ==="
 echo "Passed: $PASS"
 echo "Failed: $FAIL"

--- a/scripts/test-tracking-issue-write.sh
+++ b/scripts/test-tracking-issue-write.sh
@@ -2,11 +2,13 @@
 # test-tracking-issue-write.sh — regression harness for tracking-issue-write.sh.
 #
 # Mirrors the stub-gh + PATH-override pattern of scripts/test-redact-secrets.sh.
-# Nine assertion categories (a-i) covering redaction, exit codes, truncation,
+# Ten assertion categories (a-j) covering redaction, exit codes, truncation,
 # anchor-skeleton preservation, anchor-upsert semantics, gh-failure redaction,
-# the anchor-section-markers.sh startup-guard fail-closed, and the
-# SECTION_MARKERS ⊆ COLLAPSE_PRIORITY invariant. All assertions run in a
-# hermetic mktemp -d tmproot with a stub gh binary on PATH.
+# the anchor-section-markers.sh startup-guard fail-closed, the
+# SECTION_MARKERS ⊆ COLLAPSE_PRIORITY invariant, and the rename subcommand
+# (idempotency, strip-exactly-one, redaction, invalid --state). All
+# assertions run in a hermetic mktemp -d tmproot with a stub gh binary on
+# PATH.
 #
 # Usage:
 #   bash scripts/test-tracking-issue-write.sh
@@ -576,7 +578,24 @@ fi
 # (j6) invalid --state → FAILED=true exit 1
 out_j6=$(PATH="$STUB_J:$PATH" bash "$WRITE" rename --issue 42 --state bogus --repo owner/repo 2>&1 || true)
 assert_contains "$out_j6" 'FAILED=true' '(j6) invalid --state emits FAILED=true'
-assert_contains "$out_j6" 'ERROR=invalid --state' '(j6) invalid --state emits ERROR=invalid --state'
+assert_contains "$out_j6" 'ERROR=invalid --state: bogus' '(j6) invalid --state emits full canonical ERROR=invalid --state: bogus'
+
+# (j7) idempotency + redactable token in current title: rename to same state
+# must be a no-op even when CUR_TITLE contains a secret. Without redacting
+# both sides of the comparison, the raw CUR_TITLE (with token) would never
+# equal the redacted NEW_TITLE, spuriously firing gh issue edit.
+rm -f "$EDIT_CAPTURE" "$EDIT_CALLED_FILE"
+printf '[DONE] Fix %s handler' "$SK_TOKEN" > "$MOCK_TITLE_FILE"
+out_j7=$(PATH="$STUB_J:$PATH" bash "$WRITE" rename --issue 42 --state 'done' --repo owner/repo 2>&1)
+assert_contains "$out_j7" 'RENAMED=false' '(j7) redactable title already at target state emits RENAMED=false'
+if [[ -f "$EDIT_CALLED_FILE" ]]; then
+    FAIL=$((FAIL + 1))
+    FAILED_TESTS+=("(j7) gh issue edit was called despite redactable idempotent no-op")
+    echo "  FAIL: (j7) gh issue edit was called despite redactable idempotent no-op" >&2
+else
+    PASS=$((PASS + 1))
+    echo "  ok: (j7) gh issue edit was NOT called (redactable idempotent no-op)"
+fi
 
 echo ""
 echo "=== Summary ==="

--- a/scripts/tracking-issue-write.md
+++ b/scripts/tracking-issue-write.md
@@ -10,6 +10,7 @@ Phase 1 (umbrella #348) foundation layer: outbound helper for the tracking-issue
 tracking-issue-write.sh create-issue   --title T --body-file F [--repo OWNER/REPO]
 tracking-issue-write.sh append-comment --issue N --body-file F [--lifecycle-marker ID] [--repo OWNER/REPO]
 tracking-issue-write.sh upsert-anchor  --issue N [--anchor-id ID] --body-file F [--repo OWNER/REPO]
+tracking-issue-write.sh rename         --issue N --state in-progress|done|stalled [--repo OWNER/REPO]
 ```
 
 ## Output contract (KEY=value on stdout)
@@ -25,6 +26,7 @@ This script emits `FAILED=true` / `ERROR=<msg>` on failure — NOT the `ISSUE_FA
 | `create-issue` | `ISSUE_NUMBER=<N>`, `ISSUE_URL=<url>` |
 | `append-comment` | `COMMENT_ID=<id>`, `COMMENT_URL=<url>` |
 | `upsert-anchor` | `ANCHOR_COMMENT_ID=<id>`, `ANCHOR_COMMENT_URL=<url>`, `UPDATED=true\|false` (`true` when an existing anchor was PATCHed; `false` when a new anchor comment was created) |
+| `rename` | `RENAMED=true\|false`, `NEW_TITLE=<title>` (`false` when the current title already starts with the target prefix — no `gh issue edit` call was made) |
 
 ### Failure keys
 
@@ -76,6 +78,30 @@ Truncation is byte-length based. Multibyte UTF-8 splitting is tolerated because 
 ## Lifecycle markers
 
 `append-comment` accepts `--lifecycle-marker <id>`, which prepends `<!-- larch:lifecycle-marker:<id> -->\n` to the body before redaction+truncation. Three canonical markers for Phase 2+ callers: `pr-opened`, `pr-closed`, `in-progress`. These machine-owned markers replace the prose-prefix filters (`PR opened:`, `Closed by PR #`) from the original design — prose prefixes were too loose (matched ordinary English comments).
+
+## Title-prefix lifecycle (rename subcommand)
+
+Tracking issues carry a machine-owned title-prefix lifecycle: `[IN PROGRESS]` during active work, `[DONE]` after the tracking run completes, `[STALLED]` when a run fails without closing. Each prefix is followed by a single space before the rest of the title (e.g., `[IN PROGRESS] Fix login bug`). `rename` is the single mutator for these prefixes; every consumer MUST use this subcommand rather than inlining `gh issue edit --title`.
+
+### Algorithm
+
+1. Fetch the current title via `gh issue view --json title`.
+2. Strip **exactly one** leading managed prefix (anchored at start; regex matching one of `[IN PROGRESS]`, `[DONE]`, or `[STALLED]` followed by a single space). Stacked prefixes beyond the first are preserved — the helper does not "heal" corrupted titles because the healing policy (prefer first vs. last vs. middle) is ambiguous.
+3. Prepend the target-state prefix (`[IN PROGRESS]`, `[DONE]`, or `[STALLED]`) followed by one space.
+4. Pipe the prospective new title through `scripts/redact-secrets.sh` (same posture as `create-issue`).
+5. Truncate to 256 bytes if the result exceeds GitHub's title limit. Truncation is byte-oriented and preserves the prefix (tail is sliced). Safe for ASCII; UTF-8 is a known minor limitation (section interiors are machine-composed by `/implement` so this has not been a practical concern).
+6. If the resulting title equals the current title (already in target state), emit `RENAMED=false` and skip the `gh` call.
+7. Otherwise call `gh issue edit --title` and emit `RENAMED=true`.
+
+### Idempotency
+
+Re-calling `rename --state X` on an issue already at state X is a no-op (`RENAMED=false`). This matters for resumed `/implement` sessions and for the bash drivers' EXIT-trap paths (the trap may fire after a successful explicit rename-to-done; the re-rename to `[STALLED]` is a no-op because the guard flag prevents it, but even without that the helper would emit `RENAMED=false` for an already-stalled title).
+
+### Distinction from `/fix-issue`'s "IN PROGRESS" comment lock
+
+The title prefix `[IN PROGRESS]` (followed by a space) is the **tracking-issue lifecycle state** — whose job is to signal human triage and filter `/fix-issue` auto-pick. It is orthogonal to `/fix-issue`'s existing **comment-based** lock (last comment equal to the bare text `IN PROGRESS`), which is the **concurrency lock** preventing two concurrent `/fix-issue` runners from picking the same subject issue. Both mechanisms coexist:
+- Comment lock: applies to any `/fix-issue` subject issue; set at step 2 of `/fix-issue`; cleared when work completes.
+- Title prefix: applies only to `/implement`-created tracking issues AND to `/improve-skill` / `/loop-improve-skill` standalone issues; never applied to adopted issues.
 
 ## Conventions
 

--- a/scripts/tracking-issue-write.md
+++ b/scripts/tracking-issue-write.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Phase 1 (umbrella #348) foundation layer: outbound helper for the tracking-issue lifecycle. Three narrow subcommands that each perform exactly one GitHub write, sharing a KEY=value stdout envelope and fail-closed redaction posture modelled on `skills/issue/scripts/create-one.sh`. No consumers wired in Phase 1; Phase 3 is the first consumer.
+Phase 1 (umbrella #348) foundation layer: outbound helper for the tracking-issue lifecycle. Four narrow subcommands (`create-issue`, `append-comment`, `upsert-anchor`, `rename`) that each perform exactly one GitHub write, sharing a KEY=value stdout envelope and fail-closed redaction posture modelled on `skills/issue/scripts/create-one.sh`. The first three were added in Phase 1; `rename` was added alongside the tracking-issue title-prefix lifecycle (see "Title-prefix lifecycle" below).
 
 ## Subcommands
 
@@ -89,7 +89,7 @@ Tracking issues carry a machine-owned title-prefix lifecycle: `[IN PROGRESS]` du
 2. Strip **exactly one** leading managed prefix (anchored at start; regex matching one of `[IN PROGRESS]`, `[DONE]`, or `[STALLED]` followed by a single space). Stacked prefixes beyond the first are preserved — the helper does not "heal" corrupted titles because the healing policy (prefer first vs. last vs. middle) is ambiguous.
 3. Prepend the target-state prefix (`[IN PROGRESS]`, `[DONE]`, or `[STALLED]`) followed by one space.
 4. Pipe the prospective new title through `scripts/redact-secrets.sh` (same posture as `create-issue`).
-5. Truncate to 256 bytes if the result exceeds GitHub's title limit. Truncation is byte-oriented and preserves the prefix (tail is sliced). Safe for ASCII; UTF-8 is a known minor limitation (section interiors are machine-composed by `/implement` so this has not been a practical concern).
+5. Truncate to 256 chars if the result exceeds GitHub's title limit. Truncation uses bash string semantics (`${#var}` + `${var:0:256}`), which matches GitHub's character-based 256 limit under UTF-8 locales. The prefix is preserved (tail is sliced). Managed prefixes are ASCII so truncation is stable regardless of locale.
 6. If the resulting title equals the current title (already in target state), emit `RENAMED=false` and skip the `gh` call.
 7. Otherwise call `gh issue edit --title` and emit `RENAMED=true`.
 
@@ -113,7 +113,7 @@ The regression harness `scripts/test-tracking-issue-write.sh` is wired into `mak
 
 ## Test harness
 
-`scripts/test-tracking-issue-write.sh` covers nine assertion categories:
+`scripts/test-tracking-issue-write.sh` covers ten assertion categories (a-j):
 
 - **(a)** `create-issue` redacts title + body (`sk-ant-*` secret → `<REDACTED-TOKEN>`).
 - **(b)** `create-issue` exits 3 with `FAILED=true` / `ERROR=redaction:…` when the redactor is missing. Pins exact key literals `FAILED=true` (not `ISSUE_FAILED`).
@@ -125,6 +125,7 @@ The regression harness `scripts/test-tracking-issue-write.sh` is wired into `mak
 - **(g) gh-failure redaction**: stub-gh emits a token-bearing stderr on failure → the `FAILED=true ERROR=…` line contains `<REDACTED-TOKEN>` and not the raw token.
 - **(h) Missing `anchor-section-markers.sh` helper**: when the script's sourced helper is missing from the script's `$SCRIPT_DIR`, it fails closed with `FAILED=true` / `ERROR=missing helper: …` on stdout and exits 1 — preserving the stdout contract invariant.
 - **(i) `SECTION_MARKERS` ⊆ `COLLAPSE_PRIORITY` invariant**: every slug defined in `scripts/anchor-section-markers.sh` appears in `COLLAPSE_PRIORITY`, so the body-level truncation pass has a collapse target for every section.
+- **(j) `rename` subcommand**: base rename (no existing prefix → prepend), transition rename (`[IN PROGRESS]` → `[DONE]`), idempotent no-op (already at target state → `RENAMED=false`, no `gh` call), strip-exactly-one (stacked-prefix residue preserved), redact pipeline applied (token in title → `<REDACTED-TOKEN>` in outbound), invalid `--state` → `FAILED=true ERROR=invalid --state: ...`.
 
 ## Edit-in-sync pointers
 

--- a/scripts/tracking-issue-write.sh
+++ b/scripts/tracking-issue-write.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 # tracking-issue-write.sh — outbound helper for the tracking-issue lifecycle.
 #
-# Phase 1 (umbrella #348) foundation layer. Ships three narrow subcommands
-# that each perform exactly one GitHub write, all sharing the same KEY=value
-# stdout envelope and fail-closed redaction posture as
-# skills/issue/scripts/create-one.sh.
+# Phase 1 (umbrella #348) foundation layer. Ships four narrow subcommands
+# (create-issue, append-comment, upsert-anchor, rename) that each perform
+# exactly one GitHub write, all sharing the same KEY=value stdout envelope
+# and fail-closed redaction posture as skills/issue/scripts/create-one.sh.
 #
 # Subcommands:
 #   create-issue   --title T --body-file F [--repo OWNER/REPO]
@@ -35,8 +35,10 @@
 #   scripts/redact-secrets.sh before the gh call, matching the security
 #   posture of create-issue. Stacked-prefix corruption (e.g., "[IN PROGRESS]
 #   [DONE] Foo") is NOT healed — only one prefix is stripped. Title length:
-#   truncated to 256 bytes if the prepended title exceeds GitHub's limit.
-#   Truncation is byte-oriented; safe for ASCII, known limitation for UTF-8.
+#   truncated to 256 chars using bash string semantics (`${#var}` + slice).
+#   GitHub's limit is 256 characters — matching bash's native length under
+#   UTF-8 locales. Managed prefixes are ASCII so truncation is stable
+#   regardless of locale.
 #
 # Failure keys:
 #   FAILED=true  ERROR=<single-line message>
@@ -147,10 +149,13 @@ strip_managed_prefix() {
     esac
 }
 
-# truncate_title_to_256 <title> — byte-oriented truncation to 256 bytes.
-# Preserves leading managed prefix by design: the caller prepends the
-# prefix, and if the result exceeds 256 bytes we slice the TAIL, leaving
-# the prefix intact.
+# truncate_title_to_256 <title> — character-oriented truncation to 256
+# chars using bash string semantics (`${#var}` + `${var:0:256}`). GitHub's
+# title limit is 256 characters, matching bash's native string semantics
+# under UTF-8 locales. Preserves leading managed prefix by design: the
+# caller prepends the prefix, and if the result exceeds 256 chars we
+# slice the TAIL, leaving the prefix intact. Managed prefixes are ASCII,
+# so the truncation is stable regardless of locale.
 truncate_title_to_256() {
     local t="$1"
     if (( ${#t} <= 256 )); then
@@ -681,7 +686,17 @@ case "$cmd" in
         # token). Length check must be on the actual outbound title.
         NEW_TITLE=$(redact "$NEW_TITLE") || emit_redaction_failure
         NEW_TITLE=$(truncate_title_to_256 "$NEW_TITLE")
-        if [[ "$NEW_TITLE" == "$CUR_TITLE" ]]; then
+        # Idempotency comparison: compare the prospective outbound title
+        # against the redacted+truncated form of the CURRENT title so a
+        # title that already carries a redactable token is not spuriously
+        # re-edited (which would both violate the no-op contract AND
+        # rewrite the on-GitHub title to the redacted form without
+        # changing the lifecycle state). CUR_TITLE is the raw GitHub
+        # title; applying the same redact+truncate pipeline yields the
+        # canonical "what would we emit if the state was already X?" form.
+        CUR_TITLE_CANONICAL=$(redact "$CUR_TITLE") || emit_redaction_failure
+        CUR_TITLE_CANONICAL=$(truncate_title_to_256 "$CUR_TITLE_CANONICAL")
+        if [[ "$NEW_TITLE" == "$CUR_TITLE_CANONICAL" ]]; then
             echo "RENAMED=false"
             echo "NEW_TITLE=$NEW_TITLE"
             exit 0

--- a/scripts/tracking-issue-write.sh
+++ b/scripts/tracking-issue-write.sh
@@ -10,6 +10,7 @@
 #   create-issue   --title T --body-file F [--repo OWNER/REPO]
 #   append-comment --issue N --body-file F [--lifecycle-marker ID] [--repo OWNER/REPO]
 #   upsert-anchor  --issue N [--anchor-id ID] --body-file F [--repo OWNER/REPO]
+#   rename         --issue N --state in-progress|done|stalled [--repo OWNER/REPO]
 #
 # Output contract (KEY=value on stdout; warnings on stderr). NAMESPACE note:
 # this script emits FAILED=true / ERROR=<msg> on failure — NOT the
@@ -24,6 +25,18 @@
 #   create-issue:   ISSUE_NUMBER=<N>  ISSUE_URL=<url>
 #   append-comment: COMMENT_ID=<id>   COMMENT_URL=<url>
 #   upsert-anchor:  ANCHOR_COMMENT_ID=<id>  ANCHOR_COMMENT_URL=<url>  UPDATED=true|false
+#   rename:         RENAMED=true|false  NEW_TITLE=<title>
+#
+# Rename semantics (tracking-issue title-prefix lifecycle):
+#   Strips exactly ONE leading managed prefix (anchored regex
+#   ^\[(IN PROGRESS|DONE|STALLED)\] ) from the current title, then prepends
+#   the target-state prefix. No-op when the current title already starts
+#   with the target prefix (RENAMED=false). The new title is piped through
+#   scripts/redact-secrets.sh before the gh call, matching the security
+#   posture of create-issue. Stacked-prefix corruption (e.g., "[IN PROGRESS]
+#   [DONE] Foo") is NOT healed — only one prefix is stripped. Title length:
+#   truncated to 256 bytes if the prepended title exceeds GitHub's limit.
+#   Truncation is byte-oriented; safe for ASCII, known limitation for UTF-8.
 #
 # Failure keys:
 #   FAILED=true  ERROR=<single-line message>
@@ -104,7 +117,47 @@ Usage:
   tracking-issue-write.sh create-issue   --title T --body-file F [--repo OWNER/REPO]
   tracking-issue-write.sh append-comment --issue N --body-file F [--lifecycle-marker ID] [--repo OWNER/REPO]
   tracking-issue-write.sh upsert-anchor  --issue N [--anchor-id ID] --body-file F [--repo OWNER/REPO]
+  tracking-issue-write.sh rename         --issue N --state in-progress|done|stalled [--repo OWNER/REPO]
 USAGE
+}
+
+# State-to-prefix mapping for the rename subcommand. Using a function rather
+# than an associative array keeps us Bash 3.2 compatible (see top-of-file
+# conventions).
+state_to_prefix() {
+    case "$1" in
+        in-progress) printf '[IN PROGRESS] ' ;;
+        done)        printf '[DONE] ' ;;
+        stalled)     printf '[STALLED] ' ;;
+        *)           return 1 ;;
+    esac
+}
+
+# strip_managed_prefix <title> — prints the title with exactly ONE leading
+# managed prefix removed (if present). Anchored at the start; stacked
+# prefixes beyond the first are preserved. Uses shell parameter expansion
+# so the stripper is regex-engine-agnostic and safe for bash 3.2.
+strip_managed_prefix() {
+    local t="$1"
+    case "$t" in
+        '[IN PROGRESS] '*) printf '%s' "${t#\[IN PROGRESS\] }" ;;
+        '[DONE] '*)        printf '%s' "${t#\[DONE\] }" ;;
+        '[STALLED] '*)     printf '%s' "${t#\[STALLED\] }" ;;
+        *)                 printf '%s' "$t" ;;
+    esac
+}
+
+# truncate_title_to_256 <title> — byte-oriented truncation to 256 bytes.
+# Preserves leading managed prefix by design: the caller prepends the
+# prefix, and if the result exceeds 256 bytes we slice the TAIL, leaving
+# the prefix intact.
+truncate_title_to_256() {
+    local t="$1"
+    if (( ${#t} <= 256 )); then
+        printf '%s' "$t"
+    else
+        printf '%s' "${t:0:256}"
+    fi
 }
 
 # emit_redaction_failure — runs outside command substitution (via `|| ...`)
@@ -582,6 +635,64 @@ case "$cmd" in
             ERR_CONTENT=$(cat "$ERR_TMP")
             emit_gh_failure "$ERR_CONTENT"
         fi
+        ;;
+
+    rename)
+        ISSUE=""
+        STATE=""
+        REPO=""
+        while [[ $# -gt 0 ]]; do
+            case "$1" in
+                --issue) ISSUE="${2:?--issue requires a value}"; shift 2 ;;
+                --state) STATE="${2:?--state requires a value}"; shift 2 ;;
+                --repo)  REPO="${2:?--repo requires a value}"; shift 2 ;;
+                *) echo "Unknown option for rename: $1" >&2; usage; exit 1 ;;
+            esac
+        done
+        if [[ -z "$ISSUE" ]] || [[ -z "$STATE" ]]; then
+            usage
+            exit 1
+        fi
+        TARGET_PREFIX=$(state_to_prefix "$STATE") || {
+            echo "FAILED=true"
+            echo "ERROR=invalid --state: $STATE (expected in-progress|done|stalled)"
+            exit 1
+        }
+        if [[ -z "$REPO" ]]; then
+            REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null) || REPO=""
+            if [[ -z "$REPO" ]]; then
+                echo "FAILED=true"
+                echo "ERROR=could not determine repo"
+                exit 2
+            fi
+        fi
+        ERR_TMP=$(mktemp)
+        # shellcheck disable=SC2317
+        cleanup() { rm -f "$ERR_TMP"; }
+        trap cleanup EXIT
+        if ! CUR_TITLE=$(gh issue view "$ISSUE" --repo "$REPO" --json title --jq '.title' 2>"$ERR_TMP"); then
+            ERR_CONTENT=$(cat "$ERR_TMP")
+            emit_gh_failure "gh issue view failed: $ERR_CONTENT"
+        fi
+        STRIPPED=$(strip_managed_prefix "$CUR_TITLE")
+        NEW_TITLE="${TARGET_PREFIX}${STRIPPED}"
+        # Redact before length check: redacted content may differ in byte
+        # length from input (e.g., "<REDACTED-TOKEN>" replaces a longer
+        # token). Length check must be on the actual outbound title.
+        NEW_TITLE=$(redact "$NEW_TITLE") || emit_redaction_failure
+        NEW_TITLE=$(truncate_title_to_256 "$NEW_TITLE")
+        if [[ "$NEW_TITLE" == "$CUR_TITLE" ]]; then
+            echo "RENAMED=false"
+            echo "NEW_TITLE=$NEW_TITLE"
+            exit 0
+        fi
+        if ! gh issue edit "$ISSUE" --repo "$REPO" --title "$NEW_TITLE" >/dev/null 2>"$ERR_TMP"; then
+            ERR_CONTENT=$(cat "$ERR_TMP")
+            emit_gh_failure "gh issue edit failed: $ERR_CONTENT"
+        fi
+        echo "RENAMED=true"
+        echo "NEW_TITLE=$NEW_TITLE"
+        exit 0
         ;;
 
     *)

--- a/skills/fix-issue/scripts/fetch-eligible-issue.sh
+++ b/skills/fix-issue/scripts/fetch-eligible-issue.sh
@@ -4,11 +4,26 @@
 # Without --issue: lists open issues, checks each for the "GO" sentinel as
 # the last comment, excludes issues locked with "IN PROGRESS", excludes
 # issues blocked by other open issues (via GitHub's native issue dependencies),
-# and emits the first match (oldest first).
+# excludes issues whose titles start with a managed lifecycle prefix
+# ([IN PROGRESS], [DONE], [STALLED] — see below), and emits the first match
+# (oldest first).
 #
 # With --issue: targets a specific issue (by number or GitHub URL), verifies
-# it is open, has "GO" as the last comment, and has no currently-open
-# blocking dependencies.
+# it is open, does not carry a managed lifecycle title prefix, has "GO" as
+# the last comment, and has no currently-open blocking dependencies.
+#
+# Two orthogonal mechanisms coexist in this script:
+#   1) Comment-based "IN PROGRESS" lock — concurrency control on the
+#      fix-issue subject issue. Set at /fix-issue step 2 (last comment =
+#      exactly "IN PROGRESS"); cleared when work completes. Prevents two
+#      concurrent /fix-issue runners from picking the same subject.
+#   2) Title-based "[IN PROGRESS]" / "[DONE]" / "[STALLED]" lifecycle —
+#      machine-owned tracking-issue state on /implement-created issues
+#      (and /improve-skill / /loop-improve-skill standalone issues). Set
+#      at creation, flipped to [DONE] on confirmed merge, or [STALLED] on
+#      failure paths. Excluded by this script so tracking issues never
+#      appear as fix-issue candidates. See scripts/tracking-issue-write.md
+#      "Title-prefix lifecycle" for the full state machine.
 #
 # Usage:
 #   fetch-eligible-issue.sh [<number-or-url>]
@@ -26,6 +41,21 @@
 #   2 — error: gh CLI failure, or explicit issue not eligible
 
 set -euo pipefail
+
+# Returns 0 if the title starts with a managed lifecycle prefix
+# ("[IN PROGRESS] ", "[DONE] ", "[STALLED] "), 1 otherwise. Anchored at
+# the start; trailing-space-sensitive (matches the helper exactly — no
+# fuzzy match, so user titles containing the literal substring "[IN
+# PROGRESS]" mid-text are NOT excluded).
+has_managed_prefix() {
+    local t="$1"
+    case "$t" in
+        '[IN PROGRESS] '*) return 0 ;;
+        '[DONE] '*)        return 0 ;;
+        '[STALLED] '*)     return 0 ;;
+        *)                 return 1 ;;
+    esac
+}
 
 ISSUE_ARG=""
 
@@ -260,6 +290,18 @@ if [[ -n "$ISSUE_ARG" ]]; then
         exit 2
     fi
 
+    # Exclude issues with a managed lifecycle title prefix
+    # ([IN PROGRESS] / [DONE] / [STALLED]). These are machine-owned
+    # tracking issues (/implement, /improve-skill, /loop-improve-skill),
+    # not candidates for /fix-issue automated work. Placed BEFORE the
+    # comment pagination to save API calls on an obviously-excluded
+    # issue.
+    if has_managed_prefix "$ISSUE_TITLE"; then
+        echo "ELIGIBLE=false"
+        echo "ERROR=Issue #$ISSUE_NUM has a managed lifecycle title prefix ([IN PROGRESS] / [DONE] / [STALLED]); not a fix-issue candidate"
+        exit 2
+    fi
+
     # Verify last comment is GO.
     # Using --slurp so `jq` sees a single array-of-arrays and can select the
     # globally-last comment via `add // [] | .[-1]`. The older `--jq '.[-1].body'`
@@ -324,6 +366,15 @@ fi
 while IFS= read -r issue_row; do
     ISSUE_NUM=$(echo "$issue_row" | jq -r '.number')
     ISSUE_TITLE=$(echo "$issue_row" | jq -r '.title')
+
+    # Skip issues with a managed lifecycle title prefix
+    # ([IN PROGRESS] / [DONE] / [STALLED]) — machine-owned tracking
+    # issues, not fix-issue candidates. Placed BEFORE the comment
+    # pagination to save one API round-trip per excluded issue.
+    if has_managed_prefix "$ISSUE_TITLE"; then
+        echo "Skipping issue #$ISSUE_NUM: managed lifecycle title prefix" >&2
+        continue
+    fi
 
     # Get the globally-last comment body. See the explicit-issue path above for
     # the rationale on `--slurp` + `add // [] | .[-1]`.

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -422,7 +422,7 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/rebase-push.sh --no-push
 
 `--skip-if-pushed` is intentionally NOT used here: `main` is always on origin so that flag would always short-circuit. `SKIPPED_ALREADY_FRESH=true` keeps this call cheap when local `main` already matches `origin/main`.
 
-On non-zero exit, print `**⚠ Failed to ensure local main is fresh. Bailing to cleanup.**` and skip to Step 18. On success: if stdout contains `SKIPPED_ALREADY_FRESH=true`, print `⏩ 1.m: design plan | update main — already at latest` only when `debug_mode=true`; otherwise print `✅ 1.m: design plan | update main — rebased onto latest origin/main (<elapsed>)`.
+On non-zero exit, print `**⚠ Failed to ensure local main is fresh. Bailing to cleanup.**`, set `STALL_TRACKING=true` (parallels Rebase Checkpoint Macro M3 and Step 12d — signals Step 18 to rename the tracking issue to `[STALLED]` when Step 0.5 Branch 4 has already created one), and skip to Step 18. On success: if stdout contains `SKIPPED_ALREADY_FRESH=true`, print `⏩ 1.m: design plan | update main — already at latest` only when `debug_mode=true`; otherwise print `✅ 1.m: design plan | update main — rebased onto latest origin/main (<elapsed>)`.
 
 ### Quick mode (`quick_mode=true`)
 

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -114,7 +114,7 @@ Standardizes the four post-step rebase checkpoints (Steps 1.r, 4.r, 7.r, 7a.r). 
   ${CLAUDE_PLUGIN_ROOT}/scripts/rebase-push.sh --no-push --skip-if-pushed
   ```
 
-- **M3 — On non-zero exit**: print `**⚠ Rebase onto main failed. Bailing to cleanup.**` and skip to Step 18.
+- **M3 — On non-zero exit**: print `**⚠ Rebase onto main failed. Bailing to cleanup.**`, set `STALL_TRACKING=true` (signals Step 18 to rename the tracking issue to `[STALLED]` — see "Title-prefix lifecycle" below), and skip to Step 18.
 
 - **M4 — On success**, branch on stdout (check `SKIPPED_ALREADY_PUSHED` BEFORE `SKIPPED_ALREADY_FRESH` — `rebase-push.sh` exits early on already-pushed before fetch):
   - If stdout contains `SKIPPED_ALREADY_PUSHED=true`: if `debug_mode=true`, print: `⏩ <step-prefix>: <short-name> | rebase — already pushed` Otherwise silently continue.
@@ -308,6 +308,8 @@ Create the tracking issue **immediately** so all subsequent anchor-accumulation 
 
 1. **Derive the tracking-issue title** from `FEATURE_DESCRIPTION`: take the first line if present (everything before the first `\n`), else the first 80 characters; strip leading/trailing whitespace; collapse internal whitespace runs to a single space. Do NOT use any PR-related identifier — the PR is not created until Step 9.
 
+   **Prepend `[IN PROGRESS]` (followed by a space)** to the derived title. This is the tracking-issue title-prefix lifecycle (see `scripts/tracking-issue-write.md` "Title-prefix lifecycle"): `[IN PROGRESS]` signals an active run, later flipped to `[DONE]` on confirmed merge (Step 12a/12b), or `[STALLED]` on failure paths (Step 18). `/fix-issue`'s `fetch-eligible-issue.sh` excludes any title starting with a managed prefix from auto-pick, so prefixed tracking issues never appear as candidates. Adopted issues (Branch 2/3) do NOT get the prefix — user may own the title, and the title-prefix lifecycle is machine-owned. Distinct from `/fix-issue`'s comment-based "IN PROGRESS" lock (concurrency control on the subject issue); the two mechanisms coexist.
+
 2. **Sanitize `FEATURE_DESCRIPTION` at compose time** (MANDATORY — parallel to the anchor compose-time sanitization rule in `anchor-comment-template.md`, and a strict gate because the issue body is a public GitHub surface). Apply prompt-level redaction to the prompt text BEFORE it is written to the issue body:
    - Secrets / API keys / OAuth / JWT / passwords / certificates → `<REDACTED-TOKEN>`
    - Internal hostnames / URLs / private IPs → `<INTERNAL-URL>`
@@ -327,9 +329,9 @@ Create the tracking issue **immediately** so all subsequent anchor-accumulation 
    > **Note**: the prompt above was sanitized at compose time (secrets / internal URLs / PII redacted where detected). Operators should still avoid pasting sensitive content into the /implement prompt because sanitization is best-effort and not comprehensive.
    ```
 
-4. **Create the tracking issue**:
+4. **Create the tracking issue** with the `[IN PROGRESS]` prefix (plus a trailing space) applied to the title (see step 1):
    ```bash
-   ${CLAUDE_PLUGIN_ROOT}/scripts/tracking-issue-write.sh create-issue --title "<derived-title>" --body-file "$IMPLEMENT_TMPDIR/tracking-issue-body.md"
+   ${CLAUDE_PLUGIN_ROOT}/scripts/tracking-issue-write.sh create-issue --title "[IN PROGRESS] <derived-title>" --body-file "$IMPLEMENT_TMPDIR/tracking-issue-body.md"
    ```
    Parse `ISSUE_NUMBER` and `ISSUE_URL` from stdout. On `FAILED=true` OR non-zero exit, print `**⚠ 0.5: tracking issue — Branch 4 create-issue failed: $ERROR. Continuing with deferred/absent anchor.**`, log to `Tool Failures`, set `deferred=true`, leave `$ISSUE_NUMBER` unset, and proceed to Step 1. Downstream: Step 9a omits the `Closes #<N>` line entirely and replaces it with `_No tracking issue — auto-close N/A._`; Step 11 branch 3 skips cleanly; Step 18 URL print is silently skipped.
 
@@ -860,7 +862,7 @@ Use `timeout: 1860000` on the Bash call. Parse the same fields as Step 10.
 
    - **`ACTION=rebase`**: print a context-specific message from `CI_STATUS` — `CI_STATUS=pass` → `🔃 12: CI+merge loop — CI passed, main advanced, rebasing + re-bumping`; `CI_STATUS=pending` → `🔃 12: CI+merge loop — main advanced, rebasing + re-bumping`. Invoke the Rebase + Re-bump Sub-procedure with `rebase_already_done=false`, `caller_kind=step12_rebase`. Counter updates and `ci-wait.sh` re-invocation happen inside the sub-procedure's step 7. On hard failure, the sub-procedure bails to 12d directly.
    - **`ACTION=merge`**: print `✅ 12: CI+merge loop — CI passed, main up-to-date, merging! (<elapsed>)` → proceed to **12b**.
-   - **`ACTION=already_merged`**: print `✅ PR was force-merged externally — skipping CI wait and merge. (<elapsed>)`. Set `pr_closed=true` (consumed by Step 16a's outcome state machine). Skip 12b, proceed to Step 14. Counts as merged for Steps 14–15.
+   - **`ACTION=already_merged`**: print `✅ PR was force-merged externally — skipping CI wait and merge. (<elapsed>)`. Set `pr_closed=true` (consumed by Step 16a's outcome state machine). **Title-prefix lifecycle terminal transition**: if `$ISSUE_NUMBER` is set AND the tracking issue is fresh-created (sentinel `ADOPTED=false` — see Step 0.5) AND `repo_unavailable=false`, call `${CLAUDE_PLUGIN_ROOT}/scripts/tracking-issue-write.sh rename --issue $ISSUE_NUMBER --state done`. Best-effort: on `FAILED=true` or non-zero exit, log to `Tool Failures` and continue. Set `DONE_RENAME_APPLIED=true` on any return (including `RENAMED=false` no-op) so Step 18 does not double-fire. Skip 12b, proceed to Step 14. Counts as merged for Steps 14–15.
    - **`ACTION=rebase_then_evaluate`**: invoke the sub-procedure with `rebase_already_done=false`, `caller_kind=step12_rebase_then_evaluate`. On success, **fall through to 12c** (counter updates already done; do NOT re-invoke `ci-wait.sh` here — the sub-procedure's `step12_rebase_then_evaluate` branch skips the re-invocation for this path). On hard failure, the sub-procedure bails to 12d.
    - **`ACTION=evaluate_failure`**: → **12c**.
    - **`ACTION=bail`**: print `BAIL_REASON` → **12d**.
@@ -878,11 +880,11 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/merge-pr.sh --pr <PR-NUMBER> --repo $REPO
 ```
 
 Parse `MERGE_RESULT` and `ERROR`:
-- **`merged`**: print `✅ 12: CI+merge loop — PR #<NUMBER> merged! (<elapsed>)`. Set `pr_closed=true` (consumed by Step 16a's outcome state machine). Continue.
-- **`admin_merged`**: print `**⚠ Merged with --admin (review overridden).** ✅ 12: CI+merge loop — PR #<NUMBER> merged! (<elapsed>)`. Set `pr_closed=true`. Continue.
-- **`main_advanced`**: back to **12a** (next iteration detects behind and rebases).
-- **`ci_not_ready`**: back to **12a** (CI may need more time or a rerun).
-- **`admin_failed`** / **`error`**: bail (12d) with `ERROR`.
+- **`merged`**: print `✅ 12: CI+merge loop — PR #<NUMBER> merged! (<elapsed>)`. Set `pr_closed=true` (consumed by Step 16a's outcome state machine). **Title-prefix lifecycle terminal transition**: if `$ISSUE_NUMBER` set AND `ADOPTED=false` AND `repo_unavailable=false`, call `${CLAUDE_PLUGIN_ROOT}/scripts/tracking-issue-write.sh rename --issue $ISSUE_NUMBER --state done`. Best-effort (log to `Tool Failures` on failure; do not abort the run — the merge has already succeeded). Set `DONE_RENAME_APPLIED=true` on any return. Continue.
+- **`admin_merged`**: print `**⚠ Merged with --admin (review overridden).** ✅ 12: CI+merge loop — PR #<NUMBER> merged! (<elapsed>)`. Set `pr_closed=true`. Apply the same terminal rename-to-done as the `merged` branch (same guards; same `DONE_RENAME_APPLIED=true` on return). Continue.
+- **`main_advanced`**: back to **12a** (next iteration detects behind and rebases). Do NOT rename the tracking issue — the PR is not yet merged.
+- **`ci_not_ready`**: back to **12a** (CI may need more time or a rerun). Do NOT rename.
+- **`admin_failed`** / **`error`**: bail (12d) with `ERROR`. Do NOT rename (12d sets `STALL_TRACKING=true`).
 
 **CRITICAL: The `--admin` safety invariant is enforced inside `merge-pr.sh` — it re-verifies CI and branch freshness before attempting `--admin`. See the script's header for the full invariant. This is the canonical `--admin` implementation.**
 
@@ -911,6 +913,7 @@ Bail if any: 3 fix iterations attempted without progress; failure fundamentally 
 
 **Before proceeding to Step 14**, persist the bail reason + user-input signal into parent scope so Step 16a's outcome state machine can read them:
 - Set `FINAL_BAIL_REASON` = the `BAIL_REASON` value from the `ci-wait.sh` output that triggered the bail (or the caller-synthesized reason if the bail came from the Rebase + Re-bump Sub-procedure, a conflict, or fix-attempt exhaustion). Leave `BAIL_NEEDS_USER_INPUT` alone if it was already set by the Conflict Resolution Procedure Phase 2 under `auto_mode=true`; otherwise it stays `false`.
+- Set `STALL_TRACKING=true` — signals Step 18 to rename the tracking issue's title from `[IN PROGRESS]` to `[STALLED]` (see Step 18 "Title-prefix lifecycle terminal transition").
 
 ## Step 14 — Local Cleanup
 
@@ -993,6 +996,30 @@ If `quick_mode=true`: print `✅ 17: final report — quick mode, /design skippe
 If `quick_mode=false`: print a summary noting plan review findings were reported by `/design` (visible above) and code review findings by `/review` (visible above). If both phases reported all suggestions implemented, print `✅ 17: final report — all suggestions implemented, plan + code review (<elapsed>)`.
 
 ## Step 18 — Cleanup and Final Warnings
+
+### Title-prefix lifecycle terminal transition
+
+Before `cleanup-tmpdir.sh` runs (so `$IMPLEMENT_TMPDIR/parent-issue.md` is still available if needed), flip the tracking issue's title prefix to its terminal state. All three branches share the same pre-conditions:
+
+- `$ISSUE_NUMBER` is set (Branch 4 succeeded, or Branch 1/2/3 adopted).
+- `$ADOPTED=false` (parsed from sentinel at Step 0.5 — Branch 4 fresh-creates). Adopted issues (Branch 2/3) are NEVER retitled by this step; the user may own the title.
+- `$repo_unavailable=false`.
+
+If any precondition is missing, skip the rename block entirely.
+
+**Branch A — STALLED (failure path)**: if `$STALL_TRACKING=true`, check that the issue is still OPEN before renaming (renaming a closed issue to `[STALLED]` is semantically wrong — closed means merged means done):
+
+```bash
+ISSUE_STATE=$(gh issue view "$ISSUE_NUMBER" --json state --jq '.state' 2>/dev/null || echo "")
+```
+
+If `ISSUE_STATE == "OPEN"`, call `${CLAUDE_PLUGIN_ROOT}/scripts/tracking-issue-write.sh rename --issue $ISSUE_NUMBER --state stalled`. Best-effort: on `FAILED=true` or non-zero exit, log to `Tool Failures` and continue. Do not print a completion line; the Step 18 `✅` is sufficient.
+
+**Branch B — DONE (clean non-merge / draft completion)**: if `$STALL_TRACKING=false` AND `$DONE_RENAME_APPLIED` is NOT `true` (merge-path rename didn't already fire) AND `$PR_NUMBER` is set (a PR was created this run), call `rename --state done`. This handles the `--merge=false` and `--draft` paths where `/implement` completes successfully without attempting auto-merge — the run is logically done and the title should reflect that.
+
+**Branch C — no-op**: neither stall nor late-done applies. The merge-path rename (Step 12a `already_merged` / Step 12b `merged` / `admin_merged`) has already set `DONE_RENAME_APPLIED=true`, so this branch is the expected merge-path code flow; nothing more to do.
+
+The `rename` subcommand is idempotent — calling it with the same target state is a no-op (`RENAMED=false`) — so the only practical risk from guard-check errors is a redundant best-effort `gh` call. Failures never abort Step 18.
 
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/scripts/cleanup-tmpdir.sh --dir "$IMPLEMENT_TMPDIR"

--- a/skills/improve-skill/scripts/iteration.sh
+++ b/skills/improve-skill/scripts/iteration.sh
@@ -13,7 +13,7 @@
 # transitions in the parent shell. See SECURITY.md /improve-skill subsection.
 #
 # Usage:
-#   iteration.sh [--no-slack] [--issue <N>] [--breadcrumb-prefix <P>] \
+#   iteration.sh [--no-slack] [--subordinate] [--issue <N>] [--breadcrumb-prefix <P>] \
 #                [--work-dir <path>] [--iter-num <N>] <skill-name>
 #
 # Flags:
@@ -142,6 +142,17 @@ WORK_DIR=""
 OWNS_WORK_DIR="false"   # true only in standalone mode (no --work-dir passed)
 PRESERVE_WORK_DIR="false"  # sticky; once true, cleanup is suppressed (issue #399)
 
+# Tracking-issue title-prefix lifecycle state (see scripts/tracking-issue-write.md).
+# ITERATION_SUCCESS=true → on_success() called before exit; rename-to-done
+# already invoked. EXIT trap skips its best-effort stall rename.
+# ITERATION_SUCCESS=false at EXIT → trap calls rename-to-stalled (best-effort).
+# SUBORDINATE=true (driver.sh sets via --subordinate) → iteration.sh does NOT
+# own the lifecycle; trap skips rename entirely. ADOPTED=true (user passed
+# --issue) → iteration.sh does NOT rename the issue — user may own the title.
+ITERATION_SUCCESS="false"
+SUBORDINATE="false"
+ADOPTED="false"
+
 # shellcheck disable=SC2317  # invoked via trap on EXIT
 cleanup_on_exit() {
   local rc=$?
@@ -153,8 +164,23 @@ cleanup_on_exit() {
     breadcrumb_done "tracking issue URL: ${ISSUE_URL}" || true
   fi
   # Emit KV footer so parsers see the result even when work-dir cleanup fails
-  # (FINDING_2 guarantee).
+  # (FINDING_2 guarantee). MUST stay before the rename call below so the
+  # driver's subprocess-failure detector always sees the footer — a failing
+  # `gh issue edit` MUST NOT starve the footer emission.
   emit_kv_footer || true
+  # Title-prefix lifecycle terminal transition (best-effort; MUST NOT touch
+  # kernel stdout shape or exit semantics — all gh output suppressed, errors
+  # swallowed with `|| true`). Skip entirely when this iteration does NOT own
+  # the lifecycle: SUBORDINATE=true (driver owns), ADOPTED=true (user-owned
+  # title), or ISSUE_NUM unset (creation failed before we got here).
+  if [[ "$SUBORDINATE" != "true" && "$ADOPTED" != "true" && -n "${ISSUE_NUM:-}" ]]; then
+    if [[ "$ITERATION_SUCCESS" != "true" ]]; then
+      # on_success not called — iteration stalled / failed. Rename to [STALLED].
+      "${CLAUDE_PLUGIN_ROOT:-}/scripts/tracking-issue-write.sh" rename \
+        --issue "$ISSUE_NUM" --state stalled >/dev/null 2>&1 || true
+    fi
+    # ITERATION_SUCCESS=true → on_success already ran rename-to-done; no-op here.
+  fi
   # Retention gate (issue #399): preserve the work-dir on any non-success
   # iteration status so operators can inspect per-iteration artifacts
   # (iter-<N>-*.txt and .stderr sidecars). Cleanup still runs on grade_a/ok.
@@ -173,6 +199,22 @@ cleanup_on_exit() {
 }
 trap cleanup_on_exit EXIT
 
+# on_success — called before both success terminals (grade-A short-circuit at
+# Step 4.j.v, and normal `ok` exit at Step 5). Flips ITERATION_SUCCESS=true
+# so the EXIT trap skips the stall rename, then renames the tracking issue
+# to [DONE] (only when this iteration owns the lifecycle — same guards as
+# the trap). Best-effort: gh failures are swallowed; success flag is set
+# FIRST so a gh failure cannot cause the trap to later overwrite [DONE]
+# with [STALLED].
+# shellcheck disable=SC2317  # invoked via explicit call site at success exits
+on_success() {
+  ITERATION_SUCCESS="true"
+  if [[ "$SUBORDINATE" != "true" && "$ADOPTED" != "true" && -n "${ISSUE_NUM:-}" ]]; then
+    "${CLAUDE_PLUGIN_ROOT:-}/scripts/tracking-issue-write.sh" rename \
+      --issue "$ISSUE_NUM" --state 'done' >/dev/null 2>&1 || true
+  fi
+}
+
 # --------------------------------------------------------------------------
 # Step 1 — Parse flags + positional arg
 # --------------------------------------------------------------------------
@@ -185,6 +227,7 @@ ITER_NUM="1"
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --no-slack) NO_SLACK_FLAG="--no-slack "; shift ;;
+    --subordinate) SUBORDINATE="true"; shift ;;
     --issue)
       if [[ $# -lt 2 || -z "${2:-}" ]]; then
         breadcrumb_warn "1: parse args — --issue requires a value. Aborting."
@@ -229,7 +272,7 @@ while [[ $# -gt 0 ]]; do
       shift 2 ;;
     --) shift; break ;;
     --*)
-      breadcrumb_warn "1: parse args — unknown flag '$1'. Valid flags: --no-slack, --issue, --breadcrumb-prefix, --work-dir, --iter-num."
+      breadcrumb_warn "1: parse args — unknown flag '$1'. Valid flags: --no-slack, --subordinate, --issue, --breadcrumb-prefix, --work-dir, --iter-num."
       KV_EXIT_REASON="unknown flag '$1'"
       exit 1
       ;;
@@ -238,7 +281,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ $# -lt 1 ]]; then
-  breadcrumb_warn "1: parse args — missing <skill-name>. Usage: iteration.sh [--no-slack] [--issue <N>] [--breadcrumb-prefix <P>] [--work-dir <path>] [--iter-num <N>] <skill-name>"
+  breadcrumb_warn "1: parse args — missing <skill-name>. Usage: iteration.sh [--no-slack] [--subordinate] [--issue <N>] [--breadcrumb-prefix <P>] [--work-dir <path>] [--iter-num <N>] <skill-name>"
   KV_EXIT_REASON="missing <skill-name>"
   exit 1
 fi
@@ -376,6 +419,8 @@ KV_ITERATION_TMPDIR="$WORK_DIR"
 
 if [[ -n "$ISSUE_ARG" ]]; then
   ISSUE_NUM="$ISSUE_ARG"
+  ADOPTED="true"  # Title-prefix lifecycle: adopted issues are NOT retitled
+                  # (user may own the title). See scripts/tracking-issue-write.md.
   # Hydrate ISSUE_URL so the EXIT-trap URL breadcrumb fires on standalone-adopt
   # runs too. Loop mode (OWNS_WORK_DIR=false) suppresses the trap line and the
   # driver emits its own URL at loop end, so the hydration is only load-bearing
@@ -398,8 +443,12 @@ else
     printf 'Target: %s\n' "${TARGET_SKILL_PATH}"
   } > "$ISSUE_BODY_FILE"
   ISSUE_CREATE_STDERR="$WORK_DIR/gh-create-issue.stderr"
+  # Tracking-issue title-prefix lifecycle: [IN PROGRESS] at fresh-create;
+  # flipped to [DONE] via on_success helper below on success terminal exits,
+  # or to [STALLED] by the EXIT trap on failure paths. See
+  # scripts/tracking-issue-write.md "Title-prefix lifecycle".
   ISSUE_URL="$(gh issue create \
-    --title "Improve /${SKILL_NAME} skill via /improve-skill (one iteration)" \
+    --title "[IN PROGRESS] Improve /${SKILL_NAME} skill via /improve-skill (one iteration)" \
     --body-file "$ISSUE_BODY_FILE" 2> "$ISSUE_CREATE_STDERR")" || {
     breadcrumb_warn "3: issue — gh issue create failed. Aborting."
     dump_helper_stderr "gh-create-issue" "$ISSUE_CREATE_STDERR"
@@ -722,6 +771,7 @@ if [[ "$KV_GRADE_A" == "true" && "$KV_PARSE_STATUS" == "ok" ]]; then
   KV_ITER_STATUS="grade_a"
   KV_EXIT_REASON="grade A achieved on all dimensions at iteration ${ITER_NUM}"
   breadcrumb_done "4.j.v: grade parse — grade A achieved (iteration done)"
+  on_success
   exit 0
 fi
 
@@ -889,4 +939,5 @@ KV_EXIT_REASON="iteration ${ITER_NUM} completed (continue loop)"
 
 breadcrumb_done "5: iteration complete"
 
+on_success
 exit 0

--- a/skills/improve-skill/scripts/iteration.sh
+++ b/skills/improve-skill/scripts/iteration.sh
@@ -419,8 +419,21 @@ KV_ITERATION_TMPDIR="$WORK_DIR"
 
 if [[ -n "$ISSUE_ARG" ]]; then
   ISSUE_NUM="$ISSUE_ARG"
-  ADOPTED="true"  # Title-prefix lifecycle: adopted issues are NOT retitled
-                  # (user may own the title). See scripts/tracking-issue-write.md.
+  # Title-prefix lifecycle: adopted issues default to ADOPTED=true
+  # (user may own the title). BUT if the current title already starts
+  # with a managed prefix ([IN PROGRESS] / [DONE] / [STALLED] — all
+  # machine-owned markers), the issue is tool-owned and we should
+  # continue to manage its lifecycle (resume from a prior stalled run,
+  # or a continuation of a previous [DONE]). Fetch the title and check
+  # — best-effort; on gh failure leave ADOPTED=true (safer default).
+  ADOPTED="true"
+  _ADOPT_TITLE="$(gh issue view "$ISSUE_NUM" --json title --jq .title 2>/dev/null || printf '')"
+  case "$_ADOPT_TITLE" in
+    '[IN PROGRESS] '*|'[DONE] '*|'[STALLED] '*)
+      ADOPTED="false"  # tool-owned title — keep managing the lifecycle
+      ;;
+  esac
+  unset _ADOPT_TITLE
   # Hydrate ISSUE_URL so the EXIT-trap URL breadcrumb fires on standalone-adopt
   # runs too. Loop mode (OWNS_WORK_DIR=false) suppresses the trap line and the
   # driver emits its own URL at loop end, so the hydration is only load-bearing

--- a/skills/loop-improve-skill/scripts/driver.sh
+++ b/skills/loop-improve-skill/scripts/driver.sh
@@ -106,6 +106,14 @@ breadcrumb_warn()       { printf '**⚠ %s**\n' "$*"; }
 
 LOOP_TMPDIR=""
 LOOP_PRESERVE_TMPDIR="false"   # sticky; once true, cleanup is suppressed
+# Tracking-issue title-prefix lifecycle state (see scripts/tracking-issue-write.md).
+# LOOP_SUCCESS=true → on_success() called before exit; rename-to-done already
+# invoked. EXIT trap skips its best-effort stall rename.
+# LOOP_SUCCESS=false at EXIT → trap calls rename-to-stalled (best-effort).
+# ISSUE_NUM is populated at Step 3 ("create issue"); empty when the trap
+# fires before issue creation (skip rename entirely in that case).
+LOOP_SUCCESS="false"
+ISSUE_NUM=""
 # shellcheck disable=SC2317  # invoked via trap on EXIT
 cleanup_on_exit() {
   local rc=$?
@@ -113,8 +121,17 @@ cleanup_on_exit() {
   if [[ -n "$LOOP_TMPDIR" && -f "$LOOP_TMPDIR/preserve.sentinel" ]]; then
     LOOP_PRESERVE_TMPDIR="true"
   fi
-  # Always emit LOOP_TMPDIR for test-harness parse stability.
+  # Always emit LOOP_TMPDIR for test-harness parse stability. MUST stay
+  # first so test harnesses always see the parse token even when the
+  # rename call below encounters gh failures.
   printf 'LOOP_TMPDIR=%s\n' "${LOOP_TMPDIR}"
+  # Title-prefix lifecycle terminal transition (best-effort; gh output
+  # suppressed; errors swallowed with `|| true`). Skip entirely when
+  # ISSUE_NUM is empty (pre-Step-3 exit).
+  if [[ -n "$ISSUE_NUM" && "$LOOP_SUCCESS" != "true" ]]; then
+    "${CLAUDE_PLUGIN_ROOT:-}/scripts/tracking-issue-write.sh" rename \
+      --issue "$ISSUE_NUM" --state stalled >/dev/null 2>&1 || true
+  fi
   if [[ -n "$LOOP_TMPDIR" && -d "$LOOP_TMPDIR" ]]; then
     if [[ "$LOOP_PRESERVE_TMPDIR" == "true" ]]; then
       breadcrumb_warn "6: cleanup — Retained working directory: ${LOOP_TMPDIR}"
@@ -334,8 +351,11 @@ ISSUE_BODY_FILE="$LOOP_TMPDIR/issue-body.md"
 } > "$ISSUE_BODY_FILE"
 
 ISSUE_CREATE_STDERR="$LOOP_TMPDIR/gh-create-issue.stderr"
+# Tracking-issue title-prefix lifecycle: [IN PROGRESS] at create; flipped
+# to [DONE] via on_success helper below (pre-closeout) or to [STALLED] by
+# the EXIT trap on any bail. See scripts/tracking-issue-write.md.
 ISSUE_URL="$(gh issue create \
-  --title "Improve /${SKILL_NAME} skill via loop-improve-skill" \
+  --title "[IN PROGRESS] Improve /${SKILL_NAME} skill via loop-improve-skill" \
   --body-file "$ISSUE_BODY_FILE" 2> "$ISSUE_CREATE_STDERR")" || {
   breadcrumb_warn "3: create issue — gh issue create failed. Aborting."
   dump_helper_stderr "gh-create-issue" "$ISSUE_CREATE_STDERR"
@@ -438,6 +458,11 @@ while [[ $ITER -le 10 ]]; do
   if [[ -n "$NO_SLACK_FLAG" ]]; then
     ITER_ARGV+=(--no-slack)
   fi
+  # --subordinate: driver owns the tracking-issue title-prefix lifecycle
+  # (see scripts/tracking-issue-write.md). iteration.sh MUST NOT rename the
+  # issue in this mode — the driver renames to [DONE] pre-closeout and the
+  # driver's EXIT trap renames to [STALLED] on bail.
+  ITER_ARGV+=(--subordinate)
   ITER_ARGV+=(--issue "$ISSUE_NUM")
   ITER_ARGV+=(--work-dir "$LOOP_TMPDIR")
   ITER_ARGV+=(--iter-num "$ITER")
@@ -672,6 +697,22 @@ CLOSEOUT_BODY="$LOOP_TMPDIR/closeout-body.md"
 # --------------------------------------------------------------------------
 # Step 5c — Post close-out comment (redacted)
 # --------------------------------------------------------------------------
+
+# Tracking-issue title-prefix lifecycle terminal transition (rename-to-done).
+# Runs BEFORE the closeout comment so the [DONE] flip is the final visible
+# title if the closeout comment later triggers auto-close (it doesn't —
+# driver.sh never calls `gh issue close` — but the ordering is still the
+# semantically correct one: the work is done at this point). Only flip
+# to [DONE] on the grade-A success paths; all other EXIT_REASON values
+# (max iterations, infeasibility, subprocess failures) let the EXIT trap
+# mark [STALLED]. LOOP_SUCCESS is consumed by the EXIT trap.
+case "$EXIT_REASON" in
+  "grade A achieved on all dimensions at iteration "*|"grade A achieved after final post-iter-cap re-evaluation")
+    LOOP_SUCCESS="true"
+    "${CLAUDE_PLUGIN_ROOT:-}/scripts/tracking-issue-write.sh" rename \
+      --issue "$ISSUE_NUM" --state 'done' >/dev/null 2>&1 || true
+    ;;
+esac
 
 CLOSEOUT_REDACTED="${CLOSEOUT_BODY}.redacted"
 REDACT_STDERR="${CLOSEOUT_BODY}.redact.stderr"


### PR DESCRIPTION
## Summary

- Add `[IN PROGRESS]` / `[DONE]` / `[STALLED]` tracking-issue title-prefix lifecycle across `/implement`, `/improve-skill`, and `/loop-improve-skill`, so anyone browsing issues can instantly see which are in flight, done, or stalled.
- Teach `/fix-issue` to exclude any issue whose title starts with a managed prefix from auto-pick and explicit-issue eligibility, so tracking issues never appear as fix-issue candidates.
- Ship one idempotent `tracking-issue-write.sh rename --issue N --state in-progress|done|stalled` subcommand as the single mutator — strip-exactly-one-then-prepend, redact-parity with `create-issue`, char-oriented 256-char truncation.

## Architecture Diagram

```mermaid
flowchart TD
    subgraph shared["scripts/ (shared)"]
        TW["tracking-issue-write.sh<br/>subcommands:<br/>create-issue · append-comment<br/>upsert-anchor · <b>rename</b> (NEW)"]
    end

    subgraph implement["/implement"]
        S0_5_B4["Step 0.5 Branch 4<br/>create: prepend [IN PROGRESS]"]
        S0_5_ADOPT["Step 0.5 Branch 2/3<br/>adopted: ADOPTED=true (no rename)"]
        S12A_AM["Step 12a already_merged → [DONE]"]
        S12B["Step 12b merged/admin_merged → [DONE]"]
        S_BAILS["Step 1.m/1.r/4.r/7.r/7a.r bails<br/>Step 12d bail → STALL_TRACKING=true"]
        S18["Step 18 terminal:<br/>if STALL_TRACKING → [STALLED]<br/>elif PR+clean → [DONE]<br/>(guards: ADOPTED=false)"]
    end

    subgraph fix["/fix-issue"]
        FE["fetch-eligible-issue.sh<br/>NEW title-prefix filter<br/>(auto-pick + explicit)"]
    end

    subgraph improve["/improve-skill (standalone)"]
        ITER["iteration.sh<br/>[IN PROGRESS] at create<br/>--subordinate suppresses rename<br/>on_success (grade-A + normal)<br/>EXIT trap: footer → rename-stalled"]
    end

    subgraph loop["/loop-improve-skill"]
        DRV["driver.sh<br/>[IN PROGRESS] at create<br/>pre-closeout rename-done (grade-A only)<br/>EXIT trap: footer → rename-stalled<br/>invokes iteration.sh --subordinate"]
    end

    S0_5_B4 --> TW
    S0_5_ADOPT -.->|guard| S18
    S12A_AM --> TW
    S12B --> TW
    S_BAILS --> S18
    S18 --> TW
    ITER --> TW
    DRV --> TW
    DRV -->|--subordinate| ITER
    FE -.->|filters prefixed titles| TW
```

## Code Flow Diagram

```mermaid
sequenceDiagram
    actor User
    participant Impl as /implement
    participant IW as tracking-issue-write.sh
    participant GH as GitHub
    participant FE as /fix-issue
    participant Drv as driver.sh
    participant Iter as iteration.sh

    User->>Impl: /implement --merge "feature X"
    Impl->>IW: create-issue --title "[IN PROGRESS] feature X"
    IW->>GH: gh issue create
    GH-->>Impl: ISSUE_NUMBER=N

    Note over Impl,GH: Happy path — merge
    Impl->>IW: rename --state done (pre merge-pr.sh)
    IW->>GH: gh issue edit --title "[DONE] feature X"
    Impl->>GH: merge-pr.sh → merged

    Note over Impl,GH: Failure path — bail
    Note over Impl: Step 12d or 1.m rebase fail → STALL_TRACKING=true
    Impl->>IW: rename --state stalled (Step 18)

    User->>FE: /fix-issue (auto-pick or --issue)
    FE->>FE: has_managed_prefix() — skip prefixed

    User->>Drv: /loop-improve-skill my-skill
    Drv->>GH: gh issue create --title "[IN PROGRESS] Improve /my-skill…"
    loop up to 10 rounds
        Drv->>Iter: --subordinate --issue N
    end
    alt grade A
        Drv->>IW: rename --state done
    else bail/max-iters
        Drv->>IW: rename --state stalled (EXIT trap)
    end

    User->>Iter: /improve-skill --issue 42 my-skill
    Iter->>GH: gh issue view --json title
    alt managed prefix
        Note over Iter: Tool-owned → ADOPTED=false, manage lifecycle
    else user-owned
        Note over Iter: ADOPTED=true → skip all renames
    end
```

## Test plan

- [x] New unit tests `(j1)-(j7)` in `scripts/test-tracking-issue-write.sh` (base rename, transition, idempotent no-op, strip-exactly-one, redaction, invalid --state, redactable-title idempotent no-op).
- [x] Existing `scripts/test-improve-skill-iteration.sh` — 77/77 pass (no regressions in KV-footer contract).
- [x] Existing `scripts/test-loop-improve-skill-driver.sh` — 59/59 pass (no regressions in retention / subprocess-failure detection).
- [x] `/relevant-checks` — pre-commit (shellcheck + markdownlint + JSON validation + agent-lint + secret detection) + full-repo agent-lint → all green.
- [x] End-to-end dogfood on this PR: tracking issue [#403](https://github.com/zhupanov/larch/issues/403) was created with `[IN PROGRESS]` prefix; on successful merge it will rename to `[DONE]` before auto-close.

Closes #403

🤖 Generated with [Claude Code](https://claude.com/claude-code)
