### PR TITLE
Add /research lane attribution: distinguish binary-missing/probe-failed/runtime-timeout (#421)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.0.10",
+  "version": "7.0.11",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.0.11] - 2026-04-24
+
+### Changed
+
+- `skills/research/SKILL.md` Step 3 final-report header now distinguishes WHY each external lane fell back to a Claude subagent instead of collapsing to ✅/❌. Five canonical states render: `✅` (ran natively), `Claude-fallback (binary missing)`, `Claude-fallback (probe failed: <reason>)`, `Claude-fallback (runtime timeout)`, and `Claude-fallback (runtime failed: <reason>)`. Pre-launch state from `session-setup.sh --check-reviewers` (`*_AVAILABLE`/`*_HEALTHY`/`*_PROBE_ERROR`) and runtime state from `collect-reviewer-results.sh` (`STATUS`/`FAILURE_REASON`) accumulate into `$RESEARCH_TMPDIR/lane-status.txt` via surgical phase-local rewrites at Step 0b (init), Step 1.3 (research runtime), Step 2 entry (propagate research-phase fallbacks to validation lanes), and Step 2.4 (validation runtime). New `scripts/render-lane-status.sh` (with sibling `.md` contract and 10-fixture regression harness wired into `make lint`) parses the KV file at Step 3 and emits the rendered header lines; the Code (Claude code-reviewer subagent) lane is hard-coded `✅` (no fallback path). KV writes use quoted heredocs (`<<'EOF'`) to neutralize shell-injection vectors in untrusted probe-error text. `scripts/test-research-structure.sh` extended with two new structural pins (Step 3 references `render-lane-status.sh`; both phase references mention `lane-status.txt`). Closes #421.
+
 ## [7.0.10] - 2026-04-24
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Larch Makefile
 # Thin wrapper around pre-commit. Linter definitions live in .pre-commit-config.yaml.
 
-.PHONY: lint lint-only test-harnesses shellcheck markdownlint jsonlint actionlint agent-lint agnix gitleaks trufflehog setup test-redact test-parse-input test-parse-args test-parse-prose-blockers test-issue-lifecycle test-fix-issue-bail-detection test-sessionstart test-audit-edit-write test-block-submodule test-deny-edit-write test-post-scaffold-hints test-render-skill test-verify-skill-called test-check-bump-version test-lint-skill-invocations test-anti-halt test-orchestrator-scope-sync test-design-structure test-implement-rebase-macro test-implement-structure test-quick-mode-docs-sync test-references-headers test-render-reviewer-prompt test-research-structure test-review-structure test-subskill-anchors test-loop-improve-skill-driver test-loop-improve-skill-skill-md test-improve-skill-iteration test-improve-skill-skill-md test-parse-skill-judge-grade test-lib-halt-ledger test-tracking-issue-write test-tracking-issue-read-sentinel test-assemble-anchor smoke-dialectic halt-rate-probe
+.PHONY: lint lint-only test-harnesses shellcheck markdownlint jsonlint actionlint agent-lint agnix gitleaks trufflehog setup test-redact test-parse-input test-parse-args test-parse-prose-blockers test-issue-lifecycle test-fix-issue-bail-detection test-sessionstart test-audit-edit-write test-block-submodule test-deny-edit-write test-post-scaffold-hints test-render-skill test-render-lane-status test-verify-skill-called test-check-bump-version test-lint-skill-invocations test-anti-halt test-orchestrator-scope-sync test-design-structure test-implement-rebase-macro test-implement-structure test-quick-mode-docs-sync test-references-headers test-render-reviewer-prompt test-research-structure test-review-structure test-subskill-anchors test-loop-improve-skill-driver test-loop-improve-skill-skill-md test-improve-skill-iteration test-improve-skill-skill-md test-parse-skill-judge-grade test-lib-halt-ledger test-tracking-issue-write test-tracking-issue-read-sentinel test-assemble-anchor smoke-dialectic halt-rate-probe
 
 # CI splits `lint` into `lint-only` (pre-commit) and `test-harnesses`
 # (regression harnesses). `lint` remains the local-dev convenience target
@@ -11,7 +11,7 @@ lint: test-harnesses lint-only
 lint-only:
 	pre-commit run --all-files
 
-test-harnesses: test-redact test-parse-input test-parse-args test-parse-prose-blockers test-issue-lifecycle test-fix-issue-bail-detection test-sessionstart test-audit-edit-write test-block-submodule test-deny-edit-write test-post-scaffold-hints test-render-skill test-verify-skill-called test-check-bump-version test-lint-skill-invocations test-anti-halt test-orchestrator-scope-sync test-design-structure test-implement-rebase-macro test-implement-structure test-quick-mode-docs-sync test-references-headers test-render-reviewer-prompt test-research-structure test-review-structure test-subskill-anchors test-loop-improve-skill-driver test-loop-improve-skill-skill-md test-improve-skill-iteration test-improve-skill-skill-md test-parse-skill-judge-grade test-lib-halt-ledger test-tracking-issue-write test-tracking-issue-read-sentinel test-assemble-anchor
+test-harnesses: test-redact test-parse-input test-parse-args test-parse-prose-blockers test-issue-lifecycle test-fix-issue-bail-detection test-sessionstart test-audit-edit-write test-block-submodule test-deny-edit-write test-post-scaffold-hints test-render-skill test-render-lane-status test-verify-skill-called test-check-bump-version test-lint-skill-invocations test-anti-halt test-orchestrator-scope-sync test-design-structure test-implement-rebase-macro test-implement-structure test-quick-mode-docs-sync test-references-headers test-render-reviewer-prompt test-research-structure test-review-structure test-subskill-anchors test-loop-improve-skill-driver test-loop-improve-skill-skill-md test-improve-skill-iteration test-improve-skill-skill-md test-parse-skill-judge-grade test-lib-halt-ledger test-tracking-issue-write test-tracking-issue-read-sentinel test-assemble-anchor
 
 test-redact:
 	bash scripts/test-redact-secrets.sh
@@ -48,6 +48,9 @@ test-post-scaffold-hints:
 
 test-render-skill:
 	bash skills/create-skill/scripts/test-render-skill-md.sh
+
+test-render-lane-status:
+	bash scripts/test-render-lane-status.sh
 
 test-verify-skill-called:
 	bash scripts/test-verify-skill-called.sh

--- a/agent-lint.toml
+++ b/agent-lint.toml
@@ -378,6 +378,13 @@ exclude = [
   # target only (no SKILL.md invocation). Same Makefile-only shape as the
   # other test-* harnesses above.
   "scripts/test-assemble-anchor.sh",
+  # scripts/test-render-lane-status.sh is the regression harness for
+  # scripts/render-lane-status.sh (the /research lane-attribution formatter
+  # added by #421). Wired only via Makefile test-render-lane-status target;
+  # the formatter itself IS structurally referenced from skills/research/
+  # SKILL.md Step 3, but the harness is not — same Makefile-only shape as
+  # the other test-* harnesses above.
+  "scripts/test-render-lane-status.sh",
   # Skill-local sibling .md files — co-located contract docs for scripts
   # under skills/<name>/scripts/. Not orchestrator references (not cited
   # from the owning SKILL.md by design — contributors discover them by

--- a/scripts/render-lane-status.md
+++ b/scripts/render-lane-status.md
@@ -1,0 +1,92 @@
+# `scripts/render-lane-status.sh` — sibling contract
+
+## Purpose
+
+Format the per-lane attribution record used by `/research`'s Step 3 final-report header. Reads a small KV file, emits two `<NAME>_HEADER=<value>` lines on stdout that SKILL.md Step 3 substitutes into the report. Closes #421.
+
+## Invariants
+
+1. **Pure formatter** — no I/O beyond stdin/stdout/stderr. No git, no network, no temp files. Reads `--input <path>`; writes two lines to stdout; exits.
+2. **3-lane count is hard-coded** — both header lines emit `3 agents` / `3 reviewers`. The 3-lane invariant is pinned in `skills/research/references/research-phase.md` and `validation-phase.md`; if the lane count ever changes, this script and those references must be updated together.
+3. **Code lane is hard-coded `✅`** — the Claude code-reviewer subagent has no fallback path (it is the always-on lane in the validation phase). This script does NOT consult the input file for the Code lane.
+4. **Status tokens are the single rendering vocabulary** — the case statement in `render_lane()` is the authoritative token list. Tokens that do not match render as `(unknown)` with a stderr warning.
+5. **Reasons are sanitized on render** — defense-in-depth. The orchestrator prompt in SKILL.md / phase references is supposed to sanitize before heredoc-write, but `sanitize_reason()` re-applies the same rules so a misformed file never breaks the report markdown.
+
+## Input KV schema
+
+```
+RESEARCH_CURSOR_STATUS=<token>
+RESEARCH_CURSOR_REASON=<short reason text>
+RESEARCH_CODEX_STATUS=<token>
+RESEARCH_CODEX_REASON=<short reason text>
+VALIDATION_CURSOR_STATUS=<token>
+VALIDATION_CURSOR_REASON=<short reason text>
+VALIDATION_CODEX_STATUS=<token>
+VALIDATION_CODEX_REASON=<short reason text>
+```
+
+All keys are optional. A missing or empty `*_STATUS` renders as `(unknown)`.
+
+## Status tokens (canonical)
+
+| Token | Rendered |
+|-------|----------|
+| `ok` | `✅` |
+| `fallback_binary_missing` | `Claude-fallback (binary missing)` |
+| `fallback_probe_failed` | `Claude-fallback (probe failed: <reason>)` (parenthetical omitted when reason empty) |
+| `fallback_runtime_timeout` | `Claude-fallback (runtime timeout)` |
+| `fallback_runtime_failed` | `Claude-fallback (runtime failed: <reason>)` (parenthetical omitted when reason empty) |
+| anything else / empty | `(unknown)` (with stderr warning) |
+
+## Reason sanitization
+
+Applied inside the script after parse, before render:
+
+1. Collapse all whitespace runs (incl. `\n`, `\t`, `\r`) into single spaces.
+2. Strip embedded `=` and `|` characters.
+3. Trim leading/trailing whitespace.
+4. Truncate to 80 characters.
+
+The orchestrator prompt should apply the same rules before writing to `lane-status.txt` (defense-in-depth).
+
+## Output (stdout)
+
+```
+RESEARCH_HEADER=3 agents (Cursor: <rendered>, Codex: <rendered>)
+VALIDATION_HEADER=3 reviewers (Code: ✅, Cursor: <rendered>, Codex: <rendered>)
+```
+
+The orchestrator parses these lines via prefix-strip (e.g., `RESEARCH_HEADER="${line#RESEARCH_HEADER=}"`), not `cut -d=`, so values containing `=` are not truncated (the script's sanitization strips `=` from reasons, but the orchestrator should be `=`-safe regardless).
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | Usage error (missing flag, unknown flag) |
+| 2 | I/O failure (input file missing or unreadable) |
+
+## Stderr
+
+| Trigger | Message | Exit |
+|---------|---------|------|
+| `--input` missing | `**⚠ render-lane-status: input file missing**` | 2 |
+| `--input` unreadable | `**⚠ render-lane-status: input file unreadable**` | 2 |
+| Unknown status token | `**⚠ render-lane-status: unknown status token <token>**` | 0 (per occurrence) |
+
+## Consumers
+
+- `skills/research/SKILL.md` Step 3 — invokes the script and parses both header lines into the final report.
+- `skills/research/references/research-phase.md` Step 1.3 — surgically updates the `RESEARCH_*` slice of `lane-status.txt` after `collect-reviewer-results.sh` returns.
+- `skills/research/references/validation-phase.md` Step 2 entry + Step 2.4 — surgically updates the `VALIDATION_*` slice (Step 2 entry propagates downgrades from research phase per #421 plan-review FINDING_6; Step 2.4 captures runtime failures).
+
+## Test harness
+
+`scripts/test-render-lane-status.sh` — offline regression harness, 9 fixtures. Wired via the Makefile `test-render-lane-status` target into `test-harnesses`. The harness MUST stay in sync with the case statement in `render_lane()` and the sanitization rules in `sanitize_reason()`. When adding a new status token, add a fixture; when changing the rendered string for an existing token, update the byte-exact assertions.
+
+## Edit-in-sync rules
+
+- **Adding/removing/renaming a status token** → update the case statement in `render_lane()`, the table in this contract, the orchestrator-side mapping in `skills/research/references/research-phase.md` (Step 1.3) and `validation-phase.md` (Step 2.4), and add/update a fixture in `scripts/test-render-lane-status.sh`.
+- **Changing the rendered string for an existing token** → update `render_lane()`, the table above, and the byte-exact stdout assertion in the harness fixture.
+- **Changing the reason sanitization rules** → update `sanitize_reason()`, the "Reason sanitization" section above, and the orchestrator-side prompt sanitization in SKILL.md Step 0a / phase references' Step 1.3 / 2.4.
+- **Changing the lane count or the Code-lane special case** → update both `printf` lines at the bottom of the script, the "Invariants" section above, and the "all 8 structural invariants hold" success message in `scripts/test-research-structure.sh`.

--- a/scripts/render-lane-status.md
+++ b/scripts/render-lane-status.md
@@ -6,7 +6,7 @@ Format the per-lane attribution record used by `/research`'s Step 3 final-report
 
 ## Invariants
 
-1. **Pure formatter** — no I/O beyond stdin/stdout/stderr. No git, no network, no temp files. Reads `--input <path>`; writes two lines to stdout; exits.
+1. **Pure formatter** — I/O is limited to the single input file path (`--input`) plus stdout/stderr (stdin is unused). No git, no network, no temp files.
 2. **3-lane count is hard-coded** — both header lines emit `3 agents` / `3 reviewers`. The 3-lane invariant is pinned in `skills/research/references/research-phase.md` and `validation-phase.md`; if the lane count ever changes, this script and those references must be updated together.
 3. **Code lane is hard-coded `✅`** — the Claude code-reviewer subagent has no fallback path (it is the always-on lane in the validation phase). This script does NOT consult the input file for the Code lane.
 4. **Status tokens are the single rendering vocabulary** — the case statement in `render_lane()` is the authoritative token list. Tokens that do not match render as `(unknown)` with a stderr warning.
@@ -36,7 +36,8 @@ All keys are optional. A missing or empty `*_STATUS` renders as `(unknown)`.
 | `fallback_probe_failed` | `Claude-fallback (probe failed: <reason>)` (parenthetical omitted when reason empty) |
 | `fallback_runtime_timeout` | `Claude-fallback (runtime timeout)` |
 | `fallback_runtime_failed` | `Claude-fallback (runtime failed: <reason>)` (parenthetical omitted when reason empty) |
-| anything else / empty | `(unknown)` (with stderr warning) |
+| `` (missing or empty) | `(unknown)` (no stderr warning) |
+| anything else, non-empty | `(unknown)` (with stderr warning) |
 
 ## Reason sanitization
 
@@ -68,11 +69,28 @@ The orchestrator parses these lines via prefix-strip (e.g., `RESEARCH_HEADER="${
 
 ## Stderr
 
+Two distinct error paths share this surface:
+
+**Usage errors (exit 1):** the `--input` flag was omitted, or an unknown flag was supplied.
+
 | Trigger | Message | Exit |
 |---------|---------|------|
-| `--input` missing | `**⚠ render-lane-status: input file missing**` | 2 |
-| `--input` unreadable | `**⚠ render-lane-status: input file unreadable**` | 2 |
-| Unknown status token | `**⚠ render-lane-status: unknown status token <token>**` | 0 (per occurrence) |
+| `--input` flag omitted | `**⚠ render-lane-status: --input is required**` | 1 |
+| Unknown flag | `**⚠ render-lane-status: unknown flag: <flag>**` | 1 |
+| `--input` flag with no value | `**⚠ render-lane-status: --input requires a value**` | 1 |
+
+**Input-file errors (exit 2):** the `--input` flag was supplied but its path is missing or unreadable.
+
+| Trigger | Message | Exit |
+|---------|---------|------|
+| Path does not exist (or is not a regular file) | `**⚠ render-lane-status: input file missing**` | 2 |
+| Path exists but is not readable | `**⚠ render-lane-status: input file unreadable**` | 2 |
+
+**Per-occurrence warnings (exit 0):** emitted while rendering and do not block exit status.
+
+| Trigger | Message | Exit |
+|---------|---------|------|
+| Unknown non-empty status token | `**⚠ render-lane-status: unknown status token <token>**` | 0 (per occurrence) |
 
 ## Consumers
 

--- a/scripts/render-lane-status.sh
+++ b/scripts/render-lane-status.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# render-lane-status.sh — format the per-lane attribution record into the two
+# header lines used by /research's Step 3 final report.
+#
+# Reads a small KV file holding the codified status of each external lane
+# (Research × Cursor/Codex + Validation × Cursor/Codex) and emits two
+# `<NAME>_HEADER=<value>` lines on stdout that SKILL.md Step 3 substitutes
+# into the report. The Code (Claude code-reviewer subagent) lane has no
+# fallback path and is rendered as a hard-coded ✅.
+#
+# Usage:
+#   render-lane-status.sh --input <path>
+#
+# Input KV schema (8 keys, all optional — missing keys render as `(unknown)`):
+#   RESEARCH_CURSOR_STATUS=<token>
+#   RESEARCH_CURSOR_REASON=<short reason text>
+#   RESEARCH_CODEX_STATUS=<token>
+#   RESEARCH_CODEX_REASON=<short reason text>
+#   VALIDATION_CURSOR_STATUS=<token>
+#   VALIDATION_CURSOR_REASON=<short reason text>
+#   VALIDATION_CODEX_STATUS=<token>
+#   VALIDATION_CODEX_REASON=<short reason text>
+#
+# Status tokens (canonical):
+#   ok                            → ✅
+#   fallback_binary_missing       → Claude-fallback (binary missing)
+#   fallback_probe_failed         → Claude-fallback (probe failed: <reason>)
+#                                   (parenthetical omitted when REASON is empty)
+#   fallback_runtime_timeout      → Claude-fallback (runtime timeout)
+#   fallback_runtime_failed       → Claude-fallback (runtime failed: <reason>)
+#                                   (parenthetical omitted when REASON is empty)
+#   <anything else / missing>     → (unknown)  + stderr warning
+#
+# Reason sanitization (applied after parse, before render):
+#   - collapse all whitespace runs (incl. \n, \t, \r) into single spaces
+#   - strip embedded `=` and `|` characters
+#   - trim leading/trailing whitespace
+#   - truncate to 80 characters
+#
+# Output (KEY=value on stdout):
+#   RESEARCH_HEADER=3 agents (Cursor: <rendered>, Codex: <rendered>)
+#   VALIDATION_HEADER=3 reviewers (Code: ✅, Cursor: <rendered>, Codex: <rendered>)
+#
+# Exit codes:
+#   0 — success
+#   1 — usage error (missing flag, unknown flag)
+#   2 — I/O failure (input file missing or unreadable)
+#
+# Stderr:
+#   `**⚠ render-lane-status: input file missing**`     (exit 2)
+#   `**⚠ render-lane-status: unknown status token <t>**` (per-occurrence; exit 0)
+
+set -euo pipefail
+
+fail_usage() {
+    echo "**⚠ render-lane-status: $1**" >&2
+    exit 1
+}
+
+INPUT=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --input)
+            [ $# -ge 2 ] || fail_usage "--input requires a value"
+            INPUT="$2"; shift 2 ;;
+        --help|-h)
+            sed -n '2,52p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0 ;;
+        *)
+            fail_usage "unknown flag: $1" ;;
+    esac
+done
+
+[ -n "$INPUT" ] || fail_usage "--input is required"
+
+if [ ! -f "$INPUT" ]; then
+    echo "**⚠ render-lane-status: input file missing**" >&2
+    exit 2
+fi
+if [ ! -r "$INPUT" ]; then
+    echo "**⚠ render-lane-status: input file unreadable**" >&2
+    exit 2
+fi
+
+# Parse the KV file. Use prefix-strip (not `cut -d=`) so values containing `=`
+# don't get truncated. Each line: KEY=VALUE; lines without `=` and lines with
+# unrecognized keys are silently ignored.
+RESEARCH_CURSOR_STATUS=""
+RESEARCH_CURSOR_REASON=""
+RESEARCH_CODEX_STATUS=""
+RESEARCH_CODEX_REASON=""
+VALIDATION_CURSOR_STATUS=""
+VALIDATION_CURSOR_REASON=""
+VALIDATION_CODEX_STATUS=""
+VALIDATION_CODEX_REASON=""
+
+while IFS= read -r line || [ -n "$line" ]; do
+    case "$line" in
+        ''|'#'*) continue ;;
+        *=*)
+            key="${line%%=*}"
+            value="${line#*=}"
+            ;;
+        *)
+            continue ;;
+    esac
+    case "$key" in
+        RESEARCH_CURSOR_STATUS)    RESEARCH_CURSOR_STATUS="$value" ;;
+        RESEARCH_CURSOR_REASON)    RESEARCH_CURSOR_REASON="$value" ;;
+        RESEARCH_CODEX_STATUS)     RESEARCH_CODEX_STATUS="$value" ;;
+        RESEARCH_CODEX_REASON)     RESEARCH_CODEX_REASON="$value" ;;
+        VALIDATION_CURSOR_STATUS)  VALIDATION_CURSOR_STATUS="$value" ;;
+        VALIDATION_CURSOR_REASON)  VALIDATION_CURSOR_REASON="$value" ;;
+        VALIDATION_CODEX_STATUS)   VALIDATION_CODEX_STATUS="$value" ;;
+        VALIDATION_CODEX_REASON)   VALIDATION_CODEX_REASON="$value" ;;
+    esac
+done < "$INPUT"
+
+# sanitize_reason — collapse whitespace, strip = and |, trim, truncate to 80.
+# Defense-in-depth: the writer is supposed to sanitize before heredoc-write,
+# but we apply the same rules here so a misformed file never breaks markdown.
+sanitize_reason() {
+    local s="$1"
+    # Strip embedded = and | characters first (stripping can create new
+    # whitespace gaps; the subsequent collapse pass merges them).
+    s="${s//=/}"
+    s="${s//|/}"
+    # Collapse all whitespace runs (incl. tabs, newlines, CRs) to single space.
+    s="$(printf '%s' "$s" | tr -s '[:space:]' ' ')"
+    # Trim leading/trailing whitespace.
+    s="${s#"${s%%[![:space:]]*}"}"
+    s="${s%"${s##*[![:space:]]}"}"
+    # Truncate to 80 characters.
+    if [ "${#s}" -gt 80 ]; then
+        s="${s:0:80}"
+    fi
+    printf '%s' "$s"
+}
+
+# render_lane — given a status token and a (possibly empty) reason, emit the
+# human-readable string. Emits a stderr warning for unknown tokens.
+render_lane() {
+    local status="$1"
+    local reason="$2"
+    local clean
+    clean="$(sanitize_reason "$reason")"
+    case "$status" in
+        ok)
+            printf '✅' ;;
+        fallback_binary_missing)
+            printf 'Claude-fallback (binary missing)' ;;
+        fallback_probe_failed)
+            if [ -n "$clean" ]; then
+                printf 'Claude-fallback (probe failed: %s)' "$clean"
+            else
+                printf 'Claude-fallback (probe failed)'
+            fi ;;
+        fallback_runtime_timeout)
+            printf 'Claude-fallback (runtime timeout)' ;;
+        fallback_runtime_failed)
+            if [ -n "$clean" ]; then
+                printf 'Claude-fallback (runtime failed: %s)' "$clean"
+            else
+                printf 'Claude-fallback (runtime failed)'
+            fi ;;
+        '')
+            printf '(unknown)' ;;
+        *)
+            echo "**⚠ render-lane-status: unknown status token $status**" >&2
+            printf '(unknown)' ;;
+    esac
+}
+
+RESEARCH_CURSOR_RENDERED="$(render_lane "$RESEARCH_CURSOR_STATUS" "$RESEARCH_CURSOR_REASON")"
+RESEARCH_CODEX_RENDERED="$(render_lane "$RESEARCH_CODEX_STATUS" "$RESEARCH_CODEX_REASON")"
+VALIDATION_CURSOR_RENDERED="$(render_lane "$VALIDATION_CURSOR_STATUS" "$VALIDATION_CURSOR_REASON")"
+VALIDATION_CODEX_RENDERED="$(render_lane "$VALIDATION_CODEX_STATUS" "$VALIDATION_CODEX_REASON")"
+
+# 3-lane invariant pinned in research-phase.md and validation-phase.md.
+printf 'RESEARCH_HEADER=3 agents (Cursor: %s, Codex: %s)\n' \
+    "$RESEARCH_CURSOR_RENDERED" "$RESEARCH_CODEX_RENDERED"
+printf 'VALIDATION_HEADER=3 reviewers (Code: ✅, Cursor: %s, Codex: %s)\n' \
+    "$VALIDATION_CURSOR_RENDERED" "$VALIDATION_CODEX_RENDERED"
+
+exit 0

--- a/scripts/render-lane-status.sh
+++ b/scripts/render-lane-status.sh
@@ -29,7 +29,8 @@
 #   fallback_runtime_timeout      → Claude-fallback (runtime timeout)
 #   fallback_runtime_failed       → Claude-fallback (runtime failed: <reason>)
 #                                   (parenthetical omitted when REASON is empty)
-#   <anything else / missing>     → (unknown)  + stderr warning
+#   '' (missing or empty)         → (unknown)   (no stderr warning)
+#   <anything else, non-empty>    → (unknown)   + stderr warning
 #
 # Reason sanitization (applied after parse, before render):
 #   - collapse all whitespace runs (incl. \n, \t, \r) into single spaces
@@ -47,8 +48,15 @@
 #   2 — I/O failure (input file missing or unreadable)
 #
 # Stderr:
-#   `**⚠ render-lane-status: input file missing**`     (exit 2)
-#   `**⚠ render-lane-status: unknown status token <t>**` (per-occurrence; exit 0)
+#   Usage errors (exit 1):
+#     `**⚠ render-lane-status: --input is required**`
+#     `**⚠ render-lane-status: --input requires a value**`
+#     `**⚠ render-lane-status: unknown flag: <flag>**`
+#   Input-file errors (exit 2):
+#     `**⚠ render-lane-status: input file missing**`
+#     `**⚠ render-lane-status: input file unreadable**`
+#   Per-occurrence warnings (exit 0, per occurrence):
+#     `**⚠ render-lane-status: unknown status token <token>**`
 
 set -euo pipefail
 

--- a/scripts/test-render-lane-status.md
+++ b/scripts/test-render-lane-status.md
@@ -1,0 +1,48 @@
+# `scripts/test-render-lane-status.sh` — sibling contract
+
+## Purpose
+
+Offline regression harness for `scripts/render-lane-status.sh`. Asserts byte-exact stdout for happy-path cases and the contract's behavior under error conditions (exit code + stderr) for missing-input and unknown-token fixtures.
+
+## Invocation
+
+```
+make test-render-lane-status
+```
+
+or directly:
+
+```
+bash scripts/test-render-lane-status.sh
+```
+
+Exit 0 on all-pass; exit 1 on any failed assertion (with detailed expected/actual diff on stderr).
+
+## Fixture cases (9)
+
+1. **happy path** — all four lanes report `ok`. Asserts `RESEARCH_HEADER=3 agents (Cursor: ✅, Codex: ✅)` and `VALIDATION_HEADER=3 reviewers (Code: ✅, Cursor: ✅, Codex: ✅)`.
+2. **all-binary-missing** — every external lane reports `fallback_binary_missing`.
+3. **mixed** — one `ok`, one `fallback_runtime_timeout`, two `fallback_binary_missing`.
+4. **probe-failed with reason** — reason text is preserved (no special chars to sanitize away).
+5. **probe-failed without reason** — empty `*_REASON` value renders as bare `Claude-fallback (probe failed)` (no parenthetical).
+6. **runtime-timeout** — token renders the canonical `Claude-fallback (runtime timeout)` string.
+7. **runtime-failed with multi-character-class reason (sanitization)** — embedded `|` and `=` characters are stripped, whitespace runs are collapsed (post-strip).
+   - **7b**: a reason longer than 80 characters is truncated to exactly 80.
+8. **unknown-status token** — a token like `fallback-binary-missing` (with hyphens instead of underscores) renders as `(unknown)` and emits a stderr warning containing `unknown status token <token>`.
+9. **missing-input** — a non-existent `--input` path produces exit code 2 and a stderr line containing `render-lane-status: input file missing`.
+
+The "9 fixture cases" count is documented as the public-surface count even though fixture 7 has a 7b sub-case for the truncation property; both 7 and 7b exercise the same status token (`fallback_runtime_failed`).
+
+## Wired via
+
+- `Makefile` `test-render-lane-status` target.
+- `Makefile` `test-harnesses` aggregate target prerequisite list.
+- `Makefile` `.PHONY` declaration.
+- `agent-lint.toml` `exclude` array (Makefile-only harness; no `SKILL.md` reference, so the dead-script detector would false-flag without the entry).
+
+## Edit-in-sync rules
+
+- **Adding a status token in `render-lane-status.sh`** → add a fixture in this harness, plus update the table in `scripts/render-lane-status.md` and the orchestrator-side mapping in `skills/research/references/{research,validation}-phase.md`.
+- **Changing the rendered string for an existing token** → update the byte-exact stdout assertion in the corresponding fixture, plus the table in `scripts/render-lane-status.md`.
+- **Changing the reason sanitization rules** → fixture 7 (sanitization) and 7b (truncation) cover this; update both if rules change. Also update `sanitize_reason()` in `render-lane-status.sh` and the "Reason sanitization" section of its sibling `.md`.
+- **Changing the exit-code or stderr contract** → fixture 8 (unknown token, exit 0 + stderr warning) and fixture 9 (missing input, exit 2 + stderr) cover both error paths. Update them when the script's stderr message text or exit codes change.

--- a/scripts/test-render-lane-status.md
+++ b/scripts/test-render-lane-status.md
@@ -18,7 +18,7 @@ bash scripts/test-render-lane-status.sh
 
 Exit 0 on all-pass; exit 1 on any failed assertion (with detailed expected/actual diff on stderr).
 
-## Fixture cases (9)
+## Fixture cases (10)
 
 1. **happy path** — all four lanes report `ok`. Asserts `RESEARCH_HEADER=3 agents (Cursor: ✅, Codex: ✅)` and `VALIDATION_HEADER=3 reviewers (Code: ✅, Cursor: ✅, Codex: ✅)`.
 2. **all-binary-missing** — every external lane reports `fallback_binary_missing`.
@@ -26,12 +26,15 @@ Exit 0 on all-pass; exit 1 on any failed assertion (with detailed expected/actua
 4. **probe-failed with reason** — reason text is preserved (no special chars to sanitize away).
 5. **probe-failed without reason** — empty `*_REASON` value renders as bare `Claude-fallback (probe failed)` (no parenthetical).
 6. **runtime-timeout** — token renders the canonical `Claude-fallback (runtime timeout)` string.
-7. **runtime-failed with multi-character-class reason (sanitization)** — embedded `|` and `=` characters are stripped, whitespace runs are collapsed (post-strip).
+7. **runtime-failed with =/|/whitespace sanitization** — embedded `|` and `=` characters are stripped, whitespace runs are collapsed (post-strip). Reason after sanitization is 71 chars (under the 80-char cap), so this fixture does NOT exercise truncation — fixture 7b does.
    - **7b**: a reason longer than 80 characters is truncated to exactly 80.
 8. **unknown-status token** — a token like `fallback-binary-missing` (with hyphens instead of underscores) renders as `(unknown)` and emits a stderr warning containing `unknown status token <token>`.
 9. **missing-input** — a non-existent `--input` path produces exit code 2 and a stderr line containing `render-lane-status: input file missing`.
+10. **usage errors (exit 1)** — two sub-cases pinning the contract's exit-1 path:
+    - **10**: missing `--input` flag entirely → exit 1 with stderr containing `--input is required`.
+    - **10b**: unknown flag (e.g., `--bogus`) → exit 1 with stderr containing `unknown flag: --bogus`.
 
-The "9 fixture cases" count is documented as the public-surface count even though fixture 7 has a 7b sub-case for the truncation property; both 7 and 7b exercise the same status token (`fallback_runtime_failed`).
+The "10 fixture cases" count is documented as the public-surface count even though fixtures 7 and 10 each have one sub-case (7b for truncation, 10b for the unknown-flag variant of usage error).
 
 ## Wired via
 

--- a/scripts/test-render-lane-status.sh
+++ b/scripts/test-render-lane-status.sh
@@ -1,0 +1,272 @@
+#!/usr/bin/env bash
+# test-render-lane-status.sh — offline regression harness for render-lane-status.sh.
+#
+# Asserts byte-exact stdout for happy-path cases and the contract's behavior
+# under error conditions (exit code + stderr) for missing-input and
+# unknown-token fixtures. Closes #421.
+#
+# 9 fixture cases (matches the count documented in scripts/render-lane-status.md):
+#   1. happy path (all four lanes ok)
+#   2. all-binary-missing (4 × fallback_binary_missing)
+#   3. mixed (one ok, one runtime-timeout, two binary-missing)
+#   4. probe-failed with reason
+#   5. probe-failed without reason
+#   6. runtime-timeout
+#   7. runtime-failed with multiline reason (sanitization must collapse)
+#   8. unknown-status (asserts stderr + still emits headers)
+#   9. missing-input (asserts exit 2 + stderr)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd -P)"
+SCRIPT="$REPO_ROOT/scripts/render-lane-status.sh"
+
+PASS=0
+FAIL=0
+FAIL_DETAILS=()
+
+fail() {
+    FAIL=$((FAIL + 1))
+    FAIL_DETAILS+=("$1")
+}
+
+pass() {
+    PASS=$((PASS + 1))
+}
+
+assert_stdout_equals() {
+    local label="$1"
+    local expected="$2"
+    local actual="$3"
+    if [ "$actual" = "$expected" ]; then
+        pass
+    else
+        fail "$label
+  EXPECTED:
+$(printf '%s' "$expected" | sed 's/^/    /')
+  ACTUAL:
+$(printf '%s' "$actual" | sed 's/^/    /')"
+    fi
+}
+
+assert_stderr_contains() {
+    local label="$1"
+    local needle="$2"
+    local actual="$3"
+    case "$actual" in
+        *"$needle"*) pass ;;
+        *) fail "$label
+  EXPECTED stderr to contain: $needle
+  ACTUAL stderr:
+$(printf '%s' "$actual" | sed 's/^/    /')" ;;
+    esac
+}
+
+assert_exit_equals() {
+    local label="$1"
+    local expected="$2"
+    local actual="$3"
+    if [ "$actual" = "$expected" ]; then
+        pass
+    else
+        fail "$label
+  EXPECTED exit: $expected
+  ACTUAL exit:   $actual"
+    fi
+}
+
+TMPDIR_LOCAL="$(mktemp -d "/tmp/test-render-lane-status-XXXXXX")"
+trap 'rm -rf "$TMPDIR_LOCAL"' EXIT
+
+run_render() {
+    # Run script with --input <path>, capture stdout / stderr / exit separately.
+    local input="$1"
+    local out_file err_file rc
+    out_file="$TMPDIR_LOCAL/out"
+    err_file="$TMPDIR_LOCAL/err"
+    rc=0
+    "$SCRIPT" --input "$input" >"$out_file" 2>"$err_file" || rc=$?
+    STDOUT="$(cat "$out_file")"
+    STDERR="$(cat "$err_file")"
+    EXIT="$rc"
+}
+
+# ---------- Fixture 1 — happy path ----------
+cat > "$TMPDIR_LOCAL/f1.txt" <<'EOF'
+RESEARCH_CURSOR_STATUS=ok
+RESEARCH_CURSOR_REASON=
+RESEARCH_CODEX_STATUS=ok
+RESEARCH_CODEX_REASON=
+VALIDATION_CURSOR_STATUS=ok
+VALIDATION_CURSOR_REASON=
+VALIDATION_CODEX_STATUS=ok
+VALIDATION_CODEX_REASON=
+EOF
+run_render "$TMPDIR_LOCAL/f1.txt"
+assert_exit_equals "F1.exit" "0" "$EXIT"
+assert_stdout_equals "F1.stdout" \
+"RESEARCH_HEADER=3 agents (Cursor: ✅, Codex: ✅)
+VALIDATION_HEADER=3 reviewers (Code: ✅, Cursor: ✅, Codex: ✅)" "$STDOUT"
+
+# ---------- Fixture 2 — all binary missing ----------
+cat > "$TMPDIR_LOCAL/f2.txt" <<'EOF'
+RESEARCH_CURSOR_STATUS=fallback_binary_missing
+RESEARCH_CURSOR_REASON=
+RESEARCH_CODEX_STATUS=fallback_binary_missing
+RESEARCH_CODEX_REASON=
+VALIDATION_CURSOR_STATUS=fallback_binary_missing
+VALIDATION_CURSOR_REASON=
+VALIDATION_CODEX_STATUS=fallback_binary_missing
+VALIDATION_CODEX_REASON=
+EOF
+run_render "$TMPDIR_LOCAL/f2.txt"
+assert_exit_equals "F2.exit" "0" "$EXIT"
+assert_stdout_equals "F2.stdout" \
+"RESEARCH_HEADER=3 agents (Cursor: Claude-fallback (binary missing), Codex: Claude-fallback (binary missing))
+VALIDATION_HEADER=3 reviewers (Code: ✅, Cursor: Claude-fallback (binary missing), Codex: Claude-fallback (binary missing))" "$STDOUT"
+
+# ---------- Fixture 3 — mixed ----------
+cat > "$TMPDIR_LOCAL/f3.txt" <<'EOF'
+RESEARCH_CURSOR_STATUS=ok
+RESEARCH_CURSOR_REASON=
+RESEARCH_CODEX_STATUS=fallback_runtime_timeout
+RESEARCH_CODEX_REASON=
+VALIDATION_CURSOR_STATUS=fallback_binary_missing
+VALIDATION_CURSOR_REASON=
+VALIDATION_CODEX_STATUS=fallback_binary_missing
+VALIDATION_CODEX_REASON=
+EOF
+run_render "$TMPDIR_LOCAL/f3.txt"
+assert_exit_equals "F3.exit" "0" "$EXIT"
+assert_stdout_equals "F3.stdout" \
+"RESEARCH_HEADER=3 agents (Cursor: ✅, Codex: Claude-fallback (runtime timeout))
+VALIDATION_HEADER=3 reviewers (Code: ✅, Cursor: Claude-fallback (binary missing), Codex: Claude-fallback (binary missing))" "$STDOUT"
+
+# ---------- Fixture 4 — probe-failed with reason ----------
+cat > "$TMPDIR_LOCAL/f4.txt" <<'EOF'
+RESEARCH_CURSOR_STATUS=fallback_probe_failed
+RESEARCH_CURSOR_REASON=connection refused on port 5050
+RESEARCH_CODEX_STATUS=ok
+RESEARCH_CODEX_REASON=
+VALIDATION_CURSOR_STATUS=fallback_probe_failed
+VALIDATION_CURSOR_REASON=connection refused on port 5050
+VALIDATION_CODEX_STATUS=ok
+VALIDATION_CODEX_REASON=
+EOF
+run_render "$TMPDIR_LOCAL/f4.txt"
+assert_exit_equals "F4.exit" "0" "$EXIT"
+assert_stdout_equals "F4.stdout" \
+"RESEARCH_HEADER=3 agents (Cursor: Claude-fallback (probe failed: connection refused on port 5050), Codex: ✅)
+VALIDATION_HEADER=3 reviewers (Code: ✅, Cursor: Claude-fallback (probe failed: connection refused on port 5050), Codex: ✅)" "$STDOUT"
+
+# ---------- Fixture 5 — probe-failed without reason ----------
+cat > "$TMPDIR_LOCAL/f5.txt" <<'EOF'
+RESEARCH_CURSOR_STATUS=fallback_probe_failed
+RESEARCH_CURSOR_REASON=
+RESEARCH_CODEX_STATUS=ok
+RESEARCH_CODEX_REASON=
+VALIDATION_CURSOR_STATUS=fallback_probe_failed
+VALIDATION_CURSOR_REASON=
+VALIDATION_CODEX_STATUS=ok
+VALIDATION_CODEX_REASON=
+EOF
+run_render "$TMPDIR_LOCAL/f5.txt"
+assert_exit_equals "F5.exit" "0" "$EXIT"
+assert_stdout_equals "F5.stdout" \
+"RESEARCH_HEADER=3 agents (Cursor: Claude-fallback (probe failed), Codex: ✅)
+VALIDATION_HEADER=3 reviewers (Code: ✅, Cursor: Claude-fallback (probe failed), Codex: ✅)" "$STDOUT"
+
+# ---------- Fixture 6 — runtime-timeout ----------
+cat > "$TMPDIR_LOCAL/f6.txt" <<'EOF'
+RESEARCH_CURSOR_STATUS=ok
+RESEARCH_CURSOR_REASON=
+RESEARCH_CODEX_STATUS=fallback_runtime_timeout
+RESEARCH_CODEX_REASON=
+VALIDATION_CURSOR_STATUS=ok
+VALIDATION_CURSOR_REASON=
+VALIDATION_CODEX_STATUS=fallback_runtime_timeout
+VALIDATION_CODEX_REASON=
+EOF
+run_render "$TMPDIR_LOCAL/f6.txt"
+assert_exit_equals "F6.exit" "0" "$EXIT"
+assert_stdout_equals "F6.stdout" \
+"RESEARCH_HEADER=3 agents (Cursor: ✅, Codex: Claude-fallback (runtime timeout))
+VALIDATION_HEADER=3 reviewers (Code: ✅, Cursor: ✅, Codex: Claude-fallback (runtime timeout))" "$STDOUT"
+
+# ---------- Fixture 7 — runtime-failed with multiline reason (sanitization must collapse) ----------
+# The orchestrator's sanitize-on-write pass should already have collapsed
+# newlines to spaces, but the script applies a second-line defense. We write
+# a file with embedded newlines using printf to verify the script's own
+# sanitization collapses them.
+{
+    printf 'RESEARCH_CURSOR_STATUS=ok\n'
+    printf 'RESEARCH_CURSOR_REASON=\n'
+    printf 'RESEARCH_CODEX_STATUS=fallback_runtime_failed\n'
+    # Reason value spans one line (KV is line-oriented), but contains lots of
+    # extra whitespace and characters that should be sanitized.
+    printf 'RESEARCH_CODEX_REASON=exit code 124  Process killed after exceeding timeout |||  with == many == bad chars\n'
+    printf 'VALIDATION_CURSOR_STATUS=ok\n'
+    printf 'VALIDATION_CURSOR_REASON=\n'
+    printf 'VALIDATION_CODEX_STATUS=ok\n'
+    printf 'VALIDATION_CODEX_REASON=\n'
+} > "$TMPDIR_LOCAL/f7.txt"
+run_render "$TMPDIR_LOCAL/f7.txt"
+assert_exit_equals "F7.exit" "0" "$EXIT"
+# Expected: pipes and = stripped, whitespace collapsed, truncated to 80 chars.
+assert_stdout_equals "F7.stdout" \
+"RESEARCH_HEADER=3 agents (Cursor: ✅, Codex: Claude-fallback (runtime failed: exit code 124 Process killed after exceeding timeout with many bad chars))
+VALIDATION_HEADER=3 reviewers (Code: ✅, Cursor: ✅, Codex: ✅)" "$STDOUT"
+
+# ---------- Fixture 7b — reason that exceeds 80 chars must truncate ----------
+{
+    printf 'RESEARCH_CURSOR_STATUS=ok\n'
+    printf 'RESEARCH_CURSOR_REASON=\n'
+    printf 'RESEARCH_CODEX_STATUS=fallback_runtime_failed\n'
+    printf 'RESEARCH_CODEX_REASON=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA_BEYOND_TRUNCATION\n'
+    printf 'VALIDATION_CURSOR_STATUS=ok\n'
+    printf 'VALIDATION_CURSOR_REASON=\n'
+    printf 'VALIDATION_CODEX_STATUS=ok\n'
+    printf 'VALIDATION_CODEX_REASON=\n'
+} > "$TMPDIR_LOCAL/f7b.txt"
+run_render "$TMPDIR_LOCAL/f7b.txt"
+assert_exit_equals "F7b.exit" "0" "$EXIT"
+assert_stdout_equals "F7b.stdout" \
+"RESEARCH_HEADER=3 agents (Cursor: ✅, Codex: Claude-fallback (runtime failed: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA))
+VALIDATION_HEADER=3 reviewers (Code: ✅, Cursor: ✅, Codex: ✅)" "$STDOUT"
+
+# ---------- Fixture 8 — unknown status token ----------
+cat > "$TMPDIR_LOCAL/f8.txt" <<'EOF'
+RESEARCH_CURSOR_STATUS=ok
+RESEARCH_CURSOR_REASON=
+RESEARCH_CODEX_STATUS=fallback-binary-missing
+RESEARCH_CODEX_REASON=
+VALIDATION_CURSOR_STATUS=ok
+VALIDATION_CURSOR_REASON=
+VALIDATION_CODEX_STATUS=ok
+VALIDATION_CODEX_REASON=
+EOF
+run_render "$TMPDIR_LOCAL/f8.txt"
+assert_exit_equals "F8.exit" "0" "$EXIT"
+assert_stdout_equals "F8.stdout" \
+"RESEARCH_HEADER=3 agents (Cursor: ✅, Codex: (unknown))
+VALIDATION_HEADER=3 reviewers (Code: ✅, Cursor: ✅, Codex: ✅)" "$STDOUT"
+assert_stderr_contains "F8.stderr" "unknown status token fallback-binary-missing" "$STDERR"
+
+# ---------- Fixture 9 — missing input ----------
+run_render "$TMPDIR_LOCAL/does-not-exist.txt"
+assert_exit_equals "F9.exit" "2" "$EXIT"
+assert_stderr_contains "F9.stderr" "render-lane-status: input file missing" "$STDERR"
+
+# ---------- Summary ----------
+TOTAL=$((PASS + FAIL))
+if [ "$FAIL" -eq 0 ]; then
+    echo "PASS: test-render-lane-status.sh — $TOTAL assertions passed across 9 fixture cases"
+    exit 0
+else
+    echo "FAIL: test-render-lane-status.sh — $FAIL of $TOTAL assertions failed" >&2
+    for d in "${FAIL_DETAILS[@]}"; do
+        printf '%s\n' "$d" >&2
+        echo "" >&2
+    done
+    exit 1
+fi

--- a/scripts/test-render-lane-status.sh
+++ b/scripts/test-render-lane-status.sh
@@ -193,17 +193,17 @@ assert_stdout_equals "F6.stdout" \
 "RESEARCH_HEADER=3 agents (Cursor: ✅, Codex: Claude-fallback (runtime timeout))
 VALIDATION_HEADER=3 reviewers (Code: ✅, Cursor: ✅, Codex: Claude-fallback (runtime timeout))" "$STDOUT"
 
-# ---------- Fixture 7 — runtime-failed with multiline reason (sanitization must collapse) ----------
-# The orchestrator's sanitize-on-write pass should already have collapsed
-# newlines to spaces, but the script applies a second-line defense. We write
-# a file with embedded newlines using printf to verify the script's own
-# sanitization collapses them.
+# ---------- Fixture 7 — runtime-failed with =/|/whitespace sanitization ----------
+# KV is line-oriented, so the value lives on a single physical line, but it
+# contains the sanitization-relevant character classes: literal `=` and `|`,
+# plus extra whitespace runs. Verifies that strip-then-collapse produces a
+# clean rendered reason. The string after sanitization is 71 chars (under
+# the 80-char cap), so this fixture does NOT exercise truncation —
+# fixture 7b is the dedicated truncation test.
 {
     printf 'RESEARCH_CURSOR_STATUS=ok\n'
     printf 'RESEARCH_CURSOR_REASON=\n'
     printf 'RESEARCH_CODEX_STATUS=fallback_runtime_failed\n'
-    # Reason value spans one line (KV is line-oriented), but contains lots of
-    # extra whitespace and characters that should be sanitized.
     printf 'RESEARCH_CODEX_REASON=exit code 124  Process killed after exceeding timeout |||  with == many == bad chars\n'
     printf 'VALIDATION_CURSOR_STATUS=ok\n'
     printf 'VALIDATION_CURSOR_REASON=\n'
@@ -212,7 +212,7 @@ VALIDATION_HEADER=3 reviewers (Code: ✅, Cursor: ✅, Codex: Claude-fallback (r
 } > "$TMPDIR_LOCAL/f7.txt"
 run_render "$TMPDIR_LOCAL/f7.txt"
 assert_exit_equals "F7.exit" "0" "$EXIT"
-# Expected: pipes and = stripped, whitespace collapsed, truncated to 80 chars.
+# Expected: pipes and = stripped, whitespace collapsed (no truncation — under 80 chars).
 assert_stdout_equals "F7.stdout" \
 "RESEARCH_HEADER=3 agents (Cursor: ✅, Codex: Claude-fallback (runtime failed: exit code 124 Process killed after exceeding timeout with many bad chars))
 VALIDATION_HEADER=3 reviewers (Code: ✅, Cursor: ✅, Codex: ✅)" "$STDOUT"
@@ -257,10 +257,30 @@ run_render "$TMPDIR_LOCAL/does-not-exist.txt"
 assert_exit_equals "F9.exit" "2" "$EXIT"
 assert_stderr_contains "F9.stderr" "render-lane-status: input file missing" "$STDERR"
 
+# ---------- Fixture 10 — usage error: --input flag omitted ----------
+# Calls the script with no arguments at all. The contract says exit 1 with
+# "--input is required" on stderr (per the Stderr / Exit codes tables in
+# scripts/render-lane-status.md). Without this fixture, the exit-1 path
+# would be entirely untested.
+EXIT=0
+"$SCRIPT" >"$TMPDIR_LOCAL/out" 2>"$TMPDIR_LOCAL/err" || EXIT=$?
+STDOUT="$(cat "$TMPDIR_LOCAL/out")"
+STDERR="$(cat "$TMPDIR_LOCAL/err")"
+assert_exit_equals "F10.exit" "1" "$EXIT"
+assert_stderr_contains "F10.stderr" "--input is required" "$STDERR"
+
+# ---------- Fixture 10b — usage error: unknown flag ----------
+EXIT=0
+"$SCRIPT" --bogus >"$TMPDIR_LOCAL/out" 2>"$TMPDIR_LOCAL/err" || EXIT=$?
+STDOUT="$(cat "$TMPDIR_LOCAL/out")"
+STDERR="$(cat "$TMPDIR_LOCAL/err")"
+assert_exit_equals "F10b.exit" "1" "$EXIT"
+assert_stderr_contains "F10b.stderr" "unknown flag: --bogus" "$STDERR"
+
 # ---------- Summary ----------
 TOTAL=$((PASS + FAIL))
 if [ "$FAIL" -eq 0 ]; then
-    echo "PASS: test-render-lane-status.sh — $TOTAL assertions passed across 9 fixture cases"
+    echo "PASS: test-render-lane-status.sh — $TOTAL assertions passed across 10 fixture cases"
     exit 0
 else
     echo "FAIL: test-render-lane-status.sh — $FAIL of $TOTAL assertions failed" >&2

--- a/scripts/test-research-structure.sh
+++ b/scripts/test-research-structure.sh
@@ -78,5 +78,21 @@ grep -Fq "<reviewer_research_question>" "$VALIDATION_MD" \
 grep -Fq "<reviewer_research_findings>" "$VALIDATION_MD" \
   || fail "references/validation-phase.md lacks '<reviewer_research_findings>' XML wrapper tag"
 
-echo "PASS: test-research-structure.sh — all 6 structural invariants hold"
+# Check 7: SKILL.md Step 3 must invoke render-lane-status.sh (the lane-attribution
+# formatter added by #421). Without this pin, a future edit could quietly remove
+# the helper invocation and the report header would silently regress to the
+# pre-#421 collapsed ✅/❌ shape (or to a hard-coded literal).
+grep -Fq "render-lane-status.sh" "$SKILL_MD" \
+  || fail "SKILL.md must reference render-lane-status.sh in Step 3 (#421 lane attribution)"
+
+# Check 8: Both phase references must mention lane-status.txt — the on-disk
+# KV record they update via surgical phase-local rewrites. Without these pins,
+# the orchestrator-side update logic could be silently dropped, leaving the
+# render helper to emit stale Step 0b values for runtime-fallback lanes.
+grep -Fq "lane-status.txt" "$RESEARCH_MD" \
+  || fail "references/research-phase.md must mention lane-status.txt (#421 RESEARCH_* slice update)"
+grep -Fq "lane-status.txt" "$VALIDATION_MD" \
+  || fail "references/validation-phase.md must mention lane-status.txt (#421 VALIDATION_* slice update + Step 2 entry propagation)"
+
+echo "PASS: test-research-structure.sh — all 8 structural invariants hold"
 exit 0

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -94,13 +94,34 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/session-setup.sh --prefix claude-research --skip-p
 
 If the script exits non-zero, print the error and abort.
 
-Parse the output for `SESSION_TMPDIR`, `CODEX_AVAILABLE`, `CURSOR_AVAILABLE`, `CODEX_HEALTHY`, `CURSOR_HEALTHY`. Set `RESEARCH_TMPDIR` = `SESSION_TMPDIR`. Substitute the actual path in every command below.
+Parse the output for `SESSION_TMPDIR`, `CODEX_AVAILABLE`, `CURSOR_AVAILABLE`, `CODEX_HEALTHY`, `CURSOR_HEALTHY`, `CODEX_PROBE_ERROR`, `CURSOR_PROBE_ERROR`. Set `RESEARCH_TMPDIR` = `SESSION_TMPDIR`. Substitute the actual path in every command below.
 
-Set mental flags `codex_available` and `cursor_available` based on the output:
-- If `CODEX_AVAILABLE=false`: `codex_available=false`. Print: `**⚠ Codex not available (binary not found). Proceeding without Codex reviewer.**`
-- Else if `CODEX_HEALTHY=false`: `codex_available=false`. Print: `**⚠ Codex installed but not responding (health check failed). Using Claude replacement.**`
-- Else: `codex_available=true`
-- Same logic for Cursor.
+Set mental flags `codex_available` and `cursor_available` based on the output, and remember each lane's pre-launch attribution status (one of `ok` / `fallback_binary_missing` / `fallback_probe_failed`) for the Step 0b lane-status init below:
+- If `CODEX_AVAILABLE=false`: `codex_available=false`. Pre-launch status = `fallback_binary_missing` (no reason). Print: `**⚠ Codex not available (binary not found). Proceeding without Codex reviewer.**`
+- Else if `CODEX_HEALTHY=false`: `codex_available=false`. Pre-launch status = `fallback_probe_failed` with reason = `CODEX_PROBE_ERROR` (sanitized). Print: `**⚠ Codex installed but not responding (health check failed: <CODEX_PROBE_ERROR>). Using Claude replacement.**` (omit the parenthetical detail when `CODEX_PROBE_ERROR` is empty).
+- Else: `codex_available=true`. Pre-launch status = `ok`.
+- Same logic for Cursor (using `CURSOR_PROBE_ERROR`).
+
+### 0b — Initialize lane-status record
+
+Write `$RESEARCH_TMPDIR/lane-status.txt` with all four external lanes' pre-launch attribution. Step 1.3 (research-phase) and Step 2 entry / Step 2.4 (validation-phase) update this file later via surgical phase-local rewrites; Step 3 reads it via `${CLAUDE_PLUGIN_ROOT}/scripts/render-lane-status.sh` to render the final-report header.
+
+Sanitize each `*_PROBE_ERROR` value before writing: strip embedded `=` and `|` characters, collapse whitespace runs to single space, trim, truncate to 80 chars. The render script applies the same rules as a defense-in-depth, but writer-side sanitization keeps the KV file well-formed.
+
+Use the orchestrator-resolved pre-launch status for each lane (Step 0a determined `ok` / `fallback_binary_missing` / `fallback_probe_failed` per lane). Both Research and Validation rows initialize from the same pre-launch facts; runtime updates come later. Token vocabulary is documented in `${CLAUDE_PLUGIN_ROOT}/scripts/render-lane-status.md`.
+
+```bash
+cat > "$RESEARCH_TMPDIR/lane-status.txt" <<EOF
+RESEARCH_CURSOR_STATUS=<cursor pre-launch status>
+RESEARCH_CURSOR_REASON=<cursor sanitized reason or empty>
+RESEARCH_CODEX_STATUS=<codex pre-launch status>
+RESEARCH_CODEX_REASON=<codex sanitized reason or empty>
+VALIDATION_CURSOR_STATUS=<cursor pre-launch status>
+VALIDATION_CURSOR_REASON=<cursor sanitized reason or empty>
+VALIDATION_CODEX_STATUS=<codex pre-launch status>
+VALIDATION_CODEX_REASON=<codex sanitized reason or empty>
+EOF
+```
 
 ### 0c — Record Research Context
 
@@ -136,15 +157,27 @@ Execute Step 2 per the reference file above. SKILL.md is the sole owner of Step 
 
 Print: `> **🔶 3: report**`
 
-Print the final research report under a `## Research Report` header with the following structure:
+Render the per-lane attribution headers from `$RESEARCH_TMPDIR/lane-status.txt`:
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/scripts/render-lane-status.sh --input "$RESEARCH_TMPDIR/lane-status.txt"
+```
+
+Parse the two output lines via prefix-strip (NOT `cut -d=`, since rendered values can contain `=` characters):
+- `RESEARCH_HEADER="${line#RESEARCH_HEADER=}"` for the line beginning with `RESEARCH_HEADER=`
+- `VALIDATION_HEADER="${line#VALIDATION_HEADER=}"` for the line beginning with `VALIDATION_HEADER=`
+
+If the helper exits non-zero (e.g., `lane-status.txt` is missing — should not happen since Step 0b always writes it), substitute the placeholder line `_Lane attribution unavailable._` for both header rows and log to terminal: `**⚠ 3: report — render-lane-status failed; lane attribution unavailable.**`.
+
+Print the final research report under a `## Research Report` header with the following structure (substituting the rendered values for `<RESEARCH_HEADER>` and `<VALIDATION_HEADER>`):
 
 ```markdown
 ## Research Report
 
 **Research question**: <RESEARCH_QUESTION>
 **Codebase context**: Branch `<CURRENT_BRANCH>`, commit `<HEAD_SHA>`
-**Research phase**: <N> agents (Cursor: ✅/❌, Codex: ✅/❌)
-**Validation phase**: <N> reviewers (Code: ✅, Cursor: ✅/❌, Codex: ✅/❌)
+**Research phase**: <RESEARCH_HEADER>
+**Validation phase**: <VALIDATION_HEADER>
 
 ### Findings Summary
 <synthesized and validated findings, organized by topic>
@@ -163,6 +196,13 @@ Print the final research report under a `## Research Report` header with the fol
 
 ### Open Questions
 <any unresolved questions or areas that need further investigation>
+```
+
+Example rendered headers (one degraded research lane, one degraded validation lane):
+
+```markdown
+**Research phase**: 3 agents (Cursor: ✅, Codex: Claude-fallback (runtime timeout))
+**Validation phase**: 3 reviewers (Code: ✅, Cursor: Claude-fallback (binary missing), Codex: ✅)
 ```
 
 If risk assessment, difficulty estimate, or feasibility verdict are not applicable to the nature of the research question (e.g., a pure "how does X work?" question), mark them as **N/A** with a brief explanation.

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -106,12 +106,14 @@ Set mental flags `codex_available` and `cursor_available` based on the output, a
 
 Write `$RESEARCH_TMPDIR/lane-status.txt` with all four external lanes' pre-launch attribution. Step 1.3 (research-phase) and Step 2 entry / Step 2.4 (validation-phase) update this file later via surgical phase-local rewrites; Step 3 reads it via `${CLAUDE_PLUGIN_ROOT}/scripts/render-lane-status.sh` to render the final-report header.
 
-Sanitize each `*_PROBE_ERROR` value before writing: strip embedded `=` and `|` characters, collapse whitespace runs to single space, trim, truncate to 80 chars. The render script applies the same rules as a defense-in-depth, but writer-side sanitization keeps the KV file well-formed.
+Sanitize each `*_PROBE_ERROR` value before writing: strip embedded `=` and `|` characters, collapse whitespace runs to single space, trim, truncate to 80 chars. The render script applies the same rules as defense-in-depth, but writer-side sanitization keeps the KV file well-formed.
 
 Use the orchestrator-resolved pre-launch status for each lane (Step 0a determined `ok` / `fallback_binary_missing` / `fallback_probe_failed` per lane). Both Research and Validation rows initialize from the same pre-launch facts; runtime updates come later. Token vocabulary is documented in `${CLAUDE_PLUGIN_ROOT}/scripts/render-lane-status.md`.
 
+The heredoc body uses a **quoted delimiter** (`<<'EOF'`) so that any residual shell metacharacters (dollar sign, backticks, backslashes, double quotes) in a substituted reason value are preserved verbatim instead of being expanded — a defense against hostile content in `*_PROBE_ERROR` from `.diag` files of external tools. The orchestrator literally substitutes the resolved per-lane status and sanitized reason text into the placeholders below before writing the command.
+
 ```bash
-cat > "$RESEARCH_TMPDIR/lane-status.txt" <<EOF
+cat > "$RESEARCH_TMPDIR/lane-status.txt" <<'EOF'
 RESEARCH_CURSOR_STATUS=<cursor pre-launch status>
 RESEARCH_CURSOR_REASON=<cursor sanitized reason or empty>
 RESEARCH_CODEX_STATUS=<codex pre-launch status>

--- a/skills/research/references/research-phase.md
+++ b/skills/research/references/research-phase.md
@@ -115,19 +115,22 @@ For each Cursor/Codex lane with `STATUS != OK`, derive the new token + reason:
 
 If both Cursor and Codex lanes returned `STATUS=OK` (or were never launched because pre-launch fallback already applied), no update is needed — the `RESEARCH_*` keys from Step 0b remain correct.
 
-Otherwise, perform a read-filter-rewrite via temp + atomic `mv`. All four `RESEARCH_*` keys must be emitted on every rewrite (lanes that returned `OK`, or were never launched, keep the pre-launch token from Step 0b — `ok` / `fallback_binary_missing` / `fallback_probe_failed`):
+Otherwise, perform a read-filter-rewrite via temp + atomic `mv`. All four `RESEARCH_*` keys must be emitted on every rewrite (lanes that returned `OK`, or were never launched, keep the pre-launch token from Step 0b — `ok` / `fallback_binary_missing` / `fallback_probe_failed`).
+
+The append uses a **quoted heredoc** (`<<'EOF'`) so residual shell metacharacters in a substituted reason value are preserved literally rather than expanded — same shell-injection defense as Step 0b. The orchestrator literally substitutes the resolved per-lane status and sanitized reason text into the placeholders below.
 
 ```bash
 LANE_STATUS_FILE="$RESEARCH_TMPDIR/lane-status.txt"
 LANE_STATUS_TMP="$(mktemp "${LANE_STATUS_FILE}.XXXXXX")"
-# Preserve VALIDATION_* keys verbatim; emit fresh RESEARCH_* keys.
+# Preserve VALIDATION_* keys verbatim.
 grep -v '^RESEARCH_' "$LANE_STATUS_FILE" > "$LANE_STATUS_TMP"
-{
-    printf 'RESEARCH_CURSOR_STATUS=%s\n' "<cursor token>"
-    printf 'RESEARCH_CURSOR_REASON=%s\n' "<cursor sanitized reason or empty>"
-    printf 'RESEARCH_CODEX_STATUS=%s\n' "<codex token>"
-    printf 'RESEARCH_CODEX_REASON=%s\n' "<codex sanitized reason or empty>"
-} >> "$LANE_STATUS_TMP"
+# Append fresh RESEARCH_* keys with literal substitutions.
+cat >> "$LANE_STATUS_TMP" <<'EOF'
+RESEARCH_CURSOR_STATUS=<cursor token>
+RESEARCH_CURSOR_REASON=<cursor sanitized reason or empty>
+RESEARCH_CODEX_STATUS=<codex token>
+RESEARCH_CODEX_REASON=<codex sanitized reason or empty>
+EOF
 mv "$LANE_STATUS_TMP" "$LANE_STATUS_FILE"
 ```
 

--- a/skills/research/references/research-phase.md
+++ b/skills/research/references/research-phase.md
@@ -105,6 +105,34 @@ Parse the structured output for each reviewer's `STATUS` and `REVIEWER_FILE`. Fo
 
 **Runtime-timeout replacement**: For any reviewer with `STATUS` not `OK`, follow the **Runtime Timeout Fallback** procedure in `${CLAUDE_PLUGIN_ROOT}/skills/shared/external-reviewers.md` to flip the corresponding availability flag, then **immediately launch a Claude subagent fallback via the Agent tool** (no `subagent_type`, carrying `RESEARCH_PROMPT` verbatim — same as the pre-launch fallback in Step 1.2) and wait for it before synthesis. This preserves the 3-lane invariant at synthesis time; without it, a mid-run external timeout silently reduces the synthesis input from 3 perspectives to 2.
 
+### Update lane-status.txt (RESEARCH_* slice only)
+
+After Runtime Timeout Fallback determinations are made, surgically update only the `RESEARCH_*` slice of `$RESEARCH_TMPDIR/lane-status.txt`. The `VALIDATION_*` keys must be preserved verbatim — Step 0b initialized them and Step 2 (validation-phase.md) owns subsequent updates. Do NOT rewrite the full file.
+
+For each Cursor/Codex lane with `STATUS != OK`, derive the new token + reason:
+- `STATUS=TIMED_OUT` or `SENTINEL_TIMEOUT` → token `fallback_runtime_timeout`, reason empty
+- `STATUS=FAILED` or `EMPTY_OUTPUT` → token `fallback_runtime_failed`, reason = sanitized `FAILURE_REASON` (strip `=` and `|`, collapse whitespace, trim, truncate to 80 chars)
+
+If both Cursor and Codex lanes returned `STATUS=OK` (or were never launched because pre-launch fallback already applied), no update is needed — the `RESEARCH_*` keys from Step 0b remain correct.
+
+Otherwise, perform a read-filter-rewrite via temp + atomic `mv`. All four `RESEARCH_*` keys must be emitted on every rewrite (lanes that returned `OK`, or were never launched, keep the pre-launch token from Step 0b — `ok` / `fallback_binary_missing` / `fallback_probe_failed`):
+
+```bash
+LANE_STATUS_FILE="$RESEARCH_TMPDIR/lane-status.txt"
+LANE_STATUS_TMP="$(mktemp "${LANE_STATUS_FILE}.XXXXXX")"
+# Preserve VALIDATION_* keys verbatim; emit fresh RESEARCH_* keys.
+grep -v '^RESEARCH_' "$LANE_STATUS_FILE" > "$LANE_STATUS_TMP"
+{
+    printf 'RESEARCH_CURSOR_STATUS=%s\n' "<cursor token>"
+    printf 'RESEARCH_CURSOR_REASON=%s\n' "<cursor sanitized reason or empty>"
+    printf 'RESEARCH_CODEX_STATUS=%s\n' "<codex token>"
+    printf 'RESEARCH_CODEX_REASON=%s\n' "<codex sanitized reason or empty>"
+} >> "$LANE_STATUS_TMP"
+mv "$LANE_STATUS_TMP" "$LANE_STATUS_FILE"
+```
+
+Token vocabulary is documented in `${CLAUDE_PLUGIN_ROOT}/scripts/render-lane-status.md`.
+
 ## 1.4 — Synthesis
 
 Read all 3 research outputs (Claude inline + Cursor or its fallback + Codex or its fallback). Produce a synthesis that:

--- a/skills/research/references/validation-phase.md
+++ b/skills/research/references/validation-phase.md
@@ -12,6 +12,40 @@
 
 Launch **all 3 lanes in parallel** (in a single message). **Spawn order matters for parallelism** — launch the slowest first: Cursor (slowest), then Codex, then the Claude Code Reviewer subagent (fastest). Each reviewer receives the research report and the original question. Each must **only report findings** — never edit files.
 
+## Step 2 entry — Propagate research-phase fallbacks to VALIDATION_* keys
+
+Before any external launch in Step 2, copy each currently-unavailable external lane's research-phase status into the corresponding `VALIDATION_*` keys in `$RESEARCH_TMPDIR/lane-status.txt`. Without this propagation, a runtime fallback that flipped `cursor_available`/`codex_available` to `false` during research-phase Step 1.3 would leave the Step 0b-initialized `VALIDATION_<TOOL>_STATUS=ok` in place — `collect-reviewer-results.sh` is never called for a lane whose `*_available` flag is false at validation entry, so Step 2.4 below cannot downgrade it. The result would be a header showing `Cursor: ✅` for a validation lane that actually ran as a Claude fallback.
+
+For each external tool, if `cursor_available` (resp. `codex_available`) is currently `false`, copy `RESEARCH_<TOOL>_STATUS` and `RESEARCH_<TOOL>_REASON` into `VALIDATION_<TOOL>_STATUS` and `VALIDATION_<TOOL>_REASON`. Lanes whose `*_available` flag is currently `true` are left alone — Step 2.4 will update them after `collect-reviewer-results.sh` returns.
+
+If both `cursor_available` and `codex_available` are `true` at Step 2 entry, no update is needed.
+
+Otherwise, surgically update only the `VALIDATION_*` slice (preserve `RESEARCH_*` keys verbatim):
+
+```bash
+LANE_STATUS_FILE="$RESEARCH_TMPDIR/lane-status.txt"
+LANE_STATUS_TMP="$(mktemp "${LANE_STATUS_FILE}.XXXXXX")"
+# Read current RESEARCH_* values for any propagation needed below.
+RESEARCH_CURSOR_STATUS_VAL=$(grep '^RESEARCH_CURSOR_STATUS=' "$LANE_STATUS_FILE" | head -1 | { IFS= read -r line; printf '%s' "${line#RESEARCH_CURSOR_STATUS=}"; })
+RESEARCH_CURSOR_REASON_VAL=$(grep '^RESEARCH_CURSOR_REASON=' "$LANE_STATUS_FILE" | head -1 | { IFS= read -r line; printf '%s' "${line#RESEARCH_CURSOR_REASON=}"; })
+RESEARCH_CODEX_STATUS_VAL=$(grep '^RESEARCH_CODEX_STATUS=' "$LANE_STATUS_FILE" | head -1 | { IFS= read -r line; printf '%s' "${line#RESEARCH_CODEX_STATUS=}"; })
+RESEARCH_CODEX_REASON_VAL=$(grep '^RESEARCH_CODEX_REASON=' "$LANE_STATUS_FILE" | head -1 | { IFS= read -r line; printf '%s' "${line#RESEARCH_CODEX_REASON=}"; })
+# For each tool, decide the new VALIDATION_* values:
+#   - if *_available=false: copy from RESEARCH_<TOOL>_*
+#   - if *_available=true:  keep current VALIDATION_<TOOL>_* (initialized in Step 0b)
+# Then preserve RESEARCH_* keys verbatim and emit fresh VALIDATION_* keys.
+grep -v '^VALIDATION_' "$LANE_STATUS_FILE" > "$LANE_STATUS_TMP"
+{
+    printf 'VALIDATION_CURSOR_STATUS=%s\n' "<cursor token>"
+    printf 'VALIDATION_CURSOR_REASON=%s\n' "<cursor reason>"
+    printf 'VALIDATION_CODEX_STATUS=%s\n' "<codex token>"
+    printf 'VALIDATION_CODEX_REASON=%s\n' "<codex reason>"
+} >> "$LANE_STATUS_TMP"
+mv "$LANE_STATUS_TMP" "$LANE_STATUS_FILE"
+```
+
+Token vocabulary is documented in `${CLAUDE_PLUGIN_ROOT}/scripts/render-lane-status.md`.
+
 ## External Reviewer Setup (if `codex_available` or `cursor_available`)
 
 The research report is already written to `$RESEARCH_TMPDIR/research-report.txt` from Step 1.4, so both Codex and Cursor can read it.
@@ -137,6 +171,29 @@ Use `timeout: 1860000` on the Bash tool call. **Do NOT** set `run_in_background:
 1. Parse the structured output for each reviewer's `STATUS` and `REVIEWER_FILE`. Read valid output files.
 2. **Runtime-timeout replacement**: For any reviewer with `STATUS` not `OK`, follow the **Runtime Timeout Fallback** procedure in `${CLAUDE_PLUGIN_ROOT}/skills/shared/external-reviewers.md` to flip the availability flag (`cursor_available` or `codex_available`), then **immediately launch the matching single Claude Code Reviewer subagent fallback** and wait for it before negotiation. This preserves the 3-lane invariant at negotiation time.
 3. Merge external reviewer findings (and any runtime-fallback Claude findings) into the always-on Claude lane findings and any pre-launch Claude fallback findings.
+4. **Update lane-status.txt (VALIDATION_* slice only)**: After Runtime Timeout Fallback determinations are made, surgically update only the `VALIDATION_*` slice of `$RESEARCH_TMPDIR/lane-status.txt` — `RESEARCH_*` keys must be preserved verbatim. For each Cursor/Codex lane with `STATUS != OK`, derive the new token + reason:
+   - `STATUS=TIMED_OUT` or `SENTINEL_TIMEOUT` → token `fallback_runtime_timeout`, reason empty
+   - `STATUS=FAILED` or `EMPTY_OUTPUT` → token `fallback_runtime_failed`, reason = sanitized `FAILURE_REASON` (strip `=` and `|`, collapse whitespace, trim, truncate to 80 chars)
+
+   If both Cursor and Codex lanes returned `STATUS=OK` (or were never launched in this phase because pre-launch fallback or research-phase propagation already applied), no update is needed — the `VALIDATION_*` keys remain correct.
+
+   Otherwise, perform a read-filter-rewrite via temp + atomic `mv`. All four `VALIDATION_*` keys must be emitted on every rewrite (lanes that returned `OK`, or were never launched, keep their current value):
+
+   ```bash
+   LANE_STATUS_FILE="$RESEARCH_TMPDIR/lane-status.txt"
+   LANE_STATUS_TMP="$(mktemp "${LANE_STATUS_FILE}.XXXXXX")"
+   # Preserve RESEARCH_* keys verbatim; emit fresh VALIDATION_* keys.
+   grep -v '^VALIDATION_' "$LANE_STATUS_FILE" > "$LANE_STATUS_TMP"
+   {
+       printf 'VALIDATION_CURSOR_STATUS=%s\n' "<cursor token>"
+       printf 'VALIDATION_CURSOR_REASON=%s\n' "<cursor sanitized reason or empty>"
+       printf 'VALIDATION_CODEX_STATUS=%s\n' "<codex token>"
+       printf 'VALIDATION_CODEX_REASON=%s\n' "<codex sanitized reason or empty>"
+   } >> "$LANE_STATUS_TMP"
+   mv "$LANE_STATUS_TMP" "$LANE_STATUS_FILE"
+   ```
+
+   Token vocabulary is documented in `${CLAUDE_PLUGIN_ROOT}/scripts/render-lane-status.md`.
 
 ## Codex and Cursor Negotiation (in parallel)
 

--- a/skills/research/references/validation-phase.md
+++ b/skills/research/references/validation-phase.md
@@ -20,27 +20,22 @@ For each external tool, if `cursor_available` (resp. `codex_available`) is curre
 
 If both `cursor_available` and `codex_available` are `true` at Step 2 entry, no update is needed.
 
-Otherwise, surgically update only the `VALIDATION_*` slice (preserve `RESEARCH_*` keys verbatim):
+Otherwise, surgically update only the `VALIDATION_*` slice (preserve `RESEARCH_*` keys verbatim). The append uses a **quoted heredoc** (`<<'EOF'`) so residual shell metacharacters in a substituted reason value are preserved literally rather than expanded — same shell-injection defense as Step 0b. The orchestrator reads the current `RESEARCH_*` values from the file and substitutes them (or the existing `VALIDATION_*` value, when `*_available=true`) into the placeholders below before writing the command.
 
 ```bash
 LANE_STATUS_FILE="$RESEARCH_TMPDIR/lane-status.txt"
 LANE_STATUS_TMP="$(mktemp "${LANE_STATUS_FILE}.XXXXXX")"
-# Read current RESEARCH_* values for any propagation needed below.
-RESEARCH_CURSOR_STATUS_VAL=$(grep '^RESEARCH_CURSOR_STATUS=' "$LANE_STATUS_FILE" | head -1 | { IFS= read -r line; printf '%s' "${line#RESEARCH_CURSOR_STATUS=}"; })
-RESEARCH_CURSOR_REASON_VAL=$(grep '^RESEARCH_CURSOR_REASON=' "$LANE_STATUS_FILE" | head -1 | { IFS= read -r line; printf '%s' "${line#RESEARCH_CURSOR_REASON=}"; })
-RESEARCH_CODEX_STATUS_VAL=$(grep '^RESEARCH_CODEX_STATUS=' "$LANE_STATUS_FILE" | head -1 | { IFS= read -r line; printf '%s' "${line#RESEARCH_CODEX_STATUS=}"; })
-RESEARCH_CODEX_REASON_VAL=$(grep '^RESEARCH_CODEX_REASON=' "$LANE_STATUS_FILE" | head -1 | { IFS= read -r line; printf '%s' "${line#RESEARCH_CODEX_REASON=}"; })
-# For each tool, decide the new VALIDATION_* values:
+# Decide the new VALIDATION_* values per tool:
 #   - if *_available=false: copy from RESEARCH_<TOOL>_*
 #   - if *_available=true:  keep current VALIDATION_<TOOL>_* (initialized in Step 0b)
-# Then preserve RESEARCH_* keys verbatim and emit fresh VALIDATION_* keys.
+# Preserve RESEARCH_* keys verbatim; emit fresh VALIDATION_* keys.
 grep -v '^VALIDATION_' "$LANE_STATUS_FILE" > "$LANE_STATUS_TMP"
-{
-    printf 'VALIDATION_CURSOR_STATUS=%s\n' "<cursor token>"
-    printf 'VALIDATION_CURSOR_REASON=%s\n' "<cursor reason>"
-    printf 'VALIDATION_CODEX_STATUS=%s\n' "<codex token>"
-    printf 'VALIDATION_CODEX_REASON=%s\n' "<codex reason>"
-} >> "$LANE_STATUS_TMP"
+cat >> "$LANE_STATUS_TMP" <<'EOF'
+VALIDATION_CURSOR_STATUS=<cursor token>
+VALIDATION_CURSOR_REASON=<cursor reason>
+VALIDATION_CODEX_STATUS=<codex token>
+VALIDATION_CODEX_REASON=<codex reason>
+EOF
 mv "$LANE_STATUS_TMP" "$LANE_STATUS_FILE"
 ```
 
@@ -177,19 +172,21 @@ Use `timeout: 1860000` on the Bash tool call. **Do NOT** set `run_in_background:
 
    If both Cursor and Codex lanes returned `STATUS=OK` (or were never launched in this phase because pre-launch fallback or research-phase propagation already applied), no update is needed — the `VALIDATION_*` keys remain correct.
 
-   Otherwise, perform a read-filter-rewrite via temp + atomic `mv`. All four `VALIDATION_*` keys must be emitted on every rewrite (lanes that returned `OK`, or were never launched, keep their current value):
+   Otherwise, perform a read-filter-rewrite via temp + atomic `mv`. All four `VALIDATION_*` keys must be emitted on every rewrite (lanes that returned `OK`, or were never launched, keep their current value).
+
+   The append uses a **quoted heredoc** (`<<'EOF'`) so residual shell metacharacters in a substituted reason value are preserved literally rather than expanded — same shell-injection defense as Step 0b.
 
    ```bash
    LANE_STATUS_FILE="$RESEARCH_TMPDIR/lane-status.txt"
    LANE_STATUS_TMP="$(mktemp "${LANE_STATUS_FILE}.XXXXXX")"
    # Preserve RESEARCH_* keys verbatim; emit fresh VALIDATION_* keys.
    grep -v '^VALIDATION_' "$LANE_STATUS_FILE" > "$LANE_STATUS_TMP"
-   {
-       printf 'VALIDATION_CURSOR_STATUS=%s\n' "<cursor token>"
-       printf 'VALIDATION_CURSOR_REASON=%s\n' "<cursor sanitized reason or empty>"
-       printf 'VALIDATION_CODEX_STATUS=%s\n' "<codex token>"
-       printf 'VALIDATION_CODEX_REASON=%s\n' "<codex sanitized reason or empty>"
-   } >> "$LANE_STATUS_TMP"
+   cat >> "$LANE_STATUS_TMP" <<'EOF'
+   VALIDATION_CURSOR_STATUS=<cursor token>
+   VALIDATION_CURSOR_REASON=<cursor sanitized reason or empty>
+   VALIDATION_CODEX_STATUS=<codex token>
+   VALIDATION_CODEX_REASON=<codex sanitized reason or empty>
+   EOF
    mv "$LANE_STATUS_TMP" "$LANE_STATUS_FILE"
    ```
 


### PR DESCRIPTION
## Summary

- **`/research` final-report header now distinguishes WHY each external lane fell back** to a Claude subagent rather than collapsing to ✅/❌. Five canonical states render: `✅`, `Claude-fallback (binary missing)`, `Claude-fallback (probe failed: <reason>)`, `Claude-fallback (runtime timeout)`, `Claude-fallback (runtime failed: <reason>)`. The Code (Claude code-reviewer subagent) lane stays hard-coded `✅`.
- **New `scripts/render-lane-status.sh`** parses a small KV record at `$RESEARCH_TMPDIR/lane-status.txt` and emits the two header lines via prefix-strip-safe `RESEARCH_HEADER=…` / `VALIDATION_HEADER=…` output. Pure formatter; sibling `.md` contract; 10-fixture offline regression harness wired into `make lint`.
- **State accumulates in three surgical write points**: Step 0b (init from `session-setup.sh --check-reviewers` output, including new `*_PROBE_ERROR` parsing), Step 1.3 (research-phase runtime fallback), Step 2 entry (propagate research-phase fallbacks to validation lanes — closes the #421 plan-review FINDING_6 gap), and Step 2.4 (validation-phase runtime fallback). Each phase performs read-filter-rewrite of its own slice via temp + atomic `mv`; quoted heredocs (`<<'EOF'`) neutralize shell-injection vectors in untrusted probe-error text. `scripts/test-research-structure.sh` extended with two new structural pins.

## Architecture Diagram

```mermaid
flowchart TB
    subgraph SS["session-setup.sh --check-reviewers"]
        SSout["CODEX_AVAILABLE / CURSOR_AVAILABLE<br/>CODEX_HEALTHY / CURSOR_HEALTHY<br/>CODEX_PROBE_ERROR / CURSOR_PROBE_ERROR"]
    end

    subgraph CR["collect-reviewer-results.sh"]
        CRout["STATUS / FAILURE_REASON<br/>per launched lane"]
    end

    subgraph SKILL["skills/research/SKILL.md"]
        Step0a["Step 0a — parse SS output"]
        Step0b["Step 0b — init lane-status.txt (8 keys)<br/>quoted heredoc"]
        Step3["Step 3 — invoke render-lane-status.sh<br/>+ substitute headers into report"]
    end

    subgraph REFS["references/"]
        Step1["research-phase.md Step 1.3<br/>surgical update of RESEARCH_* slice"]
        Step2entry["validation-phase.md Step 2 entry<br/>propagate RESEARCH_* → VALIDATION_*<br/>when *_available=false"]
        Step2["validation-phase.md Step 2.4<br/>surgical update of VALIDATION_* slice"]
    end

    LaneStatus[("$RESEARCH_TMPDIR/<br/>lane-status.txt<br/>(8 KV pairs)")]

    subgraph FORMATTER["scripts/render-lane-status.sh"]
        Render["map tokens → human strings<br/>(Code lane hard-coded ✅)"]
    end

    SSout --> Step0a --> Step0b --> LaneStatus
    CRout --> Step1 --> LaneStatus
    Step1 -.runtime fallback flips *_available.-> Step2entry --> LaneStatus
    CRout --> Step2 --> LaneStatus
    LaneStatus --> Render --> Step3
```

## Code Flow Diagram

```mermaid
sequenceDiagram
    participant Orch as /research orchestrator
    participant SS as session-setup.sh
    participant CR as collect-reviewer-results.sh
    participant File as lane-status.txt
    participant Helper as render-lane-status.sh
    participant Report as Final report

    Note over Orch,Report: Step 0a + 0b — pre-launch + init
    Orch->>SS: invoke
    SS-->>Orch: *_AVAILABLE / *_HEALTHY / *_PROBE_ERROR
    Orch->>File: cat > lane-status.txt <<'EOF' (init 8 keys)

    Note over Orch,Report: Step 1 — Research phase
    Orch->>CR: launch Cursor / Codex
    CR-->>Orch: STATUS / FAILURE_REASON per lane
    alt any STATUS != OK
        Orch->>File: surgical update RESEARCH_* slice
    end

    Note over Orch,Report: Step 2 — Validation phase
    alt any *_available=false (flipped during research)
        Orch->>File: propagate RESEARCH_<TOOL>_* → VALIDATION_<TOOL>_*
    end
    Orch->>CR: launch validation reviewers
    alt any STATUS != OK
        Orch->>File: surgical update VALIDATION_* slice
    end

    Note over Orch,Report: Step 3 — render
    Orch->>Helper: --input lane-status.txt
    Helper-->>Orch: RESEARCH_HEADER=… / VALIDATION_HEADER=…
    Orch->>Report: substitute into ## Research Report
```

## Test plan

- [x] `bash scripts/test-render-lane-status.sh` — 10 fixture cases, 25 assertions covering happy path, all-binary-missing, mixed states, probe-failed with/without reason, runtime-timeout, runtime-failed with sanitization, runtime-failed with truncation (7b), unknown-status (with stderr warning), missing-input (exit 2), usage error missing flag (exit 1), usage error unknown flag (exit 1).
- [x] `bash scripts/test-research-structure.sh` — 8 structural invariants (2 new pins for the `render-lane-status.sh` callsite and `lane-status.txt` references).
- [x] `make test-render-lane-status` — wired into `test-harnesses` aggregate.
- [x] `/relevant-checks` — pre-commit + `agent-lint --pedantic` clean.
- [x] `agent-lint.toml` exclusion added for the new harness (matches the `test-assemble-anchor.sh` precedent for Makefile-only test harnesses).

Closes #421

🤖 Generated with [Claude Code](https://claude.com/claude-code)
