### PR TITLE
Fix #695: check-review-changes.sh — feed CURRENT to comm via printf

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.16.23",
+  "version": "7.16.24",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.16.24] - 2026-04-26
+
+### Fixed
+
+- `skills/implement/scripts/check-review-changes.sh` (line 81) — replace `echo "$CURRENT"` with `printf '%s\n' "$CURRENT"` so untracked filenames matching bash `echo` flags (`-n` / `-e` / `-nn` / `-E`) are not silently swallowed when the sorted current-untracked stream is fed to `comm`. Pre-fix, a real `/implement` Step-5/6 run could miss review-created untracked files when the current set contained exactly such a name (reproduced with an external baseline + a repo whose only untracked file was named `-n` — the script returned `FILES_CHANGED=false`). The existing `sed '/^$/d'` empty-CURRENT safety net is preserved (`printf '%s\n' ""` still emits a single trailing newline). Add regression case (i) to `test-check-review-changes.sh` (untracked `-n` + external empty baseline) and update the script's docstring header, `check-review-changes.md` case-count prose, and `test-check-review-changes.md` table + harness summary in sync. Closes #695.
+
 ## [7.16.23] - 2026-04-26
 
 ### Fixed

--- a/skills/implement/scripts/check-review-changes.md
+++ b/skills/implement/scripts/check-review-changes.md
@@ -68,7 +68,7 @@ The snapshot path `$IMPLEMENT_TMPDIR/pre-review-untracked.txt` is stable across 
 
 ## Test harness
 
-`skills/implement/scripts/test-check-review-changes.sh` (offline harness, wired via `make lint`'s `test-harnesses` target). 7 cases pin both the regression behavior (issue #651) and the empty-vs-missing distinction. See `skills/implement/scripts/test-check-review-changes.md` for case-by-case detail and the deliberate-behavior-change callout for case (f).
+`skills/implement/scripts/test-check-review-changes.sh` (offline harness, wired via `make lint`'s `test-harnesses` target). 9 cases pin the regression behavior (issue #651), the empty-vs-missing distinction, the `printf '%s\n'` → `comm` → `sed` safety net, and the issue #695 dash-prefixed-filename fix. See `skills/implement/scripts/test-check-review-changes.md` for case-by-case detail and the deliberate-behavior-change callout for case (f).
 
 ## Edit-in-sync
 

--- a/skills/implement/scripts/check-review-changes.sh
+++ b/skills/implement/scripts/check-review-changes.sh
@@ -78,7 +78,7 @@ UNTRACKED_DELTA=""
 if [[ -n "$BASELINE" ]] && [[ -r "$BASELINE" ]]; then
     UNTRACKED_BASELINE="present"
     CURRENT=$(git ls-files --others --exclude-standard 2>/dev/null | LC_ALL=C sort || echo "")
-    UNTRACKED_DELTA=$(comm -23 <(echo "$CURRENT") <(LC_ALL=C sort "$BASELINE") | sed '/^$/d' || echo "")
+    UNTRACKED_DELTA=$(comm -23 <(printf '%s\n' "$CURRENT") <(LC_ALL=C sort "$BASELINE") | sed '/^$/d' || echo "")
 fi
 
 FILES_CHANGED="false"

--- a/skills/implement/scripts/test-check-review-changes.md
+++ b/skills/implement/scripts/test-check-review-changes.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Offline regression harness for `skills/implement/scripts/check-review-changes.sh`. Pins the post-fix behavior for issue #651 (the false-positive scenario where ANY pre-existing untracked file flipped `FILES_CHANGED=true`), the empty-vs-missing baseline-state distinction introduced by the fix, and the `echo ""` → `comm` → `sed` safety-net path for the empty-`CURRENT` case.
+Offline regression harness for `skills/implement/scripts/check-review-changes.sh`. Pins the post-fix behavior for issue #651 (the false-positive scenario where ANY pre-existing untracked file flipped `FILES_CHANGED=true`), the empty-vs-missing baseline-state distinction introduced by the fix, the `printf '%s\n' ""` → `comm` → `sed` safety-net path for the empty-`CURRENT` case, and the issue #695 fix (untracked filenames matching `echo` flags such as `-n` / `-e` / `-nn` / `-E` must not be silently swallowed when CURRENT is fed to `comm`).
 
 ## Test cases
 
@@ -17,7 +17,8 @@ Each case sets up an isolated `git init` sandbox via `mktemp -d`, optionally wri
 | (e) | unstaged modification (with empty baseline) | `FILES_CHANGED=true UNTRACKED_BASELINE=present` | unstaged-only path is unchanged |
 | (f) | pre-existing untracked, NO `--baseline` flag | `FILES_CHANGED=false UNTRACKED_BASELINE=missing` | **deliberate behavior change** — see callout below |
 | (g) | zero-byte readable baseline + new untracked file | `FILES_CHANGED=true UNTRACKED_BASELINE=present` | empty-vs-missing distinction (readable zero-byte = present, delta = current) |
-| (h) | non-empty baseline + empty current untracked (file removed after snapshot) | `FILES_CHANGED=false UNTRACKED_BASELINE=present` | exercises the `echo ""` → `comm` → `sed '/^$/d'` safety net inside the SUT — pins the empty-`CURRENT` path that would otherwise yield a phantom delta entry if the trailing `sed` filter were removed |
+| (h) | non-empty baseline + empty current untracked (file removed after snapshot) | `FILES_CHANGED=false UNTRACKED_BASELINE=present` | exercises the `printf '%s\n' ""` → `comm` → `sed '/^$/d'` safety net inside the SUT — pins the empty-`CURRENT` path that would otherwise yield a phantom delta entry if the trailing `sed` filter were removed |
+| (i) | untracked file named `-n` + empty external (outside-repo) baseline | `FILES_CHANGED=true UNTRACKED_BASELINE=present` | **issue #695 regression case** — feeding CURRENT to `comm` via `printf '%s\n'` instead of `echo` so filenames matching `echo` flags (`-n` / `-e` / `-nn` / `-E`) are detected; pre-fix the SUT reported `FILES_CHANGED=false` |
 
 ## Case (f) is a deliberate behavior change — do NOT "fix" it
 

--- a/skills/implement/scripts/test-check-review-changes.sh
+++ b/skills/implement/scripts/test-check-review-changes.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 # test-check-review-changes.sh — Offline regression harness for check-review-changes.sh.
 #
-# Pins eight cases that together cover the issue #651 regression
+# Pins nine cases that together cover the issue #651 regression
 # (pre-existing untracked → false positive), the empty-vs-missing
-# baseline-state distinction, and the echo "" -> comm -> sed safety net
-# inside the SUT:
+# baseline-state distinction, the printf '%s\n' -> comm -> sed safety net
+# inside the SUT, and the issue #695 dash-prefixed-filename regression:
 #   (a) clean tree, no baseline → FILES_CHANGED=false UNTRACKED_BASELINE=missing
 #   (b) pre-existing untracked + matching baseline →
 #       FILES_CHANGED=false UNTRACKED_BASELINE=present (THE regression case)
@@ -20,7 +20,12 @@
 #       distinction — readable empty file is present, not missing)
 #   (h) non-empty baseline + empty current untracked →
 #       FILES_CHANGED=false UNTRACKED_BASELINE=present (pins the
-#       echo "" -> comm -> sed '/^$/d' safety net for empty CURRENT)
+#       printf '%s\n' -> comm -> sed '/^$/d' safety net for empty CURRENT)
+#   (i) untracked file named "-n" + empty external baseline →
+#       FILES_CHANGED=true UNTRACKED_BASELINE=present (issue #695:
+#       feeding CURRENT to comm via printf '%s\n' instead of echo, so
+#       filenames matching echo flags like -n / -e / -nn / -E are not
+#       silently swallowed)
 #
 # Usage:
 #   bash skills/implement/scripts/test-check-review-changes.sh
@@ -146,10 +151,11 @@ run_case "(g) zero-byte readable baseline + non-empty current untracked" \
     "true" "present" "$SBX_G" "$BL_G"
 
 # Case (h): non-empty baseline + empty current untracked. Exercises the
-# echo "" -> comm -> sed '/^$/d' safety net path inside the SUT (when
-# CURRENT is empty, echo "" emits one blank line that sed must strip).
-# A regression that removes the trailing sed filter would yield a phantom
-# delta entry and flip FILES_CHANGED to true incorrectly.
+# printf '%s\n' -> comm -> sed '/^$/d' safety net path inside the SUT
+# (when CURRENT is empty, printf '%s\n' "" emits one blank line that
+# sed must strip). A regression that removes the trailing sed filter
+# would yield a phantom delta entry and flip FILES_CHANGED to true
+# incorrectly.
 SBX_H=$(mkrepo)
 ( cd "$SBX_H" && touch ephemeral.txt )
 BL_H="$SBX_H/baseline.txt"
@@ -158,8 +164,24 @@ BL_H="$SBX_H/baseline.txt"
 run_case "(h) non-empty baseline + empty current untracked (sed safety net)" \
     "false" "present" "$SBX_H" "$BL_H"
 
+# Case (i): untracked file named "-n" with an EXTERNAL (outside-repo)
+# empty baseline file. Issue #695: bash builtin echo treats values like
+# "-n" / "-e" / "-nn" / "-E" as flags, so feeding CURRENT through
+# `echo "$CURRENT"` would emit nothing on these names and comm would
+# report an empty delta — silently masking review-created untracked
+# files matching such names. The fix replaces echo with printf '%s\n'
+# inside check-review-changes.sh; this case fails pre-fix and passes
+# post-fix. The baseline lives outside the repo so `git ls-files
+# --others` doesn't pick it up as part of CURRENT.
+SBX_I=$(mkrepo)
+BL_I=$(mktemp)  # external (outside the repo), empty baseline
+( cd "$SBX_I" && touch -- -n )
+run_case '(i) untracked filename "-n" + external empty baseline (#695)' \
+    "true" "present" "$SBX_I" "$BL_I"
+rm -f "$BL_I"
+
 # Cleanup sandboxes.
-rm -rf "$SBX_A" "$SBX_B" "$SBX_C" "$SBX_D" "$SBX_E" "$SBX_F" "$SBX_G" "$SBX_H"
+rm -rf "$SBX_A" "$SBX_B" "$SBX_C" "$SBX_D" "$SBX_E" "$SBX_F" "$SBX_G" "$SBX_H" "$SBX_I"
 
 echo ""
 echo "RESULTS: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## Summary
- Replaced `echo "$CURRENT"` with `printf '%s\n' "$CURRENT"` on `skills/implement/scripts/check-review-changes.sh:81` so untracked filenames matching bash `echo` flags (`-n` / `-e` / `-nn` / `-E`) are not silently swallowed when the sorted current-untracked stream is fed to `comm`. Pre-fix, `/implement` Step-5/6 could miss review-created untracked files when the current set contained exactly such a name.
- Added regression case (i) to `test-check-review-changes.sh` (untracked `-n` + empty external baseline asserts `FILES_CHANGED=true UNTRACKED_BASELINE=present`) and updated sibling docs (`check-review-changes.md`, `test-check-review-changes.md`, harness header) in sync. The existing `sed '/^$/d'` empty-CURRENT safety net is preserved (case (h) re-passes; `printf '%s\n' ""` still emits a single trailing newline).

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] `bash skills/implement/scripts/test-check-review-changes.sh` — all 9 cases pass (a-h regressions preserved, new case (i) green).
- [x] Pre-fix simulation — running the original `echo "$CURRENT"` form in a sandbox repo whose only untracked file is `-n` produces empty `comm` output (confirmed bug); post-fix `printf '%s\n'` correctly emits `-n`.
- [x] `/relevant-checks` — pre-commit (shellcheck, markdownlint, agnix, gitleaks) + agent-lint clean.
- [x] CI — pre-commit, agent-lint, test harnesses, and link-checker workflows green.

</details>

Closes #695

Generated with [Claude Code](https://claude.com/claude-code)
