### PR TITLE
Document preflight exit 3 argument validation

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "15.11.2",
+  "version": "15.11.3",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 6-reviewer specialist panel (5 Cursor specialists + 1 Codex generic) — extended to 7 with an optional Gemini reviewer when the Gemini CLI is installed and healthy — with 3-voter adjudication; plan review runs a 3-reviewer panel (Claude + Codex + Cursor); design sketches run a 9-agent diverge-then-converge phase in regular mode (1 Claude + 4 Cursor + 4 Codex) or 3 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [15.11.3] - 2026-05-05
+
+### Changed
+
+- Update `scripts/preflight.sh` header comment so the exit-code listing for code 3 documents argument-validation failures in addition to fetch and rebase failures (closes #1125). The script already exits 3 on unknown CLI options at line 22 and the sibling contract `scripts/preflight.md` already enumerates all three exit-3 paths; this aligns the header comment with both. Comment-only change; no behavior change.
+
 ## [15.11.2] - 2026-05-05
 
 ### Changed

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -11,7 +11,7 @@
 #   0 — all checks passed
 #   1 — not on main branch (only without --skip-branch-check)
 #   2 — dirty working tree (only without --skip-branch-check)
-#   3 — git fetch or rebase failed
+#   3 — argument validation, git fetch, or rebase failed
 
 set -euo pipefail
 


### PR DESCRIPTION
## Summary
- Updated `scripts/preflight.sh` header comment so the exit-code listing for code 3 documents argument-validation failures in addition to fetch and rebase failures (closes #1125).
- Comment-only change; no behavior change. The script already exits 3 on unknown CLI options at line 22, and the sibling contract `scripts/preflight.md` already enumerates all three exit-3 paths — the header comment now matches both.

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] `bash -n scripts/preflight.sh`
- [x] `/relevant-checks` (pre-commit + agent-lint, full repo)
- [x] Visual confirmation against `scripts/preflight.md` exit-code table

</details>

Closes #1125

Generated with [Claude Code](https://claude.com/claude-code)
