### PR TITLE
Fix #556: refresh test-implement-structure.sh header to reflect 13 assertions

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.11.0",
+  "version": "7.11.1",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.11.1] - 2026-04-25
+
+### Changed
+
+- `scripts/test-implement-structure.sh` header refreshed to reflect the 13 structural invariants the body actually implements: line 3 count word "10"→"13", line 19 count word "Ten"→"Thirteen", and the enumeration extended past `(10)` with summaries of `(11)` Phase 5 rebase-rebump-subprocedure.md reference set with sub-assertions `(11a)–(11d)`, `(12)` Phase 5 single-source-of-truth invariant for `SECTION_MARKERS` with sub-assertions `(12a)–(12b)`, and `(13)` orchestrator-judgment-bail invariant. Pure documentation drift fix — no behavioral change; the PASS line at the end of the script already correctly said "all 13 structural invariants hold". Closes #556.
+
 ## [7.10.4] - 2026-04-25
 
 ### Changed

--- a/scripts/test-implement-structure.sh
+++ b/scripts/test-implement-structure.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Structural regression test for /implement SKILL.md + references/ topology (closes #234).
-# Asserts 10 load-bearing invariants across skills/implement/SKILL.md and the five
+# Asserts 13 load-bearing invariants across skills/implement/SKILL.md and the five
 # reference docs extracted from it. Complements scripts/test-implement-rebase-macro.sh,
 # which owns the Rebase Checkpoint Macro mechanics; this harness owns top-level section
 # headings, the MANDATORY ↔ reference-file binding, the focus-area CI-parity check,
@@ -16,7 +16,7 @@
 # peer-harness assertions (A) and (D) respectively — accepted duplication per design-
 # phase sketch consensus.
 #
-# Ten assertions:
+# Thirteen assertions:
 #  (1) Exactly 1 `^## Load-Bearing Invariants$` heading in skills/implement/SKILL.md.
 #  (2) Exactly 1 `^## NEVER List$` heading.
 #  (3) Exactly 1 `^## Rebase Checkpoint Macro$` heading.
@@ -58,6 +58,27 @@
 #      is simultaneously pinned in skills/fix-issue/SKILL.md by
 #      skills/fix-issue/scripts/test-fix-issue-bail-detection.sh. A rename of
 #      the token is therefore a dual-repo change caught by CI.
+# (11) Phase 5 (umbrella #348) rebase-rebump-subprocedure.md reference set.
+#      Sub-procedure step 6 retargeted from PR-body refresh to anchor
+#      `version-bump-reasoning` refresh:
+#      (11a) references `anchor-comment-template.md` ≥1 (Contract citation).
+#      (11b) references `tracking-issue-read.sh --sentinel` ≥1 (Step 6a).
+#      (11c) references `assemble-anchor.sh` ≥1 AND `upsert-anchor` ≥1 (Step 6d,e).
+#      (11d) zero invocation lines of `${CLAUDE_PLUGIN_ROOT}/scripts/gh-pr-body-read.sh`
+#            or `${CLAUDE_PLUGIN_ROOT}/scripts/gh-pr-body-update.sh` — scoped to
+#            invocation patterns to preserve historical/prose mentions (per
+#            design FINDING_7). A lingering invocation is a Phase 5 regression.
+# (12) Phase 5 single-source-of-truth invariant for SECTION_MARKERS:
+#      (12a) tracking-issue-write.sh must reference `anchor-section-markers.sh`
+#            (the shared source-of-truth helper).
+#      (12b) tracking-issue-write.sh must NOT contain a standalone
+#            `SECTION_MARKERS=(` declaration — any re-inline would silently
+#            diverge its ordering from assemble-anchor.sh.
+# (13) Orchestrator-judgment-bail invariant (closes #553): two byte-pinned
+#      anchor literals must be present in skills/implement/SKILL.md so future
+#      edits cannot silently delete the rule — the headline of NEVER #7 and the
+#      headline of the Step 2 "scope-lock" cue. Mirrors the byte-pin pattern of
+#      assertion (5).
 #
 # Exit 0 on pass, exit 1 on any assertion failure.
 # shellcheck disable=SC2016 # single-quoted strings are intentional grep literals


### PR DESCRIPTION
## Summary

- Refreshed the header comment in `scripts/test-implement-structure.sh` to reflect the 13 structural invariants the body actually implements (was stuck at 10 — drift introduced by umbrella #348 Phase 5 and #553).
- Updated the two count words on lines 3 and 19 ("10"→"13", "Ten"→"Thirteen") and extended the enumeration past `(10)` with summaries of `(11)` Phase 5 rebase-rebump-subprocedure.md reference set, `(12)` Phase 5 single-source-of-truth invariant for `SECTION_MARKERS`, and `(13)` orchestrator-judgment-bail invariant.
- Pure documentation drift fix — no behavioral change. The PASS line at the end of the script already correctly said "all 13 structural invariants hold".

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] `bash scripts/test-implement-structure.sh` passes ("all 13 structural invariants hold").
- [x] `/relevant-checks` clean.
- [x] CI green.

</details>

Closes #556

Generated with [Claude Code](https://claude.com/claude-code)
