### PR TITLE
Fix #739: replace stale /issue wording with /umbrella in skills/review/SKILL.md slice-mode descriptions

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.17.0",
+  "version": "7.17.1",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.17.1] - 2026-04-27
+
+### Changed
+
+- `skills/review/SKILL.md` — replaced four stale `/issue` references with `/umbrella` in slice-mode descriptions (frontmatter `description:`, Slice Mode bullet, voting.md slice-mode-bypass note, and Step 4 heading) so the documentation matches the actual Step 4b runtime, which has invoked `/umbrella` (wrapping `/issue` for batch creation) since the umbrella was introduced. Documentation-only — runtime behavior unchanged. Surviving `/issue` mentions intentionally remain to describe `/umbrella`'s wrapping of `/issue` and the underlying OOS-format parser. Closes #739.
+
 ## [7.17.0] - 2026-04-27
 
 ### Changed

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review
-description: "Use when reviewing code changes (current branch diff, or a verbal slice of the repo) with a 3-reviewer panel (1 Claude Code Reviewer subagent + 1 Codex + 1 Cursor). Slice mode supports file-batch review and inline /issue filing for /loop-review."
+description: "Use when reviewing code changes (current branch diff, or a verbal slice of the repo) with a 3-reviewer panel (1 Claude Code Reviewer subagent + 1 Codex + 1 Cursor). Slice mode supports file-batch review and inline /umbrella filing for /loop-review."
 argument-hint: "[--debug] [--session-env <path>] [--slice <text> | --slice-file <path>] [--create-issues [<slice-text>]] [--label <label>] [--security-output <path>]"
 allowed-tools: Bash, Read, Edit, Write, Grep, Glob, Agent, Task, WebFetch, Skill
 ---
@@ -79,7 +79,7 @@ When `--slice <text>` is set, `--slice-file <path>` is set, or trailing position
 
 - Step 1 (Gather Context): replaced by a **slice-resolve** step that maps the verbal description to a canonical file list at `$REVIEW_TMPDIR/slice-files.txt` via Glob/Grep/Read. The canonical list anchors OOS classification.
 - Step 2 (Launch Reviewers): reviewer prompts instruct the panel to review the canonical file list (existing code, not a diff). Reviewers may explore further via Glob/Grep/Read for context but OOS classification is anchored to the canonical list.
-- Step 3 (Review Cycle): runs ONE round only (no recursive re-review loop). After voting, either compose a findings batch and invoke `/issue` via the Skill tool (if `--create-issues`) or just print the findings.
+- Step 3 (Review Cycle): runs ONE round only (no recursive re-review loop). After voting, either compose a findings batch and invoke `/umbrella` via the Skill tool (if `--create-issues`) or just print the findings.
 - Step 3e (Implement Fixes): SKIPPED in slice mode — slice mode is read-only review for issue filing, not implement-fixes.
 - Step 4 (Final Summary): writes accepted security findings to `--security-output` path; emits a `### slice-result` KV footer for driver consumption.
 
@@ -250,7 +250,7 @@ Merge findings from all reviewers into a single deduplicated list, grouped by fi
 
 ### 3c.1 — Voting Panel (round 1 only)
 
-**In round 1**: **MANDATORY — READ ENTIRE FILE** `${CLAUDE_PLUGIN_ROOT}/skills/review/references/voting.md` and execute its body — three-voter setup with proportionality guidance, ballot file handling rule (Write tool, not `cat`-heredoc), parallel launch order (Cursor → Codex → Claude subagent), threshold rules + competition scoring per `${CLAUDE_PLUGIN_ROOT}/skills/shared/voting-protocol.md`, the zero-accepted-findings short-circuit to **Step 4**, the OOS-accepted-by-vote artifact write to `$(dirname "$SESSION_ENV_PATH")/oos-accepted-review.md` (only when `SESSION_ENV_PATH` is non-empty AND slice mode is OFF — slice mode bypasses this artifact and files directly via /issue at Step 4), and the save-not-accepted-IDs rule used to suppress re-raised findings in rounds 2+ (diff mode only).
+**In round 1**: **MANDATORY — READ ENTIRE FILE** `${CLAUDE_PLUGIN_ROOT}/skills/review/references/voting.md` and execute its body — three-voter setup with proportionality guidance, ballot file handling rule (Write tool, not `cat`-heredoc), parallel launch order (Cursor → Codex → Claude subagent), threshold rules + competition scoring per `${CLAUDE_PLUGIN_ROOT}/skills/shared/voting-protocol.md`, the zero-accepted-findings short-circuit to **Step 4**, the OOS-accepted-by-vote artifact write to `$(dirname "$SESSION_ENV_PATH")/oos-accepted-review.md` (only when `SESSION_ENV_PATH` is non-empty AND slice mode is OFF — slice mode bypasses this artifact and files directly via /umbrella at Step 4), and the save-not-accepted-IDs rule used to suppress re-raised findings in rounds 2+ (diff mode only).
 
 **In rounds 2+ (diff mode only)**: Skip voting — accept all Claude-only findings directly, **except** findings that match round-1 rejected findings. **Do NOT load** `${CLAUDE_PLUGIN_ROOT}/skills/review/references/voting.md` in rounds 2+ — the body is round-1-only and would waste tokens. Same `Do NOT load` guidance applies on the Step 3b zero-findings short-circuit.
 
@@ -288,7 +288,7 @@ After all fixes are applied, invoke `/relevant-checks` via the Skill tool to run
 
 **Diff mode only.** If the loop has run **5 rounds** without converging, stop and print a warning, then proceed to Step 4.
 
-## Step 4 — Final Summary (and slice-mode /issue filing)
+## Step 4 — Final Summary (and slice-mode /umbrella filing)
 
 ### 4a — Print summary (both modes)
 


### PR DESCRIPTION
## Summary
- Replaced four stale `/issue` references with `/umbrella` in `skills/review/SKILL.md` slice-mode descriptions (frontmatter `description:`, Slice Mode bullet, voting.md slice-mode-bypass note, Step 4 heading) so the documentation matches the actual Step 4b runtime behavior, which has invoked `/umbrella` (wrapping `/issue` for batch creation) since the umbrella was introduced.
- Documentation-only — runtime behavior unchanged. Surviving `/issue` mentions intentionally remain to describe `/umbrella`'s wrapping of `/issue` and the underlying OOS-format parser.

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- `grep -n '/issue\|/umbrella' skills/review/SKILL.md` — confirmed the four target lines (3, 82, 253, 291) now reference `/umbrella` and surviving `/issue` mentions are legitimate (describing `/umbrella` wrapping `/issue` for batch creation).
- `/relevant-checks` — both phases passed (changed-file pre-commit + full-repo agent-lint).

</details>

Closes #739

Generated with [Claude Code](https://claude.com/claude-code)
