### PR TITLE
Fix #789: drop stale line-number reference in test-eval-research-baseline-flag.md

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.17.29",
+  "version": "7.17.30",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.17.30] - 2026-04-27
+
+### Fixed
+
+- `scripts/test-eval-research-baseline-flag.md` — dropped the stale absolute line-number reference in the `claude` PATH-stub paragraph ("`require_tool claude` check at line 130"). The actual call drifted to a different line after subsequent growth in `scripts/eval-research.sh`, and per the user's stated principle ("There should be no line number references like this, since it is obviously a maintenance nightmare") the line-number clause is removed entirely — the script-name + function-name pair (`eval-research.sh` `require_tool claude`) is already a precise machine-greppable identifier and is robust to future drift. Documentation-only; runtime behavior unchanged. Closes #789.
+
 ## [7.17.29] - 2026-04-27
 
 ### Fixed

--- a/scripts/test-eval-research-baseline-flag.md
+++ b/scripts/test-eval-research-baseline-flag.md
@@ -32,7 +32,7 @@ make test-eval-research-baseline-flag
 
 `.github/workflows/ci.yaml`'s `test-harnesses` job only installs PyYAML — no `claude` or `jq`. Even though this harness is not wired into `test-harnesses`, it is designed to run offline so an operator on any machine can exercise it without the real Claude CLI:
 
-- A stub `claude` is planted in a `mktemp -d` PATH-prefix so `eval-research.sh`'s `require_tool claude` check at line 130 succeeds. The real binary is never invoked because `--id nonexistent-id-zzz` causes the eval loop to iterate zero entries.
+- A stub `claude` is planted in a `mktemp -d` PATH-prefix so `eval-research.sh`'s `require_tool claude` check succeeds. The real binary is never invoked because `--id nonexistent-id-zzz` causes the eval loop to iterate zero entries.
 - A stub `jq` is planted similarly. The only `jq` call before the baseline block is `validate_baseline_json`'s `jq -e '.version and .scale and (.entries | type == "array")' <file>`, which only checks exit status. The stub returns exit 0 unconditionally. The committed `eval-baseline.json` is a schema-only stub, so any real `jq` would also pass.
 - The PATH-stub pattern mirrors `scripts/test-loop-improve-skill-driver.sh:25` and is the repo precedent for offline operation in tests that exercise `claude`-dependent scripts.
 


### PR DESCRIPTION
## Summary
- Dropped the stale absolute line-number reference (`at line 130`) in `scripts/test-eval-research-baseline-flag.md`'s `claude` PATH-stub paragraph. The actual call drifted to a different line after subsequent growth in `scripts/eval-research.sh`; the line-number clause is removed entirely so the doc is robust to future drift.
- Per the user's stated principle on the issue ("There should be no line number references like this, since it is obviously a maintenance nightmare"), used the simplest fix — the script-name + function-name pair (`eval-research.sh` `require_tool claude`) is already a precise machine-greppable identifier.

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] `grep -n "line 130" scripts/test-eval-research-baseline-flag.md` returns no matches.
- [x] `/relevant-checks` (pre-commit on modified files + `agent-lint` full repo): clean.
- [x] CI green on PR.

</details>

Closes #789

Generated with [Claude Code](https://claude.com/claude-code)
