### PR TITLE
Fix #538: harden token-tally.sh validate_dir against symlink-parent escape

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.10.0",
+  "version": "7.10.1",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.10.1] - 2026-04-25
+
+### Fixed
+
+- `scripts/token-tally.sh` `validate_dir` now canonicalizes the nearest existing-or-symlink ancestor of `--dir` before any subcommand body runs, replacing the prior `[[ -d "$d" ]]`-gated canonicalization that allowed `cmd_write`'s `mkdir -p` to materialize directories outside `/tmp/` via a symlinked parent. The walk uses `! -e && ! -L` so dangling symlinks are caught at validation rather than letting `cd` (or downstream `mkdir -p`) fail with an opaque error; a regular-file ancestor is rejected explicitly rather than silently normalized via `dirname`. Both `/tmp` and `/private/tmp` are canonicalized when distinct so the dual-root contract is preserved on hosts where `/tmp` is not a symlink to `/private/tmp`. Pattern mirrors `scripts/deny-edit-write.sh`'s nearest-existing-ancestor probe with a `/tmp`-allow predicate. New `scripts/test-token-tally.sh` T17 adds 5 assertions across three sub-cases (live-symlink escape — the verified reproducer; dangling-symlink; regular-file ancestor) and uses `/var/tmp` as the primary escape-target location with a `$HOME` fallback so the harness stays portable in restricted CI sandboxes. Operator-visible: `--dir` whose ancestor escapes `/tmp/` now exits 1 in `report` and `check-budget` instead of emitting the "missing dir" placeholder; the tolerant missing-dir paths still apply when the ancestor is safely under `/tmp/`. Closes #538.
+
 ## [7.10.0] - 2026-04-25
 
 ### Added

--- a/scripts/test-token-tally.md
+++ b/scripts/test-token-tally.md
@@ -27,12 +27,13 @@
 | 14 | report | `--budget-aborted true` + `--adjudicate true` + no adjudication sidecars | Adjudication row reads "skipped … aborted before Step 2.5" (review FINDING_10) |
 | 15 | (all) | `--dir /tmp/../etc` (path-escape attempt) | exit 1 (review FINDING_2 — `..` segments rejected) |
 | 16 | check-budget | `--dir` points at non-existent directory | success line includes `BUDGET=<N>` (review FINDING_3 — uniform success-line shape across missing-dir and present-dir paths) |
+| 17 | (all) | symlink-parent escape under /tmp/ | exit 1 across all 3 subcommands; no escape directory created (issue #538). 17a: live symlink to outside-/tmp target (the reproducer). 17b: dangling symlink (`! -L` clause must stop the walk before `cd` fails). 17c: nearest existing ancestor is a regular file (validator must reject, not normalize via dirname). |
 
-Total: 34 individual assertions across 17 test cases (12 original + 5 new from review-round-1 fixes; Test 6 split into 6 and 6b; T15 covers all 3 subcommands per round-2 review nit).
+Total: 39 individual assertions across 18 test cases (12 original + 5 new from review-round-1 fixes + 5 new from #538 plan-review; Test 6 split into 6 and 6b; T15 covers all 3 subcommands; T17 has three sub-cases 17a/17b/17c).
 
 ## Invariants
 
-- All test fixtures use `mktemp -d "/tmp/test-token-tally.XXXXXX"` to satisfy the `--dir` path-prefix guard. Fixtures are removed at the end of each test (`rm -rf "$T"`).
+- All test fixtures use `mktemp -d "/tmp/test-token-tally.XXXXXX"` to satisfy the `--dir` path-prefix guard. Fixtures are removed at the end of each test (`rm -rf "$T"`). **T17 exception**: T17 must demonstrate that `validate_dir` rejects a symlink whose target lies *outside* `/tmp/`, so its escape-target fixture lives under `$HOME` (created via `mktemp -d "${HOME}/test-token-tally-escape.XXXXXX"`) and cleanup is wrapped in a `trap … RETURN` to survive mid-assertion failures. This deviation from the under-/tmp rule is intentional and unique to T17.
 - The harness uses three assertion helpers: `assert_exit_code`, `assert_stdout_contains`, `assert_stdout_not_contains`. Failures collect into `FAIL_DETAILS` and print at the end.
 - Exit code 1 on any failure; exit code 0 only when all assertions pass.
 

--- a/scripts/test-token-tally.md
+++ b/scripts/test-token-tally.md
@@ -33,7 +33,7 @@ Total: 39 individual assertions across 18 test cases (12 original + 5 new from r
 
 ## Invariants
 
-- All test fixtures use `mktemp -d "/tmp/test-token-tally.XXXXXX"` to satisfy the `--dir` path-prefix guard. Fixtures are removed at the end of each test (`rm -rf "$T"`). **T17 exception**: T17 must demonstrate that `validate_dir` rejects a symlink whose target lies *outside* `/tmp/`, so its escape-target fixture lives under `$HOME` (created via `mktemp -d "${HOME}/test-token-tally-escape.XXXXXX"`) and cleanup is wrapped in a `trap … RETURN` to survive mid-assertion failures. This deviation from the under-/tmp rule is intentional and unique to T17.
+- All test fixtures use `mktemp -d "/tmp/test-token-tally.XXXXXX"` to satisfy the `--dir` path-prefix guard. Fixtures are removed at the end of each test (`rm -rf "$T"`). **T17 exception**: T17 must demonstrate that `validate_dir` rejects a symlink whose target lies *outside* `/tmp/`, so its escape-target fixture lives outside `/tmp/`'s canonical tree. T17 attempts `/var/tmp` first (POSIX standard, outside `/tmp/` on both macOS and Linux, and reliably writable in CI sandboxes), falls back to `$HOME`, and finally skips T17 with a `WARNING:` to stderr if neither location is writable. The cleanup trap is installed immediately after `T_DIR` is created (before the escape-target `mktemp`) so a `mktemp` failure under `set -euo pipefail` does not leak the under-`/tmp` fixture. This deviation from the under-`/tmp` rule is intentional and unique to T17.
 - The harness uses three assertion helpers: `assert_exit_code`, `assert_stdout_contains`, `assert_stdout_not_contains`. Failures collect into `FAIL_DETAILS` and print at the end.
 - Exit code 1 on any failure; exit code 0 only when all assertions pass.
 

--- a/scripts/test-token-tally.sh
+++ b/scripts/test-token-tally.sh
@@ -257,6 +257,52 @@ out=$("$SCRIPT" check-budget --budget 1000 --dir "$T" 2>&1)
 assert_stdout_contains "T16: BUDGET= on missing-dir success" "BUDGET=1000" "$out"
 assert_stdout_contains "T16: success on missing-dir" "BUDGET_EXCEEDED=false" "$out"
 
+# ─── Test 17 (#538): validate_dir rejects symlink-parent escape ───
+# T17 is the only test case whose escape target lives outside /tmp/ —
+# the test must demonstrate that a symlinked parent under /tmp/ cannot
+# materialize a directory under $HOME via mkdir -p. mktemp -d under
+# $HOME gives a unique target; trap-based cleanup ensures no fixture
+# leak even if an assertion fails partway through.
+t17_run() {
+    local T_ESCAPE_DIR T_DIR T_DANGLING T_FILE rc
+    T_DIR="$(make_dir)"
+    T_ESCAPE_DIR=$(mktemp -d "${HOME}/test-token-tally-escape.XXXXXX")
+    # shellcheck disable=SC2317  # cleanup invoked via RETURN trap
+    t17_cleanup() { rm -rf "$T_DIR" "$T_ESCAPE_DIR"; }
+    trap t17_cleanup RETURN
+
+    # 17a: live symlink-parent escape (the #538 reproducer).
+    ln -s "$T_ESCAPE_DIR" "$T_DIR/link"
+    rc=0
+    "$SCRIPT" write --phase research --lane code --tool claude --total-tokens 100 --dir "$T_DIR/link/escaped" >/dev/null 2>&1 || rc=$?
+    assert_exit_code "T17a: write symlink-parent escape → exit 1" 1 "$rc"
+    if [ -d "$T_ESCAPE_DIR/escaped" ]; then
+        fail "T17a: write created escape directory at $T_ESCAPE_DIR/escaped"
+    fi
+    rc=0
+    "$SCRIPT" report --dir "$T_DIR/link/escaped" --scale standard --adjudicate false >/dev/null 2>&1 || rc=$?
+    assert_exit_code "T17a: report symlink-parent escape → exit 1" 1 "$rc"
+    rc=0
+    "$SCRIPT" check-budget --budget 1000 --dir "$T_DIR/link/escaped" >/dev/null 2>&1 || rc=$?
+    assert_exit_code "T17a: check-budget symlink-parent escape → exit 1" 1 "$rc"
+
+    # 17b: dangling-symlink case — `! -L` clause must stop the walk and
+    # surface a validator-level error (not a downstream mkdir error).
+    T_DANGLING="$T_DIR/dangling-link"
+    ln -s "/tmp/test-token-tally-nonexistent-target.$$" "$T_DANGLING"
+    rc=0
+    "$SCRIPT" write --phase research --lane code --tool claude --total-tokens 100 --dir "$T_DANGLING/escaped" >/dev/null 2>&1 || rc=$?
+    assert_exit_code "T17b: write dangling-symlink → exit 1" 1 "$rc"
+
+    # 17c: regular-file ancestor — must reject, not normalize via dirname.
+    T_FILE="$T_DIR/regular-file"
+    : > "$T_FILE"
+    rc=0
+    "$SCRIPT" write --phase research --lane code --tool claude --total-tokens 100 --dir "$T_FILE" >/dev/null 2>&1 || rc=$?
+    assert_exit_code "T17c: write regular-file ancestor → exit 1" 1 "$rc"
+}
+t17_run
+
 # ─── Summary ───
 echo
 echo "─────────────────────────────────────────"

--- a/scripts/test-token-tally.sh
+++ b/scripts/test-token-tally.sh
@@ -260,16 +260,23 @@ assert_stdout_contains "T16: success on missing-dir" "BUDGET_EXCEEDED=false" "$o
 # ─── Test 17 (#538): validate_dir rejects symlink-parent escape ───
 # T17 is the only test case whose escape target lives outside /tmp/ —
 # the test must demonstrate that a symlinked parent under /tmp/ cannot
-# materialize a directory under $HOME via mkdir -p. mktemp -d under
-# $HOME gives a unique target; trap-based cleanup ensures no fixture
-# leak even if an assertion fails partway through.
+# materialize a directory outside /tmp/ via mkdir -p. The escape-target
+# fixture lives under /var/tmp (POSIX standard, outside /tmp/'s canonical
+# tree on both macOS and Linux, and reliably writable in CI sandboxes
+# where $HOME may be restricted). The RETURN trap is installed BEFORE
+# the escape-target mktemp so a /var/tmp or $HOME write failure does
+# not leak the under-/tmp fixture under set -euo pipefail.
 t17_run() {
-    local T_ESCAPE_DIR T_DIR T_DANGLING T_FILE rc
+    local T_ESCAPE_DIR="" T_DIR T_DANGLING T_FILE rc
     T_DIR="$(make_dir)"
-    T_ESCAPE_DIR=$(mktemp -d "${HOME}/test-token-tally-escape.XXXXXX")
     # shellcheck disable=SC2317  # cleanup invoked via RETURN trap
-    t17_cleanup() { rm -rf "$T_DIR" "$T_ESCAPE_DIR"; }
+    t17_cleanup() { rm -rf "$T_DIR" ${T_ESCAPE_DIR:+"$T_ESCAPE_DIR"}; }
     trap t17_cleanup RETURN
+    T_ESCAPE_DIR=$(mktemp -d /var/tmp/test-token-tally-escape.XXXXXX 2>/dev/null) || \
+        T_ESCAPE_DIR=$(mktemp -d "${HOME}/test-token-tally-escape.XXXXXX" 2>/dev/null) || {
+            echo "WARNING: T17 skipped — could not create escape-target outside /tmp/ (tried /var/tmp and \$HOME)" >&2
+            return 0
+        }
 
     # 17a: live symlink-parent escape (the #538 reproducer).
     ln -s "$T_ESCAPE_DIR" "$T_DIR/link"

--- a/scripts/token-tally.md
+++ b/scripts/token-tally.md
@@ -69,6 +69,8 @@ Operators can audit the unmeasurable lanes via the sidecar files directly when i
 
 All three subcommands validate `--dir` is under `/tmp/` or `/private/tmp/` (matching `cleanup-tmpdir.sh:36-40`). This is defense in depth: although the orchestrator only ever passes `$RESEARCH_TMPDIR` (always under `/tmp/`), a misinvocation or future caller mistake could otherwise glob and read filenames from any user-supplied directory. Reject early with exit 1.
 
+**Symlink-parent canonicalization (issue #538)**: `validate_dir` walks `--dir` upward via `dirname` to the nearest **existing-or-symlink** ancestor (the `! -e && ! -L` loop guard catches dangling symlinks instead of walking past them), canonicalizes that ancestor with `cd … && pwd -P`, and accepts only when the canonical anchor is exactly `/tmp` (canonical) or under it. Both `/tmp` and `/private/tmp` are canonicalized at validation time when distinct (typically only on Linux) so the dual-root contract is preserved. A nearest existing ancestor that is a regular file (or symlink-to-file) is rejected — `validate_dir` does not silently take its parent. The pattern mirrors `scripts/deny-edit-write.sh`'s nearest-existing-ancestor probe with a `/tmp`-allow predicate. **Operator-visible behavior change**: a `--dir` whose ancestor resolves outside `/tmp/` now exits 1 in `report` and `check-budget` instead of emitting the "missing dir" placeholder / `BUDGET_EXCEEDED=false` success line. The tolerant missing-dir paths still apply when the ancestor is safely under `/tmp/` (the `[[ ! -d "$dir" ]]` branches in `cmd_report` and `cmd_check_budget` still fire for legitimate not-yet-created tmpdirs).
+
 ## Test harness
 
 `scripts/test-token-tally.sh` is the offline regression harness. Test cases:

--- a/scripts/token-tally.sh
+++ b/scripts/token-tally.sh
@@ -57,24 +57,69 @@ validate_dir() {
         return 1
     fi
     # Canonical-path guard (defense in depth — resolves symlinks, ., ..).
-    # Skip when the directory does not yet exist (the `report` and
-    # `check-budget` paths handle the missing-dir case explicitly via their
-    # own `[[ ! -d $dir ]]` branches; `write` calls `mkdir -p` after this
-    # function returns). Use `cd ... && pwd -P` rather than `realpath` for
-    # portability — `realpath` is not POSIX and missing on some macOS
-    # installs without coreutils.
-    if [[ -d "$d" ]]; then
-        local resolved
-        resolved=$(cd "$d" 2>/dev/null && pwd -P) || {
-            echo "ERROR: cannot resolve --dir: $d" >&2
-            return 1
-        }
-        if [[ "$resolved" != /tmp/* && "$resolved" != /private/tmp/* ]]; then
-            echo "ERROR: --dir resolves outside /tmp/ (resolved: $resolved)" >&2
-            return 1
-        fi
+    # The string-prefix check above rejects literal escapes like /home/foo,
+    # but a path like /tmp/foo/link/leaf where /tmp/foo/link is a symlink
+    # to outside /tmp still passes the string check. Until #538 we only
+    # canonicalized when [[ -d $d ]] held, leaving cmd_write's mkdir -p
+    # to materialize the escaped directory on a not-yet-existing leaf.
+    # Fix: walk to the nearest existing-or-symlink ancestor and require
+    # it to canonicalize under /tmp or /private/tmp. Use `cd ... && pwd -P`
+    # rather than `realpath` for portability (realpath is not POSIX and
+    # missing on some macOS installs without coreutils). This mirrors
+    # scripts/deny-edit-write.sh's pattern.
+
+    # Canonicalize the allowed roots once. On macOS /tmp -> /private/tmp,
+    # so both spellings collapse to one canonical path; on Linux they
+    # are typically distinct (and /private/tmp may not exist). Accept
+    # paths that resolve under either canonical root.
+    local allowed_root_a allowed_root_b=""
+    allowed_root_a=$(cd /tmp 2>/dev/null && pwd -P) || {
+        echo "ERROR: cannot canonicalize /tmp" >&2
+        return 1
+    }
+    if [[ -d /private/tmp ]]; then
+        allowed_root_b=$(cd /private/tmp 2>/dev/null && pwd -P) || true
     fi
-    return 0
+
+    # Walk up from $d to the nearest existing-or-symlink anchor. The
+    # `! -L` clause stops at dangling symlinks so the validator surfaces
+    # a clear error rather than letting `cd` (or a subsequent mkdir -p)
+    # fail later with a confusing message. Note `-e` is true for a
+    # symlink only when its target exists, so dangling symlinks would
+    # otherwise be silently walked past.
+    local probe="$d"
+    while [[ ! -e "$probe" && ! -L "$probe" ]] && [[ "$probe" != "/" ]]; do
+        probe=$(dirname "$probe")
+    done
+    if [[ "$probe" == "/" ]]; then
+        echo "ERROR: --dir has no existing ancestor: $d" >&2
+        return 1
+    fi
+    # A regular file (or symlink-to-file) is not a directory; reject
+    # with a clear error rather than silently taking dirname.
+    if [[ -f "$probe" ]]; then
+        echo "ERROR: --dir nearest existing ancestor is not a directory: $probe" >&2
+        return 1
+    fi
+
+    # Canonicalize the probe directory. Symlinks anywhere on the chain
+    # are resolved here — this is the load-bearing security check. A
+    # dangling-symlink probe makes `cd` fail; treat that as a hard error.
+    local resolved
+    resolved=$(cd "$probe" 2>/dev/null && pwd -P) || {
+        echo "ERROR: cannot resolve --dir: $d" >&2
+        return 1
+    }
+
+    # Accept iff resolved anchor matches either canonical root.
+    if [[ "$resolved" == "$allowed_root_a" ]] || [[ "$resolved" == "$allowed_root_a"/* ]]; then
+        return 0
+    fi
+    if [[ -n "$allowed_root_b" ]] && { [[ "$resolved" == "$allowed_root_b" ]] || [[ "$resolved" == "$allowed_root_b"/* ]]; }; then
+        return 0
+    fi
+    echo "ERROR: --dir resolves outside /tmp/ (resolved: $resolved)" >&2
+    return 1
 }
 
 # Sanitize a lane label: lowercase, non-alphanumerics → '-'.


### PR DESCRIPTION
## Summary

- Replaced `validate_dir`'s `[[ -d "$d" ]]`-gated canonicalization with a nearest-existing-ancestor probe matching `scripts/deny-edit-write.sh`'s pattern, so a symlinked parent under `/tmp/` can no longer let `cmd_write`'s `mkdir -p` materialize directories outside `/tmp/`.
- Hardened against dangling symlinks (`! -L` walk-loop guard), regular-file ancestors (explicit reject), and dual-root `/tmp` ↔ `/private/tmp` divergence (canonicalize both when distinct).
- Added T17 regression covering all three vectors with portable `/var/tmp` → `$HOME` escape-target fallback so the harness stays robust in restricted CI sandboxes; documented operator-visible behavior change in `scripts/token-tally.md` (`report` and `check-budget` now exit 1 on escape-ancestor paths instead of emitting the placeholder).

<details><summary>Architecture Diagram</summary>

```mermaid
flowchart TD
    CLI[token-tally.sh CLI dispatch] --> WR[cmd_write]
    CLI --> RP[cmd_report]
    CLI --> CB[cmd_check_budget]
    WR --> VD[validate_dir<br/><i>single choke point</i>]
    RP --> VD
    CB --> VD

    subgraph VD_INTERNALS [validate_dir hardened]
        E1[empty/..  rejection<br/><i>fast-fail</i>] --> E2[string-prefix /tmp/, /private/tmp/<br/><i>fast-fail</i>]
        E2 --> RC[canonicalize /tmp + /private/tmp<br/><i>dual-root</i>]
        RC --> WK[walk to nearest existing-or-symlink<br/><i>! -e and ! -L</i>]
        WK --> FC[file check<br/><i>reject regular files</i>]
        FC --> CD[cd probe and pwd -P<br/><i>resolves all symlink hops</i>]
        CD --> AC[accept iff under either canonical root]
    end

    VD -.-> VD_INTERNALS
    VD --> WMK[mkdir -p<br/><i>only after validation</i>]
    WMK --> SC[write sidecar]

    T17[test-token-tally.sh T17<br/><i>regression: link to outside-/tmp/escaped</i>] -.exercises.-> CLI
```

</details>

<details><summary>Code Flow Diagram</summary>

```mermaid
flowchart TD
    Start([token-tally.sh write/report/check-budget --dir D]) --> VD[validate_dir D]
    VD --> EmptyChk{D empty?}
    EmptyChk -->|yes| Err1([exit 1: --dir is required])
    EmptyChk -->|no| DotChk{contains '..'?}
    DotChk -->|yes| Err2([exit 1: '..' segments rejected])
    DotChk -->|no| PrefixChk{starts with /tmp/ or /private/tmp/?}
    PrefixChk -->|no| Err3([exit 1: must be under /tmp/])
    PrefixChk -->|yes| CanonRoot[allowed_root_a = cd /tmp + pwd -P<br/>allowed_root_b = cd /private/tmp + pwd -P if exists]

    CanonRoot --> WalkInit[probe = D]
    WalkInit --> WalkLoop{[[ ! -e probe<br/>&& ! -L probe ]]<br/>&& probe != /?}
    WalkLoop -->|yes — non-existent and non-link| WalkUp[probe = dirname probe]
    WalkUp --> WalkLoop
    WalkLoop -->|no — exists OR is symlink OR hit /| AtRoot{probe == / ?}
    AtRoot -->|yes| Err4([exit 1: no existing ancestor])
    AtRoot -->|no| FileChk{[[ -f probe ]]<br/>regular file?}
    FileChk -->|yes| Err5([exit 1: ancestor is not a directory])
    FileChk -->|no| CD[resolved = cd probe + pwd -P]
    CD -->|cd fails<br/>e.g. dangling symlink| Err6([exit 1: cannot resolve --dir])
    CD -->|cd succeeds| RootCmp{resolved == allowed_root_a OR<br/>resolved under allowed_root_a/ OR<br/>resolved under allowed_root_b/?}
    RootCmp -->|yes| OK([return 0 — proceed to subcommand body])
    RootCmp -->|no — escape detected| Err7([exit 1: resolves outside /tmp/])
```

</details>

<details><summary>Test plan</summary>

- [x] `bash scripts/test-token-tally.sh` — 39 PASS / 0 FAIL (5 new T17 assertions over the previous 34, across 3 sub-cases).
- [x] Manual reproducer of issue #538 (`/tmp/foo/link -> $HOME` + `token-tally.sh write --dir /tmp/foo/link/escaped`) now exits 1 with `ERROR: --dir resolves outside /tmp/ (resolved: /Users/zhupanov)` and does NOT create `$HOME/escaped/`.
- [x] `/relevant-checks` — pre-commit (shellcheck, markdownlint, agent-lint) + full-repo agent-lint clean.
- [x] Existing T11 (non-/tmp rejection), T15 (`..` segments), T16 (`check-budget` missing-dir success) regressions still pass — legitimate tolerant-path semantics preserved when the ancestor is under `/tmp/`.

</details>

Closes #538

Generated with [Claude Code](https://claude.com/claude-code)
