### PR TITLE
Fix cursor-wrap-prompt.md printf format string

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "12.0.1",
+  "version": "12.0.2",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/scripts/cursor-wrap-prompt.md
+++ b/scripts/cursor-wrap-prompt.md
@@ -7,7 +7,7 @@
 - **Input**: exactly one positional argument — the raw prompt string.
 - **Output (stdout)**: <code>&nbsp;/max-mode on. Prompt: &lt;prompt&gt;</code> (leading `U+0020` space intentional, no trailing newline).
 - **Exit codes**: `0` on success; `1` if no argument supplied.
-- **Implementation**: `printf '%s'` (not `echo`) so the prompt content passes through literally without re-interpreting backslash escapes.
+- **Implementation**: `printf ' /max-mode on. Prompt: %s'` (not `echo`) so the prompt content passes through literally without re-interpreting backslash escapes.
 
 ## Why
 


### PR DESCRIPTION
## Summary
- Updated `scripts/cursor-wrap-prompt.md` Implementation line to quote the exact `printf` format string (`printf ' /max-mode on. Prompt: %s'`) used in `cursor-wrap-prompt.sh`, replacing the inaccurate `printf '%s'`

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] `/relevant-checks` passes (documentation-only change)
- [x] Verify the `.md` Implementation line now matches the actual `printf` format string in `cursor-wrap-prompt.sh:29`

</details>

Closes #886

Generated with [Claude Code](https://claude.com/claude-code)
