### PR TITLE
Remove dead prefix_re awk variable in build-research-adjudication-ballot.sh (#458)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.4.8",
+  "version": "7.4.9",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.4.9] - 2026-04-25
+
+### Changed
+
+- `scripts/build-research-adjudication-ballot.sh`'s `strip_attribution()` awk END block dropped the dead `prefix_re` variable assignment. Only `prefix_re_short` was ever read (applied to the first non-empty line); the unused `prefix_re` was a maintenance/clarity hazard for future regex tweaks. `prefix_re_short` and `suffix_re` remain unchanged. Pre-existing OOS surfaced during issue #420 review. Closes #458.
+
 ## [7.4.8] - 2026-04-25
 
 ### Fixed

--- a/scripts/build-research-adjudication-ballot.sh
+++ b/scripts/build-research-adjudication-ballot.sh
@@ -235,7 +235,6 @@ function trim_right(s) { sub(/[[:space:]]+$/, "", s); return s; }
 }
 END {
   if (NR == 0) exit 0;
-  prefix_re = "^[[:space:]]*(Cursor|Codex|Claude|Code|orchestrator|Code Reviewer)[:|]?[[:space:]]*\\)?[[:space:]]*";
   prefix_re_short = "^[[:space:]]*(Cursor|Codex|Claude|Code|orchestrator|Code Reviewer)[[:space:]]*[:\\]\\)][[:space:]]*";
   suffix_re = "[[:space:]]*[\\(—-][[:space:]]*(Cursor|Codex|Claude|Code|orchestrator|Code Reviewer)[[:space:]]*\\)?[[:space:]]*$";
   if (first_nb > 0) {


### PR DESCRIPTION
## Summary
- Removed the dead `prefix_re` awk variable assignment from `strip_attribution()` in `scripts/build-research-adjudication-ballot.sh`. Only `prefix_re_short` was ever read; `prefix_re` was a maintenance/clarity hazard for future regex tweaks. `prefix_re_short` and `suffix_re` are unchanged.

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] `bash -n scripts/build-research-adjudication-ballot.sh` — shell parses cleanly.
- [x] `grep -n 'prefix_re' scripts/build-research-adjudication-ballot.sh` — only `prefix_re_short` references remain.
- [x] `/relevant-checks` — pre-commit + agent-lint pass.
- [x] Quick-mode `/review` round 1 by Cursor — `NO_ISSUES_FOUND`.

</details>

Closes #458

Generated with [Claude Code](https://claude.com/claude-code)
