### PR TITLE
Clarify Gemini model flag in docs/configuration-and-permissions.md (closes #1109)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "15.10.9",
+  "version": "15.10.10",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 6-reviewer specialist panel (5 Cursor specialists + 1 Codex generic) — extended to 7 with an optional Gemini reviewer when the Gemini CLI is installed and healthy — with 3-voter adjudication; plan review runs a 3-reviewer panel (Claude + Codex + Cursor); design sketches run a 9-agent diverge-then-converge phase in regular mode (1 Claude + 4 Cursor + 4 Codex) or 3 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [15.10.9] - 2026-05-05
+## [15.10.10] - 2026-05-05
 
 ### Fixed
 

--- a/docs/configuration-and-permissions.md
+++ b/docs/configuration-and-permissions.md
@@ -196,7 +196,7 @@ The Slack channel ID (e.g., `C0123456789`) where tracking-issue status messages 
 
 ### External Agent Model Configuration
 
-These variables control which model Cursor, Codex, and Gemini use when running as external agents. Cursor and Codex run reviews, sketches, voting, and implementation (when selected with `--coder`); Gemini runs reviews and implementation (when selected with `--coder=gemini`). When unset, Cursor defaults to `composer-2` (with the `/max-mode on.` slash-command prefix applied to every substantive prompt via `scripts/cursor-wrap-prompt.sh`), Codex defaults to `gpt-5.5` (hardcoded in `scripts/agent-model-args.sh`), and Gemini defaults to `gemini-2.5-pro`. The model is passed via the `--model` flag (Cursor) or `-m` flag (Codex / Gemini). To restore the pre-`composer-2` behavior, set `LARCH_CURSOR_MODEL=composer-2-fast`.
+These variables control which model Cursor, Codex, and Gemini use when running as external agents. Cursor and Codex run reviews, sketches, voting, and implementation (when selected with `--coder`); Gemini runs reviews and implementation (when selected with `--coder=gemini`). When unset, Cursor defaults to `composer-2` (with the `/max-mode on.` slash-command prefix applied to every substantive prompt via `scripts/cursor-wrap-prompt.sh`), Codex defaults to `gpt-5.5` (hardcoded in `scripts/agent-model-args.sh`), and Gemini defaults to `gemini-2.5-pro`. The model is passed via `--model` for Cursor and Gemini implementation, and via `-m` for Codex and Gemini review. To restore the pre-`composer-2` behavior, set `LARCH_CURSOR_MODEL=composer-2-fast`.
 
 Model configuration is also available via plugin `userConfig` — environment variables take precedence if both are set.
 
@@ -228,7 +228,7 @@ The model name to pass to Codex's `-m` flag (e.g., `o3`, `o4-mini`).
 
 ### `LARCH_GEMINI_MODEL`
 
-The model name to pass to Gemini's `-m` flag (e.g., `gemini-2.5-pro`, `gemini-2.5-flash`).
+The model name to pass to Gemini review's `-m` flag and Gemini implementation's `--model` flag (e.g., `gemini-2.5-pro`, `gemini-2.5-flash`).
 
 **When set:**
 - All Gemini reviewer invocations, the Gemini health probe, and Gemini implementation launches (`/implement --coder=gemini`) use this model


### PR DESCRIPTION
## Summary

- Fix `docs/configuration-and-permissions.md` to correctly document Gemini's model flag: implement uses `--model` (via `scripts/agent-model-args.sh --tool gemini`), only Codex and Gemini *review* use `-m` (via `scripts/launch-gemini-review.sh`).
- Two paragraphs updated: the "External Agent Model Configuration" intro and the `### LARCH_GEMINI_MODEL` opener.

## Test plan

- [x] Verified against scripts: `scripts/agent-model-args.sh:119` prints `--model $MODEL`; `scripts/launch-gemini-implement.sh:113` calls `agent-model-args.sh --tool gemini`; `scripts/launch-gemini-review.sh:137` uses `-m "$GEMINI_MODEL"`.
- [x] `/relevant-checks` passes (pre-commit + agent-lint).
- [x] Re-grep `docs/configuration-and-permissions.md` for residual misstatements — none remain.

Closes #1109

🤖 Generated with [Claude Code](https://claude.com/claude-code)
