### PR TITLE
Fix #837: surface push failures on existing-PR fast-path of create-pr.sh

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.17.44",
+  "version": "7.17.45",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.17.45] - 2026-04-27
+
+### Fixed
+
+- `scripts/create-pr.sh` — the existing-PR fast-path's `git push -u origin HEAD >/dev/null 2>&1 || true` (line 69) silently swallowed every push failure (non-fast-forward, lease failures, network errors), causing the script to emit `PR_STATUS=existing` and exit 0 while origin's branch tip was actually stale. Replaced with a plain-push-first / force-with-lease-fallback strategy that surfaces real push failures via exit 1, mirroring the new-PR path's exit-1 channel (lines 88-91). Plain `git push -u origin HEAD` handles the routine fast-forward case; on non-fast-forward (commonly after `/implement` Step 12 rebase + re-bump), escalation delegates to `scripts/git-force-push.sh` which already encodes lease + fetch + race-recovery + single retry. Helper stdout is suppressed to `/dev/null` so its `BRANCH=`/`PUSHED=`/`STATUS=` keys do not leak into create-pr.sh's documented `PR_*` stdout contract; helper stderr is captured and surfaced on real failure. Defensive `git fetch origin "$BRANCH"` + `git branch --set-upstream-to=origin/$BRANCH` guards run before the helper invocation, since git-force-push.sh requires upstream tracking + a populated origin/$BRANCH ref. `scripts/git-force-push.sh` and the new-PR path at line 88 are not modified. Per design dialectic DECISION_1 (voted 2-1 ALTERNATIVE — plain-push-first chosen over unconditional force-with-lease) and DECISION_2 (voted 2-1 THESIS — exit-code-only preserved over a new `PUSH_STATUS` stdout key); 2 accepted plan-review findings (defensive fetch before set-upstream; testing-strategy phrasing). Adds sibling `scripts/create-pr.md` per AGENTS.md "Per-script contracts live beside the script". Closes #837.
+
 ## [7.17.44] - 2026-04-27
 
 ### Fixed

--- a/scripts/create-pr.md
+++ b/scripts/create-pr.md
@@ -1,0 +1,84 @@
+# create-pr.sh contract
+
+## Purpose
+
+Push the current branch to `origin` and create or detect a GitHub pull request. Two paths:
+
+- **Existing-PR fast-path**: when `gh pr view` reports an OPEN PR for the current branch, push any new local commits and emit `PR_STATUS=existing`. Used by `/implement` Step 9b on resumed runs and on every CI+rebase+merge iteration where the branch already has a PR.
+- **New-PR path**: no OPEN PR exists for the current branch. Push the branch (creates the upstream ref) and `gh pr create` with the supplied title/body. Emit `PR_STATUS=created`.
+
+Both paths emit the same four `PR_*` keys on stdout so downstream consumers parse one contract regardless of path.
+
+## Interface
+
+```
+create-pr.sh --title TEXT --body-file FILE [--draft]
+```
+
+Flags:
+
+- `--title TEXT` (required) — PR title. Recommended under 70 characters; not enforced.
+- `--body-file FILE` (required) — path to a markdown file containing the PR body. File must exist; checked at startup. Forwarded verbatim to `gh pr create --body-file` on the new-PR path; ignored on the existing-PR fast-path (existing PR body is not updated by this script — see `gh-pr-body-update.sh` for that operation).
+- `--draft` (optional, no value) — pass `--draft` to `gh pr create` so a fresh PR is opened in draft state. Has no effect on the existing-PR fast-path (an already-open PR's draft state is not changed).
+
+## Output contract (KEY=value on stdout)
+
+### Success (both paths)
+
+```
+PR_NUMBER=<integer>
+PR_URL=<full GitHub PR URL>
+PR_TITLE=<title text>
+PR_STATUS=created|existing
+```
+
+`PR_STATUS=created` indicates a fresh PR was opened by this run. `PR_STATUS=existing` indicates an OPEN PR was already present and the script only synced the branch tip.
+
+### Failure
+
+Failure is signalled exclusively via non-zero exit code + a human-readable `ERROR:` message on stderr. The script does NOT emit failure key=value lines on stdout — `/implement` Step 9b's parser detects failure by exit code.
+
+## Exit codes
+
+| Exit | Meaning |
+|------|---------|
+| 0    | PR created or pre-existing PR detected; remote branch confirmed up-to-date with local. |
+| 1    | Push failed. Either path: stderr carries the underlying git rejection. |
+| 2    | Argument validation failed, branch detection failed (detached HEAD), `gh pr create` failed, or PR number/URL extraction failed. |
+
+## Existing-PR fast-path push semantics (issue #837)
+
+On the existing-PR fast-path, the script attempts a plain `git push -u origin HEAD` first. If the plain push succeeds (fast-forward or no-op), the script proceeds to emit the `PR_*` lines and exits 0.
+
+If the plain push fails (commonly non-fast-forward after a history rewrite — e.g., `/implement` Step 12's rebase + re-bump path), the script escalates to `git-force-push.sh` (force-with-lease + race-recovery + single retry). Before invoking the helper, the script defensively populates the local `origin/$BRANCH` ref via `git fetch origin "$BRANCH"` and sets upstream tracking via `git branch --set-upstream-to=origin/$BRANCH "$BRANCH"`, since `git-force-push.sh`'s `git push --force-with-lease` (no refspec) requires both. If the helper exits non-zero (`STATUS=diverged_retry_failed` — diverged history that lease cannot reconcile), this script exits 1 with the helper's stderr surfaced. The helper's stdout (`BRANCH=`/`PUSHED=`/`STATUS=` keys) is suppressed to `/dev/null` so the documented `PR_*` stdout contract this script publishes stays intact.
+
+Prior to the #837 fix, the fast-path's push line read `git push -u origin HEAD >/dev/null 2>&1 || true`, silently swallowing every push failure (non-fast-forward, lease failures, network errors). That violated the documented exit-1-on-push-failure contract on this path and caused `/implement` to emit `PR_STATUS=existing` while origin's branch tip was actually stale. The current fail-closed behavior is the documented contract.
+
+## New-PR path push semantics
+
+The new-PR path uses plain `git push -u origin HEAD` (no force semantics) — the branch is freshly named and origin has no prior tip on it, so there is no lease scenario to consider. Push failure exits 1 with stderr surfaced.
+
+## Exit-code parity invariant
+
+Both paths surface push failure as exit 1 with stderr, and both paths surface success as exit 0 with the four `PR_*` keys on stdout. Callers depend on this parity — `/implement` Step 9b runs the same parser regardless of `PR_STATUS=created|existing`.
+
+## Sibling files
+
+- `scripts/git-force-push.sh` — invoked on the existing-PR fast-path's escalation branch.
+- `scripts/gh-pr-body-update.sh` — used by `/implement` Step 9b to update an existing PR's body when `PR_STATUS=existing` (since this script does not update the body of pre-existing PRs).
+
+## Test harness
+
+No dedicated test harness today. Real-world coverage comes from `/implement`'s continuous CI execution: the existing-PR fast-path runs on every PR resumption / CI-rebase iteration; the new-PR path runs on every initial PR creation. Issue #837's plan review surfaced this gap (FINDING_7) but the panel exonerated adding a hermetic harness as out of scope for the bug fix.
+
+## Edit-in-sync rules
+
+When changing `scripts/create-pr.sh`:
+
+- Update this file (`scripts/create-pr.md`) in the same PR if any of the following changes:
+  - Stdout contract (`PR_*` keys, format).
+  - Exit code semantics.
+  - Push semantics on either path (especially the existing-PR fast-path's escalation policy).
+  - The set of CLI flags or their defaults.
+- Verify `/implement` Step 9b's parser in `skills/implement/SKILL.md` still parses the four `PR_*` keys and continues to abort on non-zero exit.
+- Verify the helper invocation path (`$SCRIPT_DIR/git-force-push.sh`) is robust to the caller's CWD — `SCRIPT_DIR` is derived once at the top of the script.

--- a/scripts/create-pr.sh
+++ b/scripts/create-pr.sh
@@ -25,6 +25,8 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
 usage() { echo "Usage: create-pr.sh --title TEXT --body-file FILE [--draft]" >&2; }
 
 TITLE=""
@@ -65,8 +67,30 @@ if [[ -n "$EXISTING_PR" ]]; then
         PR_NUMBER=$(echo "$EXISTING_PR" | jq -r '.number // empty' 2>/dev/null || echo "")
         PR_URL=$(echo "$EXISTING_PR" | jq -r '.url // empty' 2>/dev/null || echo "")
         if [[ -n "$PR_NUMBER" ]] && [[ -n "$PR_URL" ]]; then
-            # Push any new local commits before returning
-            git push -u origin HEAD >/dev/null 2>&1 || true
+            # Push any new local commits before returning. Fail closed on real
+            # push errors rather than swallowing them — a stale remote on an
+            # OPEN PR is exactly the silent-failure mode this branch must avoid.
+            PUSH_STDERR=$(mktemp)
+            trap 'rm -f "$PUSH_STDERR"' EXIT
+            if git push -u origin HEAD >/dev/null 2>"$PUSH_STDERR"; then
+                : # plain push succeeded (fast-forward or already-in-sync)
+            else
+                # Plain push failed — commonly non-fast-forward after history
+                # rewrite (e.g., /implement Step 12 rebase + re-bump). Escalate
+                # to force-with-lease via the shared helper, which encodes
+                # lease + race-recovery + single retry.
+                # The helper does `git push --force-with-lease` with no refspec
+                # and requires upstream tracking + a populated origin/$BRANCH ref:
+                git fetch origin "$BRANCH" 2>/dev/null || true
+                git branch --set-upstream-to="origin/$BRANCH" "$BRANCH" >/dev/null 2>&1 || true
+                # Suppress helper stdout (BRANCH=/PUSHED=/STATUS= keys) so the
+                # PR_* stdout contract this script publishes stays intact;
+                # capture helper stderr to surface on real failure.
+                if ! "$SCRIPT_DIR/git-force-push.sh" >/dev/null 2>>"$PUSH_STDERR"; then
+                    echo "ERROR: Failed to push branch on existing-PR fast-path: $(cat "$PUSH_STDERR")" >&2
+                    exit 1
+                fi
+            fi
             # Fetch the existing PR title
             PR_TITLE=$(echo "$EXISTING_PR" | jq -r '.title // empty' 2>/dev/null || echo "")
             if [[ -z "$PR_TITLE" ]]; then


### PR DESCRIPTION
## Summary
- Replaced the silent-swallow `git push -u origin HEAD >/dev/null 2>&1 || true` at `scripts/create-pr.sh:69` with a plain-push-first / force-with-lease-fallback strategy that surfaces real push failures via exit 1, mirroring the new-PR path's exit-1 channel (lines 88-91).
- Plain push handles the routine fast-forward case; on non-fast-forward (commonly after `/implement` Step 12 rebase + re-bump), escalation delegates to the existing `scripts/git-force-push.sh` for lease + fetch + race-recovery + single retry. Helper stdout is suppressed so the documented `PR_*` stdout contract stays intact.
- Added sibling `scripts/create-pr.md` per AGENTS.md "Per-script contracts live beside the script". `scripts/git-force-push.sh` and the new-PR path at line 88 are not modified.

<details><summary>Architecture Diagram</summary>

```mermaid
flowchart TD
    Caller["/implement Step 9b<br/>(or operator)"] --> CreatePR[scripts/create-pr.sh]
    CreatePR --> CheckPR{gh pr view<br/>finds OPEN PR?}
    CheckPR -- "yes" --> FastPath[Existing-PR Fast-Path<br/>lines 64-103]
    CheckPR -- "no" --> NewPath[New-PR Path<br/>lines 108-135]

    FastPath --> PlainPush["git push -u origin HEAD<br/>capture stderr"]
    PlainPush -- "exit 0" --> EmitPR["Emit PR_NUMBER/PR_URL/<br/>PR_TITLE/PR_STATUS=existing<br/>exit 0"]
    PlainPush -- "exit ≠ 0" --> Escalate[Escalation block]
    Escalate --> Fetch["git fetch origin BRANCH<br/>or true"]
    Fetch --> SetUpstream["git branch --set-upstream-to<br/>or true"]
    SetUpstream --> Helper["git-force-push.sh<br/>stdout → /dev/null<br/>stderr → PUSH_STDERR"]
    Helper -- "exit 0<br/>(STATUS=pushed or noop_same_ref)" --> EmitPR
    Helper -- "exit 1<br/>(STATUS=diverged_retry_failed)" --> SurfaceErr["Echo PUSH_STDERR to stderr<br/>exit 1"]

    NewPath --> NewPush["git push -u origin HEAD<br/>(line 112)<br/>exit 1 on failure"]
    NewPush --> GhCreate["gh pr create<br/>exit 2 on failure"]
    GhCreate --> EmitPRCreated["Emit PR_NUMBER/PR_URL/<br/>PR_TITLE/PR_STATUS=created<br/>exit 0"]

    classDef changed fill:#fef3c7,stroke:#d97706,color:#000
    classDef unchanged fill:#dbeafe,stroke:#2563eb,color:#000
    classDef boundary fill:#fce7f3,stroke:#be185d,color:#000

    class FastPath,PlainPush,Escalate,Fetch,SetUpstream,Helper,SurfaceErr changed
    class NewPath,NewPush,GhCreate,EmitPRCreated unchanged
    class CreatePR,Caller,EmitPR boundary
```

</details>

<details><summary>Code Flow Diagram</summary>

```mermaid
sequenceDiagram
    participant C as Caller<br/>(/implement Step 9b)
    participant CP as create-pr.sh
    participant Git as git
    participant FP as git-force-push.sh
    participant Origin as origin

    C->>CP: invoke --title --body-file
    CP->>CP: SCRIPT_DIR=$(cd $(dirname BASH_SOURCE) && pwd)
    CP->>Git: gh pr view --json
    Git-->>CP: EXISTING_PR (or empty)

    alt EXISTING_PR.state == "OPEN" AND PR_NUMBER/URL non-empty
        Note over CP: Existing-PR fast-path<br/>(lines 64-103)
        CP->>CP: PUSH_STDERR=$(mktemp); trap rm EXIT
        CP->>Git: git push -u origin HEAD<br/>2>PUSH_STDERR
        alt plain push success
            Git-->>CP: exit 0
            Note over CP: : (no-op; success)
        else plain push fails (e.g. non-FF after rebase)
            Git-->>CP: exit ≠ 0
            CP->>Origin: git fetch origin $BRANCH<br/>(|| true — best-effort)
            CP->>Git: git branch --set-upstream-to=origin/$BRANCH<br/>(|| true — best-effort)
            CP->>FP: $SCRIPT_DIR/git-force-push.sh<br/>stdout→/dev/null<br/>stderr→PUSH_STDERR
            FP->>Origin: git push --force-with-lease
            alt lease OK / noop_same_ref
                FP-->>CP: exit 0<br/>(STATUS=pushed or noop_same_ref<br/>suppressed on stdout)
            else lease fails / diverged_retry_failed
                FP-->>CP: exit 1
                CP->>C: echo ERROR: <PUSH_STDERR><br/>to stderr; exit 1
            end
        end
        CP->>Git: gh pr view --json title<br/>(if PR_TITLE empty)
        CP->>C: echo PR_NUMBER/PR_URL/<br/>PR_TITLE/PR_STATUS=existing<br/>exit 0
    else no existing OPEN PR
        Note over CP: New-PR path<br/>(lines 108-135, unchanged)
        CP->>CP: PUSH_STDERR=$(mktemp); trap rm EXIT
        CP->>Origin: git push -u origin HEAD
        alt push success
            CP->>Origin: gh pr create --title --body-file
            Origin-->>CP: PR URL
            CP->>C: echo PR_NUMBER/PR_URL/<br/>PR_TITLE/PR_STATUS=created<br/>exit 0
        else push fails
            CP->>C: ERROR; exit 1
        end
    end
```

</details>

<details><summary>Test plan</summary>

- [x] Pre-commit + agent-lint pass (`/relevant-checks` clean).
- [ ] Manual: stage a branch with an open PR; add a local commit; run `create-pr.sh --title X --body-file Y`; verify the new commit lands on origin and `PR_STATUS=existing` prints, exit 0.
- [ ] Manual: stage a branch where local has rewritten history (`git commit --amend`) but origin has the older history; run `create-pr.sh`; verify the helper's force-with-lease path engages and origin is updated to the new history.
- [ ] Manual: stage a branch with diverged remote and unsynced local; run `create-pr.sh`; verify exit 1 with git's raw rejection message reaching stderr.
- [x] Indirect: `/implement` exercises this code path on every PR creation; the green CI for this PR's own merge is a real-world test.

</details>

Closes #837

Generated with [Claude Code](https://claude.com/claude-code)
