### PR TITLE
Add Gemini CLI install docs to docs/installation-and-setup.md

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "15.7.13",
+  "version": "15.7.14",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 6-reviewer specialist panel (5 Cursor specialists + 1 Codex generic) with 3-voter adjudication; plan review runs a 3-reviewer panel (Claude + Codex + Cursor); design sketches run a 9-agent diverge-then-converge phase in regular mode (1 Claude + 4 Cursor + 4 Codex) or 3 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [15.7.14] - 2026-05-04
+
+### Added
+
+- Document Gemini CLI install + setup in `docs/installation-and-setup.md`: Homebrew/npm install, OAuth login, `~/.gemini/settings.json` and `~/.gemini/trustedFolders.json` (with the macOS case-sensitivity gotcha), the Gemini CLI 0.40.x bundled-`rg` workaround, and free-tier `MODEL_CAPACITY_EXHAUSTED` vs Google AI Pro/Ultra capacity notes. Closes #1078; sibling integration issues under umbrella #1081 will wire Gemini into reviewer/coder paths.
+
 ## [15.7.13] - 2026-05-04
 
 ### Changed

--- a/docs/installation-and-setup.md
+++ b/docs/installation-and-setup.md
@@ -101,6 +101,45 @@ claude plugin install larch@larch-local
 
 > **Note — larch overrides the cli-config.json model for its own Cursor invocations.**
 
+### Gemini
+- Install Gemini CLI with Homebrew or npm:
+```bash
+brew install gemini-cli
+# or
+npm install -g @google/gemini-cli
+```
+- Authenticate with OAuth:
+```bash
+gemini auth login
+```
+- Add/edit `~/.gemini/settings.json` with your authentication mode and preferred model. For Gemini 3 preview work, use a model name such as:
+```JSON
+{
+  "auth": {
+    "type": "oauth"
+  },
+  "model": {
+    "name": "gemini-3-pro-preview"
+  }
+}
+```
+- Add every repo you want Gemini to access to `~/.gemini/trustedFolders.json` using case-correct absolute paths:
+```JSON
+{
+  "trustedFolders": [
+    "/Users/<your-user-name>/path/to/repo"
+  ]
+}
+```
+- `trustedFolders.json` path matching is case-sensitive even on case-insensitive macOS filesystems. If the path case differs from the real checkout path, headless `gemini -p` runs can hang silently behind a trust prompt.
+- Gemini CLI 0.40.x does not look up `rg` on `PATH`; it only checks for a bundled binary at `<gemini-pkg>/bundle/vendor/ripgrep/rg-<platform>-<arch>`, which Homebrew/npm installs may omit. Install ripgrep first (`brew install ripgrep`) so `which rg` resolves, then on Apple Silicon macOS create the missing bundled path as a symlink:
+```bash
+mkdir -p <gemini-pkg>/bundle/vendor/ripgrep
+ln -sf "$(which rg)" <gemini-pkg>/bundle/vendor/ripgrep/rg-darwin-arm64
+```
+  Re-run the symlink command after each `brew upgrade gemini-cli`.
+- Free-tier accounts can hit hard `MODEL_CAPACITY_EXHAUSTED` 429s on `gemini-3-*-preview` models when used from the Gemini CLI. Google AI Pro may raise available capacity; Google AI Ultra unblocks these preview-model capacity failures.
+
 ## What the plugin provides
 
 | Component | Description |


### PR DESCRIPTION
## Summary

- Add a `### Gemini` subsection to `docs/installation-and-setup.md` parallel to the existing Claude / Codex / Cursor sections.
- Cover Homebrew/npm install + `gemini auth login`, `~/.gemini/settings.json` (auth + `model.name`), `~/.gemini/trustedFolders.json` with the macOS case-sensitivity caveat, the Gemini CLI 0.40.x bundled-`rg` symlink workaround, and free-tier vs Google AI Pro/Ultra capacity notes.
- Out of scope: launcher scripts and reviewer/coder integration — tracked in sibling issues under umbrella #1081.

## Architecture Diagram

Architecture diagram not available.

## Code Flow Diagram

(Code Flow Diagram skipped — quick mode)

## Test plan

- [x] `/relevant-checks` passes (pre-commit + agent-lint).
- [x] Visual review of the rendered Gemini section.

Closes #1078

🤖 Generated with [Claude Code](https://claude.com/claude-code)
