### PR TITLE
Fix #859: remove redundant 2>&2 on ci-decide.sh invocation

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.17.51",
+  "version": "7.17.52",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/scripts/ci-wait.sh
+++ b/scripts/ci-wait.sh
@@ -195,7 +195,7 @@ while true; do
         --behind "$BEHIND_COUNT" \
         --iteration "$ITERATION" \
         --rebase-count "$REBASE_COUNT" \
-        --fix-attempts "$FIX_ATTEMPTS" 2>&2)
+        --fix-attempts "$FIX_ATTEMPTS")
     DECIDE_EXIT=$?
 
     if [[ "$DECIDE_EXIT" -ne 0 ]]; then


### PR DESCRIPTION
## Summary
- Removed the redundant `2>&2` redirect on the `ci-decide.sh` invocation in `scripts/ci-wait.sh:198`, which was a no-op (stderr-to-stderr) and misleading

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] Verified `2>&2` is removed from line 198
- [x] `/relevant-checks` passes (shellcheck, agent-lint)
- [x] Cursor code review confirms no behavioral change

</details>

Closes #859

Generated with [Claude Code](https://claude.com/claude-code)
