### PR TITLE
Fix #664: add curl-unavailable row to validate-citations.md

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.16.9",
+  "version": "7.16.10",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.16.10] - 2026-04-26
+
+### Fixed
+
+- `skills/research/scripts/validate-citations.md` — add the missing `curl-unavailable` row to the Reason vocabulary table. The script emits `STATUS=UNKNOWN(curl-unavailable)` at line 353 when the `curl` binary is not found on PATH, and the sibling reference `skills/research/references/citation-validation-phase.md` already documents this token, but the script's own contract `.md` table omitted it. A cross-check of every `STATUS=...` emission in `validate-citations.sh` against the table confirmed `curl-unavailable` was the only missing token. Closes #664.
+
 ## [7.16.9] - 2026-04-26
 
 ### Fixed

--- a/skills/research/scripts/validate-citations.md
+++ b/skills/research/scripts/validate-citations.md
@@ -75,6 +75,7 @@ network calls.
 | Reason token | Status | Meaning |
 |---|---|---|
 | `non-https` | FAIL | URL did not start with `https://` |
+| `curl-unavailable` | UNKNOWN | `curl` binary not found on PATH |
 | `ssrf-private-host` | FAIL | URL host literal matched RFC1918 / IPv6 link-local / RFC6598 / loopback |
 | `ssrf-private-resolved` | FAIL | DNS resolved to a private IP (any answer in a multi-answer set) |
 | `head-not-found` | FAIL | HEAD returned 404 / 410 |


### PR DESCRIPTION
## Summary
- Added the missing `curl-unavailable` row to the Reason vocabulary table in `skills/research/scripts/validate-citations.md` so the script's contract documentation enumerates every reason token actually emitted by `validate-citations.sh` (the script emits `STATUS=UNKNOWN(curl-unavailable)` at line 353; the sibling reference `citation-validation-phase.md` already documented it).

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] `/relevant-checks` passes on the modified file (markdownlint + agent-lint).
- [x] Cross-check confirmed `curl-unavailable` is the only missing reason token; every other `STATUS=...` emission in `validate-citations.sh` is already represented in the table.
- [x] Sibling reference `skills/research/references/citation-validation-phase.md` already documents `curl-unavailable` (line 129) — no companion edit required.

</details>

Closes #664

Generated with [Claude Code](https://claude.com/claude-code)
