### PR TITLE
Fix #668: clarify validator exit-code contract

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.16.19",
+  "version": "7.16.20",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.16.20] - 2026-04-26
+
+### Fixed
+
+- `skills/research/scripts/validate-citations.md` and `skills/research/references/citation-validation-phase.md` — clarify the citation-validator's exit-code contract by replacing every "always exits 0 on every path"-style claim with "exits 0 on validation paths; exit 2 only for argument/flag errors — operator or harness bug." `validate-citations.sh:124,128,147,153` already exit 2 for unknown args, missing required args, invalid numeric flag values, and missing `--tmpdir`; the documentation now matches that shipped behavior. Three in-script doc surfaces in `validate-citations.sh` (header banner at line 11, `# Exit code:` block at line 35, and the `set -uo pipefail` introduction comment) are aligned to the same canonical wording for consistency. Closes #668.
+
 ## [7.16.19] - 2026-04-26
 
 ### Fixed

--- a/skills/research/references/citation-validation-phase.md
+++ b/skills/research/references/citation-validation-phase.md
@@ -2,7 +2,7 @@
 
 **Consumer**: `/research` Step 2.7 — loaded via the `MANDATORY — READ ENTIRE FILE` directive at Step 2.7 entry in SKILL.md.
 
-**Contract**: scale-agnostic citation-credibility check. Runs unconditionally on every `/research` invocation that produced a `research-report.txt` (every scale: `quick`/`standard`/`deep`), executing between Step 2.5 (adjudication) and Step 3 (final report). The phase reads the validated synthesis at `$RESEARCH_TMPDIR/research-report.txt`, extracts cited provenance (file:line, URL, DOI), HEAD-fetches each unique URL with bounded timeout in parallel under SSRF guards (HTTPS-only, `--max-redirs 0`, `--noproxy '*'`, RFC1918/IPv6 link-local/RFC6598 hostname pre-rejection, DNS resolved-IP private-range check via `host`→`nslookup` fallback chain, connection-pinning via `--resolve` to mitigate rebinding TOCTOU), classifies domain credibility heuristically (advisory only — never flips PASS to FAIL), validates DOIs syntactically + via `HEAD https://doi.org/<doi>` under the same SSRF rules, spot-checks file:line existence + line-range against `git rev-parse --show-toplevel` with `realpath` canonical-path containment check, and writes a 3-state per-claim ledger (`PASS` / `FAIL` / `UNKNOWN` with reason classifier on `UNKNOWN`) to `$RESEARCH_TMPDIR/citation-validation.md` (sidecar). Step 3 splices the sidecar as a `## Citation Validation` section into `research-report-final.md` after the standard report block. **Fail-soft**: per-claim failures surface as warnings only; the validator script always exits 0; Step 3 is never blocked.
+**Contract**: scale-agnostic citation-credibility check. Runs unconditionally on every `/research` invocation that produced a `research-report.txt` (every scale: `quick`/`standard`/`deep`), executing between Step 2.5 (adjudication) and Step 3 (final report). The phase reads the validated synthesis at `$RESEARCH_TMPDIR/research-report.txt`, extracts cited provenance (file:line, URL, DOI), HEAD-fetches each unique URL with bounded timeout in parallel under SSRF guards (HTTPS-only, `--max-redirs 0`, `--noproxy '*'`, RFC1918/IPv6 link-local/RFC6598 hostname pre-rejection, DNS resolved-IP private-range check via `host`→`nslookup` fallback chain, connection-pinning via `--resolve` to mitigate rebinding TOCTOU), classifies domain credibility heuristically (advisory only — never flips PASS to FAIL), validates DOIs syntactically + via `HEAD https://doi.org/<doi>` under the same SSRF rules, spot-checks file:line existence + line-range against `git rev-parse --show-toplevel` with `realpath` canonical-path containment check, and writes a 3-state per-claim ledger (`PASS` / `FAIL` / `UNKNOWN` with reason classifier on `UNKNOWN`) to `$RESEARCH_TMPDIR/citation-validation.md` (sidecar). Step 3 splices the sidecar as a `## Citation Validation` section into `research-report-final.md` after the standard report block. **Fail-soft**: per-claim failures surface as warnings only; the validator script always exits 0 on validation paths (exit 2 only for argument/flag errors); Step 3 is never blocked.
 
 **When to load**: once Step 2.7 is about to execute. Do NOT load during Step 0, Step 1, Step 2, Step 2.5, Step 3, or Step 4. SKILL.md emits the Step 2.7 entry breadcrumb and the Step 2.7 completion print; this file does NOT emit those — it owns body content only.
 
@@ -10,7 +10,7 @@
 
 ## Step 2.7 — Citation Validation
 
-**IMPORTANT: Citation validation runs unconditionally on every scale that produced a synthesis. The phase is fail-soft: every per-claim failure is recorded in the sidecar; the validator exits 0; Step 3 never blocks on this phase. Domain credibility is advisory only — it never flips a `PASS` to `FAIL`. Quick mode runs the same validation against its single-lane synthesis output as standard/deep — there is no scale-specific skip path.**
+**IMPORTANT: Citation validation runs unconditionally on every scale that produced a synthesis. The phase is fail-soft: every per-claim failure is recorded in the sidecar; the validator exits 0 on validation paths (exit 2 only for argument/flag errors); Step 3 never blocks on this phase. Domain credibility is advisory only — it never flips a `PASS` to `FAIL`. Quick mode runs the same validation against its single-lane synthesis output as standard/deep — there is no scale-specific skip path.**
 
 ### 2.7.1 — Skip preconditions (input gate)
 
@@ -43,7 +43,7 @@ ${CLAUDE_PLUGIN_ROOT}/skills/research/scripts/validate-citations.sh \
   --tmpdir "$RESEARCH_TMPDIR"
 ```
 
-The script writes the sidecar to the path passed via `--output` and exits 0 on every path (fail-soft contract). On any internal error (curl missing, git rev-parse failure, etc.), the script writes a minimally-formed sidecar that explains the degraded path and still exits 0 — Step 3's splice consumer must always have a sidecar to read.
+The script writes the sidecar to the path passed via `--output` and exits 0 on validation paths (exit 2 only for argument/flag errors — operator or harness bug; fail-soft contract). On any internal error (curl missing, git rev-parse failure, etc.), the script writes a minimally-formed sidecar that explains the degraded path and still exits 0 — Step 3's splice consumer must always have a sidecar to read.
 
 See `${CLAUDE_PLUGIN_ROOT}/skills/research/scripts/validate-citations.md` for the full contract (argv, exit codes, sidecar schema, SSRF defenses, regex tiers, idempotency rerun semantics, budget-exhaustion process-group kill — Linux `setsid` + single `kill -- -$$`, macOS `set -m` + per-background `kill -- -<pid>` with no `kill -- -$$` fallback because that would self-signal the validator).
 
@@ -124,7 +124,7 @@ The validator does not consume measurable Claude subagent tokens (it is a shell 
 
 ### Failure modes and fail-soft posture
 
-The validator script always exits 0. Failure modes that would otherwise abort a strict validator are reclassified into `UNKNOWN` reasons in the per-claim ledger:
+The validator script always exits 0 on validation paths; exit 2 only for argument/flag errors. Failure modes that would otherwise abort a strict validator are reclassified into `UNKNOWN` reasons in the per-claim ledger:
 
 | Failure mode | Sidecar reason |
 |---|---|
@@ -166,7 +166,7 @@ A small allow-list of widely-recognized reputable hosts (e.g., `*.wikipedia.org`
   → § 2.7.1 input gates (evaluated in order):
       1. budget-abort gate → skip 2.7 → Step 4 (Step 3 was already skipped)
       2. empty-synthesis gate → skip 2.7 → Step 3
-    → § 2.7.2 validator invocation (always exits 0)
+    → § 2.7.2 validator invocation (exits 0 on validation paths; exit 2 only on argument errors)
     → § 2.7.5 completion line + conditional advisory warnings
   → Step 3 splice (§ 2.7.6) appends sidecar to research-report-final.md
   → Step 3 cat displays the spliced report to stdout

--- a/skills/research/scripts/validate-citations.md
+++ b/skills/research/scripts/validate-citations.md
@@ -24,9 +24,9 @@ validate-citations.sh --report <path> --output <path> --tmpdir <path>
 
 ## Exit code
 
-**Always 0** (fail-soft contract). Per-claim failures land in the sidecar
-Status column. The ONLY non-zero exit is exit 2 on argument-parser errors,
-which are programmer bugs (missing required flag, unknown flag).
+Exit 0 for all fail-soft validation runs; exit 2 only for argument/flag
+errors — operator or harness bug. Per-claim failures land in the sidecar
+Status column.
 
 ## Stdout machine surface
 

--- a/skills/research/scripts/validate-citations.sh
+++ b/skills/research/scripts/validate-citations.sh
@@ -8,7 +8,8 @@
 # writes a 3-state ledger (PASS / FAIL / UNKNOWN) sidecar markdown file.
 # Domain credibility is advisory only — never flips PASS to FAIL.
 #
-# **Fail-soft contract**: this script always exits 0. Per-claim failures are
+# **Fail-soft contract**: this script exits 0 on validation paths; exit 2 only
+# for argument/flag errors (operator or harness bug). Per-claim failures are
 # recorded in the sidecar's Status column. The Step 2.7 orchestrator parses
 # the script's last stdout line `SUMMARY=PASS=<n> FAIL=<n> UNKNOWN=<n>
 # TOTAL=<n>` to drive the completion breadcrumb and conditional advisory
@@ -32,8 +33,9 @@
 #   --max-claims N            cap on extracted claims (default 200, soft DoS guard)
 #
 # Exit code:
-#   Always 0 (fail-soft). Non-zero exits ONLY on argument-parser bugs (programmer
-#   error) — operators MUST treat any non-zero exit as a bug report.
+#   Exit 0 on validation paths (fail-soft). Exit 2 only for argument/flag
+#   errors (operator or harness bug) — operators MUST treat any non-zero exit
+#   as a bug report.
 #
 # SSRF defenses (every curl invocation):
 #   - HTTPS-only: URLs not starting with https:// are pre-rejected.
@@ -75,8 +77,8 @@
 # (preferred) or nslookup for DNS resolution.
 
 # Intentionally NOT setting -e: this validator is fail-soft. Per-claim failures
-# are recorded in the sidecar; the script always exits 0 (except on
-# argument-parser bugs, which are programmer error). Per-statement non-zero
+# are recorded in the sidecar; the script exits 0 on validation paths and exit
+# 2 only for argument/flag errors (operator or harness bug). Per-statement non-zero
 # exits are expected (grep returning 1 on no-match, kill -0 on dead PIDs, etc.)
 # and MUST NOT abort the script. A defense-in-depth EXIT trap writes a degraded
 # sidecar if the script is about to exit non-zero AND no sidecar was produced


### PR DESCRIPTION
## Summary

- Replaced contradictory "always exits 0 on every path"-style claims in `validate-citations.md` and `citation-validation-phase.md` with the carve-out wording "exits 0 on validation paths; exit 2 only for argument/flag errors — operator or harness bug" so the docs match the shipped `validate-citations.sh:124,128,147,153` exit-2 paths (closes #668).
- Aligned three in-script doc surfaces in `validate-citations.sh` (the header banner, the `# Exit code:` block, and the `set -uo pipefail` introduction comment) to the same canonical phrasing for consistency. Comment-only edits — no behavior change.

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] `grep -n "always exits 0" skills/research/references/citation-validation-phase.md` — every remaining match carries the carve-out clause.
- [x] `/relevant-checks` passed (pre-commit + agent-lint, both phases) on each round.
- [x] No script behavior change — all edits are prose (`.md` body) or in-comment (`.sh` header).

</details>

Closes #668

Generated with [Claude Code](https://claude.com/claude-code)
