### PR TITLE
Fix #632: align driver.sh comment for LARCH_LOOP_FIX_ISSUE_CLAUDE_OVERRIDE with shipped state

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.14.9",
+  "version": "7.14.10",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.14.10] - 2026-04-26
+
+### Fixed
+
+- `skills/loop-fix-issue/scripts/driver.sh` header comment block (lines 54-56 on `main`) claimed `LARCH_LOOP_FIX_ISSUE_CLAUDE_OVERRIDE` was "Documented in SECURITY.md as test-only", but `SECURITY.md` only documents the parallel `LARCH_LOOP_REVIEW_CLAUDE_OVERRIDE` (under `## /loop-review subprocess invocation`); no entry exists for `LARCH_LOOP_FIX_ISSUE_CLAUDE_OVERRIDE`. The sibling `skills/loop-fix-issue/scripts/driver.md:99` already correctly defers SECURITY.md registration to Tier-2 stub-shim work. Apply option (b) from the issue: rephrase the comment block to point readers at `driver.md` and explicitly defer SECURITY.md registration to Tier-2, mirroring the wording structure used by the post-#633 loop-review-side `driver.sh` comment block; cross-reference uses a section-heading anchor (`## /loop-review subprocess invocation`) rather than a fragile line number. Comment-only change; no behavioral effect; assertion K of `scripts/test-loop-fix-issue-driver.sh` (which greps for the env-var name token) continues to pass. Closes #632.
+
 ## [7.14.9] - 2026-04-26
 
 ### Fixed

--- a/skills/loop-fix-issue/scripts/driver.sh
+++ b/skills/loop-fix-issue/scripts/driver.sh
@@ -53,9 +53,14 @@
 #     the cleanup warning names the iter-*-out.txt and iter-*-out.txt.stderr
 #     artifact glob patterns so they can be located without consulting docs.
 #
-# LARCH_LOOP_FIX_ISSUE_CLAUDE_OVERRIDE is an advisory env var used ONLY by
-# tests to redirect `claude -p` invocations at a stub shim. Documented in
-# SECURITY.md as test-only; never set in production.
+# LARCH_LOOP_FIX_ISSUE_CLAUDE_OVERRIDE is an advisory env var reserved for
+# forthcoming Tier-2 stub-shim integration tests in
+# scripts/test-loop-fix-issue-driver.sh; the shipped Tier-1 structural test
+# only references the env-var name (assertion K) and does not exercise the
+# override at runtime. Documented in skills/loop-fix-issue/scripts/driver.md
+# as test-only; SECURITY.md registration is deferred until Tier-2 stub-shim
+# coverage lands (mirrors the LARCH_LOOP_REVIEW_CLAUDE_OVERRIDE precedent at
+# SECURITY.md line 97). Never set in production.
 
 set -euo pipefail
 

--- a/skills/loop-fix-issue/scripts/driver.sh
+++ b/skills/loop-fix-issue/scripts/driver.sh
@@ -59,8 +59,9 @@
 # only references the env-var name (assertion K) and does not exercise the
 # override at runtime. Documented in skills/loop-fix-issue/scripts/driver.md
 # as test-only; SECURITY.md registration is deferred until Tier-2 stub-shim
-# coverage lands (mirrors the LARCH_LOOP_REVIEW_CLAUDE_OVERRIDE precedent at
-# SECURITY.md line 97). Never set in production.
+# coverage lands (mirrors the LARCH_LOOP_REVIEW_CLAUDE_OVERRIDE precedent
+# under SECURITY.md "## /loop-review subprocess invocation"). Never set in
+# production.
 
 set -euo pipefail
 


### PR DESCRIPTION
## Summary
- Rephrased the `LARCH_LOOP_FIX_ISSUE_CLAUDE_OVERRIDE` header comment in `skills/loop-fix-issue/scripts/driver.sh` to match the actual shipped state — point readers at the sibling `driver.md` (which already documents the override correctly) and explicitly defer SECURITY.md registration to Tier-2 stub-shim work, instead of falsely claiming SECURITY.md already documents the override.
- Mirrored the wording structure used by the post-#633 loop-review-side `driver.sh` comment block; the cross-reference uses a section-heading anchor (`## /loop-review subprocess invocation`) rather than a fragile line number so the reference does not silently rot when SECURITY.md is edited above that bullet.

<details><summary>Architecture Diagram</summary>

Architecture diagram not available (quick mode — `/design` skipped).

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available (quick mode — Step 7a skipped).

</details>

<details><summary>Test plan</summary>

- [x] `/relevant-checks` runs clean on the changed file (pre-commit + agent-lint full-repo pass).
- [x] `LARCH_LOOP_FIX_ISSUE_CLAUDE_OVERRIDE` token preserved in `driver.sh` (assertion K of `scripts/test-loop-fix-issue-driver.sh` greps for it).
- [x] Live code paths at the env-var lookup sites (lines 111, 177 post-edit) are untouched.
- [ ] CI green: `gitleaks` (Layer 1 + Layer 2), `trufflehog` (Layer 3), `agent-lint`, and the existing `test-loop-fix-issue-driver` / `test-loop-fix-issue-skill-md` Tier-1 harnesses.

</details>

Closes #632

Generated with [Claude Code](https://claude.com/claude-code)
