### PR TITLE
Narrow step-order test assertions (8)-(9) to registry-row patterns

### DIFF
--- a/skills/fix-issue/scripts/test-fix-issue-step-order.md
+++ b/skills/fix-issue/scripts/test-fix-issue-step-order.md
@@ -11,8 +11,8 @@ Thirteen assertions against `skills/fix-issue/SKILL.md` — ten textual literal 
 5. Anti-pattern #1 contains `treat Step 0 as structural`.
 6. Find & lock success breadcrumb literal `✅ 0: find & lock` present.
 7. Find & lock failure breadcrumb literal `⚠ 0: find & lock` present.
-8. No stale `1: lock` breadcrumb remains (catches both `✅ 1: lock` and `⚠ 1: lock` patterns).
-9. No stale `2: lock` breadcrumb remains.
+8. No stale `| 1 | lock |` step-name-registry row remains (narrowed from bare `1: lock` substring to avoid false positives on unrelated text — see #889).
+9. No stale `| 2 | lock |` step-name-registry row remains (same narrowing).
 10. The Step 0 block contains the `find-lock-issue.sh` invocation.
 11. The Step 0 block does NOT contain `session-setup.sh` (operational ordering).
 12. The Step 1 block contains `session-setup.sh --prefix claude-fix-issue --skip-branch-check`.

--- a/skills/fix-issue/scripts/test-fix-issue-step-order.sh
+++ b/skills/fix-issue/scripts/test-fix-issue-step-order.sh
@@ -17,8 +17,8 @@
 #   (5) Anti-pattern #1 contains "treat Step 0 as structural".
 #   (6) Find & lock success breadcrumb literal "✅ 0: find & lock" present.
 #   (7) Find & lock failure breadcrumb literal "⚠ 0: find & lock" present.
-#   (8) No stale "1: lock" breadcrumb remains.
-#   (9) No stale "2: lock" breadcrumb remains.
+#   (8) No stale "| 1 | lock |" step-name-registry row remains.
+#   (9) No stale "| 2 | lock |" step-name-registry row remains.
 #  (10) Step 0 (Find and Lock) block contains the find-lock-issue.sh invocation.
 #  (11) Step 0 block does NOT contain `session-setup.sh` (operational ordering).
 #  (12) Step 1 (Setup) block contains the session-setup.sh invocation.
@@ -99,9 +99,9 @@ assert_contains 'treat Step 0 as structural' '(5) anti-pattern #1 says "treat St
 assert_contains '✅ 0: find & lock' '(6) find & lock success breadcrumb uses "0: find & lock"'
 assert_contains '⚠ 0: find & lock' '(7) find & lock failure breadcrumb uses "0: find & lock"'
 
-# (8)-(9) No stale "lock" breadcrumbs from the pre-fold structure
-assert_not_contains '1: lock' '(8) no stale "1: lock" breadcrumb'
-assert_not_contains '2: lock' '(9) no stale "2: lock" breadcrumb'
+# (8)-(9) No stale "lock" step-name-registry rows from the pre-fold structure
+assert_not_contains '| 1 | lock |' '(8) no stale "| 1 | lock |" registry row'
+assert_not_contains '| 2 | lock |' '(9) no stale "| 2 | lock |" registry row'
 
 # (10)-(12) Operational-ordering assertions on awk-scoped step blocks.
 # These guard against a future edit that keeps the headings/registry/


### PR DESCRIPTION
## Summary
- Narrowed assertions (8) and (9) in `test-fix-issue-step-order.sh` from overbroad `grep -qF` substring matches (`1: lock`, `2: lock`) to specific step-name-registry row patterns (`| 1 | lock |`, `| 2 | lock |`)
- Updated sibling contract doc (`test-fix-issue-step-order.md`) to reflect the narrowed patterns and cite #889

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] Run `bash skills/fix-issue/scripts/test-fix-issue-step-order.sh` — all 13 assertions pass
- [x] Run `/relevant-checks` — pre-commit + agent-lint pass

</details>

Closes #889

Generated with [Claude Code](https://claude.com/claude-code)
