### PR TITLE
Rebalance test harness matrix shards (closes #1028)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "15.4.6",
+  "version": "15.4.7",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 6-reviewer specialist panel (5 Cursor specialists + 1 Codex generic) with 3-voter adjudication; plan review runs a 3-reviewer panel (Claude + Codex + Cursor); design sketches run a 9-agent diverge-then-converge phase in regular mode (1 Claude + 4 Cursor + 4 Codex) or 3 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [15.4.7] - 2026-05-03
+
+### Changed
+
+- Rebalance test-harnesses matrix shards in CI so shard run times are more even. `test-validate-citations` (the wall-clock floor) now shares shard 6 with the partition-invariant guard `test-harness-shards-coverage`; previous shard 1/2 contents are redistributed across the lighter shards. Adds a "Last manual rebalance: 2026-05-03 (issue #1028)" audit-trail line in `docs/linting.md` "Refreshing harness shard balance" per the Makefile-shard-layout lockstep contract in `scripts/test-harness-shards-coverage.md` (closes #1028).
+
 ## [15.4.6] - 2026-05-03
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -11,30 +11,29 @@ lint: test-harnesses lint-only
 lint-only:
 	pre-commit run --all-files
 
-# Six balanced regression-harness shards (LPT bin-packing on measured per-harness
-# timings captured 2026-05-03; see docs/linting.md "Refreshing harness shard
-# balance" for the manual procedure used to regenerate these lists when
-# imbalance grows). Total measured runtime: 91.11s across 66 legacy harnesses +
-# 1 partition guard. The 18.34s test-validate-citations on shard-1 is the
-# wall-clock floor. IMPORTANT: each test-harnesses-N rule below stays on a
-# single physical line (no `\` continuations); the drift-detection script
-# `scripts/test-harness-shards-coverage.sh` parses these lines literally. New
-# harnesses get appended to one shard line.
+# Six balanced regression-harness shards. Lists are manually adjusted from
+# observed CI timings; see docs/linting.md "Refreshing harness shard balance"
+# for the procedure used to regenerate these lists when imbalance grows. The
+# test-validate-citations harness is the wall-clock floor, so it runs by itself
+# except for shard-6's partition guard. IMPORTANT: each test-harnesses-N rule
+# below stays on a single physical line (no `\` continuations); the
+# drift-detection script `scripts/test-harness-shards-coverage.sh`
+# parses these lines literally. New harnesses get appended to one shard line.
 test-harnesses: test-harnesses-1 test-harnesses-2 test-harnesses-3 test-harnesses-4 test-harnesses-5 test-harnesses-6
 
-test-harnesses-1: test-validate-citations
+test-harnesses-1: test-umbrella-handler test-issue-lifecycle test-finalize-umbrella test-add-blocked-by test-design-manifest test-umbrella-render-batch-input test-run-research-planner test-deny-edit-write test-render-lane-status test-research-structure test-implement-rebase-macro test-alias-structure test-fix-issue-bail-detection test-synthesis-subagent test-find-lock-issue test-render-specialist-prompt
 
-test-harnesses-2: test-find-lock-issue test-render-specialist-prompt test-alias-target-resolution test-umbrella-emit-output-contract test-review-structure test-research-banner test-post-scaffold-hints test-body-file-title test-cursor-implementer
+test-harnesses-2: test-research-banner test-post-scaffold-hints test-body-file-title test-cursor-implementer test-drop-bump-commit test-check-bump-version test-lint-skill-invocations test-ci-wait-exit-trap
 
-test-harnesses-3: test-umbrella-handler test-issue-lifecycle test-finalize-umbrella test-add-blocked-by test-design-manifest test-umbrella-render-batch-input test-run-research-planner test-deny-edit-write test-render-lane-status test-research-structure test-implement-rebase-macro test-alias-structure test-fix-issue-bail-detection test-synthesis-subagent
+test-harnesses-3: test-tracking-issue-write test-allocate-candidates test-block-submodule test-redact test-validate-research-output test-prepare-description test-assemble-anchor test-tracking-issue-read-sentinel test-token-tally test-collect-agent-bash32 test-sentinel-write test-design-structure test-fix-issue-step-order test-orchestrator-scope-sync test-intra-batch-deps test-review-structure
 
-test-harnesses-4: test-umbrella-helpers test-render-findings-batch test-verify-skill-called test-check-review-changes test-parse-prose-blockers test-umbrella-parse-args test-render-umbrella-body test-references-headers test-implement-structure test-implement-post-design-boundary test-audit-edit-write test-parse-args test-anti-halt
+test-harnesses-4: test-umbrella-helpers test-render-findings-batch test-verify-skill-called test-check-review-changes test-parse-prose-blockers test-umbrella-parse-args test-render-umbrella-body test-references-headers test-implement-structure test-implement-post-design-boundary test-audit-edit-write test-parse-args test-anti-halt test-alias-target-resolution
 
-test-harnesses-5: test-tracking-issue-write test-allocate-candidates test-block-submodule test-redact test-validate-research-output test-prepare-description test-assemble-anchor test-tracking-issue-read-sentinel test-token-tally test-collect-agent-bash32 test-sentinel-write test-design-structure test-fix-issue-step-order test-orchestrator-scope-sync test-intra-batch-deps
+test-harnesses-5: test-render-reviewer-prompt test-parse-input test-validate-pieces-json test-step2-dispatch test-subskill-anchors test-render-skill test-quick-mode-docs-sync test-sessionstart test-check-reviewers test-research-angle-prompts test-implement-anti-polling-rule test-umbrella-emit-output-contract
 
 # Shard-6 leads with the partition-invariant guard so partition bugs surface
 # even when other shard-6 harnesses fail.
-test-harnesses-6: test-harness-shards-coverage test-drop-bump-commit test-check-bump-version test-lint-skill-invocations test-ci-wait-exit-trap test-render-reviewer-prompt test-parse-input test-validate-pieces-json test-step2-dispatch test-subskill-anchors test-render-skill test-quick-mode-docs-sync test-sessionstart test-check-reviewers test-research-angle-prompts test-implement-anti-polling-rule
+test-harnesses-6: test-harness-shards-coverage test-validate-citations
 
 test-redact:
 	bash scripts/test-redact-secrets.sh

--- a/docs/linting.md
+++ b/docs/linting.md
@@ -31,7 +31,7 @@ Local ordering changed: under `make test-harnesses` and therefore `make lint`, h
 
 ### Refreshing harness shard balance
 
-Rebalance manually when one shard's sustained wall-clock materially exceeds the `test-validate-citations` floor of about 18s, or when another shard drops far below the rest.
+Rebalance manually when one shard's sustained wall-clock materially exceeds the `test-validate-citations` floor of about 18s, or when another shard drops far below the rest. Last manual rebalance: 2026-05-03 (issue #1028) — `test-validate-citations` was moved behind shard 6's partition guard so the citation floor and the partition guard share a shard, and the previously crowded shard 2 was redistributed across the lighter shards.
 
 Capture timings:
 


### PR DESCRIPTION
## Summary

- Reduce sustained CI matrix spread by moving work off the two slowest harness shards
- Keep the shard partition guard first so duplicate or missing harness assignments still fail early

## Architecture Diagram

Architecture diagram not available.

## Code Flow Diagram

(Code Flow Diagram skipped — quick mode)

## Test plan

- [x] `make test-harness-shards-coverage` passes (partition invariant: every test target is on exactly one shard, shard 6 still leads with the partition guard)
- [x] `/relevant-checks` passes (pre-commit + agent-lint full-repo)
- [ ] Observe the next PR CI matrix to confirm shard wall-clock spread narrows under runner timings

Closes #1028

🤖 Generated with [Claude Code](https://claude.com/claude-code)
