### PR TITLE
Add project-local /analyze-issues skill

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "15.12.16",
+  "version": "15.12.17",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 6-reviewer specialist panel (5 Cursor specialists + 1 Codex generic) — extended to 7 with an optional Gemini reviewer when the Gemini CLI is installed and healthy — with 3-voter adjudication; plan review runs a 3-reviewer panel (Claude + Codex + Cursor); design sketches run a 9-agent diverge-then-converge phase in regular mode (1 Claude + 4 Cursor + 4 Codex) or 3 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/.claude/skills/analyze-issues/SKILL.md
+++ b/.claude/skills/analyze-issues/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: analyze-issues
 description: "Use when generating a backlog-and-process insight report from a repository's GitHub issues -- coverage stats, category breakdown, cumulative-growth chart, wasteful-work signatures, and reviewer/persona effectiveness."
-argument-hint: ""
 allowed-tools: Bash, Read
 ---
 
@@ -15,7 +14,13 @@ Generate a backlog-and-process insight report from the current repository's GitH
 
 ## Run the Analysis
 
-Call `$PWD/.claude/skills/analyze-issues/scripts/run-analysis.sh` with any forwarded flags via the Bash tool. The script fetches issues, analyzes the local JSON dump, and prints the assembled report to stdout. Do not parse, format, branch, or perform the analysis in the main agent.
+Call the coordinator with any forwarded flags via the Bash tool:
+
+```bash
+$PWD/.claude/skills/analyze-issues/scripts/run-analysis.sh [flags]
+```
+
+The coordinator fetches issues, analyzes the local JSON dump, and prints the assembled report to stdout. Do not parse, format, branch, or perform the analysis in the main agent.
 
 Flags:
 
@@ -25,6 +30,15 @@ Flags:
 - `--categories=auto|default`: category mode. Default: `default`.
 
 The raw `gh` JSON dump is saved to `/tmp/<repo>-issues.json` for follow-up reanalysis.
+
+## Implementation
+
+Logic lives in `scripts/`. SKILL.md is a thin coordinator. Per-script contracts are documented beside each file:
+
+- `scripts/run-analysis.sh` (contract: `scripts/run-analysis.md`) — top-level coordinator. Parses flags, detects the repo, chains the fetch and the analyzer.
+- `scripts/fetch-issues.sh` (contract: `scripts/fetch-issues.md`) — wraps the single `gh issue list` shell-out.
+- `scripts/analyze.py` (contract: `scripts/analyze.md`) — main analyzer (categories, coverage, growth, patterns, waste signatures, reviewer/persona effectiveness, executive summary).
+- `scripts/render-chart.py` (contract: `scripts/render-chart.md`) — cumulative-growth ASCII chart helper imported by `analyze.py`.
 
 ## Anti-patterns
 

--- a/.claude/skills/analyze-issues/SKILL.md
+++ b/.claude/skills/analyze-issues/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: analyze-issues
+description: "Use when generating a backlog-and-process insight report from a repository's GitHub issues -- coverage stats, category breakdown, cumulative-growth chart, wasteful-work signatures, and reviewer/persona effectiveness."
+argument-hint: ""
+allowed-tools: Bash, Read
+---
+
+# analyze-issues
+
+Generate a backlog-and-process insight report from the current repository's GitHub issues, including coverage stats, category breakdown, cumulative growth, wasteful-work signatures, and reviewer/persona effectiveness.
+
+## Usage
+
+`/analyze-issues [--limit N] [--span-days N] [--top-K N] [--categories=auto|default]`
+
+## Run the Analysis
+
+Call `$PWD/.claude/skills/analyze-issues/scripts/run-analysis.sh` with any forwarded flags via the Bash tool. The script fetches issues, analyzes the local JSON dump, and prints the assembled report to stdout. Do not parse, format, branch, or perform the analysis in the main agent.
+
+Flags:
+
+- `--limit N`: maximum issues to fetch. Default: `2000`.
+- `--span-days N`: analysis span override. Default: auto.
+- `--top-K N`: number of top items to show in ranked sections. Default: `10`.
+- `--categories=auto|default`: category mode. Default: `default`.
+
+The raw `gh` JSON dump is saved to `/tmp/<repo>-issues.json` for follow-up reanalysis.
+
+## Anti-patterns
+
+- Keep reviewer attribution regexes longest-first, with `codex` before `code`.
+- Do not use Agent or Explore subagents for the analysis itself.
+- Do not exclude `[OOS]` issues; they are workflow-driven-waste signal.
+- Do not collapse duplicate titles at fetch time; duplicates are evidence.

--- a/.claude/skills/analyze-issues/scripts/analyze.md
+++ b/.claude/skills/analyze-issues/scripts/analyze.md
@@ -1,0 +1,13 @@
+# analyze.py
+
+Purpose: generate the `/analyze-issues` backlog-and-process report from a local GitHub issue JSON dump.
+
+Primary callers: `run-analysis.sh`.
+
+Invariants: use only Python stdlib, cap issue bodies to the first 5 KB before analysis, keep output deterministic, assign every issue exactly one category, preserve `[OOS]` and duplicate-title evidence, and keep reviewer attribution regexes ordered so `codex` cannot be counted as `code`.
+
+Makefile wiring: none; this is a dev-only local skill helper.
+
+Test harness: `python3 -c "import ast; ast.parse(open('.claude/skills/analyze-issues/scripts/analyze.py').read())"`.
+
+Edit in sync: update this contract, `run-analysis.sh`, and `SKILL.md` whenever CLI flags, output sections, category rules, or reviewer attribution semantics change.

--- a/.claude/skills/analyze-issues/scripts/analyze.py
+++ b/.claude/skills/analyze-issues/scripts/analyze.py
@@ -237,6 +237,17 @@ def growth_chart(
         for index, value in enumerate(matrix[category]):
             running += value
             matrix[category][index] = running
+    # WHY: cap legend keys at A-Z; collapse the tail into "Other (overflow)" so the
+    # chart never emits non-letter symbols when the category set exceeds 26.
+    if len(category_order) > 26:
+        head = category_order[:25]
+        tail = category_order[25:]
+        overflow = [0] * bucket_count
+        for category in tail:
+            for index, value in enumerate(matrix[category]):
+                overflow[index] += value
+        category_order = head + ["Other (overflow)"]
+        matrix = {**{c: matrix[c] for c in head}, "Other (overflow)": overflow}
     keys = [chr(ord("A") + index) for index in range(len(category_order))]
 
     chart_module = load_render_chart()
@@ -406,13 +417,29 @@ def reviewer_effectiveness(issues: Sequence[Mapping[str, Any]]) -> Tuple[str, Di
     tool_done: collections.Counter[str] = collections.Counter()
     vote_rows: List[Tuple[int, str, str, str]] = []
 
+    # WHY: larch issues use canonical markdown fields; tolerate plain "Surfaced by:" too.
+    attribution_re = re.compile(
+        r"^\s*(?:[-*]\s*)?(?:\*\*\s*)?(?:reviewer|surfaced\s+by)\s*(?:\*\*)?\s*[:\-]\s*(.+?)\s*$",
+        re.I,
+    )
+    # WHY: real tallies use comma separators and may include EXONERATE; accept both.
+    vote_re = re.compile(
+        r"YES\s*=\s*(\d+)\s*[,\s]+\s*NO\s*=\s*(\d+)(?:\s*[,\s]+\s*EXONERATE\s*=\s*(\d+))?",
+        re.I,
+    )
+
     for issue in issues:
         body = str(issue.get("body") or "")
-        surfaced = next((line for line in body.splitlines() if line.lower().startswith("surfaced by:")), "")
-        if not surfaced:
+        attribution = ""
+        for line in body.splitlines():
+            match = attribution_re.match(line)
+            if match:
+                attribution = match.group(1)
+                break
+        if not attribution:
             continue
-        tool_match = tool_re.search(surfaced)
-        persona_match = persona_re.search(surfaced)
+        tool_match = tool_re.search(attribution)
+        persona_match = persona_re.search(attribution)
         tool = normalize_tool(tool_match.group(1).replace("  ", " ").lower()) if tool_match else "unknown"
         persona = persona_match.group(1).lower() if persona_match else "generic"
         persona = {"arch": "architect", "edge": "edge-cases"}.get(persona, persona)
@@ -423,9 +450,13 @@ def reviewer_effectiveness(issues: Sequence[Mapping[str, Any]]) -> Tuple[str, Di
         if done:
             pair_done[key] += 1
             tool_done[tool] += 1
-        vote_match = re.search(r"\bYES=(\d+)\s+NO=(\d+)\b", body, re.I)
+        vote_match = vote_re.search(body)
         if vote_match:
-            vote_rows.append((issue_number(issue), tool, persona, f"YES={vote_match.group(1)} NO={vote_match.group(2)}"))
+            yes, no, exonerate = vote_match.group(1), vote_match.group(2), vote_match.group(3)
+            tally = f"YES={yes} NO={no}"
+            if exonerate is not None:
+                tally += f" EXONERATE={exonerate}"
+            vote_rows.append((issue_number(issue), tool, persona, tally))
 
     lines = ["## Reviewer/Persona Tables"]
     lines.append("Aggregate per tool:")
@@ -434,7 +465,7 @@ def reviewer_effectiveness(issues: Sequence[Mapping[str, Any]]) -> Tuple[str, Di
             done = tool_done[tool]
             lines.append(f"- {tool}: {total} findings, {done} done ({done / total * 100:.1f}%)")
     else:
-        lines.append("- No Surfaced by lines detected.")
+        lines.append("- No reviewer attribution lines detected.")
 
     lines.append("Per tool/persona:")
     for (tool, persona), total in sorted(pair_counts.items(), key=lambda item: (-item[1], item[0])):

--- a/.claude/skills/analyze-issues/scripts/analyze.py
+++ b/.claude/skills/analyze-issues/scripts/analyze.py
@@ -1,0 +1,546 @@
+#!/usr/bin/env python3
+"""Analyze GitHub issue JSON for backlog and process insight."""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import importlib.util
+import json
+import math
+import re
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Sequence, Tuple
+
+BODY_CAP = 5 * 1024
+PREFIX_RE = re.compile(r"^\s*(?:\[(?:DONE|OOS|IN PROGRESS|STALLED|URGENT)\]\s*)+", re.I)
+FILE_RE = re.compile(r"\b[a-z][a-z0-9/_.-]+\.(?:sh|md)\b", re.I)
+
+CATEGORY_RULES: Sequence[Tuple[str, Sequence[str]]] = (
+    ("Documentation/contract drift", ("doc", "readme", "contract", "prompt", "instruction", "schema")),
+    ("Bug fix", ("bug", "fix", "broken", "failure", "error", "crash", "regression")),
+    ("Test coverage", ("test", "coverage", "harness", "fixture", "assert")),
+    ("Hardening/validation/security", ("security", "secret", "validate", "guard", "permission", "sanitize", "safe")),
+    ("Refactor/code clarity", ("refactor", "cleanup", "clarity", "simplify", "rename")),
+    ("Determinism/halt-prevention", ("determin", "halt", "timeout", "race", "idempotent", "retry")),
+    ("New feature/new skill", ("feature", "skill", "scaffold", "add", "new")),
+    ("Performance/token-cost reduction", ("performance", "token", "cost", "speed", "latency", "cache")),
+)
+
+STOP_WORDS = {
+    "a",
+    "an",
+    "and",
+    "are",
+    "as",
+    "be",
+    "by",
+    "for",
+    "from",
+    "in",
+    "into",
+    "is",
+    "it",
+    "of",
+    "on",
+    "or",
+    "the",
+    "to",
+    "with",
+}
+
+
+def parse_iso(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        if value.endswith("Z"):
+            value = value[:-1] + "+00:00"
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def issue_text(issue: Mapping[str, Any], cap: int = BODY_CAP) -> str:
+    return f"{issue.get('title') or ''}\n{(issue.get('body') or '')[:cap]}"
+
+
+def strip_prefixes(title: str) -> str:
+    return PREFIX_RE.sub("", title or "").strip()
+
+
+def load_issues(path: str) -> List[Dict[str, Any]]:
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            raw = json.load(handle)
+    except Exception as exc:
+        raise SystemExit(f"ERROR=Unable to parse issue JSON dump at {path}: {exc}") from exc
+    if not isinstance(raw, list):
+        raise SystemExit(f"ERROR=Issue JSON dump at {path} is not a list")
+    issues: List[Dict[str, Any]] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        issue = dict(item)
+        issue["body"] = (issue.get("body") or "")[:BODY_CAP]
+        issues.append(issue)
+    return issues
+
+
+def percentile(values: Sequence[float], percent: float) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    rank = (len(ordered) - 1) * (percent / 100.0)
+    lower = math.floor(rank)
+    upper = math.ceil(rank)
+    if lower == upper:
+        return ordered[int(rank)]
+    return ordered[lower] + (ordered[upper] - ordered[lower]) * (rank - lower)
+
+
+def fmt_days(value: float | None) -> str:
+    if value is None:
+        return "n/a"
+    return f"{value:.1f}d"
+
+
+def coverage_stats(issues: Sequence[Mapping[str, Any]]) -> Dict[str, Any]:
+    created_dates = [parse_iso(str(issue.get("createdAt") or "")) for issue in issues]
+    created_dates = [date for date in created_dates if date is not None]
+    close_durations: List[float] = []
+    pr_closed = 0
+    closed = 0
+    for issue in issues:
+        if str(issue.get("state") or "").upper() == "CLOSED":
+            closed += 1
+            refs = issue.get("closedByPullRequestsReferences") or []
+            if isinstance(refs, list) and refs:
+                pr_closed += 1
+            created = parse_iso(str(issue.get("createdAt") or ""))
+            closed_at = parse_iso(str(issue.get("closedAt") or ""))
+            if created and closed_at and closed_at >= created:
+                close_durations.append((closed_at - created).total_seconds() / 86400.0)
+    total = len(issues)
+    return {
+        "total": total,
+        "open": sum(1 for issue in issues if str(issue.get("state") or "").upper() == "OPEN"),
+        "closed": closed,
+        "oldest": min(created_dates).date().isoformat() if created_dates else "n/a",
+        "newest": max(created_dates).date().isoformat() if created_dates else "n/a",
+        "median_close": percentile(close_durations, 50),
+        "p90_close": percentile(close_durations, 90),
+        "p25_close": percentile(close_durations, 25),
+        "p75_close": percentile(close_durations, 75),
+        "pr_closed_pct": (pr_closed / closed * 100.0) if closed else 0.0,
+    }
+
+
+def default_category(issue: Mapping[str, Any]) -> str:
+    title = str(issue.get("title") or "")
+    body = str(issue.get("body") or "")
+    if body.lstrip().lower().startswith("tracking issue for") and "original prompt" in body.lower():
+        return "Tracking/umbrella"
+    if re.match(r"^\s*(?:\[research[^\]]*\]\s*)?(?:investigate|research)\b", title, re.I):
+        return "Research/investigation"
+    haystack = issue_text(issue).lower()
+    for category, keywords in CATEGORY_RULES:
+        if any(keyword in haystack for keyword in keywords):
+            return category
+    return "Other"
+
+
+def title_tokens(title: str) -> List[str]:
+    cleaned = strip_prefixes(title).lower()
+    return [
+        token
+        for token in re.findall(r"[a-z][a-z0-9-]{2,}", cleaned)
+        if token not in STOP_WORDS and not token.isdigit()
+    ]
+
+
+def categorize(issues: Sequence[Mapping[str, Any]], mode: str, top_k: int) -> Dict[int, str]:
+    if mode == "default":
+        return {int(issue.get("number") or 0): default_category(issue) for issue in issues}
+
+    # Auto mode strips common status prefixes, counts distinctive title tokens,
+    # and assigns each issue to its highest-ranked token bucket.
+    frequency: collections.Counter[str] = collections.Counter()
+    issue_tokens: Dict[int, List[str]] = {}
+    for issue in issues:
+        number = int(issue.get("number") or 0)
+        tokens = title_tokens(str(issue.get("title") or ""))
+        issue_tokens[number] = tokens
+        frequency.update(set(tokens))
+    leaders = [token for token, _count in frequency.most_common(max(top_k, 1))]
+    leader_set = set(leaders)
+    categories: Dict[int, str] = {}
+    for issue in issues:
+        number = int(issue.get("number") or 0)
+        bucket = next((token for token in issue_tokens.get(number, []) if token in leader_set), None)
+        categories[number] = f"Auto: {bucket}" if bucket else "Other"
+    return categories
+
+
+def category_breakdown(
+    issues: Sequence[Mapping[str, Any]], categories: Mapping[int, str]
+) -> Tuple[str, collections.Counter[str]]:
+    counts: collections.Counter[str] = collections.Counter()
+    for issue in issues:
+        counts[categories.get(int(issue.get("number") or 0), "Other")] += 1
+    total = max(len(issues), 1)
+    lines = ["## Category Breakdown"]
+    for category, count in counts.most_common():
+        lines.append(f"- {category}: {count} ({count / total * 100:.1f}%)")
+    return "\n".join(lines), counts
+
+
+def growth_chart(
+    issues: Sequence[Mapping[str, Any]], categories: Mapping[int, str], span_days: int
+) -> str:
+    dated = [
+        (issue, parse_iso(str(issue.get("createdAt") or "")))
+        for issue in issues
+        if parse_iso(str(issue.get("createdAt") or "")) is not None
+    ]
+    if not dated:
+        return "## Growth Chart\nNo growth data available."
+    oldest = min(date for _issue, date in dated if date is not None)
+    newest = max(date for _issue, date in dated if date is not None)
+    if span_days > 0:
+        oldest = newest - timedelta(days=span_days)
+        dated = [(issue, date) for issue, date in dated if date and date >= oldest]
+    computed_span = max((newest.date() - oldest.date()).days, 0)
+    weekly = computed_span > 60
+    bucket_count = computed_span // (7 if weekly else 1) + 1
+    buckets = [
+        (oldest + timedelta(days=index * (7 if weekly else 1))).date().isoformat()
+        for index in range(bucket_count)
+    ]
+    category_order = sorted({categories.get(int(issue.get("number") or 0), "Other") for issue, _date in dated})
+    matrix: Dict[str, List[int]] = {category: [0] * bucket_count for category in category_order}
+    for issue, created in sorted(dated, key=lambda pair: pair[1] or oldest):
+        if created is None:
+            continue
+        category = categories.get(int(issue.get("number") or 0), "Other")
+        index = (created.date() - oldest.date()).days // (7 if weekly else 1)
+        if 0 <= index < bucket_count:
+            matrix[category][index] += 1
+    for category in category_order:
+        running = 0
+        for index, value in enumerate(matrix[category]):
+            running += value
+            matrix[category][index] = running
+    keys = [chr(ord("A") + index) for index in range(len(category_order))]
+
+    chart_module = load_render_chart()
+    return "## Growth Chart\n" + chart_module.render_chart(buckets, [
+        (key, category, matrix[category]) for key, category in zip(keys, category_order)
+    ])
+
+
+def load_render_chart() -> Any:
+    path = Path(__file__).with_name("render-chart.py")
+    spec = importlib.util.spec_from_file_location("render_chart", path)
+    if spec is None or spec.loader is None:
+        raise SystemExit(f"ERROR=Unable to load chart renderer at {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def pattern_observations(issues: Sequence[Mapping[str, Any]], top_k: int, stats: Mapping[str, Any]) -> str:
+    daily: collections.Counter[str] = collections.Counter()
+    paths: collections.Counter[str] = collections.Counter()
+    auto_count = 0
+    for issue in issues:
+        created = parse_iso(str(issue.get("createdAt") or ""))
+        if created:
+            daily[created.date().isoformat()] += 1
+        text = issue_text(issue)
+        paths.update(match.lower() for match in FILE_RE.findall(text))
+        lowered = text.lower()
+        if "automatically created" in lowered or "[oos]" in str(issue.get("title") or "").lower() or "[oos]" in lowered:
+            auto_count += 1
+
+    mean_daily = (sum(daily.values()) / len(daily)) if daily else 0
+    bursts = [(day, count) for day, count in daily.items() if mean_daily and count >= 2 * mean_daily]
+    bursts.sort(key=lambda item: (-item[1], item[0]))
+
+    lines = ["## Pattern Observations"]
+    lines.append("- Bursty filing days:")
+    if bursts:
+        for day, count in bursts[:5]:
+            lines.append(f"  - {day}: {count} issues ({count / mean_daily:.1f}x mean)")
+    else:
+        lines.append("  - None above 2x mean daily creation rate.")
+    lines.append("- File-path and skill-name hot spots:")
+    if paths:
+        for path, count in paths.most_common(top_k):
+            lines.append(f"  - {path}: {count}")
+    else:
+        lines.append("  - None detected.")
+    total = max(len(issues), 1)
+    lines.append(f"- Auto-spawned share: {auto_count}/{len(issues)} ({auto_count / total * 100:.1f}%)")
+    lines.append(
+        "- Closure velocity: "
+        f"P25 {fmt_days(stats.get('p25_close'))}, "
+        f"P50 {fmt_days(stats.get('median_close'))}, "
+        f"P75 {fmt_days(stats.get('p75_close'))}, "
+        f"P90 {fmt_days(stats.get('p90_close'))}"
+    )
+    return "\n".join(lines)
+
+
+def issue_number(issue: Mapping[str, Any]) -> int:
+    return int(issue.get("number") or 0)
+
+
+def pr_ref_id(ref: Mapping[str, Any]) -> str:
+    for key in ("url", "number", "title"):
+        value = ref.get(key)
+        if value:
+            return str(value)
+    return json.dumps(ref, sort_keys=True)
+
+
+def wasteful_findings(issues: Sequence[Mapping[str, Any]], top_k: int) -> str:
+    by_title: MutableMapping[str, List[Mapping[str, Any]]] = collections.defaultdict(list)
+    for issue in issues:
+        by_title[strip_prefixes(str(issue.get("title") or "")).lower()].append(issue)
+
+    lines = ["## Wasteful-work Findings"]
+    lines.append("- W1 duplicate-titled issues opened within 7 days:")
+    w1_count = 0
+    for title, group in sorted(by_title.items()):
+        ordered = sorted(group, key=lambda issue: parse_iso(str(issue.get("createdAt") or "")) or datetime.min.replace(tzinfo=timezone.utc))
+        for left, right in zip(ordered, ordered[1:]):
+            left_date = parse_iso(str(left.get("createdAt") or ""))
+            right_date = parse_iso(str(right.get("createdAt") or ""))
+            if left_date and right_date and right_date - left_date <= timedelta(days=7):
+                lines.append(f"  - #{issue_number(left)} and #{issue_number(right)}: {title}")
+                w1_count += 1
+                if w1_count >= top_k:
+                    break
+        if w1_count >= top_k:
+            break
+    if not w1_count:
+        lines.append("  - None detected.")
+
+    reversal_re = re.compile(
+        r"\b(revert|undo|superseded|re-introduce|re-add|closed in favor of)\b.*?(#[0-9]+|[0-9a-f]{7,40}|https?://\S+)?",
+        re.I | re.S,
+    )
+    lines.append("- W2 reversal/supersession mentions:")
+    found = 0
+    for issue in issues:
+        text = f"{issue.get('title') or ''}\n{(issue.get('body') or '')[:3072]}"
+        match = reversal_re.search(text)
+        if match:
+            ref = match.group(2) or "no explicit PR/commit reference"
+            lines.append(f"  - #{issue_number(issue)}: {match.group(1)} ({ref})")
+            found += 1
+            if found >= top_k:
+                break
+    if not found:
+        lines.append("  - None detected.")
+
+    stalled = [issue for issue in issues if str(issue.get("title") or "").lstrip().lower().startswith("[stalled]")]
+    lines.append(f"- W3 [STALLED] issues: {len(stalled)} total")
+    for issue in stalled[:top_k]:
+        lines.append(f"  - #{issue_number(issue)} {issue.get('title') or ''}")
+
+    pr_clusters: MutableMapping[str, List[int]] = collections.defaultdict(list)
+    for issue in issues:
+        refs = issue.get("closedByPullRequestsReferences") or []
+        if isinstance(refs, list):
+            for ref in refs:
+                if isinstance(ref, dict):
+                    pr_clusters[pr_ref_id(ref)].append(issue_number(issue))
+    lines.append("- W4 PR-to-issue closure clusters:")
+    clusters = [(pr, numbers) for pr, numbers in pr_clusters.items() if len(numbers) >= 3]
+    clusters.sort(key=lambda item: (-len(item[1]), item[0]))
+    if clusters:
+        for pr, numbers in clusters[:top_k]:
+            lines.append(f"  - {pr}: closes {len(numbers)} issues ({', '.join('#' + str(n) for n in sorted(numbers))})")
+    else:
+        lines.append("  - None detected.")
+
+    lines.append("- W5 auto-loop duplicate filings:")
+    duplicates = [(title, group) for title, group in by_title.items() if title and len(group) >= 2]
+    duplicates.sort(key=lambda item: (-len(item[1]), item[0]))
+    if duplicates:
+        for title, group in duplicates[:top_k]:
+            numbers = ", ".join(f"#{issue_number(issue)}" for issue in sorted(group, key=issue_number))
+            lines.append(f"  - {title}: {len(group)} issues ({numbers})")
+    else:
+        lines.append("  - None detected.")
+    return "\n".join(lines)
+
+
+def normalize_tool(raw: str) -> str:
+    value = raw.lower()
+    if value.startswith("code,") or value == "code":
+        return "claude"
+    if value == "main agent":
+        return "main agent"
+    return value
+
+
+def reviewer_effectiveness(issues: Sequence[Mapping[str, Any]]) -> Tuple[str, Dict[str, Any]]:
+    # WHY: keep codex/code alternatives longest-first so "codex" is not counted as "code".
+    tool_re = re.compile(r"\b(codex|cursor|claude|gemini|main\s+agent|code,\s*claude\s+code\s+reviewer|code)\b", re.I)
+    persona_re = re.compile(
+        r"\b(architect|arch|correctness|edge-cases|edge|structure|testing|innovation|pragmatic|security|generic)\b",
+        re.I,
+    )
+    pair_counts: collections.Counter[Tuple[str, str]] = collections.Counter()
+    pair_done: collections.Counter[Tuple[str, str]] = collections.Counter()
+    tool_counts: collections.Counter[str] = collections.Counter()
+    tool_done: collections.Counter[str] = collections.Counter()
+    vote_rows: List[Tuple[int, str, str, str]] = []
+
+    for issue in issues:
+        body = str(issue.get("body") or "")
+        surfaced = next((line for line in body.splitlines() if line.lower().startswith("surfaced by:")), "")
+        if not surfaced:
+            continue
+        tool_match = tool_re.search(surfaced)
+        persona_match = persona_re.search(surfaced)
+        tool = normalize_tool(tool_match.group(1).replace("  ", " ").lower()) if tool_match else "unknown"
+        persona = persona_match.group(1).lower() if persona_match else "generic"
+        persona = {"arch": "architect", "edge": "edge-cases"}.get(persona, persona)
+        key = (tool, persona)
+        done = str(issue.get("title") or "").lstrip().upper().startswith("[DONE]")
+        pair_counts[key] += 1
+        tool_counts[tool] += 1
+        if done:
+            pair_done[key] += 1
+            tool_done[tool] += 1
+        vote_match = re.search(r"\bYES=(\d+)\s+NO=(\d+)\b", body, re.I)
+        if vote_match:
+            vote_rows.append((issue_number(issue), tool, persona, f"YES={vote_match.group(1)} NO={vote_match.group(2)}"))
+
+    lines = ["## Reviewer/Persona Tables"]
+    lines.append("Aggregate per tool:")
+    if tool_counts:
+        for tool, total in tool_counts.most_common():
+            done = tool_done[tool]
+            lines.append(f"- {tool}: {total} findings, {done} done ({done / total * 100:.1f}%)")
+    else:
+        lines.append("- No Surfaced by lines detected.")
+
+    lines.append("Per tool/persona:")
+    for (tool, persona), total in sorted(pair_counts.items(), key=lambda item: (-item[1], item[0])):
+        done = pair_done[(tool, persona)]
+        lines.append(f"- {tool} / {persona}: {total} findings, {done} done ({done / total * 100:.1f}%)")
+    if not pair_counts:
+        lines.append("- No tool/persona pairs detected.")
+
+    lines.append("Design-phase vote findings:")
+    if vote_rows:
+        for number, tool, persona, votes in vote_rows:
+            lines.append(f"- #{number}: {tool} / {persona} ({votes})")
+    else:
+        lines.append("- None with explicit YES=N NO=M tallies.")
+
+    eligible = [
+        (pair_done[key] / total, key, total, pair_done[key])
+        for key, total in pair_counts.items()
+        if total >= 10
+    ]
+    eligible.sort(key=lambda item: (-item[0], item[1]))
+    lines.append("Top ROI reviewer/persona pairs:")
+    if eligible:
+        for rate, (tool, persona), total, done in eligible[:3]:
+            lines.append(f"- {tool} / {persona}: {done}/{total} done ({rate * 100:.1f}%)")
+    else:
+        lines.append("- None with at least 10 findings.")
+
+    best = eligible[0] if eligible else None
+    return "\n".join(lines), {"pair_counts": pair_counts, "pair_done": pair_done, "best": best}
+
+
+def executive_summary(
+    stats: Mapping[str, Any],
+    category_counts: Mapping[str, int],
+    reviewer_stats: Mapping[str, Any],
+) -> str:
+    dominant = ", ".join(category for category, _count in collections.Counter(category_counts).most_common(3)) or "no dominant categories"
+    best = reviewer_stats.get("best")
+    if best:
+        rate, (tool, persona), total, done = best
+        reviewer = f"{tool} / {persona} ({done}/{total} done, {rate * 100:.1f}%)"
+    else:
+        reviewer = "no reviewer/persona pair with at least 10 findings"
+    return (
+        "## Executive Summary\n"
+        f"Analyzed {stats['total']} issues across {stats['oldest']} to {stats['newest']}. "
+        f"Dominant categories: {dominant}. "
+        "The strongest waste signals are duplicate titles, stalled issues, reversal/supersession mentions, "
+        "and PR closure clusters listed below. "
+        f"Highest-ROI reviewer/persona signal: {reviewer}."
+    )
+
+
+def render_coverage(stats: Mapping[str, Any]) -> str:
+    return "\n".join(
+        [
+            "## Coverage Stats",
+            f"- Total issues: {stats['total']}",
+            f"- Open / closed: {stats['open']} / {stats['closed']}",
+            f"- Created date range: {stats['oldest']} -> {stats['newest']}",
+            f"- Time to close: median {fmt_days(stats['median_close'])}, P90 {fmt_days(stats['p90_close'])}",
+            f"- Closed by PR reference: {stats['pr_closed_pct']:.1f}% of closed issues",
+        ]
+    )
+
+
+def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--json", required=True)
+    parser.add_argument("--span-days", type=int, default=0)
+    parser.add_argument("--top-k", type=int, default=10)
+    parser.add_argument("--categories", choices=("auto", "default"), default="default")
+    return parser.parse_args(list(argv) if argv is not None else None)
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    args = parse_args(argv)
+    issues = load_issues(args.json)
+    if not issues:
+        print("No issues to analyze.")
+        return 0
+    top_k = max(args.top_k, 1)
+    stats = coverage_stats(issues)
+    categories = categorize(issues, args.categories, top_k)
+    breakdown_text, category_counts = category_breakdown(issues, categories)
+    chart_text = growth_chart(issues, categories, max(args.span_days, 0))
+    patterns_text = pattern_observations(issues, top_k, stats)
+    waste_text = wasteful_findings(issues, top_k)
+    reviewer_text, reviewer_stats = reviewer_effectiveness(issues)
+    summary_text = executive_summary(stats, category_counts, reviewer_stats)
+    print(
+        "\n\n".join(
+            [
+                summary_text,
+                render_coverage(stats),
+                breakdown_text,
+                chart_text,
+                patterns_text,
+                waste_text,
+                reviewer_text,
+            ]
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/analyze-issues/scripts/fetch-issues.md
+++ b/.claude/skills/analyze-issues/scripts/fetch-issues.md
@@ -1,0 +1,13 @@
+# fetch-issues.sh
+
+Purpose: wrap the single `gh issue list` fetch used by `/analyze-issues`.
+
+Primary callers: `run-analysis.sh`.
+
+Invariants: perform no issue processing, do not filter duplicate titles or `[OOS]` issues, and write the GitHub JSON response to the requested output path. Keep shell scripts on `set -euo pipefail`.
+
+Makefile wiring: none; this is a dev-only local skill helper.
+
+Test harness: `bash -n .claude/skills/analyze-issues/scripts/*.sh`.
+
+Edit in sync: update this contract if the fetched JSON fields, flags, or failure behavior change.

--- a/.claude/skills/analyze-issues/scripts/fetch-issues.sh
+++ b/.claude/skills/analyze-issues/scripts/fetch-issues.sh
@@ -11,17 +11,28 @@ Usage: fetch-issues.sh --repo OWNER/REPO --limit N --output PATH
 EOF
 }
 
+require_value() {
+  if [[ $# -lt 2 ]]; then
+    echo "ERROR=Flag $1 requires a value" >&2
+    usage
+    exit 2
+  fi
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --repo)
+      require_value "$@"
       REPO="$2"
       shift 2
       ;;
     --limit)
+      require_value "$@"
       LIMIT="$2"
       shift 2
       ;;
     --output)
+      require_value "$@"
       OUTPUT="$2"
       shift 2
       ;;
@@ -43,9 +54,18 @@ if [[ -z "$REPO" || -z "$LIMIT" || -z "$OUTPUT" ]]; then
   exit 2
 fi
 
+# Atomic write: stage to a temp file with restrictive permissions, then rename
+# on success so a partial gh failure never leaves a torn JSON dump in place.
+umask 077
+TMP_OUTPUT="${OUTPUT}.tmp.$$"
+trap 'rm -f -- "$TMP_OUTPUT"' EXIT
+
 if ! gh issue list --repo "$REPO" --state all --limit "$LIMIT" \
   --json number,title,state,createdAt,closedAt,body,labels,closedByPullRequestsReferences \
-  > "$OUTPUT"; then
+  > "$TMP_OUTPUT"; then
   echo "ERROR=gh issue list failed for repo $REPO" >&2
   exit 1
 fi
+
+mv -f -- "$TMP_OUTPUT" "$OUTPUT"
+trap - EXIT

--- a/.claude/skills/analyze-issues/scripts/fetch-issues.sh
+++ b/.claude/skills/analyze-issues/scripts/fetch-issues.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO=""
+LIMIT=""
+OUTPUT=""
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: fetch-issues.sh --repo OWNER/REPO --limit N --output PATH
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      REPO="$2"
+      shift 2
+      ;;
+    --limit)
+      LIMIT="$2"
+      shift 2
+      ;;
+    --output)
+      OUTPUT="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "ERROR=Unknown argument: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$REPO" || -z "$LIMIT" || -z "$OUTPUT" ]]; then
+  echo "ERROR=Missing required --repo, --limit, or --output" >&2
+  usage
+  exit 2
+fi
+
+if ! gh issue list --repo "$REPO" --state all --limit "$LIMIT" \
+  --json number,title,state,createdAt,closedAt,body,labels,closedByPullRequestsReferences \
+  > "$OUTPUT"; then
+  echo "ERROR=gh issue list failed for repo $REPO" >&2
+  exit 1
+fi

--- a/.claude/skills/analyze-issues/scripts/render-chart.md
+++ b/.claude/skills/analyze-issues/scripts/render-chart.md
@@ -1,0 +1,13 @@
+# render-chart.py
+
+Purpose: render the cumulative category matrix produced by `analyze.py` as a compact ASCII chart.
+
+Primary callers: `analyze.py` imports `render-chart.py` from the same scripts directory.
+
+Invariants: accept TSV matrix input, use one single-letter legend key per category, preserve deterministic output, and use `*` when multiple series collide in the same cell.
+
+Makefile wiring: none; this is a dev-only local skill helper.
+
+Test harness: `python3 -c "import ast; ast.parse(open('.claude/skills/analyze-issues/scripts/render-chart.py').read())"`.
+
+Edit in sync: update this contract and `analyze.py` whenever the chart input format or rendering semantics change.

--- a/.claude/skills/analyze-issues/scripts/render-chart.py
+++ b/.claude/skills/analyze-issues/scripts/render-chart.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Render a compact ASCII cumulative-growth chart from TSV input."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Iterable, List, Sequence, Tuple
+
+
+def parse_tsv(text: str) -> Tuple[List[str], List[Tuple[str, str, List[int]]]]:
+    lines = [line.rstrip("\n") for line in text.splitlines() if line.strip()]
+    if not lines:
+        return [], []
+    header = lines[0].split("\t")
+    buckets = header[2:]
+    rows = []
+    for line in lines[1:]:
+        parts = line.split("\t")
+        if len(parts) < 3:
+            continue
+        key, label = parts[0], parts[1]
+        values = [int(value or "0") for value in parts[2:]]
+        rows.append((key, label, values))
+    return buckets, rows
+
+
+def render_chart(buckets: Sequence[str], rows: Sequence[Tuple[str, str, Sequence[int]]]) -> str:
+    if not rows or not buckets:
+        return "No growth data available."
+
+    width = len(buckets)
+    max_final = max((values[-1] if values else 0) for _, _, values in rows)
+    max_final = max(max_final, 1)
+    canvas = [["." for _ in range(width)] for _ in range(len(rows))]
+
+    for _row_index, (key, _label, values) in enumerate(rows):
+        for col_index, value in enumerate(values[:width]):
+            if value <= 0:
+                continue
+            scaled = max(0, min(len(rows) - 1, round((value / max_final) * (len(rows) - 1))))
+            target = len(rows) - 1 - scaled
+            existing = canvas[target][col_index]
+            canvas[target][col_index] = key if existing == "." or existing == key else "*"
+
+    output = ["Cumulative growth chart"]
+    output.append(f"Buckets: {buckets[0]} -> {buckets[-1]} ({len(buckets)} buckets)")
+    for line in canvas:
+        output.append("".join(line))
+    output.append("Legend:")
+    for key, label, values in rows:
+        final = values[-1] if values else 0
+        output.append(f"  {key}: {label} ({final})")
+    return "\n".join(output)
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("path", nargs="?")
+    args = parser.parse_args(list(argv) if argv is not None else None)
+    if args.path:
+        with open(args.path, "r", encoding="utf-8") as handle:
+            text = handle.read()
+    else:
+        text = sys.stdin.read()
+    buckets, rows = parse_tsv(text)
+    print(render_chart(buckets, rows))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/analyze-issues/scripts/run-analysis.md
+++ b/.claude/skills/analyze-issues/scripts/run-analysis.md
@@ -1,0 +1,13 @@
+# run-analysis.sh
+
+Purpose: top-level coordinator for the project-local `/analyze-issues` skill.
+
+Primary callers: `.claude/skills/analyze-issues/SKILL.md` invokes this script through the Bash tool.
+
+Invariants: parse only the documented flags, detect the current GitHub repo, write the raw issue dump to `/tmp/<repo>-issues.json`, delegate fetching to `fetch-issues.sh`, and delegate report generation to `analyze.py`. Keep shell scripts on `set -euo pipefail`.
+
+Makefile wiring: none; this is a dev-only local skill helper.
+
+Test harness: `bash -n .claude/skills/analyze-issues/scripts/*.sh`.
+
+Edit in sync: update this contract and `SKILL.md` whenever flags, output paths, or helper responsibilities change.

--- a/.claude/skills/analyze-issues/scripts/run-analysis.sh
+++ b/.claude/skills/analyze-issues/scripts/run-analysis.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+LIMIT=2000
+SPAN_DAYS=0
+TOP_K=10
+CATEGORIES="default"
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: run-analysis.sh [--limit N] [--span-days N] [--top-K N] [--categories=auto|default]
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --limit)
+      LIMIT="$2"
+      shift 2
+      ;;
+    --span-days)
+      SPAN_DAYS="$2"
+      shift 2
+      ;;
+    --top-K|--top-k)
+      TOP_K="$2"
+      shift 2
+      ;;
+    --categories=*)
+      CATEGORIES="${1#--categories=}"
+      shift
+      ;;
+    --categories)
+      CATEGORIES="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "ERROR=Unknown argument: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+case "$CATEGORIES" in
+  auto|default) ;;
+  *)
+    echo "ERROR=--categories must be auto or default" >&2
+    exit 2
+    ;;
+esac
+
+if REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null)"; then
+  :
+else
+  REMOTE_URL="$(git config --get remote.origin.url || true)"
+  REPO="$(printf '%s\n' "$REMOTE_URL" |
+    sed -E 's#^git@[^:]+:##; s#^https?://[^/]+/##; s#\.git$##')"
+fi
+
+if [[ ! "$REPO" =~ ^[^/]+/[^/]+$ ]]; then
+  echo "ERROR=Unable to detect GitHub repo owner/name" >&2
+  exit 1
+fi
+
+SANITIZED_REPO="$(printf '%s' "$REPO" | tr '/' '-' | tr -cd '[:alnum:]-_')"
+DUMP_PATH="/tmp/${SANITIZED_REPO}-issues.json"
+
+"$SCRIPT_DIR/fetch-issues.sh" --repo "$REPO" --limit "$LIMIT" --output "$DUMP_PATH"
+
+ANALYZE_ARGS=(--json "$DUMP_PATH" --top-k "$TOP_K" --categories "$CATEGORIES")
+if [[ "$SPAN_DAYS" != "0" ]]; then
+  ANALYZE_ARGS+=(--span-days "$SPAN_DAYS")
+fi
+
+python3 "$SCRIPT_DIR/analyze.py" "${ANALYZE_ARGS[@]}"

--- a/.claude/skills/analyze-issues/scripts/run-analysis.sh
+++ b/.claude/skills/analyze-issues/scripts/run-analysis.sh
@@ -14,17 +14,28 @@ Usage: run-analysis.sh [--limit N] [--span-days N] [--top-K N] [--categories=aut
 EOF
 }
 
+require_value() {
+  if [[ $# -lt 2 ]]; then
+    echo "ERROR=Flag $1 requires a value" >&2
+    usage
+    exit 2
+  fi
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --limit)
+      require_value "$@"
       LIMIT="$2"
       shift 2
       ;;
     --span-days)
+      require_value "$@"
       SPAN_DAYS="$2"
       shift 2
       ;;
     --top-K|--top-k)
+      require_value "$@"
       TOP_K="$2"
       shift 2
       ;;
@@ -33,6 +44,7 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --categories)
+      require_value "$@"
       CATEGORIES="$2"
       shift 2
       ;;
@@ -70,7 +82,16 @@ if [[ ! "$REPO" =~ ^[^/]+/[^/]+$ ]]; then
 fi
 
 SANITIZED_REPO="$(printf '%s' "$REPO" | tr '/' '-' | tr -cd '[:alnum:]-_')"
-DUMP_PATH="/tmp/${SANITIZED_REPO}-issues.json"
+if [[ -z "$SANITIZED_REPO" ]]; then
+  echo "ERROR=Sanitized repo name is empty (REPO='$REPO')" >&2
+  exit 1
+fi
+
+# Issue bodies can contain sensitive content — keep dumps user-private.
+TMPROOT="${TMPDIR:-/tmp}"
+DUMP_DIR="${TMPROOT%/}"
+DUMP_PATH="${DUMP_DIR}/${SANITIZED_REPO}-issues.json"
+umask 077
 
 "$SCRIPT_DIR/fetch-issues.sh" --repo "$REPO" --limit "$LIMIT" --output "$DUMP_PATH"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [15.12.17] - 2026-05-05
+
+### Added
+
+- Project-local `/analyze-issues` skill at `.claude/skills/analyze-issues/` that produces a backlog-and-process insight report from a repository's GitHub issues. Single shell-out point (`gh issue list`) plus local `python3` processing covers coverage stats, category breakdown, cumulative-growth ASCII chart, pattern observations, wasteful-work findings, reviewer/persona effectiveness (with longest-first regex alternation so `codex` is not confused with `code`), and a one-paragraph executive summary. Coordinator at `scripts/run-analysis.sh` writes the raw `gh` JSON dump under `${TMPDIR:-/tmp}` with `umask 077` and atomic temp+mv so issue bodies stay user-private and never torn on partial fetch failure. Per-script contracts at `scripts/{run-analysis,fetch-issues,analyze,render-chart}.md`. Dev-only — does not ship in the plugin tree.
+
 ## [15.12.16] - 2026-05-05
 
 ### Changed


### PR DESCRIPTION
## Summary

- New project-local `/analyze-issues` skill at `.claude/skills/analyze-issues/` that produces a backlog-and-process insight report from a repository's GitHub issues with a single `gh issue list` shell-out and all other processing local (jq + `python3`).
- The skill is a thin coordinator: SKILL.md delegates to `scripts/run-analysis.sh`, which fetches via `scripts/fetch-issues.sh`, then runs `scripts/analyze.py` (which imports `scripts/render-chart.py`). Each script ships with a sibling `.md` contract.
- Reviewer attribution recognizes the canonical larch `- **Reviewer**:` markdown form alongside plain `Surfaced by:` lines, with longest-first regex alternation so `codex` is not collapsed onto `code`. Vote-tally parsing accepts comma separators and optional `EXONERATE`. Chart legend keys are capped at A-Z by collapsing categories beyond index 25 into `Other (overflow)`.
- The raw `gh` JSON dump is written under `${TMPDIR:-/tmp}` with `umask 077` and atomic temp+mv so issue bodies stay user-private and never torn on partial fetch failure.

## Architecture Diagram

Architecture diagram not available.

## Code Flow Diagram

(Code Flow Diagram skipped — quick mode)

## Test plan

- [x] `bash -n` on `run-analysis.sh` and `fetch-issues.sh`
- [x] `python3 -c "import ast; ast.parse(...)"` on `analyze.py` and `render-chart.py`
- [x] `/relevant-checks` (pre-commit on modified files + agent-lint full-repo) — clean after fixes
- [x] Frontmatter description starts with `Use when…`
- [x] SKILL.md body remains thin and delegates to `scripts/run-analysis.sh`
- [ ] Spot-run `bash .claude/skills/analyze-issues/scripts/run-analysis.sh --limit 200` against `character-ai/larch` (deferred — manual run after merge; tracked under OOS_1 follow-up to add a behavioral smoke harness)

Closes #1235
