### PR TITLE
Align external-tool-registry.sh header with .meta TOOL= sanitization contract

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "15.11.23",
+  "version": "15.11.24",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 6-reviewer specialist panel (5 Cursor specialists + 1 Codex generic) — extended to 7 with an optional Gemini reviewer when the Gemini CLI is installed and healthy — with 3-voter adjudication; plan review runs a 3-reviewer panel (Claude + Codex + Cursor); design sketches run a 9-agent diverge-then-converge phase in regular mode (1 Claude + 4 Cursor + 4 Codex) or 3 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [15.11.24] - 2026-05-05
+
+### Changed
+
+- Update the header comment block in `scripts/external-tool-registry.sh` (lines 10-12 pre-PR) so it mirrors the `## Related` section in the sibling `scripts/external-tool-registry.md`. The previous header described `scripts/run-external-agent.sh` as a "label-only" consumer (citing only DECISION_1 of #1099), which drifted from the contract introduced by #1145 — the wrapper now sanitizes the `.meta` `TOOL=` field through a label-safe allowlist (alphanumerics, `.`, `_`, `-`); disallowed bytes translate to `_` (length-preserved); empty falls back to `sanitized-empty`. The updated header keeps the human-facing log / no-validation framing from #1099 while documenting the `.meta` sanitization behavior, and points readers to `scripts/run-external-agent.md` for the full sanitization contract. Comment-only change; no code or behavior modification. Closes #1181.
+
 ## [15.11.23] - 2026-05-05
 
 ### Changed

--- a/scripts/external-tool-registry.sh
+++ b/scripts/external-tool-registry.sh
@@ -7,9 +7,15 @@
 #   - scripts/check-reviewers.sh
 #   - skills/implement/scripts/step2-implement.sh
 #
-# Related (NOT sourced - permissive label-only consumer):
-#   - scripts/run-external-agent.sh (uses --tool only as a log/.meta label;
-#     DECISION_1 of #1099 keeps that wrapper permissive intentionally)
+# Related:
+#   - scripts/run-external-agent.sh is NOT sourced from this registry and still
+#     does not validate `--tool` against it, per DECISION_1 of #1099. The
+#     human-facing log keeps the raw label, while the `.meta` `TOOL=` sidecar
+#     field is sanitized at write time through a label-safe allowlist
+#     (alphanumerics, `.`, `_`, `-`); disallowed bytes are translated to `_`
+#     (length-preserved), and an empty sanitized result falls back to
+#     `sanitized-empty`. See scripts/run-external-agent.md for the full
+#     sanitization contract.
 #
 # Non-goals: per-tool model defaults, probe argv templates, launcher paths,
 # capture-mode policy, runtime-failure tokens. Those stay with their owners.


### PR DESCRIPTION
## Summary
- Updated the header comment block in `scripts/external-tool-registry.sh` so it mirrors the `## Related` section in the sibling `scripts/external-tool-registry.md`, replacing the stale "label-only consumer" framing with the documented `.meta TOOL=` sanitization contract introduced by #1145.
- Comment-only change: no code paths, exports, or runtime behavior modified.
- Bumped plugin version to 15.11.22 (PATCH) and recorded the entry in `CHANGELOG.md`.

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] `make lint` (shellcheck + agent-lint + pre-commit hooks) passes via `/relevant-checks`.
- [x] Visual diff confirms the updated `.sh` header matches the wording in `scripts/external-tool-registry.md`'s `## Related` section.
- [x] `bash -n scripts/external-tool-registry.sh` parses cleanly (implicit via shellcheck).

</details>

Closes #1181

Generated with [Claude Code](https://claude.com/claude-code)
