### PR TITLE
Validate strict OK sentinel in check-reviewers.sh health probe (#887)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "12.0.3",
+  "version": "12.0.4",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/scripts/check-reviewers.sh
+++ b/scripts/check-reviewers.sh
@@ -2,8 +2,10 @@
 # check-reviewers.sh — Check external reviewer binary availability and optional health probe.
 #
 # Checks if codex and cursor binaries are installed. With --probe, also sends a
-# trivial prompt to each available tool with a 60-second timeout to verify it is
-# actually responding (catches auth failures, network issues, outages).
+# trivial prompt ("Respond with OK") to each available tool with a 60-second
+# timeout and validates that the trimmed response is exactly "OK" (all whitespace
+# stripped). Catches auth failures, network issues, outages, and banner-style
+# responses that produce non-empty but non-OK output.
 # Failed probes are retried once to tolerate transient timeouts.
 #
 # Usage:
@@ -12,8 +14,8 @@
 # Outputs (key=value to stdout):
 #   CODEX_AVAILABLE=true|false    — binary exists on PATH
 #   CURSOR_AVAILABLE=true|false   — binary exists on PATH
-#   CODEX_HEALTHY=true|false      — (only with --probe) responded to trivial prompt within timeout
-#   CURSOR_HEALTHY=true|false     — (only with --probe) responded to trivial prompt within timeout
+#   CODEX_HEALTHY=true|false      — (only with --probe) exit 0 and trimmed output == "OK"
+#   CURSOR_HEALTHY=true|false     — (only with --probe) exit 0 and trimmed output == "OK"
 #
 # Exit codes:
 #   0 — always (availability/health are informational, not errors)
@@ -123,7 +125,7 @@ if [[ "$PROBE" == "true" ]]; then
                     if [[ "$CODEX_PROBE_REPLY" == "OK" ]]; then
                         CODEX_HEALTHY="true"
                     else
-                        CODEX_PROBE_ERROR="Probe returned non-OK response: $(head -c 200 "$PROBE_DIR/codex-probe.txt")"
+                        CODEX_PROBE_ERROR="Probe returned non-OK response: $(head -c 200 "$PROBE_DIR/codex-probe.txt" | tr '\n\r' '  ')"
                     fi
                 elif [[ -f "$PROBE_DIR/codex-probe.txt.diag" ]]; then
                     CODEX_PROBE_ERROR=$(cat "$PROBE_DIR/codex-probe.txt.diag")
@@ -152,7 +154,7 @@ if [[ "$PROBE" == "true" ]]; then
                     if [[ "$CURSOR_PROBE_REPLY" == "OK" ]]; then
                         CURSOR_HEALTHY="true"
                     else
-                        CURSOR_PROBE_ERROR="Probe returned non-OK response: $(head -c 200 "$PROBE_DIR/cursor-probe.txt")"
+                        CURSOR_PROBE_ERROR="Probe returned non-OK response: $(head -c 200 "$PROBE_DIR/cursor-probe.txt" | tr '\n\r' '  ')"
                     fi
                 elif [[ -f "$PROBE_DIR/cursor-probe.txt.diag" ]]; then
                     CURSOR_PROBE_ERROR=$(cat "$PROBE_DIR/cursor-probe.txt.diag")
@@ -233,7 +235,7 @@ if [[ "$PROBE" == "true" ]]; then
                         CODEX_HEALTHY="true"
                         CODEX_PROBE_ERROR=""
                     else
-                        CODEX_PROBE_ERROR="Retry returned non-OK response: $(head -c 200 "$PROBE_DIR/codex-probe.txt")"
+                        CODEX_PROBE_ERROR="Retry returned non-OK response: $(head -c 200 "$PROBE_DIR/codex-probe.txt" | tr '\n\r' '  ')"
                     fi
                 else
                     if [[ -f "$PROBE_DIR/codex-probe.txt.diag" ]]; then
@@ -259,7 +261,7 @@ if [[ "$PROBE" == "true" ]]; then
                         CURSOR_HEALTHY="true"
                         CURSOR_PROBE_ERROR=""
                     else
-                        CURSOR_PROBE_ERROR="Retry returned non-OK response: $(head -c 200 "$PROBE_DIR/cursor-probe.txt")"
+                        CURSOR_PROBE_ERROR="Retry returned non-OK response: $(head -c 200 "$PROBE_DIR/cursor-probe.txt" | tr '\n\r' '  ')"
                     fi
                 else
                     if [[ -f "$PROBE_DIR/cursor-probe.txt.diag" ]]; then

--- a/scripts/check-reviewers.sh
+++ b/scripts/check-reviewers.sh
@@ -118,16 +118,19 @@ if [[ "$PROBE" == "true" ]]; then
         if [[ -f "$PROBE_DIR/codex-probe.txt.done" ]]; then
             CODEX_EXIT=$(cat "$PROBE_DIR/codex-probe.txt.done")
             if [[ "$CODEX_EXIT" == "0" ]]; then
-                # Verify output is non-empty
                 if [[ -s "$PROBE_DIR/codex-probe.txt" ]]; then
-                    CODEX_HEALTHY="true"
+                    CODEX_PROBE_REPLY=$(tr -d '[:space:]' < "$PROBE_DIR/codex-probe.txt")
+                    if [[ "$CODEX_PROBE_REPLY" == "OK" ]]; then
+                        CODEX_HEALTHY="true"
+                    else
+                        CODEX_PROBE_ERROR="Probe returned non-OK response: $(head -c 200 "$PROBE_DIR/codex-probe.txt")"
+                    fi
                 elif [[ -f "$PROBE_DIR/codex-probe.txt.diag" ]]; then
                     CODEX_PROBE_ERROR=$(cat "$PROBE_DIR/codex-probe.txt.diag")
                 else
                     CODEX_PROBE_ERROR="Probe exited successfully but produced no output"
                 fi
             else
-                # Read .diag file if available, fall back to exit code
                 if [[ -f "$PROBE_DIR/codex-probe.txt.diag" ]]; then
                     CODEX_PROBE_ERROR=$(cat "$PROBE_DIR/codex-probe.txt.diag")
                 else
@@ -145,7 +148,12 @@ if [[ "$PROBE" == "true" ]]; then
             CURSOR_EXIT=$(cat "$PROBE_DIR/cursor-probe.txt.done")
             if [[ "$CURSOR_EXIT" == "0" ]]; then
                 if [[ -s "$PROBE_DIR/cursor-probe.txt" ]]; then
-                    CURSOR_HEALTHY="true"
+                    CURSOR_PROBE_REPLY=$(tr -d '[:space:]' < "$PROBE_DIR/cursor-probe.txt")
+                    if [[ "$CURSOR_PROBE_REPLY" == "OK" ]]; then
+                        CURSOR_HEALTHY="true"
+                    else
+                        CURSOR_PROBE_ERROR="Probe returned non-OK response: $(head -c 200 "$PROBE_DIR/cursor-probe.txt")"
+                    fi
                 elif [[ -f "$PROBE_DIR/cursor-probe.txt.diag" ]]; then
                     CURSOR_PROBE_ERROR=$(cat "$PROBE_DIR/cursor-probe.txt.diag")
                 else
@@ -220,10 +228,14 @@ if [[ "$PROBE" == "true" ]]; then
             if [[ -f "$PROBE_DIR/codex-probe.txt.done" ]]; then
                 CODEX_EXIT=$(cat "$PROBE_DIR/codex-probe.txt.done")
                 if [[ "$CODEX_EXIT" == "0" && -s "$PROBE_DIR/codex-probe.txt" ]]; then
-                    CODEX_HEALTHY="true"
-                    CODEX_PROBE_ERROR=""  # retry succeeded, clear error
+                    CODEX_PROBE_REPLY=$(tr -d '[:space:]' < "$PROBE_DIR/codex-probe.txt")
+                    if [[ "$CODEX_PROBE_REPLY" == "OK" ]]; then
+                        CODEX_HEALTHY="true"
+                        CODEX_PROBE_ERROR=""
+                    else
+                        CODEX_PROBE_ERROR="Retry returned non-OK response: $(head -c 200 "$PROBE_DIR/codex-probe.txt")"
+                    fi
                 else
-                    # Update error with retry failure info
                     if [[ -f "$PROBE_DIR/codex-probe.txt.diag" ]]; then
                         CODEX_PROBE_ERROR="Retry also failed: $(cat "$PROBE_DIR/codex-probe.txt.diag")"
                     elif [[ "$CODEX_EXIT" == "0" ]]; then
@@ -242,8 +254,13 @@ if [[ "$PROBE" == "true" ]]; then
             if [[ -f "$PROBE_DIR/cursor-probe.txt.done" ]]; then
                 CURSOR_EXIT=$(cat "$PROBE_DIR/cursor-probe.txt.done")
                 if [[ "$CURSOR_EXIT" == "0" && -s "$PROBE_DIR/cursor-probe.txt" ]]; then
-                    CURSOR_HEALTHY="true"
-                    CURSOR_PROBE_ERROR=""  # retry succeeded, clear error
+                    CURSOR_PROBE_REPLY=$(tr -d '[:space:]' < "$PROBE_DIR/cursor-probe.txt")
+                    if [[ "$CURSOR_PROBE_REPLY" == "OK" ]]; then
+                        CURSOR_HEALTHY="true"
+                        CURSOR_PROBE_ERROR=""
+                    else
+                        CURSOR_PROBE_ERROR="Retry returned non-OK response: $(head -c 200 "$PROBE_DIR/cursor-probe.txt")"
+                    fi
                 else
                     if [[ -f "$PROBE_DIR/cursor-probe.txt.diag" ]]; then
                         CURSOR_PROBE_ERROR="Retry also failed: $(cat "$PROBE_DIR/cursor-probe.txt.diag")"


### PR DESCRIPTION
## Summary
- Replaced non-empty file check (`-s`) with strict "OK" sentinel validation in health probe for both Codex and Cursor reviewers (initial + retry paths)
- Updated header documentation to reflect the new health check contract
- Sanitized newlines in non-OK error messages to prevent breaking KEY=value line-oriented parsing

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] shellcheck passes on `scripts/check-reviewers.sh`
- [x] agent-lint passes (full repo structural check)
- [x] Quick-mode code review (Cursor) — 2 accepted, 4 rejected findings

</details>

Closes #887

Generated with [Claude Code](https://claude.com/claude-code)
