### PR TITLE
Fix #626: add --no-admin-fallback to driver.sh Usage block

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.14.7",
+  "version": "7.14.8",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.14.8] - 2026-04-26
+
+### Fixed
+
+- `skills/loop-fix-issue/scripts/driver.sh` Usage block (lines 9-19) gains a `--no-admin-fallback` entry, matching the existing parser at line 148 and the SKILL.md frontmatter (line 4) + Flags section (line 21) advertisement. Pre-existing inconsistency surfaced as out-of-scope by the codex reviewer during an earlier `/loop-fix-issue` design phase. Pure docstring fix; no behavioral change. Closes #626.
+
 ## [7.14.7] - 2026-04-26
 
 ### Added

--- a/skills/loop-fix-issue/scripts/driver.sh
+++ b/skills/loop-fix-issue/scripts/driver.sh
@@ -7,7 +7,7 @@
 # and this driver's post-call Bash.
 #
 # Usage:
-#   driver.sh [--debug] [--max-iterations N] [--no-slack]
+#   driver.sh [--debug] [--max-iterations N] [--no-slack] [--no-admin-fallback]
 #
 # Arguments:
 #   --debug            — optional flag (currently no-op; reserved for future
@@ -16,6 +16,8 @@
 #                        when /fix-issue reports no eligible issues OR this
 #                        cap is hit.
 #   --no-slack         — forwarded to /fix-issue (which forwards to /implement)
+#                        each iteration.
+#   --no-admin-fallback — forwarded to /fix-issue (which forwards to /implement)
 #                        each iteration.
 #
 # Termination signal:


### PR DESCRIPTION
## Summary
- Added `--no-admin-fallback` to the Usage block in `skills/loop-fix-issue/scripts/driver.sh` (lines 9-19), bringing it in line with the existing argv parser at line 148 and the SKILL.md frontmatter (line 4) + Flags section (line 21) advertisement.
- Pre-existing inconsistency, surfaced as out-of-scope by codex during an earlier `/loop-fix-issue` design phase (#626). Pure docstring fix; no behavioral change.

<details><summary>Architecture Diagram</summary>

Architecture diagram not available (quick mode skipped /design).

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available (quick mode skipped /design and Step 7a).

</details>

<details><summary>Test plan</summary>

- [x] `/relevant-checks` passed (pre-commit + agent-lint clean).
- [x] Visual diff: only the Usage block in `driver.sh` and `CHANGELOG.md` (release notes) changed; no behavior change.
- [x] Confirmed parser at `driver.sh:148` already accepts `--no-admin-fallback`; SKILL.md frontmatter and Flags section already advertise it.

</details>

Closes #626

Generated with [Claude Code](https://claude.com/claude-code)
