### PR TITLE
Document direct-read default for repo Q&A in AGENTS.md

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "15.8.3",
+  "version": "15.8.4",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 6-reviewer specialist panel (5 Cursor specialists + 1 Codex generic) — extended to 7 with an optional Gemini reviewer when the Gemini CLI is installed and healthy — with 3-voter adjudication; plan review runs a 3-reviewer panel (Claude + Codex + Cursor); design sketches run a 9-agent diverge-then-converge phase in regular mode (1 Claude + 4 Cursor + 4 Codex) or 3 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,3 +47,16 @@ Plugin ships the entire repo. **Runtime surface**: `skills/`, `agents/`, `hooks/
 - Run `gh issue create` through `/larch:issue`, not manually. Scripts under `scripts/` and `skills/*/scripts/` (e.g., hooks) may continue to call `gh issue create` directly — the rule targets interactive / assistant-driven issue creation only.
 - Slack env vars are optional; skills degrade gracefully when absent.
 - **Don't spawn a Monitor or a Bash `run_in_background` polling loop (`for`/`while`/`until` + `sleep`) to watch another `run_in_background` job finish — and don't reach for `ScheduleWakeup` as a third polling mechanism either.** The Bash tool already emits a `<task-notification>` with `status=completed` (or `failed`) when the original process exits — both forms of poller would just deliver the same signal twice, and a stale poller can keep the session alive long after the watched job has reported. `ScheduleWakeup` is worse than a poller in this role: a non-sentinel `prompt` re-fires on wakeup as a `/loop` input and (per the tool's "pass the same `/loop` prompt back each turn" guidance) perpetuates a `/loop`-style chain that survives past the watched step and into post-completion turns. If you genuinely need a wakeup, rely on the task notification. Use Monitor only for tailing logs, polling *external* state, or per-occurrence event streams; for one-shot "wait until done," rely on the Bash notification. (`/implement` ratchets this stricter — see `skills/implement/SKILL.md` NEVER #9, which forbids `ScheduleWakeup` anywhere in the orchestrator.)
+
+## Answering questions about this repo
+
+For Q&A about this repository, default to direct file reads instead of dispatching Explore, Agent, or Plan.
+
+1. Name the files you expect to answer the question, then Read them in parallel.
+2. If you cannot name the files after consulting AGENTS.md and the skill layout, run one or two targeted greps to find the relevant candidates.
+3. Escalate to Explore or Agent only when direct reads are no longer the efficient path:
+   - The obvious candidate files were read and did not contain the answer.
+   - The answer plausibly spans more than three files that cannot be enumerated up front.
+   - A targeted grep returned more than 20 hits across unfamiliar directories.
+
+Before escalating, announce the escalation in one sentence so the user can interrupt. Treat subagents as a larger-context tool: a subagent spends roughly 15k-25k tokens of baseline overhead before doing useful work, while a direct Read costs a few hundred to a few thousand tokens.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [15.8.4] - 2026-05-04
+
+### Changed
+
+- Give repository Q&A a direct-read default before broader agent dispatch.
+- Clarify the limited cases where Explore or Agent escalation is appropriate.
+
 ## [15.8.3] - 2026-05-04
 
 ### Added


### PR DESCRIPTION
## Summary

- Give repository Q&A a direct-read default before broader agent dispatch.
- Clarify the limited cases where Explore or Agent escalation is appropriate.

## Architecture Diagram

Architecture diagram not available.

## Code Flow Diagram

(Code Flow Diagram skipped — quick mode)

## Test plan

- [x] `/relevant-checks` — pre-commit (shellcheck, markdownlint, JSON, agent-lint, gitleaks, agnix) and full-repo `agent-lint` pass on the modified `AGENTS.md` and bumped `.claude-plugin/plugin.json` + `CHANGELOG.md`.
- [x] Visual sanity check — new `## Answering questions about this repo` section renders, escalation triggers parse as a sub-list, no Markdown lint warnings.

Closes #1091

🤖 Generated with [Claude Code](https://claude.com/claude-code)
