### PR TITLE
Add release-tag workflow to auto-tag main with semver

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "12.4.3",
+  "version": "12.4.4",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 6-reviewer specialist panel (5 Cursor specialists + 1 Codex generic) with 3-voter adjudication; plan review runs a 3-reviewer panel (Claude + Codex + Cursor); design sketches run a 9-agent diverge-then-converge phase in regular mode (1 Claude + 4 Cursor + 4 Codex) or 3 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/.github/workflows/release-tag.yaml
+++ b/.github/workflows/release-tag.yaml
@@ -24,15 +24,25 @@ jobs:
             echo "::error::No version field found in .claude-plugin/plugin.json"
             exit 1
           fi
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid semver in .claude-plugin/plugin.json: $VERSION"
+            exit 1
+          fi
           echo "tag=v${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Create release tag
         run: |
           set -euo pipefail
           TAG="${{ steps.version.outputs.tag }}"
-          if git ls-remote --tags origin "$TAG" | grep -q "$TAG"; then
+          if [[ -n "$(git ls-remote --tags origin "refs/tags/${TAG}")" ]]; then
             echo "Tag $TAG already exists on remote — skipping."
             exit 0
           fi
           git tag "$TAG"
-          git push origin "$TAG"
+          git push origin "$TAG" 2>&1 || {
+            if [[ -n "$(git ls-remote --tags origin "refs/tags/${TAG}")" ]]; then
+              echo "Tag $TAG was created by a concurrent run — skipping."
+              exit 0
+            fi
+            exit 1
+          }

--- a/.github/workflows/release-tag.yaml
+++ b/.github/workflows/release-tag.yaml
@@ -1,0 +1,38 @@
+name: Release Tag
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Read version from plugin.json
+        id: version
+        run: |
+          set -euo pipefail
+          VERSION=$(jq -r '.version' .claude-plugin/plugin.json)
+          if [[ -z "$VERSION" || "$VERSION" == "null" ]]; then
+            echo "::error::No version field found in .claude-plugin/plugin.json"
+            exit 1
+          fi
+          echo "tag=v${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Create release tag
+        run: |
+          set -euo pipefail
+          TAG="${{ steps.version.outputs.tag }}"
+          if git ls-remote --tags origin "$TAG" | grep -q "$TAG"; then
+            echo "Tag $TAG already exists on remote — skipping."
+            exit 0
+          fi
+          git tag "$TAG"
+          git push origin "$TAG"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [12.4.4] - 2026-04-30
+
+### Added
+
+- `.github/workflows/release-tag.yaml` — new GitHub Actions workflow that auto-creates a `v<semver>` git tag on every push to main, derived from `.claude-plugin/plugin.json` version. Includes strict semver validation, exact ref matching, and TOCTOU race handling for concurrent runs.
+
 ## [12.4.3] - 2026-04-30
 
 ### Fixed


### PR DESCRIPTION
## Summary
- Added a new GitHub Actions workflow (`release-tag.yaml`) that auto-creates a `v<semver>` git tag on every push to main, derived from the version in `.claude-plugin/plugin.json`.
- Includes strict semver validation to prevent GITHUB_OUTPUT injection, exact ref matching to avoid substring false positives, and graceful handling of TOCTOU races from concurrent runs.

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] `actionlint` passes on the new workflow file
- [x] `agent-lint` structural checks pass
- [x] `gitleaks` secret scanning passes
- [ ] Merge to main and verify tag `v12.4.4` is created automatically

</details>

Closes #938

Generated with [Claude Code](https://claude.com/claude-code)
