### PR TITLE
Document Gemini cwd contract in /implement Step 2.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "15.10.11",
+  "version": "15.10.12",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 6-reviewer specialist panel (5 Cursor specialists + 1 Codex generic) — extended to 7 with an optional Gemini reviewer when the Gemini CLI is installed and healthy — with 3-voter adjudication; plan review runs a 3-reviewer panel (Claude + Codex + Cursor); design sketches run a 9-agent diverge-then-converge phase in regular mode (1 Claude + 4 Cursor + 4 Codex) or 3 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [15.10.12] - 2026-05-05
+
+### Changed
+
+- Update the Cwd contract paragraph in `skills/implement/SKILL.md` Step 2.1 so the enumeration of external implementers covers Gemini in addition to Codex and Cursor (closes #1112). The same `REPO_ROOT` / cwd rules already apply once `--coder=gemini` passes the health gate; the paragraph now documents all three implementers uniformly. No behavior change.
+
 ## [15.10.11] - 2026-05-05
 
 ### Changed

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -641,7 +641,7 @@ case "$TOOL" in
 esac
 ```
 
-**Cwd contract**: invoke the dispatcher with process cwd = the consumer git repo's working tree (the orchestrator's normal cwd). The dispatcher derives its `REPO_ROOT` from `git rev-parse --show-toplevel` against cwd because `${CLAUDE_PLUGIN_ROOT}` may resolve into the installed plugin cache (no `.git`). On Codex, or on Cursor after the health gate passes, a cwd outside any git working tree exits 2 with a clear caller-error message; do not chdir before invoking. See `skills/implement/scripts/step2-implement.md` invariant "Two distinct roots".
+**Cwd contract**: invoke the dispatcher with process cwd = the consumer git repo's working tree (the orchestrator's normal cwd). The dispatcher derives its `REPO_ROOT` from `git rev-parse --show-toplevel` against cwd because `${CLAUDE_PLUGIN_ROOT}` may resolve into the installed plugin cache (no `.git`). On Codex, on Cursor after the health gate passes, or on Gemini after the health gate passes, a cwd outside any git working tree exits 2 with a clear caller-error message; do not chdir before invoking. See `skills/implement/scripts/step2-implement.md` invariant "Two distinct roots".
 
 **2.1.5 — Envelope validation (fail-closed)**:
 


### PR DESCRIPTION
## Summary

- Update the Step 2.1 Cwd contract paragraph in `skills/implement/SKILL.md` (line 644) to enumerate Gemini alongside Codex and Cursor: "On Codex, on Cursor after the health gate passes, or on Gemini after the health gate passes…". The same `REPO_ROOT` / cwd rules already apply once `--coder=gemini` passes the health gate; this aligns the orchestrator-facing doc with `skills/implement/scripts/step2-implement.md`'s "Two distinct roots" invariant.

No behavior change.

## Architecture Diagram

Architecture diagram not available.

## Code Flow Diagram

(Code Flow Diagram skipped — quick mode)

## Test plan

- [x] `/relevant-checks` (markdownlint, agent-lint) passed.
- [x] Quick-mode review: 5 Cursor specialists + Codex generic returned NO_ISSUES_FOUND; one Gemini style nit rejected.

Closes #1112

🤖 Generated with [Claude Code](https://claude.com/claude-code)
