### PR TITLE
Strengthen implementer-harness tests: pin validation messages + Cursor resume parity

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "15.12.11",
+  "version": "15.12.12",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 6-reviewer specialist panel (5 Cursor specialists + 1 Codex generic) — extended to 7 with an optional Gemini reviewer when the Gemini CLI is installed and healthy — with 3-voter adjudication; plan review runs a 3-reviewer panel (Claude + Codex + Cursor); design sketches run a 9-agent diverge-then-converge phase in regular mode (1 Claude + 4 Cursor + 4 Codex) or 3 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [15.12.12] - 2026-05-05
+
+### Changed
+
+- Strengthen the three implementer-launcher harnesses (`skills/implement/scripts/test-{codex,cursor,gemini}-implementer.sh`) so missing-input Tests 3 / 3a / 3b / 3c capture stderr to per-test scratch paths and pin the launcher's literal validation phrasing via `grep -F -- "<expected>"` (`plan file not found`, `feature file not found`, `agent prompt not found`, `--answers-file given but path does not exist`) — a future launcher regression where a different exit-2 path fires first or the input-file check is silently disabled now fails CI instead of satisfying the existing exit-code-only assertion. Add a Cursor `--answers-file` positive resume-path test to `test-cursor-implementer.sh` (mirroring `test-codex-implementer.sh:256-288` / `test-gemini-implementer.sh:230-258`): create an `ANSWERS` JSON fixture, invoke the existing PATH-stub launcher with `--answers-file "$ANSWERS"`, capture the wrapped prompt via `STUB_PROMPT_FILE`, and assert the prompt contains both `## Resume invocation` and the `$ANSWERS` path so the Cursor wrapper can no longer drop the resume block without an offline-harness failure. Update the three implementer-test sibling `.md` Coverage sections to record the pinned validation phrasing and (for cursor) the new resume-path assertion. Closes #1223 (combines #1213 + #1214).
+
 ## [15.12.11] - 2026-05-05
 
 ### Added

--- a/skills/implement/scripts/test-codex-implementer.md
+++ b/skills/implement/scripts/test-codex-implementer.md
@@ -7,7 +7,7 @@
 - Bad timeout exits 2.
 - Zero-valued timeouts (`0`, `00`, `000`) exit 2 and report the positive-integer timeout contract.
 - Positive leading-zero timeouts (e.g. `010`) are accepted: launcher exits 0 with the standard five-line stdout envelope. Pins acceptance of the leading-zero positive form so a future refactor tightening the digit-only `case` validation (e.g. to `^[1-9][0-9]*$`) breaks CI. Note: the stub exits immediately, so this does NOT prove that downstream treats `010` as decimal 10 vs. octal 8 — only contract stability at the launcher boundary.
-- Missing input files exit 2 — specifically: missing `--plan-file`, missing `--feature-file`, missing `--agent-prompt`, and `--answers-file` pointing at a non-existent path.
+- Missing input files exit 2 with the launcher's literal validation messages — specifically: missing `--plan-file` (`plan file not found`), missing `--feature-file` (`feature file not found`), missing `--agent-prompt` (`agent prompt not found`), and `--answers-file` pointing at a non-existent path (`--answers-file given but path does not exist`).
 - PATH-stubbed `codex` writes a minimal valid `manifest.json`; the launcher emits exactly five KV stdout lines and no progress chatter.
 - Codex's `--output-last-message` transcript path receives the stubbed output payload.
 - Codex argv shape includes `exec`, `--full-auto`, `-C "$PWD"`, `--output-last-message`, and model/effort args from `scripts/agent-model-args.sh --tool codex --with-effort`.

--- a/skills/implement/scripts/test-codex-implementer.sh
+++ b/skills/implement/scripts/test-codex-implementer.sh
@@ -100,8 +100,12 @@ EXIT=0
     --plan-file "$SCRATCH/missing-plan.md" \
     --feature-file "$FEATURE" \
     --agent-prompt "$AGENT_PROMPT" \
-    --timeout 30 >/dev/null 2>&1 || EXIT=$?
-if [[ "$EXIT" == "2" ]]; then pass; else fail 3 "missing plan should exit 2, got $EXIT"; fi
+    --timeout 30 >/dev/null 2>"$SCRATCH/t3-stderr.txt" || EXIT=$?
+if [[ "$EXIT" == "2" ]] && grep -Fq -- "plan file not found" "$SCRATCH/t3-stderr.txt"; then
+    pass
+else
+    fail 3 "missing plan should exit 2 with stderr literal 'plan file not found', got $EXIT"
+fi
 
 # Test 3a: missing feature-file exits 2.
 EXIT=0
@@ -113,8 +117,12 @@ EXIT=0
     --plan-file "$PLAN" \
     --feature-file "$SCRATCH/missing-feature.txt" \
     --agent-prompt "$AGENT_PROMPT" \
-    --timeout 30 >/dev/null 2>&1 || EXIT=$?
-if [[ "$EXIT" == "2" ]]; then pass; else fail 3a "missing feature should exit 2, got $EXIT"; fi
+    --timeout 30 >/dev/null 2>"$SCRATCH/t3a-stderr.txt" || EXIT=$?
+if [[ "$EXIT" == "2" ]] && grep -Fq -- "feature file not found" "$SCRATCH/t3a-stderr.txt"; then
+    pass
+else
+    fail 3a "missing feature should exit 2 with stderr literal 'feature file not found', got $EXIT"
+fi
 
 # Test 3b: missing agent-prompt exits 2.
 EXIT=0
@@ -126,8 +134,12 @@ EXIT=0
     --plan-file "$PLAN" \
     --feature-file "$FEATURE" \
     --agent-prompt "$SCRATCH/missing-agent-prompt.md" \
-    --timeout 30 >/dev/null 2>&1 || EXIT=$?
-if [[ "$EXIT" == "2" ]]; then pass; else fail 3b "missing agent-prompt should exit 2, got $EXIT"; fi
+    --timeout 30 >/dev/null 2>"$SCRATCH/t3b-stderr.txt" || EXIT=$?
+if [[ "$EXIT" == "2" ]] && grep -Fq -- "agent prompt not found" "$SCRATCH/t3b-stderr.txt"; then
+    pass
+else
+    fail 3b "missing agent-prompt should exit 2 with stderr literal 'agent prompt not found', got $EXIT"
+fi
 
 # Test 3c: --answers-file pointing at non-existent path exits 2.
 EXIT=0
@@ -140,8 +152,12 @@ EXIT=0
     --feature-file "$FEATURE" \
     --agent-prompt "$AGENT_PROMPT" \
     --timeout 30 \
-    --answers-file "$SCRATCH/missing-answers.json" >/dev/null 2>&1 || EXIT=$?
-if [[ "$EXIT" == "2" ]]; then pass; else fail 3c "missing answers-file should exit 2, got $EXIT"; fi
+    --answers-file "$SCRATCH/missing-answers.json" >/dev/null 2>"$SCRATCH/t3c-stderr.txt" || EXIT=$?
+if [[ "$EXIT" == "2" ]] && grep -Fq -- "--answers-file given but path does not exist" "$SCRATCH/t3c-stderr.txt"; then
+    pass
+else
+    fail 3c "missing answers-file should exit 2 with stderr literal '--answers-file given but path does not exist', got $EXIT"
+fi
 
 STUB_BIN="$SCRATCH/bin"
 mkdir -p "$STUB_BIN"

--- a/skills/implement/scripts/test-cursor-implementer.md
+++ b/skills/implement/scripts/test-cursor-implementer.md
@@ -7,12 +7,13 @@
 - Bad timeout exits 2.
 - Zero-valued timeouts (`0`, `00`, `000`) exit 2 and report the positive-integer timeout contract.
 - Positive leading-zero timeouts (e.g. `010`) are accepted: launcher exits 0 with the standard five-line stdout envelope. Pins acceptance of the leading-zero positive form so a future refactor tightening the digit-only `case` validation (e.g. to `^[1-9][0-9]*$`) breaks CI. Note: the stub exits immediately, so this does NOT prove that downstream treats `010` as decimal 10 vs. octal 8 — only contract stability at the launcher boundary.
-- Missing input files exit 2 — specifically: missing `--plan-file`, missing `--feature-file`, missing `--agent-prompt`, and `--answers-file` pointing at a non-existent path.
+- Missing input files exit 2 with the launcher's literal validation messages — specifically: missing `--plan-file` (`plan file not found`), missing `--feature-file` (`feature file not found`), missing `--agent-prompt` (`agent prompt not found`), and `--answers-file` pointing at a non-existent path (`--answers-file given but path does not exist`).
 - PATH-stubbed `cursor` writes a minimal valid `manifest.json`; the launcher emits exactly five KV stdout lines and no progress chatter.
 - `run-external-agent.sh --capture-stdout` captures Cursor stdout to the transcript path.
 - Cursor argv shape matches `scripts/launch-cursor-review.sh`: `cursor agent -p --force --trust $MODEL_ARGS --workspace "$PWD" "$WRAPPED_PROMPT"`.
 - No `--` end-of-options separator is inserted before the prompt.
 - The prompt is wrapped by `scripts/cursor-wrap-prompt.sh`.
+- Passing `--answers-file` adds the `## Resume invocation` block to the composed prompt.
 
 **Optional smoke**: `CURSOR_HEALTHY=true bash skills/implement/scripts/test-cursor-implementer.sh --real-smoke` launches a real `cursor agent` against a tiny prompt. This is a local development smoke only and is not wired into the Makefile.
 

--- a/skills/implement/scripts/test-cursor-implementer.sh
+++ b/skills/implement/scripts/test-cursor-implementer.sh
@@ -53,8 +53,10 @@ export RUN_EXTERNAL_AGENT_POLL_INTERVAL=0.05
 
 PLAN="$SCRATCH/plan.md"
 FEATURE="$SCRATCH/feature.txt"
+ANSWERS="$SCRATCH/answers.json"
 printf 'fake plan\n' > "$PLAN"
 printf 'fake feature\n' > "$FEATURE"
+printf '{"answers":[{"id":"q1","text":"yes"}]}\n' > "$ANSWERS"
 
 # Test 1: missing required flags exits 2.
 EXIT=0
@@ -122,8 +124,12 @@ EXIT=0
     --plan-file "$SCRATCH/missing-plan.md" \
     --feature-file "$FEATURE" \
     --agent-prompt "$AGENT_PROMPT" \
-    --timeout 30 >/dev/null 2>&1 || EXIT=$?
-if [[ "$EXIT" == "2" ]]; then pass; else fail 3 "missing plan should exit 2, got $EXIT"; fi
+    --timeout 30 >/dev/null 2>"$SCRATCH/t3-stderr.txt" || EXIT=$?
+if [[ "$EXIT" == "2" ]] && grep -Fq -- "plan file not found" "$SCRATCH/t3-stderr.txt"; then
+    pass
+else
+    fail 3 "missing plan should exit 2 with stderr literal 'plan file not found', got $EXIT"
+fi
 
 # Test 3a: missing feature-file exits 2.
 EXIT=0
@@ -135,8 +141,12 @@ EXIT=0
     --plan-file "$PLAN" \
     --feature-file "$SCRATCH/missing-feature.txt" \
     --agent-prompt "$AGENT_PROMPT" \
-    --timeout 30 >/dev/null 2>&1 || EXIT=$?
-if [[ "$EXIT" == "2" ]]; then pass; else fail 3a "missing feature should exit 2, got $EXIT"; fi
+    --timeout 30 >/dev/null 2>"$SCRATCH/t3a-stderr.txt" || EXIT=$?
+if [[ "$EXIT" == "2" ]] && grep -Fq -- "feature file not found" "$SCRATCH/t3a-stderr.txt"; then
+    pass
+else
+    fail 3a "missing feature should exit 2 with stderr literal 'feature file not found', got $EXIT"
+fi
 
 # Test 3b: missing agent-prompt exits 2.
 EXIT=0
@@ -148,8 +158,12 @@ EXIT=0
     --plan-file "$PLAN" \
     --feature-file "$FEATURE" \
     --agent-prompt "$SCRATCH/missing-agent-prompt.md" \
-    --timeout 30 >/dev/null 2>&1 || EXIT=$?
-if [[ "$EXIT" == "2" ]]; then pass; else fail 3b "missing agent-prompt should exit 2, got $EXIT"; fi
+    --timeout 30 >/dev/null 2>"$SCRATCH/t3b-stderr.txt" || EXIT=$?
+if [[ "$EXIT" == "2" ]] && grep -Fq -- "agent prompt not found" "$SCRATCH/t3b-stderr.txt"; then
+    pass
+else
+    fail 3b "missing agent-prompt should exit 2 with stderr literal 'agent prompt not found', got $EXIT"
+fi
 
 # Test 3c: --answers-file pointing at non-existent path exits 2.
 EXIT=0
@@ -162,8 +176,12 @@ EXIT=0
     --feature-file "$FEATURE" \
     --agent-prompt "$AGENT_PROMPT" \
     --timeout 30 \
-    --answers-file "$SCRATCH/missing-answers.json" >/dev/null 2>&1 || EXIT=$?
-if [[ "$EXIT" == "2" ]]; then pass; else fail 3c "missing answers-file should exit 2, got $EXIT"; fi
+    --answers-file "$SCRATCH/missing-answers.json" >/dev/null 2>"$SCRATCH/t3c-stderr.txt" || EXIT=$?
+if [[ "$EXIT" == "2" ]] && grep -Fq -- "--answers-file given but path does not exist" "$SCRATCH/t3c-stderr.txt"; then
+    pass
+else
+    fail 3c "missing answers-file should exit 2 with stderr literal '--answers-file given but path does not exist', got $EXIT"
+fi
 
 STUB_BIN="$SCRATCH/bin"
 mkdir -p "$STUB_BIN"
@@ -284,6 +302,37 @@ if [[ "$OUT" == "$T9_EXPECTED" ]]; then
     pass
 else
     fail 9 "leading-zero timeout 010 should be accepted with standard envelope; got: $OUT"
+fi
+
+# Test 10: --answers-file adds the resume invocation block to the wrapped prompt.
+RESUME_TRANSCRIPT="$SCRATCH/resume-transcript.txt"
+RESUME_SIDECAR="$SCRATCH/resume-sidecar.log"
+RESUME_MANIFEST="$SCRATCH/resume-manifest.json"
+RESUME_QA="$SCRATCH/resume-qa.json"
+RESUME_ARGV="$SCRATCH/resume-argv.txt"
+RESUME_PROMPT="$SCRATCH/resume-prompt.txt"
+
+OUT=$(cd "$REPO_ROOT" && \
+    PATH="$STUB_BIN:$PATH" \
+    STUB_ARGV_FILE="$RESUME_ARGV" \
+    STUB_PROMPT_FILE="$RESUME_PROMPT" \
+    STUB_MANIFEST_PATH="$RESUME_MANIFEST" \
+    LARCH_CURSOR_MODEL="stub-model" \
+    "$LAUNCHER" \
+        --transcript-path "$RESUME_TRANSCRIPT" \
+        --sidecar-log "$RESUME_SIDECAR" \
+        --manifest-path "$RESUME_MANIFEST" \
+        --qa-pending-path "$RESUME_QA" \
+        --plan-file "$PLAN" \
+        --feature-file "$FEATURE" \
+        --agent-prompt "$AGENT_PROMPT" \
+        --timeout 30 \
+        --answers-file "$ANSWERS")
+
+if grep -Fq '## Resume invocation' "$RESUME_PROMPT" && grep -Fq "$ANSWERS" "$RESUME_PROMPT"; then
+    pass
+else
+    fail 10 "resume invocation block missing from composed prompt"
 fi
 
 TOTAL=$((PASS_COUNT + FAIL_COUNT))

--- a/skills/implement/scripts/test-gemini-implementer.md
+++ b/skills/implement/scripts/test-gemini-implementer.md
@@ -7,7 +7,7 @@
 - Bad timeout exits 2.
 - Zero-valued timeouts (`0`, `00`, `000`) exit 2 and report the positive-integer timeout contract.
 - Positive leading-zero timeouts (e.g. `010`) are accepted: launcher exits 0 with the standard five-line stdout envelope. Pins acceptance of the leading-zero positive form so a future refactor tightening the digit-only `case` validation (e.g. to `^[1-9][0-9]*$`) breaks CI. Note: the stub exits immediately, so this does NOT prove that downstream treats `010` as decimal 10 vs. octal 8 — only contract stability at the launcher boundary.
-- Missing input files exit 2 — specifically: missing `--plan-file`, missing `--feature-file`, missing `--agent-prompt`, and `--answers-file` pointing at a non-existent path.
+- Missing input files exit 2 with the launcher's literal validation messages — specifically: missing `--plan-file` (`plan file not found`), missing `--feature-file` (`feature file not found`), missing `--agent-prompt` (`agent prompt not found`), and `--answers-file` pointing at a non-existent path (`--answers-file given but path does not exist`).
 - PATH-stubbed `gemini` writes a minimal valid `manifest.json`; the launcher emits exactly five KV stdout lines and no progress chatter.
 - `run-external-agent.sh --capture-stdout` captures Gemini stdout/stderr to the transcript path.
 - Gemini argv shape includes `--prompt`, `--approval-mode yolo`, `--skip-trust`, and `--model "$GEMINI_MODEL"` (resolved inline by `launch-gemini-implement.sh` from `LARCH_GEMINI_MODEL` / `CLAUDE_PLUGIN_OPTION_GEMINI_MODEL` / hardcoded `gemini-2.5-pro`; the launcher does NOT shell out to `agent-model-args.sh`).

--- a/skills/implement/scripts/test-gemini-implementer.sh
+++ b/skills/implement/scripts/test-gemini-implementer.sh
@@ -100,8 +100,12 @@ EXIT=0
     --plan-file "$SCRATCH/missing-plan.md" \
     --feature-file "$FEATURE" \
     --agent-prompt "$AGENT_PROMPT" \
-    --timeout 30 >/dev/null 2>&1 || EXIT=$?
-if [[ "$EXIT" == "2" ]]; then pass; else fail 3 "missing plan should exit 2, got $EXIT"; fi
+    --timeout 30 >/dev/null 2>"$SCRATCH/t3-stderr.txt" || EXIT=$?
+if [[ "$EXIT" == "2" ]] && grep -Fq -- "plan file not found" "$SCRATCH/t3-stderr.txt"; then
+    pass
+else
+    fail 3 "missing plan should exit 2 with stderr literal 'plan file not found', got $EXIT"
+fi
 
 # Test 3a: missing feature-file exits 2.
 EXIT=0
@@ -113,8 +117,12 @@ EXIT=0
     --plan-file "$PLAN" \
     --feature-file "$SCRATCH/missing-feature.txt" \
     --agent-prompt "$AGENT_PROMPT" \
-    --timeout 30 >/dev/null 2>&1 || EXIT=$?
-if [[ "$EXIT" == "2" ]]; then pass; else fail 3a "missing feature should exit 2, got $EXIT"; fi
+    --timeout 30 >/dev/null 2>"$SCRATCH/t3a-stderr.txt" || EXIT=$?
+if [[ "$EXIT" == "2" ]] && grep -Fq -- "feature file not found" "$SCRATCH/t3a-stderr.txt"; then
+    pass
+else
+    fail 3a "missing feature should exit 2 with stderr literal 'feature file not found', got $EXIT"
+fi
 
 # Test 3b: missing agent-prompt exits 2.
 EXIT=0
@@ -126,8 +134,12 @@ EXIT=0
     --plan-file "$PLAN" \
     --feature-file "$FEATURE" \
     --agent-prompt "$SCRATCH/missing-agent-prompt.md" \
-    --timeout 30 >/dev/null 2>&1 || EXIT=$?
-if [[ "$EXIT" == "2" ]]; then pass; else fail 3b "missing agent-prompt should exit 2, got $EXIT"; fi
+    --timeout 30 >/dev/null 2>"$SCRATCH/t3b-stderr.txt" || EXIT=$?
+if [[ "$EXIT" == "2" ]] && grep -Fq -- "agent prompt not found" "$SCRATCH/t3b-stderr.txt"; then
+    pass
+else
+    fail 3b "missing agent-prompt should exit 2 with stderr literal 'agent prompt not found', got $EXIT"
+fi
 
 # Test 3c: --answers-file pointing at non-existent path exits 2.
 EXIT=0
@@ -140,8 +152,12 @@ EXIT=0
     --feature-file "$FEATURE" \
     --agent-prompt "$AGENT_PROMPT" \
     --timeout 30 \
-    --answers-file "$SCRATCH/missing-answers.json" >/dev/null 2>&1 || EXIT=$?
-if [[ "$EXIT" == "2" ]]; then pass; else fail 3c "missing answers-file should exit 2, got $EXIT"; fi
+    --answers-file "$SCRATCH/missing-answers.json" >/dev/null 2>"$SCRATCH/t3c-stderr.txt" || EXIT=$?
+if [[ "$EXIT" == "2" ]] && grep -Fq -- "--answers-file given but path does not exist" "$SCRATCH/t3c-stderr.txt"; then
+    pass
+else
+    fail 3c "missing answers-file should exit 2 with stderr literal '--answers-file given but path does not exist', got $EXIT"
+fi
 
 STUB_BIN="$SCRATCH/bin"
 mkdir -p "$STUB_BIN"


### PR DESCRIPTION
## Summary

- Strengthen implementer-launcher harnesses so missing-input Tests 3/3a/3b/3c lock onto the launcher's literal stderr validation message (`plan file not found`, `feature file not found`, `agent prompt not found`, `--answers-file given but path does not exist`) instead of merely asserting exit 2.
- Add a Cursor `--answers-file` positive resume-path test to `test-cursor-implementer.sh` (mirroring the existing codex/gemini coverage) so the Cursor wrapper cannot drop the `## Resume invocation` block or mis-substitute the `$ANSWERS` path without an offline-harness failure.
- Keep the three implementer-test sibling `.md` Coverage sections aligned with the new validation pinning and the new Cursor resume assertion.

## Architecture Diagram

Architecture diagram not available.

## Code Flow Diagram

(Code Flow Diagram skipped — quick mode)

## Test plan

- [x] All three implementer-launcher harnesses pass (`bash skills/implement/scripts/test-{codex,cursor,gemini}-implementer.sh`).
- [x] `/relevant-checks` (pre-commit + agent-lint) clean.
- [x] CHANGELOG entry for v15.12.12 added.
- [ ] CI runs the same three harnesses via the Makefile shard wiring and stays green.

Closes #1223

🤖 Generated with [Claude Code](https://claude.com/claude-code)
