### PR TITLE
Sanitize .meta TOOL= label in run-external-agent.sh (#1145)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "15.11.4",
+  "version": "15.11.5",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 6-reviewer specialist panel (5 Cursor specialists + 1 Codex generic) — extended to 7 with an optional Gemini reviewer when the Gemini CLI is installed and healthy — with 3-voter adjudication; plan review runs a 3-reviewer panel (Claude + Codex + Cursor); design sketches run a 9-agent diverge-then-converge phase in regular mode (1 Claude + 4 Cursor + 4 Codex) or 3 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [15.11.5] - 2026-05-05
+
+### Changed
+
+- Sanitize the `TOOL=` value written to `<output>.meta` in `scripts/run-external-agent.sh` through a label-safe allowlist (`LC_ALL=C tr -c 'a-zA-Z0-9._-' '_'`) so unusual `--tool` labels cannot corrupt line-oriented metadata parsing in `collect-agent-results.sh::derive_tool()` (closes #1145). Translation (rather than deletion) preserves length so adversarial labels like `cu\nrsor` become `cu_rsor` instead of collapsing into the canonical `cursor` id; the same logic blocks `=`, whitespace, and non-ASCII bytes (including Unicode line/paragraph separators U+2028/U+2029). Empty results fall back to a distinct `sanitized-empty` sentinel so the empty-output retry path stays functional. Human-readable log messages still use the raw `--tool` value as-is. Per the contract in `scripts/external-tool-registry.md`, `--tool` registry validation remains unchanged — labels remain permissive at the registry level.
+
 ## [15.11.4] - 2026-05-05
 
 ### Changed

--- a/scripts/run-external-agent.md
+++ b/scripts/run-external-agent.md
@@ -6,7 +6,7 @@ Monitored wrapper for external agents. It launches a command, writes `<output>.m
 
 `--tool` is intentionally permissive: it is used only for log messages and the `.meta` `TOOL=` field. The canonical external-tool name set lives in `scripts/external-tool-registry.sh`; callers SHOULD pass a registered name, but this wrapper does not enforce it so out-of-tree callers can pass arbitrary provenance tags.
 
-Before writing `.meta`, the wrapper strips ASCII control characters and `=` from the `TOOL=` value so unusual labels cannot corrupt line-oriented metadata parsing. The original `--tool` value is still preserved for human-readable progress and diagnostics.
+Before writing `.meta`, the wrapper sanitizes the `TOOL=` value: ASCII control characters are stripped and `=` is translated to `_`, so unusual labels cannot corrupt line-oriented metadata parsing or collapse into canonical tool ids consumed by `collect-agent-results.sh::derive_tool()` (e.g. `c=u=r=s=o=r` would otherwise become `cursor`). If sanitization yields an empty string, the `.meta` field falls back to `unknown` so the retry path (which skips when `META_TOOL` is empty) stays functional. The original `--tool` value is still preserved for human-readable progress and diagnostics.
 
 This script is listed as the "Related (label-only consumer, NOT sourced)" entry in `scripts/external-tool-registry.md`, not as a `Sourced by` consumer.
 

--- a/scripts/run-external-agent.md
+++ b/scripts/run-external-agent.md
@@ -4,9 +4,9 @@ Monitored wrapper for external agents. It launches a command, writes `<output>.m
 
 ## Tool labels
 
-`--tool` is intentionally permissive: it is used only for log messages and the `.meta` `TOOL=` field. The canonical external-tool name set lives in `scripts/external-tool-registry.sh`; callers SHOULD pass a registered name, but this wrapper does not enforce it so out-of-tree callers can pass arbitrary provenance tags.
+`--tool` is intentionally permissive at the registry level: callers SHOULD pass a registered name (the canonical external-tool name set lives in `scripts/external-tool-registry.sh`), but this wrapper does not enforce that, so out-of-tree callers can pass arbitrary provenance tags. The raw `--tool` value is used as-is in human-readable log messages.
 
-Before writing `.meta`, the wrapper sanitizes the `TOOL=` value: ASCII control characters are stripped and `=` is translated to `_`, so unusual labels cannot corrupt line-oriented metadata parsing or collapse into canonical tool ids consumed by `collect-agent-results.sh::derive_tool()` (e.g. `c=u=r=s=o=r` would otherwise become `cursor`). If sanitization yields an empty string, the `.meta` field falls back to `unknown` so the retry path (which skips when `META_TOOL` is empty) stays functional. The original `--tool` value is still preserved for human-readable progress and diagnostics.
+Before writing `.meta`, the wrapper sanitizes the `TOOL=` value through a label-safe allowlist (alphanumerics, `.`, `_`, `-`); any other byte — control characters, `=`, whitespace, and any non-ASCII byte (including Unicode line/paragraph separators U+2028/U+2029) — is translated to `_`. Translation (rather than deletion) preserves length so an adversarial label cannot collapse into the canonical tool ids consumed by `collect-agent-results.sh::derive_tool()`; for example, `cu\nrsor` becomes `cu_rsor`, not `cursor`. If sanitization yields an empty string, the `.meta` field falls back to `sanitized-empty` (a distinct sentinel from `unknown`, which `derive_tool()` uses for unclassifiable tools) so the retry path — which skips when `META_TOOL` is empty — stays functional.
 
 This script is listed as the "Related (label-only consumer, NOT sourced)" entry in `scripts/external-tool-registry.md`, not as a `Sourced by` consumer.
 

--- a/scripts/run-external-agent.md
+++ b/scripts/run-external-agent.md
@@ -6,7 +6,9 @@ Monitored wrapper for external agents. It launches a command, writes `<output>.m
 
 `--tool` is intentionally permissive: it is used only for log messages and the `.meta` `TOOL=` field. The canonical external-tool name set lives in `scripts/external-tool-registry.sh`; callers SHOULD pass a registered name, but this wrapper does not enforce it so out-of-tree callers can pass arbitrary provenance tags.
 
-This script is listed as the "Related (label-only consumer, NOT sourced)" entry in `scripts/external-tool-registry.md`, not as a `Sourced by` consumer. A pre-existing observability concern (`.meta TOOL=` is unsanitized and line-oriented metadata could be disrupted by unusual labels) is tracked separately as the OOS_1 follow-up filed alongside #1099.
+Before writing `.meta`, the wrapper strips ASCII control characters and `=` from the `TOOL=` value so unusual labels cannot corrupt line-oriented metadata parsing. The original `--tool` value is still preserved for human-readable progress and diagnostics.
+
+This script is listed as the "Related (label-only consumer, NOT sourced)" entry in `scripts/external-tool-registry.md`, not as a `Sourced by` consumer.
 
 ## Output capture modes
 

--- a/scripts/run-external-agent.sh
+++ b/scripts/run-external-agent.sh
@@ -6,11 +6,17 @@
 # minute, and kills after a configurable timeout (e.g., 30 minutes for
 # reviews/implementation, 20 minutes for votes/sketches).
 #
-# The --tool value is used as-is for log messages. For the .meta TOOL= field
-# it is sanitized for line-oriented parsing (ASCII control characters stripped,
-# `=` replaced with `_`) so unusual labels cannot corrupt downstream metadata
-# parsers. If sanitization yields an empty string, the .meta field falls back
-# to `unknown` so retry logic in collect-agent-results.sh stays functional.
+# The --tool value is used as-is for human-readable log messages. For the
+# .meta TOOL= field it is sanitized through a label-safe allowlist
+# (alphanumerics, `.`, `_`, `-`); any other byte — control characters, `=`,
+# whitespace, and any non-ASCII byte (including Unicode line/paragraph
+# separators like U+2028/U+2029) — is translated to `_`. The translation
+# preserves length so distinct inputs cannot collapse into the canonical
+# tool ids consumed by collect-agent-results.sh::derive_tool() (e.g.
+# `cu\nrsor` becomes `cu_rsor`, not `cursor`). If sanitization yields an
+# empty string, the .meta field falls back to `sanitized-empty` (a distinct
+# sentinel from `unknown`, which derive_tool() uses for unclassifiable
+# tools) so retry logic in collect-agent-results.sh stays functional.
 # No registry validation is performed here by design (see issue #1099 /
 # DECISION_1): the wrapper accepts any string label so out-of-tree callers can
 # pass arbitrary provenance tags without importing the registry. The canonical
@@ -21,7 +27,9 @@
 #   run-external-agent.sh --tool NAME --output FILE --timeout SECS [--capture-stdout|--capture-stdout-only] -- CMD...
 #
 # Options:
-#   --tool            Tool name (e.g., "codex", "cursor") — used only for log messages
+#   --tool            Tool name (e.g., "codex", "cursor") — used as-is for log
+#                     messages; sanitized to a label-safe form for the .meta
+#                     TOOL= field (see header comment above for the contract)
 #   --output          Path where tool output is written
 #   --timeout         Timeout in seconds (e.g., 1800 for 30 minutes)
 #   --capture-stdout  Redirect the tool's stdout/stderr to the output file.
@@ -113,14 +121,20 @@ trap 'echo "$EXIT_CODE" > "${OUTPUT_FILE}.done" 2>/dev/null || true' EXIT
 
 # Write metadata for collect-agent-results.sh retry support.
 # CMD is shell-quoted via printf '%q' to preserve argument boundaries.
-# Sanitize TOOL_NAME for the line-oriented .meta sidecar:
-#   - strip ASCII control chars (newlines, etc.) — would split the value across lines
-#   - translate `=` to `_` — preserve distinguishability without collapsing labels
-#     into canonical tool ids (e.g. `c=u=r=s=o=r` -> `c_u_r_s_o_r`, not `cursor`)
-# If the result is empty, fall back to `unknown` so collect-agent-results.sh's
-# retry path (which skips on empty META_TOOL) stays functional.
-META_TOOL_NAME=$(printf '%s' "$TOOL_NAME" | LC_ALL=C tr -d '[:cntrl:]' | LC_ALL=C tr '=' '_')
-[[ -z "$META_TOOL_NAME" ]] && META_TOOL_NAME="unknown"
+# Sanitize TOOL_NAME for the line-oriented .meta sidecar via a label-safe
+# allowlist: keep alphanumerics, dot, underscore, hyphen; translate every
+# other byte to `_`. Translation (not deletion) preserves length so an
+# adversarial label cannot collapse into a canonical tool id consumed by
+# collect-agent-results.sh::derive_tool() — e.g. `cu\nrsor` becomes
+# `cu_rsor`, not `cursor`; `c=u=r=s=o=r` becomes `c_u_r_s_o_r`. The
+# allowlist also handles non-ASCII bytes (including Unicode line/paragraph
+# separators U+2028/U+2029) which `tr '[:cntrl:]'` under LC_ALL=C does not
+# cover. Empty result falls back to `sanitized-empty` (distinct from
+# derive_tool()'s `unknown` so callers can tell sanitization apart from
+# unclassifiable input), keeping collect-agent-results.sh's retry path
+# (which skips on empty META_TOOL) functional.
+META_TOOL_NAME=$(printf '%s' "$TOOL_NAME" | LC_ALL=C tr -c 'a-zA-Z0-9._-' '_')
+[[ -z "$META_TOOL_NAME" ]] && META_TOOL_NAME="sanitized-empty"
 {
     echo "TOOL=$META_TOOL_NAME"
     echo "TIMEOUT=$TIMEOUT_SECONDS"

--- a/scripts/run-external-agent.sh
+++ b/scripts/run-external-agent.sh
@@ -6,10 +6,14 @@
 # minute, and kills after a configurable timeout (e.g., 30 minutes for
 # reviews/implementation, 20 minutes for votes/sketches).
 #
-# The --tool value is used only for log messages and the .meta TOOL= field.
-# No validation is performed here by design (see issue #1099 / DECISION_1):
-# the wrapper accepts any string label so out-of-tree callers can pass
-# arbitrary provenance tags without importing the registry. The canonical
+# The --tool value is used as-is for log messages. For the .meta TOOL= field
+# it is sanitized for line-oriented parsing (ASCII control characters stripped,
+# `=` replaced with `_`) so unusual labels cannot corrupt downstream metadata
+# parsers. If sanitization yields an empty string, the .meta field falls back
+# to `unknown` so retry logic in collect-agent-results.sh stays functional.
+# No registry validation is performed here by design (see issue #1099 /
+# DECISION_1): the wrapper accepts any string label so out-of-tree callers can
+# pass arbitrary provenance tags without importing the registry. The canonical
 # external-tool name set is owned by scripts/external-tool-registry.sh; see
 # scripts/external-tool-registry.md for the registry contract.
 #
@@ -109,7 +113,14 @@ trap 'echo "$EXIT_CODE" > "${OUTPUT_FILE}.done" 2>/dev/null || true' EXIT
 
 # Write metadata for collect-agent-results.sh retry support.
 # CMD is shell-quoted via printf '%q' to preserve argument boundaries.
-META_TOOL_NAME=$(printf '%s' "$TOOL_NAME" | LC_ALL=C tr -d '[:cntrl:]=')
+# Sanitize TOOL_NAME for the line-oriented .meta sidecar:
+#   - strip ASCII control chars (newlines, etc.) — would split the value across lines
+#   - translate `=` to `_` — preserve distinguishability without collapsing labels
+#     into canonical tool ids (e.g. `c=u=r=s=o=r` -> `c_u_r_s_o_r`, not `cursor`)
+# If the result is empty, fall back to `unknown` so collect-agent-results.sh's
+# retry path (which skips on empty META_TOOL) stays functional.
+META_TOOL_NAME=$(printf '%s' "$TOOL_NAME" | LC_ALL=C tr -d '[:cntrl:]' | LC_ALL=C tr '=' '_')
+[[ -z "$META_TOOL_NAME" ]] && META_TOOL_NAME="unknown"
 {
     echo "TOOL=$META_TOOL_NAME"
     echo "TIMEOUT=$TIMEOUT_SECONDS"

--- a/scripts/run-external-agent.sh
+++ b/scripts/run-external-agent.sh
@@ -109,8 +109,9 @@ trap 'echo "$EXIT_CODE" > "${OUTPUT_FILE}.done" 2>/dev/null || true' EXIT
 
 # Write metadata for collect-agent-results.sh retry support.
 # CMD is shell-quoted via printf '%q' to preserve argument boundaries.
+META_TOOL_NAME=$(printf '%s' "$TOOL_NAME" | LC_ALL=C tr -d '[:cntrl:]=')
 {
-    echo "TOOL=$TOOL_NAME"
+    echo "TOOL=$META_TOOL_NAME"
     echo "TIMEOUT=$TIMEOUT_SECONDS"
     echo "CAPTURE_STDOUT=$CAPTURE_STDOUT"
     echo "CAPTURE_STDOUT_ONLY=$CAPTURE_STDOUT_ONLY"


### PR DESCRIPTION
## Summary

- Sanitize the `TOOL=` value written to `<output>.meta` in `scripts/run-external-agent.sh` so unusual `--tool` labels cannot corrupt the line-oriented metadata sidecar that `collect-agent-results.sh::derive_tool()` and the empty-output retry path consume.
- Use a label-safe allowlist via `LC_ALL=C tr -c 'a-zA-Z0-9._-' '_'`: any byte outside `[a-zA-Z0-9._-]` (control chars, `=`, whitespace, non-ASCII bytes including Unicode line separators U+2028/U+2029) becomes `_`. Translation preserves length so adversarial labels cannot collapse into canonical tool ids — `cu\nrsor` becomes `cu_rsor`, not `cursor`.
- Distinct `sanitized-empty` fallback for the (defense-in-depth) empty case so it does not collide with `derive_tool()`'s `unknown` marker. Human-readable log messages still use the raw `--tool` value as-is. Closes #1145.

## Architecture Diagram

Architecture diagram not available.

## Code Flow Diagram

(Code Flow Diagram skipped — quick mode)

## Test plan

- [x] `bash -n scripts/run-external-agent.sh` (syntax OK)
- [x] Empirical sanitizer probes (`cu\nrsor → cu_rsor`, `c=u=r=s=o=r → c_u_r_s_o_r`, `codex → codex`, `cursor → cursor`, U+2028 sequence `\xe2\x80\xa8sep → ___sep`, empty-input fallback)
- [x] `/relevant-checks` (pre-commit + agent-lint, all passed)
- [ ] CI (shellcheck, agent-lint, lint matrix) green on the PR

Closes #1145

🤖 Generated with [Claude Code](https://claude.com/claude-code)
