### PR TITLE
Fix #754: rewrite finalize-umbrella.sh idempotency-guard header to match implementation

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.17.10",
+  "version": "7.17.11",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.17.11] - 2026-04-27
+
+### Fixed
+
+- `skills/fix-issue/scripts/finalize-umbrella.sh` — rewrote the obsolete "Idempotency guard (FINDING_2)" header comment block to match the current contract documented in `finalize-umbrella.md` and the actual `cmd_finalize` implementation. The prior header described a single rule ("any of CLOSED / `[DONE]` title / closing-comment marker → `FINALIZED=false ALREADY_FINALIZED=true`") that did not reflect runtime behavior; only `state=CLOSED` is a strict short-circuit, while OPEN issues with `[DONE]` title or marker are partial-success signals that drive selective skips (title → skip rename only; marker → skip comment-post only; close-only is the intersection). Also added the missing `REASON=already CLOSED` line to the in-script Stdout contract so all stdout keys are documented. Comment-only; no executable code changed. Closes #754.
+
 ## [7.17.10] - 2026-04-27
 
 ### Fixed

--- a/skills/fix-issue/scripts/finalize-umbrella.sh
+++ b/skills/fix-issue/scripts/finalize-umbrella.sh
@@ -23,29 +23,36 @@
 #   Before posting any comment or running rename/close, probe the umbrella's
 #   current state and look for partial-success signals from a prior finalize
 #   attempt. The guard distinguishes a strict short-circuit from two
-#   close-only retry paths:
+#   independent partial-success skip-flags:
 #     1. State is CLOSED — strict short-circuit. Emit
 #        FINALIZED=false ALREADY_FINALIZED=true REASON=already CLOSED and
 #        exit 0 without further mutation.
 #     2. State is OPEN AND title starts with "[DONE] " (managed lifecycle
 #        prefix) — partial-success: a prior rename succeeded but
-#        `gh issue close` did not complete. Skip the rename API call and
-#        proceed to close-only retry; on success emit FINALIZED=true
-#        CLOSED=true.
+#        `gh issue close` did not complete. Skip ONLY the rename API call;
+#        the closing comment is still posted (unless signal #3 also fires)
+#        and `gh issue close` is still invoked. On success emit
+#        FINALIZED=true CLOSED=true (with RENAMED=false reflecting "no
+#        rename happened in this call").
 #     3. State is OPEN AND a comment body contains the literal marker
 #        "<!-- larch:fix-issue:umbrella-finalized -->" — partial-success:
 #        a prior comment-post succeeded but `gh issue close` did not
-#        complete. Skip the comment-post step (avoid double-comment under
-#        concurrency) and proceed to close-only retry; on success emit
-#        FINALIZED=true CLOSED=true.
+#        complete. Skip ONLY the comment-post step (avoid double-comment
+#        under concurrency); the rename is still attempted (unless signal
+#        #2 also fires) and `gh issue close` is still invoked. On success
+#        emit FINALIZED=true CLOSED=true.
+#   Signals 2 and 3 are independent and may fire together (a prior attempt
+#   may have completed both rename and comment-post but failed close), in
+#   which case the executed path becomes close-only.
 #   Title-prefix and marker signals MUST NOT short-circuit on their own
 #   (FINDING_3): issue-lifecycle.sh close posts the comment BEFORE its
 #   close call, so a transient close failure leaves rename and/or comment
 #   in place but the issue still OPEN. An aggressive short-circuit on
 #   title or marker alone would leave the umbrella stuck OPEN forever —
 #   every retry would return ALREADY_FINALIZED=true and skip the close
-#   call. Routing those signals to close-only retries also avoids
-#   double-comment under concurrent finalize attempts.
+#   call. Routing those signals to selective skips (rather than a flat
+#   short-circuit) also avoids double-comment under concurrent finalize
+#   attempts while still driving the close to its terminal state.
 #
 # Sequence on the non-idempotent path:
 #   1. Rename the umbrella's title to "[DONE] <title>" via
@@ -59,7 +66,12 @@
 #
 # Stdout contract (KEY=value lines):
 #   FINALIZED=true|false
-#   ALREADY_FINALIZED=true        (only when the idempotency guard fired)
+#   ALREADY_FINALIZED=true        (only when the strict short-circuit fired,
+#                                  i.e. state=CLOSED)
+#   REASON=already CLOSED         (paired with ALREADY_FINALIZED=true on the
+#                                  CLOSED short-circuit path; not emitted on
+#                                  the close-only retry paths, which succeed
+#                                  with FINALIZED=true)
 #   RENAMED=true|false            (rename outcome — present on the executed
 #                                  path; omitted on ALREADY_FINALIZED)
 #   CLOSED=true|false             (close outcome — present on the executed

--- a/skills/fix-issue/scripts/finalize-umbrella.sh
+++ b/skills/fix-issue/scripts/finalize-umbrella.sh
@@ -19,20 +19,33 @@
 # Subcommand:
 #   finalize --issue N
 #
-# Idempotency guard (FINDING_2):
+# Idempotency guard (FINDING_2 + FINDING_3):
 #   Before posting any comment or running rename/close, probe the umbrella's
-#   current state and look for a sentinel HTML-comment marker that would have
-#   been embedded by a prior successful finalize. The guard treats ANY of the
-#   following as "already finalized":
-#     1. Issue state is CLOSED.
-#     2. Title starts with "[DONE] " (managed lifecycle prefix).
-#     3. Any existing comment body contains the literal marker
-#        "<!-- larch:fix-issue:umbrella-finalized -->".
-#   On any of these, emit FINALIZED=false ALREADY_FINALIZED=true and exit 0
-#   without posting a duplicate comment. issue-lifecycle.sh close ALREADY
-#   skips the gh issue close call when state is CLOSED, but it posts the
-#   --comment BEFORE its idempotency probe — so without this pre-flight guard
-#   we would still double-comment under concurrent finalize attempts.
+#   current state and look for partial-success signals from a prior finalize
+#   attempt. The guard distinguishes a strict short-circuit from two
+#   close-only retry paths:
+#     1. State is CLOSED — strict short-circuit. Emit
+#        FINALIZED=false ALREADY_FINALIZED=true REASON=already CLOSED and
+#        exit 0 without further mutation.
+#     2. State is OPEN AND title starts with "[DONE] " (managed lifecycle
+#        prefix) — partial-success: a prior rename succeeded but
+#        `gh issue close` did not complete. Skip the rename API call and
+#        proceed to close-only retry; on success emit FINALIZED=true
+#        CLOSED=true.
+#     3. State is OPEN AND a comment body contains the literal marker
+#        "<!-- larch:fix-issue:umbrella-finalized -->" — partial-success:
+#        a prior comment-post succeeded but `gh issue close` did not
+#        complete. Skip the comment-post step (avoid double-comment under
+#        concurrency) and proceed to close-only retry; on success emit
+#        FINALIZED=true CLOSED=true.
+#   Title-prefix and marker signals MUST NOT short-circuit on their own
+#   (FINDING_3): issue-lifecycle.sh close posts the comment BEFORE its
+#   close call, so a transient close failure leaves rename and/or comment
+#   in place but the issue still OPEN. An aggressive short-circuit on
+#   title or marker alone would leave the umbrella stuck OPEN forever —
+#   every retry would return ALREADY_FINALIZED=true and skip the close
+#   call. Routing those signals to close-only retries also avoids
+#   double-comment under concurrent finalize attempts.
 #
 # Sequence on the non-idempotent path:
 #   1. Rename the umbrella's title to "[DONE] <title>" via


### PR DESCRIPTION
## Summary
- Rewrote the obsolete "Idempotency guard (FINDING_2)" header comment block in `skills/fix-issue/scripts/finalize-umbrella.sh` to match the actual `cmd_finalize` implementation and the sibling `finalize-umbrella.md` contract: only `state=CLOSED` is a strict short-circuit; OPEN issues with `[DONE]` title or marker comment drive selective skips (title → skip rename only; marker → skip comment-post only; close-only is the intersection of both signals).
- Added the missing `REASON=already CLOSED` line to the in-script Stdout contract block so the documented stdout keys match what the script emits.
- Comment-only documentation-rot fix; no executable code changed.

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] Re-read the rewritten header block; confirmed it lists the three branches and matches the `finalize-umbrella.md` Idempotency guard section.
- [x] `/relevant-checks` runs pre-commit on the modified file plus repo-wide agent-lint and reports clean (run twice — after initial impl commit and after review-fix commit).
- [x] No executable code is touched; the existing test harness (`bash skills/fix-issue/scripts/test-finalize-umbrella.sh`) still passes 15/15 against the unchanged implementation.

</details>

Closes #754

Generated with [Claude Code](https://claude.com/claude-code)
