### PR TITLE
Add IN PROGRESS lock check to /fix-issue explicit-mode (#410)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.0.5",
+  "version": "7.0.6",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.0.6] - 2026-04-24
+
+### Fixed
+
+- `skills/fix-issue/scripts/fetch-eligible-issue.sh` explicit-issue path now emits a lock-specific error (`Issue #N is locked by another /fix-issue run (last comment: IN PROGRESS)`) when the requested issue's last comment is `IN PROGRESS`, instead of the misleading `not approved` framing. Mirrors the auto-pick path's existing `IN PROGRESS` skip; behavior is unchanged (already rejected via the GO check), only the message clarity improves. Closes #410.
+
 ## [7.0.5] - 2026-04-24
 
 ### Added

--- a/skills/fix-issue/scripts/fetch-eligible-issue.sh
+++ b/skills/fix-issue/scripts/fetch-eligible-issue.sh
@@ -317,6 +317,16 @@ if [[ -n "$ISSUE_ARG" ]]; then
 
     TRIMMED=$(echo "$LAST_COMMENT" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
 
+    # Reject with a lock-specific error when the issue is locked by a
+    # concurrent /fix-issue run. Mirrors the auto-pick path's IN PROGRESS
+    # skip below; without this branch the GO check would still reject but
+    # with the misleading "not approved" framing.
+    if [ "$TRIMMED" = "IN PROGRESS" ]; then
+        echo "ELIGIBLE=false"
+        echo "ERROR=Issue #$ISSUE_NUM is locked by another /fix-issue run (last comment: IN PROGRESS)"
+        exit 2
+    fi
+
     if [ "$TRIMMED" != "GO" ]; then
         echo "ELIGIBLE=false"
         echo "ERROR=Issue #$ISSUE_NUM is not approved (last comment: ${TRIMMED:-empty})"


### PR DESCRIPTION
## Summary
- Added a lock-specific `IN PROGRESS` last-comment branch to `fetch-eligible-issue.sh`'s explicit-issue path so the rejection message accurately reflects a `/fix-issue` lock instead of "not approved", bringing the explicit and auto-pick paths to message-symmetry.

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] `/relevant-checks` (pre-commit lint + agent-lint) green on the changed file.
- [x] Inserted block trims comparison input (uses `$TRIMMED`) and exits with code 2, matching the explicit-mode contract.
- [x] Auto-pick path's `IN PROGRESS` `continue` branch is unchanged; only explicit mode gains the new error.

</details>

Closes #410

Generated with [Claude Code](https://claude.com/claude-code)
