### PR TITLE
Fix #862: setsid re-exec forwards original argv instead of hardcoded flag list

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "7.17.54",
+  "version": "7.17.55",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/skills/research/scripts/test-validate-citations.sh
+++ b/skills/research/scripts/test-validate-citations.sh
@@ -441,7 +441,7 @@ See https://example-hang.invalid/page1 and https://example-hang.invalid/page2.
 REPORT
             # Hermetic clean-bin: symlink common tools into a directory that
             # explicitly omits `setsid`. PATH=$CLEAN_BIN forces the
-            # validator's `command -v setsid` check (validate-citations.sh:665)
+            # validator's `command -v setsid` check (validate-citations.sh:669)
             # to fail so it takes the no-setsid Linux branch (the production
             # scenario under test). Directory-stripping `/usr/bin` is unsafe
             # on merged-/usr distros (would also remove grep/awk/etc.).
@@ -505,7 +505,7 @@ FAKEEOF
             # any leaked marker from the parent environment that would
             # otherwise route the validator into the unsafe kill branch.
             # PATH=$CLEAN_BIN strips setsid from the validator's own PATH so
-            # `command -v setsid` at :665 fails (the production no-setsid
+            # `command -v setsid` at :669 fails (the production no-setsid
             # scenario under test). The setsid binary used by the outer
             # wrapper is resolved from the runner's PATH (not the clean-bin).
             __VC_FAKE_CURL="$FAKE_CURL_PIDREC" __VC_LAST_ARGV="$ARGV_LOG" \

--- a/skills/research/scripts/validate-citations.md
+++ b/skills/research/scripts/validate-citations.md
@@ -154,11 +154,13 @@ must be terminated cleanly. OS-specific:
 
 - **Linux**: when `setsid` is available, `setsid` puts curl children in
   the script's session. The script self-execs into a new session if not
-  already a session leader; `__VC_SETSID_DONE=1` is exported just before
-  the `exec setsid` so the re-exec'd child inherits it (idempotency guard
-  preventing infinite recursion) AND so the budget-exhaustion handler can
-  use it as a "running in dedicated session" signal. A single `kill -- -$$`
-  then signals every descendant. When `setsid` is unavailable, the re-exec
+  already a session leader, forwarding the original argv via a saved
+  `__vc_orig_args` array (so new flags added to the parser are
+  automatically included in the re-exec). `__VC_SETSID_DONE=1` is
+  exported just before the `exec setsid` so the re-exec'd child inherits
+  it (idempotency guard preventing infinite recursion) AND so the
+  budget-exhaustion handler can use it as a "running in dedicated session"
+  signal. A single `kill -- -$$` then signals every descendant. When `setsid` is unavailable, the re-exec
   is skipped, `__VC_SETSID_DONE` stays unset, and the budget-exhaustion
   handler falls back to per-PID `kill "$pid"` over `CURL_PIDS` — the
   validator runs in its caller's process group on this branch, so

--- a/skills/research/scripts/validate-citations.sh
+++ b/skills/research/scripts/validate-citations.sh
@@ -123,6 +123,10 @@ __VC_STUB_RESOLVE="${__VC_STUB_RESOLVE:-}"
 # assert claim parsing without making any network call.
 __VC_DRY_RUN="${__VC_DRY_RUN:-}"
 
+# Preserve original argv for the Linux setsid re-exec below (the while
+# loop consumes $@ via shift).
+__vc_orig_args=("$@")
+
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --report) REPORT="${2:?--report requires a value}"; shift 2 ;;
@@ -672,11 +676,7 @@ case "$(uname -s 2>/dev/null)" in
                 # carry the marker without actually being in its own session.
                 export __VC_SETSID_DONE=1
                 # Re-exec under setsid so curl children share our session.
-                exec setsid -w "$0" \
-                    --report "$REPORT" --output "$OUTPUT" --tmpdir "$TMPDIR" \
-                    --budget-seconds "$BUDGET_SECONDS" \
-                    --per-fetch-timeout "$PER_FETCH_TIMEOUT" \
-                    --max-claims "$MAX_CLAIMS"
+                exec setsid -w "$0" "${__vc_orig_args[@]}"
             fi
         fi
         ;;


### PR DESCRIPTION
## Summary
- Replaced hardcoded flag list in validate-citations.sh's Linux setsid re-exec with original-argv forwarding via a saved `__vc_orig_args` array, eliminating the latent flag-drift bug where new flags would be silently dropped on re-exec
- Updated stale line-number references in test harness comments (`:665` → `:669`) and the sibling contract doc to reflect the argv-preservation approach

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] `/relevant-checks` passes (shellcheck, markdownlint, agent-lint)
- [x] Existing test harness (`test-validate-citations.sh`) passes — exercises argument parsing and setsid paths
- [x] Verify `__vc_orig_args` is saved before the `while` loop consumes `$@`
- [x] Verify the setsid re-exec uses `"${__vc_orig_args[@]}"` instead of the hardcoded flag list

</details>

Closes #862

Generated with [Claude Code](https://claude.com/claude-code)
