### PR TITLE
Mark auto-created releases as pre-release; promote-release clears it (#944)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "12.4.6",
+  "version": "12.4.7",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 6-reviewer specialist panel (5 Cursor specialists + 1 Codex generic) with 3-voter adjudication; plan review runs a 3-reviewer panel (Claude + Codex + Cursor); design sketches run a 9-agent diverge-then-converge phase in regular mode (1 Claude + 4 Cursor + 4 Codex) or 3 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/.github/workflows/release-tag.yaml
+++ b/.github/workflows/release-tag.yaml
@@ -93,4 +93,5 @@ jobs:
           gh release create "$TAG" \
             --title "$TAG" \
             --notes-file "${{ steps.changelog.outputs.body_file }}" \
-            --latest=false
+            --latest=false \
+            --prerelease

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [12.4.7] - 2026-04-30
+
+### Changed
+
+- `.github/workflows/release-tag.yaml` — auto-created releases are now marked as pre-release (`--prerelease`) in addition to `--latest=false`
+- `scripts/promote-release.sh` — promotion now clears the pre-release flag (`--prerelease=false`) alongside setting latest; also handles the "already latest but still pre-release" edge case idempotently
+
 ## [12.4.6] - 2026-04-30
 
 ### Added

--- a/scripts/promote-release.md
+++ b/scripts/promote-release.md
@@ -1,10 +1,10 @@
 # scripts/promote-release.sh — contract
 
-`scripts/promote-release.sh` promotes a GitHub Release to "Latest" by semver version number. Used to designate which release appears on the repo's front page.
+`scripts/promote-release.sh` promotes a GitHub Release to "Latest" and clears its pre-release flag by semver version number. Used to designate which release appears on the repo's front page.
 
 ## Purpose
 
-Every merge to main creates a GitHub Release with `--latest=false` (via `.github/workflows/release-tag.yaml`). This script manually promotes one of those releases to "Latest", making it the version shown on the repo's front page and installed by default via `claude plugin marketplace add`.
+Every merge to main creates a GitHub Release with `--latest=false --prerelease` (via `.github/workflows/release-tag.yaml`). This script manually promotes one of those releases to "Latest" and clears the pre-release flag, making it the version shown on the repo's front page and installed by default via `claude plugin marketplace add`.
 
 ## Usage
 
@@ -20,7 +20,7 @@ The argument is a bare semver (`X.Y.Z`) — no `v` prefix. The script prepends `
 2. Checks that `v<VERSION>` exists as a GitHub Release via `gh release view`.
 3. Queries `gh release list --json tagName,isLatest` to find the current "Latest" release.
 4. If `v<VERSION>` is already "Latest", prints a message and exits 0.
-5. Otherwise, runs `gh release edit v<VERSION> --latest` to promote it.
+5. Otherwise, runs `gh release edit v<VERSION> --latest --prerelease=false` to promote it (marks as latest and clears the pre-release flag).
 
 ## Exit codes
 

--- a/scripts/promote-release.md
+++ b/scripts/promote-release.md
@@ -37,5 +37,5 @@ The argument is a bare semver (`X.Y.Z`) — no `v` prefix. The script prepends `
 ## Edit-in-sync
 
 - `scripts/promote-release.sh` — the script itself
-- `.github/workflows/release-tag.yaml` — creates releases with `--latest=false`; this script is the manual promotion counterpart
+- `.github/workflows/release-tag.yaml` — creates releases with `--latest=false --prerelease`; this script is the manual promotion counterpart (sets latest, clears pre-release)
 - `docs/installation-and-setup.md` — documents the "Latest" release concept and version pinning

--- a/scripts/promote-release.sh
+++ b/scripts/promote-release.sh
@@ -43,5 +43,5 @@ if [[ "$CURRENT_LATEST" == "$TAG" ]]; then
     exit 0
 fi
 
-gh release edit "$TAG" --latest || exit 1
+gh release edit "$TAG" --latest --prerelease=false || exit 1
 echo "Promoted $TAG to latest release."

--- a/scripts/promote-release.sh
+++ b/scripts/promote-release.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
-# promote-release.sh — Promote a GitHub Release to "Latest".
+# promote-release.sh — Promote a GitHub Release to "Latest" and clear pre-release.
 #
 # Takes a semver version (X.Y.Z, no "v" prefix) and marks the
-# corresponding GitHub Release as "Latest" via gh release edit.
+# corresponding GitHub Release as "Latest" and clears the pre-release
+# flag via gh release edit.
 #
 # Usage:
 #   promote-release.sh X.Y.Z
@@ -39,7 +40,13 @@ fi
 CURRENT_LATEST=$(gh release list --json tagName,isLatest --jq '.[] | select(.isLatest) | .tagName') || exit 1
 
 if [[ "$CURRENT_LATEST" == "$TAG" ]]; then
-    echo "$TAG is already the latest release."
+    IS_PRERELEASE=$(gh release view "$TAG" --json isPrerelease --jq '.isPrerelease')
+    if [[ "$IS_PRERELEASE" == "true" ]]; then
+        gh release edit "$TAG" --prerelease=false || exit 1
+        echo "$TAG is already the latest release; cleared pre-release flag."
+    else
+        echo "$TAG is already the latest release."
+    fi
     exit 0
 fi
 


### PR DESCRIPTION
## Summary
- Added `--prerelease` flag to auto-created GitHub Releases so every merge to main produces a pre-release by default
- Updated `promote-release.sh` to clear the pre-release flag (`--prerelease=false`) when promoting a release to latest
- Added idempotent handling for the "already latest but still pre-release" edge case

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] Verified `gh release edit --prerelease` and `--prerelease=false` flags work against a real release (v12.4.5)
- [x] shellcheck passes on modified promote-release.sh
- [x] markdownlint passes on modified promote-release.md
- [x] actionlint passes on modified release-tag.yaml
- [x] agent-lint passes (full repo structural check)

</details>

Closes #944

Generated with [Claude Code](https://claude.com/claude-code)
