### PR TITLE
Fix run-external-agent.sh jq CMD_JSON failure sentinel (closes #1195)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "15.12.4",
+  "version": "15.12.5",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 6-reviewer specialist panel (5 Cursor specialists + 1 Codex generic) — extended to 7 with an optional Gemini reviewer when the Gemini CLI is installed and healthy — with 3-voter adjudication; plan review runs a 3-reviewer panel (Claude + Codex + Cursor); design sketches run a 9-agent diverge-then-converge phase in regular mode (1 Claude + 4 Cursor + 4 Codex) or 3 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [15.12.5] - 2026-05-05
+
+### Fixed
+
+- Align `<output>.done` with the real exit code on the `scripts/run-external-agent.sh` jq `CMD_JSON` serialization-failure path. Previously the script set `EXIT_CODE=99` ("wrapper crashed before capturing real exit code") as a default at line ~138, installed an EXIT trap that wrote `$EXIT_CODE` to `<output>.done`, then called `exit 1` on jq failure without updating `EXIT_CODE` — so callers reading `.done` saw `99` instead of `1` and could not distinguish a clean configuration / wrapper failure from an unhandled wrapper crash. Now the jq-failure branch sets `EXIT_CODE=1` immediately before `exit 1`, the EXIT trap writes `1` to the sentinel, and `scripts/test-run-external-agent.sh` carries a regression case with a `PATH`-prefixed stub `jq` that asserts wrapper exit `1`, the expected stderr line, `<output>.done == 1`, and absence of `<output>.meta`. The `99` default remains reserved for true wrapper crashes after trap installation. Closes #1195.
+
 ## [15.12.4] - 2026-05-05
 
 ### Changed

--- a/scripts/run-external-agent.md
+++ b/scripts/run-external-agent.md
@@ -44,6 +44,7 @@ There is no backward compatibility with the old `CMD=` metadata line. A collecto
 
 - Always remove stale `<output>`, `<output>.done`, `<output>.meta`, and `<output>.diag` before launch.
 - Always write `<output>.done` via the exit trap.
+- The trap writes the value of `EXIT_CODE`, which defaults to `99` ("wrapper crashed before capturing real exit code"). Failure paths between trap installation and child launch (e.g. `CMD_JSON` serialization) must assign `EXIT_CODE` to the real exit value before calling `exit`, so the sentinel matches the process exit status; the `99` default is reserved for unhandled crashes.
 - Keep `set -euo pipefail`; child exit codes are captured via guarded `wait`.
 - Diagnostic text is appended to `<output>.diag` so stdout-only capture can retain child stderr.
 - `jq` is a hard prerequisite for this wrapper, in addition to the repo-wide `jq` dependency used by other larch scripts.

--- a/scripts/run-external-agent.sh
+++ b/scripts/run-external-agent.sh
@@ -160,6 +160,7 @@ META_TOOL_NAME=$(printf '%s' "$TOOL_NAME" | LC_ALL=C tr -c 'a-zA-Z0-9._-' '_')
 # exit status under `set -e`, so jq must succeed before we write the sidecar.
 if ! META_CMD_JSON=$(jq -cn --args '$ARGS.positional' -- "$@"); then
     echo "ERROR: jq failed to serialize argv to CMD_JSON for ${OUTPUT_FILE}.meta" >&2
+    EXIT_CODE=1
     exit 1
 fi
 {

--- a/scripts/test-run-external-agent.md
+++ b/scripts/test-run-external-agent.md
@@ -9,6 +9,7 @@ Regression harness for `scripts/run-external-agent.sh`; the primary behavioral c
 - Verifies safe nested paths and dot/dash/underscore path components are accepted.
 - Verifies empty `--output` is rejected by wrapper argv validation.
 - Verifies `scripts/lib-validate-meta-path.sh` is sourced-only, non-executable, silent when sourced, and idempotent when sourced twice.
+- Verifies the `jq` `CMD_JSON` serialization-failure path: with a `PATH`-prefixed stub `jq` that exits non-zero, the wrapper exits `1`, stderr contains `ERROR: jq failed to serialize argv to CMD_JSON`, `<output>.done` records `1` (not the pre-launch default `99`), and `<output>.meta` is not written. Pins the `EXIT_CODE=1` assignment that synchronizes the trap-written sentinel with the real exit status on this branch.
 
 ## Wiring
 

--- a/scripts/test-run-external-agent.sh
+++ b/scripts/test-run-external-agent.sh
@@ -167,6 +167,34 @@ else
     fail "helper double source should be idempotent"
 fi
 
+# 13. jq CMD_JSON serialization failure path: the EXIT trap must write the
+# real exit code (1) to <output>.done, not the pre-launch default sentinel
+# (99). Regression guard for the EXIT_CODE=1 line preceding `exit 1` on the
+# jq-failure branch in run-external-agent.sh.
+JQ_FAIL_OUT="$TMPDIR/jq-fail-output.txt"
+JQ_SHIM_DIR="$TMPDIR/jq-shim"
+mkdir -p "$JQ_SHIM_DIR"
+cat > "$JQ_SHIM_DIR/jq" <<'JQ_SHIM_EOF'
+#!/bin/sh
+echo "stub jq: forced failure" >&2
+exit 1
+JQ_SHIM_EOF
+chmod +x "$JQ_SHIM_DIR/jq"
+RUN_STDOUT="$TMPDIR/jq-fail.stdout"
+RUN_STDERR="$TMPDIR/jq-fail.stderr"
+set +e
+PATH="$JQ_SHIM_DIR:$PATH" "$WRAPPER" --tool codex --output "$JQ_FAIL_OUT" --timeout 5 -- bash -c 'printf should-not-run' >"$RUN_STDOUT" 2>"$RUN_STDERR"
+RUN_CODE=$?
+set -e
+assert_equals "jq-fail exit" "1" "$RUN_CODE"
+assert_grep "jq-fail stderr" "ERROR: jq failed to serialize argv to CMD_JSON" "$RUN_STDERR"
+assert_file_content "jq-fail done" "${JQ_FAIL_OUT}.done" "1"
+if [[ -e "${JQ_FAIL_OUT}.meta" ]]; then
+    fail "jq-fail no meta: ${JQ_FAIL_OUT}.meta should not exist on jq-failure path"
+else
+    pass
+fi
+
 if [[ "$FAIL" -ne 0 ]]; then
     printf 'FAIL: test-run-external-agent.sh - %s failed, %s passed\n' "$FAIL" "$PASS" >&2
     printf '  %s\n' "${FAIL_DETAILS[@]}" >&2


### PR DESCRIPTION
## Summary
- Set `EXIT_CODE=1` immediately before `exit 1` on the `scripts/run-external-agent.sh` jq `CMD_JSON` serialization-failure path so the EXIT trap writes the real exit code to `<output>.done` instead of leaving the pre-launch default `99` (wrapper-crash sentinel).
- Documented the trap-EXIT_CODE invariant in the sibling contract `scripts/run-external-agent.md` (failure paths between trap installation and child launch must assign `EXIT_CODE` before `exit`; `99` is reserved for true wrapper crashes).
- Added a regression case to `scripts/test-run-external-agent.sh` using a `PATH`-prefixed stub `jq` that exits non-zero, asserting wrapper exit `1`, the expected stderr line, `<output>.done == 1`, and absence of `<output>.meta`; updated `scripts/test-run-external-agent.md` accordingly.

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] `make test-run-external-agent` (81 assertions pass, including the new jq-failure case).
- [x] Negative regression check: temporarily removed the `EXIT_CODE=1` line and confirmed the new harness case fails with `expected ${output}.done to contain '1'`; restored the line and confirmed pass.
- [x] `/relevant-checks` passed across the changed-file (pre-commit on shellcheck/markdownlint/agent-lint/gitleaks) and full-repo (`agent-lint`) phases.

</details>

Closes #1195

Generated with [Claude Code](https://claude.com/claude-code)
