### PR TITLE
Fix #690: skill-evolver --debug placement bug

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.16.21",
+  "version": "7.16.22",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.16.22] - 2026-04-27
+
+### Fixed
+
+- `skills/skill-evolver/SKILL.md` — fix `--debug` placement on the `/research` (line 86) and `/umbrella` (line 108) invocation lines. The skill previously documented "append `--debug` only if `DEBUG=true`", but both downstream skills parse flags from the start of `$ARGUMENTS` and stop at the first non-flag token (`skills/research/SKILL.md:21`, `.claude/skills/umbrella/SKILL.md:24`), so an appended `--debug` would be swallowed into the research question / umbrella task description instead of enabling debug mode. Move `[--debug]` to the front of each documented args spec and rewrite the trailing prose ("prepend" instead of "append") with an inline rationale citing the downstream parsers. Closes #690.
+
 ## [7.16.21] - 2026-04-26
 
 ### Fixed

--- a/skills/skill-evolver/SKILL.md
+++ b/skills/skill-evolver/SKILL.md
@@ -83,7 +83,7 @@ Output: a structured `## Research Report` with one numbered finding per improvem
 
 Invoke the Skill tool:
 - Try skill `"research"` first (bare name). If no skill matches, try `"larch:research"` (fully-qualified plugin name).
-- args: `--scale=deep <substituted-prompt>`. Append `--debug` only if `DEBUG=true`.
+- args: `[--debug] --scale=deep <substituted-prompt>`. Prepend `--debug` only if `DEBUG=true` — placement before the positional argument is required because `/research` stops flag parsing at the first non-flag token (see `skills/research/SKILL.md:21`).
 
 After `/research` returns, read its `## Research Report` from conversation context. The report is followed by an optional `## Citation Validation` block when `/research`'s sidecar exists (Step 3 splice in `skills/research/SKILL.md`), so the literal last line of the combined output is NOT necessarily the count. Parse the **last line of the file matching `^ACTIONABLE_IMPROVEMENTS_COUNT=`**, ignoring any trailing `## Citation Validation` content. The integer on that line drives Step 3.
 
@@ -105,7 +105,7 @@ If no such line is present (the `/research` lane synthesis dropped the requested
 
   Then invoke the Skill tool:
   - Try skill `"umbrella"` first (bare name). If no skill matches, try `"larch:umbrella"`.
-  - args: `--label evolved-by:skill-evolver --label skill:<SKILL_NAME> --title-prefix "[skill-evolver:<SKILL_NAME>] " <umbrella-task-description>`. Append `--debug` only if `DEBUG=true`.
+  - args: `[--debug] --label evolved-by:skill-evolver --label skill:<SKILL_NAME> --title-prefix "[skill-evolver:<SKILL_NAME>] " <umbrella-task-description>`. Prepend `--debug` only if `DEBUG=true` — placement before the positional argument is required because `/umbrella` stops flag parsing at the first non-flag token (see `.claude/skills/umbrella/SKILL.md:24`).
 
   After `/umbrella` returns, branch on its `UMBRELLA_VERDICT` line (per `.claude/skills/umbrella/SKILL.md` Step 4 stdout grammar — `UMBRELLA_NUMBER` and `UMBRELLA_URL` are emitted only on the multi-piece success path; one-shot success emits `CHILD_1_URL` instead; failure paths omit `UMBRELLA_NUMBER` and `UMBRELLA_URL` entirely; `CHILDREN_CREATED=<N>` is emitted on every multi-piece path):
   - `UMBRELLA_VERDICT=multi-piece` AND `UMBRELLA_URL` present: print `✅ /skill-evolver: filed umbrella #<UMBRELLA_NUMBER> at <UMBRELLA_URL> with <CHILDREN_CREATED> child issues.`


### PR DESCRIPTION
## Summary
- Fixed `--debug` placement on the `/research` (line 86) and `/umbrella` (line 108) invocation lines in `skills/skill-evolver/SKILL.md`. `[--debug]` now appears at the front of each documented args spec, with the trailing prose rewritten as "prepend ... only if `DEBUG=true`".
- Added an inline rationale on each line citing the downstream parsers' "stop at the first non-flag token" rule (`skills/research/SKILL.md:21`, `.claude/skills/umbrella/SKILL.md:24`), so future readers can see why leading placement is required.

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] `grep -n "Append \`--debug\`" skills/skill-evolver/SKILL.md` returns no matches.
- [x] `grep -n "Prepend \`--debug\`" skills/skill-evolver/SKILL.md` shows two matches (lines 86 and 108).
- [x] `[--debug]` appears at the front of both documented args specs.
- [x] `/relevant-checks` passes (pre-commit + agent-lint).

</details>

Closes #690

Generated with [Claude Code](https://claude.com/claude-code)
