### PR TITLE
Fix #652: add sibling contract for check-review-changes.sh

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.15.6",
+  "version": "7.15.7",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.15.7] - 2026-04-26
+
+### Added
+
+- `skills/implement/scripts/check-review-changes.md` — sibling contract file for `skills/implement/scripts/check-review-changes.sh` per the AGENTS.md per-script-contract convention. Documents the script's purpose ("detect whether code-review step modified the working tree"), output contract (`FILES_CHANGED=true|false` to stdout, always exit 0), the unstaged/staged/untracked detection union, the known limitation that any pre-existing untracked file flips the flag, the sole call site (Step 6 of `skills/implement/SKILL.md`), read-only/idempotent invariants, and edit-in-sync rules. `agent-lint.toml` skill-local-sibling-`.md` exclude list extended to include the new file (matches the existing pattern for `skills/<name>/scripts/*.md` contracts not cited from the owning SKILL.md). Closes #652.
+
 ## [7.15.6] - 2026-04-26
 
 ### Fixed

--- a/agent-lint.toml
+++ b/agent-lint.toml
@@ -594,6 +594,7 @@ exclude = [
   # entries above (test-fix-issue-bail-detection.md, test-find-lock-issue.md,
   # etc.).
   "skills/create-skill/scripts/test-render-skill-md.md",
+  "skills/implement/scripts/check-review-changes.md",
   "skills/simplify-skill/scripts/build-feature-description.md",
   # scripts/test-alias-target-resolution.md and scripts/test-alias-structure.md
   # are the sibling contracts for the two alias-rework regression harnesses

--- a/skills/implement/scripts/check-review-changes.md
+++ b/skills/implement/scripts/check-review-changes.md
@@ -1,0 +1,11 @@
+# skills/implement/scripts/check-review-changes.sh — contract
+
+`skills/implement/scripts/check-review-changes.sh` is the `/implement` Step 6 (Relevant Checks, second pass) probe that decides whether the code-review step modified the working tree. Output: a single `FILES_CHANGED=true|false` line on stdout. Detection unions three sources — unstaged modifications (`git diff --name-only`), staged modifications (`git diff --name-only --cached`), and untracked files (`git ls-files --others --exclude-standard`); any non-empty source flips the flag. Always exits 0 (read-only probe; transient `git` errors degrade to empty output rather than non-zero exit).
+
+**Known limitation**: any pre-existing untracked file in the working tree at Step 6 entry flips `FILES_CHANGED=true` even when the code-review step itself made no changes. Step 6 then runs a no-op `/relevant-checks` pass and Step 7 may attempt to commit the unrelated untracked files. Operators should keep the working tree clean of untracked scratch files before invoking `/implement`.
+
+**Invariants**: read-only (no working-tree mutation); idempotent (repeated calls return the same `FILES_CHANGED` value when the working tree is unchanged); exit code is always 0 — callers parse `FILES_CHANGED` rather than branching on `$?`.
+
+**Call sites**: `skills/implement/SKILL.md` Step 6 (sole consumer) — the printed `FILES_CHANGED` value gates whether Step 6 runs `/relevant-checks` and whether Step 7 creates a `Address code review feedback` commit. No test harness or Makefile wiring; the script's behavior is exercised end-to-end by `/implement` runs.
+
+**Edit-in-sync**: behavior changes (new detection source, exit-code semantics, output token rename) must be mirrored in this file AND in Step 6 of `skills/implement/SKILL.md` in the same PR — Step 6's branch logic parses the `FILES_CHANGED` token verbatim.


### PR DESCRIPTION
## Summary
- Added `skills/implement/scripts/check-review-changes.md` as the sibling contract file for `skills/implement/scripts/check-review-changes.sh`, restoring AGENTS.md per-script-contract convention compliance for that script.
- Documented the script's purpose ("detect whether code-review step modified the working tree"), output contract (`FILES_CHANGED=true|false` printed to stdout, always exit 0), the unstaged/staged/untracked detection union and its known limitation that any pre-existing untracked file flips the flag, the sole call site (Step 6 of `skills/implement/SKILL.md`), read-only/idempotent invariants, and edit-in-sync rules.
- Extended `agent-lint.toml`'s skill-local-sibling-`.md` exclude list to include the new file (matches the existing pattern for `skills/<name>/scripts/*.md` contracts not cited from the owning SKILL.md).

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] `/relevant-checks` passes (pre-commit + agent-lint).
- [x] New file is co-located with the script under `skills/implement/scripts/`.
- [x] CI green on the PR.

</details>

Closes #652

Generated with [Claude Code](https://claude.com/claude-code)
