### PR TITLE
Fold /upgrade-larch verification into a single bash script

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "15.12.47",
+  "version": "15.12.48",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 6-reviewer specialist panel (5 Cursor specialists + 1 Codex generic) — extended to 7 with an optional Gemini reviewer when the Gemini CLI is installed and healthy — with 3-voter adjudication; plan review runs a 3-reviewer panel (Claude + Codex + Cursor); design sketches run a 9-agent diverge-then-converge phase in regular mode (1 Claude + 4 Cursor + 4 Codex) or 3 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [15.12.48] - 2026-05-06
+
+### Changed
+
+- Fold the installed-version listing into `skills/upgrade-larch/scripts/upgrade-larch.sh` so `/upgrade-larch` makes a single Bash invocation instead of two. The script now prints `Installed larch plugin version:` followed by the `claude plugin list | grep -A2 'larch@larch-local'` block (best-effort with `|| true` so listing failures do not turn a successful install into a failed upgrade). Updates `skills/upgrade-larch/SKILL.md`, `skills/upgrade-larch/scripts/upgrade-larch.md`, and `docs/installation-and-setup.md` to describe the version-listing block as best-effort confirmation rather than a gate on the restart instruction.
+
 ## [15.12.47] - 2026-05-06
 
 ### Changed

--- a/docs/installation-and-setup.md
+++ b/docs/installation-and-setup.md
@@ -35,7 +35,7 @@ To upgrade larch to the latest version, run the `/upgrade-larch` skill in any Cl
 /upgrade-larch
 ```
 
-After the skill completes, restart Claude Code to apply the new version.
+After the skill prints the installed version, restart Claude Code to apply the new version.
 
 ## Install for local development (contributors)
 

--- a/docs/installation-and-setup.md
+++ b/docs/installation-and-setup.md
@@ -35,7 +35,7 @@ To upgrade larch to the latest version, run the `/upgrade-larch` skill in any Cl
 /upgrade-larch
 ```
 
-After the skill prints the installed version, restart Claude Code to apply the new version.
+After `/upgrade-larch` finishes, restart Claude Code to apply the new version. The upgrade script prints an installed-version block when `claude plugin list` succeeds; treat it as best-effort confirmation.
 
 ## Install for local development (contributors)
 

--- a/skills/upgrade-larch/SKILL.md
+++ b/skills/upgrade-larch/SKILL.md
@@ -14,14 +14,6 @@ Upgrade the larch plugin to the latest version. This skill is for the standard G
 ${CLAUDE_PLUGIN_ROOT}/skills/upgrade-larch/scripts/upgrade-larch.sh
 ```
 
-2. Verify the upgrade succeeded by checking the installed version:
-
-```bash
-claude plugin list 2>&1 | grep -A2 'larch@larch-local'
-```
-
-Confirm the version line shows the expected latest version.
-
-3. Tell the user to restart Claude Code to apply the new version.
+2. Confirm the script output prints the installed `larch@larch-local` version line, then tell the user to restart Claude Code to apply the new version.
 
 See `${CLAUDE_PLUGIN_ROOT}/skills/upgrade-larch/scripts/upgrade-larch.md` for script contract and failure recovery details.

--- a/skills/upgrade-larch/SKILL.md
+++ b/skills/upgrade-larch/SKILL.md
@@ -14,6 +14,6 @@ Upgrade the larch plugin to the latest version. This skill is for the standard G
 ${CLAUDE_PLUGIN_ROOT}/skills/upgrade-larch/scripts/upgrade-larch.sh
 ```
 
-2. Confirm the script output prints the installed `larch@larch-local` version line, then tell the user to restart Claude Code to apply the new version.
+2. Verify the script exited successfully (no recovery banner printed). If the script printed an `Installed larch plugin version:` block with a `larch@larch-local` line, confirm it matches the expected new version; if the block is empty, the install still succeeded — version-listing is best-effort. Then tell the user to restart Claude Code to apply the new version.
 
 See `${CLAUDE_PLUGIN_ROOT}/skills/upgrade-larch/scripts/upgrade-larch.md` for script contract and failure recovery details.

--- a/skills/upgrade-larch/scripts/upgrade-larch.md
+++ b/skills/upgrade-larch/scripts/upgrade-larch.md
@@ -12,8 +12,9 @@ Automates the full teardown-and-reinstall sequence needed to pick up the latest 
 2. Removes the `larch-local` marketplace (best-effort — may not be registered).
 3. Re-adds the marketplace from `character-ai/larch` on GitHub.
 4. Installs the `larch` plugin from the freshly-added marketplace.
+5. Prints the installed `larch@larch-local` version block for visual confirmation.
 
-Steps 1–2 use `|| true` because the plugin/marketplace may not exist (first install, or already removed). Steps 3–4 run under `set -e` and will fail loudly on network errors, auth issues, or CLI problems. On failure after teardown, the script prints recovery commands so the user can manually re-add.
+Steps 1–2 use `|| true` because the plugin/marketplace may not exist (first install, or already removed). Steps 3–4 run under `set -e` and will fail loudly on network errors, auth issues, or CLI problems. Step 5 also uses `|| true` so an unexpected `claude plugin list` failure or missing `larch@larch-local` line does not turn a successful install into a failed upgrade. On failure after teardown, the script prints recovery commands so the user can manually re-add.
 
 ## Edit-in-sync
 

--- a/skills/upgrade-larch/scripts/upgrade-larch.sh
+++ b/skills/upgrade-larch/scripts/upgrade-larch.sh
@@ -22,4 +22,8 @@ echo "Installing larch plugin..."
 claude plugin install larch@larch-local 2>&1
 
 echo ""
+echo "Installed larch plugin version:"
+claude plugin list 2>&1 | grep -A2 'larch@larch-local' || true
+
+echo ""
 echo "Upgrade complete. Restart Claude Code to apply the new version."


### PR DESCRIPTION
## Summary

- Fold the installed-version listing into `skills/upgrade-larch/scripts/upgrade-larch.sh` so `/upgrade-larch` makes a single Bash invocation instead of two.
- Reword `skills/upgrade-larch/SKILL.md` step 2 and `docs/installation-and-setup.md` to describe the printed version block as best-effort confirmation rather than a gate on the restart instruction.
- Document the new step in `skills/upgrade-larch/scripts/upgrade-larch.md` along with the `|| true` rationale.

## Architecture Diagram

Architecture diagram not available.

## Code Flow Diagram

(Code Flow Diagram skipped — quick mode)

## Test plan

- [x] `/relevant-checks` — passed (pre-commit + agent-lint full-repo)
- [ ] Manual: run `/upgrade-larch` and confirm a single Bash invocation, with the script printing the `Installed larch plugin version:` block when `claude plugin list` succeeds.

Closes #1332

🤖 Generated with [Claude Code](https://claude.com/claude-code)
