### PR TITLE
Add /combine-issues skill for merging related GitHub issues

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "11.0.0",
+  "version": "12.0.0",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/.claude/skills/combine-issues/SKILL.md
+++ b/.claude/skills/combine-issues/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: combine-issues
+description: "Use when asked to try to combine existing issue to reduce issue count.  Examine all open issues that are not currently being worked on, and see if any number of them can be combined into one issue (closing the source issues afterwords), in order to save tokens / reduce the number of tasks to do.  Good candidated would be issues that either work in the same code area, or that apply very similar changes to different code areas, but think of other criteria that it would be appropriate as well.  Again, the primary goal is to reduce the tokens spent on executing unnecessarily fine-grained tasks."
+argument-hint: "[--dry-run]"
+allowed-tools: Bash, Read, Write
+---
+
+# Combine Issues
+
+Reduce open issue count by merging related issues into combined ones. The primary goal is saving tokens — fewer, broader issues mean fewer `/fix-issue` invocations and less duplicated context loading.
+
+## When to Combine
+
+Good candidates share at least one of:
+
+- **Same code area** — multiple issues touching the same file(s) or module.
+- **Similar change pattern** — issues applying analogous edits to different files (e.g., "add error handling to script A" + "add error handling to script B").
+- **Overlapping scope** — one issue is a subset of another, or both contribute to the same goal.
+- **Sequential dependency** — issues that must land in order and are small enough to ship as one unit.
+
+Do NOT combine issues that are genuinely independent and benefit from separate review (e.g., a bug fix and an unrelated feature).
+
+## Step 1 — Fetch Eligible Issues
+
+```bash
+$PWD/.claude/skills/combine-issues/scripts/fetch-combinable-issues.sh
+```
+
+Parse `ISSUES_FILE` and `COUNT` from stdout. If `COUNT=0`, print `No open issues eligible for combination.` and stop.
+
+Read the JSON file at `$ISSUES_FILE` to get the full issue list (number, title, body, labels).
+
+## Step 2 — Analyze and Propose Groups
+
+Read each issue's title and body. Identify groups of 2+ issues that meet the combination criteria above. For each proposed group:
+
+1. List the source issue numbers and titles.
+2. State the combination rationale (which criterion from "When to Combine" applies).
+3. Draft a combined title and a combined body that preserves all actionable content from the source issues.
+
+Present all proposed groups to the user in a numbered list. If no groups are identified, print `No combination candidates found among <COUNT> open issues.` and stop.
+
+Ask the user which groups to apply (e.g., "all", "1,3", or "none").
+
+## Step 3 — Apply Approved Combinations
+
+For each approved group, write the combined body to a temp file, then invoke:
+
+```bash
+$PWD/.claude/skills/combine-issues/scripts/apply-combination.sh \
+  --title "<combined title>" \
+  --body-file "<temp-file>" \
+  --source-issues "<comma-separated issue numbers>"
+```
+
+Parse `COMBINED_ISSUE` and `CLOSED_ISSUES` from stdout. Print a summary line per group: `Combined #X, #Y, #Z → #<new> (<N> issues closed)`.
+
+After all groups are applied, print a final tally: `Done — <N> issues combined into <M>, net reduction: <N-M>`.
+
+## Anti-patterns
+
+- **NEVER combine issues without user confirmation.** The analysis is advisory; the user decides which groups to merge. Combining the wrong issues loses important context that is hard to recover.
+- **NEVER combine an issue that has an `[IN PROGRESS]`, `[STALLED]`, or `[DONE]` title prefix.** The fetch script filters these out, but if one slips through (e.g., prefix applied after fetch), skip it and warn.
+- **NEVER discard actionable content from source issues.** The combined body must preserve every concrete task, file reference, and reproduction step from the originals. Summarizing away specifics defeats the purpose.

--- a/.claude/skills/combine-issues/scripts/apply-combination.sh
+++ b/.claude/skills/combine-issues/scripts/apply-combination.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Create a combined issue and close the source issues.
+#
+# Required flags:
+#   --title <title>         Title for the combined issue.
+#   --body-file <path>      Path to a file containing the combined issue body.
+#   --source-issues <list>  Comma-separated issue numbers to close (e.g. "12,34,56").
+#
+# Optional flags:
+#   --repo <owner/name>     Repository. Auto-detected if omitted.
+#   --dry-run               Print what would happen without making changes.
+#
+# Output on stdout:
+#   COMBINED_ISSUE=<number>
+#   CLOSED_ISSUES=<count>
+#   DRY_RUN=true|false
+# On failure: ERROR=<message> on stderr, exit 1.
+
+set -euo pipefail
+
+TITLE=""
+BODY_FILE=""
+SOURCE_ISSUES=""
+REPO=""
+DRY_RUN=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --title)         TITLE="$2";         shift 2 ;;
+    --body-file)     BODY_FILE="$2";     shift 2 ;;
+    --source-issues) SOURCE_ISSUES="$2"; shift 2 ;;
+    --repo)          REPO="$2";          shift 2 ;;
+    --dry-run)       DRY_RUN=true;       shift ;;
+    *)
+      echo "ERROR=Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$TITLE" ]]; then
+  echo "ERROR=Missing --title" >&2
+  exit 1
+fi
+if [[ -z "$BODY_FILE" || ! -r "$BODY_FILE" ]]; then
+  echo "ERROR=Missing or unreadable --body-file: $BODY_FILE" >&2
+  exit 1
+fi
+if [[ -z "$SOURCE_ISSUES" ]]; then
+  echo "ERROR=Missing --source-issues" >&2
+  exit 1
+fi
+
+if [[ -z "$REPO" ]]; then
+  REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null) || true
+  if [[ -z "$REPO" ]]; then
+    echo "ERROR=Could not determine repository" >&2
+    exit 1
+  fi
+fi
+
+IFS=',' read -ra ISSUES <<< "$SOURCE_ISSUES"
+
+if [[ "$DRY_RUN" == "true" ]]; then
+  echo "DRY_RUN=true"
+  echo "WOULD_CREATE=$TITLE"
+  echo "WOULD_CLOSE=${#ISSUES[@]} issues: ${SOURCE_ISSUES}"
+  exit 0
+fi
+
+COMBINED_NUMBER=$(gh issue create --repo "$REPO" --title "$TITLE" --body-file "$BODY_FILE" 2>/dev/null \
+  | grep -oE '[0-9]+$') || {
+  echo "ERROR=Failed to create combined issue" >&2
+  exit 1
+}
+
+CLOSED=0
+for issue_num in "${ISSUES[@]}"; do
+  issue_num=$(echo "$issue_num" | tr -d ' ')
+  if gh issue close "$issue_num" --repo "$REPO" \
+    --comment "Combined into #${COMBINED_NUMBER}" 2>/dev/null; then
+    CLOSED=$((CLOSED + 1))
+  fi
+done
+
+echo "DRY_RUN=false"
+echo "COMBINED_ISSUE=$COMBINED_NUMBER"
+echo "CLOSED_ISSUES=$CLOSED"

--- a/.claude/skills/combine-issues/scripts/apply-combination.sh
+++ b/.claude/skills/combine-issues/scripts/apply-combination.sh
@@ -18,6 +18,10 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_ROOT="$(cd "$SCRIPT_DIR/../../../../" && pwd)"
+REDACT="$PLUGIN_ROOT/scripts/redact-secrets.sh"
+
 TITLE=""
 BODY_FILE=""
 SOURCE_ISSUES=""
@@ -68,20 +72,42 @@ if [[ "$DRY_RUN" == "true" ]]; then
   exit 0
 fi
 
-COMBINED_NUMBER=$(gh issue create --repo "$REPO" --title "$TITLE" --body-file "$BODY_FILE" 2>/dev/null \
-  | grep -oE '[0-9]+$') || {
-  echo "ERROR=Failed to create combined issue" >&2
+REDACTED_TITLE="$TITLE"
+REDACTED_BODY_FILE="$BODY_FILE"
+if [[ -x "$REDACT" ]]; then
+  REDACTED_TITLE=$("$REDACT" <<< "$TITLE")
+  REDACTED_BODY_FILE=$(mktemp /tmp/combine-redacted-XXXXXX)
+  "$REDACT" < "$BODY_FILE" > "$REDACTED_BODY_FILE"
+fi
+
+CREATE_OUT=$(gh issue create --repo "$REPO" \
+  --title "$REDACTED_TITLE" \
+  --body-file "$REDACTED_BODY_FILE" 2>&1) || {
+  echo "ERROR=Failed to create combined issue: $CREATE_OUT" >&2
   exit 1
 }
 
+COMBINED_NUMBER=$(echo "$CREATE_OUT" | grep -oE '/issues/[0-9]+' | grep -oE '[0-9]+' | tail -1) || true
+if [[ -z "$COMBINED_NUMBER" ]]; then
+  echo "ERROR=Could not parse issue number from gh output: $CREATE_OUT" >&2
+  exit 1
+fi
+
 CLOSED=0
+CLOSE_ERRORS=""
 for issue_num in "${ISSUES[@]}"; do
   issue_num=$(echo "$issue_num" | tr -d ' ')
-  if gh issue close "$issue_num" --repo "$REPO" \
-    --comment "Combined into #${COMBINED_NUMBER}" 2>/dev/null; then
+  if CLOSE_ERR=$(gh issue close "$issue_num" --repo "$REPO" \
+    --comment "Combined into #${COMBINED_NUMBER}" 2>&1); then
     CLOSED=$((CLOSED + 1))
+  else
+    CLOSE_ERRORS="${CLOSE_ERRORS}Failed to close #${issue_num}: ${CLOSE_ERR}; "
   fi
 done
+
+if [[ -n "$CLOSE_ERRORS" ]]; then
+  echo "WARNING=${CLOSE_ERRORS}" >&2
+fi
 
 echo "DRY_RUN=false"
 echo "COMBINED_ISSUE=$COMBINED_NUMBER"

--- a/.claude/skills/combine-issues/scripts/fetch-combinable-issues.sh
+++ b/.claude/skills/combine-issues/scripts/fetch-combinable-issues.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Fetch open GitHub issues eligible for combination.
+# Excludes issues with managed title prefixes ([IN PROGRESS], [STALLED], [DONE]).
+#
+# Output on stdout: ISSUES_FILE=<path> and COUNT=<n>.
+# On failure: ERROR=<message> on stderr, exit 1.
+
+set -euo pipefail
+
+REPO=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo) REPO="$2"; shift 2 ;;
+    *)
+      echo "ERROR=Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$REPO" ]]; then
+  REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null) || true
+  if [[ -z "$REPO" ]]; then
+    echo "ERROR=Could not determine repository" >&2
+    exit 1
+  fi
+fi
+
+RAW=$(gh issue list --repo "$REPO" --state open --limit 200 \
+  --json number,title,body,labels 2>/dev/null) || {
+  echo "ERROR=Failed to fetch issues from $REPO" >&2
+  exit 1
+}
+
+if [[ -z "$RAW" || "$RAW" == "[]" ]]; then
+  TMPFILE=$(mktemp /tmp/combine-issues-XXXXXX.json)
+  echo "[]" > "$TMPFILE"
+  echo "ISSUES_FILE=$TMPFILE"
+  echo "COUNT=0"
+  exit 0
+fi
+
+FILTERED=$(echo "$RAW" | jq '[
+  .[] |
+  select(
+    (.title | test("^\\[(IN PROGRESS|STALLED|DONE)\\] ") | not) and
+    (.title | test("^\\[LOCKED\\]") | not)
+  )
+]')
+
+TMPFILE=$(mktemp /tmp/combine-issues-XXXXXX.json)
+echo "$FILTERED" > "$TMPFILE"
+COUNT=$(echo "$FILTERED" | jq 'length')
+
+echo "ISSUES_FILE=$TMPFILE"
+echo "COUNT=$COUNT"

--- a/.claude/skills/combine-issues/scripts/fetch-combinable-issues.sh
+++ b/.claude/skills/combine-issues/scripts/fetch-combinable-issues.sh
@@ -34,7 +34,7 @@ RAW=$(gh issue list --repo "$REPO" --state open --limit 200 \
 }
 
 if [[ -z "$RAW" || "$RAW" == "[]" ]]; then
-  TMPFILE=$(mktemp /tmp/combine-issues-XXXXXX.json)
+  TMPFILE=$(mktemp /tmp/combine-issues-XXXXXX)
   echo "[]" > "$TMPFILE"
   echo "ISSUES_FILE=$TMPFILE"
   echo "COUNT=0"
@@ -49,7 +49,7 @@ FILTERED=$(echo "$RAW" | jq '[
   )
 ]')
 
-TMPFILE=$(mktemp /tmp/combine-issues-XXXXXX.json)
+TMPFILE=$(mktemp /tmp/combine-issues-XXXXXX)
 echo "$FILTERED" > "$TMPFILE"
 COUNT=$(echo "$FILTERED" | jq 'length')
 


### PR DESCRIPTION
## Summary
- Added `/combine-issues` dev skill that examines open GitHub issues, identifies groups that can be combined, and merges them with user confirmation
- Created `fetch-combinable-issues.sh` (filters out managed-prefix issues) and `apply-combination.sh` (creates combined issue, closes sources with backlink, applies secret redaction)

<details><summary>Architecture Diagram</summary>

```mermaid
flowchart TD
    U[User invokes /combine-issues] --> S1[Step 1: fetch-combinable-issues.sh]
    S1 --> |ISSUES_FILE + COUNT| S2[Step 2: LLM analyzes + proposes groups]
    S2 --> |User confirms| S3[Step 3: apply-combination.sh per group]
    S3 --> |Creates combined issue| GH[GitHub API]
    S3 --> |Closes source issues| GH
    GH --> R[Summary: net reduction tally]
```

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] `shellcheck` passes on both scripts
- [x] `markdownlint` passes on SKILL.md
- [x] `agent-lint` passes (full-repo structural check)
- [x] YAML frontmatter validates correctly
- [x] Pre-commit hooks all green

</details>

Closes #897

Generated with [Claude Code](https://claude.com/claude-code)
