### PR TITLE
Fix #669: require jq for eval-research.sh --smoke-test, drop grep fallback

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.16.24",
+  "version": "7.16.25",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.16.25] - 2026-04-26
+
+### Fixed
+
+- `scripts/eval-research.sh` — close the `--smoke-test` grep-fallback bypass that let truncated/malformed `eval-baseline.json` pass schema validation. Previously, when `jq` was unavailable, `validate_baseline_json` fell back to three substring `grep` checks for `"version"`, `"scale"`, `"entries"` — a bug-shaped JSON containing those literals anywhere (including inside string values or comments) returned success even though it was not parseable, contradicting the contract at `scripts/eval-research.md` ("parse and schema-validate"). Move `require_tool jq` outside the `SMOKE_TEST` guard so `jq` is required in all modes and drop the grep-fallback `else` branch in `validate_baseline_json` so JSON validation has a single deterministic path. Updates the `--smoke-test` row in `scripts/eval-research.md` to document `jq` as required in this mode and rewrites the exit-code-3 prose (and the script's matching usage-block comment / tooling-check section title) to spell out per-mode tool requirements. Existing test harnesses are unaffected: `test-eval-research-baseline-flag.sh` already PATH-stubs `jq`, and `test-eval-set-structure.sh`'s `--smoke-test` invocation will surface a clear exit-3 if `jq` is genuinely missing. Closes #669.
+
 ## [7.16.24] - 2026-04-26
 
 ### Fixed

--- a/scripts/eval-research.md
+++ b/scripts/eval-research.md
@@ -33,7 +33,7 @@ make eval-research ARGS="--id eval-1 --timeout 4200"
 | `--write-baseline <file>` | unset | Write run results in `eval-baseline.json` shape to this file path. Used to populate the committed baseline after a clean end-to-end run. |
 | `--timeout <sec>` | `4200` | Per-question timeout for the `/research` subprocess. Default is above `/research`'s composite budget (Step 1 1860s + Step 2 1860s = 3720s) so healthy runs never misclassify as harness timeouts. |
 | `--judge-timeout <sec>` | `600` | Per-question timeout for the LLM-as-judge call. |
-| `--smoke-test` | off | Parse and schema-validate `eval-set.md` and `eval-baseline.json`, then exit 0 without invoking `claude -p`. No API cost. Used by `scripts/test-eval-set-structure.sh`. |
+| `--smoke-test` | off | Parse and schema-validate `eval-set.md` and `eval-baseline.json`, then exit 0 without invoking `claude -p`. No API cost. Requires `jq` (the `claude` binary is not required in this mode, but `jq` is — schema validation has no fallback). Used by `scripts/test-eval-set-structure.sh`. |
 | `--help` | — | Print the script's usage block and exit 0. |
 
 ## Operational definitions
@@ -138,7 +138,7 @@ Authors editing `skills/research/references/eval-set.md` MUST follow:
 - `0` — harness ran. Per-entry timeouts and parse failures are reported in the `status` column / `research_status` JSON field, not the exit code.
 - `1` — schema validation of `eval-set.md` or `eval-baseline.json` failed.
 - `2` — argument parse error or invalid argument value (bad timeout integer, regex-invalid baseline ref, baseline ref that cannot be resolved via `git show`, or a value-taking flag with no following value — e.g. a trailing `--baseline` — which previously aborted with code 1 under `set -e` and collided with the schema-validation code; issue #477 separated the two).
-- `3` — required tooling missing (`claude`, `jq`, or `awk`).
+- `3` — required tooling missing. `jq` and `awk` are required in all modes (including `--smoke-test`); `claude` is required in non-smoke-test runs.
 
 ## Security
 

--- a/scripts/eval-research.sh
+++ b/scripts/eval-research.sh
@@ -146,9 +146,9 @@ require_tool() {
   }
 }
 require_tool awk
+require_tool jq
 if [[ "$SMOKE_TEST" != "true" ]]; then
   require_tool claude
-  require_tool jq
 fi
 
 # ---- Validate baseline ref against strict regex --------------------------
@@ -281,24 +281,9 @@ validate_baseline_json() {
     printf 'eval-research: eval-baseline.json not found at %s\n' "$file" >&2
     return 1
   fi
-  if command -v jq >/dev/null 2>&1; then
-    if ! jq -e '.version and .scale and (.entries | type == "array")' "$file" >/dev/null 2>&1; then
-      printf 'eval-research: eval-baseline.json missing required keys (version, scale, entries)\n' >&2
-      return 1
-    fi
-  else
-    if ! grep -q '"version"' "$file"; then
-      printf 'eval-research: eval-baseline.json missing required key: version (jq not available; using grep fallback)\n' >&2
-      return 1
-    fi
-    if ! grep -q '"scale"' "$file"; then
-      printf 'eval-research: eval-baseline.json missing required key: scale (jq not available; using grep fallback)\n' >&2
-      return 1
-    fi
-    if ! grep -q '"entries"' "$file"; then
-      printf 'eval-research: eval-baseline.json missing required key: entries (jq not available; using grep fallback)\n' >&2
-      return 1
-    fi
+  if ! jq -e '.version and .scale and (.entries | type == "array")' "$file" >/dev/null 2>&1; then
+    printf 'eval-research: eval-baseline.json missing required keys (version, scale, entries) or not valid JSON\n' >&2
+    return 1
   fi
   return 0
 }

--- a/scripts/eval-research.sh
+++ b/scripts/eval-research.sh
@@ -57,7 +57,9 @@
 #       integer, regex-invalid baseline ref, baseline ref that cannot be
 #       resolved via git show, or a value-taking flag with no following
 #       value such as a trailing `--baseline`).
-#   3 — required tooling missing (claude, jq, awk).
+#   3 — required tooling missing. jq and awk are required in all modes
+#       (including --smoke-test); claude is required only when not using
+#       --smoke-test.
 #
 # Security: --baseline accepts only [0-9A-Za-z_./-]+ to avoid shell
 # injection into git show. See OOS_1 in the tracking issue for #419.
@@ -138,7 +140,10 @@ if ! [[ "$JUDGE_TIMEOUT_SECONDS" =~ ^[0-9]+$ ]] || (( JUDGE_TIMEOUT_SECONDS < 1 
   exit 2
 fi
 
-# ---- Tooling check (skipped under --smoke-test) --------------------------
+# ---- Tooling check -------------------------------------------------------
+# awk + jq are required in all modes (jq schema-validates eval-baseline.json
+# in both smoke-test and full-run paths). claude is required only when not
+# using --smoke-test.
 require_tool() {
   command -v "$1" >/dev/null 2>&1 || {
     printf 'eval-research: required tool missing: %s\n' "$1" >&2


### PR DESCRIPTION
## Summary
- Closed the `--smoke-test` grep-fallback bypass in `scripts/eval-research.sh` by requiring `jq` unconditionally and dropping the substring-grep `else` branch in `validate_baseline_json`, so a malformed/truncated `eval-baseline.json` containing the literals `"version"`, `"scale"`, `"entries"` no longer passes schema validation.
- Updated `scripts/eval-research.md` to document `jq` as required for `--smoke-test` and rewrote the exit-code-3 prose (and the script's matching usage-block / tooling-check section title) to spell out per-mode tool requirements.

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] `bash scripts/eval-research.sh --smoke-test` exits 0 against the committed `eval-baseline.json` (jq available).
- [x] `bash scripts/test-eval-set-structure.sh` passes (Check 9 invokes `--smoke-test`).
- [x] `bash scripts/test-eval-research-baseline-flag.sh` passes (PATH-stubs `jq` + `claude`; exercises the non-smoke-test path).
- [x] `/relevant-checks` clean (pre-commit + agent-lint).
- [x] Manual: with `jq` removed from PATH, `bash scripts/eval-research.sh --smoke-test` exits 3 ("required tool missing: jq") — the previous behavior would have passed via grep fallback against a malformed baseline.

</details>

Closes #669

Generated with [Claude Code](https://claude.com/claude-code)
