### PR TITLE
Sweep stragglers in external-tool enumerations (closes #1097)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "15.11.7",
+  "version": "15.11.8",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 6-reviewer specialist panel (5 Cursor specialists + 1 Codex generic) — extended to 7 with an optional Gemini reviewer when the Gemini CLI is installed and healthy — with 3-voter adjudication; plan review runs a 3-reviewer panel (Claude + Codex + Cursor); design sketches run a 9-agent diverge-then-converge phase in regular mode (1 Claude + 4 Cursor + 4 Codex) or 3 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [15.11.8] - 2026-05-05
+
+### Changed
+
+- Align setup documentation with Gemini as an optional external tool (closes #1097).
+- Keep collector and dispatcher harness documentation in sync with the canonical external-tool taxonomy.
+
 ## [15.11.7] - 2026-05-05
 
 ### Changed

--- a/docs/installation-and-setup.md
+++ b/docs/installation-and-setup.md
@@ -55,9 +55,9 @@ claude plugin marketplace add .
 claude plugin install larch@larch-local
 ```
 
-## Setting Up Claude, Codex, Cursor, etc.
-- **Only `claude` is mandatory.** `codex` and `cursor` are optional — when either binary is missing or fails to authenticate, larch skills substitute Claude subagents automatically. See [Optional integrations](#optional-integrations) for the full fallback semantics.
-- **Larch is agent-agnostic about authentication.** Each agent can be set up either with an **API key** in your shell environment, or with a **subscription plan** via web-based login from the binary itself. Larch does not care which — it only needs the corresponding binary (`claude`, `codex`, `cursor`) to be on your `PATH` and to land in an authenticated session when invoked.
+## Setting Up Claude, Codex, Cursor, Gemini
+- **Only `claude` is mandatory.** `codex`, `cursor`, and `gemini` are optional — when `codex` or `cursor` is missing or fails to authenticate, larch skills substitute Claude subagents automatically; `gemini` is additive (skipped silently when unavailable for reviewer use, falls back to Claude when selected as `--coder=gemini`). See [Optional integrations](#optional-integrations) for the full fallback semantics.
+- **Larch is agent-agnostic about authentication.** Each agent can be set up either with an **API key** in your shell environment, or with a **subscription plan** via web-based login from the binary itself. Larch does not care which — it only needs the corresponding binary (`claude`, `codex`, `cursor`, `gemini`) to be on your `PATH` and to land in an authenticated session when invoked.
 - The subsections below document one concrete setup recipe per agent (API-key path). If you prefer the subscription-plan path, install the binary and follow its own web-login flow instead — the rest of larch's configuration (settings, model overrides) still applies.
 
 ### Claude

--- a/scripts/collect-agent-results.sh
+++ b/scripts/collect-agent-results.sh
@@ -435,7 +435,7 @@ if [[ "$SUBSTANTIVE_VALIDATION" == "true" ]]; then
         entry="${RESULTS[$j]}"
         # Precise field-by-field extraction. Fields 1-5 (REVIEWER_FILE, TOOL,
         # STATUS, EXIT_CODE, HEALTHY) never contain '|' by construction (paths
-        # are tmpdir paths; tools are codex|cursor|unknown; STATUS/HEALTHY are
+        # are tmpdir paths; tools are codex|cursor|gemini|unknown; STATUS/HEALTHY are
         # fixed enums; EXIT_CODE is numeric). FAILURE_REASON (field 6) is the
         # only field that may carry user content, and it's the trailing field
         # — its content cannot collide with the field-1..5 prefixes.

--- a/skills/implement/scripts/test-step2-dispatch.md
+++ b/skills/implement/scripts/test-step2-dispatch.md
@@ -1,6 +1,6 @@
 # test-step2-dispatch.sh
 
-**Purpose**: Offline regression harness for `skills/implement/scripts/step2-implement.sh` covering the dispatcher branches that do not require spawning an external implementer. Runs in <1s with no `codex`/`cursor` binary and no network.
+**Purpose**: Offline regression harness for `skills/implement/scripts/step2-implement.sh` covering the dispatcher branches that do not require spawning an external implementer. Runs in <1s with no `codex`/`cursor`/`gemini` binary and no network.
 
 **Coverage** (37 assertions):
 1. `--coder claude` emits `STATUS=claude_fallback` and `ORCHESTRATOR_EDIT_AUTHORITY=allowed` (and no other KV keys — no `MANIFEST=`, no `TRANSCRIPT=`, etc.), and writes no baseline files.


### PR DESCRIPTION
## Summary
- Aligned the optional-binaries setup heading + prose in `docs/installation-and-setup.md` to include Gemini, with its specific fallback semantics (additive for reviewers; claude-fallback for `--coder=gemini`).
- Updated stale comment in `scripts/collect-agent-results.sh` so the substantive-validation block matches `derive_tool`'s `codex|cursor|gemini|unknown` enum.
- Updated `skills/implement/scripts/test-step2-dispatch.md` to mention `gemini` alongside `codex`/`cursor` in the harness's no-binary precondition.

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] `/relevant-checks` passed (pre-commit + agent-lint).
- [x] Verified the changed files match the intended scope (3 files, 5 insertions / 5 deletions vs `origin/main`).
- [x] Quick-mode review loop (5 Cursor specialists + Codex + Gemini) converged in 1 round; no in-PR-scope findings.

</details>

Closes #1097

Generated with [Claude Code](https://claude.com/claude-code)
