### PR TITLE
Fix #575: align research SKILL.md budget-abort prelude with relocated gate set

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.13.6",
+  "version": "7.13.7",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.13.7] - 2026-04-26
+
+### Fixed
+
+- `skills/research/SKILL.md` line 587 (Step 4 Budget-abort prelude) now reads `set by any of the budget gates after Steps 1, 2.5, or 2.8` instead of the stale `Steps 1, 2, or 2.5`. The prelude both named a non-existent post-Step-2 gate (relocated to post-Step-2.8 by #517) and omitted the actual post-Step-2.8 gate that sets `BUDGET_ABORTED=true` and skips Step 3. Mirrors the sibling fix #574 (PR #591) which corrected the line-56 measurable-lanes inventory after the same #517 relocation. Closes #575.
+
 ## [7.13.6] - 2026-04-26
 
 ### Fixed

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -584,7 +584,7 @@ Print: `✅ 3: report — complete (<elapsed>)`
 
 ### Budget-abort prelude (when `BUDGET_ABORTED=true`)
 
-If `BUDGET_ABORTED=true` (set by any of the budget gates after Steps 1, 2, or 2.5), Step 3 was skipped — no `## Research Report` was rendered. Print: `**Step 3 skipped (aborted: --token-budget exceeded). Partial telemetry follows.**` so the operator sees the cause clearly.
+If `BUDGET_ABORTED=true` (set by any of the budget gates after Steps 1, 2.5, or 2.8), Step 3 was skipped — no `## Research Report` was rendered. Print: `**Step 3 skipped (aborted: --token-budget exceeded). Partial telemetry follows.**` so the operator sees the cause clearly.
 
 ### Token Spend report (always)
 


### PR DESCRIPTION
## Summary
- Replaced the stale phrase `set by any of the budget gates after Steps 1, 2, or 2.5` with `set by any of the budget gates after Steps 1, 2.5, or 2.8` on `skills/research/SKILL.md` line 587 (Step 4 Budget-abort prelude).
- Mirrors the sibling fix #574 (PR #591) which corrected the line-56 measurable-lanes inventory after #517 relocated the post-Step-2 budget gate to post-Step-2.8.

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] `grep` `skills/research/SKILL.md` confirms no remaining `Steps 1, 2, or 2.5` substring; only the corrected `Steps 1, 2.5, or 2.8` remains on line 587.
- [x] `/relevant-checks` (pre-commit on the modified file + agent-lint on the full repo) passes.

</details>

Closes #575

Generated with [Claude Code](https://claude.com/claude-code)
