### PR TITLE
Fix #657: correct reviewer-panel label in skills/review/diagram.svg

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.16.2",
+  "version": "7.16.3",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.16.3] - 2026-04-26
+
+### Fixed
+
+- `skills/review/diagram.svg` — correct the "Launch Reviewers" rect label from `Reviewers (2 Claude + 2 Codex + Cursor)` to `Reviewers (1 Claude + 1 Codex + 1 Cursor)` so the rendered diagram matches the documented 3-reviewer panel topology used by `/review` (`skills/review/SKILL.md:10`, `docs/external-reviewers.md:12`, `docs/review-agents.md:92`). The previous label implied a 5-reviewer panel that never existed in the implementation. Closes #657.
+
 ## [7.16.2] - 2026-04-26
 
 ### Fixed

--- a/skills/review/diagram.svg
+++ b/skills/review/diagram.svg
@@ -25,7 +25,7 @@
 
   <!-- Step 2: Launch Reviewers (parallel) -->
   <rect x="70" y="180" width="300" height="40" rx="4" fill="#17A2B8" stroke="#17A2B8" stroke-width="3"/>
-  <text x="220" y="200">Reviewers (2 Claude + 2 Codex + Cursor)</text>
+  <text x="220" y="200">Reviewers (1 Claude + 1 Codex + 1 Cursor)</text>
   <line x1="220" y1="220" x2="220" y2="250"/>
 
   <!-- Step 3a: Collect & Deduplicate -->


### PR DESCRIPTION
## Summary
- Corrected the "Launch Reviewers" rect label in `skills/review/diagram.svg:28` from `Reviewers (2 Claude + 2 Codex + Cursor)` to `Reviewers (1 Claude + 1 Codex + 1 Cursor)` so the rendered diagram matches the documented 3-reviewer panel topology used by `/review`.
- Aligns the diagram with `skills/review/SKILL.md:10`, `docs/external-reviewers.md:12`, and `docs/review-agents.md:92`.

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] Confirm `skills/review/diagram.svg:28` reads `Reviewers (1 Claude + 1 Codex + 1 Cursor)`.
- [x] `grep -rn "2 Claude + 2 Codex" skills/ docs/` returns no matches.
- [x] `/relevant-checks` (pre-commit + agent-lint) clean.

</details>

Closes #657

Generated with [Claude Code](https://claude.com/claude-code)
