### PR TITLE
Fix #751: refresh stale call-site step numbers in scripts/post-issue-slack.md

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.17.17",
+  "version": "7.17.18",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.17.18] - 2026-04-27
+
+### Fixed
+
+- `scripts/post-issue-slack.md` — refreshed stale call-site step numbers to match the current `/fix-issue` SKILL.md numbering: not-material close moved from Step 4 to Step 3 (triage sub-flow), NON_PR Slack announce moved from Step 8b to Step 7b, and the PR-path Slack-skip note moved from Step 8a to Step 7. Mechanical text-only fix; no behavior change. Closes #751.
+
 ## [7.17.17] - 2026-04-27
 
 ### Fixed

--- a/scripts/post-issue-slack.md
+++ b/scripts/post-issue-slack.md
@@ -1,6 +1,6 @@
 # post-issue-slack.sh
 
-**Purpose**: Post a single one-line Slack status message about a tracking issue. Consumed by `/implement` Step 16a (once per run) and by `/fix-issue` Steps 4 and 8b. Replaces the former PR-scoped Slack stack (`post-pr-announce.sh` + `slack-announce.sh` + `post-merged-emoji.sh` + `add-merged-emoji.sh` + `add-slack-emoji.sh`) and the former `skills/fix-issue/scripts/post-issue-slack.sh`.
+**Purpose**: Post a single one-line Slack status message about a tracking issue. Consumed by `/implement` Step 16a (once per run) and by `/fix-issue` Steps 3 and 7b. Replaces the former PR-scoped Slack stack (`post-pr-announce.sh` + `slack-announce.sh` + `post-merged-emoji.sh` + `add-merged-emoji.sh` + `add-slack-emoji.sh`) and the former `skills/fix-issue/scripts/post-issue-slack.sh`.
 
 ## Output contract
 
@@ -14,7 +14,7 @@ One-liner body (Slack mrkdwn):
 - **Link**: mrkdwn link composed from `gh issue view --repo "$REPO"` output when available (scoped to the caller-supplied repo so gh's default-repo context cannot fetch the wrong issue). When `gh issue view` fails, falls back to `gh repo view "$REPO" --json url` and appends `/issues/$N` — preserves GitHub Enterprise host correctly. Last-resort synthesis hardcodes `https://github.com/$REPO/issues/$N` only when both gh calls fail.
 - **Safe-title**: `|`, `<`, `>` are backslash-escaped; `"` is replaced with U+201C left curly quote (matching the pre-existing convention from the deleted `slack-announce.sh`).
 - **Status tail**: fixed per status enum (e.g. `closed`, `PR opened, awaiting merge`). When `--pr-url` is given with `pr-opened`, the tail renders the PR URL as a nested link.
-- **Detail suffix**: when `--detail` is provided, appended (preceded by ` — `) after the status tail, with the same mrkdwn-reserved-character escaping as the title. Used by `/fix-issue` to preserve closure reason context (Step 4 not-material reason; Step 8b WORK_SUMMARY one-liner).
+- **Detail suffix**: when `--detail` is provided, appended (preceded by ` — `) after the status tail, with the same mrkdwn-reserved-character escaping as the title. Used by `/fix-issue` to preserve closure reason context (Step 3 not-material reason; Step 7b WORK_SUMMARY one-liner).
 
 ## Identity
 
@@ -57,10 +57,10 @@ Non-zero exit on argument or API failure. Callers should never abort their run o
 ## Call sites
 
 - `skills/implement/SKILL.md` Step 16a — once near end of run, gated on `slack_enabled AND slack_available AND ISSUE_NUMBER set AND !deferred AND !repo_unavailable`.
-- `skills/fix-issue/SKILL.md` Step 4 — not-material close, `--status closed --detail "<reason>"`.
-- `skills/fix-issue/SKILL.md` Step 8b — NON_PR close, `--status closed --detail "<WORK_SUMMARY one-liner>"`.
+- `skills/fix-issue/SKILL.md` Step 3 (not-material close sub-step) — `--status closed --detail "<reason>"`.
+- `skills/fix-issue/SKILL.md` Step 7b (NON_PR Slack announce) — `--status closed --detail "<WORK_SUMMARY one-liner>"`.
 
-`/fix-issue` Step 8a (INTENT=PR) does NOT call this script directly — the child `/implement` invocation handles the Slack post via its Step 16a.
+`/fix-issue` Step 7 (INTENT=PR) does NOT call this script directly — the child `/implement` invocation handles the Slack post via its Step 16a.
 
 ## Edit-in-sync
 


### PR DESCRIPTION
## Summary

- Refreshed stale call-site step numbers in `scripts/post-issue-slack.md` so the doc reflects the current `/fix-issue` SKILL.md numbering: not-material close moved from Step 4 to Step 3 (triage sub-flow), NON_PR Slack announce moved from Step 8b to Step 7b, and the PR-path Slack-skip note moved from Step 8a to Step 7.
- Mechanical text-only fix; no script behavior, signature, or workflow changed.

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] After edits, `grep "Step" scripts/post-issue-slack.md` shows no remaining `Step 4` / `Step 8a` / `Step 8b` references.
- [x] New tokens (`Step 3`, `Step 7`, `Step 7b`) appear at lines 3, 17, 60, 61, 63 as expected.
- [x] `/relevant-checks` passes (pre-commit + agent-lint).

</details>

Closes #751

Generated with [Claude Code](https://claude.com/claude-code)
