### PR TITLE
Align baseline-flag harness jq stub doc with code (closes #1025)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "15.4.4",
+  "version": "15.4.5",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 6-reviewer specialist panel (5 Cursor specialists + 1 Codex generic) with 3-voter adjudication; plan review runs a 3-reviewer panel (Claude + Codex + Cursor); design sketches run a 9-agent diverge-then-converge phase in regular mode (1 Claude + 4 Cursor + 4 Codex) or 3 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [15.4.5] - 2026-05-03
+
+### Fixed
+
+- `scripts/test-eval-research-baseline-flag.md` — drop the spurious `.scale` clause from the documented jq stub expression so the contract doc matches the actual `validate_baseline_json` predicate in `scripts/eval-research.sh` (`.version and (.entries | type == "array")`) and the harness header in `scripts/test-eval-research-baseline-flag.sh` (closes #1025).
+
 ## [15.4.4] - 2026-05-03
 
 ### Changed

--- a/scripts/test-eval-research-baseline-flag.md
+++ b/scripts/test-eval-research-baseline-flag.md
@@ -33,7 +33,7 @@ make test-eval-research-baseline-flag
 `.github/workflows/ci.yaml`'s `test-harnesses` job only installs PyYAML — no `claude` or `jq`. Even though this harness is not wired into `test-harnesses`, it is designed to run offline so an operator on any machine can exercise it without the real Claude CLI:
 
 - A stub `claude` is planted in a `mktemp -d` PATH-prefix so `eval-research.sh`'s `require_tool claude` check succeeds. The real binary is never invoked because `--id nonexistent-id-zzz` causes the eval loop to iterate zero entries.
-- A stub `jq` is planted similarly. The only `jq` call before the baseline block is `validate_baseline_json`'s `jq -e '.version and .scale and (.entries | type == "array")' <file>`, which only checks exit status. The stub returns exit 0 unconditionally. The committed `eval-baseline.json` is a schema-only stub, so any real `jq` would also pass.
+- A stub `jq` is planted similarly. The only `jq` call before the baseline block is `validate_baseline_json`'s `jq -e '.version and (.entries | type == "array")' <file>`, which only checks exit status. The stub returns exit 0 unconditionally. The committed `eval-baseline.json` is a schema-only stub, so any real `jq` would also pass.
 - The PATH-stub pattern is the repo precedent for offline operation in tests that exercise `claude`-dependent scripts.
 
 ## Edit-in-sync


### PR DESCRIPTION
## Summary

- Update `scripts/test-eval-research-baseline-flag.md` line 36 to drop the `.scale` clause from the documented jq stub expression so the contract doc matches the real `validate_baseline_json` predicate in `scripts/eval-research.sh` and the harness header in `scripts/test-eval-research-baseline-flag.sh`.

## Test plan

- [x] grep confirms the stale `.version and .scale and (.entries` form no longer appears in the repo.
- [x] `/relevant-checks` (pre-commit + agent-lint).

Closes #1025

🤖 Generated with [Claude Code](https://claude.com/claude-code)
