### PR TITLE
Add promote-release.sh to promote a GitHub Release to Latest

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "12.4.5",
+  "version": "12.4.6",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 6-reviewer specialist panel (5 Cursor specialists + 1 Codex generic) with 3-voter adjudication; plan review runs a 3-reviewer panel (Claude + Codex + Cursor); design sketches run a 9-agent diverge-then-converge phase in regular mode (1 Claude + 4 Cursor + 4 Codex) or 3 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [12.4.6] - 2026-04-30
+
+### Added
+
+- `scripts/promote-release.sh` — operator utility to promote a GitHub Release to "Latest" by semver version. Takes mandatory `X.Y.Z` argument, validates format, checks release existence, and promotes via `gh release edit --latest`. Idempotent (exits 0 if already latest).
+
 ## [12.4.5] - 2026-04-30
 
 ### Changed

--- a/agent-lint.toml
+++ b/agent-lint.toml
@@ -577,4 +577,10 @@ exclude = [
   # test-find-lock-issue.md entries above.
   "scripts/test-alias-target-resolution.md",
   "scripts/test-alias-structure.md",
+  # scripts/promote-release.sh is a standalone operator utility for promoting
+  # a GitHub Release to "Latest". It is not invoked by any SKILL.md — operators
+  # call it directly from the terminal. Its sibling contract
+  # scripts/promote-release.md is excluded for the same reason.
+  "scripts/promote-release.sh",
+  "scripts/promote-release.md",
 ]

--- a/docs/installation-and-setup.md
+++ b/docs/installation-and-setup.md
@@ -28,6 +28,8 @@ claude plugin install larch@larch-local
 
 Replace `v12.4.4` with the desired release tag. Available tags are listed on the [Releases page](https://github.com/zhupanov/larch/releases).
 
+**For maintainers:** to promote a release to "Latest", run `scripts/promote-release.sh X.Y.Z` (see `scripts/promote-release.md` for details).
+
 ## Install for local development (contributors)
 
 If you are hacking on larch itself and want Claude Code to load the plugin directly from your working checkout (so `${CLAUDE_PLUGIN_ROOT}` resolves to the repo you are editing), launch Claude Code with `--plugin-dir`:

--- a/scripts/promote-release.md
+++ b/scripts/promote-release.md
@@ -18,8 +18,9 @@ The argument is a bare semver (`X.Y.Z`) — no `v` prefix. The script prepends `
 
 1. Validates the argument matches `^[0-9]+\.[0-9]+\.[0-9]+$`.
 2. Checks that `v<VERSION>` exists as a GitHub Release via `gh release view`.
-3. If the release is already "Latest", prints a message and exits 0.
-4. Otherwise, runs `gh release edit v<VERSION> --latest` to promote it.
+3. Queries `gh release list --json tagName,isLatest` to find the current "Latest" release.
+4. If `v<VERSION>` is already "Latest", prints a message and exits 0.
+5. Otherwise, runs `gh release edit v<VERSION> --latest` to promote it.
 
 ## Exit codes
 

--- a/scripts/promote-release.md
+++ b/scripts/promote-release.md
@@ -1,0 +1,40 @@
+# scripts/promote-release.sh — contract
+
+`scripts/promote-release.sh` promotes a GitHub Release to "Latest" by semver version number. Used to designate which release appears on the repo's front page.
+
+## Purpose
+
+Every merge to main creates a GitHub Release with `--latest=false` (via `.github/workflows/release-tag.yaml`). This script manually promotes one of those releases to "Latest", making it the version shown on the repo's front page and installed by default via `claude plugin marketplace add`.
+
+## Usage
+
+```bash
+scripts/promote-release.sh 12.4.5
+```
+
+The argument is a bare semver (`X.Y.Z`) — no `v` prefix. The script prepends `v` internally.
+
+## Behavior
+
+1. Validates the argument matches `^[0-9]+\.[0-9]+\.[0-9]+$`.
+2. Checks that `v<VERSION>` exists as a GitHub Release via `gh release view`.
+3. If the release is already "Latest", prints a message and exits 0.
+4. Otherwise, runs `gh release edit v<VERSION> --latest` to promote it.
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Release promoted (or already latest) |
+| 1 | Release not found or `gh` error |
+| 2 | Usage / argument error |
+
+## Dependencies
+
+- `gh` — authenticated with repo access
+
+## Edit-in-sync
+
+- `scripts/promote-release.sh` — the script itself
+- `.github/workflows/release-tag.yaml` — creates releases with `--latest=false`; this script is the manual promotion counterpart
+- `docs/installation-and-setup.md` — documents the "Latest" release concept and version pinning

--- a/scripts/promote-release.sh
+++ b/scripts/promote-release.sh
@@ -31,17 +31,17 @@ fi
 
 TAG="v${VERSION}"
 
-if ! gh release view "$TAG" >/dev/null 2>&1; then
+if ! gh release view "$TAG" >/dev/null; then
     echo "ERROR: release $TAG not found." >&2
     exit 1
 fi
 
-IS_LATEST=$(gh release view "$TAG" --json isLatest --jq '.isLatest')
+CURRENT_LATEST=$(gh release list --json tagName,isLatest --jq '.[] | select(.isLatest) | .tagName') || exit 1
 
-if [[ "$IS_LATEST" == "true" ]]; then
+if [[ "$CURRENT_LATEST" == "$TAG" ]]; then
     echo "$TAG is already the latest release."
     exit 0
 fi
 
-gh release edit "$TAG" --latest
+gh release edit "$TAG" --latest || exit 1
 echo "Promoted $TAG to latest release."

--- a/scripts/promote-release.sh
+++ b/scripts/promote-release.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# promote-release.sh — Promote a GitHub Release to "Latest".
+#
+# Takes a semver version (X.Y.Z, no "v" prefix) and marks the
+# corresponding GitHub Release as "Latest" via gh release edit.
+#
+# Usage:
+#   promote-release.sh X.Y.Z
+#
+# Exit codes:
+#   0 — release promoted (or already latest)
+#   1 — release not found or gh error
+#   2 — usage/argument error
+
+set -euo pipefail
+
+usage() { echo "Usage: promote-release.sh X.Y.Z" >&2; }
+
+if [[ $# -ne 1 ]]; then
+    usage
+    exit 2
+fi
+
+VERSION="$1"
+
+if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "ERROR: invalid semver format: $VERSION (expected X.Y.Z)" >&2
+    usage
+    exit 2
+fi
+
+TAG="v${VERSION}"
+
+if ! gh release view "$TAG" >/dev/null 2>&1; then
+    echo "ERROR: release $TAG not found." >&2
+    exit 1
+fi
+
+IS_LATEST=$(gh release view "$TAG" --json isLatest --jq '.isLatest')
+
+if [[ "$IS_LATEST" == "true" ]]; then
+    echo "$TAG is already the latest release."
+    exit 0
+fi
+
+gh release edit "$TAG" --latest
+echo "Promoted $TAG to latest release."


### PR DESCRIPTION
## Summary
- Added `scripts/promote-release.sh` — operator utility to promote a GitHub Release to "Latest" by semver version (`X.Y.Z`). Validates format, checks release existence via `gh release view`, queries current latest via `gh release list`, and promotes via `gh release edit --latest`. Idempotent (exits 0 if already latest).
- Added sibling contract `scripts/promote-release.md` and `agent-lint.toml` exclusion for the operator-only script.
- Updated `docs/installation-and-setup.md` with maintainer note pointing to the promote script.

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] `shellcheck` passes on promote-release.sh
- [x] `markdownlint` passes on promote-release.md and installation docs
- [x] `agent-lint` structural checks pass (exclusion verified)
- [ ] Manual test: `scripts/promote-release.sh 12.4.4` reports "already latest"
- [ ] Manual test: `scripts/promote-release.sh 99.99.99` reports "release not found"

</details>

Closes #942

Generated with [Claude Code](https://claude.com/claude-code)
