### PR TITLE
Fix #650: align stale comment in test-implement-structure.sh with enforced threshold

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.15.2",
+  "version": "7.15.3",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.15.3] - 2026-04-26
+
+### Fixed
+
+- `scripts/test-implement-structure.sh` line 129 — the explanatory block comment for assertion (4) said "at least 4 occurrences" while the actual enforcement on line 135 (`(( occurrences < 5 ))`), the error message on line 136 ("expected at least 5"), and the sibling contract `scripts/test-implement-structure.md` all require at least 5. Aligned the comment to "at least 5 occurrences" so a maintainer reading only the comment sees the correct threshold. Documentation-only edit; no behavioral effect on the test. Closes #650.
+
 ## [7.15.2] - 2026-04-26
 
 ### Changed

--- a/scripts/test-implement-structure.sh
+++ b/scripts/test-implement-structure.sh
@@ -126,7 +126,7 @@ count=$(grep -c '^## Rebase Checkpoint Macro$' "$SKILL_MD" || true)
   || fail "(3) expected exactly 1 '^## Rebase Checkpoint Macro$' heading in SKILL.md, found $count"
 
 # ---------------------------------------------------------------------------
-# (4) MANDATORY — READ ENTIRE FILE: at least 4 occurrences AND each expected
+# (4) MANDATORY — READ ENTIRE FILE: at least 5 occurrences AND each expected
 #     reference filename appears on a MANDATORY line (step-to-reference binding).
 # ---------------------------------------------------------------------------
 # Use `|| true` to keep set -e + pipefail from aborting before the fail() diagnostic


### PR DESCRIPTION
## Summary
- Aligned the explanatory block comment on `scripts/test-implement-structure.sh:129` with the actual enforced threshold ("at least 5 occurrences"), matching line 135 (`(( occurrences < 5 ))`), the line-136 error message, and the sibling contract `scripts/test-implement-structure.md`.
- One-line documentation-only fix; no test logic or threshold changes.

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] Ran `bash scripts/test-implement-structure.sh` — passes (`PASS: test-implement-structure.sh — all 13 structural invariants hold`).
- [x] Grepped `scripts/test-implement-structure.sh` for "at least 4" — zero remaining occurrences.
- [x] Ran `/relevant-checks` — pre-commit + agent-lint pass.

</details>

Closes #650

Generated with [Claude Code](https://claude.com/claude-code)
