### PR TITLE
Bump /implement rebase-count safety limit from 5 to 20

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.17.13",
+  "version": "7.17.14",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.17.14] - 2026-04-27
+
+### Changed
+
+- `scripts/ci-decide.sh` — bumped the rebase-count safety limit from 5 to 20 so /implement's CI+rebase+merge loop tolerates a much busier `main` before bailing on `BAIL_REASON=Too many rebases (...)`. Updated all three sites (header comment, the `-ge` guard at line 113, and the bail-reason text) in lock-step. The other safety limits (`iteration >= 50`, `fix_attempts >= 3`) are unchanged. Closes #799.
+
 ## [7.17.13] - 2026-04-27
 
 ### Fixed

--- a/scripts/ci-decide.sh
+++ b/scripts/ci-decide.sh
@@ -7,7 +7,7 @@
 # Merge is always allowed when CI passes and branch is up-to-date,
 # regardless of safety limits. Safety limits only block non-merge actions:
 #   - iteration >= 50: bail (timeout)
-#   - rebase_count >= 5: bail (too many rebases)
+#   - rebase_count >= 20: bail (too many rebases)
 #   - fix_attempts >= 3: bail (too many fixes)
 #
 # Decision matrix (when no safety limit triggers):
@@ -110,9 +110,9 @@ if [[ "$ITERATION" -ge 50 ]]; then
     exit 0
 fi
 
-if [[ "$REBASE_COUNT" -ge 5 ]]; then
+if [[ "$REBASE_COUNT" -ge 20 ]]; then
     echo "ACTION=bail"
-    echo "BAIL_REASON=Too many rebases (5) without converging — main branch too active"
+    echo "BAIL_REASON=Too many rebases (20) without converging — main branch too active"
     exit 0
 fi
 


### PR DESCRIPTION
## Summary
- Bumped /implement's rebase-count safety limit from 5 to 20 in `scripts/ci-decide.sh` (header comment, `-ge` guard, and `BAIL_REASON` text in lock-step) so the CI+rebase+merge loop tolerates a much busier `main` before bailing.
- Added a `[7.17.11]` `### Changed` entry to `CHANGELOG.md` describing the limit bump.

<details><summary>Architecture Diagram</summary>

Architecture diagram not available (quick mode — `/design` skipped).

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available (quick mode).

</details>

<details><summary>Test plan</summary>

- [x] `/relevant-checks` (pre-commit on modified files + repo-wide `agent-lint`) passed.
- [x] Sanity grep `Too many rebases (5)` in `scripts/ci-decide.sh` returns zero hits post-edit.
- [x] Sanity grep `Too many rebases (20)` in `scripts/ci-decide.sh` returns one hit post-edit.
- [ ] CI green on the PR.

</details>

Closes #799

Generated with [Claude Code](https://claude.com/claude-code)
