### PR TITLE
Reject zero wait-for-reviewers timeout (closes #1166)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "15.11.22",
+  "version": "15.11.23",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 6-reviewer specialist panel (5 Cursor specialists + 1 Codex generic) — extended to 7 with an optional Gemini reviewer when the Gemini CLI is installed and healthy — with 3-voter adjudication; plan review runs a 3-reviewer panel (Claude + Codex + Cursor); design sketches run a 9-agent diverge-then-converge phase in regular mode (1 Claude + 4 Cursor + 4 Codex) or 3 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [15.11.23] - 2026-05-05
+
+### Changed
+
+- Reject zero reviewer wait timeouts in `scripts/wait-for-reviewers.sh` so timeout values must be positive (case pattern `''|*[!0-9]*)` extended to `''|*[!0-9]*|0)`), aligning with the implement-family launchers (#1115) and `scripts/launch-gemini-review.sh`. `scripts/wait-for-reviewers.md` documents the `--timeout` argument contract beside the script. Closes #1166.
+
 ## [15.11.22] - 2026-05-05
 
 ### Added

--- a/scripts/wait-for-reviewers.md
+++ b/scripts/wait-for-reviewers.md
@@ -8,6 +8,10 @@
 - `/design` Step 2a (sketches) and Step 3 (plan review) via the same collector.
 - `/implement` does not invoke this script directly — it runs through `/review` and `/design`.
 
+## Timeout (`--timeout`)
+
+Wrapper timeout in seconds. The validator accepts positive integer values and rejects empty, non-numeric, or `0` values with exit `1`.
+
 ## Poll interval (`WAIT_FOR_REVIEWERS_POLL_INTERVAL`)
 
 Sentinel-file check cadence. Default `5` seconds for production callers — real reviewers take many minutes, so the 5s noise floor is negligible. Test harnesses that wrap stub binaries via `run-external-agent.sh` (e.g. `scripts/test-check-reviewers.sh`) export `WAIT_FOR_REVIEWERS_POLL_INTERVAL=0.05` to avoid paying a 5s sleep per probe when stubs exit in microseconds. The validator accepts positive integer or decimal seconds and rejects `0`, negative, or non-numeric input with exit `1`.

--- a/scripts/wait-for-reviewers.sh
+++ b/scripts/wait-for-reviewers.sh
@@ -31,7 +31,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 case "$TIMEOUT" in
-    ''|*[!0-9]*) echo "Error: --timeout value must be a positive integer, got '$TIMEOUT'" >&2; exit 1 ;;
+    ''|*[!0-9]*|0) echo "Error: --timeout value must be a positive integer, got '$TIMEOUT'" >&2; exit 1 ;;
 esac
 
 # Sentinel-poll interval. Default 5s for production callers (real reviewers


### PR DESCRIPTION
## Summary

- Reject zero reviewer wait timeouts so timeout values must be positive
- Document the wait-for-reviewers timeout argument contract beside the script

## Architecture Diagram

Architecture diagram not available.

## Code Flow Diagram

(Code Flow Diagram skipped — quick mode)

## Test plan

No test changes required (issue #1166 explicitly carves this out via OOS_4). Verification:

- [x] `/relevant-checks` (pre-commit + agent-lint) passes
- [x] Manual smoke: `bash scripts/wait-for-reviewers.sh --timeout 0 ...` exits 1 with `Error: --timeout value must be a positive integer, got '0'`

Closes #1166

🤖 Generated with [Claude Code](https://claude.com/claude-code)
