### PR TITLE
Fix #658: qualify voting.md OOS routing parenthetical for slice mode

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.16.3",
+  "version": "7.16.4",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.16.4] - 2026-04-26
+
+### Fixed
+
+- `skills/review/references/voting.md` — qualify the "Zero accepted in-scope findings" parenthetical on line 27 so it correctly distinguishes diff-mode and slice-mode OOS routing. The prior text ("OOS items accepted for issue filing are processed separately by `/implement`.") read as an unconditional rule on first encounter, but the same file's "Slice mode" bullet (further down) specifies that under `--create-issues` slice-mode runs, `/review` Step 4b files OOS findings inline via `/issue` and bypasses the `/implement` Step 9a.1 pipeline entirely. Round-1 readers hit the misleading parenthetical before reaching the qualifying bullet. The new wording names the routing explicitly per mode and points to the bullets by stable label rather than by line number. Closes #658.
+
 ## [7.16.3] - 2026-04-26
 
 ### Fixed

--- a/skills/review/references/voting.md
+++ b/skills/review/references/voting.md
@@ -24,7 +24,7 @@ Launch all available voters **in parallel** (Cursor first, then Codex, then Clau
 
 **Competition scoring**: Compute and print the **Reviewer Competition Scoreboard** per the Voting Protocol. Note in the scoreboard that scores apply to round 1 only — round 2+ findings are auto-accepted and do not contribute to scores.
 
-**Zero accepted in-scope findings**: If voting rejects all in-scope findings, print `**ℹ Voting panel rejected all in-scope findings. No changes to implement.**` (In diff mode driven by `/implement`, OOS items accepted for issue filing are processed by `/implement` Step 9a.1; in slice mode with `--create-issues`, `/review` Step 4b files them inline via `/issue` — see lines 31-32 below.) and skip to **Step 4**.
+**Zero accepted in-scope findings**: If voting rejects all in-scope findings, print `**ℹ Voting panel rejected all in-scope findings. No changes to implement.**` (In diff mode driven by `/implement`, OOS items accepted for issue filing are processed by `/implement` Step 9a.1; in slice mode with `--create-issues`, `/review` Step 4b files them inline via `/issue` — see the **Diff mode** / **Slice mode** bullets below.) and skip to **Step 4**.
 
 **OOS items accepted by vote** (2+ YES in round 1): These are accepted for GitHub issue filing, NOT for code implementation.
 

--- a/skills/review/references/voting.md
+++ b/skills/review/references/voting.md
@@ -24,7 +24,7 @@ Launch all available voters **in parallel** (Cursor first, then Codex, then Clau
 
 **Competition scoring**: Compute and print the **Reviewer Competition Scoreboard** per the Voting Protocol. Note in the scoreboard that scores apply to round 1 only — round 2+ findings are auto-accepted and do not contribute to scores.
 
-**Zero accepted in-scope findings**: If voting rejects all in-scope findings, print `**ℹ Voting panel rejected all in-scope findings. No changes to implement.**` (OOS items accepted for issue filing are processed separately by `/implement`.) and skip to **Step 4**.
+**Zero accepted in-scope findings**: If voting rejects all in-scope findings, print `**ℹ Voting panel rejected all in-scope findings. No changes to implement.**` (In diff mode driven by `/implement`, OOS items accepted for issue filing are processed by `/implement` Step 9a.1; in slice mode with `--create-issues`, `/review` Step 4b files them inline via `/issue` — see lines 31-32 below.) and skip to **Step 4**.
 
 **OOS items accepted by vote** (2+ YES in round 1): These are accepted for GitHub issue filing, NOT for code implementation.
 


### PR DESCRIPTION
## Summary
- Qualified the parenthetical on `skills/review/references/voting.md:27` so it correctly distinguishes the diff-mode and slice-mode OOS routing instead of unconditionally claiming `/implement` processes accepted-OOS items.
- Pointed the cross-reference at the stable **Diff mode** / **Slice mode** bullet labels rather than at line numbers (`lines 31-32`) so the pointer survives unrelated edits above the section.

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] `/relevant-checks` (changed-file phase + full-repo `agent-lint`) passes after each edit
- [x] grep confirms the new diff-mode / slice-mode wording on line 27 and that the **Diff mode** (line 31) and **Slice mode** (line 32) bullets are unchanged
- [x] CHANGELOG.md updated for v7.16.3 with the issue link

</details>

Closes #658

Generated with [Claude Code](https://claude.com/claude-code)
