### PR TITLE
Fix #655: align cursor-wrap-prompt.md callers registry with reality

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.16.0",
+  "version": "7.16.1",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.16.1] - 2026-04-26
+
+### Fixed
+
+- `scripts/cursor-wrap-prompt.md` — align the Callers registry with the actual `cursor-wrap-prompt.sh` invocations across the codebase. The registry undercounted call sites in three places and listed one stale entry, weakening the auditor invariant the registry exists for ("auditors can verify every Cursor invocation routes through the max-mode wrapper"): `skills/review/SKILL.md` corrected from `(1)` to `(2 — diff-mode and slice-mode Cursor reviewer blocks)` (the original code-review finding); `skills/research/references/research-phase.md` corrected from `(1)` to `(3 — standard-mode Cursor lane and deep-mode Cursor slots 1 and 2)`; new bullet added for `skills/research/references/adjudication-phase.md (1 — Cursor judge launch)`; stale `skills/loop-review/SKILL.md` entry removed (the file no longer invokes the wrapper). Header total updated from `12 wrapped launch strings in 11 files` to `15 wrapped launch strings in 11 files`. Closes #655.
+
 ## [7.16.0] - 2026-04-26
 
 ### Added

--- a/scripts/cursor-wrap-prompt.md
+++ b/scripts/cursor-wrap-prompt.md
@@ -15,18 +15,18 @@ Cursor supports `~/.cursor/cli-config.json` for model pinning and max-mode, but 
 
 Cursor also has no way to configure a non-default model via config file that overrides the CLI's own fallback; larch passes `--model` on the command line via `scripts/reviewer-model-args.sh`. The two concerns are kept in separate single-source-of-truth files.
 
-## Callers (12 wrapped launch strings in 11 files)
+## Callers (15 wrapped launch strings in 11 files)
 
-- `skills/research/references/research-phase.md` (1)
+- `skills/research/references/research-phase.md` (3 — standard-mode Cursor lane and deep-mode Cursor slots 1 and 2)
 - `skills/research/references/validation-phase.md` (1)
+- `skills/research/references/adjudication-phase.md` (1 — Cursor judge launch)
 - `skills/design/SKILL.md` (1 — plan-review Cursor reviewer)
 - `skills/design/references/sketch-launch.md` (2 — Architecture/Standards and Edge-cases/Failure-modes sketch slots)
 - `skills/design/references/dialectic-execution.md` (1 — Cursor debater launch template)
 - `skills/shared/voting-protocol.md` (1 — Cursor voter template)
 - `skills/shared/dialectic-protocol.md` (1 — Cursor judge template)
-- `skills/review/SKILL.md` (1)
+- `skills/review/SKILL.md` (2 — diff-mode and slice-mode Cursor reviewer blocks)
 - `skills/implement/SKILL.md` (1 — quick-mode Cursor reviewer; block stays inline in SKILL.md per NEVER #6 in that skill)
-- `skills/loop-review/SKILL.md` (1 — slice-review Cursor reviewer)
 - `scripts/run-negotiation-round.sh` (1 — Cursor negotiation-round branch)
 
 ## Non-callers (intentional exclusions)


### PR DESCRIPTION
## Summary
- Aligned `scripts/cursor-wrap-prompt.md`'s Callers registry with the actual `cursor-wrap-prompt.sh` invocations in the codebase: `skills/review/SKILL.md` corrected from `(1)` to `(2)`, `skills/research/references/research-phase.md` from `(1)` to `(3)`, new bullet for `skills/research/references/adjudication-phase.md (1)`, stale `skills/loop-review/SKILL.md` entry removed, and the header total updated from `12 wrapped launch strings in 11 files` to `15 wrapped launch strings in 11 files`.
- Restored the registry's auditor invariant — every Cursor invocation routing through the max-mode wrapper is now correctly accounted for, so an auditor sampling per-file counts can verify max-mode coverage end-to-end.

<details><summary>Architecture Diagram</summary>

Architecture diagram not available (quick mode skips `/design`).

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available (quick mode).

</details>

<details><summary>Test plan</summary>

- [x] Byte-level diff inspection of `scripts/cursor-wrap-prompt.md`.
- [x] Grep audit: `grep -rln 'cursor-wrap-prompt\.sh' --include='*.md' --include='*.sh' .` cross-checked against the new registry's per-file counts and total — confirmed 15 invocations across 11 files.
- [x] `/relevant-checks` clean (pre-commit + agent-lint).

</details>

Closes #655

Generated with [Claude Code](https://claude.com/claude-code)
