### PR TITLE
Forbid spawning Monitor to wait for Bash run_in_background to finish

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "15.1.0",
+  "version": "15.1.1",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 6-reviewer specialist panel (5 Cursor specialists + 1 Codex generic) with 3-voter adjudication; plan review runs a 3-reviewer panel (Claude + Codex + Cursor); design sketches run a 9-agent diverge-then-converge phase in regular mode (1 Claude + 4 Cursor + 4 Codex) or 3 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,3 +46,4 @@ Plugin ships the entire repo. **Runtime surface**: `skills/`, `agents/`, `hooks/
 - Run `gh pr create` through the skill, not manually.
 - Run `gh issue create` through `/larch:issue`, not manually. Scripts under `scripts/` and `skills/*/scripts/` (e.g., hooks) may continue to call `gh issue create` directly — the rule targets interactive / assistant-driven issue creation only.
 - Slack env vars are optional; skills degrade gracefully when absent.
+- **Don't spawn a Monitor to watch a Bash `run_in_background` job finish.** The Bash tool already emits a `<task-notification>` with `status=completed` when the process exits — the Monitor would just deliver the same signal twice. Use Monitor only for tailing logs, polling remote state, or per-occurrence event streams; for one-shot "wait until done," rely on the Bash notification.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [15.1.1] - 2026-05-03
+
+### Added
+
+- `AGENTS.md` Conventions: bullet forbidding spawning a Monitor task to wait for a Bash `run_in_background` job to finish (the Bash task-completion notification already covers that case).
+
 ## [15.1.0] - 2026-05-03
 
 ### Added


### PR DESCRIPTION
## Summary

- Adds a Conventions bullet to `AGENTS.md` forbidding spawning a Monitor task to wait for a Bash `run_in_background` job to finish.
- The Bash background-task system already emits `<task-notification>` with `status=completed`; Monitor would just deliver the same signal twice.
- Reserves Monitor for log tailing, remote state polling, and per-occurrence event streams.

## Architecture Diagram

_Documentation-only change — no architecture diagram._

## Code Flow Diagram

_Documentation-only change — no code-flow diagram._

## Test plan

- [x] `/relevant-checks` passes (pre-commit + agent-lint).
- [x] New bullet renders correctly under `## Conventions` in `AGENTS.md`.

Closes #996

🤖 Generated with [Claude Code](https://claude.com/claude-code)
