### PR TITLE
Fix echo corruption and empty-label fallback in get-issue-details.sh

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "12.0.6",
+  "version": "12.0.7",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Plan and code review run a 3-reviewer panel (Claude Code Reviewer + Codex + Cursor); design sketches run a 5-agent diverge-then-converge phase (1 Claude + 2 Cursor + 2 Codex).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [12.0.7] - 2026-04-28
+
+### Fixed
+
+- `get-issue-details.sh` — replaced `echo` with `printf '%s\n'` for issue body and comment body serialization to prevent corruption when bodies start with `-n` or `-e`.
+- `get-issue-details.sh` — fixed empty-label fallback from `join(", ") // "none"` (jq `//` does not substitute for empty string) to explicit `if length == 0` check.
+
 ## [12.0.1] - 2026-04-28
 
 ### Removed

--- a/skills/fix-issue/scripts/get-issue-details.sh
+++ b/skills/fix-issue/scripts/get-issue-details.sh
@@ -9,7 +9,7 @@
 #
 # Output file format:
 #   # Issue #N: <title>
-#   **Labels**: <comma-separated>
+#   **Labels**: <comma-separated, or "none" when no labels>
 #   **Created**: <date>
 #
 #   ## Description
@@ -81,7 +81,7 @@ COMMENTS=$(gh api --paginate --slurp "repos/${REPO}/issues/${ISSUE_NUMBER}/comme
     if [ "$COMMENT_COUNT" -eq 0 ]; then
         printf '%s\n' "No comments."
     else
-        echo "$COMMENTS" | jq -r '.[] | "### Comment by \(.user.login) at \(.created_at)\n\n\(.body)\n"'
+        printf '%s\n' "$COMMENTS" | jq -r '.[] | "### Comment by \(.user.login) at \(.created_at)\n\n\(.body)\n"'
     fi
 } > "$OUTPUT_PATH"
 

--- a/skills/fix-issue/scripts/get-issue-details.sh
+++ b/skills/fix-issue/scripts/get-issue-details.sh
@@ -55,7 +55,7 @@ ISSUE_JSON=$(gh issue view "$ISSUE_NUMBER" --json title,body,labels,createdAt 2>
 
 TITLE=$(echo "$ISSUE_JSON" | jq -r '.title // "Untitled"')
 BODY=$(echo "$ISSUE_JSON" | jq -r '.body // "No description provided."')
-LABELS=$(echo "$ISSUE_JSON" | jq -r '[.labels[].name] | join(", ") // "none"')
+LABELS=$(echo "$ISSUE_JSON" | jq -r '[.labels[].name] | if length == 0 then "none" else join(", ") end')
 CREATED=$(echo "$ISSUE_JSON" | jq -r '.createdAt // "unknown"')
 
 # Fetch all comments (paginated)
@@ -66,20 +66,20 @@ COMMENTS=$(gh api --paginate --slurp "repos/${REPO}/issues/${ISSUE_NUMBER}/comme
 
 # Write structured output
 {
-    echo "# Issue #${ISSUE_NUMBER}: ${TITLE}"
-    echo "**Labels**: ${LABELS}"
-    echo "**Created**: ${CREATED}"
-    echo ""
-    echo "## Description"
-    echo ""
-    echo "$BODY"
-    echo ""
-    echo "## Comments"
-    echo ""
+    printf '%s\n' "# Issue #${ISSUE_NUMBER}: ${TITLE}"
+    printf '%s\n' "**Labels**: ${LABELS}"
+    printf '%s\n' "**Created**: ${CREATED}"
+    printf '%s\n' ""
+    printf '%s\n' "## Description"
+    printf '%s\n' ""
+    printf '%s\n' "$BODY"
+    printf '%s\n' ""
+    printf '%s\n' "## Comments"
+    printf '%s\n' ""
 
     COMMENT_COUNT=$(echo "$COMMENTS" | jq 'length')
     if [ "$COMMENT_COUNT" -eq 0 ]; then
-        echo "No comments."
+        printf '%s\n' "No comments."
     else
         echo "$COMMENTS" | jq -r '.[] | "### Comment by \(.user.login) at \(.created_at)\n\n\(.body)\n"'
     fi


### PR DESCRIPTION
## Summary
- Fixed `echo` corruption in `get-issue-details.sh` by replacing content-bearing `echo` calls with `printf '%s\n'` to prevent flag interpretation when issue bodies start with `-n` or `-e`.
- Fixed empty-label fallback by replacing jq `join(", ") // "none"` with `if length == 0 then "none" else join(", ") end` since jq's `//` does not substitute for empty string.

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] Verify `printf '%s\n'` handles `-n` and `-e` prefixed strings without corruption
- [x] Verify jq `if length == 0` returns `"none"` for empty label arrays and `join(", ")` for populated arrays
- [x] shellcheck passes on modified script
- [x] agent-lint passes on full repo

</details>

Closes #903

Generated with [Claude Code](https://claude.com/claude-code)
