### PR TITLE
Fix #827: drop stale line-number references from CHANGELOG.md v7.17.27 entry

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.17.36",
+  "version": "7.17.37",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.17.37] - 2026-04-27
+
+### Fixed
+
+- `CHANGELOG.md` — rewrote the v7.17.27 entry to drop the absolute line-number references `(line 833)` and `(line 928)` in `skills/improve-skill/scripts/iteration.sh`. The line-number anchors went stale as soon as `iteration.sh` gained or lost lines above those sites (same maintenance-nightmare anti-pattern that drove #789 / #828). The bullet now refers to "the primary `/larch:design` and `/larch:im` prompt builders in `iteration.sh`" — a stable phrase that survives future edits to the script. Documentation-only correction; runtime behavior unchanged. Closes #827.
+
 ## [7.17.36] - 2026-04-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `skills/improve-skill/scripts/iteration.sh` — prepended `--auto` to the primary `/larch:design` invocation (line 833) and the primary `/larch:im` invocation (line 928), matching the rescue retry which already passed `--auto`. Without `--auto`, the iteration kernel's `claude -p` subprocesses had no interactive user but `/design` and `/implement` were free to invoke `AskUserQuestion` (`/design` Steps 1c, 1d, 3.5 when `auto_mode=false`), stalling the subprocess until the 3600s watchdog fired. Updated the sibling `iteration.md` contract with a new "Non-interactive `--auto` flag forwarding" subsection and added Tier 1 regression-guard pins (`/larch:design --auto`, `/larch:im --auto`) to `scripts/test-improve-skill-iteration.sh`. Closes #758 and the merged duplicate #761.
+- `skills/improve-skill/scripts/iteration.sh` — prepended `--auto` to the primary `/larch:design` and `/larch:im` prompt builders in `iteration.sh`, matching the rescue retry which already passed `--auto`. Without `--auto`, the iteration kernel's `claude -p` subprocesses had no interactive user but `/design` and `/implement` were free to invoke `AskUserQuestion` (`/design` Steps 1c, 1d, 3.5 when `auto_mode=false`), stalling the subprocess until the 3600s watchdog fired. Updated the sibling `iteration.md` contract with a new "Non-interactive `--auto` flag forwarding" subsection and added Tier 1 regression-guard pins (`/larch:design --auto`, `/larch:im --auto`) to `scripts/test-improve-skill-iteration.sh`. Closes #758 and the merged duplicate #761.
 
 ## [7.17.26] - 2026-04-27
 


### PR DESCRIPTION
## Summary
- Rewrote the v7.17.27 entry in `CHANGELOG.md` to drop the absolute line-number references `(line 833)` and `(line 928)` in `skills/improve-skill/scripts/iteration.sh`, replacing them with the stable phrase "the primary `/larch:design` and `/larch:im` prompt builders in `iteration.sh`".
- Mirrors the line-number-drift fix pattern from #789 / #828 — same maintenance-nightmare anti-pattern, different file.

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] `grep -n 'line 833\|line 928' CHANGELOG.md` returns no match inside the v7.17.27 entry.
- [x] `/relevant-checks` is green.
- [ ] CI on the PR is green.

</details>

Closes #827

Generated with [Claude Code](https://claude.com/claude-code)
