### PR TITLE
Add provenance schema (clause 4) to /research RESEARCH_PROMPT (Phase 1, umbrella #413)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.0.6",
+  "version": "7.0.7",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.0.7] - 2026-04-24
+
+### Changed
+
+- `skills/research/references/research-phase.md`: shared `RESEARCH_PROMPT` literal now mandates a provenance schema (Phase 1 of umbrella #413). Added clause (4) requiring every concrete claim to carry one of `file:line` / `file:line-range`, a fenced command + output snippet, or a URL; tightened the existing "Explore the codebase to ground your findings" sentence to point at clause (4). Phase 1 is schema-only — no validator change yet (Phase 3, #416). Closes #414.
+
 ## [7.0.6] - 2026-04-24
 
 ### Fixed

--- a/skills/research/references/research-phase.md
+++ b/skills/research/references/research-phase.md
@@ -26,7 +26,7 @@ The 3 research agents:
 
 **Shared prompt** (used verbatim by all 3 lanes — Cursor, Codex, inline Claude, and any Claude fallbacks):
 
-`RESEARCH_PROMPT` = `"You are researching a codebase to answer this question: <RESEARCH_QUESTION>. Consider alternative perspectives to the obvious interpretation. Actively scrutinize for edge cases, gaps, missing pieces, and assumption failures. Explore the codebase to ground your findings. Write 2-3 paragraphs covering: (1) key findings and observations, including any that challenge the obvious reading, (2) relevant files/modules/areas and architectural patterns, (3) risks, constraints, feasibility concerns, edge cases, and gaps. Do NOT modify files."`
+`RESEARCH_PROMPT` = ``"You are researching a codebase to answer this question: <RESEARCH_QUESTION>. Consider alternative perspectives to the obvious interpretation. Actively scrutinize for edge cases, gaps, missing pieces, and assumption failures. Explore the codebase to ground your findings with verifiable provenance (see (4)). Write 2-3 paragraphs covering: (1) key findings and observations, including any that challenge the obvious reading, (2) relevant files/modules/areas and architectural patterns, (3) risks, constraints, feasibility concerns, edge cases, and gaps, (4) Every concrete claim must carry provenance: a `file:line` (or `file:line-range`) reference for repo-internal claims, a fenced command + 1–3 lines of its output for behavior claims, or a URL for external claims. Pure prose summaries without provenance are acceptable only for synthesis sentences that aggregate already-cited claims. Do NOT modify files."``
 
 **Cursor research** (if `cursor_available`):
 


### PR DESCRIPTION
## Summary
- Added a provenance schema (clause 4) to the shared `RESEARCH_PROMPT` literal in `skills/research/references/research-phase.md` (Phase 1 of umbrella #413). Every concrete claim a research lane writes must now carry one of: `file:line` (or `file:line-range`) for repo-internal claims, a fenced command + 1–3 lines of output for behavior claims, or a URL for external claims. Tightened the existing "Explore the codebase to ground your findings" sentence to point at clause (4).
- Phase 1 is schema-only — no validator or synthesis-instruction change. Enforcement lives in Phase 3 (#416); external-evidence broadening lives in Phase 2 (#415).
- Bumped plugin version to `7.0.7` (PATCH) and recorded the change in `CHANGELOG.md`.

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] `bash scripts/test-research-structure.sh` — passes (the test pins the `RESEARCH_PROMPT` identifier and the opening substring; both preserved).
- [x] `/relevant-checks` — pre-commit hooks + `agent-lint` pass on the changed file and full repo.

</details>

Closes #414

Generated with [Claude Code](https://claude.com/claude-code)
