### PR TITLE
Fix #752: document --subordinate flag in iteration.md synopsis

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.17.1",
+  "version": "7.17.2",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.17.2] - 2026-04-27
+
+### Changed
+
+- `skills/improve-skill/scripts/iteration.md` — added `[--subordinate]` to the documented invocation synopsis (line 12) and a brief description of its purpose. The flag was already parsed by `iteration.sh` (line 230) and always passed by `driver.sh` (line 470); the contract sibling `.md` is now in sync with the kernel's actual argv. Closes #752.
+
 ## [7.17.1] - 2026-04-27
 
 ### Changed

--- a/skills/improve-skill/scripts/iteration.md
+++ b/skills/improve-skill/scripts/iteration.md
@@ -9,8 +9,10 @@
 ## Invocation
 
 ```
-iteration.sh [--no-slack] [--issue <N>] [--breadcrumb-prefix <P>] [--work-dir <path>] [--iter-num <N>] <skill-name>
+iteration.sh [--no-slack] [--subordinate] [--issue <N>] [--breadcrumb-prefix <P>] [--work-dir <path>] [--iter-num <N>] <skill-name>
 ```
+
+`--subordinate` suppresses the standalone tracking-issue lifecycle management (EXIT-trap title rename + `on_success()` rename) when a loop driver owns the lifecycle. `driver.sh` passes it on every iteration so the driver alone holds the title-prefix transitions; standalone `/improve-skill` invocations omit it and let the kernel manage the lifecycle itself.
 
 ## Modes
 


### PR DESCRIPTION
## Summary

- Documents the `--subordinate` flag in `skills/improve-skill/scripts/iteration.md`'s synopsis (line 12) so the contract sibling `.md` matches the kernel's actual argv. Adds a one-sentence description of the flag's purpose: it suppresses standalone tracking-issue lifecycle management (EXIT-trap stall rename + `on_success()` done rename) when the loop driver owns the lifecycle.
- The flag was already parsed by `iteration.sh` (line 230 — `--subordinate) SUBORDINATE="true"; shift ;;`) and always passed by `driver.sh` (line 470 — `ITER_ARGV+=(--subordinate)`); only the documented synopsis was missing it.

## Test plan

- [x] `/relevant-checks` — pre-commit hooks and full-repo `agent-lint` pass.

Closes #752.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
