### PR TITLE
Document /analyze-issues dump path sensitivity

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "15.12.17",
+  "version": "15.12.18",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 6-reviewer specialist panel (5 Cursor specialists + 1 Codex generic) — extended to 7 with an optional Gemini reviewer when the Gemini CLI is installed and healthy — with 3-voter adjudication; plan review runs a 3-reviewer panel (Claude + Codex + Cursor); design sketches run a 9-agent diverge-then-converge phase in regular mode (1 Claude + 4 Cursor + 4 Codex) or 3 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/.claude/skills/analyze-issues/SKILL.md
+++ b/.claude/skills/analyze-issues/SKILL.md
@@ -29,7 +29,7 @@ Flags:
 - `--top-K N`: number of top items to show in ranked sections. Default: `10`.
 - `--categories=auto|default`: category mode. Default: `default`.
 
-The raw `gh` JSON dump is saved to `/tmp/<repo>-issues.json` for follow-up reanalysis.
+The raw `gh` JSON dump is saved to `${TMPDIR:-/tmp}/<sanitized-repo>-issues.json` for follow-up reanalysis. The slug converts `/` to `-` and keeps only alnum, `-`, and `_`; dumps are intentionally user-private via `umask 077` and an atomic temp+mv write. See `scripts/run-analysis.md` for the full contract.
 
 ## Implementation
 

--- a/.claude/skills/analyze-issues/scripts/run-analysis.md
+++ b/.claude/skills/analyze-issues/scripts/run-analysis.md
@@ -4,7 +4,7 @@ Purpose: top-level coordinator for the project-local `/analyze-issues` skill.
 
 Primary callers: `.claude/skills/analyze-issues/SKILL.md` invokes this script through the Bash tool.
 
-Invariants: parse only the documented flags, detect the current GitHub repo, write the raw issue dump to `/tmp/<repo>-issues.json`, delegate fetching to `fetch-issues.sh`, and delegate report generation to `analyze.py`. Keep shell scripts on `set -euo pipefail`.
+Invariants: parse only the documented flags, detect the current GitHub repo, write the raw issue dump to `${TMPDIR:-/tmp}/<sanitized-repo>-issues.json` where the slug converts `/` to `-` and keeps only alnum, `-`, and `_`, use `umask 077` plus `fetch-issues.sh`'s atomic temp+mv write for user-private dumps, and delegate report generation to `analyze.py`. Keep shell scripts on `set -euo pipefail`.
 
 Makefile wiring: none; this is a dev-only local skill helper.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [15.12.18] - 2026-05-05
+
+### Changed
+
+- Document the `/analyze-issues` coordinator's sensitivity behavior in `.claude/skills/analyze-issues/SKILL.md` — the dump path is now correctly described as `${TMPDIR:-/tmp}/<sanitized-repo>-issues.json` with the slug rule (forward-slash → dash, alnum/`-`/`_` only), `umask 077`, and `fetch-issues.sh`'s atomic temp+mv contract, plus a link to `scripts/run-analysis.md` for the full contract. The sibling `scripts/run-analysis.md` Invariants line is updated in lockstep so the cross-reference is credible. Documentation-only; no behavioral change. Closes #1249.
+
 ## [15.12.17] - 2026-05-05
 
 ### Added


### PR DESCRIPTION
## Summary
- Documented the `/analyze-issues` coordinator's sensitivity behavior in `.claude/skills/analyze-issues/SKILL.md`: dump path now correctly shown as `${TMPDIR:-/tmp}/<sanitized-repo>-issues.json`, with the slug rule (`/` → `-`, alnum/`-`/`_` only), `umask 077`, and the atomic temp+mv contract from `fetch-issues.sh`, plus a link to `scripts/run-analysis.md` for the full contract.
- Updated `scripts/run-analysis.md` Invariants line in lockstep so the cross-reference is credible. Documentation-only; no behavioral change.

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] `/relevant-checks` — pre-commit (markdownlint, agent-lint, gitleaks) + full-repo `agent-lint` pass
- [x] Re-read SKILL.md and run-analysis.md to confirm well-formed paragraph and accurate cross-reference
- [x] Verified diff matches: `run-analysis.sh` already does `${TMPDIR:-/tmp}` + sanitized slug + `umask 077`, `fetch-issues.sh` already does atomic temp+mv

</details>

Closes #1249

Generated with [Claude Code](https://claude.com/claude-code)
