### PR TITLE
Reject --timeout 0 in implement launchers (closes #1115)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "15.11.10",
+  "version": "15.11.11",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 6-reviewer specialist panel (5 Cursor specialists + 1 Codex generic) — extended to 7 with an optional Gemini reviewer when the Gemini CLI is installed and healthy — with 3-voter adjudication; plan review runs a 3-reviewer panel (Claude + Codex + Cursor); design sketches run a 9-agent diverge-then-converge phase in regular mode (1 Claude + 4 Cursor + 4 Codex) or 3 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [15.11.11] - 2026-05-05
+
+### Fixed
+
+- Align implement-launcher timeout validation with the documented positive-integer contract.
+- Reject literal zero before any external implementer process is spawned.
+
 ## [15.11.10] - 2026-05-05
 
 ### Changed

--- a/scripts/launch-codex-implement.sh
+++ b/scripts/launch-codex-implement.sh
@@ -85,7 +85,7 @@ if [[ -n "$ANSWERS_FILE" && ! -f "$ANSWERS_FILE" ]]; then
 fi
 
 case "$TIMEOUT" in
-    ''|*[!0-9]*) echo "launch-codex-implement.sh: --timeout must be a positive integer (seconds), got '$TIMEOUT'" >&2; exit 2 ;;
+    ''|*[!0-9]*|0) echo "launch-codex-implement.sh: --timeout must be a positive integer (seconds), got '$TIMEOUT'" >&2; exit 2 ;;
 esac
 
 # Compose the Codex prompt by concatenating the agent system prompt with

--- a/scripts/launch-cursor-implement.sh
+++ b/scripts/launch-cursor-implement.sh
@@ -85,7 +85,7 @@ if [[ -n "$ANSWERS_FILE" && ! -f "$ANSWERS_FILE" ]]; then
 fi
 
 case "$TIMEOUT" in
-    ''|*[!0-9]*) echo "launch-cursor-implement.sh: --timeout must be a positive integer (seconds), got '$TIMEOUT'" >&2; exit 2 ;;
+    ''|*[!0-9]*|0) echo "launch-cursor-implement.sh: --timeout must be a positive integer (seconds), got '$TIMEOUT'" >&2; exit 2 ;;
 esac
 
 # Compose the Cursor prompt by concatenating the agent system prompt with

--- a/scripts/run-external-agent.sh
+++ b/scripts/run-external-agent.sh
@@ -89,7 +89,7 @@ if [[ "$CAPTURE_STDOUT" == "true" && "$CAPTURE_STDOUT_ONLY" == "true" ]]; then
 fi
 
 case "$TIMEOUT_SECONDS" in
-    ''|*[!0-9]*) echo "ERROR: --timeout must be a positive integer, got '$TIMEOUT_SECONDS'" >&2; exit 1 ;;
+    ''|*[!0-9]*|0) echo "ERROR: --timeout must be a positive integer, got '$TIMEOUT_SECONDS'" >&2; exit 1 ;;
 esac
 
 # Poll interval (seconds) for the kill -0 wait loop below. Default 10s keeps


### PR DESCRIPTION
## Summary
- Aligned `--timeout 0` rejection across `scripts/launch-cursor-implement.sh`, `scripts/launch-codex-implement.sh`, and `scripts/run-external-agent.sh` to match `scripts/launch-gemini-implement.sh`'s existing pattern.
- Rejected literal zero before any external implementer process is spawned, so all four scripts now agree with their shared "must be a positive integer" error wording.

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] `bash scripts/launch-cursor-implement.sh ... --timeout 0 ...` exits 2 with `launch-cursor-implement.sh: --timeout must be a positive integer (seconds), got '0'` on stderr.
- [x] `bash scripts/launch-codex-implement.sh ... --timeout 0 ...` exits 2 with the analogous message.
- [x] `bash scripts/run-external-agent.sh ... --timeout 0 ...` exits 1 with `ERROR: --timeout must be a positive integer, got '0'` on stderr.
- [x] Sanity: `--timeout 30` continues to be accepted by all three (no positive-integer error).
- [x] `/relevant-checks` (pre-commit + agent-lint) clean.

</details>

Closes #1115

Generated with [Claude Code](https://claude.com/claude-code)
