### PR TITLE
Fix #644: pin parenthetical variant of /umbrella partial-failure breadcrumb

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.15.1",
+  "version": "7.15.2",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/.claude/skills/umbrella/scripts/test-umbrella-emit-output-contract.md
+++ b/.claude/skills/umbrella/scripts/test-umbrella-emit-output-contract.md
@@ -10,22 +10,23 @@ This is a *structural* test (literal-substring assertions on `awk`-extracted blo
 
 ## Coverage
 
-Twelve assertions, fail-fast on first miss.
+Thirteen assertions, fail-fast on first miss.
 
 ### Step 4 block (extracted from SKILL.md)
 
 - (a1) Orchestrator-attribution: the human summary breadcrumb is printed by the orchestrator (the LLM running this skill), not by the `emit-output` helper.
 - (a2) Single-emission-point invariant: Step 4 is the only place in SKILL.md that emits the breadcrumb (Step 3B.3's umbrella-creation-failure path defers to Step 4).
-- (c1)–(c7) The seven concrete breadcrumb shape literals on disk:
-  - one-shot filed: `✅ /umbrella: filed #<N> — <url>`
-  - one-shot dedup'd: `ℹ /umbrella: dedup'd to #<N> — <url>`
-  - one-shot failed: `**⚠ /umbrella: failed — <error>**`
-  - multi-piece success: `✅ /umbrella: filed umbrella #<M> with <N> children, <E> dependency edge(s), <B> back-link(s) — <umbrella-url>`
-  - multi-piece dry-run: `ℹ /umbrella: dry-run — would file umbrella with <N> children`
-  - multi-piece partial (children created, umbrella failed): `**⚠ /umbrella: <N> children created but umbrella creation failed. Children remain unlinked.**`
-  - multi-piece children-batch-failed (umbrella never attempted): `**⚠ /umbrella: /issue batch reported <F> failure(s); refusing to create a half-populated umbrella. <N> children remain unlinked.**`
+- (c1)–(c7) plus (c6b) — the eight concrete breadcrumb shape literals on disk:
+  - (c1) one-shot filed: `✅ /umbrella: filed #<N> — <url>`
+  - (c2) one-shot dedup'd: `ℹ /umbrella: dedup'd to #<N> — <url>`
+  - (c3) one-shot failed: `**⚠ /umbrella: failed — <error>**`
+  - (c4) multi-piece success: `✅ /umbrella: filed umbrella #<M> with <N> children, <E> dependency edge(s), <B> back-link(s) — <umbrella-url>`
+  - (c5) multi-piece dry-run: `ℹ /umbrella: dry-run — would file umbrella with <N> children`
+  - (c6) multi-piece partial — fallback (no `UMBRELLA_FAILURE_REASON`): `**⚠ /umbrella: <N> children created but umbrella creation failed. Children remain unlinked.**`
+  - (c6b) multi-piece partial — with `UMBRELLA_FAILURE_REASON` parenthetical: `**⚠ /umbrella: <N> children created but umbrella creation failed (<UMBRELLA_FAILURE_REASON>). Children remain unlinked.**`
+  - (c7) multi-piece children-batch-failed (umbrella never attempted): `**⚠ /umbrella: /issue batch reported <F> failure(s); refusing to create a half-populated umbrella. <N> children remain unlinked.**`
 
-  Issue #602 specifies "the four canonical shape templates" but explicitly includes "dry-run and partial-failure variants of multi-piece as documented in Step 4". On disk, Step 4 contains seven concrete breadcrumb literals (the children-batch-failed variant added after #602 was filed). The harness pins each concrete literal to guard against silent shape deletion — pinning fewer would let one variant disappear unnoticed.
+  Issue #602 specifies "the four canonical shape templates" but explicitly includes "dry-run and partial-failure variants of multi-piece as documented in Step 4". On disk, Step 4 contains eight concrete breadcrumb literals — the multi-piece partial case has dual shapes (with-reason / fallback) that #644 surfaced as both load-bearing, and the children-batch-failed variant was added after #602 was filed. The harness pins each concrete literal to guard against silent shape deletion — pinning fewer would let one variant disappear unnoticed.
 
 ### emit-output subsection (extracted from helpers.md)
 

--- a/.claude/skills/umbrella/scripts/test-umbrella-emit-output-contract.md
+++ b/.claude/skills/umbrella/scripts/test-umbrella-emit-output-contract.md
@@ -47,7 +47,7 @@ The Step 5 end regex is deliberately a prefix match (not the full heading): it t
 
 ## Edit-in-sync rules
 
-- Any change to SKILL.md Step 4 prose (orchestrator-attribution sentence, single-emission-point invariant, or any of the seven canonical breadcrumb shape literals) requires a same-PR update to the corresponding assertion literal in this harness.
+- Any change to SKILL.md Step 4 prose (orchestrator-attribution sentence, single-emission-point invariant, or any of the eight concrete literals — c1–c7 plus c6b) requires a same-PR update to the corresponding assertion literal in this harness.
 - Any change to helpers.md `emit-output` subsection (stderr discipline sentence, the orchestrator-emits-breadcrumb sentence, or the wire-dag carve-out) requires the same.
 - Renaming or renumbering Step 4 in SKILL.md, or renaming the `emit-output` subcommand in helpers.md, requires updating the boundary regexes here AND in the table above.
 - Adding a new canonical breadcrumb shape to SKILL.md Step 4: add a corresponding `(c<N>)` assertion here.

--- a/.claude/skills/umbrella/scripts/test-umbrella-emit-output-contract.sh
+++ b/.claude/skills/umbrella/scripts/test-umbrella-emit-output-contract.sh
@@ -129,8 +129,16 @@ assert_contains "c4: multi-piece success" \
 assert_contains "c5: multi-piece dry-run" \
     'ℹ /umbrella: dry-run — would file umbrella with <N> children' \
     "$STEP4_BLOCK"
-assert_contains "c6: multi-piece partial (children created, umbrella failed)" \
+assert_contains "c6: multi-piece partial — fallback (no UMBRELLA_FAILURE_REASON)" \
     '**⚠ /umbrella: <N> children created but umbrella creation failed. Children remain unlinked.**' \
+    "$STEP4_BLOCK"
+# (c6b) The parenthetical variant of the multi-piece partial breadcrumb, rendered
+# when emit-output's `output.kv` carries `UMBRELLA_FAILURE_REASON`. SKILL.md Step 4
+# documents both shapes for the same partial case (with-reason / fallback). The
+# fallback is pinned by c6; without c6b, a future edit could remove or reword
+# only the parenthetical variant unnoticed.
+assert_contains "c6b: multi-piece partial — with UMBRELLA_FAILURE_REASON parenthetical" \
+    '**⚠ /umbrella: <N> children created but umbrella creation failed (<UMBRELLA_FAILURE_REASON>). Children remain unlinked.**' \
     "$STEP4_BLOCK"
 assert_contains "c7: multi-piece children-batch-failed (umbrella never attempted)" \
     '**⚠ /umbrella: /issue batch reported <F> failure(s); refusing to create a half-populated umbrella. <N> children remain unlinked.**' \

--- a/.claude/skills/umbrella/scripts/test-umbrella-emit-output-contract.sh
+++ b/.claude/skills/umbrella/scripts/test-umbrella-emit-output-contract.sh
@@ -112,8 +112,10 @@ assert_contains "a2: single-emission-point invariant" \
 # (c*) The canonical breadcrumb shape templates remain present in SKILL.md
 # Step 4. The issue spec lists four conceptual templates (one-shot success /
 # dedup / failed; multi-piece success — including dry-run and partial-failure
-# variants); on disk these expand to seven concrete breadcrumb literals.
-# Pinning each concrete literal guards against silent shape deletion.
+# variants); on disk these expand to eight concrete breadcrumb literals
+# (c6 and c6b are two literals for one conceptual partial case — fallback and
+# UMBRELLA_FAILURE_REASON-parenthetical respectively). Pinning each concrete
+# literal guards against silent shape deletion.
 assert_contains "c1: one-shot filed" \
     '✅ /umbrella: filed #<N> — <url>' \
     "$STEP4_BLOCK"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.15.2] - 2026-04-26
+
+### Changed
+
+- `.claude/skills/umbrella/scripts/test-umbrella-emit-output-contract.sh` — adds a `c6b` structural assertion pinning the `(<UMBRELLA_FAILURE_REASON>)`-parenthetical variant of the multi-piece partial breadcrumb literal. SKILL.md Step 4 documents two on-disk shapes for the same partial case (with-reason / fallback); the existing `c6` assertion only pinned the fallback, so a future edit could remove or reword only the parenthetical variant unnoticed. Sibling `test-umbrella-emit-output-contract.md` updated in lock-step (assertion count 12→13, coverage table now lists eight concrete literals split as c1–c5, c6, c6b, c7, supporting prose and Edit-in-sync rules aligned). Closes #644.
+
 ## [7.15.1] - 2026-04-26
 
 ### Fixed


### PR DESCRIPTION
## Summary

- Pin the `(<UMBRELLA_FAILURE_REASON>)`-parenthetical variant of `/umbrella`'s multi-piece partial-failure breadcrumb in `test-umbrella-emit-output-contract.sh` via a new `c6b` structural assertion. SKILL.md Step 4 documents two on-disk shapes for the same partial case (with-reason / fallback); `c6` already pinned the fallback, but the parenthetical variant was unguarded — a future edit could remove or reword it unnoticed and CI would still pass.
- Update the sibling `test-umbrella-emit-output-contract.md` in lock-step: assertion count `12 → 13`, coverage list split as `c1–c5, c6, c6b, c7` with both shapes named, supporting prose and Edit-in-sync rules realigned to "eight concrete literals".
- PATCH bump (7.15.0 → 7.15.1) — all changes are dev-only `.claude/skills/umbrella/scripts/*`; no public skill or agent surface is touched.

## Test plan

- [x] `bash .claude/skills/umbrella/scripts/test-umbrella-emit-output-contract.sh` — all 13 assertions pass (c6b added without breaking existing pins).
- [x] `/relevant-checks` — pre-commit + agent-lint both green.
- [x] Cursor quick-mode review (round 1 surfaced two stale "seven" prose references; both fixed in round-2 commit; round 2 returned `NO_ISSUES_FOUND`).

Closes #644

🤖 Generated with [Claude Code](https://claude.com/claude-code)
