### PR TITLE
Remove dead trailing for-loop in scripts/hydrate-anchor.sh

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "15.12.2",
+  "version": "15.12.3",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 6-reviewer specialist panel (5 Cursor specialists + 1 Codex generic) — extended to 7 with an optional Gemini reviewer when the Gemini CLI is installed and healthy — with 3-voter adjudication; plan review runs a 3-reviewer panel (Claude + Codex + Cursor); design sketches run a 9-agent diverge-then-converge phase in regular mode (1 Claude + 4 Cursor + 4 Codex) or 3 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [15.12.3] - 2026-05-05
+
+### Removed
+
+- Drop the dead trailing for-loop and its misleading comment block from `scripts/hydrate-anchor.sh`. The loop body was a single no-op (`:`) yet the surrounding comment claimed to "strip exactly one trailing newline that awk's `>>` reliably appends per `print`" — behavior that was never actually implemented. The hydrate→assemble round-trip is byte-stable in practice via the awk-level `>>` accumulation symmetry between `hydrate-anchor.sh` and `assemble-anchor.sh`. The script's section extraction and stdout contract (`HYDRATED=` / `SECTIONS=` / `ERROR=`) are unchanged. Closes #1159.
+
 ## [15.12.2] - 2026-05-05
 
 ### Fixed

--- a/scripts/hydrate-anchor.sh
+++ b/scripts/hydrate-anchor.sh
@@ -152,18 +152,6 @@ SECTIONS_COUNT=$(awk -v outdir="$SECTIONS_DIR" -v allowed="$ALLOWED_SLUGS" '
     exit 0
 }
 
-# Strip exactly one trailing newline that awk's `>>` reliably appends per
-# `print` so the round-trip with assemble-anchor.sh stays byte-clean.
-for f in "$SECTIONS_DIR"/*.md; do
-    [ -f "$f" ] || continue
-    if [ -s "$f" ]; then
-        # Detect last byte; if newline, the awk-level print added it. Leave
-        # one newline (matches how callers author fragments). No-op if file
-        # has no trailing newline.
-        :
-    fi
-done
-
 echo "HYDRATED=true"
 echo "SECTIONS=$SECTIONS_COUNT"
 exit 0


### PR DESCRIPTION
## Summary
- Removed the dead trailing for-loop and its misleading comment block from `scripts/hydrate-anchor.sh` per issue #1159 option (b). The loop body was a no-op (`:`) and the comment described newline normalization that was never implemented; the hydrate→assemble round-trip is byte-stable in practice via awk-level `>>` accumulation symmetry.
- Kept the script's section extraction logic and stdout contract (`HYDRATED=` / `SECTIONS=` / `ERROR=`) unchanged.

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] `/relevant-checks` (pre-commit + agent-lint) green
- [x] `bash -n scripts/hydrate-anchor.sh` syntactic validity
- [x] CI green on PR

</details>

Closes #1159

Generated with [Claude Code](https://claude.com/claude-code)
