### PR TITLE
issue: skip Research/Investigate-prefixed titles in list-issues dedup snapshot

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "15.7.4",
+  "version": "15.7.5",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 6-reviewer specialist panel (5 Cursor specialists + 1 Codex generic) with 3-voter adjudication; plan review runs a 3-reviewer panel (Claude + Codex + Cursor); design sketches run a 9-agent diverge-then-converge phase in regular mode (1 Claude + 4 Cursor + 4 Codex) or 3 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [15.7.5] - 2026-05-04
+
+### Changed
+
+- `skills/issue/scripts/list-issues.sh`: Phase 1 dedup snapshot now drops issues whose trimmed, lowercased title starts with `research`, `[research]`, `investigate`, `[investigate]`, or `[research report]`. /research-style archival reports no longer crowd out real semantic candidates from the per-item Phase 2 cap. Filter applies uniformly to the open-only and closed-window fetch branches. Closes #1055.
+
 ## [15.7.4] - 2026-05-04
 
 ### Changed

--- a/skills/issue/scripts/list-issues.sh
+++ b/skills/issue/scripts/list-issues.sh
@@ -133,9 +133,13 @@ RAW=$(gh api --paginate "repos/${REPO}/issues?state=all&per_page=100" 2>/dev/nul
 # closed-issue branch in jq entirely rather than falling back to a sentinel
 # cutoff (the original 0000-00-00 fallback was >= every real date and silently
 # included all closed issues).
+#
+# Omit /research-style archival titles from the Phase 1 dedup snapshot (case-
+# insensitive, leading whitespace trimmed) to reduce prompt noise.
+# shellcheck disable=SC2016  # jq filter ($t is jq binding, not shell)
+DEDUP_SKIP_PREFIX_FILTER='select((.title // "" | ascii_downcase | sub("^[[:space:]]+"; "")) as $t | (($t | startswith("research")) or ($t | startswith("[research]")) or ($t | startswith("investigate")) or ($t | startswith("[investigate]")) or ($t | startswith("[research report]"))) | not)'
 if [[ "$CLOSED_WINDOW_DAYS" -eq 0 ]]; then
-    # shellcheck disable=SC2016  # jq filter, not shell expansion
-    JQ_FILTER='.[] | select(.pull_request == null) | select(.state == "open") | [(.number|tostring), (.title | gsub("\t"; " ") | gsub("\n"; " ") | gsub("\r"; " ")), .state, .html_url] | @tsv'
+    JQ_FILTER='.[] | select(.pull_request == null) | select(.state == "open") | '"$DEDUP_SKIP_PREFIX_FILTER"' | [(.number|tostring), (.title | gsub("\t"; " ") | gsub("\n"; " ") | gsub("\r"; " ")), .state, .html_url] | @tsv'
     TSV=$(echo "$RAW" | jq -r "$JQ_FILTER" 2>/dev/null) || {
         echo "LIST_STATUS=failed"
         echo "WARN: jq failed to parse gh api output" >&2
@@ -143,7 +147,7 @@ if [[ "$CLOSED_WINDOW_DAYS" -eq 0 ]]; then
     }
 else
     # shellcheck disable=SC2016  # $cutoff is a jq variable passed via --arg, not a shell variable
-    JQ_FILTER='.[] | select(.pull_request == null) | select(.state == "open" or (.state == "closed" and .closed_at != null and (.closed_at[:10] >= $cutoff))) | [(.number|tostring), (.title | gsub("\t"; " ") | gsub("\n"; " ") | gsub("\r"; " ")), .state, .html_url] | @tsv'
+    JQ_FILTER='.[] | select(.pull_request == null) | select(.state == "open" or (.state == "closed" and .closed_at != null and (.closed_at[:10] >= $cutoff))) | '"$DEDUP_SKIP_PREFIX_FILTER"' | [(.number|tostring), (.title | gsub("\t"; " ") | gsub("\n"; " ") | gsub("\r"; " ")), .state, .html_url] | @tsv'
     TSV=$(echo "$RAW" | jq -r --arg cutoff "$CUTOFF_DATE" "$JQ_FILTER" 2>/dev/null) || {
         echo "LIST_STATUS=failed"
         echo "WARN: jq failed to parse gh api output" >&2


### PR DESCRIPTION
## Summary

- Exclude /research-style issue titles from the Phase 1 dedup snapshot so real duplicates stay under the per-item cap.
- Matching is case-insensitive with leading whitespace trimmed; bracketed Research/Investigate and [Research Report] forms are covered.
- The same filter runs for open-only and closed-window fetches so dedup always sees a consistent title universe.

## Architecture Diagram

_Architecture diagram not available — quick mode._

## Code Flow Diagram

_Code Flow Diagram skipped — quick mode._

## Test plan

- [x] Manual jq smoke test against synthetic mixed-prefix titles (filter kept normal titles, dropped all five prefix variants including mixed-case `ReSeARCH`).
- [x] Cursor implementer ran `bash -n`, `shellcheck`, and a live `list-issues.sh --repo zhupanov/larch --closed-window-days 30` invocation.
- [x] Round 1 quick-mode review: 5 Cursor specialists + generic Codex; reviewer findings about prefix breadth rejected as user-spec-driven and recorded under Rejected Code Review Findings on the tracking issue.
- [ ] CI green on the bump commit.

Closes #1055

🤖 Generated with [Claude Code](https://claude.com/claude-code)
