### PR TITLE
Split citation budget tests into shardable harness (closes #1032)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "15.4.7",
+  "version": "15.4.8",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 6-reviewer specialist panel (5 Cursor specialists + 1 Codex generic) with 3-voter adjudication; plan review runs a 3-reviewer panel (Claude + Codex + Cursor); design sketches run a 9-agent diverge-then-converge phase in regular mode (1 Claude + 4 Cursor + 4 Codex) or 3 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Larch Makefile
 # Thin wrapper around pre-commit. Linter definitions live in .pre-commit-config.yaml.
 
-.PHONY: lint lint-only test-harnesses test-harnesses-1 test-harnesses-2 test-harnesses-3 test-harnesses-4 test-harnesses-5 test-harnesses-6 shellcheck markdownlint jsonlint actionlint agent-lint agnix gitleaks trufflehog setup test-redact test-validate-research-output test-validate-citations test-collect-agent-bash32 test-parse-input test-allocate-candidates test-add-blocked-by test-parse-args test-prepare-description test-parse-prose-blockers test-issue-lifecycle test-fix-issue-bail-detection test-fix-issue-step-order test-find-lock-issue test-umbrella-handler test-finalize-umbrella test-sentinel-write test-sessionstart test-audit-edit-write test-block-submodule test-deny-edit-write test-post-scaffold-hints test-render-skill test-render-lane-status test-verify-skill-called test-check-bump-version test-drop-bump-commit test-ci-wait-exit-trap test-lint-skill-invocations test-anti-halt test-orchestrator-scope-sync test-alias-target-resolution test-alias-structure test-design-structure test-design-manifest test-implement-rebase-macro test-implement-structure test-implement-anti-polling-rule test-implement-post-design-boundary test-step2-dispatch test-cursor-implementer test-quick-mode-docs-sync test-harness-shards-coverage test-references-headers test-render-reviewer-prompt test-render-specialist-prompt test-research-structure test-review-structure test-run-research-planner test-render-findings-batch test-research-banner test-synthesis-subagent test-research-angle-prompts test-subskill-anchors test-tracking-issue-write test-tracking-issue-read-sentinel test-assemble-anchor test-token-tally test-umbrella-helpers test-umbrella-parse-args test-umbrella-emit-output-contract test-umbrella-render-batch-input test-render-umbrella-body test-check-review-changes test-check-reviewers test-validate-pieces-json smoke-dialectic eval-research test-eval-set-structure test-eval-research-baseline-flag test-body-file-title test-intra-batch-deps
+.PHONY: lint lint-only test-harnesses test-harnesses-1 test-harnesses-2 test-harnesses-3 test-harnesses-4 test-harnesses-5 test-harnesses-6 shellcheck markdownlint jsonlint actionlint agent-lint agnix gitleaks trufflehog setup test-redact test-validate-research-output test-validate-citations test-validate-citations-budget test-collect-agent-bash32 test-parse-input test-allocate-candidates test-add-blocked-by test-parse-args test-prepare-description test-parse-prose-blockers test-issue-lifecycle test-fix-issue-bail-detection test-fix-issue-step-order test-find-lock-issue test-umbrella-handler test-finalize-umbrella test-sentinel-write test-sessionstart test-audit-edit-write test-block-submodule test-deny-edit-write test-post-scaffold-hints test-render-skill test-render-lane-status test-verify-skill-called test-check-bump-version test-drop-bump-commit test-ci-wait-exit-trap test-lint-skill-invocations test-anti-halt test-orchestrator-scope-sync test-alias-target-resolution test-alias-structure test-design-structure test-design-manifest test-implement-rebase-macro test-implement-structure test-implement-anti-polling-rule test-implement-post-design-boundary test-step2-dispatch test-cursor-implementer test-quick-mode-docs-sync test-harness-shards-coverage test-references-headers test-render-reviewer-prompt test-render-specialist-prompt test-research-structure test-review-structure test-run-research-planner test-render-findings-batch test-research-banner test-synthesis-subagent test-research-angle-prompts test-subskill-anchors test-tracking-issue-write test-tracking-issue-read-sentinel test-assemble-anchor test-token-tally test-umbrella-helpers test-umbrella-parse-args test-umbrella-emit-output-contract test-umbrella-render-batch-input test-render-umbrella-body test-check-review-changes test-check-reviewers test-validate-pieces-json smoke-dialectic eval-research test-eval-set-structure test-eval-research-baseline-flag test-body-file-title test-intra-batch-deps
 
 # CI splits `lint` into `lint-only` (pre-commit) and `test-harnesses`
 # (regression harnesses). `lint` remains the local-dev convenience target
@@ -14,11 +14,13 @@ lint-only:
 # Six balanced regression-harness shards. Lists are manually adjusted from
 # observed CI timings; see docs/linting.md "Refreshing harness shard balance"
 # for the procedure used to regenerate these lists when imbalance grows. The
-# test-validate-citations harness is the wall-clock floor, so it runs by itself
-# except for shard-6's partition guard. IMPORTANT: each test-harnesses-N rule
-# below stays on a single physical line (no `\` continuations); the
-# drift-detection script `scripts/test-harness-shards-coverage.sh`
-# parses these lines literally. New harnesses get appended to one shard line.
+# test-validate-citations harness remains the dominant wall-clock harness;
+# its real-time budget-exhaustion tests live in test-validate-citations-budget
+# so their sleeps can be billed to a different shard. IMPORTANT: each
+# test-harnesses-N rule below stays on a single physical line (no `\`
+# continuations); the drift-detection script
+# `scripts/test-harness-shards-coverage.sh` parses these lines literally.
+# New harnesses get appended to one shard line.
 test-harnesses: test-harnesses-1 test-harnesses-2 test-harnesses-3 test-harnesses-4 test-harnesses-5 test-harnesses-6
 
 test-harnesses-1: test-umbrella-handler test-issue-lifecycle test-finalize-umbrella test-add-blocked-by test-design-manifest test-umbrella-render-batch-input test-run-research-planner test-deny-edit-write test-render-lane-status test-research-structure test-implement-rebase-macro test-alias-structure test-fix-issue-bail-detection test-synthesis-subagent test-find-lock-issue test-render-specialist-prompt
@@ -29,10 +31,9 @@ test-harnesses-3: test-tracking-issue-write test-allocate-candidates test-block-
 
 test-harnesses-4: test-umbrella-helpers test-render-findings-batch test-verify-skill-called test-check-review-changes test-parse-prose-blockers test-umbrella-parse-args test-render-umbrella-body test-references-headers test-implement-structure test-implement-post-design-boundary test-audit-edit-write test-parse-args test-anti-halt test-alias-target-resolution
 
-test-harnesses-5: test-render-reviewer-prompt test-parse-input test-validate-pieces-json test-step2-dispatch test-subskill-anchors test-render-skill test-quick-mode-docs-sync test-sessionstart test-check-reviewers test-research-angle-prompts test-implement-anti-polling-rule test-umbrella-emit-output-contract
+test-harnesses-5: test-render-reviewer-prompt test-parse-input test-validate-pieces-json test-step2-dispatch test-subskill-anchors test-render-skill test-quick-mode-docs-sync test-sessionstart test-check-reviewers test-research-angle-prompts test-implement-anti-polling-rule test-umbrella-emit-output-contract test-validate-citations-budget
 
-# Shard-6 leads with the partition-invariant guard so partition bugs surface
-# even when other shard-6 harnesses fail.
+# Shard-6 leads with the partition-invariant guard so partition bugs surface.
 test-harnesses-6: test-harness-shards-coverage test-validate-citations
 
 test-redact:
@@ -43,6 +44,9 @@ test-validate-research-output:
 
 test-validate-citations:
 	bash skills/research/scripts/test-validate-citations.sh
+
+test-validate-citations-budget:
+	bash skills/research/scripts/test-validate-citations-budget.sh
 
 test-collect-agent-bash32:
 	bash scripts/test-collect-agent-bash32.sh

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -228,7 +228,7 @@ Then conditionally print advisory warnings (not errors — fail-soft):
 - When `<fail> > 0`: `**⚠ 2.5: citation-validation — <fail> claim(s) FAILED. See ## Citation Validation in the report.**`
 - When `<unknown> > 0`: `**ℹ 2.5: citation-validation — <unknown> claim(s) UNKNOWN. See ## Citation Validation in the report.**`
 
-The sidecar at `$RESEARCH_TMPDIR/citation-validation.md` is consumed by Step 3 (splice contract: appended as a `## Citation Validation` section to `research-report-final.md` before the user-visible `cat`). See `${CLAUDE_PLUGIN_ROOT}/skills/research/scripts/validate-citations.md` for the full validator contract; the offline regression harness is `${CLAUDE_PLUGIN_ROOT}/skills/research/scripts/test-validate-citations.sh` (contract in sibling `${CLAUDE_PLUGIN_ROOT}/skills/research/scripts/test-validate-citations.md`), wired into `make lint`.
+The sidecar at `$RESEARCH_TMPDIR/citation-validation.md` is consumed by Step 3 (splice contract: appended as a `## Citation Validation` section to `research-report-final.md` before the user-visible `cat`). See `${CLAUDE_PLUGIN_ROOT}/skills/research/scripts/validate-citations.md` for the full validator contract; the offline regression harness is `${CLAUDE_PLUGIN_ROOT}/skills/research/scripts/test-validate-citations.sh` (contract in sibling `${CLAUDE_PLUGIN_ROOT}/skills/research/scripts/test-validate-citations.md`), wired into `make lint`. Real-time budget-exhaustion coverage (Tests 20 / 21) lives in the sibling harness `${CLAUDE_PLUGIN_ROOT}/skills/research/scripts/test-validate-citations-budget.sh` (contract in `${CLAUDE_PLUGIN_ROOT}/skills/research/scripts/test-validate-citations-budget.md`) so its real sleeps can be billed to a different CI matrix shard.
 
 ## Step 2.6 — Critique Loop
 

--- a/skills/research/scripts/test-validate-citations-budget.md
+++ b/skills/research/scripts/test-validate-citations-budget.md
@@ -1,0 +1,39 @@
+# skills/research/scripts/test-validate-citations-budget.sh — Contract
+
+Offline budget-exhaustion regression harness for `validate-citations.sh`.
+Split from `test-validate-citations.sh` so the real-time sleep scenarios can
+run on a separate CI shard from the CPU-bound citation validator scenarios.
+
+## What it pins
+
+| Scenario | Assertion target |
+|---|---|
+| Darwin budget exhaustion (Test 20, Darwin-only) | hung fake-curl + `--budget-seconds 1` -> exit 0, sidecar present with `UNKNOWN`/`timeout` rows for hung URLs, no surviving fake-curl PIDs after kill loop. Exercises the macOS `set -m` per-PG-kill branch. Linux runners skip; Test 21 covers the Linux no-setsid path. Test 20 runs on developer macOS (current CI is Ubuntu-only). |
+| Linux no-setsid budget exhaustion (Test 21, Linux-only, #849) | outer `setsid -w` wraps the validator in its own session; hermetic clean-bin (symlinks excluding `setsid`, including `uname`) makes `command -v setsid` fail inside the validator so the no-setsid branch (`validate-citations.sh:765`) is exercised; hung fake-curl honoring `--max-time` + `--budget-seconds 1` -> exit 0, sidecar present, `UNKNOWN`/`timeout` rows for both hung URLs, no orphan fake-curl PIDs after the shortened `--per-fetch-timeout` window. Runs when `setsid` is available on the runner PATH; otherwise skipped with note. Demonstrably fails if the `__VC_SETSID_DONE` marker gate at `validate-citations.sh:765` is reverted to unconditional `kill -- -$$` (validator gets SIGTERM under outer setsid -> exit 143). Test 21 is exercised by current Ubuntu CI. |
+
+## Test seams
+
+| Var | Effect on `validate-citations.sh` |
+|---|---|
+| `__VC_FAKE_CURL` | replaces real `curl` with PID-recording fake-curl shims |
+| `__VC_LAST_ARGV` | absolute path the fake-curl shim writes argv records to |
+| `__VC_SKIP_DNS` | skip real DNS resolution |
+| `__VC_STUB_RESOLVE` | `host=ip;host=ip;...` for fake resolution |
+
+## Edit-in-sync
+
+When this harness changes:
+
+1. This `.md` (the contract).
+2. `test-validate-citations-budget.sh` (the harness body).
+3. `test-validate-citations.sh` / `test-validate-citations.md` when moving
+   coverage between the CPU-bound and real-time-bound harnesses.
+4. `Makefile` `test-validate-citations-budget` target and shard assignment.
+5. `validate-citations.md` § Test harness (the validator contract's mirrored
+   summary).
+
+## Wiring
+
+`make lint` invokes this harness via the `test-validate-citations-budget`
+target, which is a prerequisite of exactly one `test-harnesses-N:` shard. The
+harness exits non-zero on any assertion failure; CI fails the same way.

--- a/skills/research/scripts/test-validate-citations-budget.sh
+++ b/skills/research/scripts/test-validate-citations-budget.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+# test-validate-citations-budget.sh — Budget-exhaustion regression harness for validate-citations.sh.
+#
+# Split from test-validate-citations.sh to keep CI harness shards under the
+# target wall-clock. Tests 20 and 21 are real-time-bound because they assert
+# timeout and process-cleanup behavior around deliberate sleeps; Tests 1-19
+# are CPU-bound and stay in the parent harness.
+#
+# Test seams (env vars exported per case):
+#   __VC_FAKE_CURL    : absolute path to a fake-curl shim that returns scripted
+#                       HTTP codes per --output-flag URL pattern.
+#   __VC_SKIP_DNS     : skip real DNS resolution.
+#   __VC_STUB_RESOLVE : 'host=ip;host=ip;...' for stub resolution.
+#   __VC_DRY_RUN      : exit after extraction, print to stderr.
+#
+# Exit 0 on pass, 1 on any failure.
+
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "$0")/../../.." && pwd -P)
+VALIDATOR="$REPO_ROOT/skills/research/scripts/validate-citations.sh"
+WORK=$(mktemp -d -t validate-citations-test.XXXXXX)
+trap 'rm -rf "$WORK"' EXIT
+
+[[ -x "$VALIDATOR" ]] || { echo "FAIL: $VALIDATOR is not executable"; exit 1; }
+
+PASS=0
+FAIL=0
+
+note() { printf '  %s\n' "$1"; }
+
+assert() {
+    local name="$1" cond_cmd="$2"
+    if eval "$cond_cmd"; then
+        PASS=$((PASS + 1))
+        note "ok: $name"
+    else
+        FAIL=$((FAIL + 1))
+        note "FAIL: $name"
+    fi
+}
+
+ARGV_LOG="$WORK/last-argv"
+
+# ---------- Test 20: Darwin budget-exhaustion kills background curl (#662) ----------
+echo "=== Test 20: Darwin budget-exhaustion no-orphan-curl ==="
+case "$(uname -s 2>/dev/null)" in
+    Darwin*)
+        mkdir -p "$WORK/c20"
+        cat > "$WORK/c20/report.txt" <<'REPORT'
+See https://example-hang.invalid/page1 and https://example-hang.invalid/page2.
+REPORT
+        # PID-recording fake curl: records its own PID to a per-invocation file
+        # at start, removes it on clean exit. After the validator returns, any
+        # surviving .pid file whose process is still alive is an orphan.
+        PIDS_DIR="$WORK/c20/pids"
+        mkdir -p "$PIDS_DIR"
+        FAKE_CURL_PIDREC="$WORK/c20/fake-curl-pidrec"
+        cat > "$FAKE_CURL_PIDREC" <<FAKEEOF
+#!/usr/bin/env bash
+PIDS_DIR="$PIDS_DIR"
+echo "\$\$" > "\$PIDS_DIR/\$\$.pid"
+trap 'rm -f "\$PIDS_DIR/\$\$.pid"' EXIT
+url=""
+for a in "\$@"; do
+    case "\$a" in http://*|https://*) url="\$a" ;; esac
+done
+case "\$url" in
+    *example-hang.invalid*) sleep 15; printf '200'; exit 0 ;;
+    *) printf '200'; exit 0 ;;
+esac
+FAKEEOF
+        chmod +x "$FAKE_CURL_PIDREC"
+        START=$(date +%s)
+        set +e
+        __VC_FAKE_CURL="$FAKE_CURL_PIDREC" __VC_LAST_ARGV="$ARGV_LOG" \
+        __VC_SKIP_DNS=1 __VC_STUB_RESOLVE='example-hang.invalid=8.8.8.8' \
+            "$VALIDATOR" --report "$WORK/c20/report.txt" --output "$WORK/c20/cv.md" \
+                         --tmpdir "$WORK/c20" --budget-seconds 1 >/dev/null 2>&1
+        VALIDATOR_RC=$?
+        set -e
+        END=$(date +%s)
+        ELAPSED=$((END - START))
+        # Wait briefly for any in-flight kill signals to land before scanning
+        # for survivors. Bug behavior leaves ~15s sleeps running.
+        sleep 2
+        ORPHAN_COUNT=0
+        for pf in "$PIDS_DIR"/*.pid; do
+            [[ -e "$pf" ]] || continue
+            opid=$(cat "$pf" 2>/dev/null || echo "")
+            [[ -z "$opid" ]] && continue
+            if kill -0 "$opid" 2>/dev/null; then
+                ORPHAN_COUNT=$((ORPHAN_COUNT + 1))
+            fi
+        done
+        # Bug-#662 leak behavior is ~15s (the fake-curl sleep); ceiling 15s
+        # filters that out while leaving slack for slow / shared CI.
+        assert "Test 20: validator returned within budget + slack (got ${ELAPSED}s)" "[[ \"$ELAPSED\" -le 15 ]]"
+        # Fail-soft contract: validator MUST exit 0 even on budget timeout.
+        # Catches the regression class where the kill path signals $$'s
+        # process group and SIGTERMs the validator itself (exit 143, no
+        # sidecar).
+        assert "Test 20: validator exited 0 (fail-soft contract on timeout)" "[[ \"$VALIDATOR_RC\" -eq 0 ]]"
+        assert "Test 20: sidecar produced" "[[ -s \"$WORK/c20/cv.md\" ]]"
+        assert "Test 20: sidecar has UNKNOWN | timeout for hung URL #1" "grep -F 'https://example-hang.invalid/page1' \"$WORK/c20/cv.md\" | grep -F 'UNKNOWN' | grep -Fq 'timeout'"
+        assert "Test 20: sidecar has UNKNOWN | timeout for hung URL #2" "grep -F 'https://example-hang.invalid/page2' \"$WORK/c20/cv.md\" | grep -F 'UNKNOWN' | grep -Fq 'timeout'"
+        assert "Test 20: no orphan fake-curl processes after budget-kill (got $ORPHAN_COUNT)" "[[ \"$ORPHAN_COUNT\" == 0 ]]"
+        ;;
+    *)
+        note "skip: Darwin-only (Linux no-setsid path covered by Test 21)"
+        ;;
+esac
+
+# ---------- Test 21: Linux no-setsid budget-exhaustion fail-soft (#849) ----------
+echo "=== Test 21: Linux no-setsid budget-exhaustion fail-soft ==="
+case "$(uname -s 2>/dev/null)" in
+    Linux*)
+        # Test 21 verifies the no-setsid Linux branch of validate-citations.sh
+        # (the per-PID `kill <subshell>` fallback at :765, gated by the
+        # __VC_SETSID_DONE marker). The runner needs `setsid` available on
+        # its PATH so the harness can put the validator in its OWN session;
+        # without that isolation, a hypothetical regression of the marker
+        # gate (`kill -- -$$` running unconditionally) would also kill the
+        # test runner, leaving the failure mode ambiguous.
+        if ! command -v setsid >/dev/null 2>&1; then
+            note "skip: setsid not available on this Linux runner — cannot isolate validator session for regression test"
+        else
+            mkdir -p "$WORK/c21"
+            cat > "$WORK/c21/report.txt" <<'REPORT'
+See https://example-hang.invalid/page1 and https://example-hang.invalid/page2.
+REPORT
+            # Hermetic clean-bin: symlink common tools into a directory that
+            # explicitly omits `setsid`. PATH=$CLEAN_BIN forces the
+            # validator's `command -v setsid` check (validate-citations.sh:669)
+            # to fail so it takes the no-setsid Linux branch (the production
+            # scenario under test). Directory-stripping `/usr/bin` is unsafe
+            # on merged-/usr distros (would also remove grep/awk/etc.).
+            # Profile: URL-only fixture with __VC_SKIP_DNS / __VC_STUB_RESOLVE
+            # set; if the scenario ever grows beyond URL-only fetches, the
+            # tool list here must be extended in sync.
+            CLEAN_BIN="$WORK/c21/clean-bin"
+            mkdir -p "$CLEAN_BIN"
+            for t in bash sh mktemp mkdir rm mv cp grep sed awk wc sort head tail tr cut sleep kill ps echo date dirname basename env cat tee touch chmod ln readlink stat find xargs which test '[' printf shasum md5sum md5 expr seq uname; do
+                src=$(command -v "$t" 2>/dev/null || true)
+                [[ -n "$src" && -x "$src" ]] && ln -sf "$src" "$CLEAN_BIN/$t"
+            done
+            # Defense in depth: explicit removal in case any tool above is
+            # named/aliased to setsid on some distro.
+            rm -f "$CLEAN_BIN/setsid"
+
+            # PID-recording fake curl that honors --max-time so orphans
+            # naturally die after $PER_FETCH_TIMEOUT per the documented
+            # contract on the no-setsid Linux branch (orphan curls bounded
+            # by --per-fetch-timeout). Handles both two-element form
+            # (`--max-time N`) and bundled form (`--max-time=N`).
+            PIDS_DIR="$WORK/c21/pids"
+            mkdir -p "$PIDS_DIR"
+            FAKE_CURL_PIDREC="$WORK/c21/fake-curl-pidrec"
+            cat > "$FAKE_CURL_PIDREC" <<FAKEEOF
+#!/usr/bin/env bash
+PIDS_DIR="$PIDS_DIR"
+echo "\$\$" > "\$PIDS_DIR/\$\$.pid"
+trap 'rm -f "\$PIDS_DIR/\$\$.pid"' EXIT
+url=""
+max_time=10
+prev=""
+for a in "\$@"; do
+    case "\$prev" in --max-time) max_time="\$a" ;; esac
+    case "\$a" in --max-time=*) max_time="\${a#--max-time=}" ;; esac
+    case "\$a" in http://*|https://*) url="\$a" ;; esac
+    prev="\$a"
+done
+case "\$url" in
+    *example-hang.invalid*) sleep \$((max_time + 1)); exit 28 ;;
+    *) printf '200'; exit 0 ;;
+esac
+FAKEEOF
+            chmod +x "$FAKE_CURL_PIDREC"
+
+            # Pre-flight: hermetic PATH must hide setsid AND must still
+            # expose uname (the validator branches on `case "$(uname -s)"`
+            # at :662 and :755 — without uname both OS branches fall
+            # through and the test would pass for the wrong reason).
+            assert "Test 21: clean-bin hides setsid (command -v setsid fails under clean PATH)" "! PATH=\"$CLEAN_BIN\" command -v setsid >/dev/null 2>&1"
+            UNAME_OUT=$(PATH="$CLEAN_BIN" uname -s 2>/dev/null || echo "")
+            assert "Test 21: clean-bin exposes uname returning Linux* (got '${UNAME_OUT}')" "[[ \"$UNAME_OUT\" == Linux* ]]"
+
+            PER_FETCH_TIMEOUT_T21=2
+            START=$(date +%s)
+            set +e
+            # Outer `setsid -w` puts the validator in its own POSIX session
+            # so a hypothetical regression of the :765 marker gate
+            # (`kill -- -$$` unconditional) only kills the validator's
+            # session, not this test runner. `env -u __VC_SETSID_DONE` clears
+            # any leaked marker from the parent environment that would
+            # otherwise route the validator into the unsafe kill branch.
+            # PATH=$CLEAN_BIN strips setsid from the validator's own PATH so
+            # `command -v setsid` at :669 fails (the production no-setsid
+            # scenario under test). The setsid binary used by the outer
+            # wrapper is resolved from the runner's PATH (not the clean-bin).
+            __VC_FAKE_CURL="$FAKE_CURL_PIDREC" __VC_LAST_ARGV="$ARGV_LOG" \
+            __VC_SKIP_DNS=1 __VC_STUB_RESOLVE='example-hang.invalid=8.8.8.8' \
+                setsid -w env -u __VC_SETSID_DONE PATH="$CLEAN_BIN" \
+                    "$VALIDATOR" --report "$WORK/c21/report.txt" --output "$WORK/c21/cv.md" \
+                                 --tmpdir "$WORK/c21" --budget-seconds 1 \
+                                 --per-fetch-timeout "$PER_FETCH_TIMEOUT_T21" >/dev/null 2>&1
+            VALIDATOR_RC=$?
+            set -e
+            END=$(date +%s)
+            ELAPSED=$((END - START))
+            # The no-setsid Linux branch runs `kill <subshell-pid>` (NOT
+            # `kill -- -<pgid>`), so subshells die but their fake-curl
+            # children persist as orphans until self-termination via
+            # --max-time. Wait per-fetch-timeout + 3 lets all orphans
+            # clear before the assertion.
+            sleep $((PER_FETCH_TIMEOUT_T21 + 3))
+            ORPHAN_COUNT=0
+            for pf in "$PIDS_DIR"/*.pid; do
+                [[ -e "$pf" ]] || continue
+                opid=$(cat "$pf" 2>/dev/null || echo "")
+                [[ -z "$opid" ]] && continue
+                if kill -0 "$opid" 2>/dev/null; then
+                    ORPHAN_COUNT=$((ORPHAN_COUNT + 1))
+                fi
+            done
+            assert "Test 21: validator returned within budget + slack (got ${ELAPSED}s)" "[[ \"$ELAPSED\" -le 15 ]]"
+            # Regression-detection assertion: if validate-citations.sh:765
+            # is reverted to unconditional `kill -- -$$`, the validator
+            # gets SIGTERM under outer setsid, exits 143, and this fails.
+            assert "Test 21: validator exited 0 (fail-soft contract on timeout, no-setsid branch)" "[[ \"$VALIDATOR_RC\" -eq 0 ]]"
+            assert "Test 21: sidecar produced" "[[ -s \"$WORK/c21/cv.md\" ]]"
+            assert "Test 21: sidecar has UNKNOWN | timeout for hung URL #1" "grep -F 'https://example-hang.invalid/page1' \"$WORK/c21/cv.md\" | grep -F 'UNKNOWN' | grep -Fq 'timeout'"
+            assert "Test 21: sidecar has UNKNOWN | timeout for hung URL #2" "grep -F 'https://example-hang.invalid/page2' \"$WORK/c21/cv.md\" | grep -F 'UNKNOWN' | grep -Fq 'timeout'"
+            assert "Test 21: no orphan fake-curl processes after per-fetch-timeout window (got $ORPHAN_COUNT)" "[[ \"$ORPHAN_COUNT\" == 0 ]]"
+        fi
+        ;;
+    *)
+        note "skip: Linux-only (Darwin coverage in Test 20)"
+        ;;
+esac
+
+# ---------- Summary ----------
+echo "=== Summary ==="
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+if [[ "$FAIL" -gt 0 ]]; then
+    exit 1
+fi
+echo "All assertions passed."
+exit 0

--- a/skills/research/scripts/test-validate-citations.md
+++ b/skills/research/scripts/test-validate-citations.md
@@ -1,10 +1,12 @@
 # skills/research/scripts/test-validate-citations.sh — Contract
 
-Offline regression harness for `validate-citations.sh`. Pins the consumer-side
-behavior of the citation validator under fail-soft semantics: every scenario
-asserts (a) exit 0, (b) sidecar created at the configured path, (c) the
-`SUMMARY=...` line on stdout has the expected counts, (d) where applicable,
-the sidecar body contains the expected `Status` / `Reason` tokens.
+Offline regression harness for `validate-citations.sh`. Pins the CPU-bound
+consumer-side behavior of the citation validator under fail-soft semantics:
+every scenario asserts (a) exit 0, (b) sidecar created at the configured path,
+(c) the `SUMMARY=...` line on stdout has the expected counts, (d) where
+applicable, the sidecar body contains the expected `Status` / `Reason` tokens.
+Budget-exhaustion tests with real sleeps live in sibling harness
+`test-validate-citations-budget.sh`.
 
 ## What it pins
 
@@ -29,8 +31,6 @@ the sidecar body contains the expected `Status` / `Reason` tokens.
 | Git-root-unavailable | non-git cwd → `UNKNOWN(git-root-unavailable)` |
 | DOI syntax | malformed `10.123/...` (3 digits) → not extracted (regex tier) |
 | URL dedup | duplicate URL appears in exactly one ledger row |
-| Darwin budget exhaustion (Test 20, Darwin-only) | hung fake-curl + `--budget-seconds 1` → exit 0, sidecar present with `UNKNOWN`/`timeout` rows for hung URLs, no surviving fake-curl PIDs after kill loop. Exercises the macOS `set -m` per-PG-kill branch. Linux runners skip; Test 21 covers the Linux no-setsid path. Test 20 runs on developer macOS (current CI is Ubuntu-only). |
-| Linux no-setsid budget exhaustion (Test 21, Linux-only, #849) | outer `setsid -w` wraps the validator in its own session; hermetic clean-bin (symlinks excluding `setsid`, including `uname`) makes `command -v setsid` fail inside the validator so the no-setsid branch (`validate-citations.sh:765`) is exercised; hung fake-curl honoring `--max-time` + `--budget-seconds 1` → exit 0, sidecar present, `UNKNOWN`/`timeout` rows for both hung URLs, no orphan fake-curl PIDs after `--per-fetch-timeout` window. Runs when `setsid` is available on the runner PATH (so the harness can isolate the validator session); otherwise skipped with note. Demonstrably fails if the `__VC_SETSID_DONE` marker gate at `validate-citations.sh:765` is reverted to unconditional `kill -- -$$` (validator gets SIGTERM under outer setsid → exit 143). Test 21 is exercised by current Ubuntu CI. |
 
 ## Test seams (env vars exercised by the harness)
 
@@ -48,14 +48,16 @@ When this harness changes:
 
 1. This `.md` (the contract).
 2. `test-validate-citations.sh` (the harness body).
-3. `Makefile` `test-validate-citations` target if a new fixture file is added
+3. `test-validate-citations-budget.sh` when moving coverage between harnesses.
+4. `Makefile` `test-validate-citations` target if a new fixture file is added
    to the test invocation.
-4. `validate-citations.md` § Test harness (the contract's mirrored summary
+5. `validate-citations.md` § Test harness (the contract's mirrored summary
    in the validator's sibling contract).
 
 ## Wiring
 
 `make lint` invokes this harness via the `test-validate-citations` target,
 which is a prerequisite of exactly one `test-harnesses-N:` shard (the umbrella
-`test-harnesses` aggregates all six shards). The harness exits non-zero on
-any assertion failure; CI fails the same way.
+`test-harnesses` aggregates all six shards). Its sibling budget harness runs
+via `test-validate-citations-budget` on a different shard. Each harness exits
+non-zero on any assertion failure; CI fails the same way.

--- a/skills/research/scripts/test-validate-citations.sh
+++ b/skills/research/scripts/test-validate-citations.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 # test-validate-citations.sh — Offline regression harness for validate-citations.sh.
+# Budget-exhaustion cases live in test-validate-citations-budget.sh so CI
+# can bill their real-time sleeps to a separate harness shard.
 #
 # Pins the consumer-side behavior of skills/research/scripts/validate-citations.sh
 # under fail-soft semantics: every scenario asserts (a) exit 0, (b) sidecar
@@ -49,7 +51,7 @@ assert() {
 #       *://example-403.invalid/*        → 403
 #       *://example-404.invalid/*        → 404
 #       *://example-501.invalid/*        → 501
-#       *://example-hang.invalid/*       → sleep 60 (budget tester drives this)
+#       *://example-hang.invalid/*       → sleep 15 (budget tester drives this)
 #       https://doi.org/*                → 302 (doi.org is a redirect resolver
 #                                             by design; with --max-redirs 0
 #                                             the validator reads this as
@@ -83,7 +85,7 @@ case "$url" in
     *example-501.invalid*) printf '501'; exit 0 ;;
     *://doi.org/*) printf '302'; exit 0 ;;
     *example-hang.invalid*)
-        sleep 60
+        sleep 15
         printf '200'; exit 0 ;;
     *) printf '200'; exit 0 ;;
 esac
@@ -351,203 +353,6 @@ __VC_SKIP_DNS=1 __VC_STUB_RESOLVE='example.com=8.8.8.8;doi.org=8.8.8.8' \
 # 5+5+5 = 15 raw claims, cap=6 → exactly 6 ledger rows total (in stable URL→DOI→file order).
 LEDGER_ROWS=$(grep -c '^| `' "$WORK/c19/cv.md" || echo 0)
 assert "Test 19: combined cap yields exactly --max-claims rows (got $LEDGER_ROWS)" "[[ \"$LEDGER_ROWS\" == 6 ]]"
-
-# ---------- Test 20: Darwin budget-exhaustion kills background curl (#662) ----------
-echo "=== Test 20: Darwin budget-exhaustion no-orphan-curl ==="
-case "$(uname -s 2>/dev/null)" in
-    Darwin*)
-        mkdir -p "$WORK/c20"
-        cat > "$WORK/c20/report.txt" <<'REPORT'
-See https://example-hang.invalid/page1 and https://example-hang.invalid/page2.
-REPORT
-        # PID-recording fake curl: records its own PID to a per-invocation file
-        # at start, removes it on clean exit. After the validator returns, any
-        # surviving .pid file whose process is still alive is an orphan.
-        PIDS_DIR="$WORK/c20/pids"
-        mkdir -p "$PIDS_DIR"
-        FAKE_CURL_PIDREC="$WORK/c20/fake-curl-pidrec"
-        cat > "$FAKE_CURL_PIDREC" <<FAKEEOF
-#!/usr/bin/env bash
-PIDS_DIR="$PIDS_DIR"
-echo "\$\$" > "\$PIDS_DIR/\$\$.pid"
-trap 'rm -f "\$PIDS_DIR/\$\$.pid"' EXIT
-url=""
-for a in "\$@"; do
-    case "\$a" in http://*|https://*) url="\$a" ;; esac
-done
-case "\$url" in
-    *example-hang.invalid*) sleep 60; printf '200'; exit 0 ;;
-    *) printf '200'; exit 0 ;;
-esac
-FAKEEOF
-        chmod +x "$FAKE_CURL_PIDREC"
-        START=$(date +%s)
-        set +e
-        __VC_FAKE_CURL="$FAKE_CURL_PIDREC" __VC_LAST_ARGV="$ARGV_LOG" \
-        __VC_SKIP_DNS=1 __VC_STUB_RESOLVE='example-hang.invalid=8.8.8.8' \
-            "$VALIDATOR" --report "$WORK/c20/report.txt" --output "$WORK/c20/cv.md" \
-                         --tmpdir "$WORK/c20" --budget-seconds 1 >/dev/null 2>&1
-        VALIDATOR_RC=$?
-        set -e
-        END=$(date +%s)
-        ELAPSED=$((END - START))
-        # Wait briefly for any in-flight kill signals to land before scanning
-        # for survivors. Bug behavior leaves ~60s sleeps running.
-        sleep 2
-        ORPHAN_COUNT=0
-        for pf in "$PIDS_DIR"/*.pid; do
-            [[ -e "$pf" ]] || continue
-            opid=$(cat "$pf" 2>/dev/null || echo "")
-            [[ -z "$opid" ]] && continue
-            if kill -0 "$opid" 2>/dev/null; then
-                ORPHAN_COUNT=$((ORPHAN_COUNT + 1))
-            fi
-        done
-        # Bug-#662 leak behavior is ~60s (the fake-curl sleep); ceiling 15s
-        # filters that out while leaving slack for slow / shared CI.
-        assert "Test 20: validator returned within budget + slack (got ${ELAPSED}s)" "[[ \"$ELAPSED\" -le 15 ]]"
-        # Fail-soft contract: validator MUST exit 0 even on budget timeout.
-        # Catches the regression class where the kill path signals $$'s
-        # process group and SIGTERMs the validator itself (exit 143, no
-        # sidecar).
-        assert "Test 20: validator exited 0 (fail-soft contract on timeout)" "[[ \"$VALIDATOR_RC\" -eq 0 ]]"
-        assert "Test 20: sidecar produced" "[[ -s \"$WORK/c20/cv.md\" ]]"
-        assert "Test 20: sidecar has UNKNOWN | timeout for hung URL #1" "grep -F 'https://example-hang.invalid/page1' \"$WORK/c20/cv.md\" | grep -F 'UNKNOWN' | grep -Fq 'timeout'"
-        assert "Test 20: sidecar has UNKNOWN | timeout for hung URL #2" "grep -F 'https://example-hang.invalid/page2' \"$WORK/c20/cv.md\" | grep -F 'UNKNOWN' | grep -Fq 'timeout'"
-        assert "Test 20: no orphan fake-curl processes after budget-kill (got $ORPHAN_COUNT)" "[[ \"$ORPHAN_COUNT\" == 0 ]]"
-        ;;
-    *)
-        note "skip: Darwin-only (Linux no-setsid path covered by Test 21)"
-        ;;
-esac
-
-# ---------- Test 21: Linux no-setsid budget-exhaustion fail-soft (#849) ----------
-echo "=== Test 21: Linux no-setsid budget-exhaustion fail-soft ==="
-case "$(uname -s 2>/dev/null)" in
-    Linux*)
-        # Test 21 verifies the no-setsid Linux branch of validate-citations.sh
-        # (the per-PID `kill <subshell>` fallback at :765, gated by the
-        # __VC_SETSID_DONE marker). The runner needs `setsid` available on
-        # its PATH so the harness can put the validator in its OWN session;
-        # without that isolation, a hypothetical regression of the marker
-        # gate (`kill -- -$$` running unconditionally) would also kill the
-        # test runner, leaving the failure mode ambiguous.
-        if ! command -v setsid >/dev/null 2>&1; then
-            note "skip: setsid not available on this Linux runner — cannot isolate validator session for regression test"
-        else
-            mkdir -p "$WORK/c21"
-            cat > "$WORK/c21/report.txt" <<'REPORT'
-See https://example-hang.invalid/page1 and https://example-hang.invalid/page2.
-REPORT
-            # Hermetic clean-bin: symlink common tools into a directory that
-            # explicitly omits `setsid`. PATH=$CLEAN_BIN forces the
-            # validator's `command -v setsid` check (validate-citations.sh:669)
-            # to fail so it takes the no-setsid Linux branch (the production
-            # scenario under test). Directory-stripping `/usr/bin` is unsafe
-            # on merged-/usr distros (would also remove grep/awk/etc.).
-            # Profile: URL-only fixture with __VC_SKIP_DNS / __VC_STUB_RESOLVE
-            # set; if the scenario ever grows beyond URL-only fetches, the
-            # tool list here must be extended in sync.
-            CLEAN_BIN="$WORK/c21/clean-bin"
-            mkdir -p "$CLEAN_BIN"
-            for t in bash sh mktemp mkdir rm mv cp grep sed awk wc sort head tail tr cut sleep kill ps echo date dirname basename env cat tee touch chmod ln readlink stat find xargs which test '[' printf shasum md5sum md5 expr seq uname; do
-                src=$(command -v "$t" 2>/dev/null || true)
-                [[ -n "$src" && -x "$src" ]] && ln -sf "$src" "$CLEAN_BIN/$t"
-            done
-            # Defense in depth: explicit removal in case any tool above is
-            # named/aliased to setsid on some distro.
-            rm -f "$CLEAN_BIN/setsid"
-
-            # PID-recording fake curl that honors --max-time so orphans
-            # naturally die after $PER_FETCH_TIMEOUT per the documented
-            # contract on the no-setsid Linux branch (orphan curls bounded
-            # by --per-fetch-timeout). Handles both two-element form
-            # (`--max-time N`) and bundled form (`--max-time=N`).
-            PIDS_DIR="$WORK/c21/pids"
-            mkdir -p "$PIDS_DIR"
-            FAKE_CURL_PIDREC="$WORK/c21/fake-curl-pidrec"
-            cat > "$FAKE_CURL_PIDREC" <<FAKEEOF
-#!/usr/bin/env bash
-PIDS_DIR="$PIDS_DIR"
-echo "\$\$" > "\$PIDS_DIR/\$\$.pid"
-trap 'rm -f "\$PIDS_DIR/\$\$.pid"' EXIT
-url=""
-max_time=10
-prev=""
-for a in "\$@"; do
-    case "\$prev" in --max-time) max_time="\$a" ;; esac
-    case "\$a" in --max-time=*) max_time="\${a#--max-time=}" ;; esac
-    case "\$a" in http://*|https://*) url="\$a" ;; esac
-    prev="\$a"
-done
-case "\$url" in
-    *example-hang.invalid*) sleep \$((max_time + 1)); exit 28 ;;
-    *) printf '200'; exit 0 ;;
-esac
-FAKEEOF
-            chmod +x "$FAKE_CURL_PIDREC"
-
-            # Pre-flight: hermetic PATH must hide setsid AND must still
-            # expose uname (the validator branches on `case "$(uname -s)"`
-            # at :662 and :755 — without uname both OS branches fall
-            # through and the test would pass for the wrong reason).
-            assert "Test 21: clean-bin hides setsid (command -v setsid fails under clean PATH)" "! PATH=\"$CLEAN_BIN\" command -v setsid >/dev/null 2>&1"
-            UNAME_OUT=$(PATH="$CLEAN_BIN" uname -s 2>/dev/null || echo "")
-            assert "Test 21: clean-bin exposes uname returning Linux* (got '${UNAME_OUT}')" "[[ \"$UNAME_OUT\" == Linux* ]]"
-
-            PER_FETCH_TIMEOUT_T21=5
-            START=$(date +%s)
-            set +e
-            # Outer `setsid -w` puts the validator in its own POSIX session
-            # so a hypothetical regression of the :765 marker gate
-            # (`kill -- -$$` unconditional) only kills the validator's
-            # session, not this test runner. `env -u __VC_SETSID_DONE` clears
-            # any leaked marker from the parent environment that would
-            # otherwise route the validator into the unsafe kill branch.
-            # PATH=$CLEAN_BIN strips setsid from the validator's own PATH so
-            # `command -v setsid` at :669 fails (the production no-setsid
-            # scenario under test). The setsid binary used by the outer
-            # wrapper is resolved from the runner's PATH (not the clean-bin).
-            __VC_FAKE_CURL="$FAKE_CURL_PIDREC" __VC_LAST_ARGV="$ARGV_LOG" \
-            __VC_SKIP_DNS=1 __VC_STUB_RESOLVE='example-hang.invalid=8.8.8.8' \
-                setsid -w env -u __VC_SETSID_DONE PATH="$CLEAN_BIN" \
-                    "$VALIDATOR" --report "$WORK/c21/report.txt" --output "$WORK/c21/cv.md" \
-                                 --tmpdir "$WORK/c21" --budget-seconds 1 \
-                                 --per-fetch-timeout "$PER_FETCH_TIMEOUT_T21" >/dev/null 2>&1
-            VALIDATOR_RC=$?
-            set -e
-            END=$(date +%s)
-            ELAPSED=$((END - START))
-            # The no-setsid Linux branch runs `kill <subshell-pid>` (NOT
-            # `kill -- -<pgid>`), so subshells die but their fake-curl
-            # children persist as orphans until self-termination via
-            # --max-time. Wait per-fetch-timeout + 3 = 8s lets all orphans
-            # clear before the assertion.
-            sleep $((PER_FETCH_TIMEOUT_T21 + 3))
-            ORPHAN_COUNT=0
-            for pf in "$PIDS_DIR"/*.pid; do
-                [[ -e "$pf" ]] || continue
-                opid=$(cat "$pf" 2>/dev/null || echo "")
-                [[ -z "$opid" ]] && continue
-                if kill -0 "$opid" 2>/dev/null; then
-                    ORPHAN_COUNT=$((ORPHAN_COUNT + 1))
-                fi
-            done
-            assert "Test 21: validator returned within budget + slack (got ${ELAPSED}s)" "[[ \"$ELAPSED\" -le 15 ]]"
-            # Regression-detection assertion: if validate-citations.sh:765
-            # is reverted to unconditional `kill -- -$$`, the validator
-            # gets SIGTERM under outer setsid, exits 143, and this fails.
-            assert "Test 21: validator exited 0 (fail-soft contract on timeout, no-setsid branch)" "[[ \"$VALIDATOR_RC\" -eq 0 ]]"
-            assert "Test 21: sidecar produced" "[[ -s \"$WORK/c21/cv.md\" ]]"
-            assert "Test 21: sidecar has UNKNOWN | timeout for hung URL #1" "grep -F 'https://example-hang.invalid/page1' \"$WORK/c21/cv.md\" | grep -F 'UNKNOWN' | grep -Fq 'timeout'"
-            assert "Test 21: sidecar has UNKNOWN | timeout for hung URL #2" "grep -F 'https://example-hang.invalid/page2' \"$WORK/c21/cv.md\" | grep -F 'UNKNOWN' | grep -Fq 'timeout'"
-            assert "Test 21: no orphan fake-curl processes after per-fetch-timeout window (got $ORPHAN_COUNT)" "[[ \"$ORPHAN_COUNT\" == 0 ]]"
-        fi
-        ;;
-    *)
-        note "skip: Linux-only (Darwin coverage in Test 20)"
-        ;;
-esac
 
 # ---------- Summary ----------
 echo "=== Summary ==="

--- a/skills/research/scripts/validate-citations.md
+++ b/skills/research/scripts/validate-citations.md
@@ -177,9 +177,9 @@ must be terminated cleanly. OS-specific:
   before it writes the per-claim `UNKNOWN(timeout)` rows and the sidecar
   — i.e. exit 143, sidecar absent, fail-soft contract broken.
 
-The test harness asserts the macOS branch via Test 20 (Darwin-only) using
-a stub-curl fixture that hangs deliberately past the budget; the Linux
-`setsid` branch is exercised end-to-end by the existing CI pipeline.
+The budget test harness asserts the macOS branch via Test 20 (Darwin-only)
+using a stub-curl fixture that hangs deliberately past the budget, and the
+Linux no-setsid branch via Test 21 on current Ubuntu CI.
 
 ## Test seams (NOT operator flags)
 
@@ -203,13 +203,20 @@ When this script's behavior changes:
 3. `skills/research/references/citation-validation-phase.md` (the phase
    reference; specifically the Reason vocabulary and SSRF defenses
    sections, which mirror the tables here).
-4. `skills/research/scripts/test-validate-citations.sh` (regression harness).
-5. `Makefile` `test-validate-citations` target.
+4. `skills/research/scripts/test-validate-citations.sh` (CPU-bound regression
+   harness).
+5. `skills/research/scripts/test-validate-citations-budget.sh` (real-time
+   budget-exhaustion regression harness).
+6. `Makefile` `test-validate-citations` / `test-validate-citations-budget`
+   targets.
 
 ## Test harness
 
-`skills/research/scripts/test-validate-citations.sh` runs offline against
-fixture inputs with stubbed curl and stubbed DNS. Verified scenarios:
+`skills/research/scripts/test-validate-citations.sh` runs CPU-bound offline
+scenarios against fixture inputs with stubbed curl and stubbed DNS.
+`skills/research/scripts/test-validate-citations-budget.sh` carries the
+real-time budget-exhaustion scenarios so CI can assign them to a different
+shard. Verified scenarios:
 
 - Provenance extraction (URL, DOI, file:line; LONG-tier and SHORT-tier
   per `scripts/file-line-regex-lib.sh`).
@@ -228,11 +235,12 @@ fixture inputs with stubbed curl and stubbed DNS. Verified scenarios:
   `out-of-tree-path-after-realpath` / `broken-symlink`.
 - HEAD 403/405/501 → `head-not-supported`.
 - HEAD 3xx → `redirect-not-followed`.
-- Darwin budget-exhaustion no-orphan-curl (Test 20, Darwin-only): a hanging
-  fake-curl fixture is run with `--budget-seconds 1`; after the kill loop
-  no fake-curl PID survives. Exercises the macOS `set -m` per-PG-kill
+- Darwin budget-exhaustion no-orphan-curl (budget Test 20, Darwin-only): a
+  hanging fake-curl fixture is run with `--budget-seconds 1`; after the kill
+  loop no fake-curl PID survives. Exercises the macOS `set -m` per-PG-kill
   branch. Test 20 runs on developer macOS (current CI is Ubuntu-only).
-- Linux no-setsid budget-exhaustion fail-soft (Test 21, Linux-only, #849):
+- Linux no-setsid budget-exhaustion fail-soft (budget Test 21, Linux-only,
+  #849):
   the validator is invoked under outer `setsid -w` (so a hypothetical
   regression of the marker gate at line 765 only kills the validator's
   own session) with a hermetic clean-bin in PATH that omits `setsid`. The


### PR DESCRIPTION
## Summary

- Split `test-validate-citations` into two harnesses so the matrix shard wall-clock floor drops below ~20s. Tests 1–19 (CPU-bound) stay in `test-validate-citations`; Tests 20 / 21 (real-time budget-exhaustion sleeps) move to a new `test-validate-citations-budget` harness.
- Reduce real-time sleeps in the budget harness: Test 21's `PER_FETCH_TIMEOUT_T21` drops from 5 → 2 (saves ~6s on Linux CI), Test 20's fake-curl `sleep 60` drops to `sleep 15` (still well above the validator's `--budget-seconds 1` so the kill-path assertion is preserved).
- Place the new `test-validate-citations-budget` harness on shard 5 so shard 6 is no longer dominated by Test 21.

## Test plan

- [x] `make test-validate-citations` passes locally (~16s on Mac, expected ~10s on Linux CI)
- [x] `make test-validate-citations-budget` passes locally (~3s on Mac with Test 21 skipped; ~10s on Linux CI)
- [x] `make test-harness-shards-coverage` passes — new harness is shard-assigned and listed in `.PHONY`
- [x] Pre-commit (shellcheck, agent-lint, markdownlint, gitleaks, trufflehog) passes on changed files
- [ ] CI matrix shows all 6 shards under ~20s

Closes #1032
