### PR TITLE
Fix #839: initialize OUT/ERR/EC globals in test-finalize-umbrella.sh

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.17.40",
+  "version": "7.17.41",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.17.41] - 2026-04-27
+
+### Fixed
+
+- `skills/fix-issue/scripts/test-finalize-umbrella.sh` — initialized `OUT=""`, `ERR=""`, `EC=0` as globals near the top of the harness (alongside `PASS=0`, `FAIL=0`). The `run_script_capture` helper writes to these as implicit globals while the script runs under `set -euo pipefail`; without the explicit init, any future fixture that read `$OUT`/`$ERR`/`$EC` before the first `run_script_capture` call would trip `set -u`'s unbound-variable error. Defensive — current fixtures all call `run_script_capture` first, so behavior is unchanged. Closes #839.
+
 ## [7.17.40] - 2026-04-27
 
 ### Fixed

--- a/skills/fix-issue/scripts/test-finalize-umbrella.sh
+++ b/skills/fix-issue/scripts/test-finalize-umbrella.sh
@@ -47,6 +47,13 @@ fi
 PASS=0
 FAIL=0
 FAILED_TESTS=()
+# run_script_capture's OUT/ERR/EC are written as implicit globals from inside
+# the function. Initialize them here so any future fixture that reads
+# $OUT/$ERR/$EC before the first run_script_capture call cannot trip
+# `set -u`'s unbound-variable error.
+OUT=""
+ERR=""
+EC=0
 
 TMPROOT=$(mktemp -d "${TMPDIR:-/tmp}/test-finalize-umbrella-XXXXXX")
 # shellcheck disable=SC2317


### PR DESCRIPTION
## Summary

- Initialized `OUT=""`, `ERR=""`, `EC=0` as globals near the top of `skills/fix-issue/scripts/test-finalize-umbrella.sh` so `run_script_capture`'s implicit-global contract is robust under `set -u` regardless of fixture ordering.

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] `bash skills/fix-issue/scripts/test-finalize-umbrella.sh` — all 5 fixtures (26 assertions) pass.
- [x] `/relevant-checks` — pre-commit + agent-lint pass.

</details>

Closes #839

Generated with [Claude Code](https://claude.com/claude-code)
