### PR TITLE
Fix voting-protocol.md wording divergence and OOS attribution

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "12.0.4",
+  "version": "12.0.5",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/skills/shared/voting-protocol.md
+++ b/skills/shared/voting-protocol.md
@@ -186,7 +186,7 @@ For out-of-scope items, the vote meanings are:
 - **NO**: Not worth tracking — the observation is trivial or incorrect.
 - **EXONERATE**: Legitimate observation worth documenting, but not worth filing a GitHub issue.
 
-If an OOS item receives 2+ YES votes, it is **accepted** and will be filed as a GitHub issue by `/implement`. Otherwise it remains an observation reported in the PR body.
+If an OOS item receives 2+ YES votes, it is **accepted** and will be filed as a GitHub issue by `/implement`. In `/review` slice mode (with `--create-issues`), accepted OOS items are filed by `/review` Step 4b directly via `/umbrella`, not by `/implement`. Otherwise it remains an observation reported in the PR body.
 
 **OOS items are never implemented in the current PR** — accepted OOS items result in issue creation only. This cleanly separates "fix now" (in-scope findings) from "fix later" (OOS observations).
 
@@ -222,4 +222,4 @@ External reviewers (Codex, Cursor) **in diff mode** use single-list prompts and 
 
 ## Zero Accepted Findings
 
-If voting filters out **all** in-scope findings (every in-scope finding rejected by the panel), print: `**ℹ Voting panel rejected all findings. No changes to implement.**` and skip the implementation/revision step. Proceed directly to the rejected findings report. (OOS items accepted for issue filing are processed separately by `/implement` and do not count as implementation work.)
+If voting filters out **all** in-scope findings (every in-scope finding rejected by the panel), print: `**ℹ Voting panel rejected all in-scope findings. No changes to implement.**` and skip the implementation/revision step. Proceed directly to the rejected findings report. (OOS items accepted for issue filing are processed separately — by `/implement` Step 9a.1 in diff mode, or by `/review` Step 4b via `/umbrella` in slice mode — and do not count as implementation work.)

--- a/skills/shared/voting-protocol.md
+++ b/skills/shared/voting-protocol.md
@@ -222,4 +222,4 @@ External reviewers (Codex, Cursor) **in diff mode** use single-list prompts and 
 
 ## Zero Accepted Findings
 
-If voting filters out **all** in-scope findings (every in-scope finding rejected by the panel), print: `**ℹ Voting panel rejected all in-scope findings. No changes to implement.**` and skip the implementation/revision step. Proceed directly to the rejected findings report. (OOS items accepted for issue filing are processed separately — by `/implement` Step 9a.1 in diff mode, or by `/review` Step 4b via `/umbrella` in slice mode — and do not count as implementation work.)
+If voting filters out **all** in-scope findings (every in-scope finding rejected by the panel), print: `**ℹ Voting panel rejected all in-scope findings. No changes to implement.**` and skip the implementation/revision step. Proceed directly to the rejected findings report. (OOS items accepted for issue filing are processed separately — by `/implement` Step 9a.1, or by `/review` Step 4b via `/umbrella` in slice mode with `--create-issues` — and do not count as implementation work.)


### PR DESCRIPTION
## Summary
- Fixed zero-accepted wording divergence: aligned `voting-protocol.md` line 225 with `voting.md` line 27 to say "rejected all in-scope findings" instead of "rejected all findings"
- Added slice-mode clarification to OOS filing attribution at line 189 and line 225, documenting that `/review` Step 4b files OOS items via `/umbrella` in slice mode with `--create-issues`
- Removed overloaded "in diff mode" label from the OOS parenthetical at line 225 per code review

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] Verify `voting-protocol.md` line 225 zero-accepted string matches `voting.md` line 27 ("rejected all in-scope findings")
- [x] Verify `voting-protocol.md` line 189 mentions slice-mode OOS filing via `/review` Step 4b / `/umbrella`
- [x] Verify `voting-protocol.md` line 225 parenthetical mentions both `/implement` Step 9a.1 and `/review` Step 4b via `/umbrella` in slice mode with `--create-issues`
- [x] `/relevant-checks` passes (markdownlint + agent-lint)

</details>

Closes #904

Generated with [Claude Code](https://claude.com/claude-code)
