### PR TITLE
Document strict clean-main entry contract for /implement and /design

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "15.10.4",
+  "version": "15.10.5",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 6-reviewer specialist panel (5 Cursor specialists + 1 Codex generic) — extended to 7 with an optional Gemini reviewer when the Gemini CLI is installed and healthy — with 3-voter adjudication; plan review runs a 3-reviewer panel (Claude + Codex + Cursor); design sketches run a 9-agent diverge-then-converge phase in regular mode (1 Claude + 4 Cursor + 4 Codex) or 3 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [15.10.5] - 2026-05-05
+
+### Changed
+
+- Document the strict clean-main entry contract for `/implement` and standalone `/design` in `docs/installation-and-setup.md`. The new section covers the four parts of the contract: (a) clean `main` is required by default — preflight asserts on-main + clean working tree + fetch + rebase before any side effects; (b) running on a `<USER_PREFIX>/*` branch is the explicit continuation opt-in; (c) `--issue <N>` adopts identity but does not waive the gate; (d) the normalized `PREFLIGHT_ERROR=...` failure message and three remediation paths (clean main, prefix-branch continuation, commit-or-stash). README's Setup TOC links to the new section.
+
 ## [15.10.3] - 2026-05-04
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Larch is a Claude Code workflow automation framework that orchestrates multi-age
 ## Table of Contents
 
 - **Setup**
-  - [Installation and Setup](docs/installation-and-setup.md) — plugin install, local development, agent setup recipes (Claude / Codex / Cursor), what the plugin provides, `/relevant-checks` consumer dependency, prerequisites
+  - [Installation and Setup](docs/installation-and-setup.md) — plugin install, local development, agent setup recipes (Claude / Codex / Cursor), [clean-main entry contract](docs/installation-and-setup.md#clean-main-entry-contract-for-implement-and-design) for `/implement` and `/design`, what the plugin provides, `/relevant-checks` consumer dependency, prerequisites
   - [Configuration and Permissions](docs/configuration-and-permissions.md) — [Strict-permissions consumers](docs/configuration-and-permissions.md#strict-permissions-consumers--skill-permission-entries), [`--admin` merge behavior](docs/configuration-and-permissions.md#--admin-merge-behavior), [Environment Variables](docs/configuration-and-permissions.md#environment-variables) (`LARCH_SLACK_*`, `LARCH_CURSOR_MODEL`, `LARCH_CODEX_MODEL`, `LARCH_CODEX_EFFORT`, `LARCH_BUMP_FILES`)
 - **Reference**
   - [Features](#features)

--- a/docs/installation-and-setup.md
+++ b/docs/installation-and-setup.md
@@ -166,7 +166,7 @@ Larch's own copy at `.claude/skills/relevant-checks/` serves as a reference impl
 
 ## Clean-main entry contract for `/implement` and `/design`
 
-`/implement` and standalone `/design` fail closed at entry unless one of two preconditions holds. This is enforced by `preflight.sh` before any tracking-issue side effects (no issue is created, no anchor comment is planted, no branch is created) so an aborted entry leaves no remote state behind.
+`/implement` and standalone `/design` fail closed at entry unless one of two preconditions holds. The check runs in `preflight.sh` before any side effects — for `/implement`, before any tracking-issue side effects (no issue is created, no anchor comment is planted) and before any branch is created; for standalone `/design` (which does not create a tracking issue at entry), before any branch is created. An aborted entry leaves no remote state behind.
 
 **(a) Default — clean `main`.** The skill asserts that the working tree is on `main`, has no uncommitted changes, fetches `origin/main`, and rebases local `main` onto it. A dirty tree, a non-`main` branch with no recognized prefix, or a fetch failure aborts with a normalized error.
 
@@ -174,11 +174,11 @@ Larch's own copy at `.claude/skills/relevant-checks/` serves as a reference impl
 
 **(c) `--issue <N>` does not waive the gate.** Adopting an existing tracking issue with `--issue <N>` controls *identity* (which issue is updated and auto-closed) but does not relax the working-tree requirement. You still need either a clean `main` or a `<USER_PREFIX>/*` branch to start.
 
-**(d) Failure modes and recovery.** When preflight fails, the orchestrator prints the raw `PREFLIGHT_ERROR=...` followed by the normalized message:
+**(d) Failure modes and recovery.** When preflight fails, the orchestrator prints the raw `PREFLIGHT_ERROR=...` followed by a normalized message naming the skill that was invoked. From `/implement`:
 
 > ⚠ /implement requires clean main to start. To continue, choose one of: (a) `git checkout main && git status` clean → re-run; (b) check out or create a `<USER_PREFIX>/*` feature branch and re-run (the branch naming convention is the explicit opt-in to continue from current state); (c) commit or stash uncommitted changes on `main` first.
 
-The three remediation paths (clean `main`, `<USER_PREFIX>/*` continuation, commit-or-stash) cover dirty trees, wrong-branch starts, and transient fetch failures.
+Standalone `/design` prints the same message with `/design` substituted for `/implement`. The three remediation paths (clean `main`, `<USER_PREFIX>/*` continuation, commit-or-stash) cover dirty trees, wrong-branch starts, and transient fetch failures.
 
 ## Prerequisites
 

--- a/docs/installation-and-setup.md
+++ b/docs/installation-and-setup.md
@@ -164,6 +164,22 @@ The `/relevant-checks` skill is **not part of the plugin surface** — it is pre
 
 Larch's own copy at `.claude/skills/relevant-checks/` serves as a reference implementation — it runs `pre-commit` linters plus `agent-lint` (if available on PATH).
 
+## Clean-main entry contract for `/implement` and `/design`
+
+`/implement` and standalone `/design` fail closed at entry unless one of two preconditions holds. This is enforced by `preflight.sh` before any tracking-issue side effects (no issue is created, no anchor comment is planted, no branch is created) so an aborted entry leaves no remote state behind.
+
+**(a) Default — clean `main`.** The skill asserts that the working tree is on `main`, has no uncommitted changes, fetches `origin/main`, and rebases local `main` onto it. A dirty tree, a non-`main` branch with no recognized prefix, or a fetch failure aborts with a normalized error.
+
+**(b) Continuation opt-in — `<USER_PREFIX>/*` feature branch.** Running on a branch whose name starts with your configured `<USER_PREFIX>/` (e.g., `sergey-zhupanov/foo`) is the explicit signal that you want to continue from current state. The gate is bypassed; the skill keeps working on the current branch.
+
+**(c) `--issue <N>` does not waive the gate.** Adopting an existing tracking issue with `--issue <N>` controls *identity* (which issue is updated and auto-closed) but does not relax the working-tree requirement. You still need either a clean `main` or a `<USER_PREFIX>/*` branch to start.
+
+**(d) Failure modes and recovery.** When preflight fails, the orchestrator prints the raw `PREFLIGHT_ERROR=...` followed by the normalized message:
+
+> ⚠ /implement requires clean main to start. To continue, choose one of: (a) `git checkout main && git status` clean → re-run; (b) check out or create a `<USER_PREFIX>/*` feature branch and re-run (the branch naming convention is the explicit opt-in to continue from current state); (c) commit or stash uncommitted changes on `main` first.
+
+The three remediation paths (clean `main`, `<USER_PREFIX>/*` continuation, commit-or-stash) cover dirty trees, wrong-branch starts, and transient fetch failures.
+
 ## Prerequisites
 
 Larch skills have different dependency requirements depending on which features you use.


### PR DESCRIPTION
## Summary

- Document the strict clean-main entry contract for `/implement` and standalone `/design` in a new section of `docs/installation-and-setup.md`. Covers (a) default clean-`main` requirement enforced by `preflight.sh` before any side effects, (b) `<USER_PREFIX>/*` branch as the continuation opt-in, (c) `--issue <N>` adopts identity without waiving the gate, (d) the `PREFLIGHT_ERROR=...` failure surface plus three remediation paths.
- Link to the new section from README's Setup TOC entry so consumers can discover the contract without reading SKILL.md.

## Test plan

- [x] `/relevant-checks` (changed-file phase + full-repo `agent-lint`) green.
- [ ] Manual smoke (operator): the new section accurately describes what `/implement` and `/design` do on dirty `main`, on a `<USER_PREFIX>/*` branch, and with `--issue <N>` against a clean tree.

Closes #1108

🤖 Generated with [Claude Code](https://claude.com/claude-code)
