### PR TITLE
Fix #663: classify HTTP 3xx HEAD responses as UNKNOWN(redirect-not-followed)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.16.16",
+  "version": "7.16.17",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.16.17] - 2026-04-26
+
+### Fixed
+
+- `skills/research/scripts/validate-citations.sh` — split the case arm `2??|3??)` so 3xx HEAD responses are reclassified as `UNKNOWN(redirect-not-followed)` instead of `PASS`. With `--max-redirs 0` (set as part of the SSRF guard), curl never fetches the redirect destination, so a cited URL that 301s to a removed page or to a private/internal host appeared valid in the citation ledger — silently overstating audit certainty for any redirected URL. The DOI ledger composer is special-cased in lockstep: `https://doi.org/<doi>` is a redirect resolver by design (every resolvable DOI returns a 3xx HEAD), so the DOI path interprets `UNKNOWN(redirect-not-followed)` as PASS rather than collapsing it to `UNKNOWN(doi-unresolved)` — preserving DOI ledger behavior bit-identically while correcting URL ledger behavior. Sibling docs updated in sync (`validate-citations.md` Reason vocabulary + Test harness bullet, `references/citation-validation-phase.md` Failure-modes table, `test-validate-citations.md` scenarios table). New Test 9b pins HEAD 301 → `UNKNOWN(redirect-not-followed)` and new Test 9c pins DOI HEAD 302 → PASS via the special-case; the shared fake-curl shim gains explicit `example-301.invalid → 301` and `doi.org → 302` arms. Closes #663.
+
 ## [7.16.16] - 2026-04-26
 
 ### Fixed

--- a/skills/research/references/citation-validation-phase.md
+++ b/skills/research/references/citation-validation-phase.md
@@ -143,7 +143,7 @@ The validator script always exits 0. Failure modes that would otherwise abort a 
 | File exists but the cited line range exceeds the file length | `FAIL(line-out-of-range)` |
 | File exists, line range valid, but range is empty (start > end) | `FAIL(line-range-empty)` |
 | DOI fails syntactic validation (e.g., not `10.NNNN/...`) | `FAIL(doi-syntax)` |
-| DOI is syntactically valid but doi.org HEAD does not resolve to a permanent URL | `UNKNOWN(doi-unresolved)` |
+| DOI is syntactically valid but doi.org HEAD does not resolve to a permanent URL | `UNKNOWN(doi-unresolved)` (a 3xx HEAD on `https://doi.org/<doi>` IS the registry's success signal — the DOI path interprets `UNKNOWN(redirect-not-followed)` as PASS, not as `doi-unresolved`) |
 
 The `UNKNOWN` bucket is deliberately broad: every transient or environment-dependent failure ends there so the validator's strictness scales with the operator's environment without false negatives skewing the audit.
 

--- a/skills/research/references/citation-validation-phase.md
+++ b/skills/research/references/citation-validation-phase.md
@@ -135,7 +135,8 @@ The validator script always exits 0. Failure modes that would otherwise abort a 
 | Multi-answer DNS where ANY answer is private (rebinding defense) | `FAIL(ssrf-private-resolved)` |
 | HEAD returns 4xx/5xx that does not indicate non-support (e.g., 404, 410) | `FAIL(head-not-found)` for 404/410; `FAIL(head-server-error)` for ≥500 |
 | HEAD returns 403/405/501 | `UNKNOWN(head-not-supported)` (some servers reject HEAD; an optional constrained GET retry MAY upgrade to PASS — see `validate-citations.md`) |
-| HEAD response inside per-fetch timeout window | `PASS` |
+| HEAD 2xx response inside per-fetch timeout window | `PASS` |
+| HEAD 3xx response inside per-fetch timeout window | `UNKNOWN(redirect-not-followed)` (redirect destination not fetched; `--max-redirs 0`) |
 | HEAD response after timeout (per-claim or overall budget) | `UNKNOWN(timeout)` |
 | Realpath escape (`..`-traversal or symlink-escape outside repo root) | `UNKNOWN(out-of-tree-path-after-realpath)` |
 | Broken symlink on the resolved path | `UNKNOWN(broken-symlink)` |

--- a/skills/research/scripts/test-validate-citations.md
+++ b/skills/research/scripts/test-validate-citations.md
@@ -19,6 +19,7 @@ the sidecar body contains the expected `Status` / `Reason` tokens.
 | Multi-answer DNS rebinding | mixed public+private answers → `FAIL(ssrf-private-resolved)` |
 | HEAD 403 / 501 mapping | both return `UNKNOWN(head-not-supported)` |
 | HEAD 404 mapping | returns `FAIL(head-not-found)` |
+| HEAD 301 mapping | returns `UNKNOWN(redirect-not-followed)` |
 | Curl argv MUST / MUST-NOT | `--max-redirs`, `--max-time`, `--noproxy`, HTTPS URL last; absent: `--insecure`, `-k`, `--proxy`, `--socks*`, `--cacert` |
 | Hostile `http_proxy` env | `--noproxy '*'` still in argv |
 | File:line PASS (existing) | `AGENTS.md:1` → `PASS` |

--- a/skills/research/scripts/test-validate-citations.md
+++ b/skills/research/scripts/test-validate-citations.md
@@ -20,6 +20,7 @@ the sidecar body contains the expected `Status` / `Reason` tokens.
 | HEAD 403 / 501 mapping | both return `UNKNOWN(head-not-supported)` |
 | HEAD 404 mapping | returns `FAIL(head-not-found)` |
 | HEAD 301 mapping | returns `UNKNOWN(redirect-not-followed)` |
+| DOI HEAD 302 (doi.org redirect-by-design) | DOI row → `PASS` (DOI path interprets `UNKNOWN(redirect-not-followed)` as success) |
 | Curl argv MUST / MUST-NOT | `--max-redirs`, `--max-time`, `--noproxy`, HTTPS URL last; absent: `--insecure`, `-k`, `--proxy`, `--socks*`, `--cacert` |
 | Hostile `http_proxy` env | `--noproxy '*'` still in argv |
 | File:line PASS (existing) | `AGENTS.md:1` → `PASS` |

--- a/skills/research/scripts/test-validate-citations.sh
+++ b/skills/research/scripts/test-validate-citations.sh
@@ -45,6 +45,7 @@ assert() {
 # A bash script that:
 #   - records every argv into $WORK/last-curl-argv.log
 #   - on `-w '%{http_code}'` mode, prints a code based on URL pattern:
+#       *://example-301.invalid/*        → 301
 #       *://example-403.invalid/*        → 403
 #       *://example-404.invalid/*        → 404
 #       *://example-501.invalid/*        → 501
@@ -71,6 +72,7 @@ for a in "$@"; do
 done
 
 case "$url" in
+    *example-301.invalid*) printf '301'; exit 0 ;;
     *example-403.invalid*) printf '403'; exit 0 ;;
     *example-404.invalid*) printf '404'; exit 0 ;;
     *example-501.invalid*) printf '501'; exit 0 ;;
@@ -184,6 +186,17 @@ __VC_FAKE_CURL="$FAKE_CURL" __VC_LAST_ARGV="$ARGV_LOG" \
 __VC_SKIP_DNS=1 __VC_STUB_RESOLVE='example-404.invalid=8.8.8.8' \
     "$VALIDATOR" --report "$WORK/c9/report.txt" --output "$WORK/c9/cv.md" --tmpdir "$WORK/c9" >/dev/null 2>&1
 assert "Test 9: head-not-found reason present" "grep -F 'head-not-found' \"$WORK/c9/cv.md\""
+
+# ---------- Test 9b: HEAD 301 → UNKNOWN(redirect-not-followed) (issue #663) ----------
+echo "=== Test 9b: HEAD 301 mapping ==="
+mkdir -p "$WORK/c9b"
+cat > "$WORK/c9b/report.txt" <<'REPORT'
+See https://example-301.invalid/old.
+REPORT
+__VC_FAKE_CURL="$FAKE_CURL" __VC_LAST_ARGV="$ARGV_LOG" \
+__VC_SKIP_DNS=1 __VC_STUB_RESOLVE='example-301.invalid=8.8.8.8' \
+    "$VALIDATOR" --report "$WORK/c9b/report.txt" --output "$WORK/c9b/cv.md" --tmpdir "$WORK/c9b" >/dev/null 2>&1
+assert "Test 9b: redirect-not-followed reason present" "grep -F 'redirect-not-followed' \"$WORK/c9b/cv.md\""
 
 # ---------- Test 10: fake-curl argv contract (MUST + MUST-NOT) ----------
 echo "=== Test 10: fake-curl argv MUST / MUST-NOT ==="

--- a/skills/research/scripts/test-validate-citations.sh
+++ b/skills/research/scripts/test-validate-citations.sh
@@ -50,7 +50,12 @@ assert() {
 #       *://example-404.invalid/*        → 404
 #       *://example-501.invalid/*        → 501
 #       *://example-hang.invalid/*       → sleep 60 (budget tester drives this)
-#       https://doi.org/10.1234/*        → 200 (allow DOI happy path)
+#       https://doi.org/*                → 302 (doi.org is a redirect resolver
+#                                             by design; with --max-redirs 0
+#                                             the validator reads this as
+#                                             UNKNOWN(redirect-not-followed),
+#                                             which the DOI path interprets
+#                                             as PASS — issue #663)
 #       any other https://*               → 200
 #   - exit 0 (curl simulated success)
 
@@ -76,6 +81,7 @@ case "$url" in
     *example-403.invalid*) printf '403'; exit 0 ;;
     *example-404.invalid*) printf '404'; exit 0 ;;
     *example-501.invalid*) printf '501'; exit 0 ;;
+    *://doi.org/*) printf '302'; exit 0 ;;
     *example-hang.invalid*)
         sleep 60
         printf '200'; exit 0 ;;
@@ -197,6 +203,20 @@ __VC_FAKE_CURL="$FAKE_CURL" __VC_LAST_ARGV="$ARGV_LOG" \
 __VC_SKIP_DNS=1 __VC_STUB_RESOLVE='example-301.invalid=8.8.8.8' \
     "$VALIDATOR" --report "$WORK/c9b/report.txt" --output "$WORK/c9b/cv.md" --tmpdir "$WORK/c9b" >/dev/null 2>&1
 assert "Test 9b: redirect-not-followed reason present" "grep -F 'redirect-not-followed' \"$WORK/c9b/cv.md\""
+
+# ---------- Test 9c: DOI HEAD 302 → PASS (doi.org is redirect-by-design; issue #663) ----------
+# Regression guard: a 3xx HEAD on https://doi.org/<doi> is the success signal for DOI
+# registration, so the DOI path must interpret UNKNOWN(redirect-not-followed) as PASS.
+echo "=== Test 9c: DOI HEAD 302 mapping → PASS ==="
+mkdir -p "$WORK/c9c"
+cat > "$WORK/c9c/report.txt" <<'REPORT'
+Reference: 10.1234/foo.bar
+REPORT
+__VC_FAKE_CURL="$FAKE_CURL" __VC_LAST_ARGV="$ARGV_LOG" \
+__VC_SKIP_DNS=1 __VC_STUB_RESOLVE='doi.org=8.8.8.8' \
+    "$VALIDATOR" --report "$WORK/c9c/report.txt" --output "$WORK/c9c/cv.md" --tmpdir "$WORK/c9c" >/dev/null 2>&1
+assert "Test 9c: DOI row marked PASS for doi.org 302" "grep -E '\\| .*10\\.1234/foo\\.bar.* \\| doi \\| PASS \\|' \"$WORK/c9c/cv.md\""
+assert "Test 9c: DOI row not marked doi-unresolved" "! grep -F 'doi-unresolved' \"$WORK/c9c/cv.md\""
 
 # ---------- Test 10: fake-curl argv contract (MUST + MUST-NOT) ----------
 echo "=== Test 10: fake-curl argv MUST / MUST-NOT ==="

--- a/skills/research/scripts/validate-citations.md
+++ b/skills/research/scripts/validate-citations.md
@@ -88,7 +88,7 @@ network calls.
 | `no-status-line` | UNKNOWN | curl exited 0 but `%{http_code}` was empty |
 | `unrecognized-status-<code>` | UNKNOWN | curl returned a code outside 2xx-5xx |
 | `doi-syntax` | FAIL | DOI does not match `^10\.[0-9]{4,9}/...` |
-| `doi-unresolved` | UNKNOWN | DOI passed syntactic check but doi.org HEAD did not return PASS |
+| `doi-unresolved` | UNKNOWN | DOI passed syntactic check but doi.org HEAD did not return PASS or a 3xx redirect (doi.org is a redirect resolver — a 3xx HEAD on `https://doi.org/<doi>` is the registry's success signal, so the DOI path interprets `UNKNOWN(redirect-not-followed)` as PASS) |
 | `git-root-unavailable` | UNKNOWN | `git rev-parse --show-toplevel` failed (not a git tree) |
 | `file-not-found` | FAIL | path does not exist relative to git root or cwd |
 | `path-is-directory` | FAIL | resolved path is a directory, not a file |

--- a/skills/research/scripts/validate-citations.md
+++ b/skills/research/scripts/validate-citations.md
@@ -82,6 +82,7 @@ network calls.
 | `head-client-error-<code>` | FAIL | HEAD returned 4xx (excl. 403/404/405/410/501) |
 | `head-server-error-<code>` | FAIL | HEAD returned 5xx |
 | `head-not-supported` | UNKNOWN | HEAD returned 403 / 405 / 501 (some servers reject HEAD) |
+| `redirect-not-followed` | UNKNOWN | HEAD returned 3xx; redirect destination not fetched (`--max-redirs 0`) |
 | `timeout` | UNKNOWN | per-fetch or overall budget elapsed |
 | `network-error` | UNKNOWN | curl exited non-zero (connection error, DNS failure) |
 | `no-status-line` | UNKNOWN | curl exited 0 but `%{http_code}` was empty |
@@ -218,6 +219,7 @@ fixture inputs with stubbed curl and stubbed DNS. Verified scenarios:
 - Realpath escape (`..`-traversal + symlink-escape) →
   `out-of-tree-path-after-realpath` / `broken-symlink`.
 - HEAD 403/405/501 → `head-not-supported`.
+- HEAD 3xx → `redirect-not-followed`.
 - Darwin budget-exhaustion no-orphan-curl (Test 20, Darwin-only): a hanging
   fake-curl fixture is run with `--budget-seconds 1`; after the kill loop
   no fake-curl PID survives. Linux runners skip this assertion and rely on

--- a/skills/research/scripts/validate-citations.sh
+++ b/skills/research/scripts/validate-citations.sh
@@ -434,7 +434,8 @@ fetch_url() {
     fi
 
     case "$code" in
-        2??|3??) printf 'STATUS=PASS\n' > "$out" ;;
+        2??) printf 'STATUS=PASS\n' > "$out" ;;
+        3??) printf 'STATUS=UNKNOWN(redirect-not-followed)\n' > "$out" ;;
         403|405|501) printf 'STATUS=UNKNOWN(head-not-supported)\n' > "$out" ;;
         404|410) printf 'STATUS=FAIL(head-not-found)\n' > "$out" ;;
         4??) printf 'STATUS=FAIL(head-client-error-%s)\n' "$code" > "$out" ;;

--- a/skills/research/scripts/validate-citations.sh
+++ b/skills/research/scripts/validate-citations.sh
@@ -832,8 +832,10 @@ if [[ -n "$DOIS" ]]; then
         local_hash=$(printf '%s' "https://doi.org/$doi" | shasum 2>/dev/null | awk '{print $1}')
         [[ -z "$local_hash" ]] && local_hash=$(printf '%s' "https://doi.org/$doi" | md5sum 2>/dev/null | awk '{print $1}')
         raw=$(read_status "$local_hash")
+        # doi.org is a redirect resolver by design — a 3xx HEAD on https://doi.org/<doi>
+        # is the success signal for DOI registration, so treat redirect-not-followed as PASS.
         case "$raw" in
-            PASS) status=PASS; reason=""; PASS=$((PASS + 1)) ;;
+            PASS|UNKNOWN\(redirect-not-followed\)) status=PASS; reason=""; PASS=$((PASS + 1)) ;;
             UNKNOWN\(*|FAIL\(*) status=UNKNOWN; reason="doi-unresolved"; UNKNOWN=$((UNKNOWN + 1)) ;;
             *) status=UNKNOWN; reason="doi-unresolved"; UNKNOWN=$((UNKNOWN + 1)) ;;
         esac


### PR DESCRIPTION
## Summary
- Split the case arm `2??|3??)` in `validate-citations.sh` so HTTP 3xx responses are reclassified as `UNKNOWN(redirect-not-followed)` instead of falsely PASSing — `--max-redirs 0` (set as part of the SSRF guard) means the redirect destination is never fetched, so the prior PASS classification silently overstated audit certainty.
- Special-cased the DOI ledger composer to interpret `UNKNOWN(redirect-not-followed)` as PASS — `https://doi.org/<doi>` is a redirect resolver by design, so a 3xx HEAD on doi.org IS the registry's success signal; the special-case preserves DOI ledger behavior bit-identically while correcting URL ledger behavior.
- Updated all four edit-in-sync mirrors named in `validate-citations.md:175-185` plus the parallel `test-validate-citations.md` scenarios mirror per the dialectic resolution; added Test 9b (HEAD 301 → UNKNOWN) and Test 9c (DOI HEAD 302 → PASS) regression tests.

<details><summary>Architecture Diagram</summary>

```mermaid
flowchart TD
  subgraph contract[Contract surfaces — validate-citations.md:175-185]
    SH["validate-citations.sh<br/>HTTP classifier (line 428-430)<br/>+ DOI ledger (line 803-808)"]
    MD["validate-citations.md<br/>Reason vocabulary table"]
    PHASE["citation-validation-phase.md<br/>Failure-modes table (line 136)"]
    TSH["test-validate-citations.sh<br/>regression harness"]
    MAKE["Makefile test-validate-citations target<br/>(verify-no-op)"]
  end
  subgraph mirror[Parallel docs mirror — dialectic resolution]
    TMD["test-validate-citations.md<br/>scenarios table"]
  end
  subgraph runtime[Runtime — every /research invocation]
    R[/"/research Step 2.7"/] --> SH
    SH -->|"HEAD via curl --max-redirs 0"| URL[("HTTP origin")]
    URL -->|2xx| SH
    URL -->|3xx Location set, NOT followed| SH
    SH -->|"STATUS=PASS or<br/>STATUS=UNKNOWN(redirect-not-followed)"| RES[("$RESULT_DIR/&lt;hash&gt;.result")]
    RES --> SIDECAR[("citation-validation.md sidecar<br/>markdown table")]
    RES --> DOIPATH["DOI path<br/>(redirect-not-followed → PASS)"]
    DOIPATH --> SIDECAR
  end
  subgraph harness[Test path]
    TSH -->|"__VC_FAKE_CURL=fake"| FC[("fake-curl heredoc<br/>+ example-301.invalid arm<br/>+ doi.org → 302 arm")]
    FC -->|"301"| SH
    FC -->|"302 (doi.org)"| SH
    TSH -->|"grep -F redirect-not-followed"| SIDECAR
    TSH -->|"grep PASS for doi row"| SIDECAR
  end
  SH -.contracts.-> MD
  SH -.contracts.-> PHASE
  SH -.contracts.-> TSH
  TSH -.contracts.-> MAKE
  TSH -.parallel.-> TMD
  classDef changed fill:#ffe4b5,stroke:#d2691e
  class SH,MD,PHASE,TSH,TMD changed
```

</details>

<details><summary>Code Flow Diagram</summary>

```mermaid
sequenceDiagram
  participant R as /research Step 2.7
  participant V as validate-citations.sh
  participant FU as fetch_url()
  participant C as curl (HEAD --max-redirs 0)
  participant RES as $RESULT_DIR/<hash>.result
  participant DOI as DOI ledger composer
  participant URL as URL ledger composer
  participant SC as sidecar (citation-validation.md)
  Note over R,SC: Successful citation flow with 3xx classification (issue #663 fix)
  R->>V: invoke with --report --output --tmpdir
  V->>V: extract URLs, DOIs, file:line claims
  par For each unique URL/DOI fetch (parallel)
    V->>FU: fetch_url(url, out=$RESULT_DIR/<hash>.result)
    FU->>C: curl -sS -I --max-redirs 0 --noproxy '*' $url
    C-->>FU: HTTP code (e.g. 200, 301, 302, 404)
    alt code matches 2??
      FU->>RES: STATUS=PASS
    else code matches 3??
      FU->>RES: STATUS=UNKNOWN(redirect-not-followed)
    else 403/405/501
      FU->>RES: STATUS=UNKNOWN(head-not-supported)
    else 404/410
      FU->>RES: STATUS=FAIL(head-not-found)
    else other 4xx
      FU->>RES: STATUS=FAIL(head-client-error-CODE)
    else 5xx
      FU->>RES: STATUS=FAIL(head-server-error-CODE)
    end
  end
  V->>URL: compose URL rows
  loop For each URL claim
    URL->>RES: read_status(hash)
    alt raw == PASS
      URL->>SC: row PASS
    else raw == UNKNOWN(redirect-not-followed)
      Note over URL: User-cited URL — opaque<br/>destination is real "unknown"
      URL->>SC: row UNKNOWN, reason redirect-not-followed
    else raw matches UNKNOWN(*) | FAIL(*)
      URL->>SC: row UNKNOWN/FAIL, reason from raw
    end
  end
  V->>DOI: compose DOI rows
  loop For each DOI claim
    DOI->>RES: read_status(hash of https://doi.org/<doi>)
    alt raw == PASS
      DOI->>SC: row PASS
    else raw == UNKNOWN(redirect-not-followed)
      Note over DOI: doi.org IS a redirect resolver —<br/>3xx is the success signal
      DOI->>SC: row PASS (NEW — issue #663)
    else raw matches UNKNOWN(*) | FAIL(*)
      DOI->>SC: row UNKNOWN, reason doi-unresolved
    end
  end
  V-->>R: SUMMARY=PASS=<n> FAIL=<n> UNKNOWN=<n> TOTAL=<n>
  R->>R: print breadcrumb + advisory warnings
  R->>SC: splice sidecar into research-report-final.md
```

</details>

<details><summary>Test plan</summary>

- [x] `bash skills/research/scripts/test-validate-citations.sh` — 42/42 assertions pass (including new Test 9b for URL 301 → UNKNOWN(redirect-not-followed) and Test 9c for DOI 302 → PASS via the redirect-not-followed special-case)
- [x] `/relevant-checks` clean (pre-commit + agent-lint full-repo pass)
- [x] All 5 contract surfaces named in `validate-citations.md:175-185` updated in lockstep (.sh, .md, phase ref, test sh, Makefile target verified-no-op) plus the parallel test-validate-citations.md mirror per the dialectic resolution
- [x] No regression on existing 2xx/4xx/5xx fixtures (Tests 1-9, 10-19 unchanged behavior)
- [x] DOI behavior preserved bit-identically: doi.org → 302 → UNKNOWN(redirect-not-followed) → PASS in DOI ledger (Test 9c)

</details>

Closes #663

Generated with [Claude Code](https://claude.com/claude-code)
