### PR TITLE
Auto-create GitHub Releases with --latest=false and update install docs

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "12.4.4",
+  "version": "12.4.5",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 6-reviewer specialist panel (5 Cursor specialists + 1 Codex generic) with 3-voter adjudication; plan review runs a 3-reviewer panel (Claude + Codex + Cursor); design sketches run a 9-agent diverge-then-converge phase in regular mode (1 Claude + 4 Cursor + 4 Codex) or 3 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/.github/workflows/release-tag.yaml
+++ b/.github/workflows/release-tag.yaml
@@ -31,18 +31,53 @@ jobs:
           echo "tag=v${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Create release tag
+        id: tag
         run: |
           set -euo pipefail
           TAG="${{ steps.version.outputs.tag }}"
           if [[ -n "$(git ls-remote --tags origin "refs/tags/${TAG}")" ]]; then
             echo "Tag $TAG already exists on remote — skipping."
+            echo "created=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           git tag "$TAG"
           git push origin "$TAG" 2>&1 || {
             if [[ -n "$(git ls-remote --tags origin "refs/tags/${TAG}")" ]]; then
               echo "Tag $TAG was created by a concurrent run — skipping."
+              echo "created=false" >> "$GITHUB_OUTPUT"
               exit 0
             fi
             exit 1
           }
+          echo "created=true" >> "$GITHUB_OUTPUT"
+
+      - name: Extract changelog entry
+        if: steps.tag.outputs.created == 'true'
+        id: changelog
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.version.outputs.tag }}"
+          VERSION="${VERSION#v}"
+          BODY_FILE=$(mktemp)
+          # Extract the section between ## [VERSION] and the next ## [
+          awk -v ver="$VERSION" '
+            /^## \[/ { if (found) exit; if (index($0, "[" ver "]")) found=1; next }
+            found { print }
+          ' CHANGELOG.md > "$BODY_FILE"
+          if [[ ! -s "$BODY_FILE" ]]; then
+            echo "No changelog entry found for $VERSION — using default." >&2
+            echo "Release v${VERSION}" > "$BODY_FILE"
+          fi
+          echo "body_file=$BODY_FILE" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        if: steps.tag.outputs.created == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          TAG="${{ steps.version.outputs.tag }}"
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --notes-file "${{ steps.changelog.outputs.body_file }}" \
+            --latest=false

--- a/.github/workflows/release-tag.yaml
+++ b/.github/workflows/release-tag.yaml
@@ -51,15 +51,28 @@ jobs:
           }
           echo "created=true" >> "$GITHUB_OUTPUT"
 
+      - name: Check if release exists
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          TAG="${{ steps.version.outputs.tag }}"
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists — skipping."
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Extract changelog entry
-        if: steps.tag.outputs.created == 'true'
+        if: steps.release.outputs.exists == 'false'
         id: changelog
         run: |
           set -euo pipefail
           VERSION="${{ steps.version.outputs.tag }}"
           VERSION="${VERSION#v}"
           BODY_FILE=$(mktemp)
-          # Extract the section between ## [VERSION] and the next ## [
           awk -v ver="$VERSION" '
             /^## \[/ { if (found) exit; if (index($0, "[" ver "]")) found=1; next }
             found { print }
@@ -71,7 +84,7 @@ jobs:
           echo "body_file=$BODY_FILE" >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release
-        if: steps.tag.outputs.created == 'true'
+        if: steps.release.outputs.exists == 'false'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [12.4.5] - 2026-04-30
+
+### Changed
+
+- `.github/workflows/release-tag.yaml` — auto-creates GitHub Releases (not just tags) with `--latest=false` and CHANGELOG body extraction. Includes idempotent recovery for tag-exists-but-no-release state.
+- `docs/installation-and-setup.md` — updated install instructions to reference the latest stable release; added section for pinning a specific version via `@vX.Y.Z` syntax.
+
 ## [12.4.4] - 2026-04-30
 
 ### Added

--- a/docs/installation-and-setup.md
+++ b/docs/installation-and-setup.md
@@ -6,6 +6,8 @@ Slack integration is optional and **on by default** when `LARCH_SLACK_BOT_TOKEN`
 
 ## Install from GitHub
 
+### Latest stable release (recommended)
+
 ```bash
 claude plugin marketplace add zhupanov/larch
 claude plugin install larch@larch-local
@@ -14,6 +16,17 @@ claude plugin install larch@larch-local
 The first command registers larch's marketplace manifest (`.claude-plugin/marketplace.json`). The second command installs the `larch` plugin into your Claude Code user scope. Once installed, all larch skills (e.g., /implement) become available in every Claude Code session.
 
 To scope the install to a single project instead of the user scope, append `--scope project` to the `install` command.
+
+### Install a specific version
+
+Every merge to main is tagged and published as a GitHub Release (`v12.4.4`, `v12.5.0`, etc.). The "Latest" release on the [Releases page](https://github.com/zhupanov/larch/releases) is the current stable version — other releases are available but not promoted. To pin a specific version:
+
+```bash
+claude plugin marketplace add zhupanov/larch --ref v12.4.4
+claude plugin install larch@larch-local
+```
+
+Replace `v12.4.4` with the desired release tag. Available tags are listed on the [Releases page](https://github.com/zhupanov/larch/releases).
 
 ## Install for local development (contributors)
 

--- a/docs/installation-and-setup.md
+++ b/docs/installation-and-setup.md
@@ -19,10 +19,10 @@ To scope the install to a single project instead of the user scope, append `--sc
 
 ### Install a specific version
 
-Every merge to main is tagged and published as a GitHub Release (`v12.4.4`, `v12.5.0`, etc.). The "Latest" release on the [Releases page](https://github.com/zhupanov/larch/releases) is the current stable version — other releases are available but not promoted. To pin a specific version:
+Each version bump on main is tagged and published as a GitHub Release (`v12.4.4`, `v12.5.0`, etc.). The "Latest" release on the [Releases page](https://github.com/zhupanov/larch/releases) is the current stable version — other releases are available but not promoted. To pin a specific version:
 
 ```bash
-claude plugin marketplace add zhupanov/larch --ref v12.4.4
+claude plugin marketplace add zhupanov/larch@v12.4.4
 claude plugin install larch@larch-local
 ```
 


### PR DESCRIPTION
## Summary
- Marked v12.4.4 as the "Latest" GitHub Release so it appears on the repo's front page.
- Extended the release-tag workflow to auto-create GitHub Releases with `--latest=false` and CHANGELOG body extraction, with idempotent recovery for the tag-exists-but-no-release edge case.
- Updated installation docs to reference the latest stable release by default and added instructions for pinning a specific version via `@vX.Y.Z` syntax.

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] `actionlint` passes on the modified workflow file
- [x] `markdownlint` passes on the modified docs
- [x] `agent-lint` structural checks pass
- [x] v12.4.4 marked as "Latest" on GitHub Releases page
- [ ] Merge to main and verify v12.4.5 release is auto-created with CHANGELOG body and `--latest=false`

</details>

Closes #940

Generated with [Claude Code](https://claude.com/claude-code)
