### PR TITLE
Fix #499: scope /design-only framing in dialectic-protocol Disposition Enum

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.4.26",
+  "version": "7.4.27",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.4.27] - 2026-04-25
+
+### Changed
+
+- `skills/shared/dialectic-protocol.md` `## Disposition Enum` section's two /design-only-framed clauses scoped for both callers after #469 made the Consumer Contract dual-caller. The `over-cap` row's `Step 3.5 treats as still-contested` clause now carries an explicit `For /design:` qualifier (no /research --adjudicate parallel — research has no Step 3.5, and the "no debate occurred" semantics already suffice). The trailing paragraph after the disposition table now scopes its /design-only `Step 2a.4` / `Step 2b` / "antithesis engagement prose" sentence with `For /design:` and adds a parallel `For /research --adjudicate:` clause matching the existing Consumer Contract item 3 vocabulary (validation-merge synthesis stands; Step 2.5 must not reinstate a finding for non-`voted` entries — no reinstatement-into-validated-synthesis sub-step where the dialectic layer did not produce a heard counter-position). Pre-existing drift; predates #469. Closes #499.
+
 ## [7.4.26] - 2026-04-25
 
 ### Fixed

--- a/skills/shared/dialectic-protocol.md
+++ b/skills/shared/dialectic-protocol.md
@@ -30,9 +30,9 @@ Every decision selected by Step 2a.5 gets exactly one resolution entry with one 
 | `voted` | Both debater sides passed the eligibility gate; a judge panel voted; a majority (per threshold rules) resolved the decision. |
 | `fallback-to-synthesis` | Debater output failed the eligibility gate, or the judge panel could not reach a majority (2-judge 1-1 tie, or <2 eligible judges). Synthesis decision stands. |
 | `bucket-skipped` | Step 2a.5 step 4 skipped the debater bucket because the assigned external tool was unavailable. No debate occurred. Synthesis decision stands. |
-| `over-cap` | The decision was listed in `contested-decisions.md` but ranked outside Step 2a.5's top-`min(5, N)` cap. No debate occurred. Synthesis decision stands; Step 3.5 treats as still-contested. |
+| `over-cap` | The decision was listed in `contested-decisions.md` but ranked outside Step 2a.5's top-`min(5, N)` cap. No debate occurred. Synthesis decision stands. For /design: Step 3.5 treats as still-contested. (For /research --adjudicate: no Step 3.5 — the "no debate occurred" semantics suffice.) |
 
-`voted` is the only binding disposition. All other dispositions mean the Step 2a.4 synthesis decision stands for that point (Step 2b must not fabricate antithesis engagement prose for non-`voted` entries).
+`voted` is the only binding disposition. All other dispositions mean the synthesis decision stands for that point. For /design: the Step 2a.4 synthesis decision stands and Step 2b must not fabricate antithesis engagement prose for non-`voted` entries. For /research --adjudicate: the validation-merge synthesis stands and Step 2.5 must not reinstate a finding for non-`voted` entries (no reinstatement-into-validated-synthesis sub-step where the dialectic layer did not produce a heard counter-position).
 
 ## Ballot Format
 


### PR DESCRIPTION
## Summary
- Scoped two /design-only-framed clauses in `skills/shared/dialectic-protocol.md` `## Disposition Enum` for both callers (/design + /research --adjudicate) after #469 made the Consumer Contract dual-caller.
- `over-cap` row's `Step 3.5 treats as still-contested` clause now carries an explicit `For /design:` qualifier (no /research analog — research has no Step 3.5).
- Trailing paragraph after the disposition table now scopes its /design-only `Step 2a.4` / `Step 2b` / "antithesis engagement prose" sentence with `For /design:` and adds a parallel `For /research --adjudicate:` clause matching Consumer Contract item 3 vocabulary.

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] `/relevant-checks` (pre-commit on modified files + agent-lint on the full repo) — passed.
- [x] Cursor reviewer (quick-mode round 1) — `NO_ISSUES_FOUND`.

</details>

Closes #499

Generated with [Claude Code](https://claude.com/claude-code)
