### PR TITLE
Fix #763: align test-fix-issue-bail-detection.md with eight harness assertions

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.17.19",
+  "version": "7.17.20",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.17.20] - 2026-04-27
+
+### Fixed
+
+- `skills/fix-issue/scripts/test-fix-issue-bail-detection.md` — aligned the intro sentence and edit-in-sync footer with the harness it documents. The .md previously opened with "six load-bearing literals (five conceptual checks)" but `test-fix-issue-bail-detection.sh` runs eight literal assertions (`a1`–`a4`, `b`–`e`) covering six conceptual checks. Updated the count to "eight literal assertions covering six conceptual checks", added the missing `--no-admin-fallback` SIMPLE/HARD bullet pair (issue #559 — branch-protection bypass safety flag) so the bullet list matches the harness's checks, and updated the closing edit-in-sync line. Doc-only correction; the harness itself and runtime behavior are unchanged. Closes #763.
+
 ## [7.17.19] - 2026-04-27
 
 ### Fixed

--- a/skills/fix-issue/scripts/test-fix-issue-bail-detection.md
+++ b/skills/fix-issue/scripts/test-fix-issue-bail-detection.md
@@ -1,9 +1,11 @@
 # skills/fix-issue/scripts/test-fix-issue-bail-detection.sh — contract
 
-`skills/fix-issue/scripts/test-fix-issue-bail-detection.sh` is the regression harness for the Phase 4 bail-detection prose in `skills/fix-issue/SKILL.md` Step 5a (originally Phase 4 of umbrella #348; renumbered from Step 6a to Step 5a by the fold-find-and-lock refactor closes #496). It is offline, hermetic, and runs against the committed `SKILL.md` — no network, no git state change, no mocks. The harness guards against accidental removal of six load-bearing literals inside the Step 5a block (five conceptual checks; `--issue $ISSUE_NUMBER` is counted once per SIMPLE and HARD bullet):
+`skills/fix-issue/scripts/test-fix-issue-bail-detection.sh` is the regression harness for the Phase 4 bail-detection prose in `skills/fix-issue/SKILL.md` Step 5a (originally Phase 4 of umbrella #348; renumbered from Step 6a to Step 5a by the fold-find-and-lock refactor closes #496). It is offline, hermetic, and runs against the committed `SKILL.md` — no network, no git state change, no mocks. The harness guards against accidental removal of eight literal assertions inside the Step 5a block, covering six conceptual checks (the `--issue $ISSUE_NUMBER` and `--no-admin-fallback` forwards each appear once per SIMPLE and HARD bullet, so each forward contributes two literal assertions):
 
 - `--issue $ISSUE_NUMBER` in the SIMPLE bullet (forwarded to `/implement` so it adopts the queue issue via Phase 3 Branch 2).
 - `--issue $ISSUE_NUMBER` in the HARD bullet (same rationale).
+- `--no-admin-fallback` in the SIMPLE bullet (issue #559 — branch-protection bypass safety flag forwarded so `/fix-issue --no-admin-fallback` callers are not silently exposed to an `--admin` override).
+- `--no-admin-fallback` in the HARD bullet (same rationale).
 - `IMPLEMENT_BAIL_REASON=adopted-issue-closed` — the exact machine token `/implement` emits when the adopted issue is CLOSED; `/fix-issue` scans captured output for this literal.
 - `/implement bailed: issue #` — the user-visible warning prefix printed on the bail branch.
 - `` Do NOT call `issue-lifecycle.sh close` `` — specific directive fragment (not a bare `Do NOT call` substring) that prevents silent re-routing of the bail path back to Step 6's close call. The full phrase is required because the awk extraction window also includes section 5b, which contains an unrelated `Do NOT call \`/implement\`` sentence.
@@ -13,4 +15,4 @@ Extraction boundary: `^### 5a` (start, prefix match) through `^## Step 6` (end, 
 
 The harness is wired into `make lint` via the `test-fix-issue-bail-detection` target in `Makefile`. It is added to `agent-lint.toml`'s `exclude` list alongside its sibling contract `.md` because agent-lint's dead-script and S030/orphaned-skill-files rules do not follow Makefile-only references. The paired token-literal assertion on the emitter side lives in `scripts/test-implement-structure.sh` (pins the same token in `skills/implement/SKILL.md`); a rename of the bail token is therefore a dual-repo change caught by CI.
 
-Edit-in-sync: if the Step 5a narrative rewords any of the six load-bearing literals (five conceptual checks) or restructures the bail branch, update this harness and this contract in the same PR.
+Edit-in-sync: if the Step 5a narrative rewords any of the eight literal assertions (six conceptual checks) or restructures the bail branch, update this harness and this contract in the same PR.


### PR DESCRIPTION
## Summary
- Aligned `skills/fix-issue/scripts/test-fix-issue-bail-detection.md` with the eight literal assertions actually run by `test-fix-issue-bail-detection.sh` (covering six conceptual checks). Replaced the stale "six load-bearing literals (five conceptual checks)" intro and the matching edit-in-sync footer.
- Added the missing `--no-admin-fallback` SIMPLE/HARD bullet pair (issue #559 — branch-protection bypass safety flag), so the bullet list now mirrors the harness's `(a1)`–`(a4)` and `(b)`–`(e)` checks.
- Doc-only correction: the harness itself and runtime behavior are unchanged; `bash skills/fix-issue/scripts/test-fix-issue-bail-detection.sh` continues to pass all 8 assertions.

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] `bash skills/fix-issue/scripts/test-fix-issue-bail-detection.sh` exits 0 with all eight assertions passing.
- [x] `/relevant-checks` (pre-commit on modified files + agent-lint on the full repo) is clean.
- [x] No remaining occurrence of "six load-bearing literals" or "five conceptual checks" in the .md.

</details>

Closes #763

Generated with [Claude Code](https://claude.com/claude-code)
