### PR TITLE
Fix #587: add scripts/repro-claude-p-edit-permissions.sh reproducer

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.13.14",
+  "version": "7.13.15",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.13.15] - 2026-04-26
+
+### Added
+
+- New opt-in operator script `scripts/repro-claude-p-edit-permissions.sh` plus its sibling contract `scripts/repro-claude-p-edit-permissions.md` (per the `AGENTS.md` per-script-contract rule). The script reproduces the `claude -p` Edit-permission stall observed in #566 across four variants (A=current settings + no kernel flag, B=`--permission-mode bypassPermissions`, C=`.claude/settings.json` replaced with path-qualified `Read`/`Edit`/`Write` allow rules built via `jq`, D=settings file renamed away). Variants A/B do not mutate `.claude/settings.json`; C/D mutate and a single EXIT/INT/TERM trap restores both `.claude/settings.json` and `.claude/settings.local.json` (staged aside for A/C/D), plus the edit target via `git checkout --`. Result classification combines a pinned stall-regex grep on combined stdout+stderr with a `git diff` ground-truth check on the edit target. Variant C is `EXPECTED=observational_only` (records the observed outcome, exits 0). `--smoke-test` mode runs the preflight + variant staging + cleanup round-trip without invoking `claude` for offline structural validation. New `agent-lint.toml` exclusion entry mirrors the `eval-research.sh` / `test-loop-improve-skill-halt-rate.sh` opt-in pattern. The script is opt-in operator instrumentation, NOT a CI gate. Closes #587.
+
 ## [7.13.14] - 2026-04-26
 
 ### Fixed

--- a/agent-lint.toml
+++ b/agent-lint.toml
@@ -480,6 +480,15 @@ exclude = [
   # pattern as the test-* harnesses and halt-rate-probe above.
   "scripts/eval-research.sh",
   "scripts/test-eval-set-structure.sh",
+  # scripts/repro-claude-p-edit-permissions.sh is the opt-in operator
+  # reproducer for the `claude -p` Edit-permission stall (closes #587;
+  # validates kernel fix #585 plus the settings audit derived from #566).
+  # Referenced only from its sibling .md contract — no Makefile target,
+  # no SKILL.md reference, no CI wiring (depends on a real authenticated
+  # `claude` binary, costs API tokens, timing-sensitive). Same opt-in
+  # operator-instrumentation shape as eval-research.sh and
+  # test-loop-improve-skill-halt-rate.sh.
+  "scripts/repro-claude-p-edit-permissions.sh",
   # scripts/test-eval-research-baseline-flag.sh is the standalone offline
   # regression harness for the --baseline flag handling in
   # scripts/eval-research.sh (closes #441). Same Makefile-only shape as

--- a/scripts/repro-claude-p-edit-permissions.md
+++ b/scripts/repro-claude-p-edit-permissions.md
@@ -1,0 +1,139 @@
+# scripts/repro-claude-p-edit-permissions.sh — contract
+
+Sibling per-script-contract doc per `AGENTS.md`. Edit this file in lockstep with `repro-claude-p-edit-permissions.sh` whenever the script's behavior changes.
+
+## Purpose
+
+Isolated reproducer for the `claude -p` Edit-permission stall first observed in #566. Validates the kernel fix (#585) and the related settings audit independently of the full `/loop-improve-skill` pipeline.
+
+The script invokes a single `claude -p --plugin-dir "$REPO_ROOT"` subprocess against the project's permission stack (`.claude/settings.json` + `.claude/settings.local.json` + `hooks/hooks.json` PreToolUse hooks), asks the model to perform a trivial edit on a tracked file under `.claude/skills/**`, and classifies the outcome by combining a pinned stall-regex grep on combined stdout+stderr with a `git diff` ground-truth check on the edit target.
+
+Opt-in operator instrumentation. NOT a CI gate. Depends on a real authenticated `claude` binary, costs API tokens, and is timing-sensitive. Same shape as `scripts/eval-research.sh` and `scripts/test-loop-improve-skill-halt-rate.sh`.
+
+## Invariants
+
+The script preserves these invariants under every normal exit path (success, failure, SIGINT, SIGTERM):
+
+- `.claude/settings.json` is byte-identical to its pre-run state.
+- `.claude/settings.local.json` (if present) is byte-identical to its pre-run state.
+- `.claude/skills/umbrella/SKILL.md` is byte-identical to its pre-run state.
+- No staging files (`*.repro.bak`, `*.repro.new`) remain on disk.
+- The mktemp scratch directory is removed.
+
+`kill -9` of the script SKIPS the EXIT/INT/TERM trap and is unrecoverable in the same way every other trap-based bash script in this repo is unrecoverable. Manual recovery: see "Manual recovery" section below.
+
+Variants A and B are read-only against the on-disk settings: they do NOT mutate `.claude/settings.json`. Variants C and D mutate `.claude/settings.json` and the trap restores it.
+
+## Variant matrix
+
+| Variant | KERNEL_FLAGS                              | settings.json operation | settings.local.json | EXPECTED              |
+| ------- | ----------------------------------------- | ----------------------- | ------------------- | --------------------- |
+| A       | (empty)                                   | none                    | staged aside        | `stall`               |
+| B       | `--permission-mode bypassPermissions`     | none                    | unchanged           | `edit_completed`      |
+| C       | (empty)                                   | replace via `jq`        | staged aside        | `observational_only`  |
+| D       | `--permission-mode bypassPermissions`     | rename aside            | staged aside        | `edit_completed`      |
+
+Variant C's replacement settings JSON is built via `jq -n --arg p "$REPO_ROOT" '{permissions:{allow:["Read(\($p)/.claude/skills/**)","Edit(\($p)/.claude/skills/**)","Write(\($p)/.claude/skills/**)"]}}'` and atomically `mv`'d from `.claude/settings.json.repro.new` (same directory as the target, guaranteeing same-filesystem rename atomicity).
+
+Variant A reproduces the original #566 incident shape (current settings, no kernel flag) — meaningful even when the live `.claude/settings.json` has `defaultMode: bypassPermissions` because #566 reproduced on that exact shape. The script emits a preflight `**⚠ WARNING**` when this combination is detected so the operator interprets the result with context.
+
+`settings.local.json` staging covers an active second permission surface in this repo. Without it, A/C/D would not be isolated.
+
+## Stall-signature parsing rule
+
+Result classification is a 4-way switch evaluated on the captured stdout file AND stderr file (concatenated):
+
+```
+if combined output contains the literal substring "Edit tool is repeatedly returning":
+  RESULT=stall
+elif `git diff -- .claude/skills/umbrella/SKILL.md` is non-empty:
+  RESULT=edit_completed
+elif timeout exit code is 124 or 137:
+  RESULT=timeout
+else:
+  RESULT=inconclusive
+```
+
+The stall substring `Edit tool is repeatedly returning` is **pinned**. It is the canonical phrasing observed in #566. If the upstream Claude CLI reworks the stall message, the substring drifts and the script reports `RESULT=inconclusive` for genuine stalls. Update the substring in lockstep with this `.md` whenever the upstream phrasing changes — the breakage signal is a Variant A run that exits non-zero with `RESULT=inconclusive` and no `Edit tool` substring on stdout/stderr.
+
+The `git diff` ground-truth check guards against the model simply ignoring the prompt: a clean diff means no edit happened, regardless of any stall phrase, so RESULT collapses to `inconclusive` rather than misreporting.
+
+Combined with the timeout exit code (124 = SIGTERM, 137 = SIGKILL after `--kill-after`), the classifier covers the four observable outcomes.
+
+## Trap-based cleanup contract
+
+A single `cleanup()` function is registered on `EXIT INT TERM`. Restoration order is bottom-up by setup order:
+
+1. `mv` `$SETTINGS_BACKUP` → `.claude/settings.json` (Variant C only).
+2. `mv` `$SETTINGS_RENAMED_AWAY` → `.claude/settings.json` (Variant D only).
+3. `mv` `$LOCAL_SETTINGS_RENAMED_AWAY` → `.claude/settings.local.json` (variants A/C/D).
+4. `git checkout -- .claude/skills/umbrella/SKILL.md 2>/dev/null || true` (no-op if clean or absent).
+5. `rm -rf "$REPRO_WORKDIR"`.
+
+All four cleanup variables are initialized to empty strings BEFORE the trap is registered so that `set -u` does not error inside the trap. Each step is idempotent and tolerant of partial-stage interrupts: if a setup phase failed before assigning a variable, the corresponding cleanup step is skipped.
+
+`git checkout --` is piped to `2>/dev/null || true` so a missing-file edge case does not abort cleanup before the `rm -rf` step.
+
+## `--smoke-test` mode
+
+`bash scripts/repro-claude-p-edit-permissions.sh --variant A --smoke-test` (or `B`/`C`/`D`) runs `parse_args`, `preflight`, `register_cleanup_trap`, `stage_variant`, then explicitly `exit 0` so the cleanup trap fires and restores all on-disk state.
+
+Smoke-test exercises:
+- Argument parsing.
+- All preflight checks (binaries: claude/git/jq/timeout, clean tree, defaultMode warning).
+- Settings staging + restoration round-trip for the chosen variant.
+- Trap registration.
+
+It does NOT invoke `claude -p`. Total runtime: <1 second. Used as a CI-friendly structural regression check (no API cost, no `claude` dependency at runtime — but `claude` is still required on PATH because preflight checks for it; if `claude` is absent, smoke-test exits 3 with `PROBE_STATUS=skipped_no_claude`).
+
+## Hooks remain active
+
+This repo's plugin-installed PreToolUse hooks (via `hooks/hooks.json` → `scripts/block-submodule-edit.sh`) fire on every `Edit`/`Write` tool use, alongside the permission engine. Observed behavior is therefore "permission manager + hook policy" combined. `block-submodule-edit.sh` does not block `.claude/skills/umbrella/SKILL.md` (not in a submodule), so the hook layer is permissive for this target.
+
+## Path resolution
+
+The script `cd`s to `git rev-parse --show-toplevel` and uses `pwd -P` to resolve symlinks before recording `$REPO_ROOT`. The path-qualified Variant C allow rule is built from this resolved path. In symlinked-checkout edge cases where the developer's clone uses a symlinked path that `claude` does not resolve identically, the variant may misbehave — run from a non-symlinked clone for reliable results.
+
+## Exit codes
+
+| Exit | Meaning |
+|------|---------|
+| 0    | Variant's expected outcome was observed (or Variant C — observational_only — exits 0 unconditionally). |
+| 1    | Observed RESULT diverged from EXPECTED for Variant A/B/D. |
+| 2    | Preflight failure: missing binary, dirty working tree, bad argument, edit target absent or untracked. |
+| 3    | `PROBE_STATUS=skipped_no_claude` — `claude` binary not on PATH. Treat like a no-op. |
+
+## Manual recovery (`kill -9` aftermath)
+
+If the trap was skipped, manually restore:
+
+```bash
+# Settings (whichever applies):
+mv .claude/settings.json.repro.bak .claude/settings.json   # variant C or D
+mv .claude/settings.local.json.repro.bak .claude/settings.local.json  # if present
+# Edit target:
+git checkout -- .claude/skills/umbrella/SKILL.md
+# Staging tmp file (variant C, mid-staging interrupt):
+rm -f .claude/settings.json.repro.new
+```
+
+## Test harness
+
+This script's structural correctness is exercised by its own `--smoke-test` mode. There is no separate `test-repro-claude-p-edit-permissions.sh` harness — the smoke-test IS the offline regression harness. `make lint` is unaffected (the script is excluded from `agent-lint --pedantic` via `agent-lint.toml` — same Makefile-only / opt-in pattern as `eval-research.sh` and `test-loop-improve-skill-halt-rate.sh`).
+
+## Edit-in-sync rules
+
+When changing this script:
+
+- Update the variant matrix table here if `EXPECTED` values, `KERNEL_FLAGS`, or `SETTINGS_OP` change.
+- Update the stall-signature substring in BOTH this file's "Stall-signature parsing rule" section AND the script's `STALL_SIGNATURE` constant.
+- Update the manual-recovery commands if staging-file paths change.
+- Update the `agent-lint.toml` exclusion entry if the script is renamed.
+
+## References
+
+- #566 — original stall incident.
+- #585 — kernel fix that this reproducer validates.
+- #587 — this reproducer.
+- `scripts/eval-research.sh` and `scripts/test-loop-improve-skill-halt-rate.sh` — pattern templates for opt-in `claude -p` operator harnesses.
+- `AGENTS.md` "Per-script contracts live beside the script" — the rule that mandates this `.md` exist beside the script.

--- a/scripts/repro-claude-p-edit-permissions.md
+++ b/scripts/repro-claude-p-edit-permissions.md
@@ -100,7 +100,7 @@ The script `cd`s to `git rev-parse --show-toplevel` and uses `pwd -P` to resolve
 |------|---------|
 | 0    | Variant's expected outcome was observed (or Variant C — observational_only — exits 0 unconditionally). |
 | 1    | Observed RESULT diverged from EXPECTED for Variant A/B/D. |
-| 2    | Preflight failure: missing binary, dirty working tree, bad argument, edit target absent or untracked. |
+| 2    | Preflight failure: missing binary, dirty working tree, bad argument, edit target absent or untracked, or `.claude/settings.json` absent when running Variants C or D (which mutate it). |
 | 3    | `PROBE_STATUS=skipped_no_claude` — `claude` binary not on PATH. Treat like a no-op. |
 
 ## Manual recovery (`kill -9` aftermath)

--- a/scripts/repro-claude-p-edit-permissions.sh
+++ b/scripts/repro-claude-p-edit-permissions.sh
@@ -1,0 +1,342 @@
+#!/usr/bin/env bash
+# repro-claude-p-edit-permissions.sh — Isolated reproducer for the `claude -p`
+# Edit-permission stall observed in #566. Runs ONE variant per invocation
+# (--variant {A,B,C,D}) and validates the kernel fix in #585 plus the
+# settings-audit hypothesis independently of the full /loop-improve-skill
+# pipeline.
+#
+# The script invokes `claude -p` as a subprocess against the project's
+# permission stack (settings.json + settings.local.json + PreToolUse hooks),
+# asks the model to perform a trivial edit on .claude/skills/umbrella/SKILL.md,
+# and classifies the outcome by combining a stall-regex grep on combined
+# stdout+stderr with a `git diff` ground-truth check on the edit target.
+#
+# Opt-in operator instrumentation. NOT a CI gate. Depends on a real
+# authenticated `claude` binary, costs API tokens, and is timing-sensitive.
+# See scripts/repro-claude-p-edit-permissions.md for the full contract.
+#
+# Usage:
+#   bash scripts/repro-claude-p-edit-permissions.sh --variant {A|B|C|D} [--smoke-test]
+#   bash scripts/repro-claude-p-edit-permissions.sh --help
+#
+# Exit codes:
+#   0   variant's expected outcome was observed (or Variant C, observational)
+#   1   variant's expected outcome diverged from observed
+#   2   preflight failure (binaries missing, dirty tree, bad arg)
+#   3   PROBE_STATUS=skipped_no_claude (claude binary not on PATH)
+
+set -euo pipefail
+
+# Variables referenced by the cleanup trap MUST be initialized before the trap
+# is registered, so `set -u` does not error on first cleanup-time check.
+SETTINGS_BACKUP=""
+SETTINGS_RENAMED_AWAY=""
+LOCAL_SETTINGS_RENAMED_AWAY=""
+REPRO_WORKDIR=""
+
+# Stall signature pinned to the canonical phrase from #566.
+STALL_SIGNATURE="Edit tool is repeatedly returning"
+
+# Edit target (must be tracked in git so `git checkout --` can restore it).
+EDIT_TARGET=".claude/skills/umbrella/SKILL.md"
+
+# Variant outcome bookkeeping.
+VARIANT=""
+SMOKE_TEST=0
+KERNEL_FLAGS=""
+SETTINGS_OP="none"
+EXPECTED=""
+RESULT=""
+REPO_ROOT=""
+TIMEOUT_CMD=""
+
+usage() {
+  sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+require_value() {
+  local flag="$1" val="${2-}"
+  if [[ -z "$val" || "$val" == --* ]]; then
+    echo "ERROR: $flag requires a value" >&2
+    exit 2
+  fi
+}
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --variant)
+        require_value "$1" "${2-}"
+        VARIANT="$2"
+        shift 2
+        ;;
+      --smoke-test)
+        SMOKE_TEST=1
+        shift
+        ;;
+      --help|-h)
+        usage
+        exit 0
+        ;;
+      *)
+        echo "ERROR: unknown argument: $1" >&2
+        usage >&2
+        exit 2
+        ;;
+    esac
+  done
+
+  case "$VARIANT" in
+    A|B|C|D) ;;
+    "") echo "ERROR: --variant {A|B|C|D} is required" >&2; exit 2 ;;
+    *)  echo "ERROR: --variant must be one of A, B, C, D (got '$VARIANT')" >&2; exit 2 ;;
+  esac
+}
+
+# shellcheck disable=SC2329,SC2317  # cleanup() is invoked indirectly via `trap`.
+cleanup() {
+  local rc=$?
+
+  if [[ -n "$SETTINGS_BACKUP" && -f "$SETTINGS_BACKUP" ]]; then
+    mv -f "$SETTINGS_BACKUP" .claude/settings.json 2>/dev/null || true
+  fi
+  if [[ -n "$SETTINGS_RENAMED_AWAY" && -f "$SETTINGS_RENAMED_AWAY" ]]; then
+    mv -f "$SETTINGS_RENAMED_AWAY" .claude/settings.json 2>/dev/null || true
+  fi
+  if [[ -n "$LOCAL_SETTINGS_RENAMED_AWAY" && -f "$LOCAL_SETTINGS_RENAMED_AWAY" ]]; then
+    mv -f "$LOCAL_SETTINGS_RENAMED_AWAY" .claude/settings.local.json 2>/dev/null || true
+  fi
+
+  # Restore edit target if it was modified (no-op when clean).
+  git checkout -- "$EDIT_TARGET" 2>/dev/null || true
+
+  if [[ -n "$REPRO_WORKDIR" && -d "$REPRO_WORKDIR" ]]; then
+    rm -rf "$REPRO_WORKDIR"
+  fi
+
+  exit "$rc"
+}
+
+register_cleanup_trap() {
+  trap cleanup EXIT INT TERM
+}
+
+require_binary() {
+  local bin="$1"
+  command -v "$bin" >/dev/null 2>&1
+}
+
+resolve_timeout_cmd() {
+  # Require the GNU `--kill-after` flag so SIGKILL margin works as documented.
+  if command -v timeout >/dev/null 2>&1 && timeout --help 2>&1 | grep -q kill-after; then
+    echo timeout
+  elif command -v gtimeout >/dev/null 2>&1 && gtimeout --help 2>&1 | grep -q kill-after; then
+    echo gtimeout
+  else
+    echo ""
+  fi
+}
+
+preflight() {
+  # Repo root + cwd normalization (resolve symlinks via pwd -P).
+  local repo_root
+  repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+  if [[ -z "$repo_root" ]]; then
+    echo "ERROR: not inside a git repository" >&2
+    exit 2
+  fi
+  cd "$repo_root"
+  REPO_ROOT="$(pwd -P)"
+
+  # Required binaries.
+  if ! require_binary git; then
+    echo "ERROR: git not on PATH" >&2
+    exit 2
+  fi
+  if ! require_binary jq; then
+    echo "ERROR: jq not on PATH (required for safe Variant C JSON build)" >&2
+    exit 2
+  fi
+  TIMEOUT_CMD="$(resolve_timeout_cmd)"
+  if [[ -z "$TIMEOUT_CMD" ]]; then
+    echo "ERROR: neither 'timeout' nor 'gtimeout' on PATH" >&2
+    exit 2
+  fi
+  if ! require_binary claude; then
+    echo "PROBE_STATUS=skipped_no_claude"
+    echo "claude binary not on PATH; nothing to reproduce. Exiting 3."
+    exit 3
+  fi
+
+  # Edit target must exist and be tracked.
+  if [[ ! -f "$EDIT_TARGET" ]]; then
+    echo "ERROR: edit target not found: $EDIT_TARGET" >&2
+    exit 2
+  fi
+  if ! git ls-files --error-unmatch -- "$EDIT_TARGET" >/dev/null 2>&1; then
+    echo "ERROR: edit target is not tracked in git: $EDIT_TARGET" >&2
+    exit 2
+  fi
+
+  # Refuse to start if the edit target or settings files are dirty —
+  # we never want to clobber operator work.
+  if ! git diff --quiet -- "$EDIT_TARGET"; then
+    echo "ERROR: $EDIT_TARGET is dirty in working tree; refusing to start" >&2
+    exit 2
+  fi
+  if [[ -f .claude/settings.json ]] && ! git diff --quiet -- .claude/settings.json; then
+    echo "ERROR: .claude/settings.json is dirty in working tree; refusing to start" >&2
+    exit 2
+  fi
+
+  # defaultMode-vs-Variant-A consistency warning.
+  if [[ "$VARIANT" == "A" && -f .claude/settings.json ]]; then
+    local default_mode
+    default_mode="$(jq -r '.permissions.defaultMode // ""' .claude/settings.json 2>/dev/null || true)"
+    if [[ "$default_mode" == "bypassPermissions" ]]; then
+      cat >&2 <<'WARN'
+**⚠ WARNING:** the live `.claude/settings.json` has `permissions.defaultMode == "bypassPermissions"`.
+Variant A is defined as "no kernel flag + current settings"; #566's stall reproduced on this same
+shape, so the test is meaningful, but the outcome may diverge from EXPECTED=stall on this tree.
+The script will report the actual observed outcome.
+WARN
+    fi
+  fi
+
+  # Scratch dir for the prompt + output captures.
+  REPRO_WORKDIR="$(mktemp -d -t repro-claude-p-edit-permissions.XXXXXX)"
+}
+
+stage_variant() {
+  local local_settings=".claude/settings.local.json"
+
+  case "$VARIANT" in
+    A)
+      KERNEL_FLAGS=""
+      SETTINGS_OP="none"
+      EXPECTED="stall"
+      # Stage settings.local.json aside so it does not pollute the test.
+      if [[ -f "$local_settings" ]]; then
+        LOCAL_SETTINGS_RENAMED_AWAY="${local_settings}.repro.bak"
+        mv -f "$local_settings" "$LOCAL_SETTINGS_RENAMED_AWAY"
+      fi
+      ;;
+    B)
+      KERNEL_FLAGS="--permission-mode bypassPermissions"
+      SETTINGS_OP="none"
+      EXPECTED="edit_completed"
+      # Variant B's invariant: do NOT mutate any settings file.
+      ;;
+    C)
+      KERNEL_FLAGS=""
+      SETTINGS_OP="replace"
+      EXPECTED="observational_only"
+      # Stage local settings aside, then replace .claude/settings.json with the
+      # path-qualified Read+Edit+Write allow rule. Build via jq to handle
+      # paths with quotes/whitespace safely.
+      if [[ -f "$local_settings" ]]; then
+        LOCAL_SETTINGS_RENAMED_AWAY="${local_settings}.repro.bak"
+        mv -f "$local_settings" "$LOCAL_SETTINGS_RENAMED_AWAY"
+      fi
+      SETTINGS_BACKUP=".claude/settings.json.repro.bak"
+      cp -f .claude/settings.json "$SETTINGS_BACKUP"
+      local staging=".claude/settings.json.repro.new"
+      jq -n --arg p "$REPO_ROOT" '{permissions:{allow:["Read(\($p)/.claude/skills/**)","Edit(\($p)/.claude/skills/**)","Write(\($p)/.claude/skills/**)"]}}' \
+        > "$staging"
+      mv -f "$staging" .claude/settings.json
+      ;;
+    D)
+      KERNEL_FLAGS="--permission-mode bypassPermissions"
+      SETTINGS_OP="rename"
+      EXPECTED="edit_completed"
+      # Stage local settings + rename main settings file aside.
+      if [[ -f "$local_settings" ]]; then
+        LOCAL_SETTINGS_RENAMED_AWAY="${local_settings}.repro.bak"
+        mv -f "$local_settings" "$LOCAL_SETTINGS_RENAMED_AWAY"
+      fi
+      SETTINGS_RENAMED_AWAY=".claude/settings.json.repro.bak"
+      mv -f .claude/settings.json "$SETTINGS_RENAMED_AWAY"
+      ;;
+  esac
+
+  echo "VARIANT=$VARIANT"
+  echo "KERNEL_FLAGS=${KERNEL_FLAGS:-(none)}"
+  echo "SETTINGS_OP=$SETTINGS_OP"
+  echo "EXPECTED=$EXPECTED"
+}
+
+write_prompt() {
+  local prompt_file="$1"
+  local marker
+  marker="$(date +%s)-$$-$VARIANT"
+  cat > "$prompt_file" <<EOF
+Append a single trailing HTML comment line to the file $EDIT_TARGET. The comment must be exactly the line:
+
+<!-- repro-claude-p-edit-permissions $marker -->
+
+Do not modify any other line. After the edit, exit immediately.
+EOF
+}
+
+invoke_claude_p() {
+  local prompt_file="$REPRO_WORKDIR/prompt.txt"
+  local out_file="$REPRO_WORKDIR/out"
+  local err_file="$REPRO_WORKDIR/err"
+
+  write_prompt "$prompt_file"
+
+  # Build claude argv: --plugin-dir and (for B/D) --permission-mode.
+  # KERNEL_FLAGS is intentionally word-split on whitespace.
+  local timeout_exit=0
+  set +e
+  # shellcheck disable=SC2086
+  "$TIMEOUT_CMD" --kill-after=10s 60s claude -p $KERNEL_FLAGS --plugin-dir "$REPO_ROOT" \
+    < "$prompt_file" > "$out_file" 2> "$err_file"
+  timeout_exit=$?
+  set -e
+
+  echo "TIMEOUT_EXIT=$timeout_exit"
+
+  # Classification on combined stdout+stderr.
+  if grep -q -F "$STALL_SIGNATURE" "$out_file" "$err_file" 2>/dev/null; then
+    RESULT="stall"
+  elif ! git diff --quiet -- "$EDIT_TARGET"; then
+    RESULT="edit_completed"
+  elif [[ "$timeout_exit" == "124" || "$timeout_exit" == "137" ]]; then
+    RESULT="timeout"
+  else
+    RESULT="inconclusive"
+  fi
+  echo "RESULT=$RESULT"
+}
+
+verify_against_expected() {
+  if [[ "$EXPECTED" == "observational_only" ]]; then
+    echo "OUTCOME=observational"
+    echo "Variant $VARIANT is observational; recorded RESULT=$RESULT. Exiting 0."
+    exit 0
+  fi
+  if [[ "$RESULT" == "$EXPECTED" ]]; then
+    echo "OUTCOME=match"
+    echo "Variant $VARIANT: RESULT=$RESULT matches EXPECTED=$EXPECTED. Exiting 0."
+    exit 0
+  fi
+  echo "OUTCOME=divergence"
+  echo "Variant $VARIANT: RESULT=$RESULT diverged from EXPECTED=$EXPECTED. Exiting 1." >&2
+  exit 1
+}
+
+main() {
+  parse_args "$@"
+  preflight
+  register_cleanup_trap
+  stage_variant
+  if [[ "$SMOKE_TEST" -eq 1 ]]; then
+    echo "SMOKE_TEST=1; skipping claude invocation. Cleanup will restore staged state."
+    exit 0
+  fi
+  invoke_claude_p
+  verify_against_expected
+}
+
+main "$@"

--- a/scripts/repro-claude-p-edit-permissions.sh
+++ b/scripts/repro-claude-p-edit-permissions.sh
@@ -189,6 +189,12 @@ preflight() {
     exit 2
   fi
 
+  # Variants C and D mutate .claude/settings.json in place; require it to exist.
+  if [[ "$VARIANT" == "C" || "$VARIANT" == "D" ]] && [[ ! -f .claude/settings.json ]]; then
+    echo "ERROR: .claude/settings.json is required for Variant $VARIANT but not found" >&2
+    exit 2
+  fi
+
   # defaultMode-vs-Variant-A consistency warning.
   if [[ "$VARIANT" == "A" && -f .claude/settings.json ]]; then
     local default_mode


### PR DESCRIPTION
## Summary

- New opt-in operator script `scripts/repro-claude-p-edit-permissions.sh` plus its sibling contract `.md` (per `AGENTS.md` per-script-contract rule). Runs ONE variant per invocation (`--variant {A,B,C,D}`) so the kernel fix in #585 and the related settings audit can be validated independently of the full `/loop-improve-skill` pipeline.
- Variants A/B never mutate `.claude/settings.json` (read-only invariant); C/D mutate via atomic `jq -n --arg` JSON construction or rename-aside, with a single EXIT/INT/TERM trap restoring `.claude/settings.json`, `.claude/settings.local.json`, and the edit target on every exit path.
- New `agent-lint.toml` exclusion entry mirrors the existing `eval-research.sh` / `test-loop-improve-skill-halt-rate.sh` opt-in pattern. `--smoke-test` flag exercises the full preflight + staging + cleanup round-trip without invoking `claude` for offline structural validation.

## Architecture Diagram

```mermaid
graph TD
    subgraph Operator["Operator (out-of-band)"]
        OP[bash scripts/repro-claude-p-edit-permissions.sh --variant ABCD or --smoke-test]
    end

    subgraph Script["repro-claude-p-edit-permissions.sh"]
        PA[parse_args]
        PF[preflight: claude/git/jq/timeout binaries; clean tree on settings + edit target; defaultMode warning; settings.json existence for C/D]
        SV[stage_variant: KERNEL_FLAGS + SETTINGS_OP]
        TR[register_cleanup_trap on EXIT/INT/TERM]
        IC[invoke_claude_p: timeout 60 claude -p $KERNEL_FLAGS --plugin-dir $REPO_ROOT]
        CL[classify: stall regex on out+err; git diff target; emit RESULT]
        VE[verify_against_expected: skipped when EXPECTED=observational_only]
    end

    subgraph FS["Filesystem state (mutated by C/D only)"]
        S1[".claude/settings.json"]
        S2[".claude/settings.local.json"]
        ET[".claude/skills/umbrella/SKILL.md edit target"]
    end

    OP --> PA --> PF --> SV --> TR --> IC --> CL --> VE
    SV -. C: jq/mv .-> S1
    SV -. D: rename .-> S1
    SV -. A/C/D: stage .-> S2
    CL -. git diff .-> ET

    style Script fill:#e8f5e9,stroke:#2e7d32
    style FS fill:#fff3e0,stroke:#e65100
```

## Code Flow Diagram

```mermaid
sequenceDiagram
    participant OP as Operator
    participant SH as repro-claude-p-edit-permissions.sh
    participant FS as Filesystem
    participant CP as claude -p subprocess
    participant TR as cleanup() trap

    OP->>SH: bash --variant {A|B|C|D} [--smoke-test]
    SH->>SH: parse_args
    SH->>SH: preflight (binaries, clean tree, existence guard for C/D)
    SH->>SH: register_cleanup_trap

    alt Variant A
        SH->>FS: stage settings.local.json aside
    else Variant B
        SH->>SH: no settings mutation (invariant)
    else Variant C
        SH->>FS: stage local settings; cp settings.json backup; jq → settings.json.repro.new; atomic mv to settings.json
    else Variant D
        SH->>FS: stage local settings; rename settings.json aside
    end

    alt --smoke-test
        SH-->>TR: exit 0 (cleanup restores state)
    else real run
        SH->>CP: timeout 60 claude -p $KERNEL_FLAGS --plugin-dir $REPO_ROOT
        CP-->>FS: may edit edit-target file OR stall
        SH->>SH: classify: grep stall regex on out+err; git diff target
        alt Variant C (observational)
            SH-->>TR: exit 0
        else RESULT==EXPECTED
            SH-->>TR: exit 0
        else divergence
            SH-->>TR: exit 1
        end
    end

    TR->>FS: restore settings.json (C/D); restore settings.local.json (A/C/D); git checkout -- edit target; rm -rf workdir
```

## Test plan

- [x] `bash scripts/repro-claude-p-edit-permissions.sh --variant Z` → preflight error, exit 2.
- [x] `bash scripts/repro-claude-p-edit-permissions.sh --help` → usage text from header comment.
- [x] `shellcheck -x scripts/repro-claude-p-edit-permissions.sh` → clean.
- [x] `/relevant-checks` (pre-commit shellcheck + markdownlint + agent-lint --pedantic + secret detection + skill-invocation lint) → green.
- [ ] Manual variant A/B/C/D runs out-of-band (out of scope for this PR per the issue's AC2/AC3 — recorded as #587 follow-up).
- [ ] `--smoke-test` end-to-end on a host with `gtimeout` available — was deferred on the dev box (coreutils brew install was incomplete locally; preflight correctly errored on missing `timeout` and exited cleanly without mutation).

Closes #587

🤖 Generated with [Claude Code](https://claude.com/claude-code)
