### PR TITLE
Document run-external-agent.sh .meta TOOL= sanitization in registry contracts

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "15.11.18",
+  "version": "15.11.19",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 6-reviewer specialist panel (5 Cursor specialists + 1 Codex generic) — extended to 7 with an optional Gemini reviewer when the Gemini CLI is installed and healthy — with 3-voter adjudication; plan review runs a 3-reviewer panel (Claude + Codex + Cursor); design sketches run a 9-agent diverge-then-converge phase in regular mode (1 Claude + 4 Cursor + 4 Codex) or 3 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [15.11.19] - 2026-05-05
+
+### Changed
+
+- Update `scripts/external-tool-registry.md` `## Related` and step 5 of `## Adding a new external tool` to reflect that `scripts/run-external-agent.sh` sanitizes the `.meta` `TOOL=` field via a label-safe allowlist (introduced by #1145) — the human-facing log retains the raw `--tool` label, while disallowed bytes in the `.meta` sidecar are translated to `_` (length-preserved) and an empty result falls back to `sanitized-empty`. Also document that non-label-safe ids may collide after sanitization (e.g. `tool/a` and `tool?a` both become `tool_a`), so `.meta` `TOOL=` is not a bijection from arbitrary labels.
+- Sync `scripts/run-external-agent.md` cross-link to `external-tool-registry.md` so both sibling contracts agree on the registry's framing (NOT sourced; no `--tool` validation; raw label in logs; sanitized `.meta` `TOOL=`).
+
 ## [15.11.18] - 2026-05-05
 
 ### Changed

--- a/scripts/external-tool-registry.md
+++ b/scripts/external-tool-registry.md
@@ -14,7 +14,7 @@ Update this list whenever a new consumer sources the registry.
 
 ## Related
 
-`scripts/run-external-agent.sh` is NOT sourced from this registry and still does not validate `--tool` against it, per DECISION_1 of #1099. The human-facing log keeps the raw label, while the `.meta` `TOOL=` sidecar field is sanitized at write time through a label-safe allowlist (alphanumerics, `.`, `_`, `-`); an empty sanitized result falls back to `sanitized-empty`.
+`scripts/run-external-agent.sh` is NOT sourced from this registry and still does not validate `--tool` against it, per DECISION_1 of #1099. The human-facing log keeps the raw label, while the `.meta` `TOOL=` sidecar field is sanitized at write time through a label-safe allowlist (alphanumerics, `.`, `_`, `-`); disallowed bytes are translated to `_` (length-preserved), and an empty sanitized result falls back to `sanitized-empty`. See `scripts/run-external-agent.md` for the full sanitization contract.
 
 ## Public API
 
@@ -48,7 +48,7 @@ Per-tool model defaults stay in `agent-model-args.sh` for Codex and Cursor; for 
 2. Add the per-tool branch in `agent-model-args.sh`.
 3. Add the per-tool branch in `check-reviewers.sh` `start_probe` and in every switch helper (`get_available`, `get_healthy`, `set_healthy`, `get_skip`, `set_probe_error`, `get_probe_error`); decide opt-in vs. default and update `--include-*` policy accordingly.
 4. If the new tool is also an implementer, add the launcher branch in `step2-implement.sh`.
-5. No change is required in `run-external-agent.sh` for a new tool id made only of label-safe characters; flag a wrapper update only if the id contains other characters, because `.meta` `TOOL=` would be sanitized or fall back to `sanitized-empty`.
+5. No change is required in `run-external-agent.sh`: it sanitizes `.meta` `TOOL=` for any input. Prefer a label-safe id (alphanumerics, `.`, `_`, `-`) so `.meta` `TOOL=` matches the registry id verbatim and distinct ids cannot collide via sanitization; only widen the wrapper's allowlist if you intentionally change that contract.
 6. Update the relevant sibling `.md` contracts.
 7. Run `make lint` and `/relevant-checks`.
 

--- a/scripts/external-tool-registry.md
+++ b/scripts/external-tool-registry.md
@@ -48,7 +48,7 @@ Per-tool model defaults stay in `agent-model-args.sh` for Codex and Cursor; for 
 2. Add the per-tool branch in `agent-model-args.sh`.
 3. Add the per-tool branch in `check-reviewers.sh` `start_probe` and in every switch helper (`get_available`, `get_healthy`, `set_healthy`, `get_skip`, `set_probe_error`, `get_probe_error`); decide opt-in vs. default and update `--include-*` policy accordingly.
 4. If the new tool is also an implementer, add the launcher branch in `step2-implement.sh`.
-5. No change is required in `run-external-agent.sh`: it sanitizes `.meta` `TOOL=` for any input. Prefer a label-safe id (alphanumerics, `.`, `_`, `-`) so `.meta` `TOOL=` matches the registry id verbatim and distinct ids cannot collide via sanitization; only widen the wrapper's allowlist if you intentionally change that contract.
+5. No change is required in `run-external-agent.sh`: it sanitizes `.meta` `TOOL=` for any input. Prefer a label-safe id (alphanumerics, `.`, `_`, `-`) so `.meta` `TOOL=` matches the registry id verbatim; non-label-safe ids may still collide after sanitization (e.g. `tool/a` and `tool?a` both become `tool_a`), so `.meta` `TOOL=` is not a bijection from arbitrary labels. Only widen the wrapper's allowlist if you intentionally change that contract.
 6. Update the relevant sibling `.md` contracts.
 7. Run `make lint` and `/relevant-checks`.
 

--- a/scripts/external-tool-registry.md
+++ b/scripts/external-tool-registry.md
@@ -14,7 +14,7 @@ Update this list whenever a new consumer sources the registry.
 
 ## Related
 
-`scripts/run-external-agent.sh` is a label-only consumer and is NOT sourced. It aligns to this registry via a header comment per DECISION_1 of #1099. The wrapper accepts any `--tool` label without validation by design.
+`scripts/run-external-agent.sh` is NOT sourced from this registry and still does not validate `--tool` against it, per DECISION_1 of #1099. The human-facing log keeps the raw label, while the `.meta` `TOOL=` sidecar field is sanitized at write time through a label-safe allowlist (alphanumerics, `.`, `_`, `-`); an empty sanitized result falls back to `sanitized-empty`.
 
 ## Public API
 
@@ -48,7 +48,7 @@ Per-tool model defaults stay in `agent-model-args.sh` for Codex and Cursor; for 
 2. Add the per-tool branch in `agent-model-args.sh`.
 3. Add the per-tool branch in `check-reviewers.sh` `start_probe` and in every switch helper (`get_available`, `get_healthy`, `set_healthy`, `get_skip`, `set_probe_error`, `get_probe_error`); decide opt-in vs. default and update `--include-*` policy accordingly.
 4. If the new tool is also an implementer, add the launcher branch in `step2-implement.sh`.
-5. No change is required in `run-external-agent.sh` because it is label-only.
+5. No change is required in `run-external-agent.sh` for a new tool id made only of label-safe characters; flag a wrapper update only if the id contains other characters, because `.meta` `TOOL=` would be sanitized or fall back to `sanitized-empty`.
 6. Update the relevant sibling `.md` contracts.
 7. Run `make lint` and `/relevant-checks`.
 

--- a/scripts/run-external-agent.md
+++ b/scripts/run-external-agent.md
@@ -8,7 +8,7 @@ Monitored wrapper for external agents. It launches a command, writes `<output>.m
 
 Before writing `.meta`, the wrapper sanitizes the `TOOL=` value through a label-safe allowlist (alphanumerics, `.`, `_`, `-`); any other byte — control characters, `=`, whitespace, and any non-ASCII byte (including Unicode line/paragraph separators U+2028/U+2029) — is translated to `_`. Translation (rather than deletion) preserves length so an adversarial label cannot collapse into the canonical tool ids consumed by `collect-agent-results.sh::derive_tool()`; for example, `cu\nrsor` becomes `cu_rsor`, not `cursor`. If sanitization yields an empty string, the `.meta` field falls back to `sanitized-empty` (a distinct sentinel from `unknown`, which `derive_tool()` uses for unclassifiable tools) so the retry path — which skips when `META_TOOL` is empty — stays functional.
 
-This script is listed as the "Related (label-only consumer, NOT sourced)" entry in `scripts/external-tool-registry.md`, not as a `Sourced by` consumer.
+This script is listed under `Related` in `scripts/external-tool-registry.md`, not under `Sourced by`: it is NOT sourced from the registry, does not validate `--tool` against it, retains the raw label in human-facing logs, and sanitizes the `.meta` `TOOL=` field as described above.
 
 ## `--output` invariants
 


### PR DESCRIPTION
## Summary
- Updated `scripts/external-tool-registry.md` `## Related` and step 5 of `## Adding a new external tool` so the doc reflects that `scripts/run-external-agent.sh` sanitizes the `.meta` `TOOL=` field via a label-safe allowlist (introduced by #1145) — the human-facing log keeps the raw `--tool` label, while disallowed bytes in the `.meta` sidecar are translated to `_` (length-preserved) and an empty result falls back to `sanitized-empty`.
- Documented that non-label-safe ids may collide after sanitization (e.g. `tool/a` and `tool?a` both become `tool_a`), so `.meta` `TOOL=` is not a bijection from arbitrary labels.
- Synced `scripts/run-external-agent.md` cross-link to `external-tool-registry.md` so both sibling contracts agree on the registry's framing (NOT sourced; no `--tool` validation; raw label in logs; sanitized `.meta` `TOOL=`).

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] Read `scripts/run-external-agent.sh` header (lines 10-19) and the sanitization block (lines 124-137) and verified the new wording in `scripts/external-tool-registry.md` matches the actual contract.
- [x] Verified `scripts/run-external-agent.sh` is unchanged (`git diff main...HEAD --stat` shows only `scripts/external-tool-registry.md` and `scripts/run-external-agent.md`).
- [x] `pre-commit` (markdownlint, agent-lint, gitleaks, skill-invocation lint) passed on each round of review fixes.
- [x] Quick-mode review loop (3 rounds, 5 Cursor specialists + Codex generic + Gemini generic per round, plus single-generic rounds 4+) converged to `NO_ISSUES_FOUND` from all 5 Cursor specialists + Codex in round 3.

</details>

Closes #1157

Generated with [Claude Code](https://claude.com/claude-code)
