### PR TITLE
Fix #756: align finalize-umbrella.md REASON enum with actual script emissions

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.17.23",
+  "version": "7.17.24",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.17.24] - 2026-04-27
+
+### Fixed
+
+- `skills/fix-issue/scripts/finalize-umbrella.md:33-39` — replaced the misleading three-value `REASON` enum in the Stdout-contract table with the granular four-row split from duplicate #759. The script `finalize-umbrella.sh` only emits `REASON=already CLOSED` (line 153, paired with `ALREADY_FINALIZED=true` on the strict CLOSED short-circuit); the prior table listed `title already prefixed [DONE]` and `existing closing-comment marker detected` as `REASON` values, but those literals exist nowhere in the script. New rows tie `ALREADY_FINALIZED` / `REASON` to the strict CLOSED short-circuit and `RENAMED` / `CLOSED` to the executed path (including the close-only retry path where `RENAMED` may be `false` when the title was already prefixed `[DONE]`). Documentation alignment only; no script behavior change. Closes #756.
+
 ## [7.17.23] - 2026-04-27
 
 ### Fixed

--- a/skills/fix-issue/scripts/finalize-umbrella.md
+++ b/skills/fix-issue/scripts/finalize-umbrella.md
@@ -33,10 +33,10 @@ If the comment-stream probe itself fails (transient `gh` API blip), the helper t
 | Key | Emitted when | Value |
 |-----|--------------|-------|
 | `FINALIZED` | always | `true` (executed path success) or `false` (idempotency hit OR error) |
-| `ALREADY_FINALIZED` | only on idempotency hit | `true` |
-| `REASON` | only on idempotency hit | `already CLOSED` / `title already prefixed [DONE]` / `existing closing-comment marker detected` |
-| `RENAMED` | executed path only | `true` (rename succeeded) or `false` (best-effort failure) |
-| `CLOSED` | executed path only | `true` (close succeeded) or `false` (close failed → `FINALIZED=false`) |
+| `ALREADY_FINALIZED` | only on strict short-circuit (state=CLOSED) | `true` |
+| `REASON` | only when `ALREADY_FINALIZED=true` | `already CLOSED` |
+| `RENAMED` | executed-path only | `true` / `false` (including the close-only retry path where it may be `false`) |
+| `CLOSED` | executed-path only | `true` / `false` |
 | `ERROR` | only on `FINALIZED=false` non-idempotent failure | one-line reason |
 
 ## Exit codes


### PR DESCRIPTION
## Summary
- Replaced the misleading three-value `REASON` enum in `skills/fix-issue/scripts/finalize-umbrella.md` Stdout-contract table with the granular four-row split from duplicate #759. The script `finalize-umbrella.sh` only ever emits `REASON=already CLOSED` (line 153, paired with `ALREADY_FINALIZED=true` on the strict CLOSED short-circuit); the prior table listed two values that exist nowhere in the script, misleading readers who grep for the literals.
- New rows tie `ALREADY_FINALIZED` / `REASON` to the strict CLOSED short-circuit and `RENAMED` / `CLOSED` to the executed path (including the close-only retry path where `RENAMED` may be `false` when the title was already prefixed `[DONE]`). Documentation alignment only; no script behavior change.

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] `grep -n "REASON" skills/fix-issue/scripts/finalize-umbrella.sh` confirms single emission site
- [x] `bash skills/fix-issue/scripts/test-finalize-umbrella.sh` — 15 passed, 0 failed
- [x] `/relevant-checks` — pre-commit on changed file + agent-lint repo-wide both passed

</details>

Closes #756

Generated with [Claude Code](https://claude.com/claude-code)
