### PR TITLE
Fix #653: lift outer fence to 4 backticks in anchor-comment-template.md

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.15.7",
+  "version": "7.15.8",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.15.8] - 2026-04-26
+
+### Fixed
+
+- `skills/implement/references/anchor-comment-template.md` — lift the outer fence of the "Canonical template" code block from three backticks to four so the inner ` ```mermaid ` blocks no longer terminate it under CommonMark / GitHub-flavored Markdown. The rendered template was previously broken on GitHub (the first inner triple-backtick run was parsed as the outer block's closing fence); anyone copying the template visually rather than via `assemble-anchor.sh` would have gotten a malformed structure. Also escapes the literal pipes in the Edit-in-sync pointers row's documentation reference (`\| OOS issues filed \|`) to silence pre-existing markdownlint MD056 / MD038 warnings on that line; the load-bearing literal `| OOS issues filed |` still appears verbatim at line 110 inside the Run Statistics table of the canonical template, so `scripts/test-implement-structure.sh` assertion (9a) is unchanged. Closes #653.
+
 ## [7.15.7] - 2026-04-26
 
 ### Added

--- a/skills/implement/references/anchor-comment-template.md
+++ b/skills/implement/references/anchor-comment-template.md
@@ -32,7 +32,7 @@ This line is suppressed as soon as any fragment contains a non-whitespace byte â
 
 ## Canonical template
 
-```markdown
+````markdown
 <!-- larch:implement-anchor v1 issue=<N> -->
 
 <!-- section:plan-goals-test -->
@@ -114,7 +114,7 @@ This line is suppressed as soon as any fragment contains a non-whitespace byte â
 | Rebase count | <N> |
 
 <!-- section-end:run-statistics -->
-```
+````
 
 ## Section markers â€” exact slug list
 
@@ -197,4 +197,4 @@ This is a defense-in-depth layer above `scripts/redact-secrets.sh`'s outbound sc
 | `scripts/assemble-anchor.sh` | Consumes `SECTION_MARKERS` via the shared helper; emits marker pairs and the first-line HTML marker documented here. |
 | `scripts/tracking-issue-read.sh` | Anchor-marker filter uses the same strict `<!-- larch:implement-anchor v1` prefix. |
 | `skills/implement/references/pr-body-template.md` | Sibling slim-projection template for the PR body (Summary + Diagrams + Test plan + `Closes #<N>` + footer only); Phase 3+ the anchor comment is canonical for rich content. |
-| `scripts/test-implement-structure.sh` | Phase 3 test-harness assertion (9a) pins the three load-bearing literals here (`Accepted OOS (GitHub issues filed)`, `| OOS issues filed |`, `<details><summary>Execution Issues</summary>`); assertion (9b) pins a â‰¥3 reference floor for `anchor-comment-template.md` in SKILL.md. |
+| `scripts/test-implement-structure.sh` | Phase 3 test-harness assertion (9a) pins the three load-bearing literals here (`Accepted OOS (GitHub issues filed)`, `\| OOS issues filed \|`, `<details><summary>Execution Issues</summary>`); assertion (9b) pins a â‰¥3 reference floor for `anchor-comment-template.md` in SKILL.md. |


### PR DESCRIPTION
## Summary
- Lifted the outer fence in `skills/implement/references/anchor-comment-template.md`'s "Canonical template" section from three backticks to four so the inner ` ```mermaid ` blocks no longer terminate it under CommonMark / GitHub-flavored Markdown — the rendered template is now a single contiguous code block on GitHub.
- Escaped the literal pipes inside the documentation reference on the Edit-in-sync pointers row (`\| OOS issues filed \|`) to silence pre-existing markdownlint MD056 / MD038 warnings; the load-bearing literal `| OOS issues filed |` still appears verbatim at line 110 inside the canonical template, so `scripts/test-implement-structure.sh` assertion (9a) is unchanged.

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- `make lint` / `/relevant-checks` passes (markdownlint, agent-lint, shellcheck, gitleaks).
- View the PR's rendered preview of `skills/implement/references/anchor-comment-template.md` on GitHub: the "Canonical template" code block renders as one contiguous block from `<!-- larch:implement-anchor v1 issue=<N> -->` through `<!-- section-end:run-statistics -->`.
- `grep -F '| OOS issues filed |' skills/implement/references/anchor-comment-template.md` still returns the literal (line 110 inside the Run Statistics table) — assertion (9a) load-bearing literal preserved.

</details>

Closes #653

Generated with [Claude Code](https://claude.com/claude-code)
