### PR TITLE
Align README and docs/skills.md argument-hint tables with SKILL canonicals (#1041)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "15.7.0",
+  "version": "15.7.1",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 6-reviewer specialist panel (5 Cursor specialists + 1 Codex generic) with 3-voter adjudication; plan review runs a 3-reviewer panel (Claude + Codex + Cursor); design sketches run a 9-agent diverge-then-converge phase in regular mode (1 Claude + 4 Cursor + 4 Codex) or 3 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [15.7.1] - 2026-05-04
+
+### Changed
+
+- README.md and `docs/skills.md`: argument-hint tables for `/design` and `/implement` now match the canonical `argument-hint:` frontmatter in `skills/design/SKILL.md` and `skills/implement/SKILL.md`. Adds `[--subagent]` and `[--session-env <path>]` to `/design`; adds `[--inline]` and `[--session-env <path>]` to `/implement`. Documentation-only; no behavior change. Closes #1041.
+
 ## [15.7.0] - 2026-05-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Larch is a Claude Code workflow automation framework that orchestrates multi-age
     <tr><td colspan="2"><hr></td></tr>
     <tr>
       <td><a href="docs/skills.md#design"><code>/design</code></a></td>
-      <td><code>[--auto] [--quick] &lt;feature description&gt;</code></td>
+      <td><code>[--auto] [--quick] [--subagent] [--session-env &lt;path&gt;] &lt;feature description&gt;</code></td>
     </tr>
     <tr><td colspan="2">Design an implementation plan with 9 sketch agents (3 in quick mode), dialectic adjudication, and a 6-reviewer validation panel.</td></tr>
     <tr><td colspan="2"><hr></td></tr>
@@ -69,7 +69,7 @@ Larch is a Claude Code workflow automation framework that orchestrates multi-age
     <tr><td colspan="2"><hr></td></tr>
     <tr>
       <td><a href="docs/skills.md#implement"><code>/implement</code></a></td>
-      <td><code>[--quick] [--auto] [--design-only] [--merge | --draft] [--no-slack] [--no-admin-fallback] [--coder=claude|codex|cursor] [--issue &lt;N&gt;] &lt;feature description&gt;</code></td>
+      <td><code>[--quick] [--auto] [--design-only] [--inline] [--merge | --draft] [--no-slack] [--no-admin-fallback] [--coder=claude|codex|cursor] [--session-env &lt;path&gt;] [--issue &lt;N&gt;] &lt;feature description&gt;</code></td>
     </tr>
     <tr><td colspan="2">Full end-to-end feature workflow — design, implement, PR. <code>--design-only</code> publishes plan/review/diagram/OOS artifacts to the tracking issue and stops before implementation. <code>--quick</code> skips <code>/design</code> and runs a code-review loop of up to 7 rounds (no voting panel): rounds 1-3 launch 5 Cursor specialists in parallel plus a generic Codex reviewer; rounds 4-7 use a single generic reviewer per round with a Cursor → Codex → Claude fallback chain. <code>--coder</code> selects the Step 2 implementer (default <code>codex</code> — spawns the Codex implementer; pass <code>claude</code> to run in the main agent / Claude context, or <code>cursor</code> for the Cursor implementer; <code>cursor</code> falls back to the main-agent path when Cursor is unhealthy or unavailable). <code>LARCH_CURSOR_MODEL</code> also drives the Cursor implementer when <code>--coder=cursor</code>.</td></tr>
     <tr><td colspan="2"><hr></td></tr>

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -49,7 +49,7 @@ Scaffold a new larch-style skill from a name and description. Validates the name
 
 ## `/design`
 
-**Arguments**: `[--auto] [--quick] <feature description>`
+**Arguments**: `[--auto] [--quick] [--subagent] [--session-env <path>] <feature description>`
 
 **Source**: [`skills/design/SKILL.md`](../skills/design/SKILL.md) · [Diagram](../skills/design/diagram.svg)
 
@@ -67,7 +67,7 @@ Process one approved GitHub issue per invocation. Step 0 (`find-lock-issue.sh`) 
 
 ## `/implement`
 
-**Arguments**: `[--quick] [--auto] [--design-only] [--merge | --draft] [--no-slack] [--no-admin-fallback] [--coder=claude|codex|cursor] [--issue <N>] <feature description>`
+**Arguments**: `[--quick] [--auto] [--design-only] [--inline] [--merge | --draft] [--no-slack] [--no-admin-fallback] [--coder=claude|codex|cursor] [--session-env <path>] [--issue <N>] <feature description>`
 
 **Source**: [`skills/implement/SKILL.md`](../skills/implement/SKILL.md) · [Diagram](../skills/implement/diagram.svg)
 


### PR DESCRIPTION
## Summary
- Aligned README.md and `docs/skills.md` argument-hint tables for `/design` and `/implement` with the canonical `argument-hint:` frontmatter in `skills/design/SKILL.md` and `skills/implement/SKILL.md`.
- Added `[--subagent]` and `[--session-env <path>]` to the `/design` row; added `[--inline]` and `[--session-env <path>]` to the `/implement` row.
- Documentation-only; no behavior change. SKILL.md files are unchanged (canonical source).

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] `grep -n 'argument-hint:' skills/design/SKILL.md skills/implement/SKILL.md` confirms canonical hints unchanged
- [x] `grep -n -- '--subagent\|--inline\|--session-env' README.md docs/skills.md` shows new flags in both files' tables
- [x] `/relevant-checks` passes (pre-commit + agent-lint)

</details>

Closes #1041

Generated with [Claude Code](https://claude.com/claude-code)
