### PR TITLE
Inject larch plugin version into /implement tracking-issue anchor

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "15.12.41",
+  "version": "15.12.42",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 6-reviewer specialist panel (5 Cursor specialists + 1 Codex generic) — extended to 7 with an optional Gemini reviewer when the Gemini CLI is installed and healthy — with 3-voter adjudication; plan review runs a 3-reviewer panel (Claude + Codex + Cursor); design sketches run a 9-agent diverge-then-converge phase in regular mode (1 Claude + 4 Cursor + 4 Codex) or 3 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [15.12.42] - 2026-05-06
+
+### Changed
+
+- Inject the larch plugin version into the `/implement` tracking issue's anchor comment under the existing `run-statistics` section, captured once per assembly via a new `scripts/read-plugin-version.sh` helper that reads `${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json` and falls back to `unknown` on any failure. `scripts/assemble-anchor.sh` now special-cases the `run-statistics` slug: it emits a self-contained minimal table on the seed (`## Run Statistics` + `| Metric | Value |` header + `| larch plugin version | <X.Y.Z> |`), and on populated fragments it strips trailing blank lines AND any pre-existing trailing `| larch plugin version | … |` rows before appending a freshly-captured row — keeping the assembler idempotent across hydration / resume so duplicate version rows never accumulate. When stripping leaves the interior empty (e.g. a fragment that contained only a stale version row), the helper falls through to the seed-style scaffold so the assembled section is always a well-formed table. Sibling contract `scripts/assemble-anchor.md` and the canonical `skills/implement/references/anchor-comment-template.md` template document the auto-injected row, the version-row injection rules, and the resume-idempotency contract. Regression harness `scripts/test-assemble-anchor.sh` adds three new assertion blocks — `(b4)` populated-fragment append, `(b5)` hydrated-stale-row dedup, `(b6)` empty-after-normalization scaffold fallback — plus `(a6)` for the missing-`CLAUDE_PLUGIN_ROOT` `unknown` fallback path; the harness now covers 18 categories.
+
 ## [15.12.41] - 2026-05-06
 
 ### Changed

--- a/scripts/assemble-anchor.md
+++ b/scripts/assemble-anchor.md
@@ -50,7 +50,7 @@ Parsers MUST use the `ERROR=` field (not exit code alone) to disambiguate — ex
 
 ### Marker order matches SECTION_MARKERS
 
-The assembly walk iterates `"${SECTION_MARKERS[@]}"` from `anchor-section-markers.sh`. Any consumer that depends on a specific section order (notably `scripts/tracking-issue-write.sh`'s truncation pass) MUST share the same source-of-truth array. Do not hardcode slug names in this script.
+The assembly walk iterates `"${SECTION_MARKERS[@]}"` from `anchor-section-markers.sh`. Any consumer that depends on a specific section order (notably `scripts/tracking-issue-write.sh`'s truncation pass) MUST share the same source-of-truth array. Do not hardcode slug names in this script except for the documented `run-statistics` normalization hook (see "Run Statistics version-row injection" below) — the hook needs the literal slug to special-case that section's content shape, but it is intentional and gated by a single equality test rather than a parallel slug list.
 
 ### First-line marker exactness
 
@@ -60,7 +60,18 @@ Output always begins with `<!-- larch:implement-anchor v1 issue=<N> -->\n`. `tra
 
 Missing fragment files emit only the open/close marker pair with no content between. This preserves the skeleton required by `tracking-issue-write.sh`'s per-section truncation algorithm (which locates interiors by marker-pair boundaries).
 
-Exception: the `run-statistics` section always receives a minimal Run Statistics table plus `| larch plugin version | <value> |` when its fragment is absent, zero-byte, or whitespace-only. When the `run-statistics` fragment is populated, the helper emits the fragment with trailing blank lines stripped and appends the same plugin-version row as the final table row. The value is read once per assembly from `scripts/read-plugin-version.sh`, which reads `${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json` and falls back to `unknown` on any failure.
+Exception — see "Run Statistics version-row injection" below for the full contract.
+
+### Run Statistics version-row injection
+
+The `run-statistics` section is the one slug whose interior is normalized rather than emitted verbatim. The helper always appends a canonical `| larch plugin version | <value> |` table row inside the section, so the larch plugin version is visible in the anchor body from the seed plant at /implement Step 0.5 onward without depending on Step 9a.1's later run-statistics fragment write.
+
+Behavior depends on the fragment's state:
+
+- **Empty / missing fragment** (seed case): the helper emits a self-contained minimal table — `## Run Statistics`, a blank line, the standard `| Metric | Value |` header + `|---|---|` separator, and the plugin-version row.
+- **Populated fragment** (Step 9a.1's full table written by /implement): the helper emits the fragment content with trailing blank lines stripped AND any trailing pre-existing `| larch plugin version | ... |` rows dropped, then appends a freshly-captured plugin-version row. The trailing-version-row strip is what keeps the assembler idempotent across resume / hydration: a fragment that was hydrated from a prior anchor body (which already carried an injected version row) does not produce duplicate rows on the next assembly.
+
+The `<value>` is read once per assembly from `scripts/read-plugin-version.sh`, which reads `${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json` (default-derived from the script path when the env var is unset) and falls back to the literal `unknown` on any failure (missing file, missing `jq`, malformed JSON, null version). Any I/O error in `read-plugin-version.sh` is non-fatal at the assembly layer — the helper continues with `PLUGIN_VERSION=unknown`.
 
 ### Seed-only visible placeholder
 
@@ -72,7 +83,7 @@ _/implement run in progress — sections below populate as the run proceeds._
 
 Why: an anchor body composed entirely of HTML comment markers renders invisible in GitHub's UI — the freshly planted seed comment looks blank to humans (issue #431). The placeholder is emitted on its own line, *outside* every section interior, so it never collides with `tracking-issue-write.sh`'s per-section truncation (which locates interiors by whole-line marker-pair boundaries).
 
-Populated runs — any fragment with at least one **non-whitespace byte** — suppress the placeholder. The output for partially or fully populated anchors is byte-for-byte unchanged from the pre-fix shape, so progressive upserts at Steps 1/2/5/7a/8/9a.1/11 only ever see the populated body shape and downstream parsers (truncation, hydration awk) are not affected.
+Populated runs — any fragment with at least one **non-whitespace byte** — suppress the placeholder. The output for partially or fully populated anchors is byte-for-byte unchanged from the pre-fix shape for every section EXCEPT `run-statistics`, which is normalized per the "Empty marker pairs preserve section shape" exception above (trailing blank lines and any pre-existing trailing `| larch plugin version | ... |` rows are stripped, and a freshly-captured plugin-version row is appended). Other sections — and the seed-only placeholder line — are unchanged, so progressive upserts at Steps 1/2/5/7a/8/9a.1/11 see the same body shape for those sections and downstream parsers (truncation, hydration awk) are not affected.
 
 The "all empty" detection runs as a separate pre-pass over `SECTION_MARKERS` after the readability pre-pass and before the assembly brace group. The predicate is `grep -q '[^[:space:]]'` against each candidate fragment file; the first non-whitespace byte hit short-circuits the walk to `ALL_EMPTY=false`. This predicate choice (lenient — whitespace-only fragments still trigger the placeholder) was resolved via dialectic adjudication and confirmed by the user during plan design.
 
@@ -82,7 +93,7 @@ The assembled body is first written to a `mktemp` sibling of `--output` and only
 
 ### No redaction, no network
 
-This helper performs pure text assembly of local files. The redaction pipeline lives in `scripts/tracking-issue-write.sh` (which runs compose → redact → truncate on the assembled body at publish time). Compose-time sanitization of fragment content (secrets → `<REDACTED-TOKEN>`, internal URLs → `<INTERNAL-URL>`, PII → `<REDACTED-PII>`) is the caller's responsibility per `skills/implement/SKILL.md` "Compose-time sanitization" — this helper emits fragments verbatim.
+This helper performs pure text assembly of local files. The redaction pipeline lives in `scripts/tracking-issue-write.sh` (which runs compose → redact → truncate on the assembled body at publish time). Compose-time sanitization of fragment content (secrets → `<REDACTED-TOKEN>`, internal URLs → `<INTERNAL-URL>`, PII → `<REDACTED-PII>`) is the caller's responsibility per `skills/implement/SKILL.md` "Compose-time sanitization" — this helper emits fragments verbatim for every section EXCEPT `run-statistics`, where the version-row injection rule above applies (the injection itself is deterministic plugin-metadata, not user-derived content, so the verbatim contract still holds for everything that flows through caller-authored fragments).
 
 ## Conventions
 
@@ -103,7 +114,7 @@ This helper performs pure text assembly of local files. The redaction pipeline l
 
 ## Test harness
 
-`scripts/test-assemble-anchor.sh` covers 16 assertion categories:
+`scripts/test-assemble-anchor.sh` covers 18 assertion categories:
 
 - **(a)** Empty sections directory: output has exactly 23 lines — `<!-- larch:implement-anchor v1 issue=<N> -->` on line 1, the seed-only visible placeholder line on line 2, 7 empty marker pairs, and the `run-statistics` marker pair wrapping a minimal table plus plugin-version row.
 - **(a2)** Empty sections directory: the seed-only placeholder literal is present on line 2 (regression guard for issue #431).
@@ -115,6 +126,8 @@ This helper performs pure text assembly of local files. The redaction pipeline l
 - **(b2)** Newline-terminated fragment → exactly one newline before the close marker (regression guard for the `$(tail -c 1 ...)` command-substitution newline-stripping bug that inserted an extra blank line). Full output compared against a byte-exact expected fixture.
 - **(b3)** Fragment without a trailing newline → helper inserts one so the close marker stays on its own line.
 - **(b4)** Populated `run-statistics` fragment: trailing blank lines are stripped and the plugin-version row is appended immediately before the section close marker.
+- **(b5)** Hydrated `run-statistics` fragment whose interior already ends with a stale `| larch plugin version | <X.Y.Z> |` row: the stale trailing version row is stripped before a freshly-captured row is appended, producing exactly one plugin-version row in the output. Regression guard against the resume / hydration duplicate-row case.
+- **(b6)** Populated `run-statistics` fragment whose entire content normalizes to empty after stripping (e.g. a single stale version row, no heading/header): the helper falls through to the seed-style scaffold (heading + table header + fresh version row) so the assembled section is well-formed instead of an orphan row.
 - **(c)** Full fragments: all 8 slugs have populated content.
 - **(d)** Missing `anchor-section-markers.sh` helper: `FAILED=true` + `ERROR=missing helper: …` on stdout + exit 1.
 - **(e)** Invalid `--issue` value (non-integer): usage error with exit 1.

--- a/scripts/assemble-anchor.md
+++ b/scripts/assemble-anchor.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Assemble the anchor comment body from local per-section fragment files under a sections directory. Walks the canonical `SECTION_MARKERS` slug list (sourced from `anchor-section-markers.sh`), emits paired `<!-- section:<slug> -->` / `<!-- section-end:<slug> -->` markers wrapping each fragment's content (empty marker pairs when a fragment file is absent), prepends the first-line HTML anchor marker `<!-- larch:implement-anchor v1 issue=<N> -->`, and writes the result to `--output`.
+Assemble the anchor comment body from local per-section fragment files under a sections directory. Walks the canonical `SECTION_MARKERS` slug list (sourced from `anchor-section-markers.sh`), emits paired `<!-- section:<slug> -->` / `<!-- section-end:<slug> -->` markers wrapping each fragment's content (empty marker pairs when a fragment file is absent), prepends the first-line HTML anchor marker `<!-- larch:implement-anchor v1 issue=<N> -->`, injects the larch plugin version into the `run-statistics` section, and writes the result to `--output`.
 
 Umbrella #348 Phase 5 extracted this helper to eliminate prose-vs-shell drift across the multiple callsites that previously implemented the walk inline (SKILL.md Step 0.5 Branch 2/3 adoption-seed, Step 0.5 Branch 4 fresh-run first-remote-write, Steps 1/2/5/7a/8/9a.1/11 progressive upserts — Step 2 covers Q/A anchor refresh, and the rebase-rebump sub-procedure Step 6). Every anchor body creation and progressive upsert now routes through this one helper.
 
@@ -60,6 +60,8 @@ Output always begins with `<!-- larch:implement-anchor v1 issue=<N> -->\n`. `tra
 
 Missing fragment files emit only the open/close marker pair with no content between. This preserves the skeleton required by `tracking-issue-write.sh`'s per-section truncation algorithm (which locates interiors by marker-pair boundaries).
 
+Exception: the `run-statistics` section always receives a minimal Run Statistics table plus `| larch plugin version | <value> |` when its fragment is absent, zero-byte, or whitespace-only. When the `run-statistics` fragment is populated, the helper emits the fragment with trailing blank lines stripped and appends the same plugin-version row as the final table row. The value is read once per assembly from `scripts/read-plugin-version.sh`, which reads `${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json` and falls back to `unknown` on any failure.
+
 ### Seed-only visible placeholder
 
 When every fragment is **absent, zero-byte, or whitespace-only** (the lenient "all empty" predicate), the assembled body carries one extra italic-markdown line between the first-line HTML marker and the first `<!-- section:plan-goals-test -->` open marker:
@@ -92,6 +94,7 @@ This helper performs pure text assembly of local files. The redaction pipeline l
 | File | Relationship |
 |---|---|
 | `scripts/anchor-section-markers.sh` | Single-source-of-truth for slug order (sourced). |
+| `scripts/read-plugin-version.sh` | Best-effort plugin-version reader for the auto-injected `run-statistics` row. |
 | `scripts/tracking-issue-write.sh` | Downstream publisher; receives the `--output` path via `upsert-anchor --body-file`. Truncation pass relies on the same SECTION_MARKERS ordering. |
 | `scripts/test-assemble-anchor.sh` | Regression harness — every behavioral change here must be mirrored in the harness. |
 | `skills/implement/SKILL.md` | Primary consumer for anchor-section accumulation. |
@@ -100,16 +103,18 @@ This helper performs pure text assembly of local files. The redaction pipeline l
 
 ## Test harness
 
-`scripts/test-assemble-anchor.sh` covers 14 assertion categories:
+`scripts/test-assemble-anchor.sh` covers 16 assertion categories:
 
-- **(a)** Empty sections directory: output has exactly 18 lines — `<!-- larch:implement-anchor v1 issue=<N> -->` on line 1, the seed-only visible placeholder line on line 2, and 8 pairs of empty marker tags on lines 3-18.
+- **(a)** Empty sections directory: output has exactly 23 lines — `<!-- larch:implement-anchor v1 issue=<N> -->` on line 1, the seed-only visible placeholder line on line 2, 7 empty marker pairs, and the `run-statistics` marker pair wrapping a minimal table plus plugin-version row.
 - **(a2)** Empty sections directory: the seed-only placeholder literal is present on line 2 (regression guard for issue #431).
 - **(a3)** Partial fragments (one slug populated): the placeholder is suppressed — only the all-empty seed case fires it.
 - **(a4)** All fragments contain only whitespace bytes (lenient predicate validation): the placeholder still fires.
 - **(a5)** Nonexistent `--sections-dir`: `ASSEMBLED=true` and the placeholder fires (the all-empty pre-pass treats a missing directory as all-empty).
+- **(a6)** Missing `CLAUDE_PLUGIN_ROOT` target: the auto-injected version row falls back to `unknown`.
 - **(b)** Partial fragments: output contains the populated content only where fragment files exist, empty marker pairs elsewhere, in `SECTION_MARKERS` order.
 - **(b2)** Newline-terminated fragment → exactly one newline before the close marker (regression guard for the `$(tail -c 1 ...)` command-substitution newline-stripping bug that inserted an extra blank line). Full output compared against a byte-exact expected fixture.
 - **(b3)** Fragment without a trailing newline → helper inserts one so the close marker stays on its own line.
+- **(b4)** Populated `run-statistics` fragment: trailing blank lines are stripped and the plugin-version row is appended immediately before the section close marker.
 - **(c)** Full fragments: all 8 slugs have populated content.
 - **(d)** Missing `anchor-section-markers.sh` helper: `FAILED=true` + `ERROR=missing helper: …` on stdout + exit 1.
 - **(e)** Invalid `--issue` value (non-integer): usage error with exit 1.

--- a/scripts/assemble-anchor.sh
+++ b/scripts/assemble-anchor.sh
@@ -11,8 +11,12 @@
 # carries one extra italic-markdown line between the first-line HTML marker
 # and the first <!-- section:... --> open marker so the comment renders
 # non-empty in GitHub's UI. Populated runs (any fragment with at least one
-# non-whitespace byte) suppress the placeholder and are byte-for-byte
-# unchanged. See scripts/assemble-anchor.md "Seed-only visible placeholder".
+# non-whitespace byte) suppress the placeholder; populated content is emitted
+# byte-for-byte for every section EXCEPT run-statistics, which is normalized
+# (trailing blank lines stripped, any pre-existing trailing `| larch plugin
+# version | ... |` rows dropped) and a fresh canonical version row is
+# appended. See scripts/assemble-anchor.md "Seed-only visible placeholder"
+# and "Run Statistics version-row injection".
 #
 # Consumers:
 #   - skills/implement/SKILL.md Step 0.5 (Branch 2/3 adoption seed body, Branch 4
@@ -79,22 +83,37 @@ fail_io() {
 emit_run_statistics() {
     fragment="$1"
 
+    normalized=""
     if [ -f "$fragment" ] && grep -q '[^[:space:]]' "$fragment" 2>/dev/null; then
-        # Emit populated run-statistics content with trailing blank lines removed,
-        # then append the auto-captured plugin version as the final table row.
-        awk '
+        # Emit populated run-statistics content with trailing blank lines
+        # AND trailing pre-existing `| larch plugin version | ... |` rows
+        # stripped, then append the freshly-captured plugin version as the
+        # canonical final table row. Stripping pre-existing version rows
+        # prevents duplicates when the run-statistics fragment was hydrated
+        # from a prior anchor body that already carried an injected row
+        # (closes #348-Phase5-resume duplicate-row regression).
+        normalized=$(awk '
             { lines[NR] = $0 }
             END {
                 last = NR
-                while (last > 0 && lines[last] ~ /^[[:space:]]*$/) {
+                while (last > 0 && (lines[last] ~ /^[[:space:]]*$/ || lines[last] ~ /^[[:space:]]*\|[[:space:]]*larch plugin version[[:space:]]*\|/)) {
                     last--
                 }
                 for (i = 1; i <= last; i++) {
                     print lines[i]
                 }
             }
-        ' "$fragment" || fail_io "failed to read fragment: $fragment"
+        ' "$fragment") || fail_io "failed to read fragment: $fragment"
+    fi
+
+    if [ -n "$normalized" ]; then
+        printf '%s\n' "$normalized"
     else
+        # Seed case OR populated fragment whose interior normalized down to
+        # nothing (e.g. a fragment that contained only a stale version row
+        # that the strip loop above removed). Either way the output needs a
+        # complete table scaffold so the appended version row renders as a
+        # well-formed table.
         printf '## Run Statistics\n\n'
         printf '| Metric | Value |\n'
         printf '|---|---|\n'
@@ -171,7 +190,8 @@ done
 # in GitHub's UI; emit one visible markdown line in that case so the seed
 # anchor is not blank between Step 0.5 plant and the first progressive
 # upsert. Populated runs (any fragment with at least one non-whitespace
-# byte) are byte-for-byte unchanged.
+# byte) are byte-for-byte unchanged for every section EXCEPT run-statistics,
+# which is normalized via emit_run_statistics (see above).
 ALL_EMPTY=true
 for slug in "${SECTION_MARKERS[@]}"; do
     fragment="$SECTIONS_DIR/$slug.md"

--- a/scripts/assemble-anchor.sh
+++ b/scripts/assemble-anchor.sh
@@ -43,6 +43,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MARKERS_HELPER="$SCRIPT_DIR/anchor-section-markers.sh"
+PLUGIN_VERSION_HELPER="$SCRIPT_DIR/read-plugin-version.sh"
 
 if [ ! -f "$MARKERS_HELPER" ]; then
     echo "FAILED=true"
@@ -54,6 +55,15 @@ fi
 # shellcheck disable=SC1091
 source "$MARKERS_HELPER"
 
+PLUGIN_VERSION="unknown"
+if [ -x "$PLUGIN_VERSION_HELPER" ]; then
+    version_stdout="$("$PLUGIN_VERSION_HELPER" 2>/dev/null || true)"
+    if version_line="$(printf '%s\n' "$version_stdout" | grep -m 1 '^LARCH_PLUGIN_VERSION=' 2>/dev/null)"; then
+        PLUGIN_VERSION="${version_line#LARCH_PLUGIN_VERSION=}"
+        [ -n "$PLUGIN_VERSION" ] || PLUGIN_VERSION="unknown"
+    fi
+fi
+
 fail_usage() {
     echo "FAILED=true"
     echo "ERROR=usage: $1"
@@ -64,6 +74,33 @@ fail_io() {
     echo "FAILED=true"
     echo "ERROR=$1"
     exit 2
+}
+
+emit_run_statistics() {
+    fragment="$1"
+
+    if [ -f "$fragment" ] && grep -q '[^[:space:]]' "$fragment" 2>/dev/null; then
+        # Emit populated run-statistics content with trailing blank lines removed,
+        # then append the auto-captured plugin version as the final table row.
+        awk '
+            { lines[NR] = $0 }
+            END {
+                last = NR
+                while (last > 0 && lines[last] ~ /^[[:space:]]*$/) {
+                    last--
+                }
+                for (i = 1; i <= last; i++) {
+                    print lines[i]
+                }
+            }
+        ' "$fragment" || fail_io "failed to read fragment: $fragment"
+    else
+        printf '## Run Statistics\n\n'
+        printf '| Metric | Value |\n'
+        printf '|---|---|\n'
+    fi
+
+    printf '| larch plugin version | %s |\n' "$PLUGIN_VERSION"
 }
 
 SECTIONS_DIR=""
@@ -157,7 +194,9 @@ trap 'rm -f "$TMP_OUTPUT"' EXIT
     for slug in "${SECTION_MARKERS[@]}"; do
         fragment="$SECTIONS_DIR/$slug.md"
         printf '<!-- section:%s -->\n' "$slug"
-        if [ -f "$fragment" ]; then
+        if [ "$slug" = "run-statistics" ]; then
+            emit_run_statistics "$fragment"
+        elif [ -f "$fragment" ]; then
             # Fragment content emitted verbatim; caller owns compose-time sanitization.
             # cat preserves trailing-newline semantics as authored by the caller.
             # Fail closed on read error so a permission-denied fragment cannot

--- a/scripts/read-plugin-version.md
+++ b/scripts/read-plugin-version.md
@@ -1,0 +1,41 @@
+# read-plugin-version.sh contract
+
+## Purpose
+
+Read the larch plugin version from `${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json` and emit a single `LARCH_PLUGIN_VERSION=<value>` line for anchor-comment metadata. If `CLAUDE_PLUGIN_ROOT` is unset, the helper computes the plugin root from its own location (`scripts/..`).
+
+The helper is best-effort by design: missing `jq`, missing or unreadable `plugin.json`, malformed JSON, null/missing `version`, or path-resolution failures all produce `LARCH_PLUGIN_VERSION=unknown`.
+
+## Interface
+
+```
+read-plugin-version.sh
+```
+
+No flags are accepted. The optional environment variable `CLAUDE_PLUGIN_ROOT` overrides the computed root.
+
+## Output contract
+
+```
+LARCH_PLUGIN_VERSION=<value>
+```
+
+The helper always exits 0. Callers must treat the value as display metadata only.
+
+## Invariants
+
+- Do not fail callers because plugin-version metadata is unavailable.
+- Do not edit `.claude-plugin/plugin.json`; this script is read-only and `.claude-plugin/plugin.json` remains owned by `/bump-version`.
+- Emit exactly one stdout line so shell callers can parse it without `eval`.
+
+## Edit-in-sync pointers
+
+| File | Relationship |
+|---|---|
+| `scripts/assemble-anchor.sh` | Primary caller; injects the emitted version into the anchor comment's `run-statistics` section. |
+| `scripts/test-assemble-anchor.sh` | Regression harness for seed, populated-fragment, and missing-root fallback behavior. |
+| `skills/implement/references/anchor-comment-template.md` | Human-readable anchor template documenting the auto-injected row. |
+
+## Test harness
+
+Covered by `scripts/test-assemble-anchor.sh`, which is wired into `make test-harnesses` and available standalone via `make test-assemble-anchor`.

--- a/scripts/read-plugin-version.sh
+++ b/scripts/read-plugin-version.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# read-plugin-version.sh — best-effort larch plugin version reader.
+#
+# Intentionally omits `set -e`: this helper is diagnostic metadata plumbing and
+# must always emit a fallback value instead of failing its caller.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd || printf '.')"
+DEFAULT_PLUGIN_ROOT="$(cd "$SCRIPT_DIR/.." 2>/dev/null && pwd || printf '.')"
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$DEFAULT_PLUGIN_ROOT}"
+PLUGIN_JSON="$PLUGIN_ROOT/.claude-plugin/plugin.json"
+
+VERSION="unknown"
+
+if command -v jq >/dev/null 2>&1 && [ -f "$PLUGIN_JSON" ] && [ -r "$PLUGIN_JSON" ]; then
+    parsed="$(jq -r '.version // "unknown"' "$PLUGIN_JSON" 2>/dev/null || true)"
+    parsed="${parsed%%$'\n'*}"
+    parsed="${parsed%%$'\r'*}"
+    if [ -n "$parsed" ] && [ "$parsed" != "null" ]; then
+        VERSION="$parsed"
+    fi
+fi
+
+printf 'LARCH_PLUGIN_VERSION=%s\n' "$VERSION"
+exit 0

--- a/scripts/test-assemble-anchor.md
+++ b/scripts/test-assemble-anchor.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Regression harness for `scripts/assemble-anchor.sh`. Covers 16 assertion categories pinned by the sibling `scripts/assemble-anchor.md` contract file: empty sections directory (line-count, line-walk, placeholder presence, injected plugin-version row), partial fragments and whitespace-only fragments (placeholder gating), nonexistent `--sections-dir` (placeholder fires for missing dir), missing plugin root fallback, exact line-shape around a newline-terminated fragment, line-shape around a no-trailing-newline fragment, populated run-statistics injection, full fragments, missing-helper failure, invalid-`--issue` usage error, first-line marker exactness, non-directory `--sections-dir` fail-closed, and unreadable-fragment fail-closed.
+Regression harness for `scripts/assemble-anchor.sh`. Covers 18 assertion categories pinned by the sibling `scripts/assemble-anchor.md` contract file: empty sections directory (line-count, line-walk, placeholder presence, injected plugin-version row), partial fragments and whitespace-only fragments (placeholder gating), nonexistent `--sections-dir` (placeholder fires for missing dir), missing plugin root fallback, exact line-shape around a newline-terminated fragment, line-shape around a no-trailing-newline fragment, populated run-statistics injection, hydrated run-statistics dedup (resume idempotency), populated-but-normalized-to-empty seed-scaffold fallback, full fragments, missing-helper failure, invalid-`--issue` usage error, first-line marker exactness, non-directory `--sections-dir` fail-closed, and unreadable-fragment fail-closed.
 
 ## Assertion catalog
 
@@ -16,6 +16,8 @@ Regression harness for `scripts/assemble-anchor.sh`. Covers 16 assertion categor
 - **(b2)** Newline-terminated fragment → exactly one newline before the close marker (regression guard for the pre-fix `$(tail -c 1 ...)` command-substitution newline-stripping bug, which inserted an extra blank line for every populated fragment). Full output compared against a byte-exact expected fixture.
 - **(b3)** Fragment without a trailing newline → helper inserts the missing newline so the close marker still appears on its own line; fragment content and close marker do not run together on the same line.
 - **(b4)** Populated `run-statistics` fragment: trailing blank lines are stripped and the plugin-version row is appended immediately before the section close marker.
+- **(b5)** Hydrated `run-statistics` fragment whose interior already ends with a stale `| larch plugin version | <X.Y.Z> |` row: the stale trailing version row is stripped before a freshly-captured row is appended, producing exactly one plugin-version row in the output. Regression guard against the resume / hydration duplicate-row case.
+- **(b6)** Populated `run-statistics` fragment whose entire content is a single stale version row (no `## Run Statistics` heading, no table header) normalizes down to empty after the strip loop. The helper falls through to the seed-style scaffold so the assembled section is a well-formed table (heading + header + fresh version row) instead of an orphan row.
 - **(c)** Full fragments: all 8 slugs populated and emitted.
 - **(d)** Missing `anchor-section-markers.sh` helper: running a copy of `assemble-anchor.sh` in a fake tree without the helper emits `FAILED=true` + `ERROR=missing helper: ...` on stdout and exits 1.
 - **(e)** Invalid `--issue` value (non-integer): emits `FAILED=true` + `ERROR=usage: invalid value for --issue ...` on stdout and exits 1.

--- a/scripts/test-assemble-anchor.md
+++ b/scripts/test-assemble-anchor.md
@@ -2,18 +2,20 @@
 
 ## Purpose
 
-Regression harness for `scripts/assemble-anchor.sh`. Covers 14 assertion categories pinned by the sibling `scripts/assemble-anchor.md` contract file: empty sections directory (line-count, line-walk, placeholder presence), partial fragments and whitespace-only fragments (placeholder gating), nonexistent `--sections-dir` (placeholder fires for missing dir), exact line-shape around a newline-terminated fragment, line-shape around a no-trailing-newline fragment, full fragments, missing-helper failure, invalid-`--issue` usage error, first-line marker exactness, non-directory `--sections-dir` fail-closed, and unreadable-fragment fail-closed.
+Regression harness for `scripts/assemble-anchor.sh`. Covers 16 assertion categories pinned by the sibling `scripts/assemble-anchor.md` contract file: empty sections directory (line-count, line-walk, placeholder presence, injected plugin-version row), partial fragments and whitespace-only fragments (placeholder gating), nonexistent `--sections-dir` (placeholder fires for missing dir), missing plugin root fallback, exact line-shape around a newline-terminated fragment, line-shape around a no-trailing-newline fragment, populated run-statistics injection, full fragments, missing-helper failure, invalid-`--issue` usage error, first-line marker exactness, non-directory `--sections-dir` fail-closed, and unreadable-fragment fail-closed.
 
 ## Assertion catalog
 
-- **(a)** Empty sections directory: output has exactly `2 + 2*N` lines (anchor first-line marker + seed-only visible placeholder line + `N` empty marker pairs, where `N = |SECTION_MARKERS|`). Marker pairs appear in `SECTION_MARKERS` order, starting at line 3. Pinned line-2 literal: `_/implement run in progress — sections below populate as the run proceeds._`.
+- **(a)** Empty sections directory: output has exactly `2 + 2*N + 5` lines (anchor first-line marker + seed-only visible placeholder line + `N` marker pairs, where `N = |SECTION_MARKERS|`, plus the injected minimal run-statistics table interior). Marker pairs appear in `SECTION_MARKERS` order, starting at line 3. Pinned line-2 literal: `_/implement run in progress — sections below populate as the run proceeds._`.
 - **(a2)** Empty sections directory: explicit regression guard that the seed-only visible placeholder literal is present in the output (issue #431).
 - **(a3)** Partial fragments (one slug populated with non-whitespace content): the placeholder is suppressed — the gate fires only on the all-empty seed.
 - **(a4)** All fragments populated with whitespace-only content (newlines, spaces, tabs): the placeholder still fires (lenient predicate per dialectic DECISION_1).
 - **(a5)** Nonexistent `--sections-dir`: `ASSEMBLED=true` and the placeholder fires; the all-empty pre-pass treats a missing directory the same as an empty one.
+- **(a6)** Missing `CLAUDE_PLUGIN_ROOT` target: the injected plugin-version row falls back to literal `unknown`.
 - **(b)** Partial fragments: populated content appears only where fragment files exist; empty marker pairs elsewhere. Order preserves `SECTION_MARKERS` indexing (`diagrams` before `version-bump-reasoning`).
 - **(b2)** Newline-terminated fragment → exactly one newline before the close marker (regression guard for the pre-fix `$(tail -c 1 ...)` command-substitution newline-stripping bug, which inserted an extra blank line for every populated fragment). Full output compared against a byte-exact expected fixture.
 - **(b3)** Fragment without a trailing newline → helper inserts the missing newline so the close marker still appears on its own line; fragment content and close marker do not run together on the same line.
+- **(b4)** Populated `run-statistics` fragment: trailing blank lines are stripped and the plugin-version row is appended immediately before the section close marker.
 - **(c)** Full fragments: all 8 slugs populated and emitted.
 - **(d)** Missing `anchor-section-markers.sh` helper: running a copy of `assemble-anchor.sh` in a fake tree without the helper emits `FAILED=true` + `ERROR=missing helper: ...` on stdout and exits 1.
 - **(e)** Invalid `--issue` value (non-integer): emits `FAILED=true` + `ERROR=usage: invalid value for --issue ...` on stdout and exits 1.

--- a/scripts/test-assemble-anchor.sh
+++ b/scripts/test-assemble-anchor.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # test-assemble-anchor.sh — regression harness for scripts/assemble-anchor.sh.
 #
-# Covers 16 assertion categories:
+# Covers 18 assertion categories:
 #   (a) Empty sections directory → 7 empty marker pairs + run-statistics
 #       minimal table + first-line marker + seed-only visible placeholder
 #       line on line 2 (23 lines total).
@@ -24,6 +24,13 @@
 #       close marker still appears on its own line.
 #   (b4) Populated run-statistics fragment → trailing blank lines are
 #       stripped and plugin-version row is appended as the final table row.
+#   (b5) Hydrated run-statistics fragment with a stale plugin-version row →
+#       the stale trailing version row is stripped before the freshly-
+#       captured one is appended (idempotency on resume / hydration).
+#   (b6) Populated fragment whose entire content normalizes to empty (e.g.
+#       a single stale version row, no heading/header) → fall through to
+#       the seed-style scaffold (heading + table header + fresh version row)
+#       instead of emitting an orphan row.
 #   (c) Full fragments → all 8 slugs populated.
 #   (d) Missing anchor-section-markers.sh helper → FAILED=true / ERROR=missing
 #       helper + exit 1.
@@ -335,6 +342,72 @@ prev_line=$(sed -n "$((version_line_num - 1))p" "$output_b4")
 [ "$prev_line" = '| OOS issues filed | 2 |' ] \
     || fail "(b4) trailing blank lines were not stripped before plugin-version row (previous line: '$prev_line')"
 pass "(b4) populated run-statistics fragment → strip trailing blanks and append plugin-version row"
+
+# --------------------------------------------------------------------------
+# (b5) Hydration / resume idempotency: a populated run-statistics fragment
+#      that ALREADY ends with a `| larch plugin version | ... |` row (the
+#      shape produced by a prior assembly that the next session hydrated
+#      back into run-statistics.md) must not produce duplicate version rows.
+#      The injection helper strips trailing pre-existing version rows AND
+#      blank lines, then appends a single freshly-captured row.
+# --------------------------------------------------------------------------
+sections_b5="$tmpdir/sections-b5"
+mkdir -p "$sections_b5"
+{
+    printf '## Run Statistics\n\n'
+    printf '| Metric | Value |\n'
+    printf '|---|---|\n'
+    printf '| OOS issues filed | 4 |\n'
+    printf '| larch plugin version | 1.2.3 |\n'
+    printf '\n'
+} > "$sections_b5/run-statistics.md"
+
+output_b5="$tmpdir/out-b5.md"
+"$ASSEMBLE_ANCHOR" --sections-dir "$sections_b5" --issue 503 --output "$output_b5" > /dev/null
+
+# Exactly one plugin-version row, value 9.8.7 (the test fixture's CLAUDE_PLUGIN_ROOT).
+total_version_rows=$(grep -cE '^\| larch plugin version \|' "$output_b5")
+[ "$total_version_rows" = "1" ] \
+    || fail "(b5) expected exactly 1 plugin-version row, got $total_version_rows (content: $(cat "$output_b5"))"
+grep -qF '| larch plugin version | 9.8.7 |' "$output_b5" \
+    || fail "(b5) plugin-version row should carry the freshly-captured 9.8.7 value, not the hydrated 1.2.3"
+if grep -qF '| larch plugin version | 1.2.3 |' "$output_b5"; then
+    fail "(b5) stale hydrated plugin-version row should have been stripped"
+fi
+pass "(b5) hydrated run-statistics fragment with stale version row → strip stale row, single fresh row appended"
+
+# --------------------------------------------------------------------------
+# (b6) Empty-after-normalization fallback: a populated run-statistics
+#      fragment whose entire content is a single stale version row (no
+#      `## Run Statistics` heading, no table header) normalizes down to
+#      empty after the strip loop. The helper must fall through to the
+#      seed-style scaffold (heading + table header + version row) so the
+#      assembled section is well-formed instead of an orphan row.
+# --------------------------------------------------------------------------
+sections_b6="$tmpdir/sections-b6"
+mkdir -p "$sections_b6"
+printf '| larch plugin version | 0.0.1 |\n' > "$sections_b6/run-statistics.md"
+
+output_b6="$tmpdir/out-b6.md"
+"$ASSEMBLE_ANCHOR" --sections-dir "$sections_b6" --issue 504 --output "$output_b6" > /dev/null
+
+# The output must include the seed-style heading and table header.
+grep -qxF '## Run Statistics' "$output_b6" \
+    || fail "(b6) missing '## Run Statistics' heading after empty-normalization fallback"
+grep -qxF '| Metric | Value |' "$output_b6" \
+    || fail "(b6) missing table header after empty-normalization fallback"
+grep -qxF '|---|---|' "$output_b6" \
+    || fail "(b6) missing table separator after empty-normalization fallback"
+# Exactly one fresh version row, value 9.8.7.
+total_version_rows_b6=$(grep -cE '^\| larch plugin version \|' "$output_b6")
+[ "$total_version_rows_b6" = "1" ] \
+    || fail "(b6) expected exactly 1 plugin-version row, got $total_version_rows_b6"
+grep -qF '| larch plugin version | 9.8.7 |' "$output_b6" \
+    || fail "(b6) version row should carry the freshly-captured value (9.8.7)"
+if grep -qF '| larch plugin version | 0.0.1 |' "$output_b6"; then
+    fail "(b6) stale version row should have been stripped"
+fi
+pass "(b6) populated fragment normalized to empty → seed-style scaffold + fresh version row"
 
 # --------------------------------------------------------------------------
 # (c) Full fragments — all 8 slugs populated

--- a/scripts/test-assemble-anchor.sh
+++ b/scripts/test-assemble-anchor.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 # test-assemble-anchor.sh — regression harness for scripts/assemble-anchor.sh.
 #
-# Covers 14 assertion categories:
-#   (a) Empty sections directory → 8 empty marker pairs + first-line marker
-#       + seed-only visible placeholder line on line 2 (18 lines total).
+# Covers 16 assertion categories:
+#   (a) Empty sections directory → 7 empty marker pairs + run-statistics
+#       minimal table + first-line marker + seed-only visible placeholder
+#       line on line 2 (23 lines total).
 #   (a2) Empty sections directory → placeholder literal present (regression
 #       guard for the seed-only visibility fix).
 #   (a3) Partial fragments (one slug populated) → placeholder is suppressed
@@ -12,6 +13,8 @@
 #       predicate per dialectic DECISION_1).
 #   (a5) Nonexistent --sections-dir → ASSEMBLED=true and placeholder still
 #       fires (the all-empty pre-pass treats missing directory as all-empty).
+#   (a6) Missing CLAUDE_PLUGIN_ROOT target → plugin version falls back to
+#       literal unknown.
 #   (b) Partial fragments → populated where present, empty pairs elsewhere,
 #       in SECTION_MARKERS order.
 #   (b2) Newline-terminated fragment → exactly one newline before the close
@@ -19,6 +22,8 @@
 #       substitution newline-stripping bug).
 #   (b3) Fragment without trailing newline → helper inserts newline so the
 #       close marker still appears on its own line.
+#   (b4) Populated run-statistics fragment → trailing blank lines are
+#       stripped and plugin-version row is appended as the final table row.
 #   (c) Full fragments → all 8 slugs populated.
 #   (d) Missing anchor-section-markers.sh helper → FAILED=true / ERROR=missing
 #       helper + exit 1.
@@ -53,6 +58,11 @@ source "$MARKERS_HELPER"
 tmpdir="$(mktemp -d -t assemble-anchor-test-XXXXXX)"
 trap 'rm -rf "$tmpdir"' EXIT
 
+plugin_root="$tmpdir/plugin-root"
+mkdir -p "$plugin_root/.claude-plugin"
+printf '{"version":"9.8.7"}\n' > "$plugin_root/.claude-plugin/plugin.json"
+export CLAUDE_PLUGIN_ROOT="$plugin_root"
+
 fail() {
     echo "FAIL: $1" >&2
     exit 1
@@ -80,12 +90,14 @@ grep -qxF "OUTPUT=$output_a" <<<"$stdout_a" \
 
 [ -f "$output_a" ] || fail "(a) output file not created"
 
-# Expected: first-line anchor marker + seed-only placeholder line + N marker pairs.
+# Expected: first-line anchor marker + seed-only placeholder line + N marker
+# pairs, with the run-statistics pair wrapping its injected minimal table.
 PLACEHOLDER_LINE='_/implement run in progress — sections below populate as the run proceeds._'
 expected_lines_a=2  # first-line marker + placeholder line
 for _ in "${SECTION_MARKERS[@]}"; do
     expected_lines_a=$((expected_lines_a + 2))  # open + close marker pair
 done
+expected_lines_a=$((expected_lines_a + 5))  # run-statistics table interior
 actual_lines_a=$(wc -l < "$output_a" | tr -d ' ')
 [ "$actual_lines_a" = "$expected_lines_a" ] \
     || fail "(a) expected $expected_lines_a lines, got $actual_lines_a; content: $(cat "$output_a")"
@@ -102,14 +114,27 @@ line2=$(sed -n '2p' "$output_a")
 line_num=3
 for slug in "${SECTION_MARKERS[@]}"; do
     open_line=$(sed -n "${line_num}p" "$output_a")
-    close_line=$(sed -n "$((line_num + 1))p" "$output_a")
     [ "$open_line" = "<!-- section:$slug -->" ] \
         || fail "(a) line $line_num: expected '<!-- section:$slug -->', got '$open_line'"
-    [ "$close_line" = "<!-- section-end:$slug -->" ] \
-        || fail "(a) line $((line_num + 1)): expected '<!-- section-end:$slug -->', got '$close_line'"
-    line_num=$((line_num + 2))
+    if [ "$slug" = "run-statistics" ]; then
+        sed -n "$((line_num + 1))p" "$output_a" | grep -qxF '## Run Statistics' \
+            || fail "(a) run-statistics missing section heading"
+        sed -n "$((line_num + 3))p" "$output_a" | grep -qxF '| Metric | Value |' \
+            || fail "(a) run-statistics missing table header"
+        sed -n "$((line_num + 5))p" "$output_a" | grep -qxF '| larch plugin version | 9.8.7 |' \
+            || fail "(a) run-statistics missing injected plugin version row"
+        close_line=$(sed -n "$((line_num + 6))p" "$output_a")
+        [ "$close_line" = "<!-- section-end:$slug -->" ] \
+            || fail "(a) line $((line_num + 6)): expected '<!-- section-end:$slug -->', got '$close_line'"
+        line_num=$((line_num + 7))
+    else
+        close_line=$(sed -n "$((line_num + 1))p" "$output_a")
+        [ "$close_line" = "<!-- section-end:$slug -->" ] \
+            || fail "(a) line $((line_num + 1)): expected '<!-- section-end:$slug -->', got '$close_line'"
+        line_num=$((line_num + 2))
+    fi
 done
-pass "(a) empty sections directory → anchor marker + placeholder + 8 empty marker pairs in SECTION_MARKERS order"
+pass "(a) empty sections directory → anchor marker + placeholder + marker pairs + injected run-statistics version row"
 
 # --------------------------------------------------------------------------
 # (a2) Empty sections directory → placeholder literal present (regression
@@ -173,6 +198,19 @@ actual_lines_a5=$(wc -l < "$output_a5" | tr -d ' ')
 pass "(a5) nonexistent --sections-dir → assembled with placeholder, $expected_lines_a lines"
 
 # --------------------------------------------------------------------------
+# (a6) Missing CLAUDE_PLUGIN_ROOT target → version row falls back to unknown.
+# --------------------------------------------------------------------------
+sections_a6="$tmpdir/sections-a6"
+mkdir -p "$sections_a6"
+output_a6="$tmpdir/out-a6.md"
+CLAUDE_PLUGIN_ROOT="$tmpdir/missing-plugin-root" \
+    "$ASSEMBLE_ANCHOR" --sections-dir "$sections_a6" --issue 46 --output "$output_a6" > /dev/null
+
+grep -Fxq '| larch plugin version | unknown |' "$output_a6" \
+    || fail "(a6) missing plugin root should inject unknown plugin version"
+pass "(a6) missing CLAUDE_PLUGIN_ROOT target → plugin version row falls back to unknown"
+
+# --------------------------------------------------------------------------
 # (b) Partial fragments — populate only version-bump-reasoning and diagrams
 # --------------------------------------------------------------------------
 sections_b="$tmpdir/sections-b"
@@ -231,10 +269,16 @@ expected_b2="$tmpdir/expected-b2.md"
     printf '<!-- section:plan-goals-test -->\n'
     printf 'line one\nline two\n'
     printf '<!-- section-end:plan-goals-test -->\n'
-    for slug in plan-review-tally code-review-tally diagrams version-bump-reasoning oos-issues execution-issues run-statistics; do
+    for slug in plan-review-tally code-review-tally diagrams version-bump-reasoning oos-issues execution-issues; do
         printf '<!-- section:%s -->\n' "$slug"
         printf '<!-- section-end:%s -->\n' "$slug"
     done
+    printf '<!-- section:run-statistics -->\n'
+    printf '## Run Statistics\n\n'
+    printf '| Metric | Value |\n'
+    printf '|---|---|\n'
+    printf '| larch plugin version | 9.8.7 |\n'
+    printf '<!-- section-end:run-statistics -->\n'
 } > "$expected_b2"
 
 if ! diff -q "$output_b2" "$expected_b2" > /dev/null; then
@@ -264,6 +308,33 @@ if grep -qF 'here<!-- section-end:plan-goals-test -->' "$output_b3"; then
     fail "(b3) fragment content runs into close marker — missing newline insertion"
 fi
 pass "(b3) fragment without trailing newline → newline inserted before close marker"
+
+# --------------------------------------------------------------------------
+# (b4) Populated run-statistics fragment → strip trailing blank lines and
+#      append plugin-version row as the final table row.
+# --------------------------------------------------------------------------
+sections_b4="$tmpdir/sections-b4"
+mkdir -p "$sections_b4"
+{
+    printf '## Run Statistics\n\n'
+    printf '| Metric | Value |\n'
+    printf '|---|---|\n'
+    printf '| OOS issues filed | 2 |\n'
+    printf '\n\n'
+} > "$sections_b4/run-statistics.md"
+
+output_b4="$tmpdir/out-b4.md"
+"$ASSEMBLE_ANCHOR" --sections-dir "$sections_b4" --issue 502 --output "$output_b4" > /dev/null
+
+version_line_num=$(grep -nF '| larch plugin version | 9.8.7 |' "$output_b4" | head -n 1 | cut -d: -f1)
+close_line_num=$(grep -nF '<!-- section-end:run-statistics -->' "$output_b4" | head -n 1 | cut -d: -f1)
+[ -n "$version_line_num" ] || fail "(b4) missing injected plugin-version row"
+[ "$version_line_num" = "$((close_line_num - 1))" ] \
+    || fail "(b4) plugin-version row should be immediately before run-statistics close marker"
+prev_line=$(sed -n "$((version_line_num - 1))p" "$output_b4")
+[ "$prev_line" = '| OOS issues filed | 2 |' ] \
+    || fail "(b4) trailing blank lines were not stripped before plugin-version row (previous line: '$prev_line')"
+pass "(b4) populated run-statistics fragment → strip trailing blanks and append plugin-version row"
 
 # --------------------------------------------------------------------------
 # (c) Full fragments — all 8 slugs populated

--- a/skills/implement/references/anchor-comment-template.md
+++ b/skills/implement/references/anchor-comment-template.md
@@ -124,6 +124,7 @@ This line is suppressed as soon as any fragment contains a non-whitespace byte â
 | Findings rejected | <N> |
 | CI wait duration | <mm:ss> |
 | Rebase count | <N> |
+| larch plugin version | <auto-injected from `.claude-plugin/plugin.json`, or `unknown`> |
 
 <!-- section-end:run-statistics -->
 ````
@@ -211,6 +212,7 @@ This is a defense-in-depth layer above `scripts/redact-secrets.sh`'s outbound sc
 | `scripts/anchor-section-markers.sh` | Single source of truth for the `SECTION_MARKERS` array (sourced by `tracking-issue-write.sh` and `assemble-anchor.sh`); slug set must match the list here. |
 | `scripts/tracking-issue-write.sh` | Inline `COLLAPSE_PRIORITY` array must be a permutation of the slug list here (same set, body-cap collapse priority order). Enforced by a test-harness invariant in `scripts/test-tracking-issue-write.sh`. |
 | `scripts/assemble-anchor.sh` | Consumes `SECTION_MARKERS` via the shared helper; emits marker pairs and the first-line HTML marker documented here. |
+| `scripts/read-plugin-version.sh` | Supplies the best-effort larch plugin version row auto-injected into `run-statistics`. |
 | `scripts/tracking-issue-read.sh` | Anchor-marker filter uses the same strict `<!-- larch:implement-anchor v1` prefix. |
 | `skills/implement/references/pr-body-template.md` | Sibling slim-projection template for the PR body (Summary + Diagrams + Test plan + `Closes #<N>` + footer only); Phase 3+ the anchor comment is canonical for rich content. |
 | `scripts/test-implement-structure.sh` | Phase 3 test-harness assertion (9a) pins the three load-bearing literals here (`Accepted OOS (GitHub issues filed)`, `\| OOS issues filed \|`, `<details><summary>Execution Issues</summary>`); assertion (9b) pins a â‰¥3 reference floor for `anchor-comment-template.md` in SKILL.md; assertion (9d) pins the Step 9a.1 procedure flag contract (must document `--title-prefix "[OOS]"`; must not pass any `--label` flag; must document `--blocked-by-issue $ISSUE_NUMBER` forwarding only when `$ISSUE_NUMBER` is set, `deferred=false`, and `repo_unavailable=false`, with the explicit degraded-mode skip rule); assertion (9e) pins `--intra-batch-deps-file` forwarding in this procedure; assertion (9f) pins the literal `oos-combined.md` (combine-pass output path consumed by `oos-file-conflict-deps.sh` and `/issue --input-file`) in this procedure; assertion (9g) pins `oos-issue-cap.sh`, `OOS_ISSUES_PER_RUN_CAP`, the fail-closed warning string, and the step 3.5 / step 4 skip wording for the per-run cap pre-pass. |


### PR DESCRIPTION
## Summary

- Inject the larch plugin version into the `/implement` tracking-issue anchor under the existing `run-statistics` section, captured once per assembly via a new `scripts/read-plugin-version.sh` helper. The version is visible from the seed plant at Step 0.5 onward, no new section marker introduced.
- `scripts/assemble-anchor.sh` special-cases the `run-statistics` slug: seed and populated cases both end up well-formed; trailing blank lines and any pre-existing `| larch plugin version | … |` rows are stripped before a freshly-captured row is appended, keeping the assembler idempotent across hydration / resume so duplicate version rows never accumulate.
- Regression harness `scripts/test-assemble-anchor.sh` adds three new assertion blocks — `(b4)` populated-fragment append, `(b5)` hydrated-stale-row dedup, `(b6)` empty-after-normalization scaffold fallback — plus `(a6)` for the `unknown` fallback path; the harness now covers 18 categories.

## Architecture Diagram

Architecture diagram not available.

## Code Flow Diagram

(Code Flow Diagram skipped — quick mode)

## Test plan

- [x] `bash scripts/test-assemble-anchor.sh` — all 18 assertions pass.
- [x] `/relevant-checks` — pre-commit (shellcheck, markdownlint, agent-lint, gitleaks, lint-skill-invocation, lint-literal-counts) + full-repo `agent-lint` clean.
- [x] Verify the version row appears in tracking issue #1313's anchor comment under `## Run Statistics`.
- [x] Verify `unknown` fallback when `CLAUDE_PLUGIN_ROOT` points to a missing path (covered by `(a6)`).
- [x] Verify hydration-resume idempotency: a fragment ending with a stale version row produces exactly one fresh row in the next assembly (covered by `(b5)`).

Closes #1313

🤖 Generated with [Claude Code](https://claude.com/claude-code)
