### PR TITLE
Fix #757: correct call-site count in finalize-umbrella.md from THREE to FOUR

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.17.18",
+  "version": "7.17.19",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.17.19] - 2026-04-27
+
+### Fixed
+
+- `skills/fix-issue/scripts/finalize-umbrella.md` — correct the "Caller contract" Edit-in-sync count from THREE to FOUR (the bullet enumerated four sites — Step 0, Step 3, Step 5a, Step 6 — but stated "THREE call sites"). Reorder the enumeration to match SKILL.md flow order and tighten the "AND ... AND" phrasing to a clean comma-separated list. Closes #757.
+
 ## [7.17.18] - 2026-04-27
 
 ### Fixed

--- a/skills/fix-issue/scripts/finalize-umbrella.md
+++ b/skills/fix-issue/scripts/finalize-umbrella.md
@@ -51,7 +51,7 @@ If the comment-stream probe itself fails (transient `gh` API blip), the helper t
 
 - **Sentinel marker literal** (`<!-- larch:fix-issue:umbrella-finalized -->`) is byte-pinned in this script and the test harness. The marker is part of the public stdout-and-comment contract; renaming it requires a coordinated update to `test-finalize-umbrella.sh` and any future caller that reads it. The marker is intentionally an HTML comment (renders invisibly on the GitHub web UI but is part of the comment body for marker-detection).
 - **Closing comment template** ("All tracked issues are closed. Marking umbrella as DONE and closing.") is documentation-grade prose; minor edits are allowed but the marker MUST remain on its own first line so the marker-detection regex (substring containment) keeps working regardless of comment-body formatting.
-- **Caller contract**: the helper is invoked from THREE call sites in `skills/fix-issue/SKILL.md`: Step 0 (exit-4 from `find-lock-issue.sh`), Step 6 after the just-closed child was the umbrella's last open child, AND Step 5a's adopted-issue-closed bailout (FINDING_8) AND Step 3's not-material close (FINDING_7 — ordering: AFTER child rename, BEFORE Slack). Adding new call sites requires verifying that the idempotency guard handles the new context.
+- **Caller contract**: the helper is invoked from FOUR call sites in `skills/fix-issue/SKILL.md`: Step 0 (exit-4 from `find-lock-issue.sh`), Step 3's not-material close (FINDING_7 — ordering: AFTER child rename, BEFORE Slack), Step 5a's adopted-issue-closed bailout (FINDING_8), and Step 6 after the just-closed child was the umbrella's last open child. Adding new call sites requires verifying that the idempotency guard handles the new context.
 
 ## Test harness
 


### PR DESCRIPTION
## Summary

- Fix the off-by-one count in `skills/fix-issue/scripts/finalize-umbrella.md` line 54 — the "Caller contract" Edit-in-sync bullet stated "THREE call sites" but enumerated four. Verified four distinct `finalize-umbrella.sh finalize` invocations exist in `skills/fix-issue/SKILL.md` at lines 100 (Step 0 exit-4), 164 (Step 3 not-material close), 222 (Step 5a adopted-issue-closed bailout), and 285 (Step 6 child-just-closed hook).
- Reorder the enumeration to match SKILL.md flow (Step 0, Step 3, Step 5a, Step 6) and replace the awkward `AND ... AND` phrasing with a clean comma-separated list.

## Test plan

- [x] Re-grep `finalize-umbrella.sh finalize` in `skills/fix-issue/SKILL.md` — count remains 4.
- [x] `/relevant-checks` (pre-commit + agent-lint) — passed.
- [x] Quick-mode single-reviewer code review (Cursor round 1) — `NO_ISSUES_FOUND`.

Closes #757

🤖 Generated with [Claude Code](https://claude.com/claude-code)
