### PR TITLE
Remove stale loop-fix-issue refs from agent-lint.toml

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "12.0.0",
+  "version": "12.0.1",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [12.0.1] - 2026-04-28
+
+### Removed
+
+- Stale `loop-fix-issue` test harness exclusion entry from `agent-lint.toml` (leftover from `/loop-fix-issue` deletion in PR #879).
+
 ## [11.0.0] - 2026-04-28
 
 ### Removed

--- a/agent-lint.toml
+++ b/agent-lint.toml
@@ -379,22 +379,6 @@ exclude = [
   # test-* harnesses above.
   "skills/research/scripts/test-classify-research-scale.sh",
   "scripts/test-anti-halt-banners.sh",
-  # scripts/test-loop-fix-issue-driver-behavior.sh is the Tier-2 NDJSON
-  # behavior fixture for skills/loop-fix-issue/scripts/driver.sh (companion
-  # to scripts/test-loop-fix-issue-driver.sh, which is the Tier-1 structural
-  # harness — already structurally referenced via the existing test-* pattern
-  # below). The behavior fixture exercises the live driver against canned
-  # NDJSON via LARCH_LOOP_FIX_ISSUE_CLAUDE_OVERRIDE plus a stub plugin tree
-  # (override CLAUDE_PLUGIN_ROOT to a tmpdir with stub session-setup.sh and
-  # cleanup-tmpdir.sh) and a PATH-mocked gh. Three scenarios: success
-  # (sentinel detected on iter 1, no-eligible on iter 2), no-eligible
-  # (clean exit on iter 1), and no-sentinel (defensive-fallback halts loop,
-  # retains LOOP_TMPDIR). Referenced only from Makefile
-  # (test-loop-fix-issue-driver-behavior target) and
-  # scripts/test-loop-fix-issue-driver-behavior.md (sibling contract),
-  # matching the same Makefile-only pattern as the other test-* harnesses
-  # above.
-  "scripts/test-loop-fix-issue-driver-behavior.sh",
   # scripts/test-alias-target-resolution.sh is the regression harness for
   # skills/alias/scripts/resolve-target.sh (closes the alias target-routing
   # rework — adds plugin-repo detection + --private flag). Referenced only


### PR DESCRIPTION
## Summary
- Removed stale `loop-fix-issue` test harness exclusion entry (16-line comment block + string) from `agent-lint.toml`, left behind when `/loop-fix-issue` was deleted in PR #879

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [ ] Verify `grep loop-fix-issue agent-lint.toml` returns no matches
- [ ] Verify agent-lint passes (TOML valid, no dangling references)
- [ ] Verify CI passes

</details>

Closes #899

Generated with [Claude Code](https://claude.com/claude-code)
