### PR TITLE
Fix #783: dedent flush-left heredoc example in validation-phase.md

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.17.2",
+  "version": "7.17.3",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.17.3] - 2026-04-27
+
+### Fixed
+
+- `skills/research/references/validation-phase.md` — dedented the third `<<'EOF'` heredoc example (lines 240-252) from 3-space indentation to flush-left at column 0, matching the convention of the two prior working examples in the same file. Previously the block was nested under numbered list item 4, so an LLM agent (or human) copying the source literally would produce a non-terminating heredoc (`<<'EOF'` requires `EOF` flush-left) and indented `VALIDATION_*` body lines that fail the downstream `grep '^VALIDATION_'` filter. Closes #783.
+
 ## [7.17.2] - 2026-04-27
 
 ### Changed

--- a/skills/research/references/validation-phase.md
+++ b/skills/research/references/validation-phase.md
@@ -237,19 +237,19 @@ Use `timeout: 1860000` on the Bash tool call. **Do NOT** set `run_in_background:
 
    The append uses a **quoted heredoc** (`<<'EOF'`) so residual shell metacharacters in a substituted reason value are preserved literally rather than expanded — same shell-injection defense as Step 0b.
 
-   ```bash
-   LANE_STATUS_FILE="$RESEARCH_TMPDIR/lane-status.txt"
-   LANE_STATUS_TMP="$(mktemp "${LANE_STATUS_FILE}.XXXXXX")"
-   # Preserve RESEARCH_* keys verbatim; emit fresh VALIDATION_* keys.
-   grep -v '^VALIDATION_' "$LANE_STATUS_FILE" > "$LANE_STATUS_TMP"
-   cat >> "$LANE_STATUS_TMP" <<'EOF'
-   VALIDATION_CURSOR_STATUS=<cursor token>
-   VALIDATION_CURSOR_REASON=<cursor sanitized reason or empty>
-   VALIDATION_CODEX_STATUS=<codex token>
-   VALIDATION_CODEX_REASON=<codex sanitized reason or empty>
-   EOF
-   mv "$LANE_STATUS_TMP" "$LANE_STATUS_FILE"
-   ```
+```bash
+LANE_STATUS_FILE="$RESEARCH_TMPDIR/lane-status.txt"
+LANE_STATUS_TMP="$(mktemp "${LANE_STATUS_FILE}.XXXXXX")"
+# Preserve RESEARCH_* keys verbatim; emit fresh VALIDATION_* keys.
+grep -v '^VALIDATION_' "$LANE_STATUS_FILE" > "$LANE_STATUS_TMP"
+cat >> "$LANE_STATUS_TMP" <<'EOF'
+VALIDATION_CURSOR_STATUS=<cursor token>
+VALIDATION_CURSOR_REASON=<cursor sanitized reason or empty>
+VALIDATION_CODEX_STATUS=<codex token>
+VALIDATION_CODEX_REASON=<codex sanitized reason or empty>
+EOF
+mv "$LANE_STATUS_TMP" "$LANE_STATUS_FILE"
+```
 
    Token vocabulary is documented in `${CLAUDE_PLUGIN_ROOT}/scripts/render-lane-status.md`.
 


### PR DESCRIPTION
## Summary

- Dedent the fenced bash heredoc example at `skills/research/references/validation-phase.md:240-252` from 3-space indentation to flush-left at column 0
- Matches the convention of the two prior working `<<'EOF'` examples in the same file (lines 27-42 and 81-94)
- Prevents the non-terminating-heredoc / indented-VALIDATION_* failure mode an LLM agent would hit when copying the example literally

## Architecture Diagram

_Architecture diagram not generated for this single-file documentation edit (quick mode)._

## Code Flow Diagram

_Code Flow Diagram skipped (quick mode)._

## Test plan

- [x] Read the file post-edit and confirm lines 240-252 start at column 0
- [x] Confirm line 254 ("Token vocabulary...") and the two earlier flush-left examples (lines 27-42, 81-94) are unchanged
- [x] `/relevant-checks` passes (pre-commit + agent-lint)

Closes #783

🤖 Generated with [Claude Code](https://claude.com/claude-code)
