### PR TITLE
Fix #666: reorder citation-validation-phase.md §2.7.1 skip preconditions

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.16.12",
+  "version": "7.16.13",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.16.13] - 2026-04-26
+
+### Fixed
+
+- `skills/research/references/citation-validation-phase.md` — reorder §2.7.1 skip preconditions to match `skills/research/SKILL.md` Step 2.7's emission order: `BUDGET_ABORTED=true` budget-abort gate FIRST (proceed to Step 4 because Step 3 was already skipped), then missing/empty `$RESEARCH_TMPDIR/research-report.txt` empty-synthesis gate SECOND (proceed to Step 3). Each gate now explicitly names its downstream branch in the prose. The line-23 prose previously folded `BUDGET_ABORTED` into the "no synthesis to validate" rationale for the Step 3 path; the budget-abort cause is now removed from that list and the empty-synthesis explanation states that `BUDGET_ABORTED=true` is handled by the budget-abort gate above and never reaches the empty-synthesis branch. Also updates the §2.7.6 "Step 2.7 → Step 3 control-flow summary" diagram to spell out the two ordered input gates with their distinct downstream targets, replacing the prior `skip if empty/budget-aborted` line that conflated the two skips. SKILL.md Step 2.7 was already correct; this is a documentation-only alignment fix. Closes #666.
+
 ## [7.16.12] - 2026-04-26
 
 ### Fixed

--- a/skills/research/references/citation-validation-phase.md
+++ b/skills/research/references/citation-validation-phase.md
@@ -14,21 +14,23 @@
 
 ### 2.7.1 — Skip preconditions (input gate)
 
-If `$RESEARCH_TMPDIR/research-report.txt` does not exist OR is empty (zero bytes), skip Step 2.7 entirely. Print:
+Evaluate the two skip conditions in this order — matching `SKILL.md` Step 2.7's emission order. Each condition has a distinct downstream branch and they must not be conflated.
 
-```
-⏩ 2.7: citation-validation — skipped (no synthesis to validate) (<elapsed>)
-```
-
-The empty-synthesis path is reachable when (a) Step 1 inline-fallback synthesis failed and produced no body, (b) `BUDGET_ABORTED=true` propagated past an earlier gate, or (c) a prior step's tmpdir cleanup left an empty placeholder. None of these warrant a citation pass.
-
-If `BUDGET_ABORTED=true` (set by any of the budget gates after Steps 1, 2, or 2.5): skip Step 2.7 entirely. Print:
+**Budget-abort gate (evaluated FIRST → proceed to Step 4).** If `BUDGET_ABORTED=true` (set by any of the budget gates after Steps 1, 2, or 2.5): skip Step 2.7 entirely and proceed directly to Step 4 (Step 3 was already skipped by the abort path). Print:
 
 ```
 ⏩ 2.7: citation-validation — skipped (--token-budget aborted upstream) (<elapsed>)
 ```
 
 The shell validator does not consume measurable Claude tokens, but skipping it on a budget-aborted run preserves the "Step 3 skipped" semantics of the abort path (Step 3 is not rendered, so a sidecar splice has no consumer).
+
+**Empty-synthesis gate (evaluated SECOND → proceed to Step 3).** If `$RESEARCH_TMPDIR/research-report.txt` does not exist OR is empty (zero bytes), skip Step 2.7 entirely and proceed to Step 3. Print:
+
+```
+⏩ 2.7: citation-validation — skipped (no synthesis to validate) (<elapsed>)
+```
+
+The empty-synthesis path is reachable when (a) Step 1 inline-fallback synthesis failed and produced no body, or (b) a prior step's tmpdir cleanup left an empty placeholder. Neither warrants a citation pass. (`BUDGET_ABORTED=true` is handled by the budget-abort gate above and never reaches this branch — the two skip conditions have different downstream targets and must stay separate.)
 
 ### 2.7.2 — Invoke the validator
 

--- a/skills/research/references/citation-validation-phase.md
+++ b/skills/research/references/citation-validation-phase.md
@@ -162,7 +162,9 @@ A small allow-list of widely-recognized reputable hosts (e.g., `*.wikipedia.org`
 
 ```
 2.7 entry breadcrumb (SKILL.md)
-  → § 2.7.1 input gate (skip if empty/budget-aborted)
+  → § 2.7.1 input gates (evaluated in order):
+      1. budget-abort gate → skip 2.7 → Step 4 (Step 3 was already skipped)
+      2. empty-synthesis gate → skip 2.7 → Step 3
     → § 2.7.2 validator invocation (always exits 0)
     → § 2.7.5 completion line + conditional advisory warnings
   → Step 3 splice (§ 2.7.6) appends sidecar to research-report-final.md


### PR DESCRIPTION
## Summary

- Reordered §2.7.1 in `skills/research/references/citation-validation-phase.md` so the skip preconditions match `skills/research/SKILL.md` Step 2.7's emission order: `BUDGET_ABORTED=true` budget-abort gate FIRST (proceed to Step 4 because Step 3 was already skipped), then missing/empty `$RESEARCH_TMPDIR/research-report.txt` empty-synthesis gate SECOND (proceed to Step 3); each gate now explicitly names its downstream branch.
- Tightened the prose so `BUDGET_ABORTED` is no longer folded into the "no synthesis to validate" rationale — that bullet listed three causes for the empty-synthesis path including `BUDGET_ABORTED`, conflating the two distinct skip conditions; `BUDGET_ABORTED` now lives only on the budget-abort gate above.
- Updated the §2.7.6 "Step 2.7 → Step 3 control-flow summary" diagram to spell out the two ordered input gates with their distinct downstream targets, replacing the prior `skip if empty/budget-aborted` line that conflated the two skips.

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] Read modified `citation-validation-phase.md` end-to-end and confirm §2.7.1 matches `SKILL.md` Step 2.7's emission order.
- [x] `grep` across `skills/research/` for any other reference doc carrying the inverted order — none found.
- [x] `/relevant-checks` (pre-commit on modified files + agent-lint on full repo) — passed.
- [x] Cursor code review (quick mode) — round 1 surfaced one in-scope finding (`§2.7.6` control-flow summary still using the old combined order); fixed; round 2 returned `NO_ISSUES_FOUND`.

</details>

Closes #666

Generated with [Claude Code](https://claude.com/claude-code)
