### PR TITLE
Wrap Step 0.5 Branch 3 PR-body Closes-recovery in helper script

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "15.0.2",
+  "version": "15.0.3",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 6-reviewer specialist panel (5 Cursor specialists + 1 Codex generic) with 3-voter adjudication; plan review runs a 3-reviewer panel (Claude + Codex + Cursor); design sketches run a 9-agent diverge-then-converge phase in regular mode (1 Claude + 4 Cursor + 4 Codex) or 3 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [15.0.3] - 2026-05-03
+
+### Changed
+
+- `skills/implement/SKILL.md` Step 0.5 Branch 3 (PR-body recovery) now invokes `scripts/extract-closes-issue-from-pr.sh` instead of inlining the `gh pr view --json body --jq | grep -oE 'Closes #[0-9]+' | head -1 | grep -oE '[0-9]+'` pipeline. The new helper script and its sibling contract `scripts/extract-closes-issue-from-pr.md` follow the per-script-contract convention in `AGENTS.md`. Behavior is unchanged: empty stdout when no PR exists on the current branch or the PR body has no `Closes #<N>` line; otherwise the matched issue number. Closes #985.
+
 ## [15.0.2] - 2026-05-03
 
 ### Fixed

--- a/scripts/extract-closes-issue-from-pr.md
+++ b/scripts/extract-closes-issue-from-pr.md
@@ -1,0 +1,41 @@
+# `extract-closes-issue-from-pr.sh`
+
+## Purpose
+
+Extract the first `Closes #<N>` issue number from the body of the PR
+associated with the current git branch. Wraps the multi-pipe `gh pr view |
+grep | head | grep` invocation that previously lived inline in
+`skills/implement/SKILL.md` Step 0.5 Branch 3 (PR-body recovery), so the
+SKILL.md prose owns intent and the shell pipeline lives in a single
+testable location (per the per-script-contract convention in `AGENTS.md`).
+
+## Inputs
+
+None. The script reads PR state from `gh` against the current branch.
+
+## Outputs
+
+- **stdout**: the matched issue number (digits only), or empty when no PR
+  exists on the current branch or the PR body has no `Closes #<N>` line.
+- **stderr**: silenced (`gh pr view` errors are swallowed by `2>/dev/null`
+  to keep "no PR on this branch" indistinguishable from "no `Closes` line",
+  matching the pre-extraction inline behavior).
+- **Exit code**: always `0`. The empty-stdout case is normal (no PR, or no
+  match) and must not be treated as an error by callers.
+
+`set -e` is in force: hard failures in the pipeline (other than the
+expected `grep` no-match) propagate via `pipefail`, but the trailing
+`|| true` neutralizes the no-match exit so the script always exits `0`.
+
+## Caller
+
+Single caller: `skills/implement/SKILL.md` Step 0.5 Branch 3 ("PR on
+current branch with `Closes #<N>`"). The caller assigns the captured
+stdout to `RECOVERED_N` and treats an empty value as "fall through to
+Branch 4".
+
+## Edit-in-sync rules
+
+If the recovery grammar in Branch 3 changes (e.g. accepts `Fixes #<N>` in
+addition to `Closes #<N>`), update both this script's pipeline and the
+prose in `skills/implement/SKILL.md` Step 0.5 Branch 3 in the same PR.

--- a/scripts/extract-closes-issue-from-pr.sh
+++ b/scripts/extract-closes-issue-from-pr.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Extract the first `Closes #<N>` issue number from the current branch's PR
+# body. Wraps the inline pipeline previously embedded in skills/implement/
+# SKILL.md Step 0.5 Branch 3 (PR-body recovery).
+#
+# Inputs: none.
+# Output: issue number on stdout, or empty when no PR exists on the current
+# branch or its body has no `Closes #<N>` line.
+# Exit code: always 0 (the empty case is normal, not an error).
+set -euo pipefail
+
+gh pr view --json body --jq '.body' 2>/dev/null \
+  | grep -oE 'Closes #[0-9]+' \
+  | head -1 \
+  | grep -oE '[0-9]+' \
+  || true

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -319,7 +319,7 @@ ADOPTED=true
 Check for an existing PR on the current branch; if present, extract the first `Closes #<N>` line from its body:
 
 ```bash
-gh pr view --json body --jq '.body' 2>/dev/null | grep -oE 'Closes #[0-9]+' | head -1 | grep -oE '[0-9]+'
+${CLAUDE_PLUGIN_ROOT}/scripts/extract-closes-issue-from-pr.sh
 ```
 
 If a number emerges as `RECOVERED_N`: validate the target issue via `gh issue view "$RECOVERED_N" --json state,url` (same PR-vs-issue + CLOSED checks as Branch 2). If target is a PR URL or CLOSED, fall through to Branch 4. Else (OPEN issue): **adopt safely without clobbering any populated existing anchor** using the same paginated, multi-anchor-fail-closed `find-anchor` subcommand as Branch 2 — only the issue-number variable differs (`$RECOVERED_N` here vs `$ISSUE_ARG` in Branch 2):


### PR DESCRIPTION
## Summary

- Wrap the multi-pipe `gh pr view ... | grep | head | grep` pipeline (used in `skills/implement/SKILL.md` Step 0.5 Branch 3 to recover a `Closes #<N>` reference from the current branch's PR body) into a new helper script `scripts/extract-closes-issue-from-pr.sh`.
- Add the sibling contract `scripts/extract-closes-issue-from-pr.md` per the per-script-contract convention in `AGENTS.md`.
- Update `skills/implement/SKILL.md` Branch 3 to invoke `${CLAUDE_PLUGIN_ROOT}/scripts/extract-closes-issue-from-pr.sh` instead of the inline pipeline.

Behavior is unchanged: empty stdout when no PR exists on the current branch or the PR body has no `Closes #<N>` line; otherwise the matched issue number.

## Test plan

- [x] `/relevant-checks` passes (pre-commit + agent-lint).
- [x] Smoke test: invoking the script outside a PR-bearing branch returns empty stdout, exit 0.
- [ ] Reviewer to confirm: invoked from a branch with a PR whose body contains `Closes #<N>` returns `<N>`.

Closes #985
