### PR TITLE
Fix #643: replace machine-local absolute path in render-batch-input.md

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.15.0",
+  "version": "7.15.1",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/.claude/skills/umbrella/scripts/render-batch-input.md
+++ b/.claude/skills/umbrella/scripts/render-batch-input.md
@@ -16,6 +16,6 @@ PIECE_<i>_DEPENDS_ON=<csv-of-ints> # may be empty
 
 **Dependencies**: `jq` is required (matches the rest of the larch toolchain — `/issue` already requires `jq`).
 
-**Edit-in-sync rules**: any change to the `pieces.json` schema OR the markdown output shape OR stdout grammar requires a same-PR update to `SKILL.md` Step 3B.1 (which writes `pieces.json` and parses the stdout) and `/issue`'s batch-mode parser at `/Users/zhupanov/larch1/skills/issue/scripts/parse-input.sh` (which consumes the markdown).
+**Edit-in-sync rules**: any change to the `pieces.json` schema OR the markdown output shape OR stdout grammar requires a same-PR update to `SKILL.md` Step 3B.1 (which writes `pieces.json` and parses the stdout) and `/issue`'s batch-mode parser at `skills/issue/scripts/parse-input.sh` (which consumes the markdown).
 
 **Test coverage**: covered by integration via `SKILL.md` end-to-end runs. JSON-shape validation is dense enough that bad input is caught at the script boundary rather than leaking into `/issue`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.15.1] - 2026-04-26
+
+### Fixed
+
+- `.claude/skills/umbrella/scripts/render-batch-input.md` line 19 — the edit-in-sync rule referenced the consuming `/issue` parser as `/Users/zhupanov/larch1/skills/issue/scripts/parse-input.sh`, a machine-local absolute path that does not exist on any clone other than the original author's. Replace with the repo-relative form `skills/issue/scripts/parse-input.sh` so contributors following the rule on any machine resolve to the actual shipped parser. Documentation-only change; no behavioral effect. Closes #643.
+
 ## [7.15.0] - 2026-04-26
 
 ### Added


### PR DESCRIPTION
## Summary
- Replaced the machine-local absolute path on `.claude/skills/umbrella/scripts/render-batch-input.md:19` with the repo-relative form `skills/issue/scripts/parse-input.sh`, so the edit-in-sync rule resolves on any clone (the original path only existed on one author's machine).

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] Verified the consumer file resolves at `skills/issue/scripts/parse-input.sh` in this tree.
- [x] Grepped `.claude/skills/` for any remaining `/Users/zhupanov` references — none found.
- [x] Ran `/relevant-checks` after the edit (pre-commit + agent-lint) — passed.

</details>

Closes #643

Generated with [Claude Code](https://claude.com/claude-code)
