### PR TITLE
Fix stale Makefile:148 line-number anchors

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "15.4.2",
+  "version": "15.4.3",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 6-reviewer specialist panel (5 Cursor specialists + 1 Codex generic) with 3-voter adjudication; plan review runs a 3-reviewer panel (Claude + Codex + Cursor); design sketches run a 9-agent diverge-then-converge phase in regular mode (1 Claude + 4 Cursor + 4 Codex) or 3 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [15.4.3] - 2026-05-03
+
+### Changed
+
+- Replace stale `Makefile:148` and `Makefile:157-163` line-number citations with target-name anchors (`test-eval-set-structure` target). Affects `Makefile`, `scripts/test-eval-research-baseline-flag.md`, and `scripts/test-eval-research-baseline-flag.sh`. Pre-existing hygiene fix unrelated to issue #1016 (closes #1021).
+
 ## [15.4.2] - 2026-05-03
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -266,9 +266,10 @@ test-eval-set-structure:
 # in scripts/eval-research.sh (closes #441). NOT a `test-harnesses`
 # prerequisite — the eval-research surface is opt-in operator
 # instrumentation explicitly carved out from CI by repo contract
-# (see Makefile:148, docs/linting.md, scripts/eval-research.md). Runs
-# offline by PATH-stubbing claude + jq so it works on machines without
-# the real binaries. See scripts/test-eval-research-baseline-flag.md.
+# (see the `test-eval-set-structure` target above, docs/linting.md,
+# scripts/eval-research.md). Runs offline by PATH-stubbing claude + jq
+# so it works on machines without the real binaries.
+# See scripts/test-eval-research-baseline-flag.md.
 test-eval-research-baseline-flag:
 	bash scripts/test-eval-research-baseline-flag.sh
 

--- a/scripts/test-eval-research-baseline-flag.md
+++ b/scripts/test-eval-research-baseline-flag.md
@@ -24,7 +24,7 @@ make test-eval-research-baseline-flag
 
 ## Wiring
 
-- **Standalone Makefile target** in the project `Makefile` — `test-eval-research-baseline-flag`. **NOT a `test-harnesses` prerequisite** by design (the runtime harness it tests is opt-in operator instrumentation explicitly carved out from CI; see `Makefile:148` and `docs/linting.md`'s `/research evaluation harness` section). Pattern follows `test-eval-set-structure` (Makefile:157-163).
+- **Standalone Makefile target** in the project `Makefile` — `test-eval-research-baseline-flag`. **NOT a `test-harnesses` prerequisite** by design (the runtime harness it tests is opt-in operator instrumentation explicitly carved out from CI; see the `Makefile` `test-eval-set-structure` target and `docs/linting.md`'s `/research evaluation harness` section). Pattern follows the `Makefile` `test-eval-set-structure` target.
 - **`agent-lint.toml`** — listed in the `[lint].exclude` array so agent-lint's G004 dead-script rule does not flag this Makefile-only harness in CI. The matching pattern is the same as for `test-eval-set-structure.sh` and other Makefile-only harnesses.
 - **CI**: locally `make lint` runs `test-harnesses` then `lint-only`; in CI those are separate jobs (`lint` + `test-harnesses`). This test runs in **neither** by default — operators invoke it on demand or as part of fixing/validating the `--baseline` flag area.
 

--- a/scripts/test-eval-research-baseline-flag.sh
+++ b/scripts/test-eval-research-baseline-flag.sh
@@ -24,8 +24,9 @@
 # Invoked via:  bash scripts/test-eval-research-baseline-flag.sh
 # Wired into:   standalone Makefile target `test-eval-research-baseline-flag`.
 #               NOT a `test-harnesses` prerequisite — eval-research is opt-in
-#               operator instrumentation by repo contract (Makefile:148,
-#               docs/linting.md, scripts/eval-research.md).
+#               operator instrumentation by repo contract (see the
+#               Makefile `test-eval-set-structure` target, docs/linting.md,
+#               and scripts/eval-research.md).
 
 set -euo pipefail
 


### PR DESCRIPTION
## Summary

- Replace stale `Makefile:148` and `Makefile:157-163` line-number citations with target-name anchors (`Makefile test-eval-set-structure target`).
- Affects three files: `Makefile`, `scripts/test-eval-research-baseline-flag.md`, and `scripts/test-eval-research-baseline-flag.sh`.
- Pre-existing hygiene fix unrelated to issue #1016 (the parent that spawned this OOS).

## Architecture Diagram

Architecture diagram not available.

## Code Flow Diagram

(Code Flow Diagram skipped — quick mode)

## Test plan

- [x] `grep -rn 'Makefile:148\|Makefile:157' .` returns zero in-scope matches.
- [x] `/relevant-checks` passes (pre-commit + agent-lint).
- [x] Quick-mode code review round 1 (5 Cursor specialists + generic Codex) — no in-scope findings; one OOS observation accepted and filed as a separate issue.

Closes #1021

🤖 Generated with [Claude Code](https://claude.com/claude-code)
