### PR TITLE
Fix #570: keep UMBRELLA_VERDICT strict, emit downgrade reason as separate KV line

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.13.2",
+  "version": "7.13.3",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/.claude/skills/umbrella/SKILL.md
+++ b/.claude/skills/umbrella/SKILL.md
@@ -90,7 +90,7 @@ Decompose `TASK` into N concrete work-pieces (`N >= 2`). Each piece must be smal
 - `body` — markdown, the implementation contract for that piece (problem, suggested approach, acceptance criteria).
 - `depends-on` — comma-separated 1-based indices of earlier pieces this one depends on (empty if none).
 
-If decomposition produces fewer than 2 pieces, fall back to one-shot: print `UMBRELLA_VERDICT=one-shot (downgraded — decomposition produced fewer than 2 pieces)` and execute Step 3A with the original `TASK`.
+If decomposition produces fewer than 2 pieces, fall back to one-shot: print two strict KV lines — `UMBRELLA_VERDICT=one-shot` (preserving the line-62 token grammar) and `UMBRELLA_DOWNGRADE=decomposition<2` (carrying the downgrade reason on a separate machine-grep-friendly line) — and execute Step 3A with the original `TASK`.
 
 Render the batch-input markdown file:
 

--- a/.claude/skills/umbrella/SKILL.md
+++ b/.claude/skills/umbrella/SKILL.md
@@ -90,7 +90,7 @@ Decompose `TASK` into N concrete work-pieces (`N >= 2`). Each piece must be smal
 - `body` — markdown, the implementation contract for that piece (problem, suggested approach, acceptance criteria).
 - `depends-on` — comma-separated 1-based indices of earlier pieces this one depends on (empty if none).
 
-If decomposition produces fewer than 2 pieces, fall back to one-shot: print two strict KV lines — `UMBRELLA_VERDICT=one-shot` (preserving the line-62 token grammar) and `UMBRELLA_DOWNGRADE=decomposition<2` (carrying the downgrade reason on a separate machine-grep-friendly line) — and execute Step 3A with the original `TASK`.
+If decomposition produces fewer than 2 pieces, fall back to one-shot: print three strict KV lines — `UMBRELLA_VERDICT=one-shot` (preserving the Step 2 `UMBRELLA_VERDICT=<one-shot|multi-piece>` token grammar), `UMBRELLA_DOWNGRADE=decomposition-lt-2` (shell-safe machine token capturing the downgrade trigger on a separate KV line), and `UMBRELLA_RATIONALE=Downgraded from multi-piece — fewer than two decomposed pieces` (preserving the Step 2 verdict + rationale shape required by the "NEVER skip the user-visible classification verdict" anti-pattern) — and execute Step 3A with the original `TASK`. Carry `UMBRELLA_DOWNGRADE=decomposition-lt-2` through to Step 4's `output.kv` (see the optional schema entry).
 
 Render the batch-input markdown file:
 
@@ -157,6 +157,7 @@ Write `$UMBRELLA_TMPDIR/output.kv` (one `KEY=VALUE` line per fact) BEFORE invoki
 ```
 UMBRELLA_VERDICT=<one-shot|multi-piece>
 UMBRELLA_RATIONALE=<one-line>
+UMBRELLA_DOWNGRADE=<token>   (only when Step 3B.1 downgraded multi-piece → one-shot; e.g., `decomposition-lt-2`)
 CHILDREN_CREATED=<N>
 CHILDREN_DEDUPLICATED=<N>
 CHILDREN_FAILED=<N>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.13.3] - 2026-04-26
+
+### Changed
+
+- `.claude/skills/umbrella/SKILL.md` Step 3B.1 fallback no longer breaks the strict `UMBRELLA_VERDICT=<one-shot|multi-piece>` token grammar declared at Step 2 (issue #570 — Cursor flagged in PR #549's `/review`). The downgrade path now emits three strict KV lines instead of a single line with a parenthetical: `UMBRELLA_VERDICT=one-shot` (preserving the line-62 token grammar), `UMBRELLA_DOWNGRADE=decomposition-lt-2` (shell-safe machine token capturing the downgrade trigger on a separate KV line), and `UMBRELLA_RATIONALE=…` (preserving the Step 2 verdict + rationale shape required by the "NEVER skip the user-visible classification verdict" anti-pattern). Step 4's canonical `output.kv` schema gains an optional `UMBRELLA_DOWNGRADE=<token>` entry so consumers reading only the final emitter output can still see the downgrade signal. Closes #570.
+
 ## [7.13.2] - 2026-04-26
 
 ### Fixed


### PR DESCRIPTION
## Summary

- `.claude/skills/umbrella/SKILL.md` Step 3B.1 fallback no longer breaks the strict `UMBRELLA_VERDICT=<one-shot|multi-piece>` token grammar declared at Step 2.
- The downgrade path emits three strict KV lines: `UMBRELLA_VERDICT=one-shot`, `UMBRELLA_DOWNGRADE=decomposition-lt-2` (shell-safe token), and `UMBRELLA_RATIONALE=…` (preserves the Step 2 verdict + rationale shape required by the "NEVER skip the user-visible classification verdict" anti-pattern).
- Step 4's `output.kv` schema gains an optional `UMBRELLA_DOWNGRADE=<token>` entry so consumers reading only the final emitter output still see the downgrade signal.

## Architecture Diagram

Architecture diagram not available.

## Code Flow Diagram

(Code Flow Diagram skipped — quick mode)

## Test plan

- grep `.claude/skills/umbrella/SKILL.md` for `UMBRELLA_VERDICT` and confirm every occurrence matches the strict `<one-shot|multi-piece>` token grammar (no parentheticals, no descriptive suffixes).
- `/relevant-checks` (pre-commit + agent-lint) green.

Closes #570

🤖 Generated with [Claude Code](https://claude.com/claude-code)
