### PR TITLE
Fix #660: split docs/external-reviewers.md "Output capture" bullet by capture pattern

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.16.5",
+  "version": "7.16.6",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.16.6] - 2026-04-26
+
+### Fixed
+
+- `docs/external-reviewers.md` — replace the single "Output capture" bullet (which read "Captures stdout to a specified output file" as if universal) with two sub-bullets that distinguish the two patterns the `run-external-reviewer.sh` wrapper supports: stdout capture under `--capture-stdout` (Cursor pattern; `skills/review/SKILL.md:146-148, 177-179`), and tool-managed output paths when the reviewer takes its own output-path argument such as Codex's `--output-last-message` (Codex pattern; `skills/review/SKILL.md:160-163, 186-190`). The prior single bullet implied a universal stdout-capture behavior, so a skill author following the doc could omit `--output-last-message` for Codex (yielding an empty output file) or add `--capture-stdout` redundantly. Closes #660.
+
 ## [7.16.5] - 2026-04-26
 
 ### Fixed

--- a/docs/external-reviewers.md
+++ b/docs/external-reviewers.md
@@ -23,7 +23,9 @@ External reviewers are launched via the `run-external-reviewer.sh` wrapper scrip
 
 - **Timeout enforcement** — Kills the process after a configurable timeout
 - **Sentinel file creation** — Writes a `.done` file containing the exit code when the process completes
-- **Output capture** — Captures stdout to a specified output file
+- **Output capture** — two patterns, opt-in per invocation:
+  - **stdout capture under `--capture-stdout`** — when the reviewer writes its results to stdout, pass `--capture-stdout` and the wrapper redirects the tool's stdout/stderr to `--output`. Cursor pattern; canonical examples at `skills/review/SKILL.md:146-148, 177-179`.
+  - **tool-managed output path** — when the reviewer takes its own output-path argument (e.g., Codex's `--output-last-message`), omit `--capture-stdout`; the wrapper does not capture stdout and the reviewer writes results directly to the file. The `--output` flag still names the expected destination so downstream readers know where to look. Codex pattern; canonical examples at `skills/review/SKILL.md:160-163, 186-190`.
 - **Elapsed time tracking** — Reports how long the review took
 
 During review and voting phases, reviewers are launched with `run_in_background: true` so they run concurrently with other work. (Negotiation rounds in `/research` and `/loop-review` run synchronously.)


### PR DESCRIPTION
## Summary
- Replaced the single misleading "Output capture" bullet at `docs/external-reviewers.md:26` with two sub-bullets distinguishing the two capture patterns the `run-external-reviewer.sh` wrapper supports: stdout capture under `--capture-stdout` (Cursor pattern) and tool-managed output paths (Codex pattern with `--output-last-message`).
- Referenced canonical examples in `skills/review/SKILL.md` for each pattern so a skill author reading the bullet can find the live invocations without having to re-derive the contract.

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] Read the modified `docs/external-reviewers.md` post-edit; confirm the two sub-bullets render with parallel structure to the surrounding "Timeout enforcement" / "Sentinel file creation" / "Elapsed time tracking" bullets.
- [x] `grep -rn "Output capture\|Captures stdout" docs/ skills/ scripts/` confirms no other docs carry the stale "Captures stdout" wording.
- [x] Verified the sub-bullet text against `scripts/run-external-reviewer.sh` (the `CAPTURE_STDOUT=true` branch redirects stdout/stderr to `--output`; otherwise stdout is not redirected and the tool writes its own output file).
- [x] `/relevant-checks` passed (pre-commit + agent-lint).
- [x] Quick-mode single-reviewer (Cursor) review: `NO_ISSUES_FOUND`.

</details>

Closes #660

Generated with [Claude Code](https://claude.com/claude-code)
