### PR TITLE
Fix #581: route empty/UNKNOWN mergeStateStatus to MERGE_RESULT=error

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.13.7",
+  "version": "7.13.8",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.13.8] - 2026-04-26
+
+### Fixed
+
+- `scripts/merge-pr.sh` no longer mis-routes empty or `UNKNOWN` `mergeStateStatus` to `MERGE_RESULT=main_advanced` with the misleading "Branch mergeStateStatus is " (empty trailing) error. After the existing `BEHIND` check at line 85-89 and before the CI re-verify block, an early branch now treats empty `MERGE_STATE` (typically caused by `gh pr view --json mergeStateStatus` API/network/`gh` failure) and the `UNKNOWN` enum value as the existing `MERGE_RESULT=error` outcome with a clear `ERROR="could not read mergeStateStatus from gh pr view (state=...)"` string. `/implement` Step 12b's `error` branch already bails to 12d, which is the correct behavior when the merge state is unreadable — preventing the prior useless rebase loop. `scripts/merge-pr.md`'s MERGE_RESULT enum table `error` row is updated to document the new coverage; the enum itself is unchanged so no cascading edits to `skills/implement/SKILL.md` Step 12b's parse table or the script header comment. Closes #581.
+
 ## [7.13.7] - 2026-04-26
 
 ### Fixed

--- a/scripts/merge-pr.md
+++ b/scripts/merge-pr.md
@@ -20,7 +20,7 @@ Emits `MERGE_RESULT=...` and `ERROR=...` on stdout via an EXIT trap. Exits 0 unc
 | `ci_not_ready` | Standard merge failed; re-verification did not find all checks passing. Caller should poll CI. |
 | `admin_failed` | `--admin` retry was attempted but failed. Hard error. |
 | `policy_denied` | Standard merge was rejected; CI re-verified green + branch fresh (admin-eligible); `--no-admin-fallback` is set so `--admin` was NOT invoked. Caller should bail to manual reviewer-approval flow. |
-| `error` | Catch-all unexpected failure. |
+| `error` | Catch-all unexpected failure. Also covers the case where `gh pr view --json mergeStateStatus` returns empty (API/network/`gh` failure) or `UNKNOWN` — the script cannot determine merge state, so it short-circuits with `error` rather than mis-routing to `main_advanced`. |
 
 ## --no-admin-fallback
 

--- a/scripts/merge-pr.sh
+++ b/scripts/merge-pr.sh
@@ -138,10 +138,12 @@ if [[ "$CI_GOOD" != "true" ]]; then
     exit 0
 fi
 
-# Double-check freshness (may have changed since first check)
+# Double-check freshness (may have changed since first check).
 # CLEAN = mergeable normally; UNSTABLE = CI passed but review not approved;
 # BLOCKED = review/policy block (--admin handles this); HAS_HOOKS = has pre-receive hooks.
-# Anything else (BEHIND, DIRTY, DRAFT, UNKNOWN) = not ready.
+# BEHIND and empty/UNKNOWN are already handled above; remaining non-admin-eligible
+# states (e.g. DIRTY, DRAFT, or any future GitHub-added value) → main_advanced
+# to retry after updating the branch.
 if [[ "$MERGE_STATE" != "CLEAN" ]] && [[ "$MERGE_STATE" != "UNSTABLE" ]] && [[ "$MERGE_STATE" != "HAS_HOOKS" ]] && [[ "$MERGE_STATE" != "BLOCKED" ]]; then
     MERGE_RESULT="main_advanced"
     ERROR="Branch mergeStateStatus is $MERGE_STATE"

--- a/scripts/merge-pr.sh
+++ b/scripts/merge-pr.sh
@@ -88,6 +88,18 @@ if [[ "$MERGE_STATE" == "BEHIND" ]]; then
     exit 0
 fi
 
+# Empty or UNKNOWN mergeStateStatus = could not determine merge state
+# (gh API/network failure on the empty path; GitHub itself unsure on UNKNOWN).
+# Routing through the admin-eligible gate below would mis-emit main_advanced
+# with a misleading "Branch mergeStateStatus is " (empty trailing) error and
+# nudge callers toward a useless rebase. Treat as the existing `error` outcome
+# so the orchestrator bails to its error-handling path.
+if [[ -z "$MERGE_STATE" ]] || [[ "$MERGE_STATE" == "UNKNOWN" ]]; then
+    MERGE_RESULT="error"
+    ERROR="could not read mergeStateStatus from gh pr view (state=\"$MERGE_STATE\")"
+    exit 0
+fi
+
 # --- Re-verify CI before attempting --admin ---
 # Use gh pr checks --json with bucket field (consistent with ci-status.sh)
 CHECKS_JSON=$(gh pr checks "$PR_NUMBER" --repo "$REPO" --json name,state,bucket,link 2>/dev/null || echo "")


### PR DESCRIPTION
## Summary

- Routed empty / `UNKNOWN` `mergeStateStatus` from `gh pr view` to the existing `MERGE_RESULT=error` outcome with a clear `ERROR` string, instead of mis-emitting `main_advanced` with the misleading "Branch mergeStateStatus is " (empty trailing) error and nudging callers into a useless rebase loop.
- Reused the existing `error` enum so `/implement` Step 12b's parse table and the `MERGE_RESULT` enum table in `scripts/merge-pr.md` are unchanged; only the `error` row in the doc gets a clarifying note about the new coverage.

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] `make lint` (shellcheck) passes on the modified `scripts/merge-pr.sh`.
- [x] `bash scripts/merge-pr.sh --help` still prints the Usage line unchanged.
- [x] `bash -n scripts/merge-pr.sh` (syntax check) passes.
- [x] `/relevant-checks` passes after both the impl commit and the review-comment cleanup commit.
- [x] Manual reasoning trace: empty `MERGE_STATE` → new `error` branch; `UNKNOWN` → new `error` branch; `BEHIND` → unchanged `main_advanced`; `CLEAN` / `UNSTABLE` / `HAS_HOOKS` / `BLOCKED` → unchanged admin path; `DIRTY` / `DRAFT` → unchanged fall-through (out of scope per issue framing).
- [ ] CI green on this PR.

</details>

Closes #581

Generated with [Claude Code](https://claude.com/claude-code)
