### PR TITLE
Abort failed preflight rebase to leave a clean working tree

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "15.10.0",
+  "version": "15.10.1",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 6-reviewer specialist panel (5 Cursor specialists + 1 Codex generic) — extended to 7 with an optional Gemini reviewer when the Gemini CLI is installed and healthy — with 3-voter adjudication; plan review runs a 3-reviewer panel (Claude + Codex + Cursor); design sketches run a 9-agent diverge-then-converge phase in regular mode (1 Claude + 4 Cursor + 4 Codex) or 3 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [15.10.1] - 2026-05-04
+
+### Fixed
+
+- `scripts/preflight.sh` now runs `git rebase --abort` when the default-mode rebase fails, mirroring `scripts/rebase-push.sh:162-165`'s `--no-push` behavior. Previously a rebase conflict left the working tree mid-rebase. Adds `scripts/preflight.md` sibling contract documenting the new failure shape and exit-code semantics, including the unknown-flag exception that uses stderr-only output.
+
 ## [15.10.0] - 2026-05-04
 
 ### Added

--- a/scripts/preflight.md
+++ b/scripts/preflight.md
@@ -18,7 +18,7 @@ Success emits:
 PREFLIGHT=ok
 ```
 
-Failure emits:
+Failure for the documented runtime checks (not-on-main, dirty working tree, fetch failure, rebase failure) emits:
 
 ```
 PREFLIGHT=fail
@@ -26,6 +26,8 @@ PREFLIGHT_ERROR=<human-readable reason>
 ```
 
 `session-setup.sh` captures and re-emits these lines verbatim on preflight failure.
+
+Argument validation (unknown flag) is the exception: it writes `Unknown option: <arg>` to stderr only and exits 3 without emitting the `PREFLIGHT_*` shape. Callers passing only documented flags will not encounter this path.
 
 ## Exit codes
 

--- a/scripts/preflight.md
+++ b/scripts/preflight.md
@@ -1,0 +1,63 @@
+# preflight.sh contract
+
+## Purpose
+
+Run the pre-skill git sanity check used by `session-setup.sh`. In default mode it verifies that the caller is on `main`, the working tree is clean, and local `main` can fetch and rebase onto `origin/main`. With `--skip-branch-check`, it skips the branch and clean-tree assertions and only refreshes `origin/main`.
+
+## Interface
+
+```
+preflight.sh [--skip-branch-check]
+```
+
+## Output contract
+
+Success emits:
+
+```
+PREFLIGHT=ok
+```
+
+Failure emits:
+
+```
+PREFLIGHT=fail
+PREFLIGHT_ERROR=<human-readable reason>
+```
+
+`session-setup.sh` captures and re-emits these lines verbatim on preflight failure.
+
+## Exit codes
+
+| Exit | Meaning |
+|------|---------|
+| 0 | All requested checks passed. |
+| 1 | Default mode only: current branch is not `main`. |
+| 2 | Default mode only: working tree is not clean. |
+| 3 | Argument validation failed, fetch failed, or default-mode rebase failed. |
+
+## Rebase failure shape
+
+In default mode, `git rebase origin/main` runs only after the working tree has been verified clean. If the rebase fails, `preflight.sh` immediately runs `git rebase --abort 2>/dev/null || true` before emitting `PREFLIGHT=fail` and exiting 3. Callers do not resolve conflicts during preflight; the abort restores the clean preflight starting point whenever Git can abort the failed rebase.
+
+`--skip-branch-check` mode does not run a rebase, so this abort behavior is default-mode only.
+
+## Test harness
+
+No dedicated harness exists today. Syntax is covered by running:
+
+```
+bash -n scripts/preflight.sh
+```
+
+## Makefile wiring
+
+No dedicated Makefile target exists today.
+
+## Edit-in-sync
+
+When changing `scripts/preflight.sh`:
+
+- Update this file for any output contract, exit code, or git-state side effect change.
+- Verify `scripts/session-setup.sh` still captures and re-emits `PREFLIGHT_*` output correctly.
+- Verify `/implement` and `/design` setup prose still matches the default versus `--skip-branch-check` behavior.

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -46,6 +46,7 @@ if [[ "$SKIP_BRANCH_CHECK" == "false" ]]; then
         exit 3
     fi
     if ! git rebase origin/main --quiet 2>/dev/null; then
+        git rebase --abort 2>/dev/null || true
         echo "PREFLIGHT=fail"
         echo "PREFLIGHT_ERROR=git rebase origin/main failed."
         exit 3


### PR DESCRIPTION
## Summary

- Add `git rebase --abort` to `scripts/preflight.sh`'s default-mode rebase-failure path so a failed rebase no longer leaves the working tree mid-rebase, mirroring `scripts/rebase-push.sh:162-165` `--no-push` behavior.
- Document the new failure shape in a new `scripts/preflight.md` sibling contract covering exit codes, output contract (including the unknown-flag stderr-only exception), and edit-in-sync rules.

## Test plan

- [x] `bash -n scripts/preflight.sh` (syntax)
- [x] `/relevant-checks` (pre-commit + agent-lint full repo)
- [ ] CI green

Closes #1105
