### PR TITLE
Fix #781: research-phase.md:309 — quick scale uses K=3 Agent-tool lanes, not inline

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.17.22",
+  "version": "7.17.23",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.17.23] - 2026-04-27
+
+### Fixed
+
+- `skills/research/references/research-phase.md` — corrected the `RESEARCH_SCALE=quick` bullet under "Baseline prompt" (line 309). It previously stated quick mode "the single inline Claude lane runs `RESEARCH_PROMPT_BASELINE` verbatim", contradicting the same file's K=3 homogeneous Claude Agent-tool lane contract at lines 5, 11, 13, 17, and the "### Quick" subsection (issue #520). Reworded so the bullet states that each of the K=3 quick lanes is a Claude Agent-tool subagent running `RESEARCH_PROMPT_BASELINE` verbatim, and that the orchestrator does not run a separate inline lane in quick mode. Doc-only correction; runtime behavior is unchanged. Closes #781.
+
 ## [7.17.22] - 2026-04-27
 
 ### Fixed

--- a/skills/research/references/research-phase.md
+++ b/skills/research/references/research-phase.md
@@ -306,7 +306,7 @@ Print: `✅ 1.2: lane-assign — N=$RESEARCH_PLAN_N, per-lane suffixes composed 
 
 **Baseline prompt** (`RESEARCH_PROMPT_BASELINE`). Per-scale applicability:
 
-- `RESEARCH_SCALE=quick` — the single inline Claude lane runs `RESEARCH_PROMPT_BASELINE` verbatim.
+- `RESEARCH_SCALE=quick` — each of the **K=3 homogeneous Claude Agent-tool lanes** (issue #520) runs `RESEARCH_PROMPT_BASELINE` verbatim; the orchestrator does not run a separate inline Claude lane in quick mode.
 - `RESEARCH_SCALE=deep` — only the **inline Claude lane** runs `RESEARCH_PROMPT_BASELINE` (general/synthesis-style role); the four external slots (Cursor-Arch, Cursor-Edge, Codex-Ext, Codex-Sec) and their per-slot Claude fallbacks run the corresponding **named angle prompts** (`RESEARCH_PROMPT_ARCH`, `RESEARCH_PROMPT_EDGE`, `RESEARCH_PROMPT_EXT`, `RESEARCH_PROMPT_SEC`) defined further below — NOT this baseline literal.
 - `RESEARCH_SCALE=standard` — does **NOT** use `RESEARCH_PROMPT_BASELINE`. All 3 standard-mode lanes use angle prompts (3 of the 4 below); see the per-lane mapping in the `### Standard` subsection.
 


### PR DESCRIPTION
## Summary
- Replaced the misleading `RESEARCH_SCALE=quick` bullet at line 309 of `skills/research/references/research-phase.md` so it matches the file's own K=3 homogeneous Claude Agent-tool lane contract (lines 5, 11, 13, 17, 380; issue #520) instead of contradicting it with "the single inline Claude lane" wording.

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] `/relevant-checks` over the modified file — pre-commit hooks pass (markdownlint, agent-lint, gitleaks); full-repo agent-lint pass.
- [x] Post-edit grep — `single inline Claude lane` no longer appears anywhere in `skills/research/references/research-phase.md`.
- [x] Manual re-read of lines 305-315 confirms the corrected wording is consistent with the K=3 contract used elsewhere in the same file.

</details>

Closes #781

Generated with [Claude Code](https://claude.com/claude-code)
