### PR TITLE
Fix #477: guard value-taking flags against missing values in eval-research.sh

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.4.20",
+  "version": "7.4.21",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.4.21] - 2026-04-25
+
+### Fixed
+
+- `scripts/eval-research.sh` now exits 2 (not 1) when a value-taking flag is invoked with no following value (e.g. a trailing `--baseline`). Pre-fix, `shift 2` aborted under `set -euo pipefail` with exit 1, colliding with the documented schema-validation exit code and making malformed flag invocations indistinguishable from real schema failures to wrappers checking `$?`. A new `require_value` helper applies an arity check before each `shift 2` for all seven value-taking flags (`--id`, `--scale`, `--baseline`, `--work-dir`, `--write-baseline`, `--timeout`, `--judge-timeout`) and emits a clear stderr message naming the offending flag. The exit-code contract in `scripts/eval-research.md` is updated, and `scripts/test-eval-research-baseline-flag.sh` adds Sub-4 spot-checking the trailing-`--baseline` regression. Closes #477.
+
 ## [7.4.20] - 2026-04-25
 
 ### Fixed

--- a/scripts/eval-research.md
+++ b/scripts/eval-research.md
@@ -124,7 +124,7 @@ Authors editing `skills/research/references/eval-set.md` MUST follow:
 | `skills/research/references/eval-baseline.json` | Schema-only stub today (`entries: []`). Operator runs `bash scripts/eval-research.sh --write-baseline <file>` to populate. |
 | `scripts/test-eval-set-structure.sh` | Offline structural regression. Asserts entry count, category coverage, schema validity, and invokes `--smoke-test` for round-trip verification. |
 | `scripts/test-eval-set-structure.md` | Sibling contract for the test harness. |
-| `scripts/test-eval-research-baseline-flag.sh` | Standalone offline regression harness for the `--baseline` flag handling (closes #441). PATH-stubs `claude` and `jq` so it runs without the real binaries. Exercises the three flag-state paths (no-flag / valid-ref / bad-ref). |
+| `scripts/test-eval-research-baseline-flag.sh` | Standalone offline regression harness for the `--baseline` flag handling (closes #441; extended for #477). PATH-stubs `claude` and `jq` so it runs without the real binaries. Exercises the flag-state paths: no-flag, valid-ref, bad-ref, and trailing-flag-with-no-value. |
 | `scripts/test-eval-research-baseline-flag.md` | Sibling contract for the `--baseline` flag test harness. |
 | `Makefile` | Adds `eval-research`, `test-eval-set-structure`, and `test-eval-research-baseline-flag` standalone targets. NONE is a `test-harnesses` prerequisite. |
 | `agent-lint.toml` | Excludes `scripts/eval-research.sh`, `scripts/test-eval-set-structure.sh`, and `scripts/test-eval-research-baseline-flag.sh` from dead-script checks (all are Makefile-only references). |

--- a/scripts/eval-research.md
+++ b/scripts/eval-research.md
@@ -137,7 +137,7 @@ Authors editing `skills/research/references/eval-set.md` MUST follow:
 
 - `0` — harness ran. Per-entry timeouts and parse failures are reported in the `status` column / `research_status` JSON field, not the exit code.
 - `1` — schema validation of `eval-set.md` or `eval-baseline.json` failed.
-- `2` — argument parse error or invalid argument value (bad timeout integer, regex-invalid baseline ref, or baseline ref that cannot be resolved via `git show`).
+- `2` — argument parse error or invalid argument value (bad timeout integer, regex-invalid baseline ref, baseline ref that cannot be resolved via `git show`, or a value-taking flag with no following value — e.g. a trailing `--baseline` — which previously aborted with code 1 under `set -e` and collided with the schema-validation code; issue #477 separated the two).
 - `3` — required tooling missing (`claude`, `jq`, or `awk`).
 
 ## Security

--- a/scripts/eval-research.sh
+++ b/scripts/eval-research.sh
@@ -53,8 +53,9 @@
 #       reported in the status column, not the exit code).
 #   1 — schema validation of eval-set.md or eval-baseline.json failed.
 #   2 — argument parse error or invalid argument value (e.g., bad timeout
-#       integer, regex-invalid baseline ref, or baseline ref that cannot be
-#       resolved via git show).
+#       integer, regex-invalid baseline ref, baseline ref that cannot be
+#       resolved via git show, or a value-taking flag with no following
+#       value such as a trailing `--baseline`).
 #   3 — required tooling missing (claude, jq, awk).
 #
 # Security: --baseline accepts only [0-9A-Za-z_./-]+ to avoid shell
@@ -91,15 +92,29 @@ print_usage() {
   awk '/^# Usage:/,/^# Security:/' "${BASH_SOURCE[0]}" | sed 's/^# \?//'
 }
 
+# Guard for value-taking flags. Without this, a trailing flag with no
+# following value (e.g. `eval-research.sh --baseline`) reaches `shift 2`
+# with only one positional left, which fails under `set -e` and exits
+# with code 1 — colliding with the documented schema-validation exit
+# code (issue #477). Routing missing values to exit 2 lines up with the
+# script's other argument-parse errors (unknown argument, regex-invalid
+# baseline ref).
+require_value() {
+  if (( $2 < 2 )); then
+    printf 'eval-research: %s requires a value\n' "$1" >&2
+    exit 2
+  fi
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --id) ID_FILTER="${2:-}"; shift 2 ;;
-    --scale) SCALE="${2:-standard}"; shift 2 ;;
-    --baseline) BASELINE_REF="${2:-}"; shift 2 ;;
-    --work-dir) WORK_DIR="${2:-}"; shift 2 ;;
-    --write-baseline) WRITE_BASELINE_FILE="${2:-}"; shift 2 ;;
-    --timeout) TIMEOUT_SECONDS="${2:-4200}"; shift 2 ;;
-    --judge-timeout) JUDGE_TIMEOUT_SECONDS="${2:-600}"; shift 2 ;;
+    --id) require_value "$1" "$#"; ID_FILTER="${2:-}"; shift 2 ;;
+    --scale) require_value "$1" "$#"; SCALE="${2:-standard}"; shift 2 ;;
+    --baseline) require_value "$1" "$#"; BASELINE_REF="${2:-}"; shift 2 ;;
+    --work-dir) require_value "$1" "$#"; WORK_DIR="${2:-}"; shift 2 ;;
+    --write-baseline) require_value "$1" "$#"; WRITE_BASELINE_FILE="${2:-}"; shift 2 ;;
+    --timeout) require_value "$1" "$#"; TIMEOUT_SECONDS="${2:-4200}"; shift 2 ;;
+    --judge-timeout) require_value "$1" "$#"; JUDGE_TIMEOUT_SECONDS="${2:-600}"; shift 2 ;;
     --smoke-test) SMOKE_TEST="true"; shift ;;
     --help|-h) print_usage; exit 0 ;;
     *)

--- a/scripts/test-eval-research-baseline-flag.md
+++ b/scripts/test-eval-research-baseline-flag.md
@@ -2,11 +2,12 @@
 
 ## Purpose
 
-Regression harness for the `--baseline` flag handling in `scripts/eval-research.sh`. Pins the post-#441 behavior so the three flag-state paths cannot silently regress:
+Regression harness for the `--baseline` flag handling in `scripts/eval-research.sh`. Pins the post-#441 and post-#477 behavior so these flag-state paths cannot silently regress:
 
 1. **Sub-1** — `--baseline` not set: no `PREVIEW MODE` banner on stdout; exit 0; no cache file at `$WORK_DIR/baseline-rows.json`.
 2. **Sub-2** — `--baseline <valid-ref>` (using `HEAD` against the committed `skills/research/references/eval-baseline.json` schema-only stub): exit 0; `PREVIEW MODE` banner present on stdout (visible alongside the summary table); baseline cached to `$WORK_DIR/baseline-rows.json`.
 3. **Sub-3** — `--baseline <bogus-ref>`: exit 2; stderr error names the unresolvable ref AND surfaces a tail of `git show`'s captured stderr (so operators can distinguish ref-missing / file-missing-at-ref / non-git-checkout); no cache file left behind.
+4. **Sub-4** — trailing `--baseline` with no following value: exit 2; stderr names `--baseline` as the flag missing its value. Pins the issue #477 fix that separated this case from the schema-validation exit-1 path; pre-fix, `shift 2` aborted under `set -e` with exit 1, indistinguishable from a real schema failure.
 
 ## Invocation
 

--- a/scripts/test-eval-research-baseline-flag.sh
+++ b/scripts/test-eval-research-baseline-flag.sh
@@ -175,9 +175,11 @@ fi
 # positional remained, exiting with code 1 — which collides with the
 # documented schema-validation exit code, making a malformed flag
 # indistinguishable from a real schema failure to wrappers checking $?
-# (issue #477). The fix adds a `[[ $# -lt 2 ]]` guard before each `shift 2`
-# in the parser loop so missing values yield exit 2 with a recognizable
-# stderr message — uniform across all seven value-taking flags.
+# (issue #477). The fix adds a `require_value` arity check before each
+# `shift 2` in the parser loop so missing values yield exit 2 with a
+# recognizable stderr message. The helper is applied uniformly to all
+# seven value-taking flags in eval-research.sh; this Sub-4 spot-checks
+# `--baseline` since that is the case the issue reported.
 # -----------------------------------------------------------------------
 
 echo "--- Sub-4: trailing --baseline with no value ---"

--- a/scripts/test-eval-research-baseline-flag.sh
+++ b/scripts/test-eval-research-baseline-flag.sh
@@ -170,6 +170,35 @@ else
 fi
 
 # -----------------------------------------------------------------------
+# Sub-4: trailing --baseline with no value → exit 2; clear error on stderr.
+# Pre-fix behavior: `shift 2` failed under `set -e` because only one
+# positional remained, exiting with code 1 — which collides with the
+# documented schema-validation exit code, making a malformed flag
+# indistinguishable from a real schema failure to wrappers checking $?
+# (issue #477). The fix adds a `[[ $# -lt 2 ]]` guard before each `shift 2`
+# in the parser loop so missing values yield exit 2 with a recognizable
+# stderr message — uniform across all seven value-taking flags.
+# -----------------------------------------------------------------------
+
+echo "--- Sub-4: trailing --baseline with no value ---"
+sub4_stdout="$fixture_tmp/sub4.stdout"
+sub4_stderr="$fixture_tmp/sub4.stderr"
+sub4_rc=0
+PATH="$stub_dir:$PATH" bash "$SCRIPT" --id nonexistent-id-zzz --baseline \
+  >"$sub4_stdout" 2>"$sub4_stderr" || sub4_rc=$?
+
+if [[ "$sub4_rc" == "2" ]]; then
+  pass "Sub-4: exit 2 on trailing --baseline with no value"
+else
+  fail "Sub-4: expected exit 2, got $sub4_rc (stderr: $(tail -n 5 "$sub4_stderr"))"
+fi
+if grep -q -- '--baseline requires a value' "$sub4_stderr"; then
+  pass "Sub-4: stderr names --baseline as the flag missing a value"
+else
+  fail "Sub-4: stderr does not name --baseline (full stderr: $(cat "$sub4_stderr"))"
+fi
+
+# -----------------------------------------------------------------------
 # Summary
 # -----------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Added a `require_value` arity guard before each `shift 2` in `scripts/eval-research.sh`'s argument parser so a value-taking flag with no following value (e.g. trailing `--baseline`) now exits 2 with a clear stderr message instead of aborting under `set -e` with exit 1 and colliding with the documented schema-validation exit code.
- Extended `scripts/test-eval-research-baseline-flag.sh` with a Sub-4 regression case pinning the trailing-`--baseline` exit-2 contract; updated the sibling contracts (`scripts/eval-research.md` exit-code section and the `scripts/test-eval-research-baseline-flag.md` Purpose list).

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] `bash scripts/test-eval-research-baseline-flag.sh` — all 12 assertions pass (Sub-1/2/3 unchanged; Sub-4 newly pinning trailing-flag exit-2)
- [x] Reproduced the bug pre-fix: `bash -c 'set -e; shift 2'` style harness exits 1 on a single-arg shift 2
- [x] Verified the post-fix: `bash scripts/eval-research.sh --id x --baseline` → exit 2 with `eval-research: --baseline requires a value` on stderr
- [x] `/relevant-checks` (pre-commit + agent-lint) green on the changed file set
- [x] All seven value-taking flags (`--id`, `--scale`, `--baseline`, `--work-dir`, `--write-baseline`, `--timeout`, `--judge-timeout`) wired through the same `require_value` helper

</details>

Closes #477

Generated with [Claude Code](https://claude.com/claude-code)
