### PR TITLE
Make umbrella assertion-count docs drift-resistant (closes #1215)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "15.12.12",
+  "version": "15.12.13",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 6-reviewer specialist panel (5 Cursor specialists + 1 Codex generic) — extended to 7 with an optional Gemini reviewer when the Gemini CLI is installed and healthy — with 3-voter adjudication; plan review runs a 3-reviewer panel (Claude + Codex + Cursor); design sketches run a 9-agent diverge-then-converge phase in regular mode (1 Claude + 4 Cursor + 4 Codex) or 3 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [15.12.13] - 2026-05-05
+
+### Changed
+
+- Replace the literal "Fifty-two assertions, fail-fast on first miss." line in `skills/umbrella/scripts/test-umbrella-emit-output-contract.md` with a structural description ("All `assert_contains` calls fail-fast on first miss; the total grows as new pinned literals are added.") so the doc cannot silently disagree with the harness's actual `assert_contains` total as new pinned literals (e.g. the recent `k*` family) are added. Documentation-only edit; no harness or CI behavior change. Closes #1215.
+
 ## [15.12.12] - 2026-05-05
 
 ### Changed

--- a/skills/umbrella/scripts/test-umbrella-emit-output-contract.md
+++ b/skills/umbrella/scripts/test-umbrella-emit-output-contract.md
@@ -10,7 +10,7 @@ This is a *structural* test (literal-substring assertions on `awk`-extracted blo
 
 ## Coverage
 
-Fifty-two assertions, fail-fast on first miss.
+All `assert_contains` calls fail-fast on first miss; the total grows as new pinned literals are added.
 
 ### Step 3B.1 block (extracted from SKILL.md) — very-small-item bundling rule
 


### PR DESCRIPTION
## Summary
- Replaced the literal "Fifty-two assertions, fail-fast on first miss." line in `skills/umbrella/scripts/test-umbrella-emit-output-contract.md` with a structural description ("All `assert_contains` calls fail-fast on first miss; the total grows as new pinned literals are added.") so the doc cannot silently disagree with the harness's actual `assert_contains` total as new pinned literals are added.
- Documentation-only edit; no harness or CI behavior change. Bumped version to 15.12.13 and added a CHANGELOG entry.

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] `bash skills/umbrella/scripts/test-umbrella-emit-output-contract.sh` — `All 52 assertions passed.`
- [x] `/relevant-checks` — pre-commit + agent-lint passed.
- [x] `grep -n "Fifty-two\|52 assertions" skills/umbrella/scripts/test-umbrella-emit-output-contract.md` — no matches in descriptive prose.

</details>

Closes #1215

Generated with [Claude Code](https://claude.com/claude-code)
