### PR TITLE
Fix #610: align umbrella Step 3B.2 partial-failure contract with Step 4

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.13.17",
+  "version": "7.13.18",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/.claude/skills/umbrella/SKILL.md
+++ b/.claude/skills/umbrella/SKILL.md
@@ -111,7 +111,7 @@ Invoke the Skill tool:
 
 Parse the per-item `ISSUE_<i>_NUMBER`, `ISSUE_<i>_URL`, `ISSUE_<i>_TITLE`, `ISSUE_<i>_DUPLICATE_OF_NUMBER`, `ISSUE_<i>_DUPLICATE_OF_URL`, `ISSUE_<i>_DRY_RUN`, `ISSUE_<i>_FAILED`, plus aggregate `ISSUES_CREATED`, `ISSUES_DEDUPLICATED`, `ISSUES_FAILED`.
 
-**Abort condition**: if `ISSUES_FAILED >= 1`, do NOT proceed to umbrella creation. Print `**⚠ /umbrella: /issue batch reported $ISSUES_FAILED failure(s); refusing to create a half-populated umbrella. See per-item ISSUE_<i>_* lines above.**`, populate the `CHILD_*` output fields with whatever did succeed (for partial-failure auditability), set `UMBRELLA_NUMBER` and `UMBRELLA_URL` empty, jump to Step 4.
+**Abort condition**: if `ISSUES_FAILED >= 1`, do NOT proceed to umbrella creation. Capture the children-batch-failure as session state (preserve `ISSUES_FAILED` and the count of successfully-resolved children for Step 4's summary), populate the `CHILD_*` output fields with whatever did succeed (for partial-failure auditability), and jump to Step 4 with `UMBRELLA_NUMBER` and `UMBRELLA_URL` **omitted** from `output.kv` entirely — do NOT write them with blank values. The canonical Step 4 grammar marks these keys present only on multi-piece success, so consumers distinguish success from failure by key presence/absence; writing blank values would validate but break that contract. Skip 3B.3 and 3B.4. Do NOT print a warning here — Step 4 is the single emission point for the human summary line and will render the multi-piece children-batch-failed shape on this path.
 
 For each successfully-resolved item (created OR deduplicated to an existing issue), record `(piece_index, issue_number, issue_url, title)` — this is the canonical child set for umbrella body, DAG wiring, and back-links. Items resolved as `ISSUE_<i>_DRY_RUN=true` count as children for output purposes but skip wiring + back-links (handled in 3B.3 / 3B.4).
 
@@ -180,6 +180,7 @@ After `emit-output` returns, the orchestrator (the LLM running this skill) MUST 
 - multi-piece success: `✅ /umbrella: filed umbrella #<M> with <N> children, <E> dependency edge(s), <B> back-link(s) — <umbrella-url>`.
 - multi-piece dry-run: `ℹ /umbrella: dry-run — would file umbrella with <N> children`.
 - multi-piece partial (children created, umbrella failed): `**⚠ /umbrella: <N> children created but umbrella creation failed. Children remain unlinked.**`.
+- multi-piece children-batch-failed (some children failed during batch creation, umbrella never attempted): `**⚠ /umbrella: /issue batch reported <F> failure(s); refusing to create a half-populated umbrella. <N> children remain unlinked.**`.
 
 ## Step 5 — Cleanup
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.13.18] - 2026-04-26
+
+### Fixed
+
+- `.claude/skills/umbrella/SKILL.md` Step 3B.2 children-batch-failure abort path now mirrors Step 3B.3's umbrella-failure pattern: capture the failure as session state, omit `UMBRELLA_NUMBER` and `UMBRELLA_URL` from `output.kv` entirely (do NOT write them with blank values), skip 3B.3 / 3B.4, and defer the human summary to Step 4 (the single emission point). A fifth Step 4 human-summary shape — `multi-piece children-batch-failed` — distinguishes the new state ("children batch had failures, umbrella never attempted") from the existing `multi-piece partial` shape ("children created, umbrella failed"). Closes #610.
+
 ## [7.13.17] - 2026-04-26
 
 ### Fixed


### PR DESCRIPTION
## Summary

- Aligned `.claude/skills/umbrella/SKILL.md` Step 3B.2 children-batch-failure abort path with Step 3B.3's umbrella-failure pattern: omit `UMBRELLA_NUMBER`/`UMBRELLA_URL` from `output.kv` (no blank values), skip 3B.3/3B.4, defer the human summary to Step 4 as the single emission point.
- Added a fifth Step 4 human-summary shape — `multi-piece children-batch-failed` — distinguishing the "children batch had failures, umbrella never attempted" state from the existing "multi-piece partial" (children created, umbrella failed) shape.

<details><summary>Architecture Diagram</summary>

Architecture diagram not available (quick mode — `/design` skipped).

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available (quick mode).

</details>

<details><summary>Test plan</summary>

- [x] `grep -n "UMBRELLA_NUMBER\|UMBRELLA_URL" .claude/skills/umbrella/SKILL.md` confirms Step 3B.2 (line 114) no longer instructs writing empty values; Step 4 line 183 carries the new shape.
- [x] `bash .claude/skills/umbrella/scripts/test-helpers.sh` and `bash .claude/skills/umbrella/scripts/test-umbrella-parse-args.sh` regression harnesses still pass.
- [x] `/relevant-checks` (pre-commit + agent-lint) passes on the modified file.

</details>

Closes #610

Generated with [Claude Code](https://claude.com/claude-code)
