### PR TITLE
Update repo references from zhupanov/larch to character-ai/larch

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -7,8 +7,8 @@
     "email": "zhupanov@yahoo.com"
   },
   "license": "MIT",
-  "repository": "https://github.com/zhupanov/larch",
-  "homepage": "https://github.com/zhupanov/larch",
+  "repository": "https://github.com/character-ai/larch",
+  "homepage": "https://github.com/character-ai/larch",
   "keywords": [
     "workflow",
     "automation",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "15.7.12",
+  "version": "15.7.13",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 6-reviewer specialist panel (5 Cursor specialists + 1 Codex generic) with 3-voter adjudication; plan review runs a 3-reviewer panel (Claude + Codex + Cursor); design sketches run a 9-agent diverge-then-converge phase in regular mode (1 Claude + 4 Cursor + 4 Codex) or 3 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [15.7.13] - 2026-05-04
+
+### Changed
+
+- Update repo references from `zhupanov/larch` to `character-ai/larch` following the GitHub ownership transfer to the `character-ai` org. Touches `.claude-plugin/plugin.json` (`repository` and `homepage` URLs), `docs/installation-and-setup.md` (the `claude plugin marketplace add` install command and the `git clone` URL), `docs/configuration-and-permissions.md` (three historical issue links — #586, #566, #585), and the `/upgrade-larch` skill (`skills/upgrade-larch/SKILL.md`, `skills/upgrade-larch/scripts/upgrade-larch.sh`, `skills/upgrade-larch/scripts/upgrade-larch.md`). Historical CHANGELOG entries, the author email (`zhupanov@yahoo.com`), references to the separate `zhupanov/agent-lint` and `zhupanov/claude-lint` repos (not part of this transfer), and machine-local `/Users/zhupanov/larch1` paths in CHANGELOG history are intentionally left untouched.
+
 ## [15.7.12] - 2026-05-04
 
 ### Changed

--- a/docs/configuration-and-permissions.md
+++ b/docs/configuration-and-permissions.md
@@ -41,7 +41,7 @@ Note the ordering: because `Skill(larch:...)` begins with `l` followed by `a`, a
 
 ## `claude -p` permission propagation
 
-Larch's loop drivers spawn `claude -p --plugin-dir "$CLAUDE_PLUGIN_ROOT"` subprocesses (after `cd "$REPO_ROOT"`). **Direct `claude -p` callers**: `scripts/eval-research.sh`. This section documents how the project-level `.claude/settings.json` propagates to all `claude -p` children regardless of which layer launched them. Audit issue: [#586](https://github.com/zhupanov/larch/issues/586). Tested against Claude Code CLI version `2.1.119`.
+Larch's loop drivers spawn `claude -p --plugin-dir "$CLAUDE_PLUGIN_ROOT"` subprocesses (after `cd "$REPO_ROOT"`). **Direct `claude -p` callers**: `scripts/eval-research.sh`. This section documents how the project-level `.claude/settings.json` propagates to all `claude -p` children regardless of which layer launched them. Audit issue: [#586](https://github.com/character-ai/larch/issues/586). Tested against Claude Code CLI version `2.1.119`.
 
 ### Empirical findings
 
@@ -76,7 +76,7 @@ Project settings cannot be silently downgraded by user-level files for entries t
 
 ### Implication for the umbrella stall (issue #566)
 
-Because the bare `"Edit"` allow rule IS honored by `claude -p` and `defaultMode: bypassPermissions` IS in effect, the umbrella stall reported in [#566](https://github.com/zhupanov/larch/issues/566) (where a `/umbrella` iteration hit a permission-prompt stall on `Edit` against `skills/umbrella/SKILL.md`) is **not caused by missing or insufficient on-disk permissions**. The decisive remedy is the kernel-side fix tracked in [#585](https://github.com/zhupanov/larch/issues/585) (pin the permission contract at the `invoke_claude_p` invocation site, e.g., via explicit `--permission-mode bypassPermissions` and/or `--allowedTools` flags), which removes the dependence on settings discovery entirely.
+Because the bare `"Edit"` allow rule IS honored by `claude -p` and `defaultMode: bypassPermissions` IS in effect, the umbrella stall reported in [#566](https://github.com/character-ai/larch/issues/566) (where a `/umbrella` iteration hit a permission-prompt stall on `Edit` against `skills/umbrella/SKILL.md`) is **not caused by missing or insufficient on-disk permissions**. The decisive remedy is the kernel-side fix tracked in [#585](https://github.com/character-ai/larch/issues/585) (pin the permission contract at the `invoke_claude_p` invocation site, e.g., via explicit `--permission-mode bypassPermissions` and/or `--allowedTools` flags), which removes the dependence on settings discovery entirely.
 
 This audit therefore does **not** modify `.claude/settings.json`. The settings are correct as-shipped; no path-qualified `Edit($PWD/.claude/skills/**)` entry is needed.
 

--- a/docs/installation-and-setup.md
+++ b/docs/installation-and-setup.md
@@ -10,7 +10,7 @@ Slack integration is optional and **on by default** when `LARCH_SLACK_BOT_TOKEN`
 
 #### Install
 ```bash
-claude plugin marketplace add zhupanov/larch
+claude plugin marketplace add character-ai/larch
 claude plugin install larch@larch-local
 ```
 The first command registers larch's marketplace manifest (`.claude-plugin/marketplace.json`). The second command installs the `larch` plugin into your Claude Code user scope. Once installed, all larch skills (e.g., /implement) become available in every Claude Code session.  Note that both commands make changes to your `~/.claude/settings.json`.
@@ -42,7 +42,7 @@ After the skill completes, restart Claude Code to apply the new version.
 If you are hacking on larch itself and want Claude Code to load the plugin directly from your working checkout (so `${CLAUDE_PLUGIN_ROOT}` resolves to the repo you are editing), launch Claude Code with `--plugin-dir`:
 
 ```bash
-git clone https://github.com/zhupanov/larch.git
+git clone https://github.com/character-ai/larch.git
 cd larch
 claude --plugin-dir .
 ```

--- a/skills/upgrade-larch/SKILL.md
+++ b/skills/upgrade-larch/SKILL.md
@@ -4,7 +4,7 @@ description: "Use when upgrading the larch plugin to the latest version. Removes
 allowed-tools: Bash
 ---
 
-Upgrade the larch plugin to the latest version. This skill is for the standard GitHub install (`claude plugin marketplace add zhupanov/larch`). Contributors using a local checkout (`claude --plugin-dir .` or `claude plugin marketplace add .`) should `git pull` instead.
+Upgrade the larch plugin to the latest version. This skill is for the standard GitHub install (`claude plugin marketplace add character-ai/larch`). Contributors using a local checkout (`claude --plugin-dir .` or `claude plugin marketplace add .`) should `git pull` instead.
 
 ## Steps
 

--- a/skills/upgrade-larch/scripts/upgrade-larch.md
+++ b/skills/upgrade-larch/scripts/upgrade-larch.md
@@ -10,7 +10,7 @@ Automates the full teardown-and-reinstall sequence needed to pick up the latest 
 
 1. Uninstalls `larch@larch-local` (best-effort — may not be installed).
 2. Removes the `larch-local` marketplace (best-effort — may not be registered).
-3. Re-adds the marketplace from `zhupanov/larch` on GitHub.
+3. Re-adds the marketplace from `character-ai/larch` on GitHub.
 4. Installs the `larch` plugin from the freshly-added marketplace.
 
 Steps 1–2 use `|| true` because the plugin/marketplace may not exist (first install, or already removed). Steps 3–4 run under `set -e` and will fail loudly on network errors, auth issues, or CLI problems. On failure after teardown, the script prints recovery commands so the user can manually re-add.

--- a/skills/upgrade-larch/scripts/upgrade-larch.sh
+++ b/skills/upgrade-larch/scripts/upgrade-larch.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 recover() {
     echo "" >&2
     echo "Recovery: run these commands manually to reinstall:" >&2
-    echo "  claude plugin marketplace add zhupanov/larch" >&2
+    echo "  claude plugin marketplace add character-ai/larch" >&2
     echo "  claude plugin install larch@larch-local" >&2
 }
 trap recover ERR
@@ -16,7 +16,7 @@ echo "Removing larch-local marketplace..."
 claude plugin marketplace remove larch-local 2>&1 || true
 
 echo "Re-adding larch marketplace from GitHub..."
-claude plugin marketplace add zhupanov/larch 2>&1
+claude plugin marketplace add character-ai/larch 2>&1
 
 echo "Installing larch plugin..."
 claude plugin install larch@larch-local 2>&1


### PR DESCRIPTION
## Summary

- Update repo references from `zhupanov/larch` to `character-ai/larch` following the GitHub ownership transfer to the `character-ai` org.
- Touches plugin manifest URLs, install/upgrade docs, the `/upgrade-larch` skill + script, and three historical issue-link URLs in `docs/configuration-and-permissions.md`.
- Intentionally untouched: historical CHANGELOG entries, the author email, references to the separate `zhupanov/agent-lint` and `zhupanov/claude-lint` repos (not part of this transfer), and machine-local `/Users/zhupanov/larch1` paths in CHANGELOG history.

## Test plan

- [x] `/relevant-checks` clean (pre-commit + agent-lint full-repo)
- [x] `git grep -n 'zhupanov/larch'` returns only CHANGELOG history and `/Users/zhupanov/larch1` filesystem paths (no live repo-slug references remain)
- [x] `.claude-plugin/plugin.json` validates as JSON; `repository` and `homepage` point to `https://github.com/character-ai/larch`
- [x] PATCH version bump (15.7.12 → 15.7.13) per `/bump-version` classifier — only docs/skill text edits, no public skill-surface changes

_No tracking issue — auto-close N/A._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
