### PR TITLE
Fix #498: typo `bothhere` → `both` in dialectic-protocol.md

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.4.25",
+  "version": "7.4.26",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.4.26] - 2026-04-25
+
+### Fixed
+
+- `skills/shared/dialectic-protocol.md` Tally and Resolution section: typo `bothhere` → `both` in the `voted`-eligible decision sentence so it reads "both sides passed the eligibility gate". Pre-existing OOS surfaced by Cursor during round-2 review of #469. Closes #498.
+
 ## [7.4.25] - 2026-04-25
 
 ### Changed

--- a/skills/shared/dialectic-protocol.md
+++ b/skills/shared/dialectic-protocol.md
@@ -232,7 +232,7 @@ If a judge's output is completely unparseable (no valid vote lines at all), prin
 
 ## Tally and Resolution
 
-For each `voted`-eligible decision (bothhere sides passed the eligibility gate and at least one judge cast a parseable vote):
+For each `voted`-eligible decision (both sides passed the eligibility gate and at least one judge cast a parseable vote):
 
 1. Count THESIS and ANTI_THESIS votes from eligible judges.
 2. Apply the threshold rules above.


### PR DESCRIPTION
## Summary
- Fixed typo `bothhere` → `both` in `skills/shared/dialectic-protocol.md:235` so the `voted`-eligible decision sentence reads "both sides passed the eligibility gate".

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] `grep -rn "bothhere" /Users/zhupanov/larch1` returns no matches after edit.
- [x] `/relevant-checks` clean (pre-commit + agent-lint).

</details>

Closes #498

Generated with [Claude Code](https://claude.com/claude-code)
