### PR TITLE
Fix #748: replace dangling "Step 0b" citation in /design SKILL.md

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.17.7",
+  "version": "7.17.8",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.17.8] - 2026-04-27
+
+### Fixed
+
+- `skills/design/SKILL.md` — Step 5 cleanup section's "Repeat any external reviewer warnings" parenthetical cited `Step 0b binary checks`, but Step 0 in the file is titled only "Session Setup" and has no `0b` subsection. Reworded the citation to `Step 0 reviewer-availability checks via session-setup.sh`, matching the simpler attribution style used in `skills/review/SKILL.md`. The other three citations (`Step 2a`, `Step 3`, `Step 3b`) correspond to real anchors and are unchanged. Documentation-only. Closes #748.
+
 ## [7.17.7] - 2026-04-27
 
 ### Fixed

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -409,7 +409,7 @@ Remove the session temp directory and all files within it:
 ${CLAUDE_PLUGIN_ROOT}/scripts/cleanup-tmpdir.sh --dir "$DESIGN_TMPDIR"
 ```
 
-**Repeat any external reviewer warnings** from earlier steps (Step 0b binary checks, Step 2a sketch-phase failures/timeouts, Step 3 runtime failures, or Step 3b diagram generation failure) so they are visible at the end of the workflow. For example:
+**Repeat any external reviewer warnings** from earlier steps (Step 0 reviewer-availability checks via `session-setup.sh`, Step 2a sketch-phase failures/timeouts, Step 3 runtime failures, or Step 3b diagram generation failure) so they are visible at the end of the workflow. For example:
 - `**⚠ Codex not available: <reason>**`
 - `**⚠ Cursor review failed: <reason>**`
 - `**⚠ Cursor sketch timed out / produced empty output**`


### PR DESCRIPTION
## Summary
- Replaced the dangling `Step 0b binary checks` citation in `skills/design/SKILL.md:412` with `Step 0 reviewer-availability checks via session-setup.sh` so readers tracing the warning source land on a real anchor instead of a non-existent `0b` subsection.
- Bumped plugin version 7.17.6 → 7.17.7 (PATCH; documentation-only change).

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] `grep -n "Step 0b" skills/design/SKILL.md` returns no matches.
- [x] `/relevant-checks` passes (pre-commit + agent-lint).
- [x] Cursor quick-mode review returned `NO_ISSUES_FOUND`.
- [x] CI green on the branch.

</details>

Closes #748

Generated with [Claude Code](https://claude.com/claude-code)
