### PR TITLE
Fix #588: route gh issue create through /larch:issue rule in AGENTS.md

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.13.9",
+  "version": "7.13.10",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,4 +44,5 @@ Plugin ships the entire repo. **Runtime surface**: `skills/`, `agents/`, `hooks/
 - Shell scripts use `set -euo pipefail` by default. Comment when `-e` is intentionally omitted.
 - Follow recent commit history style. `Bump version to X.Y.Z` is reserved for `/bump-version`.
 - Run `gh pr create` through the skill, not manually.
+- Run `gh issue create` through `/larch:issue`, not manually. Scripts under `scripts/` and `skills/*/scripts/` (e.g., `skills/improve-skill/scripts/iteration.sh`, `skills/loop-improve-skill/scripts/driver.sh`, hooks) may continue to call `gh issue create` directly — the rule targets interactive / assistant-driven issue creation only.
 - Slack env vars are optional; skills degrade gracefully when absent.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.13.10] - 2026-04-26
+
+### Changed
+
+- `AGENTS.md` "Conventions" section gains a parallel rule mandating that interactive / assistant-driven `gh issue create` calls flow through `/larch:issue` (mirroring the existing `gh pr create` rule). The rule prevents the heredoc-quoting failure mode documented in #588's "Symptom" section (markdown bodies with backticks and inline code blocks crash the bash parser when passed via `gh issue create --body "$(cat <<'EOF' ... EOF)"`); `/larch:issue` composes a body file and runs `gh ... --body-file`, sidestepping shell quoting. The new bullet carves out scripts under `scripts/` and `skills/*/scripts/` (e.g., `skills/improve-skill/scripts/iteration.sh`, `skills/loop-improve-skill/scripts/driver.sh`, hooks) which own their body composition and don't share the failure mode. Closes #588.
+
 ## [7.13.9] - 2026-04-26
 
 ### Fixed


### PR DESCRIPTION
## Summary
- Added a `Run \`gh issue create\` through \`/larch:issue\`, not manually.` bullet to `AGENTS.md`'s "Conventions" section, paralleling the existing `gh pr create` rule.
- Carved out scripts under `scripts/` and `skills/*/scripts/` (e.g., `iteration.sh`, `driver.sh`, hooks) that own their body composition — the rule targets interactive / assistant-driven invocation only.
- Bumped to v7.13.10 and added a CHANGELOG entry.

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] `pre-commit run --files AGENTS.md` passes (markdownlint, agent-lint, secrets, etc.)
- [x] `agent-lint --pedantic` passes on the full repo
- [x] `gh pr create` line in `AGENTS.md` "Conventions" remains unchanged (rule is additive)
- [x] CHANGELOG entry references issue #588

</details>

Closes #588

Generated with [Claude Code](https://claude.com/claude-code)
