### PR TITLE
Fix #442: enforce eval id format and uniqueness in validate_eval_set()

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.4.1",
+  "version": "7.4.2",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.4.2] - 2026-04-25
+
+### Fixed
+
+- `scripts/eval-research.sh validate_eval_set()` now rejects entries whose id does not match `^[a-z0-9-]+$` (lowercase letters, digits, and hyphens only) and tracks duplicate ids across the eval set, so duplicates and path-like ids fail fast under `--smoke-test` before `run_one_research()` uses the raw id as `$WORK_DIR/$id` (closes #442). The duplicate-detection `case` is gated on format-validity so glob metacharacters (`*`, `?`, `[`) in a malformed id cannot leak into the case pattern. The structural lint harness `scripts/test-eval-set-structure.sh` gains a Check 5b mirroring the same rule via a single awk pass over `### eval-N: <id>` headings, so duplicate / path-like ids are also rejected at `make lint` time. Sibling contracts updated in lockstep per AGENTS.md: `scripts/eval-research.md` authoring section adds the id rule; `scripts/test-eval-set-structure.md` adds the 5b assertion.
+
 ## [7.4.1] - 2026-04-25
 
 ### Fixed

--- a/scripts/eval-research.md
+++ b/scripts/eval-research.md
@@ -113,6 +113,7 @@ Authors editing `skills/research/references/eval-set.md` MUST follow:
 
 - The global reference rules enforced by `scripts/test-references-headers.sh` and documented in `scripts/test-references-headers.md`. The `**Consumer**:` / `**Contract**:` / `**When to load**:` triplet must appear at line-start. The `**Contract**:` paragraph must be a single paragraph (terminated by a blank line) and must NOT contain `L<digits>-<digits>` line-range citations.
 - The entry schema. Each entry begins with `### eval-N: <id>` and has six bulleted fields in order: `question`, `category`, `expected_provenance_count`, `expected_keywords`, `notes`. Fields use the format `- **<name>**: <value>`.
+- The id rule. Each `<id>` must match `^[a-z0-9-]+$` (lowercase letters, digits, and hyphens only) and must be unique across the eval set — `validate_eval_set()` rejects duplicates and path-like ids under `--smoke-test` because `run_one_research()` later uses the raw `id` as `$WORK_DIR/$id`. The same rule is enforced at lint time by `scripts/test-eval-set-structure.sh` Check 5b.
 - The structural invariants enforced by `scripts/test-eval-set-structure.sh`: at least 20 entries, all five categories present, two entries flagged `ADVERSARIAL` in `notes`, and the harness file containing the Anthropic-blog citation literal.
 
 ## Edit-in-sync

--- a/scripts/eval-research.sh
+++ b/scripts/eval-research.sh
@@ -198,12 +198,24 @@ validate_eval_set() {
   local count=0
   local rc=0
   local seen_categories=""
+  local seen_ids=""
   while IFS=$'\t' read -r id cat prov kw q notes; do
     if [[ -z "$id" || -z "$cat" || -z "$prov" || -z "$kw" || -z "$q" || -z "$notes" ]]; then
       printf 'eval-research: entry has missing field(s): id=%s cat=%s prov=%s\n' "$id" "$cat" "$prov" >&2
       rc=1
       continue
     fi
+    if ! [[ "$id" =~ ^[a-z0-9-]+$ ]]; then
+      printf 'eval-research: entry has invalid id (must match ^[a-z0-9-]+$, kebab-case): %s\n' "$id" >&2
+      rc=1
+    fi
+    case "$seen_ids" in
+      *"|$id|"*)
+        printf 'eval-research: duplicate eval id: %s\n' "$id" >&2
+        rc=1
+        ;;
+      *) seen_ids="${seen_ids}|$id|" ;;
+    esac
     case "$cat" in
       lookup|architecture|external-comparison|risk-assessment|feasibility) ;;
       *)

--- a/scripts/eval-research.sh
+++ b/scripts/eval-research.sh
@@ -206,16 +206,19 @@ validate_eval_set() {
       continue
     fi
     if ! [[ "$id" =~ ^[a-z0-9-]+$ ]]; then
-      printf 'eval-research: entry has invalid id (must match ^[a-z0-9-]+$, kebab-case): %s\n' "$id" >&2
+      printf 'eval-research: entry has invalid id (must match ^[a-z0-9-]+$ — lowercase letters, digits, and hyphens only): %s\n' "$id" >&2
       rc=1
+    else
+      # Duplicate check is gated on format validity so glob metacharacters
+      # in $id (e.g. `*`, `?`, `[`) cannot leak into the case-pattern below.
+      case "$seen_ids" in
+        *"|$id|"*)
+          printf 'eval-research: duplicate eval id: %s\n' "$id" >&2
+          rc=1
+          ;;
+        *) seen_ids="${seen_ids}|$id|" ;;
+      esac
     fi
-    case "$seen_ids" in
-      *"|$id|"*)
-        printf 'eval-research: duplicate eval id: %s\n' "$id" >&2
-        rc=1
-        ;;
-      *) seen_ids="${seen_ids}|$id|" ;;
-    esac
     case "$cat" in
       lookup|architecture|external-comparison|risk-assessment|feasibility) ;;
       *)

--- a/scripts/test-eval-set-structure.md
+++ b/scripts/test-eval-set-structure.md
@@ -13,6 +13,7 @@ It is a **standalone Makefile target**, not a `test-harnesses` prerequisite — 
 3. `eval-set.md` declares at least 20 entries via `### eval-<N>:` headings.
 4. All five required categories appear at least once: `lookup`, `architecture`, `external-comparison`, `risk-assessment`, `feasibility`.
 5. Every entry has all six required fields: `question`, `category`, `expected_provenance_count`, `expected_keywords`, `notes` (the `id` is in the heading itself; the field schema validation is line-anchored against `^- \*\*<name>\*\*:`).
+5b. Every entry id matches `^[a-z0-9-]+$` (lowercase letters, digits, and hyphens only) and is unique across the eval set. Mirrors `validate_eval_set()` in `scripts/eval-research.sh` so duplicate or path-like ids are rejected at lint time, not just at smoke-test time. Path-like ids would otherwise escape `$WORK_DIR/$id` when a future operator hand-edits `eval-set.md` (closes #442).
 6. At least two entries are flagged `ADVERSARIAL` in their `notes` line — the catalog's "test over-claiming" contract requires both a fictitious-mechanism question and a data-absence question.
 7. `skills/research/references/eval-baseline.json` exists, parses as JSON (via `jq` when available, with a `grep` fallback), and contains the `version`, `scale`, and `entries` keys with `entries` typed as an array.
 8. `scripts/eval-research.sh` contains the literal Anthropic-blog citation tag (`anthropic.com/engineering/built-multi-agent-research-system`) — pinned so a future edit cannot drop the source attribution silently.

--- a/scripts/test-eval-set-structure.sh
+++ b/scripts/test-eval-set-structure.sh
@@ -13,6 +13,12 @@
 #   5. Every entry has all six required fields: question, category,
 #      expected_provenance_count, expected_keywords, notes (the id is in
 #      the heading itself).
+#   5b. Every entry id matches ^[a-z0-9-]+$ (kebab-case) and is unique
+#       across the eval set — mirrors validate_eval_set() in
+#       scripts/eval-research.sh so duplicate / path-like ids are
+#       rejected at lint time, not just at smoke-test time. Path-like
+#       ids would otherwise escape $WORK_DIR/$id when a future operator
+#       hand-edits eval-set.md (closes #442).
 #   6. At least two entries are flagged ADVERSARIAL in their notes —
 #      one targeting fictitious-mechanism, one targeting data-absence.
 #   7. eval-baseline.json exists, parses as JSON, and has the required
@@ -98,6 +104,21 @@ missing_fields=$(awk '
 ' "$EVAL_SET")
 if [[ -n "$missing_fields" ]]; then
   fail "eval-set.md entries with missing fields:\n$missing_fields"
+fi
+
+# Check 5b: Every entry id matches ^[a-z0-9-]+$ and is unique. Walk
+# `### eval-N: <id>` headings; report format violations and duplicates
+# in one pass. Mirrors validate_eval_set() in scripts/eval-research.sh.
+bad_ids=$(awk '
+  /^### eval-[0-9]+:/ {
+    sub(/^### eval-[0-9]+:[[:space:]]*/, "")
+    id = $0
+    if (id !~ /^[a-z0-9-]+$/) print "format: " id
+    if (seen[id]++) print "duplicate: " id
+  }
+' "$EVAL_SET")
+if [[ -n "$bad_ids" ]]; then
+  fail "eval-set.md has invalid entry ids:\n$bad_ids"
 fi
 
 # Check 6: >= 2 adversarial entries, AND each documented adversarial shape


### PR DESCRIPTION
## Summary

- Enforced eval-id format (`^[a-z0-9-]+$`) and uniqueness in `scripts/eval-research.sh validate_eval_set()` so duplicates and path-like ids fail fast under `--smoke-test` before `run_one_research()` uses the raw id as `$WORK_DIR/$id` (closes #442).
- Mirrored the same checks in `scripts/test-eval-set-structure.sh` as Check 5b so the structural lint harness rejects bad ids at `make lint` time.
- Updated sibling contracts (`scripts/eval-research.md` authoring section, `scripts/test-eval-set-structure.md` assertion list) in lockstep per AGENTS.md.

<details><summary>Architecture Diagram</summary>

Architecture diagram not available (quick mode — `/design` skipped).

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available (quick mode).

</details>

<details><summary>Test plan</summary>

- [x] `bash scripts/eval-research.sh --smoke-test` exits 0 against the current 20-entry eval-set.md (existing ids are kebab-case + unique).
- [x] `bash scripts/test-eval-set-structure.sh` exits 0.
- [x] Negative ad-hoc verification with a fixture eval-set containing `../escape`, `BAD_ID`, `glob*id`, and a duplicate `dup-id`: smoke-test exits 1 with format errors for the bad ids and a duplicate error for `dup-id`. Glob-id is reported only as format-invalid (no false-positive duplicate match), confirming the format-validity gate on the duplicate `case`.
- [x] Same fixture against `test-eval-set-structure.sh`: exits 1 reporting `format: ../escape` and `duplicate: dup-id`.
- [x] `/relevant-checks` (pre-commit + agent-lint) clean.

</details>

Closes #442

Generated with [Claude Code](https://claude.com/claude-code)
