### PR TITLE
Document Gemini optional integration semantics (closes #1169)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "15.11.17",
+  "version": "15.11.18",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 6-reviewer specialist panel (5 Cursor specialists + 1 Codex generic) — extended to 7 with an optional Gemini reviewer when the Gemini CLI is installed and healthy — with 3-voter adjudication; plan review runs a 3-reviewer panel (Claude + Codex + Cursor); design sketches run a 9-agent diverge-then-converge phase in regular mode (1 Claude + 4 Cursor + 4 Codex) or 3 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [15.11.18] - 2026-05-05
+
+### Changed
+
+- Document Gemini optional integration semantics alongside Codex and Cursor in `docs/installation-and-setup.md`'s "Optional integrations" subsection (closes #1169). Also rewords the section lead-in away from the universal "Claude replacement agents fill in automatically" framing — accurate for Codex/Cursor only — to "Fallback behavior varies by tool — see each bullet below," reflecting that Gemini is additive (skipped when unavailable) and Slack silently skips per its own bullet's contract.
+
 ## [15.11.16] - 2026-05-05
 
 ### Changed

--- a/docs/installation-and-setup.md
+++ b/docs/installation-and-setup.md
@@ -198,11 +198,11 @@ These tools are required for the full design → implement → PR → merge work
 
 ### Optional integrations
 
-These tools enhance the workflow but are not required. When unavailable, Claude replacement agents fill in automatically:
+These tools enhance the workflow but are not required. Fallback behavior varies by tool — see each bullet below.
 
 - **Codex** — [OpenAI Codex CLI](https://github.com/openai/codex). Participates as an external reviewer and voter alongside Claude subagents. When unavailable, a Claude subagent replacement maintains the reviewer count.
 - **Cursor** — [Cursor AI editor](https://cursor.com/). Participates as an external reviewer and voter. When unavailable, a Claude subagent replacement maintains the reviewer count.
-- **Gemini** — [Gemini CLI](https://github.com/google-gemini/gemini-cli). Adds an optional external reviewer slot in rounds 1-3 and joins the external chain in rounds 4+ when healthy. When unavailable, reviewer use is skipped in rounds 1-3 and falls through to the next external reviewer in rounds 4+; `/implement --coder=gemini` falls back to Claude. See [Gemini](#gemini) for setup details.
+- **Gemini** — [Gemini CLI](https://github.com/google-gemini/gemini-cli). Adds an optional external reviewer slot in rounds 1-3 and joins the external chain in rounds 4+ when available. When unavailable, reviewer use is skipped in rounds 1-3 and falls through to the next external reviewer in rounds 4+; `/implement --coder=gemini` falls back to Claude. See [Gemini](#gemini) for setup details.
 - **Slack** — Single tracking-issue status message per `/implement` run (and for `/fix-issue` NON_PR closures). On by default when Slack env vars are configured; pass `--no-slack` to opt out. Requires environment variables or plugin `userConfig` (see [Environment Variables](configuration-and-permissions.md#environment-variables)). When `--no-slack` is passed, all Slack operations are skipped silently. When env vars are missing (and `--no-slack` was not passed), the operation is skipped with a warning at session setup. All other workflow steps proceed normally in either case.
 
 ### Contributor development

--- a/docs/installation-and-setup.md
+++ b/docs/installation-and-setup.md
@@ -202,6 +202,7 @@ These tools enhance the workflow but are not required. When unavailable, Claude 
 
 - **Codex** — [OpenAI Codex CLI](https://github.com/openai/codex). Participates as an external reviewer and voter alongside Claude subagents. When unavailable, a Claude subagent replacement maintains the reviewer count.
 - **Cursor** — [Cursor AI editor](https://cursor.com/). Participates as an external reviewer and voter. When unavailable, a Claude subagent replacement maintains the reviewer count.
+- **Gemini** — [Gemini CLI](https://github.com/google-gemini/gemini-cli). Adds an optional external reviewer slot in rounds 1-3 and joins the external chain in rounds 4+ when healthy. When unavailable, reviewer use is skipped in rounds 1-3 and falls through to the next external reviewer in rounds 4+; `/implement --coder=gemini` falls back to Claude. See [Gemini](#gemini) for setup details.
 - **Slack** — Single tracking-issue status message per `/implement` run (and for `/fix-issue` NON_PR closures). On by default when Slack env vars are configured; pass `--no-slack` to opt out. Requires environment variables or plugin `userConfig` (see [Environment Variables](configuration-and-permissions.md#environment-variables)). When `--no-slack` is passed, all Slack operations are skipped silently. When env vars are missing (and `--no-slack` was not passed), the operation is skipped with a warning at session setup. All other workflow steps proceed normally in either case.
 
 ### Contributor development


### PR DESCRIPTION
## Summary
- Added a Gemini bullet to the "Optional integrations" subsection of `docs/installation-and-setup.md` summarizing additive-reviewer behavior in rounds 1-3, chain participation in rounds 4+ when available, and `--coder=gemini` Claude fallback when unavailable, with a cross-link to the existing `### Gemini` setup subsection.
- Reworded the section lead-in away from the universal "Claude replacement agents fill in automatically" framing — accurate for Codex/Cursor only — to "Fallback behavior varies by tool — see each bullet below," surfaced by 5 of 7 reviewers as a contradiction with Gemini's additive (not substituted) reviewer slot.

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] Read the modified file to confirm the new bullet renders correctly between the Cursor and Slack bullets.
- [x] `grep -n "Gemini" docs/installation-and-setup.md` shows the new bullet in the Optional integrations list.
- [x] `/relevant-checks` (markdownlint + agent-lint) passes on `docs/installation-and-setup.md` and on the full repo.

</details>

Closes #1169

Generated with [Claude Code](https://claude.com/claude-code)
