### PR TITLE
Fix agnix warnings; promote agnix warnings to errors in CI + pre-commit

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "15.7.3",
+  "version": "15.7.4",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 6-reviewer specialist panel (5 Cursor specialists + 1 Codex generic) with 3-voter adjudication; plan review runs a 3-reviewer panel (Claude + Codex + Cursor); design sketches run a 9-agent diverge-then-converge phase in regular mode (1 Claude + 4 Cursor + 4 Codex) or 3 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/.claude/skills/combine-issues/SKILL.md
+++ b/.claude/skills/combine-issues/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: combine-issues
 description: "Use when asked to try to combine existing issue to reduce issue count.  Examine all open issues that are not currently being worked on, and see if any number of them can be combined into one issue (closing the source issues afterwords), in order to save tokens / reduce the number of tasks to do.  Good candidated would be issues that either work in the same code area, or that apply very similar changes to different code areas, but think of other criteria that it would be appropriate as well.  Again, the primary goal is to reduce the tokens spent on executing unnecessarily fine-grained tasks."
-argument-hint: "[--dry-run]"
 allowed-tools: Bash, Read, Write
 ---
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -99,6 +99,7 @@ jobs:
         with:
           target: 'claude-code'
           config: '.agnix.toml'
+          strict: 'true'
 
   # Dedicated gitleaks gate — git-HISTORY scan (complementary to the
   # `lint` job, which runs the pre-commit gitleaks hook over the working

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,7 +70,7 @@ repos:
     hooks:
       - id: agnix
         name: Lint AI agent configuration files
-        entry: agnix .
+        entry: agnix . --strict
         language: node
         additional_dependencies: ['agnix@0.17.0']
         pass_filenames: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [15.7.4] - 2026-05-04
+
+### Changed
+
+- Fix two agnix warnings surfaced in CI (CC-SK-012 in `.claude/skills/combine-issues/SKILL.md`, AS-010 in `skills/research/SKILL.md`) and promote agnix warnings to errors in every invocation mode: `.github/workflows/ci.yaml` agnix job now passes `strict: 'true'`, and `.pre-commit-config.yaml` invokes `agnix . --strict` (which `make agnix` inherits via pre-commit). `docs/linting.md` updated to surface the strict-mode behavior. Closes #1051.
+
 ## [15.7.3] - 2026-05-04
 
 ### Changed

--- a/docs/linting.md
+++ b/docs/linting.md
@@ -10,7 +10,7 @@ Larch uses [pre-commit](https://pre-commit.com/) as the source of truth for lint
 | [markdownlint](https://github.com/igorshubovych/markdownlint-cli) | `.md` | Markdown style enforcement (config: `.markdownlint.json`) |
 | [jq](https://jqlang.github.io/jq/) | `.json` | JSON syntax validation |
 | [actionlint](https://github.com/rhysd/actionlint) | `.yml`, `.yaml` | GitHub Actions workflow validation |
-| [agnix](https://github.com/agent-sh/agnix) | `SKILL.md`, `CLAUDE.md`, agent configs | AI agent configuration linting (config: `.agnix.toml`) |
+| [agnix](https://github.com/agent-sh/agnix) | `SKILL.md`, `CLAUDE.md`, agent configs | AI agent configuration linting (config: `.agnix.toml`). Runs in strict mode (warnings fail) in both the local pre-commit hook and the dedicated CI job. |
 | [gitleaks](https://github.com/gitleaks/gitleaks) | all tracked files | Secret detection (pre-commit + dedicated CI job, full-history). Path allowlist in `.gitleaks.toml`. See `SECURITY.md` → "Layered secret scanning". |
 
 ## Usage

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: research
-description: "Use for read-only research; planner pre-pass + 4 Codex-first lanes (arch/edge/ext/security) with Claude fallback; 3-reviewer panel (Claude+Codex+Cursor); --no-issue skips auto-issue."
+description: "Use when conducting read-only research; planner pre-pass + 4 Codex-first lanes (arch/edge/ext/security) with Claude fallback; 3-reviewer panel (Claude+Codex+Cursor); --no-issue skips auto-issue."
 argument-hint: "[--no-issue] <research question or topic>"
 allowed-tools: Bash, Read, Grep, Glob, Agent, Task, WebFetch, WebSearch, Skill, Write, Edit, NotebookEdit
 hooks:


### PR DESCRIPTION
## Summary

- Fix the two agnix warnings surfaced in CI run [#25334316609](https://github.com/zhupanov/larch/actions/runs/25334316609):
  - `skills/research/SKILL.md` description now leads with the "Use when..." trigger phrase (closes AS-010).
  - `.claude/skills/combine-issues/SKILL.md` drops the unused `argument-hint: "[--dry-run]"` line — the SKILL body never parsed `$ARGUMENTS`, so the hint was false advertising (closes CC-SK-012).
- Promote agnix warnings to errors in every invocation mode so future warnings fail at pre-commit (or, failing that, in CI) instead of slipping through as advisory annotations:
  - `.github/workflows/ci.yaml` agnix job: pass `strict: 'true'` to `agent-sh/agnix@v0.17.0`.
  - `.pre-commit-config.yaml`: change the agnix hook entry from `agnix .` to `agnix . --strict` (verified locally that pinned `agnix@0.17.0` exits 1 on warnings under `--strict`).
  - `make agnix` delegates to `pre-commit run agnix --all-files`, so it inherits the new strict behavior automatically.
- `docs/linting.md`: note that agnix runs in strict mode (warnings fail) in both the local pre-commit hook and the dedicated CI job, so contributors are not surprised by the new gate.

## Architecture Diagram

Architecture diagram not available.

## Code Flow Diagram

(Code Flow Diagram skipped — quick mode)

## Test plan

- [x] `npx -y agnix@0.17.0 . --strict --target claude-code --config .agnix.toml` exits 0 with "0 errors, 0 warnings" after fixes (was exit 1 with 2 warnings before).
- [x] `pre-commit run agnix --all-files` passes locally.
- [x] `/relevant-checks` clean (pre-commit on modified files + agent-lint on the full repo).
- [ ] CI dedicated `agnix` job exits clean under the new `strict: 'true'` input.
- [ ] CI `lint` job (which `SKIP=agnix`s the dedicated hook) is unaffected.

Closes #1051

🤖 Generated with [Claude Code](https://claude.com/claude-code)
