### PR TITLE
Fix #866: sync Claude settings docs with actual settings.json

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.17.55",
+  "version": "7.17.56",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `scripts/git-force-push.md` — sibling contract document for `scripts/git-force-push.sh`, documenting the stdout contract (`BRANCH`, `PUSHED`, `STATUS`), exit codes, callers, dependencies, and edit-in-sync rules per the AGENTS.md "Per-script contracts live beside the script" convention.
 
+### Fixed
+
+- `docs/installation-and-setup.md` — updated the `### Claude` settings snippet to match actual `~/.claude/settings.json` values: effort level `high` (was `xhigh`), model `claude-opus-4-6` (was `opus`).
+
 ## [7.17.51] - 2026-04-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.17.56] - 2026-04-27
+
+### Fixed
+
+- `docs/installation-and-setup.md` — updated the `### Claude` settings snippet to match actual `~/.claude/settings.json` values: effort level `high` (was `xhigh`), model `claude-opus-4-6` (was `opus`).
+
 ## [7.17.54] - 2026-04-27
 
 ### Added
 
 - `scripts/git-force-push.md` — sibling contract document for `scripts/git-force-push.sh`, documenting the stdout contract (`BRANCH`, `PUSHED`, `STATUS`), exit codes, callers, dependencies, and edit-in-sync rules per the AGENTS.md "Per-script contracts live beside the script" convention.
-
-### Fixed
-
-- `docs/installation-and-setup.md` — updated the `### Claude` settings snippet to match actual `~/.claude/settings.json` values: effort level `high` (was `xhigh`), model `claude-opus-4-6` (was `opus`).
 
 ## [7.17.51] - 2026-04-27
 

--- a/docs/installation-and-setup.md
+++ b/docs/installation-and-setup.md
@@ -44,9 +44,9 @@ claude plugin install larch@larch-local
 - Add/edit the following in `~/.claude/settings.json` (remember to replace `<your-API-key>` with actual value):
 ```JSON
   "env": {
-    "CLAUDE_CODE_EFFORT_LEVEL": "xhigh",
+    "CLAUDE_CODE_EFFORT_LEVEL": "high"
   },
-  "model": "opus",
+  "model": "claude-opus-4-6",
 ```
 - Install claude code: `curl -fsSL https://claude.ai/install.sh | bash`
 - Run `claude` and verify the above settings


### PR DESCRIPTION
## Summary
- Updated `docs/installation-and-setup.md` Claude settings snippet to match actual `~/.claude/settings.json` values: effort level `high` (was `xhigh`), model `claude-opus-4-6` (was `opus`).

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] Verify JSON snippet values match `~/.claude/settings.json`
- [x] Run `/relevant-checks` — all linters pass

</details>

Closes #866

Generated with [Claude Code](https://claude.com/claude-code)
