### PR TITLE
Fix #782: align skills/research/diagram.svg lane counts with K=3 quick contract

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.17.28",
+  "version": "7.17.29",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.17.29] - 2026-04-27
+
+### Fixed
+
+- `skills/research/diagram.svg` — corrected two stale lane-count claims so the diagram matches the canonical `quick=3+0 / standard=3+3 / deep=5+5` scale matrix from `skills/research/SKILL.md`. The subtitle on line 15 now reads `quick=3 lanes no validation` (was `quick=1 lane no validation`), and the research-agents box label on line 24 now reads `3/3/5 Research Agents (scale-dependent)` (was `1/3/5`). Closes #782 (part of umbrella #784 — /research slice review).
+
 ## [7.17.28] - 2026-04-27
 
 ### Fixed

--- a/skills/research/diagram.svg
+++ b/skills/research/diagram.svg
@@ -12,7 +12,7 @@
 
   <!-- Title -->
   <text x="220" y="14" fill="#333" font-size="16" font-weight="bold">/research</text>
-  <text x="220" y="30" fill="#666" font-size="10">shown: --scale=standard; quick=1 lane no validation; deep=5+5 lanes</text>
+  <text x="220" y="30" fill="#666" font-size="10">shown: --scale=standard; quick=3 lanes no validation; deep=5+5 lanes</text>
 
   <!-- Step 0: Session Setup -->
   <rect x="130" y="40" width="180" height="40" rx="4" fill="#6C757D"/>
@@ -21,7 +21,7 @@
 
   <!-- Step 1: Research Agents (parallel) -->
   <rect x="85" y="110" width="270" height="40" rx="4" fill="#17A2B8" stroke="#17A2B8" stroke-width="3"/>
-  <text x="220" y="130">1/3/5 Research Agents (scale-dependent)</text>
+  <text x="220" y="130">3/3/5 Research Agents (scale-dependent)</text>
   <line x1="220" y1="150" x2="220" y2="180"/>
 
   <!-- Wait & Validate -->


### PR DESCRIPTION
## Summary
- Corrected `skills/research/diagram.svg` subtitle (line 15) from `quick=1 lane no validation` to `quick=3 lanes no validation` so the canvas summary matches the canonical scale matrix in `skills/research/SKILL.md` (`quick=K=3` homogeneous Claude Agent-tool lanes per issue #520, validation skipped).
- Updated the research-agents box label (line 24) from `1/3/5 Research Agents (scale-dependent)` to `3/3/5` for the same per-scale lane-count consistency. Validation box (`0/3/5`) is unchanged — its counts were already correct.

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] Re-read `skills/research/diagram.svg` after the edits to confirm both lines render the corrected `3` lane count.
- [x] `/relevant-checks` (pre-commit on the changed file + agent-lint on the full repo) passed.

</details>

Closes #782

Generated with [Claude Code](https://claude.com/claude-code)
