### PR TITLE
Fix #758: prepend --auto to iteration kernel's primary /design and /im invocations

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.17.26",
+  "version": "7.17.27",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.17.27] - 2026-04-27
+
+### Fixed
+
+- `skills/improve-skill/scripts/iteration.sh` — prepended `--auto` to the primary `/larch:design` invocation (line 833) and the primary `/larch:im` invocation (line 928), matching the rescue retry which already passed `--auto`. Without `--auto`, the iteration kernel's `claude -p` subprocesses had no interactive user but `/design` and `/implement` were free to invoke `AskUserQuestion` (`/design` Steps 1c, 1d, 3.5 when `auto_mode=false`), stalling the subprocess until the 3600s watchdog fired. Updated the sibling `iteration.md` contract with a new "Non-interactive `--auto` flag forwarding" subsection and added Tier 1 regression-guard pins (`/larch:design --auto`, `/larch:im --auto`) to `scripts/test-improve-skill-iteration.sh`. Closes #758 and the merged duplicate #761.
+
 ## [7.17.26] - 2026-04-27
 
 ### Fixed

--- a/scripts/test-improve-skill-iteration.sh
+++ b/scripts/test-improve-skill-iteration.sh
@@ -91,6 +91,12 @@ check_contains '--permission-mode bypassPermissions'           'non-interactive 
 # FINDING_7: fully-qualified slash-command names for larch-shipped children.
 check_contains '/larch:design'                                 'fully-qualified /larch:design invocation'
 check_contains '/larch:im'                                     'fully-qualified /larch:im invocation'
+# Issue #758: primary /design and /im prompts MUST carry --auto so the
+# subprocess-driven /design and /im runs are non-interactive (matching the
+# rescue retry which already passes --auto). Without these pins, the fix in
+# iteration.sh could silently regress.
+check_contains '/larch:design --auto'                          'primary /larch:design --auto prompt (issue #758)'
+check_contains '/larch:im --auto'                              'primary /larch:im --auto prompt (issue #758)'
 # FINDING_10: stderr MUST NOT merge into stdout (which is posted publicly).
 # shellcheck disable=SC2016
 check_contains '2> "$stderr_file"'                             'stderr redirected to separate file (FINDING_10)'

--- a/skills/improve-skill/scripts/iteration.md
+++ b/skills/improve-skill/scripts/iteration.md
@@ -105,6 +105,10 @@ All `claude -p` child I/O stays in files under `$WORK_DIR` (via `invoke_claude_p
 
 **Minimum `claude` CLI version**: `--permission-mode bypassPermissions` is required CLI surface. Older `claude` binaries that do not recognize the flag fail-fast (subprocess returns non-zero, existing `dump_subprocess_diagnostics` captures stderr) — there is no silent corruption path. See `docs/installation-and-setup.md` for the documented minimum-version requirement.
 
+### Non-interactive `--auto` flag forwarding (issue #758)
+
+The primary `/larch:design` invocation (around the post-`/skill-judge` design phase) and the primary `/larch:im` invocation (im phase) both prepend `--auto` to the prompt. This is parallel to (and complements) the `bypassPermissions` mitigation above: `bypassPermissions` removes in-child *tool-permission* prompts, while `--auto` suppresses the in-child *`AskUserQuestion`* checkpoints that `/design` (Steps 1c, 1d, 3.5) and `/implement` would otherwise invoke when `auto_mode=false`. Without `--auto`, those checkpoints stall the non-interactive `claude -p` subprocess until the 3600s watchdog fires, wasting the iteration budget. The rescue re-invocation already passed `--auto`; the primary paths are now byte-parallel.
+
 ## Amended `/design` prompt — four-rule directive set
 
 The design phase emits four directive clauses (byte-parallel to pre-#273 driver.sh plus one new clause):

--- a/skills/improve-skill/scripts/iteration.sh
+++ b/skills/improve-skill/scripts/iteration.sh
@@ -830,7 +830,7 @@ build_deficit_lines() {
 }
 
 {
-  printf '/larch:design Improve /%s at %s' "${SKILL_NAME}" "${TARGET_SKILL_PATH}"
+  printf '/larch:design --auto Improve /%s at %s' "${SKILL_NAME}" "${TARGET_SKILL_PATH}"
   if [[ "$KV_PARSE_STATUS" == "ok" && "$KV_GRADE_A" == "false" ]]; then
     printf ' focused on %s (the Non-A dimensions from this iteration'"'"'s /skill-judge).' "${KV_NON_A_DIMS}"
     printf '\n\nNon-A dimensions from this iteration'"'"'s /skill-judge: %s.\n' "${KV_NON_A_DIMS}"
@@ -925,7 +925,7 @@ IM_OUT="$WORK_DIR/iter-${ITER_NUM}-im.txt"
 # was passed to iteration.sh; default is to post per /implement's default-on
 # behavior (gated on Slack env vars).
 {
-  printf '/larch:im %s' "$NO_SLACK_FLAG"
+  printf '/larch:im --auto %s' "$NO_SLACK_FLAG"
   cat "$DESIGN_OUT"
 } > "$IM_PROMPT"
 


### PR DESCRIPTION
## Summary

- Prepended `--auto` to the iteration kernel's primary `/larch:design` (line 833) and `/larch:im` (line 928) prompts in `skills/improve-skill/scripts/iteration.sh` so the subprocess-driven design and implement runs are non-interactive, matching the rescue retry that already used `--auto`.
- Added a "Non-interactive `--auto` flag forwarding" subsection to the sibling `iteration.md` contract documenting the parallel to the existing `bypassPermissions` mitigation (#585): `bypassPermissions` removes in-child tool-permission stalls; `--auto` removes in-child `AskUserQuestion` stalls.
- Added Tier 1 regression-guard pins (`/larch:design --auto`, `/larch:im --auto`) to `scripts/test-improve-skill-iteration.sh` so the fix cannot silently regress.

<details><summary>Architecture Diagram</summary>

Architecture diagram not available (quick mode skipped `/design`).

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available (quick mode skipped Code Flow generation).

</details>

<details><summary>Test plan</summary>

- [x] `/relevant-checks` (pre-commit on changed files + agent-lint full-repo) — passed.
- [x] `bash scripts/test-improve-skill-iteration.sh` — 87/87 PASS, including the two new `--auto` pins.
- [x] Visual diff confirms `--auto` is the only argv delta on the two `printf` lines; `NO_SLACK_FLAG` ordering is preserved (`/larch:im --auto --no-slack ` when `--no-slack` set).
- [x] Two-round Cursor quick-mode review converged to zero accepted findings in round 2.

</details>

Closes #758

Generated with [Claude Code](https://claude.com/claude-code)
