### PR TITLE
Fix codex-cli 0.125.0 prompt misparse in launch-codex-implement.sh (#991)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "15.0.1",
+  "version": "15.0.2",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 6-reviewer specialist panel (5 Cursor specialists + 1 Codex generic) with 3-voter adjudication; plan review runs a 3-reviewer panel (Claude + Codex + Cursor); design sketches run a 9-agent diverge-then-converge phase in regular mode (1 Claude + 4 Cursor + 4 Codex) or 3 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [15.0.2] - 2026-05-03
+
+### Fixed
+
+- `scripts/launch-codex-implement.sh` now passes the composed prompt to `codex exec` after a `--` end-of-options separator. The agent prompt is built by `cat`ting `agents/codex-implementer.md`, which begins with YAML frontmatter (`---`); codex-cli 0.125.0 interpreted the leading `---` as a flag delimiter and aborted with `unexpected argument`, blocking every `/implement` Step 2 Codex spawn. Operators had to fall back to `--codex-available false` (Claude implementer) to make progress. The sibling `scripts/launch-codex-implement.md` now documents the `--` separator as a load-bearing invariant. `scripts/launch-codex-review.sh` is unaffected because `render-specialist-prompt.sh` strips frontmatter from reviewer prompts. Closes #991.
+
 ## [15.0.1] - 2026-05-03
 
 ### Fixed

--- a/scripts/launch-codex-implement.md
+++ b/scripts/launch-codex-implement.md
@@ -9,6 +9,7 @@
 - Wrapper always exits 0 unless flag validation fails (exit 2). The Codex subprocess's exit code is reported via `LAUNCHER_EXIT=<int>` on stdout; the dispatcher decides whether that constitutes failure.
 - Composes Codex's prompt by concatenating `--agent-prompt` (system-prompt body, `agents/codex-implementer.md`) with this-invocation parameters and an optional resume block. Composition is in shell, not in agent-side prose, so the contract is mechanically inspectable.
 - Reuses `agent-model-args.sh --tool codex --with-effort` exactly as `launch-codex-review.sh` does — this implementer benefits from max reasoning effort.
+- The composed prompt is passed as a positional argument to `codex exec` after a `--` end-of-options separator. The separator is load-bearing: `agents/codex-implementer.md` begins with YAML frontmatter (`---`), and codex-cli (observed on 0.125.0) interprets a leading `---` as a flag delimiter and aborts. `launch-codex-review.sh` does not need this separator because `render-specialist-prompt.sh` strips frontmatter from reviewer prompts.
 
 **Stdout contract**:
 ```

--- a/scripts/launch-codex-implement.sh
+++ b/scripts/launch-codex-implement.sh
@@ -141,6 +141,7 @@ LAUNCHER_EXIT=0
     codex exec --full-auto -C "$PWD" \
     $MODEL_ARGS \
     --output-last-message "$TRANSCRIPT_PATH" \
+    -- \
     "$PROMPT" \
     >"$SIDECAR_LOG" 2>&1 || LAUNCHER_EXIT=$?
 


### PR DESCRIPTION
## Summary

- Insert `-- ` end-of-options separator before `"$PROMPT"` in `scripts/launch-codex-implement.sh` so codex-cli 0.125.0 stops misparsing the agent prompt's leading YAML frontmatter (`---`) as a flag delimiter, which had been blocking every `/implement` Step 2 Codex spawn with `unexpected argument`.
- Document the separator as a load-bearing invariant in the sibling `scripts/launch-codex-implement.md` (per AGENTS.md "Per-script contracts live beside the script") and clarify that `launch-codex-review.sh` does not need the same separator because `render-specialist-prompt.sh` already strips frontmatter from reviewer prompts.

Closes #991

## Test plan

- [x] `/relevant-checks` (pre-commit + agent-lint) green on the changed-file phase and full-repo phase
- [x] `codex exec --help` confirms `[PROMPT]` is the documented positional argument; `run-external-agent.sh` executes `"$@"` literally so the inner `--` reaches `codex`
- [x] Code review (5 Cursor specialists round 1, 1 generic Cursor round 2) — converged with NO_ISSUES_FOUND on the second round
- [ ] Manual end-to-end: a fresh `/implement` run on this version reaches Codex Step 2 without the `unexpected argument` abort (deferred — was the user's original repro signal; this PR's fix is the standard `--` end-of-options idiom and is verified statically)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
