### PR TITLE
Fix #742: replace stale `j < i` justification with topological-schedule wording

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.17.3",
+  "version": "7.17.4",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.17.4] - 2026-04-27
+
+### Changed
+
+- `skills/issue/SKILL.md` — replaced the stale `since j < i` justification in Step 6's `DUPLICATE_OF_ITEM=<j>` paragraph with topological-schedule wording. After issue #546 the batch create order is topological, not input-index order, so `j` may exceed `i` in input order yet still be processed first via the synthetic `j → i` prerequisite edge. The new phrasing matches the language already used at line 312 for `BLOCKED_BY=ITEM_<j>` edges. Documentation-only. Closes #742.
+
 ## [7.17.3] - 2026-04-27
 
 ### Fixed

--- a/skills/issue/SKILL.md
+++ b/skills/issue/SKILL.md
@@ -260,7 +260,7 @@ Iterate over `order[0..ITEMS_TOTAL-1]` (each iteration's value is one original i
   - `ISSUE_<i>_TITLE=<title>`
   - Increment `ISSUES_DEDUPLICATED`. Do NOT call create-one.sh.
 
-- If `ITEM_<i>_VERDICT=DUPLICATE` with `DUPLICATE_OF_ITEM=<j>`: resolve `j`'s eventual `ISSUE_<j>_NUMBER` / `ISSUE_<j>_URL` (these will have been emitted already since `j < i`). Emit:
+- If `ITEM_<i>_VERDICT=DUPLICATE` with `DUPLICATE_OF_ITEM=<j>`: resolve `j`'s eventual `ISSUE_<j>_NUMBER` / `ISSUE_<j>_URL` (these will have been emitted already since item `j` is ordered before item `i` in the topological schedule due to the DUPLICATE_OF_ITEM synthetic prerequisite edge `j → i`). Emit:
   - `ISSUE_<i>_DUPLICATE=true`
   - `ISSUE_<i>_DUPLICATE_OF_NUMBER=<j's number>`
   - `ISSUE_<i>_DUPLICATE_OF_URL=<j's url>`


### PR DESCRIPTION
## Summary
- Replaced the stale `since j < i` justification at `skills/issue/SKILL.md:263` with topological-schedule wording that matches Step 6's own DUPLICATE_OF_ITEM synthetic-edge rule (line 246) and the language already used at line 312 for BLOCKED_BY edges.
- Added a `[7.17.3]` CHANGELOG entry; `/bump-version` classified PATCH (no MAJOR/MINOR evidence in the public plugin surface).

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] Read `skills/issue/SKILL.md` lines 244–270 after the edit; confirm internal consistency with the topological-order paragraph (line 244) and the DUPLICATE_OF_ITEM synthetic-edge definition (line 246).
- [x] `/relevant-checks` (pre-commit + agent-lint) passed on the changed file.
- [x] Quick-mode single-reviewer pass (Cursor) flagged no findings against this PR's one-line diff.

</details>

Closes #742

Generated with [Claude Code](https://claude.com/claude-code)
