### PR TITLE
Fix #780: reject flag-name as value in eval-research.sh require_value

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.17.4",
+  "version": "7.17.5",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.17.5] - 2026-04-27
+
+### Fixed
+
+- `scripts/eval-research.sh` — `require_value` now rejects a candidate value that starts with `--`, so a trailing flag followed by another flag (e.g. `eval-research.sh --baseline --scale standard`) cleanly exits 2 with `eval-research: --baseline requires a value` instead of silently binding `BASELINE_REF=--scale` and producing a confusing downstream `git show --scale:...` error. The validity regex `^[0-9A-Za-z._/-]+$` allowed `--scale` because hyphens are valid; the third `next_val` argument plus a `[[ "$next_val" == --* ]]` guard mirrors `take_value` in `scripts/render-reviewer-prompt.sh`. All 7 call sites updated to pass `"${2:-}"`. New Sub-5 case in `scripts/test-eval-research-baseline-flag.sh` pins the behavior; sibling contracts `scripts/eval-research.md` and `scripts/test-eval-research-baseline-flag.md` updated. Closes #780.
+
 ## [7.17.4] - 2026-04-27
 
 ### Changed

--- a/scripts/eval-research.md
+++ b/scripts/eval-research.md
@@ -124,7 +124,7 @@ Authors editing `skills/research/references/eval-set.md` MUST follow:
 | `skills/research/references/eval-baseline.json` | Schema-only stub today (`entries: []`). Operator runs `bash scripts/eval-research.sh --write-baseline <file>` to populate. |
 | `scripts/test-eval-set-structure.sh` | Offline structural regression. Asserts entry count, category coverage, schema validity, and invokes `--smoke-test` for round-trip verification. |
 | `scripts/test-eval-set-structure.md` | Sibling contract for the test harness. |
-| `scripts/test-eval-research-baseline-flag.sh` | Standalone offline regression harness for the `--baseline` flag handling (closes #441; extended for #477). PATH-stubs `claude` and `jq` so it runs without the real binaries. Exercises the flag-state paths: no-flag, valid-ref, bad-ref, and trailing-flag-with-no-value. |
+| `scripts/test-eval-research-baseline-flag.sh` | Standalone offline regression harness for the `--baseline` flag handling (closes #441; extended for #477 and #780). PATH-stubs `claude` and `jq` so it runs without the real binaries. Exercises the flag-state paths: no-flag, valid-ref, bad-ref, trailing-flag-with-no-value, and value-taking-flag-followed-by-another-flag. |
 | `scripts/test-eval-research-baseline-flag.md` | Sibling contract for the `--baseline` flag test harness. |
 | `Makefile` | Adds `eval-research`, `test-eval-set-structure`, and `test-eval-research-baseline-flag` standalone targets. NONE is a `test-harnesses` prerequisite. |
 | `agent-lint.toml` | Excludes `scripts/eval-research.sh`, `scripts/test-eval-set-structure.sh`, and `scripts/test-eval-research-baseline-flag.sh` from dead-script checks (all are Makefile-only references). |
@@ -137,7 +137,7 @@ Authors editing `skills/research/references/eval-set.md` MUST follow:
 
 - `0` — harness ran. Per-entry timeouts and parse failures are reported in the `status` column / `research_status` JSON field, not the exit code.
 - `1` — schema validation of `eval-set.md` or `eval-baseline.json` failed.
-- `2` — argument parse error or invalid argument value (bad timeout integer, regex-invalid baseline ref, baseline ref that cannot be resolved via `git show`, or a value-taking flag with no following value — e.g. a trailing `--baseline` — which previously aborted with code 1 under `set -e` and collided with the schema-validation code; issue #477 separated the two).
+- `2` — argument parse error or invalid argument value (bad timeout integer, regex-invalid baseline ref, baseline ref that cannot be resolved via `git show`, a value-taking flag with no following value — e.g. a trailing `--baseline` — which previously aborted with code 1 under `set -e` and collided with the schema-validation code; issue #477 separated the two, or a value-taking flag followed by another long option — e.g. `--baseline --scale standard` — which would otherwise silently bind the next flag's name as the value because the validity regex permits hyphens; issue #780 extended `require_value` to reject `--*` candidate values).
 - `3` — required tooling missing. `jq` and `awk` are required in all modes (including `--smoke-test`); `claude` is required in non-smoke-test runs.
 
 ## Security

--- a/scripts/eval-research.sh
+++ b/scripts/eval-research.sh
@@ -55,8 +55,10 @@
 #   1 — schema validation of eval-set.md or eval-baseline.json failed.
 #   2 — argument parse error or invalid argument value (e.g., bad timeout
 #       integer, regex-invalid baseline ref, baseline ref that cannot be
-#       resolved via git show, or a value-taking flag with no following
-#       value such as a trailing `--baseline`).
+#       resolved via git show, a value-taking flag with no following
+#       value such as a trailing `--baseline`, or a value-taking flag
+#       whose next token is another long option such as `--baseline
+#       --scale standard` — issue #780).
 #   3 — required tooling missing. jq and awk are required in all modes
 #       (including --smoke-test); claude is required only when not using
 #       --smoke-test.

--- a/scripts/eval-research.sh
+++ b/scripts/eval-research.sh
@@ -101,23 +101,27 @@ print_usage() {
 # with code 1 — colliding with the documented schema-validation exit
 # code (issue #477). Routing missing values to exit 2 lines up with the
 # script's other argument-parse errors (unknown argument, regex-invalid
-# baseline ref).
+# baseline ref). The third arg also rejects a following flag name as the
+# value (issue #780): `--baseline --scale standard` would otherwise bind
+# `BASELINE_REF=--scale` because the validity regex permits hyphens —
+# parallels `take_value` in scripts/render-reviewer-prompt.sh.
 require_value() {
-  if (( $2 < 2 )); then
-    printf 'eval-research: %s requires a value\n' "$1" >&2
+  local flag="$1" argc="$2" next_val="${3:-}"
+  if (( argc < 2 )) || [[ "$next_val" == --* ]]; then
+    printf 'eval-research: %s requires a value\n' "$flag" >&2
     exit 2
   fi
 }
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --id) require_value "$1" "$#"; ID_FILTER="${2:-}"; shift 2 ;;
-    --scale) require_value "$1" "$#"; SCALE="${2:-standard}"; shift 2 ;;
-    --baseline) require_value "$1" "$#"; BASELINE_REF="${2:-}"; shift 2 ;;
-    --work-dir) require_value "$1" "$#"; WORK_DIR="${2:-}"; shift 2 ;;
-    --write-baseline) require_value "$1" "$#"; WRITE_BASELINE_FILE="${2:-}"; shift 2 ;;
-    --timeout) require_value "$1" "$#"; TIMEOUT_SECONDS="${2:-4200}"; shift 2 ;;
-    --judge-timeout) require_value "$1" "$#"; JUDGE_TIMEOUT_SECONDS="${2:-600}"; shift 2 ;;
+    --id) require_value "$1" "$#" "${2:-}"; ID_FILTER="${2:-}"; shift 2 ;;
+    --scale) require_value "$1" "$#" "${2:-}"; SCALE="${2:-standard}"; shift 2 ;;
+    --baseline) require_value "$1" "$#" "${2:-}"; BASELINE_REF="${2:-}"; shift 2 ;;
+    --work-dir) require_value "$1" "$#" "${2:-}"; WORK_DIR="${2:-}"; shift 2 ;;
+    --write-baseline) require_value "$1" "$#" "${2:-}"; WRITE_BASELINE_FILE="${2:-}"; shift 2 ;;
+    --timeout) require_value "$1" "$#" "${2:-}"; TIMEOUT_SECONDS="${2:-4200}"; shift 2 ;;
+    --judge-timeout) require_value "$1" "$#" "${2:-}"; JUDGE_TIMEOUT_SECONDS="${2:-600}"; shift 2 ;;
     --smoke-test) SMOKE_TEST="true"; shift ;;
     --help|-h) print_usage; exit 0 ;;
     *)

--- a/scripts/test-eval-research-baseline-flag.md
+++ b/scripts/test-eval-research-baseline-flag.md
@@ -2,12 +2,13 @@
 
 ## Purpose
 
-Regression harness for the `--baseline` flag handling in `scripts/eval-research.sh`. Pins the post-#441 and post-#477 behavior so these flag-state paths cannot silently regress:
+Regression harness for the `--baseline` flag handling in `scripts/eval-research.sh`. Pins the post-#441, post-#477, and post-#780 behavior so these flag-state paths cannot silently regress:
 
 1. **Sub-1** — `--baseline` not set: no `PREVIEW MODE` banner on stdout; exit 0; no cache file at `$WORK_DIR/baseline-rows.json`.
 2. **Sub-2** — `--baseline <valid-ref>` (using `HEAD` against the committed `skills/research/references/eval-baseline.json` schema-only stub): exit 0; `PREVIEW MODE` banner present on stdout (visible alongside the summary table); baseline cached to `$WORK_DIR/baseline-rows.json`.
 3. **Sub-3** — `--baseline <bogus-ref>`: exit 2; stderr error names the unresolvable ref AND surfaces a tail of `git show`'s captured stderr (so operators can distinguish ref-missing / file-missing-at-ref / non-git-checkout); no cache file left behind.
 4. **Sub-4** — trailing `--baseline` with no following value: exit 2; stderr names `--baseline` as the flag missing its value. Pins the issue #477 fix that separated this case from the schema-validation exit-1 path; pre-fix, `shift 2` aborted under `set -e` with exit 1, indistinguishable from a real schema failure.
+5. **Sub-5** — `--baseline` followed by another flag (e.g. `--baseline --scale standard`): exit 2; stderr names `--baseline` as the flag missing its value. Pins the issue #780 fix that extended `require_value` to take a third arg (the candidate value) and reject when it starts with `--`. Pre-fix, the validity regex `^[0-9A-Za-z._/-]+$` permitted `--scale` (hyphens are allowed), so `BASELINE_REF` was silently set to `--scale` and `git show --scale:...` produced a confusing downstream error. Mirrors `take_value` in `scripts/render-reviewer-prompt.sh`.
 
 ## Invocation
 

--- a/scripts/test-eval-research-baseline-flag.sh
+++ b/scripts/test-eval-research-baseline-flag.sh
@@ -1,13 +1,19 @@
 #!/usr/bin/env bash
 # test-eval-research-baseline-flag.sh — Regression harness for the
-# `--baseline` flag handling in scripts/eval-research.sh (issue #441).
+# `--baseline` flag handling in scripts/eval-research.sh (issues #441,
+# #477, #780).
 #
-# Pins the post-#441 behavior:
+# Pins behavior:
 #   1. `--baseline` not set → no PREVIEW MODE banner on stdout.
 #   2. `--baseline <valid-ref>` → exit 0; PREVIEW MODE banner on stdout;
 #      cached baseline JSON exists at $WORK_DIR/baseline-rows.json.
 #   3. `--baseline <bogus-ref>` → exit 2; ERROR with the ref + git stderr
 #      tail on stderr; no cache file left behind.
+#   4. trailing `--baseline` with no value → exit 2; --baseline named
+#      on stderr as missing its value (issue #477).
+#   5. `--baseline --<other-flag>` → exit 2; --baseline named on stderr
+#      as missing its value (issue #780; the validity regex would
+#      otherwise accept the next flag's name as the value).
 #
 # Runs offline by PATH-stubbing `claude` and `jq` so the harness exercises
 # the baseline block without needing either real binary on PATH (CI's
@@ -198,6 +204,37 @@ if grep -q -- '--baseline requires a value' "$sub4_stderr"; then
   pass "Sub-4: stderr names --baseline as the flag missing a value"
 else
   fail "Sub-4: stderr does not name --baseline (full stderr: $(cat "$sub4_stderr"))"
+fi
+
+# -----------------------------------------------------------------------
+# Sub-5: --baseline followed by another flag → exit 2 with clean error.
+# Pre-fix behavior (issue #780): `require_value` only checked `(( $# < 2 ))`,
+# so `eval-research.sh --baseline --scale standard` left $# = 3 at the
+# --baseline case, the check passed, and BASELINE_REF was silently set to
+# "--scale" (the regex `^[0-9A-Za-z._/-]+$` permits "--scale" because
+# hyphens are allowed). `git show --scale:skills/...` then produced a
+# confusing git error rather than a clean missing-value message. The fix
+# extends require_value to take a third arg (the candidate value) and
+# reject when it starts with `--`. Mirrors take_value in
+# scripts/render-reviewer-prompt.sh.
+# -----------------------------------------------------------------------
+
+echo "--- Sub-5: --baseline followed by another flag (--scale) ---"
+sub5_stdout="$fixture_tmp/sub5.stdout"
+sub5_stderr="$fixture_tmp/sub5.stderr"
+sub5_rc=0
+PATH="$stub_dir:$PATH" bash "$SCRIPT" --id nonexistent-id-zzz --baseline --scale standard \
+  >"$sub5_stdout" 2>"$sub5_stderr" || sub5_rc=$?
+
+if [[ "$sub5_rc" == "2" ]]; then
+  pass "Sub-5: exit 2 when --baseline is followed by another flag"
+else
+  fail "Sub-5: expected exit 2, got $sub5_rc (stderr: $(tail -n 5 "$sub5_stderr"))"
+fi
+if grep -q -- '--baseline requires a value' "$sub5_stderr"; then
+  pass "Sub-5: stderr names --baseline as the flag missing a value"
+else
+  fail "Sub-5: stderr does not name --baseline (full stderr: $(cat "$sub5_stderr"))"
 fi
 
 # -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Extended `require_value` in `scripts/eval-research.sh` to take a third candidate-value argument and reject any value starting with `--`, fixing the silent-bind bug where `eval-research.sh --baseline --scale standard` would set `BASELINE_REF=--scale` (the `^[0-9A-Za-z._/-]+$` regex permits hyphens) and produce a confusing `git show --scale:...` error rather than a clean missing-value message. Mirrors `take_value` in `scripts/render-reviewer-prompt.sh`.
- Updated all 7 value-taking flag call sites at lines 114-120 to pass `"${2:-}"` as the third argument to `require_value`.
- Added Sub-5 to `scripts/test-eval-research-baseline-flag.sh` pinning the new exit-2 path; updated sibling contract `.md` files (`scripts/eval-research.md`, `scripts/test-eval-research-baseline-flag.md`) and the script's own header docstring to mention #780 alongside #441 / #477.

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] Run `bash scripts/test-eval-research-baseline-flag.sh` — all 14 assertions pass (Sub-1 through Sub-5).
- [x] Confirm `--baseline --scale standard` exits 2 with `eval-research: --baseline requires a value` on stderr.
- [x] Confirm `--baseline` alone (trailing-no-value, #477) still exits 2 with the same message (Sub-4 unchanged).
- [x] Confirm `--baseline HEAD` (valid ref) still exits 0 (Sub-2 unchanged).
- [x] Run `/relevant-checks` — pre-commit + agent-lint pass.

</details>

Closes #780

Generated with [Claude Code](https://claude.com/claude-code)
