### PR TITLE
Fix #755: narrow detect_plan_status refusal regex to first non-empty line

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.17.14",
+  "version": "7.17.15",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.17.15] - 2026-04-27
+
+### Fixed
+
+- `skills/improve-skill/scripts/iteration.sh` — narrow `detect_plan_status` refusal detection to the first non-empty line of the design output (was a whole-file `grep -qiE` that silently misclassified valid plans as `design_refusal` whenever any body line — e.g. a discussion line beginning `Cannot run in parallel …` or a quoted error excerpt — matched the refusal regex). Plan presence is now established by an explicit search for the canonical `## Implementation Plan` markdown header, replacing the prior coarse structural-marker grep that could match unrelated headings. New regression fixture `issue_755_refusal_phrase_in_plan_body` in `scripts/test-improve-skill-iteration.sh` exercises the bug-fix gate. Sibling `iteration.md` gains a "Design output classification" subsection documenting the decision order. Closes #755.
+
 ## [7.17.14] - 2026-04-27
 
 ### Changed

--- a/scripts/test-improve-skill-iteration.sh
+++ b/scripts/test-improve-skill-iteration.sh
@@ -417,6 +417,23 @@ HEREDOC_EOF" \
     "printf 'Some output but no canonical completion line.\n'" \
     "im_verification_failed"
 
+  # Fixture 4b — issue #755: a valid plan whose body contains a line that
+  # matches the refusal regex (e.g. "Cannot run in parallel ...") must NOT be
+  # classified as design_refusal. The fix narrows refusal detection to the
+  # first non-empty line; the canonical `## Implementation Plan` header
+  # explicit-search establishes plan presence robustly. Expected flow:
+  # plan_ok → /im → im_verification_failed (the gate is "anything except
+  # design_refusal" — im_verification_failed is the closest reachable terminal
+  # status given the /im stub's non-canonical output).
+  run_fixture \
+    "issue_755_refusal_phrase_in_plan_body" \
+    "cat <<'HEREDOC_EOF'
+$NON_A_JUDGE
+HEREDOC_EOF" \
+    "printf '## Implementation Plan\n\n- Add retry handler.\nCannot run in parallel — must serialize.\n- Add tests.\n'" \
+    "printf 'Some output but no canonical completion line.\n'" \
+    "im_verification_failed"
+
   # Fixture 5 — issue #399: subprocess failure triggers diagnostics dump +
   # work-dir retention. The judge stub exits non-zero with stderr content;
   # iteration.sh's invoke_claude_p must (a) dump a redacted ── subprocess

--- a/scripts/test-improve-skill-iteration.sh
+++ b/scripts/test-improve-skill-iteration.sh
@@ -23,8 +23,9 @@
 #   Tier 2 — Behavioral (best-effort smoke tests with stubbed claude + gh):
 #     Stubs `claude` and `gh` on PATH under a mktemp'd fixture skill dir and
 #     invokes iteration.sh with --work-dir set, asserting on the KV footer
-#     emitted on stdout. Four cases cover: grade_a, no_plan, design_refusal,
-#     im_verification_failed.
+#     emitted on stdout. Fixtures cover grade_a, no_plan, design_refusal,
+#     im_verification_failed, issue_755_refusal_phrase_in_plan_body, and
+#     judge_subprocess_failure (issue #399 retention path).
 #
 # Invoked via:  bash scripts/test-improve-skill-iteration.sh
 # Wired into:   make lint (via the test-improve-skill-iteration target).

--- a/skills/improve-skill/scripts/iteration.md
+++ b/skills/improve-skill/scripts/iteration.md
@@ -62,6 +62,18 @@ Emitted via `trap emit_kv_footer EXIT` — guarantees the footer is present on e
 | `ITERATION_TMPDIR` | absolute path | Work-dir actually used (caller-supplied in loop mode; fresh in standalone). |
 | `ISSUE_NUM` | integer | Tracking issue number (adopted or created). |
 
+## Design output classification (`detect_plan_status`)
+
+Classifies the `/design` artifact into one of `plan_ok` / `no_plan` / `design_refusal` (consumed by the post-`/design` switch on `PLAN_STATUS`). Decision order:
+
+1. Empty file → `no_plan`.
+2. **First non-empty line** matches the refusal regex (`^(error:|error -|refus(ed|al)|cannot (run|proceed|execute)|/design (failed|could not run|is unavailable))`, case-insensitive) → `design_refusal`. Refusal detection is intentionally scoped to the leading line so a heading or quoted excerpt deeper in a valid plan does not trigger a false positive (issue #755).
+3. The canonical `## Implementation Plan` header (markdown level 2-6, case-insensitive) appears anywhere in the file → `plan_ok`. This explicit-header probe replaces the prior coarse structural-marker grep that could match unrelated headings (issue #755).
+4. The cleaned first line equals one of the no-plan sentinels (`no plan`, `no improvements`, `nothing to improve`, `already optimal`, `skill is already high quality`) → `no_plan`.
+5. Otherwise → `plan_ok` (lenient default — the rescue path at `iteration.sh` re-invokes `/design --auto` when `plan_ok` is paired with no structural markers at all).
+
+The classification rules are load-bearing for `/loop-improve-skill/scripts/driver.sh`'s terminal-status break logic (any non-`ok` ITER_STATUS terminates the loop). Behavioral changes here propagate into the test fixtures pinned by `scripts/test-improve-skill-iteration.sh` Tier 2.
+
 ## Stdout discipline
 
 Stdout is reserved for:

--- a/skills/improve-skill/scripts/iteration.sh
+++ b/skills/improve-skill/scripts/iteration.sh
@@ -643,12 +643,26 @@ detect_plan_status() {
     printf 'no_plan\n'
     return 0
   fi
-  if LC_ALL=C grep -qiE '^(error:|error -|refus(ed|al)|cannot (run|proceed|execute)|/design (failed|could not run|is unavailable))' "$design_out"; then
+  # Refusal detection: scan only the first non-empty line, not the whole file.
+  # A heading like `## Error: Handling Approach` or a quoted error excerpt
+  # appearing inside a valid plan body must NOT trigger design_refusal
+  # (issue #755).
+  local first_raw first_line
+  first_raw="$(awk 'NF {print; exit}' "$design_out")"
+  if printf '%s\n' "$first_raw" \
+    | LC_ALL=C grep -qiE '^(error:|error -|refus(ed|al)|cannot (run|proceed|execute)|/design (failed|could not run|is unavailable))'; then
     printf 'design_refusal\n'
     return 0
   fi
-  local first_line
-  first_line="$(awk 'NF {print; exit}' "$design_out" \
+  # Plan presence: prefer the canonical `## Implementation Plan` header
+  # (any markdown heading level 2-6, case-insensitive). Robust against
+  # /design preludes preceding the plan and against unrelated headings the
+  # prior coarse structural-marker grep would have matched (issue #755).
+  if LC_ALL=C grep -qiE '^#{2,6}[[:space:]]+implementation[[:space:]]+plan([[:space:]]|$)' "$design_out"; then
+    printf 'plan_ok\n'
+    return 0
+  fi
+  first_line="$(printf '%s' "$first_raw" \
     | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//' \
     | tr '[:upper:]' '[:lower:]')"
   first_line="$(printf '%s' "$first_line" | sed -E 's/^[*_]+//; s/[*_]+$//')"
@@ -662,16 +676,10 @@ detect_plan_status() {
         break ;;
     esac
   done
-  local has_structural="no"
-  if LC_ALL=C grep -qE '^#{1,6}[[:space:]]|^[1-9][0-9]?\.[[:space:]]|^[-*+][[:space:]]' "$design_out"; then
-    has_structural="yes"
-  fi
   case "$first_line" in
     "no plan"|"no improvements"|"nothing to improve"|"already optimal"|"skill is already high quality")
-      if [[ "$has_structural" == "no" ]]; then
-        printf 'no_plan\n'
-        return 0
-      fi
+      printf 'no_plan\n'
+      return 0
       ;;
   esac
   printf 'plan_ok\n'


### PR DESCRIPTION
## Summary
- Narrowed `detect_plan_status` refusal detection in `skills/improve-skill/scripts/iteration.sh` to the first non-empty line, eliminating false positives where any body line beginning with refusal-regex tokens (e.g. `Cannot run in parallel …` or a quoted error excerpt) silently mis-classified valid plans as `design_refusal`.
- Replaced the coarse structural-marker grep with an explicit search for the canonical `## Implementation Plan` markdown header for plan-presence detection. Added a regression fixture (`issue_755_refusal_phrase_in_plan_body`) to `scripts/test-improve-skill-iteration.sh` and documented the classification rules in `skills/improve-skill/scripts/iteration.md`.

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] `bash scripts/test-improve-skill-iteration.sh` — 85 PASSED, 0 FAILED (4 pre-existing fixtures still pass; new `issue_755_refusal_phrase_in_plan_body` fixture passes; structural Tier 1 asserts still pin `detect_plan_status` contract tokens).
- [x] `/relevant-checks` — pre-commit (shellcheck, markdownlint, agent-lint, gitleaks, etc.) clean on changed files; full-repo agent-lint clean.
- [ ] CI green on the PR.

</details>

Closes #755

Generated with [Claude Code](https://claude.com/claude-code)
