### PR TITLE
Fix stale Step 2 dispatch test header (#1067)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "15.7.6",
+  "version": "15.7.7",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 6-reviewer specialist panel (5 Cursor specialists + 1 Codex generic) with 3-voter adjudication; plan review runs a 3-reviewer panel (Claude + Codex + Cursor); design sketches run a 9-agent diverge-then-converge phase in regular mode (1 Claude + 4 Cursor + 4 Codex) or 3 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [15.7.7] - 2026-05-04
+
+### Fixed
+
+- `skills/implement/scripts/test-step2-dispatch.sh` header comment no longer claims the default-coder path produces `STATUS=claude_fallback`. The bullet now correctly describes the default Codex outside-git → exit 2 behavior, matching Test 1b and the sibling contract doc. Closes #1067.
+
 ## [15.7.6] - 2026-05-04
 
 ### Changed

--- a/skills/implement/scripts/test-step2-dispatch.sh
+++ b/skills/implement/scripts/test-step2-dispatch.sh
@@ -5,7 +5,7 @@
 # (28 assertions; for the full per-test inventory see test-step2-dispatch.md):
 #   - --coder claude → STATUS=claude_fallback (no launcher run; no baseline-file leak).
 #   - default coder (no --coder flag) is codex.
-#   - Default coder (neither flag) → STATUS=claude_fallback.
+#   - Default codex path outside a git work-tree → exit 2.
 #   - Legacy --codex-available false → STATUS=claude_fallback + deprecation warning on stderr.
 #   - Missing required flag (--auto-mode) → exit 2.
 #   - Bad --coder enum value → exit 2 and names {claude,codex,cursor}.


### PR DESCRIPTION
## Summary

- Correct the Step 2 dispatch harness header so it matches the documented default Codex behavior (default coder is `codex`; from a non-git cwd the codex path exits 2). Replaces the stale `STATUS=claude_fallback` bullet that contradicted line 8 and Test 1b.

## Test plan

- [x] `/relevant-checks` (pre-commit + agent-lint) green.
- [x] Inline harness assertions still match (Test 1b unchanged).

Closes #1067

🤖 Generated with [Claude Code](https://claude.com/claude-code)
