### PR TITLE
Fix #485: correct fixture row to use Code]-delimiter case

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.4.19",
+  "version": "7.4.20",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.4.20] - 2026-04-25
+
+### Fixed
+
+- `scripts/build-research-adjudication-ballot.md` fixture-case table row at line 108 corrected to use the leading `]`-delimiter case. The prior row claimed input `[Code] The orchestrator skipped negotiation step 3.` is stripped, with a rationale citing the regex `^[Code]\s*`, but the leading-prefix regex applied at `scripts/build-research-adjudication-ballot.sh:252` is anchored on the alternation members (`Cursor|Codex|Claude|Code-Sec|Code-Arch|Code|orchestrator|Code Reviewer`) followed by a delimiter from `{':', ']', ')'}` — a line whose first non-space character is `[` does not satisfy the anchored alternation, so `[Code] ...` is NOT stripped. Row rewritten to first-line input `Code] The orchestrator skipped negotiation step 3.` with rationale citing the regex `^Code\s*]\s*`, preserving pedagogical coverage of the `]`-delimiter alternative in the fixture table. Pre-existing OOS — not introduced by issue #461. Closes #485.
+
 ## [7.4.19] - 2026-04-25
 
 ### Fixed

--- a/scripts/build-research-adjudication-ballot.md
+++ b/scripts/build-research-adjudication-ballot.md
@@ -105,7 +105,7 @@ The ballot body MUST NOT contain `Cursor`, `Codex`, `Claude`, `Code`, `Code-Sec`
 | Input first/last line | Stripped? | Rationale |
 |-----------------------|-----------|-----------|
 | `Cursor: The merge step lacks a deterministic sort.` (first line) | YES — leading | Pattern matches `^Cursor:\s*` exactly. |
-| `[Code] The orchestrator skipped negotiation step 3.` (first line) | YES — leading | Pattern matches `^[Code]\s*` exactly. |
+| `Code] The orchestrator skipped negotiation step 3.` (first line) | YES — leading | Pattern matches `^Code\s*]\s*` exactly. |
 | `Code-Sec: missing input validation on user-supplied URL.` (first line) | YES — leading | Deep-mode security lane attribution; pattern matches `^Code-Sec:\s*`. |
 | `Code-Arch: violates separation of concerns between layers.` (first line) | YES — leading | Deep-mode architecture lane attribution; pattern matches `^Code-Arch:\s*`. |
 | `(— Cursor)` at end of last line | YES — trailing | Pattern matches `\s*\(—\s*Cursor\s*\)$`. |


### PR DESCRIPTION
## Summary
- Corrected the fixture-case table row at `scripts/build-research-adjudication-ballot.md:108` so the input example and rationale actually match the leading-prefix regex applied by `scripts/build-research-adjudication-ballot.sh:252`.
- Rewrote the row's first-line example from `[Code] The orchestrator skipped negotiation step 3.` to `Code] The orchestrator skipped negotiation step 3.`, and the rationale from `Pattern matches `^[Code]\s*` exactly.` to `Pattern matches `^Code\s*]\s*` exactly.` — preserving pedagogical coverage of the `]`-delimiter alternative in the fixture table (Option A from the issue).

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] Visual inspection: `Code] The orchestrator skipped negotiation step 3.` matches `^[[:space:]]*(...|Code|...)[[:space:]]*[:\]\)][[:space:]]*` (alternation hit on `Code`, delimiter hit on `]`).
- [x] `/relevant-checks` (markdownlint, agent-lint, gitleaks, repo-wide agent-lint) — all green.
- [x] CI green on the PR.

</details>

Closes #485

Generated with [Claude Code](https://claude.com/claude-code)
