### PR TITLE
Add /upgrade-larch skill and update installation docs

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "12.4.9",
+  "version": "12.5.0",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 6-reviewer specialist panel (5 Cursor specialists + 1 Codex generic) with 3-voter adjudication; plan review runs a 3-reviewer panel (Claude + Codex + Cursor); design sketches run a 9-agent diverge-then-converge phase in regular mode (1 Claude + 4 Cursor + 4 Codex) or 3 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [12.5.0] - 2026-05-01
+
+### Added
+
+- `/upgrade-larch` skill — automates upgrading the larch plugin to the latest version by removing and re-adding the marketplace, then reinstalling. Includes failure recovery guidance and a local-dev warning.
+
+### Changed
+
+- `docs/installation-and-setup.md` — removed "Install a specific version" section (version pinning caused downgrade bugs), added Upgrade section with `/upgrade-larch` instructions
+
 ## [12.4.8] - 2026-05-01
 
 ### Changed

--- a/docs/installation-and-setup.md
+++ b/docs/installation-and-setup.md
@@ -6,7 +6,7 @@ Slack integration is optional and **on by default** when `LARCH_SLACK_BOT_TOKEN`
 
 ## Install from GitHub
 
-### Latest stable release (recommended)
+### Latest stable release
 
 #### Install
 ```bash
@@ -27,18 +27,15 @@ Edit your `~/.claude/settings.json` and ensure that it has `permissions`/`allow`
   }
 ```
 
-### Install a specific version
+#### Upgrade
 
-Each version bump on main is tagged and published as a GitHub Release (`v12.4.4`, `v12.5.0`, etc.). The "Latest" release on the [Releases page](https://github.com/zhupanov/larch/releases) is the current stable version — other releases are available but not promoted. To pin a specific version:
+To upgrade larch to the latest version, run the `/upgrade-larch` skill in any Claude Code session, then restart Claude Code:
 
-```bash
-claude plugin marketplace add zhupanov/larch@v12.4.4
-claude plugin install larch@larch-local
+```
+/upgrade-larch
 ```
 
-Replace `v12.4.4` with the desired release tag. Available tags are listed on the [Releases page](https://github.com/zhupanov/larch/releases).
-
-**For maintainers:** to promote a release to "Latest", run `scripts/promote-release.sh X.Y.Z` (see `scripts/promote-release.md` for details).
+After the skill completes, restart Claude Code to apply the new version.
 
 ## Install for local development (contributors)
 
@@ -108,7 +105,7 @@ claude plugin install larch@larch-local
 
 | Component | Description |
 |---|---|
-| Skills | `/design`, `/implement`, `/review`, `/research`, `/fix-issue`, `/issue`, `/alias`, `/create-skill`, `/simplify-skill`, `/compress-skill`, `/im`, `/imaq` |
+| Skills | `/design`, `/implement`, `/review`, `/research`, `/fix-issue`, `/issue`, `/upgrade-larch`, `/alias`, `/create-skill`, `/simplify-skill`, `/compress-skill`, `/im`, `/imaq` |
 | Agents | `code-reviewer` (unified archetype covering code quality, risk/integration, correctness, architecture, security) |
 | PreToolUse hook | `block-submodule-edit.sh` — blocks `Edit`/`Write` on files inside any checked-out git submodule of the consuming project |
 | SessionStart hook | `sessionstart-health.sh` — at session start/resume/clear/compact, probes `jq` and `git` on `PATH`; if either is missing, injects an advisory into session context so the issue is visible before the first `Edit`/`Write`. Non-blocking (always exits 0); silent when both tools are present |

--- a/skills/upgrade-larch/SKILL.md
+++ b/skills/upgrade-larch/SKILL.md
@@ -4,7 +4,7 @@ description: "Use when upgrading the larch plugin to the latest version. Removes
 allowed-tools: Bash
 ---
 
-Upgrade the larch plugin to the latest version.
+Upgrade the larch plugin to the latest version. This skill is for the standard GitHub install (`claude plugin marketplace add zhupanov/larch`). Contributors using a local checkout (`claude --plugin-dir .` or `claude plugin marketplace add .`) should `git pull` instead.
 
 ## Steps
 
@@ -23,3 +23,5 @@ claude plugin list 2>&1 | grep -A2 'larch@larch-local'
 Confirm the version line shows the expected latest version.
 
 3. Tell the user to restart Claude Code to apply the new version.
+
+See `${CLAUDE_PLUGIN_ROOT}/skills/upgrade-larch/scripts/upgrade-larch.md` for script contract and failure recovery details.

--- a/skills/upgrade-larch/SKILL.md
+++ b/skills/upgrade-larch/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: upgrade-larch
+description: "Use when upgrading the larch plugin to the latest version. Removes and re-adds the marketplace, then reinstalls the plugin to pick up the newest release."
+allowed-tools: Bash
+---
+
+Upgrade the larch plugin to the latest version.
+
+## Steps
+
+1. Run the upgrade script:
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/skills/upgrade-larch/scripts/upgrade-larch.sh
+```
+
+2. Verify the upgrade succeeded by checking the installed version:
+
+```bash
+claude plugin list 2>&1 | grep -A2 'larch@larch-local'
+```
+
+Confirm the version line shows the expected latest version.
+
+3. Tell the user to restart Claude Code to apply the new version.

--- a/skills/upgrade-larch/scripts/upgrade-larch.md
+++ b/skills/upgrade-larch/scripts/upgrade-larch.md
@@ -1,0 +1,21 @@
+# scripts/upgrade-larch.sh — contract
+
+Upgrades the larch plugin to the latest version by removing and re-adding the marketplace from GitHub, then reinstalling.
+
+## Purpose
+
+Automates the full teardown-and-reinstall sequence needed to pick up the latest larch version. Invoked by `/upgrade-larch`.
+
+## Behavior
+
+1. Uninstalls `larch@larch-local` (best-effort — may not be installed).
+2. Removes the `larch-local` marketplace (best-effort — may not be registered).
+3. Re-adds the marketplace from `zhupanov/larch` on GitHub.
+4. Installs the `larch` plugin from the freshly-added marketplace.
+
+Steps 1–2 use `|| true` because the plugin/marketplace may not exist (first install, or already removed). Steps 3–4 run under `set -e` and will fail loudly on network errors, auth issues, or CLI problems. On failure after teardown, the script prints recovery commands so the user can manually re-add.
+
+## Edit-in-sync
+
+- `skills/upgrade-larch/SKILL.md` — the skill that invokes this script
+- `docs/installation-and-setup.md` — documents the Upgrade flow

--- a/skills/upgrade-larch/scripts/upgrade-larch.sh
+++ b/skills/upgrade-larch/scripts/upgrade-larch.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Upgrade the larch plugin to the latest version by removing and re-adding
+# the marketplace, then reinstalling the plugin.
+
+echo "Uninstalling larch plugin..."
+claude plugin uninstall larch@larch-local 2>&1 || true
+
+echo "Removing larch-local marketplace..."
+claude plugin marketplace remove larch-local 2>&1 || true
+
+echo "Re-adding larch marketplace from GitHub..."
+claude plugin marketplace add zhupanov/larch 2>&1
+
+echo "Installing larch plugin..."
+claude plugin install larch@larch-local 2>&1
+
+echo ""
+echo "Upgrade complete. Restart Claude Code to apply the new version."

--- a/skills/upgrade-larch/scripts/upgrade-larch.sh
+++ b/skills/upgrade-larch/scripts/upgrade-larch.sh
@@ -1,8 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Upgrade the larch plugin to the latest version by removing and re-adding
-# the marketplace, then reinstalling the plugin.
+recover() {
+    echo "" >&2
+    echo "Recovery: run these commands manually to reinstall:" >&2
+    echo "  claude plugin marketplace add zhupanov/larch" >&2
+    echo "  claude plugin install larch@larch-local" >&2
+}
+trap recover ERR
 
 echo "Uninstalling larch plugin..."
 claude plugin uninstall larch@larch-local 2>&1 || true


### PR DESCRIPTION
## Summary
- Added `/upgrade-larch` skill that automates upgrading the larch plugin to the latest version by removing and re-adding the marketplace, then reinstalling
- Updated `docs/installation-and-setup.md`: removed "Install a specific version" section (version pinning caused downgrade bugs), added Upgrade section with `/upgrade-larch` instructions

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- Verify `/upgrade-larch` skill resolves and runs the upgrade script
- Verify the script handles idempotent teardown (uninstall/remove with `|| true`) and fails loudly on re-add/install errors
- Verify `docs/installation-and-setup.md` no longer contains "Install a specific version" and contains the new Upgrade section
- Run `/relevant-checks` to validate linting and structural checks

</details>

Closes #952

Generated with [Claude Code](https://claude.com/claude-code)
