### PR TITLE
Fix #826: drop stale :25 line-number suffix in test-eval-research-baseline-flag.md

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.17.35",
+  "version": "7.17.36",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.17.36] - 2026-04-27
+
+### Fixed
+
+- `scripts/test-eval-research-baseline-flag.md` — dropped the stale `:25` line-number suffix from the cross-reference to `scripts/test-loop-improve-skill-driver.sh` on line 37. Same maintenance-nightmare pattern as #789 (which removed a separate stale line-number reference on line 35); the script-name reference is already a precise machine-greppable identifier and is robust to future drift inside that file. Documentation-only; runtime behavior unchanged. Closes #826.
+
 ## [7.17.35] - 2026-04-27
 
 ### Fixed

--- a/scripts/test-eval-research-baseline-flag.md
+++ b/scripts/test-eval-research-baseline-flag.md
@@ -34,7 +34,7 @@ make test-eval-research-baseline-flag
 
 - A stub `claude` is planted in a `mktemp -d` PATH-prefix so `eval-research.sh`'s `require_tool claude` check succeeds. The real binary is never invoked because `--id nonexistent-id-zzz` causes the eval loop to iterate zero entries.
 - A stub `jq` is planted similarly. The only `jq` call before the baseline block is `validate_baseline_json`'s `jq -e '.version and .scale and (.entries | type == "array")' <file>`, which only checks exit status. The stub returns exit 0 unconditionally. The committed `eval-baseline.json` is a schema-only stub, so any real `jq` would also pass.
-- The PATH-stub pattern mirrors `scripts/test-loop-improve-skill-driver.sh:25` and is the repo precedent for offline operation in tests that exercise `claude`-dependent scripts.
+- The PATH-stub pattern mirrors `scripts/test-loop-improve-skill-driver.sh` and is the repo precedent for offline operation in tests that exercise `claude`-dependent scripts.
 
 ## Edit-in-sync
 


### PR DESCRIPTION
## Summary
- Dropped the stale `:25` line-number suffix from the cross-reference to `scripts/test-loop-improve-skill-driver.sh` on line 37 of `scripts/test-eval-research-baseline-flag.md`. Same maintenance-nightmare pattern as #789; the script-name reference is already a precise machine-greppable identifier and is robust to future drift.

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] `/relevant-checks` (pre-commit on the modified file + agent-lint on the full repo) passed.
- [x] Verified the `:25` suffix no longer appears on line 37 of `scripts/test-eval-research-baseline-flag.md`.

</details>

Closes #826

Generated with [Claude Code](https://claude.com/claude-code)
