### PR TITLE
Fix #662: Darwin per-pgid CURL_PIDS kill on budget exhaustion

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.16.13",
+  "version": "7.16.14",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.16.14] - 2026-04-26
+
+### Fixed
+
+- `skills/research/scripts/validate-citations.sh` — on macOS (Darwin), `set -m` (job-control mode) puts each backgrounded `fetch_url` subshell in its own process group, so the budget-exhaustion `kill -- -$$` only signaled the parent's group and leaked every subshell's curl child past the deadline. Replace the Darwin handler with a per-`CURL_PIDS` loop running `kill -- -<pid>` against each recorded subshell pgid, terminating the whole subtree (subshell + curl substitution + descendants) together. The original `kill -- -$$` is intentionally NOT retained as a Darwin fallback: with `set -m` active, `$$`'s group contains the validator itself, so signaling it would kill the script before it writes the per-claim `UNKNOWN(timeout)` rows and the sidecar (verified empirically: exit 143, sidecar absent, fail-soft contract broken). When `set -m` silently fails the script now emits a stderr `WARNING:` line so operators know orphan-curl cleanup is degraded. New Test 20 (Darwin-only) in `test-validate-citations.sh` runs the validator against a hanging fake-curl shim with `--budget-seconds 1` and pins the regression class: validator exited 0, sidecar produced with `UNKNOWN | timeout` rows for the hung URLs, no surviving fake-curl PIDs after the kill loop. Linux is unaffected (the `setsid` re-exec keeps curl children in the script's session, where a single `kill -- -$$` still works). Sibling docs updated in sync (`validate-citations.md`, `test-validate-citations.md`, `references/citation-validation-phase.md`). Closes #662.
+
 ## [7.16.13] - 2026-04-26
 
 ### Fixed

--- a/skills/research/references/citation-validation-phase.md
+++ b/skills/research/references/citation-validation-phase.md
@@ -45,7 +45,7 @@ ${CLAUDE_PLUGIN_ROOT}/skills/research/scripts/validate-citations.sh \
 
 The script writes the sidecar to the path passed via `--output` and exits 0 on every path (fail-soft contract). On any internal error (curl missing, git rev-parse failure, etc.), the script writes a minimally-formed sidecar that explains the degraded path and still exits 0 — Step 3's splice consumer must always have a sidecar to read.
 
-See `${CLAUDE_PLUGIN_ROOT}/skills/research/scripts/validate-citations.md` for the full contract (argv, exit codes, sidecar schema, SSRF defenses, regex tiers, idempotency rerun semantics, budget-exhaustion process-group kill via `setsid`/`set -m`).
+See `${CLAUDE_PLUGIN_ROOT}/skills/research/scripts/validate-citations.md` for the full contract (argv, exit codes, sidecar schema, SSRF defenses, regex tiers, idempotency rerun semantics, budget-exhaustion process-group kill — Linux `setsid` + single `kill -- -$$`, macOS `set -m` + per-background `kill -- -<pid>` with no `kill -- -$$` fallback because that would self-signal the validator).
 
 ### 2.7.3 — Sidecar schema
 
@@ -148,7 +148,7 @@ The `UNKNOWN` bucket is deliberately broad: every transient or environment-depen
 
 ### Process-group kill semantics for budget exhaustion
 
-When the overall validator budget elapses (`--budget-seconds`, default 300), in-flight curl HEAD fetches MUST be terminated cleanly — orphaned curl processes can outlive the validator and skew network telemetry. Linux supports `setsid` directly (the script self-execs into a new session if not already a session leader); macOS `setsid` is non-portable, so the script falls back to `set -m` (job control) plus `kill -- -<pgid>`. The OS detection branch lives in `validate-citations.sh`; the test harness (`test-validate-citations.sh`) asserts the correct branch is taken on each platform via a stub-curl fixture that hangs deliberately past the budget.
+When the overall validator budget elapses (`--budget-seconds`, default 300), in-flight curl HEAD fetches MUST be terminated cleanly — orphaned curl processes can outlive the validator and skew network telemetry. Linux supports `setsid` directly (the script self-execs into a new session if not already a session leader, then a single `kill -- -$$` sweeps every descendant). macOS `setsid` is non-portable, so the script enables `set -m` (job control) which places each backgrounded `fetch_url` subshell in its own process group; on timeout the script signals each recorded `$!` via `kill -- -<pid>` (terminating the subshell + curl substitution + descendants together). `kill -- -$$` is **not** used as a Darwin fallback: with `set -m` active, `$$`'s process group still contains the validator itself, so signaling it would kill the script before it writes the per-claim `UNKNOWN(timeout)` rows and the sidecar — exit 143, sidecar absent, fail-soft contract broken. The OS detection branch lives in `validate-citations.sh`; the macOS path is asserted by Test 20 in `test-validate-citations.sh` (Darwin-only — Linux runners print a skip note and rely on the existing CI pipeline to exercise the `setsid` branch end-to-end).
 
 ### Curl-flag MUST / MUST-NOT contract
 

--- a/skills/research/scripts/test-validate-citations.md
+++ b/skills/research/scripts/test-validate-citations.md
@@ -27,6 +27,7 @@ the sidecar body contains the expected `Status` / `Reason` tokens.
 | Git-root-unavailable | non-git cwd → `UNKNOWN(git-root-unavailable)` |
 | DOI syntax | malformed `10.123/...` (3 digits) → not extracted (regex tier) |
 | URL dedup | duplicate URL appears in exactly one ledger row |
+| Darwin budget exhaustion (Test 20, Darwin-only) | hung fake-curl + `--budget-seconds 1` → exit 0, sidecar present with `UNKNOWN`/`timeout` rows for hung URLs, no surviving fake-curl PIDs after kill loop. Linux runners skip and rely on the existing CI pipeline to exercise the `setsid` branch end-to-end. |
 
 ## Test seams (env vars exercised by the harness)
 

--- a/skills/research/scripts/test-validate-citations.sh
+++ b/skills/research/scripts/test-validate-citations.sh
@@ -349,15 +349,17 @@ esac
 FAKEEOF
         chmod +x "$FAKE_CURL_PIDREC"
         START=$(date +%s)
+        set +e
         __VC_FAKE_CURL="$FAKE_CURL_PIDREC" __VC_LAST_ARGV="$ARGV_LOG" \
         __VC_SKIP_DNS=1 __VC_STUB_RESOLVE='example-hang.invalid=8.8.8.8' \
             "$VALIDATOR" --report "$WORK/c20/report.txt" --output "$WORK/c20/cv.md" \
-                         --tmpdir "$WORK/c20" --budget-seconds 1 >/dev/null 2>&1 || true
+                         --tmpdir "$WORK/c20" --budget-seconds 1 >/dev/null 2>&1
+        VALIDATOR_RC=$?
+        set -e
         END=$(date +%s)
         ELAPSED=$((END - START))
-        # Bug behavior: validator returns at budget (~1s) but orphan curl shims
-        # keep sleeping for ~60s. Wait briefly for kill signals to land, then
-        # check for survivors. Allow generous wall-clock slack for shared CI.
+        # Wait briefly for any in-flight kill signals to land before scanning
+        # for survivors. Bug behavior leaves ~60s sleeps running.
         sleep 2
         ORPHAN_COUNT=0
         for pf in "$PIDS_DIR"/*.pid; do
@@ -368,7 +370,17 @@ FAKEEOF
                 ORPHAN_COUNT=$((ORPHAN_COUNT + 1))
             fi
         done
+        # Bug-#662 leak behavior is ~60s (the fake-curl sleep); ceiling 15s
+        # filters that out while leaving slack for slow / shared CI.
         assert "Test 20: validator returned within budget + slack (got ${ELAPSED}s)" "[[ \"$ELAPSED\" -le 15 ]]"
+        # Fail-soft contract: validator MUST exit 0 even on budget timeout.
+        # Catches the regression class where the kill path signals $$'s
+        # process group and SIGTERMs the validator itself (exit 143, no
+        # sidecar).
+        assert "Test 20: validator exited 0 (fail-soft contract on timeout)" "[[ \"$VALIDATOR_RC\" -eq 0 ]]"
+        assert "Test 20: sidecar produced" "[[ -s \"$WORK/c20/cv.md\" ]]"
+        assert "Test 20: sidecar has UNKNOWN | timeout for hung URL #1" "grep -F 'https://example-hang.invalid/page1' \"$WORK/c20/cv.md\" | grep -F 'UNKNOWN' | grep -Fq 'timeout'"
+        assert "Test 20: sidecar has UNKNOWN | timeout for hung URL #2" "grep -F 'https://example-hang.invalid/page2' \"$WORK/c20/cv.md\" | grep -F 'UNKNOWN' | grep -Fq 'timeout'"
         assert "Test 20: no orphan fake-curl processes after budget-kill (got $ORPHAN_COUNT)" "[[ \"$ORPHAN_COUNT\" == 0 ]]"
         ;;
     *)

--- a/skills/research/scripts/test-validate-citations.sh
+++ b/skills/research/scripts/test-validate-citations.sh
@@ -319,6 +319,63 @@ __VC_SKIP_DNS=1 __VC_STUB_RESOLVE='example.com=8.8.8.8;doi.org=8.8.8.8' \
 LEDGER_ROWS=$(grep -c '^| `' "$WORK/c19/cv.md" || echo 0)
 assert "Test 19: combined cap yields exactly --max-claims rows (got $LEDGER_ROWS)" "[[ \"$LEDGER_ROWS\" == 6 ]]"
 
+# ---------- Test 20: Darwin budget-exhaustion kills background curl (#662) ----------
+echo "=== Test 20: Darwin budget-exhaustion no-orphan-curl ==="
+case "$(uname -s 2>/dev/null)" in
+    Darwin*)
+        mkdir -p "$WORK/c20"
+        cat > "$WORK/c20/report.txt" <<'REPORT'
+See https://example-hang.invalid/page1 and https://example-hang.invalid/page2.
+REPORT
+        # PID-recording fake curl: records its own PID to a per-invocation file
+        # at start, removes it on clean exit. After the validator returns, any
+        # surviving .pid file whose process is still alive is an orphan.
+        PIDS_DIR="$WORK/c20/pids"
+        mkdir -p "$PIDS_DIR"
+        FAKE_CURL_PIDREC="$WORK/c20/fake-curl-pidrec"
+        cat > "$FAKE_CURL_PIDREC" <<FAKEEOF
+#!/usr/bin/env bash
+PIDS_DIR="$PIDS_DIR"
+echo "\$\$" > "\$PIDS_DIR/\$\$.pid"
+trap 'rm -f "\$PIDS_DIR/\$\$.pid"' EXIT
+url=""
+for a in "\$@"; do
+    case "\$a" in http://*|https://*) url="\$a" ;; esac
+done
+case "\$url" in
+    *example-hang.invalid*) sleep 60; printf '200'; exit 0 ;;
+    *) printf '200'; exit 0 ;;
+esac
+FAKEEOF
+        chmod +x "$FAKE_CURL_PIDREC"
+        START=$(date +%s)
+        __VC_FAKE_CURL="$FAKE_CURL_PIDREC" __VC_LAST_ARGV="$ARGV_LOG" \
+        __VC_SKIP_DNS=1 __VC_STUB_RESOLVE='example-hang.invalid=8.8.8.8' \
+            "$VALIDATOR" --report "$WORK/c20/report.txt" --output "$WORK/c20/cv.md" \
+                         --tmpdir "$WORK/c20" --budget-seconds 1 >/dev/null 2>&1 || true
+        END=$(date +%s)
+        ELAPSED=$((END - START))
+        # Bug behavior: validator returns at budget (~1s) but orphan curl shims
+        # keep sleeping for ~60s. Wait briefly for kill signals to land, then
+        # check for survivors. Allow generous wall-clock slack for shared CI.
+        sleep 2
+        ORPHAN_COUNT=0
+        for pf in "$PIDS_DIR"/*.pid; do
+            [[ -e "$pf" ]] || continue
+            opid=$(cat "$pf" 2>/dev/null || echo "")
+            [[ -z "$opid" ]] && continue
+            if kill -0 "$opid" 2>/dev/null; then
+                ORPHAN_COUNT=$((ORPHAN_COUNT + 1))
+            fi
+        done
+        assert "Test 20: validator returned within budget + slack (got ${ELAPSED}s)" "[[ \"$ELAPSED\" -le 15 ]]"
+        assert "Test 20: no orphan fake-curl processes after budget-kill (got $ORPHAN_COUNT)" "[[ \"$ORPHAN_COUNT\" == 0 ]]"
+        ;;
+    *)
+        note "skip: Darwin-only (Linux uses setsid; kill -- -\$\$ already covers children)"
+        ;;
+esac
+
 # ---------- Summary ----------
 echo "=== Summary ==="
 echo "Passed: $PASS"

--- a/skills/research/scripts/validate-citations.md
+++ b/skills/research/scripts/validate-citations.md
@@ -151,14 +151,26 @@ Two consecutive runs against an unchanged `--report` produce a byte-identical
 When the overall `--budget-seconds` elapses, in-flight curl HEAD fetches
 must be terminated cleanly. OS-specific:
 
-- **Linux**: `setsid` puts curl children in their own session. The script
-  self-execs into a new session if not already a session leader (idempotency
-  guard: `__VC_SETSID_DONE=1` env var prevents infinite recursion).
-- **macOS**: `set -m` enables job control so the parent has its own process
-  group; `kill -- -<pgid>` per the parent's PID terminates the group.
+- **Linux**: when `setsid` is available, `setsid` puts curl children in
+  the script's session. The script self-execs into a new session if not
+  already a session leader (idempotency guard: `__VC_SETSID_DONE=1` env
+  var prevents infinite recursion). A single `kill -- -$$` then signals
+  every descendant. When `setsid` is unavailable, the re-exec is skipped
+  and the timeout `kill -- -$$` may signal the script's own group — a
+  pre-existing degraded path that #662 did not change.
+- **macOS**: `set -m` (job control) places each backgrounded `fetch_url`
+  subshell in its own process group with `pgid == $!`. The script records
+  every `$!` in `CURL_PIDS` and on timeout runs `kill -- -<pid>` for each
+  recorded PID, terminating the subshell + its curl substitution + any
+  descendants together. `kill -- -$$` is **intentionally not** used as a
+  fallback on this branch: with `set -m` active, `$$`'s process group
+  contains the validator itself, so signaling it would kill the script
+  before it writes the per-claim `UNKNOWN(timeout)` rows and the sidecar
+  — i.e. exit 143, sidecar absent, fail-soft contract broken.
 
-The test harness asserts both branches via a stub-curl fixture that hangs
-deliberately past the budget.
+The test harness asserts the macOS branch via Test 20 (Darwin-only) using
+a stub-curl fixture that hangs deliberately past the budget; the Linux
+`setsid` branch is exercised end-to-end by the existing CI pipeline.
 
 ## Test seams (NOT operator flags)
 
@@ -206,3 +218,7 @@ fixture inputs with stubbed curl and stubbed DNS. Verified scenarios:
 - Realpath escape (`..`-traversal + symlink-escape) →
   `out-of-tree-path-after-realpath` / `broken-symlink`.
 - HEAD 403/405/501 → `head-not-supported`.
+- Darwin budget-exhaustion no-orphan-curl (Test 20, Darwin-only): a hanging
+  fake-curl fixture is run with `--budget-seconds 1`; after the kill loop
+  no fake-curl PID survives. Linux runners skip this assertion and rely on
+  CI to exercise the `setsid` branch end-to-end.

--- a/skills/research/scripts/validate-citations.sh
+++ b/skills/research/scripts/validate-citations.sh
@@ -58,8 +58,16 @@
 # concern (research-report-final.md prelude lines).
 #
 # Process-group kill on budget exhaustion:
-#   Linux: setsid puts curl children in their own session.
-#   macOS: set -m + kill -- -<pgid> per the parent's process group.
+#   Linux: setsid puts curl children in the script's session, so a single
+#     kill -- -$$ signals every descendant.
+#   macOS: set -m places each backgrounded fetch_url subshell in its own
+#     process group (pgid == $!). The script records every $! in CURL_PIDS
+#     and on timeout runs kill -- -<pid> for each one, terminating the
+#     subshell + its curl substitution + any descendants together.
+#     `kill -- -$$` is intentionally NOT a fallback on this branch: it
+#     would also signal the validator itself (which lives in $$'s group),
+#     producing exit 143 with no sidecar and breaking the fail-soft
+#     contract.
 #   Either path ensures orphaned curl processes do not outlive the budget.
 #
 # Portability: bash 3.2 (macOS default) and bash 5+ (Ubuntu CI). Uses awk
@@ -658,9 +666,21 @@ case "$(uname -s 2>/dev/null)" in
         fi
         ;;
     Darwin*)
-        # Enable job control so the parent has its own process group; the
-        # `kill -- -<pgid>` fallback below uses $$.
+        # Enable job control so each `fetch_url &` subshell becomes a
+        # process group leader. The budget-exhaustion handler iterates
+        # CURL_PIDS and runs `kill -- -<pid>` per recorded subshell PID
+        # to terminate each subshell + its curl substitution. If `set -m`
+        # silently fails (rare on macOS bash 3.2+), background subshells
+        # share $$'s process group and per-PGID kills cannot reach their
+        # curl children — emit a warning so operators know orphan
+        # cleanup is degraded; we cannot fall back to `kill -- -$$`
+        # because that would also signal the validator itself and break
+        # the fail-soft contract.
         set -m 2>/dev/null || true
+        case "$-" in
+            *m*) : ;;  # job control active — normal path
+            *)   printf 'WARNING: validate-citations.sh: set -m failed; budget-exhaustion kill cannot guarantee orphan-curl cleanup\n' >&2 ;;
+        esac
         ;;
 esac
 
@@ -722,11 +742,16 @@ if [[ "$TIMED_OUT" == "true" ]]; then
             kill -- -$$ 2>/dev/null || true
             ;;
         Darwin*)
-            # `set -m` (line 663) puts each backgrounded `fetch_url &` in its
-            # own process group (pgid == subshell pid), so `kill -- -$$` only
-            # signals the parent's group and leaks each subshell's curl child.
-            # Signal each subshell's pgid directly to terminate the whole
-            # subtree (subshell + curl substitution + any descendants).
+            # The earlier Darwin case stanza enables `set -m`, which puts
+            # each backgrounded `fetch_url &` in its own process group
+            # (pgid == subshell pid), so `kill -- -$$` would only signal
+            # the parent's group and leak each subshell's curl child.
+            # `kill -- -$$` is intentionally NOT used as a fallback here:
+            # when `set -m` did take effect, $$'s group contains the
+            # validator itself, and signaling it kills the script before
+            # it can write the per-claim UNKNOWN(timeout) rows and the
+            # sidecar — i.e. it breaks the fail-soft contract (script
+            # must exit 0 with a consumable sidecar).
             for _kill_pid in "${CURL_PIDS[@]}"; do
                 kill -- -"$_kill_pid" 2>/dev/null || true
             done

--- a/skills/research/scripts/validate-citations.sh
+++ b/skills/research/scripts/validate-citations.sh
@@ -722,7 +722,14 @@ if [[ "$TIMED_OUT" == "true" ]]; then
             kill -- -$$ 2>/dev/null || true
             ;;
         Darwin*)
-            kill -- -$$ 2>/dev/null || true
+            # `set -m` (line 663) puts each backgrounded `fetch_url &` in its
+            # own process group (pgid == subshell pid), so `kill -- -$$` only
+            # signals the parent's group and leaks each subshell's curl child.
+            # Signal each subshell's pgid directly to terminate the whole
+            # subtree (subshell + curl substitution + any descendants).
+            for _kill_pid in "${CURL_PIDS[@]}"; do
+                kill -- -"$_kill_pid" 2>/dev/null || true
+            done
             ;;
     esac
     # Mark every still-missing result as UNKNOWN(timeout).


### PR DESCRIPTION
## Summary

- On macOS (Darwin), `set -m` placed each backgrounded `fetch_url` subshell in its own process group, so the budget-exhaustion `kill -- -$$` only signaled the parent's group and leaked every subshell's curl child past the deadline.
- Replace the Darwin handler with a per-`CURL_PIDS` loop running `kill -- -<pid>` against each recorded subshell pgid; the original `kill -- -$$` is intentionally not used as a fallback because under `set -m` it would also signal the validator itself (verified empirically: exit 143, no sidecar — breaks the fail-soft contract).
- New Darwin-only Test 20 in `test-validate-citations.sh` pins the regression class (validator exit 0, sidecar with `UNKNOWN`/`timeout` rows, no surviving fake-curl PIDs).

## Architecture Diagram

_No architecture diagram — quick mode._

## Code Flow Diagram

_No code flow diagram — quick mode._

## Test plan

- [x] `bash skills/research/scripts/test-validate-citations.sh` (39/39 assertions pass on macOS, including new Test 20 PID/exit-code/sidecar checks)
- [x] `/relevant-checks` (pre-commit + agent-lint, full repo)
- [x] Manual reproduce of #662: hanging fake-curl + `--budget-seconds 1` against the prior Darwin handler exits 143 with no sidecar; new handler exits 0, sidecar contains `UNKNOWN | timeout` rows, and no orphan PIDs remain.
- [x] CI green (Linux runners exercise the unchanged `setsid` branch end-to-end; Test 20 prints a skip note on Linux).

Closes #662

🤖 Generated with [Claude Code](https://claude.com/claude-code)
