### PR TITLE
Fix #469: extend dialectic-protocol Consumer Contract for /research --adjudicate caller

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.4.23",
+  "version": "7.4.24",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.4.24] - 2026-04-25
+
+### Changed
+
+- `skills/shared/dialectic-protocol.md` Consumer Contract section now enumerates both callers (`/design` Steps 2b/3.5 parsing `$DESIGN_TMPDIR/dialectic-resolutions.md`; `/research --adjudicate` Steps 2.5/3 parsing `$RESEARCH_TMPDIR/adjudication-resolutions.md`) and documents per-caller existence/short-circuit guards, the caller-specific `Resolution` literal sets (`/design` uses `{CHOSEN}`/`{ALTERNATIVE}`; `/research --adjudicate` uses `reinstate`/`rejection-stands`), and a parallel research-side paragraph in `## Scope and Precedence`. Field names and the `Disposition` enum stay shared across callers so a single parser can extract them. Pre-existing documentation gap unrelated to issue #440. Closes #469.
+
 ## [7.4.23] - 2026-04-25
 
 ### Fixed

--- a/skills/shared/dialectic-protocol.md
+++ b/skills/shared/dialectic-protocol.md
@@ -268,13 +268,18 @@ Field rules per disposition:
 
 ## Consumer Contract
 
-Step 2b (`/design` plan generation) and Step 3.5 (design discussion round 2) parse `dialectic-resolutions.md`. Consumers MUST:
+This contract is shared across both callers — the field-name set and Disposition enum below apply identically to both, so future tooling that consumes either resolutions file can use one parser. Two callers parse the resolutions, each from its own caller-specific basename:
+
+- `/design` Step 2b (plan generation) and Step 3.5 (design discussion round 2) parse `$DESIGN_TMPDIR/dialectic-resolutions.md`.
+- `/research --adjudicate` Step 2.5 (the reinstatement-into-validated-synthesis sub-step) and Step 3 (final report rendering of the `**Adjudication phase**: <X> reinstated, <Y> upheld` header line) parse `$RESEARCH_TMPDIR/adjudication-resolutions.md`.
+
+The two artifact files use distinct basenames so they do not collide on disk; the field schema below is identical across them. Consumers MUST:
 
 1. Parse field names verbatim: `**Resolution**:`, `**Disposition**:`, `**Vote tally**:`, `**Thesis summary**:`, `**Antithesis summary**:`, `**Why thesis prevails**:` / `**Why antithesis prevails**:` / `**Why fallback**:` / `**Why skipped**:` / `**Why over-cap**:`.
 2. Recognize exactly these four Disposition values: `voted`, `fallback-to-synthesis`, `bucket-skipped`, `over-cap`.
-3. Treat `voted` as binding (plan must follow `Resolution` and engage antithesis). Treat the other three as non-binding (synthesis decision stands for that point; do NOT fabricate antithesis-engagement prose where no antithesis was heard).
+3. Treat `voted` as binding (consumer must follow `Resolution` — for `/design` the plan must engage antithesis; for `/research --adjudicate` `Resolution: reinstate` triggers the reinstatement-into-validated-synthesis sub-step). Treat the other three Dispositions as non-binding (synthesis decision stands for that point; do NOT fabricate antithesis-engagement prose where no antithesis was heard).
 
-### Step 3.5 still-contested criterion
+### Step 3.5 still-contested criterion (`/design` only)
 
 Step 3.5 reads `dialectic-resolutions.md` to identify decisions that warrant user discussion. A decision is "still contested" if any of:
 

--- a/skills/shared/dialectic-protocol.md
+++ b/skills/shared/dialectic-protocol.md
@@ -19,7 +19,7 @@ This protocol is written in terms of a caller-bound path-prefix placeholder, **`
 
 ## Overview
 
-After `/design` Step 2a.5 runs the thesis/antithesis debater fanout, an eligibility gate classifies each decision's `Disposition` (`voted` | `fallback-to-synthesis` | `bucket-skipped` | `over-cap`). For `voted` decisions, a 3-judge panel (Claude Code Reviewer subagent + Codex + Cursor, with Claude replacements when externals are unhealthy) reads a single ballot containing attribution-stripped defense texts and casts one binary vote per decision. Votes are tallied per-decision with binary thresholds. Resolutions are written to `$DIALECTIC_TMPDIR/dialectic-resolutions.md` with a structured schema parseable by Step 2b and Step 3.5.
+After `/design` Step 2a.5 runs the thesis/antithesis debater fanout, an eligibility gate classifies each decision's `Disposition` (`voted` | `fallback-to-synthesis` | `bucket-skipped` | `over-cap`). For `voted` decisions, a 3-judge panel (Claude Code Reviewer subagent + Codex + Cursor, with Claude replacements when externals are unhealthy) reads a single ballot containing attribution-stripped defense texts and casts one binary vote per decision. Votes are tallied per-decision with binary thresholds. Resolutions are written to `$DIALECTIC_TMPDIR/dialectic-resolutions.md` with a structured schema parseable by Step 2b and Step 3.5 — the `/research --adjudicate` caller reuses the same schema under a different basename; see Caller Binding above and Consumer Contract below.
 
 ## Disposition Enum
 
@@ -270,14 +270,14 @@ Field rules per disposition:
 
 This contract is shared across both callers — the field-name set and Disposition enum below apply identically to both, so future tooling that consumes either resolutions file can use one parser. Two callers parse the resolutions, each from its own caller-specific basename:
 
-- `/design` Step 2b (plan generation) and Step 3.5 (design discussion round 2) parse `$DESIGN_TMPDIR/dialectic-resolutions.md`.
-- `/research --adjudicate` Step 2.5 (the reinstatement-into-validated-synthesis sub-step) and Step 3 (final report rendering of the `**Adjudication phase**: <X> reinstated, <Y> upheld` header line) parse `$RESEARCH_TMPDIR/adjudication-resolutions.md`.
+- `/design` Step 2b (plan generation, per `skills/design/SKILL.md`) and Step 3.5 (design discussion round 2, per `skills/design/references/discussion-rounds.md`) parse `$DESIGN_TMPDIR/dialectic-resolutions.md` when it exists and is non-empty. The file may be absent on the `NO_CONTESTED_DECISIONS` short-circuit at Step 2a.5; Step 3.5's still-contested matcher short-circuits naturally when no entries match its criteria.
+- `/research --adjudicate` Step 2.5 (the reinstatement-into-validated-synthesis sub-step) and Step 3 (final report rendering of the `**Adjudication phase**: <X> reinstated, <Y> upheld` header line) parse `$RESEARCH_TMPDIR/adjudication-resolutions.md` when present. On the no-rejections short-circuit path Step 2.5 does not write this file (per `skills/research/references/adjudication-phase.md`'s `RAN=false` branch); Step 3 then renders the literal `0 reinstated, 0 upheld (no rejections to adjudicate)` form (per `skills/research/SKILL.md` Step 3) instead of parsing.
 
-The two artifact files use distinct basenames so they do not collide on disk; the field schema below is identical across them. Consumers MUST:
+The two artifact files use distinct basenames so they do not collide on disk. Field **names** and the `Disposition` value set below are identical across both callers (so a single parser can extract them), but the **`Resolution` field's allowed literal values are caller-specific**: `/design` uses the synthesis `{CHOSEN}` / `{ALTERNATIVE}` literals; `/research --adjudicate` uses `reinstate` / `rejection-stands`. A single validator over `Resolution` literals would therefore need a per-caller switch — see `skills/design/references/dialectic-execution.md` and `skills/research/references/adjudication-phase.md` for the per-caller token sets. Consumers MUST:
 
 1. Parse field names verbatim: `**Resolution**:`, `**Disposition**:`, `**Vote tally**:`, `**Thesis summary**:`, `**Antithesis summary**:`, `**Why thesis prevails**:` / `**Why antithesis prevails**:` / `**Why fallback**:` / `**Why skipped**:` / `**Why over-cap**:`.
 2. Recognize exactly these four Disposition values: `voted`, `fallback-to-synthesis`, `bucket-skipped`, `over-cap`.
-3. Treat `voted` as binding (consumer must follow `Resolution` — for `/design` the plan must engage antithesis; for `/research --adjudicate` `Resolution: reinstate` triggers the reinstatement-into-validated-synthesis sub-step). Treat the other three Dispositions as non-binding (synthesis decision stands for that point; do NOT fabricate antithesis-engagement prose where no antithesis was heard).
+3. Treat `voted` as binding (consumer must follow `Resolution` — for `/design` the plan must engage antithesis; for `/research --adjudicate` `Resolution: reinstate` triggers the reinstatement-into-validated-synthesis sub-step). Treat the other three Dispositions as non-binding: synthesis decision stands for that point, and consumers must not fabricate counter-position output (`/design` antithesis-engagement prose, `/research --adjudicate` reinstatement) where the dialectic layer did not produce a heard counter-position.
 
 ### Step 3.5 still-contested criterion (`/design` only)
 
@@ -292,4 +292,6 @@ A decision with `Disposition: voted` AND `Vote tally` showing a 3-0 or 2-0 major
 
 ## Scope and Precedence
 
-Dialectic resolutions are **binding for Step 2b plan generation only**. They may be superseded by accepted Step 3 plan review findings. The finalized plan (after Step 3 review) remains the sole canonical output.
+For `/design`: dialectic resolutions are **binding for Step 2b plan generation only**. They may be superseded by accepted Step 3 plan review findings. The finalized plan (after Step 3 review) remains the sole canonical output.
+
+For `/research --adjudicate`: adjudication resolutions are binding for Step 2.5's reinstatement-into-validated-synthesis sub-step — `Resolution: reinstate` triggers integration of the reviewer's finding back into the synthesis under the existing `## Revised Research Findings` header (per `skills/research/references/adjudication-phase.md`). The validated-and-possibly-reinstated synthesis is then the sole canonical input for Step 3's final research report; there is no separate plan-review supersession step on this caller.


### PR DESCRIPTION
## Summary
- Extended the `## Consumer Contract` section of `skills/shared/dialectic-protocol.md` to enumerate both callers (`/design` Steps 2b/3.5 parsing `$DESIGN_TMPDIR/dialectic-resolutions.md`; `/research --adjudicate` Steps 2.5/3 parsing `$RESEARCH_TMPDIR/adjudication-resolutions.md`) and clarified that the same field-name set and `Disposition` enum apply to both, while allowed `Resolution` literals are caller-specific.
- Tightened the per-caller binding in Rule 3 (so the non-`voted` "do not fabricate counter-position" guard is symmetric across `/design` antithesis-engagement prose and `/research --adjudicate` reinstatement) and labeled the `Step 3.5 still-contested criterion` subsection as `/design`-only.
- Added a parallel `/research --adjudicate` paragraph under `## Scope and Precedence` and a brief forward-reference clause in `## Overview` so a reader skimming top-down does not misread the protocol as `/design`-only. Pre-existing documentation gap unrelated to issue #440.

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] `pre-commit run --files skills/shared/dialectic-protocol.md` — markdownlint, agent-lint, gitleaks, secret detection all pass
- [x] `agent-lint` full-repo pass: `Plugin structure OK`
- [x] Post-edit re-read of `skills/shared/dialectic-protocol.md` confirms the updated Consumer Contract is consistent with the file's prior cross-caller mentions at lines 5 and 18 and with `skills/research/references/adjudication-phase.md` (Step 2.5 reinstatement-into-validated-synthesis) and `skills/research/SKILL.md` Step 3 (adjudication-phase header line).

</details>

Closes #469

Generated with [Claude Code](https://claude.com/claude-code)
