### PR TITLE
Clarify ci-wait stderr progress label as polls (closes #1133)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "15.11.13",
+  "version": "15.11.14",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 6-reviewer specialist panel (5 Cursor specialists + 1 Codex generic) — extended to 7 with an optional Gemini reviewer when the Gemini CLI is installed and healthy — with 3-voter adjudication; plan review runs a 3-reviewer panel (Claude + Codex + Cursor); design sketches run a 9-agent diverge-then-converge phase in regular mode (1 Claude + 4 Cursor + 4 Codex) or 3 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [15.11.14] - 2026-05-05
+
+### Fixed
+
+- Avoid implying that a PR completed with zero GitHub CI checks when `ci-wait` exits on its first poll (closes #1133).
+- Clarify `ci-wait` stderr progress by labeling the internal loop counter as polls in user-facing strings and the surrounding comment / file-header.
+
 ## [15.11.13] - 2026-05-05
 
 ### Changed

--- a/scripts/ci-wait.sh
+++ b/scripts/ci-wait.sh
@@ -46,7 +46,7 @@
 #   synchronous-only invocation contract above is the operational defense.
 #
 # Progress (stderr):
-#   Dots every 10s, status line every ~1 minute (every 6th check)
+#   Dots every 10s, status line every ~1 minute (every 6th poll)
 #
 # Exit codes:
 #   0 — valid decision reached (read ACTION from stdout or <output-file>)
@@ -233,7 +233,7 @@ while true; do
     checks=$((checks + 1))
 
     printf "." >&2
-    # Print status line every 6 checks (~1 minute)
+    # Print status line every 6 polls (~1 minute)
     if [[ $((checks % 6)) -eq 0 ]]; then
         printf "\n⏳ CI: %dm elapsed, %d polls, status=%s\n" \
             "$((SECONDS / 60))" "$checks" "$CI_STATUS" >&2

--- a/scripts/ci-wait.sh
+++ b/scripts/ci-wait.sh
@@ -214,13 +214,13 @@ while true; do
     if [[ "$ACTION" != "wait" ]]; then
         printf "\n" >&2
         if [[ "$ACTION" == "merge" ]]; then
-            printf "✓ CI passed (%ds, %d checks)\n" "$SECONDS" "$checks" >&2
+            printf "✓ CI passed (%ds, %d polls)\n" "$SECONDS" "$checks" >&2
         elif [[ "$ACTION" == "already_merged" ]]; then
             printf "✓ PR already merged (%ds)\n" "$SECONDS" >&2
         elif [[ "$ACTION" == "bail" ]]; then
-            printf "⚠ Bailing: %s (%ds, %d checks)\n" "$BAIL_REASON" "$SECONDS" "$checks" >&2
+            printf "⚠ Bailing: %s (%ds, %d polls)\n" "$BAIL_REASON" "$SECONDS" "$checks" >&2
         else
-            printf "→ Action: %s (%ds, %d checks)\n" "$ACTION" "$SECONDS" "$checks" >&2
+            printf "→ Action: %s (%ds, %d polls)\n" "$ACTION" "$SECONDS" "$checks" >&2
         fi
         exit 0
     fi
@@ -235,7 +235,7 @@ while true; do
     printf "." >&2
     # Print status line every 6 checks (~1 minute)
     if [[ $((checks % 6)) -eq 0 ]]; then
-        printf "\n⏳ CI: %dm elapsed, %d checks, status=%s\n" \
+        printf "\n⏳ CI: %dm elapsed, %d polls, status=%s\n" \
             "$((SECONDS / 60))" "$checks" "$CI_STATUS" >&2
     fi
 


### PR DESCRIPTION
## Summary
- Renamed the user-facing `%d checks` label in `scripts/ci-wait.sh` to `%d polls` across all four stderr `printf` statements (lines 217, 221, 223, 238) so that the `0 checks` summary on a fast-CI return no longer reads as "no GitHub CI checks ran on this PR".
- Aligned the file-header progress description and the inline status-line comment (`every 6th check` → `every 6th poll`) to match the new user-facing label, eliminating the wording drift that originally triggered model-side paranoid `sleep 60` + `gh pr view --json statusCheckRollup` sanity checks between `ACTION=merge` and Step 11/Step 12.
- Internal counter variable `$checks` was intentionally NOT renamed (kept the diff scoped to user-facing labels per the implementation plan).

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] `bash -n scripts/ci-wait.sh` (syntax)
- [x] `grep -n '%d checks' scripts/ci-wait.sh` returns 0 hits
- [x] `grep -n '%d polls' scripts/ci-wait.sh` returns 4 hits
- [x] `$checks` variable still referenced at the original sites
- [x] `/relevant-checks` clean (pre-commit + agent-lint)
- [x] No tests assert on the literal "checks"/"polls" stderr strings (verified)
- [ ] Observe a future `/implement` run where `ci-wait.sh` returns `ACTION=merge` on the first poll, and confirm the model proceeds directly to Step 11/Step 12 without inserting a `sleep 60` + `gh pr view --json statusCheckRollup` sanity check

</details>

Closes #1133

Generated with [Claude Code](https://claude.com/claude-code)
