### PR TITLE
Resolve #1356: token-report presentation refactor (split tables, drop Claude total)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "15.12.60",
+  "version": "15.12.61",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 6-reviewer specialist panel (5 Cursor specialists + 1 Codex generic) — extended to 7 with an optional Gemini reviewer when the Gemini CLI is installed and healthy — with 3-voter adjudication; plan review runs a 3-reviewer panel (Claude + Codex + Cursor); design sketches run a 9-agent diverge-then-converge phase in regular mode (1 Claude + 4 Cursor + 4 Codex) or 3 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [15.12.61] - 2026-05-07
+
+### Changed
+
+- Resolve #1356: rewrite `/implement` token-spend report (`scripts/token-report.sh`) presentation. Replace the single mixed 8-column table — `Claude input | Cache read | Cache create | Output | Claude total | Vendor total` plus `N/A`-padded vendor rows and `&nbsp;`-indented skill cells — with one Claude table plus one table per vendor sharing a uniform 4-column shape `Step | Skill | Input | Output`. Drops the mixed-rate `Claude total` column whose `input + cache_read + cache_create + output` sum combined dramatically different billing rates (cache_read ~10% of normal input, cache_create ~125%) and produced numbers that did not reflect actual spend; operators who want a single billable proxy can derive `input + cache_read*0.1 + cache_create*1.25 + output` from the ledger themselves. New jq helpers: `md_cell` (escapes `|`, collapses CR/LF on every text cell), `vendor_label` (`codex→Codex / cursor→Cursor / gemini→Gemini`, with the unknown-vendor raw fallback routed through `md_cell` so a hostile vendor name cannot inject heading separators), `vendor_names` (coverage-lossless enumeration in stable order — codex first, cursor second, then any others alphabetically), `claude_table` + `vendor_table` (per-step rows + per-skill detail rows + grand total each), and `slice1` (one-array sibling of `step_slice`). `terse_line` is intentionally unchanged — terse breadcrumb mode keeps cache visibility because a one-line breadcrumb is consumed by humans tailing the chat, not as markdown. Sibling `scripts/token-report.md` Table Shape section rewritten with the breaking presentation contract. `scripts/test-token-report.sh` rewrites assertions for the new shape, derives the expected grand-total count from fixture vendor presence, and adds pipe/newline injection fixtures (mark.step containing `|`, mark.step containing a literal newline, transcript skill containing a literal newline, unknown-vendor heading containing `|` and newline) with anchored oracle checks (35/35 assertions pass). Out of scope: ledger schema (`scripts/token-ledger.sh`) and the transcript-source resolver — purely a presentation-layer change.
+
 ## [15.12.60] - 2026-05-07
 
 ### Fixed

--- a/scripts/test-token-report.md
+++ b/scripts/test-token-report.md
@@ -2,7 +2,7 @@
 
 **Purpose**: Offline regression harness for `scripts/token-report.sh`.
 
-It uses fixture ledger + Claude transcript JSONL files to assert terse output, full markdown shape, indented skill rows, vendor rows with Claude `N/A`, grand totals, `--output`, graceful unavailable output, and idempotent `## Token Report` sentinel replacement after repeated refreshes. It also smoke-tests an oversized existing `run-statistics.md` fixture so sentinel replacement remains parser-safe.
+It uses fixture ledger + Claude transcript JSONL files to assert terse output, the full markdown multi-table shape, per-vendor headings, dropped legacy columns, the anchored old `| N/A |` cell-shape check, grand-total counts derived from fixture vendor content, `--output`, graceful unavailable output, and idempotent `## Token Report` sentinel replacement after repeated refreshes. It also covers pipe-and-newline injection fixtures for table-cell sanitization and smoke-tests an oversized existing `run-statistics.md` fixture with per-heading verification so sentinel replacement remains parser-safe.
 
 Run via `make test-token-report` or the shard that includes it.
 

--- a/scripts/test-token-report.md
+++ b/scripts/test-token-report.md
@@ -2,7 +2,7 @@
 
 **Purpose**: Offline regression harness for `scripts/token-report.sh`.
 
-It uses fixture ledger + Claude transcript JSONL files to assert terse output, the full markdown multi-table shape, per-vendor headings, dropped legacy columns, the anchored old `| N/A |` cell-shape check, grand-total counts derived from fixture vendor content, `--output`, graceful unavailable output, and idempotent `## Token Report` sentinel replacement after repeated refreshes. It also covers pipe-and-newline injection fixtures for table-cell sanitization and smoke-tests an oversized existing `run-statistics.md` fixture with per-heading verification so sentinel replacement remains parser-safe.
+It uses fixture ledger + Claude transcript JSONL files to assert terse output, the full markdown multi-table shape, per-vendor headings, dropped legacy columns, the anchored old `| N/A |` cell-shape check, grand-total counts derived from fixture vendor content, `--output`, graceful unavailable output, and idempotent `## Token Report` sentinel replacement after repeated refreshes. It also covers pipe-and-newline injection fixtures for table-cell sanitization (including the unknown-vendor heading path: `vendor_label`'s raw fallback routes through `md_cell` so an arbitrary vendor name with `|` or newline cannot break the heading line or inject a fake row separator) and smoke-tests an oversized existing `run-statistics.md` fixture with per-heading verification so sentinel replacement remains parser-safe.
 
 Run via `make test-token-report` or the shard that includes it.
 

--- a/scripts/test-token-report.sh
+++ b/scripts/test-token-report.sh
@@ -118,6 +118,17 @@ case "$mismatch" in
     *) fail "$mismatch row(s) had wrong separator-pipe count after injection; md_cell escape failed" ;;
 esac
 
+# Unknown-vendor heading sanitization: vendor_label's raw fallback routes
+# through md_cell so a vendor name containing | or newline cannot break the
+# heading line or inject a fake row separator into downstream markdown.
+UNK_LEDGER="$TMP/unk-ledger.jsonl"
+jq -c -n '{type:"mark",step:"Step 1 - design",ts:"2026-05-06T00:00:00Z"}' > "$UNK_LEDGER"
+jq -c -n --arg v 'evil|vendor' '{type:"vendor",vendor:$v,input:1,output:2,total:3,ts:"2026-05-06T00:00:05Z"}' >> "$UNK_LEDGER"
+jq -c -n --arg v $'two-line\nvendor' '{type:"vendor",vendor:$v,input:4,output:5,total:9,ts:"2026-05-06T00:00:06Z"}' >> "$UNK_LEDGER"
+unk_md=$("$SCRIPT" --ledger "$UNK_LEDGER" --transcript "$TRANSCRIPT" --full --markdown)
+contains "unknown vendor pipe escaped (heading)"      'evil\|vendor'  "$unk_md"
+contains "unknown vendor newline collapsed (heading)" 'two-line vendor' "$unk_md"
+
 RUN_STATS="$TMP/run-statistics.md"
 printf '## Existing\n\nkept\n' > "$RUN_STATS"
 "$SCRIPT" --ledger "$LEDGER" --transcript "$TRANSCRIPT" --append-run-statistics "$RUN_STATS"

--- a/scripts/test-token-report.sh
+++ b/scripts/test-token-report.sh
@@ -42,10 +42,81 @@ contains "terse step" "Step 2 - implement: claude=100 tokens" "$terse"
 contains "terse vendor" "vendor=10 (cursor=10)" "$terse"
 
 md=$("$SCRIPT" --ledger "$LEDGER" --transcript "$TRANSCRIPT" --full --markdown)
-contains "markdown header" "| Step | Skill | Claude input" "$md"
-contains "skill row" "&nbsp;&nbsp;larch:implement" "$md"
-contains "vendor row" "&nbsp;&nbsp;vendor:codex" "$md"
-contains "grand total" "**Grand total**" "$md"
+contains "claude heading"  "### Claude"  "$md"
+contains "codex heading"   "### Codex"   "$md"
+contains "cursor heading"  "### Cursor"  "$md"
+contains "claude header row" "| Step | Skill | Claude Input | Claude Output |" "$md"
+contains "vendor header row" "| Step | Skill | Input | Output |" "$md"
+contains "claude skill row"  "larch:implement" "$md"
+
+# Pin the cursor step-total row to a uniquely identified line built from
+# fixture values so substring collisions cannot pass silently.
+expected_cursor_row="| Step 2 - implement | **step total** | 1 | 2 |"
+if grep -Fq "$expected_cursor_row" <<<"$md"; then pass
+else fail "cursor step-total row missing or wrong: expected '$expected_cursor_row'"
+fi
+
+# Negative assertions: old columns and HTML entities must not appear. Anchor
+# N/A to the old cell shape so legitimate labels cannot trip it.
+for needle in "Cache read" "Cache create" "Claude total" "Vendor total" "&nbsp;"; do
+    if grep -Fq "$needle" <<<"$md"; then
+        fail "rendered markdown must not contain '$needle'"
+    else
+        pass
+    fi
+done
+if grep -Fq '| N/A |' <<<"$md"; then
+    fail "rendered markdown must not contain old md_na_row cells (\`| N/A |\`)"
+else
+    pass
+fi
+
+# Per-heading existence plus per-block grand-total presence. Compute the
+# expected vendor-table count from fixture content rather than a magic number.
+codex_present=0
+cursor_present=0
+grep -F '"vendor":"codex"' "$LEDGER" >/dev/null 2>&1 && codex_present=1
+grep -F '"vendor":"cursor"' "$LEDGER" >/dev/null 2>&1 && cursor_present=1
+expected_gt=$((1 + codex_present + cursor_present))
+gt_count=$(grep -c '\*\*Grand total\*\*' <<<"$md" || true)
+if [[ "$gt_count" == "$expected_gt" ]]; then pass
+else fail "expected $expected_gt grand-total rows; got $gt_count (codex_present=$codex_present cursor_present=$cursor_present)"
+fi
+
+INJ_LEDGER="$TMP/inj-ledger.jsonl"
+INJ_TRANSCRIPT="$TMP/inj-transcript.jsonl"
+# Build with jq so embedded pipes and newlines round-trip safely as JSON.
+jq -c -n --arg s 'Step | with pipe' '{type:"mark",step:$s,ts:"2026-05-06T00:00:00Z"}' > "$INJ_LEDGER"
+jq -c -n --arg s $'Step\nnewline mark' '{type:"mark",step:$s,ts:"2026-05-06T00:00:30Z"}' >> "$INJ_LEDGER"
+jq -c -n '{type:"vendor",vendor:"cursor",input:1,output:2,total:3,ts:"2026-05-06T00:00:05Z"}' >> "$INJ_LEDGER"
+jq -c -n --arg sk 'a|b' '{type:"assistant",timestamp:"2026-05-06T00:00:03.100Z",attributionSkill:$sk,message:{usage:{input_tokens:1,output_tokens:2,cache_read_input_tokens:0,cache_creation_input_tokens:0}}}' > "$INJ_TRANSCRIPT"
+jq -c -n --arg sk $'two-line\nskill' '{type:"assistant",timestamp:"2026-05-06T00:00:31.100Z",attributionSkill:$sk,message:{usage:{input_tokens:5,output_tokens:6,cache_read_input_tokens:0,cache_creation_input_tokens:0}}}' >> "$INJ_TRANSCRIPT"
+inj_md=$("$SCRIPT" --ledger "$INJ_LEDGER" --transcript "$INJ_TRANSCRIPT" --full --markdown)
+
+contains "injection escaped pipe (step cell)"   'Step \| with pipe' "$inj_md"
+contains "injection escaped pipe (skill cell)"  'a\|b'               "$inj_md"
+contains "injection newline collapsed (step)"   "Step newline mark" "$inj_md"
+contains "injection newline collapsed (skill)"  "two-line skill"    "$inj_md"
+
+hdr_pipes=$(grep -F '| Step | Skill | Claude Input | Claude Output |' <<<"$inj_md" | head -1 | sed 's/\\|//g' | tr -cd '|' | wc -c | tr -d ' ')
+mismatch=0
+while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    case "$line" in
+        '|'*)
+            stripped=$(printf '%s' "$line" | sed 's/\\|//g')
+            n=$(printf '%s' "$stripped" | tr -cd '|' | wc -c | tr -d ' ')
+            case "$line" in
+                *'---'*) continue ;;
+            esac
+            if [[ "$n" != "$hdr_pipes" ]]; then mismatch=$((mismatch + 1)); fi
+            ;;
+    esac
+done <<< "$inj_md"
+case "$mismatch" in
+    0) pass ;;
+    *) fail "$mismatch row(s) had wrong separator-pipe count after injection; md_cell escape failed" ;;
+esac
 
 RUN_STATS="$TMP/run-statistics.md"
 printf '## Existing\n\nkept\n' > "$RUN_STATS"
@@ -86,7 +157,11 @@ contains "no-step-marks reason" "Token report unavailable: failed to parse token
 BIG="$TMP/big-run-statistics.md"
 for i in $(seq 1 250); do printf '| old | row %s |\n' "$i" >> "$BIG"; done
 "$SCRIPT" --ledger "$LEDGER" --transcript "$TRANSCRIPT" --append-run-statistics "$BIG"
-contains "oversized sentinel" "<!-- token-report-begin -->" "$(cat "$BIG")"
+big_body=$(cat "$BIG")
+contains "oversized sentinel"     "<!-- token-report-begin -->" "$big_body"
+contains "oversized claude head"  "### Claude"  "$big_body"
+contains "oversized codex head"   "### Codex"   "$big_body"
+contains "oversized cursor head"  "### Cursor"  "$big_body"
 
 total=$((PASS + FAIL))
 if (( FAIL == 0 )); then

--- a/scripts/token-report.md
+++ b/scripts/token-report.md
@@ -34,7 +34,14 @@ Token reporting must never block `/implement`.
 
 ## Table Shape
 
-The markdown table uses compact columns: step, skill, Claude input/cache/output totals, Claude total, and vendor total. Step rows contain folded vendor totals; vendor detail rows are indented below the step with Claude columns set to `N/A`. The footer row is a grand total across all steps.
+The full markdown output renders as **one Claude table plus one table per vendor present in the run**, each preceded by an `### <vendor>` heading and a blank line. The Claude table is always emitted; vendor tables are emitted only when at least one row of that vendor exists at or after the first ledger mark.
+
+1. **Claude** - `Step | Skill | Claude Input | Claude Output`. One step-summary row per ledger mark followed by per-skill detail rows (blank Step cell + skill identifier in the Skill column; no indentation marker, no HTML entities). Final `**Grand total**` footer scoped to all rows at or after the first mark.
+2. **Per-vendor** - `Step | Skill | Input | Output`. Same shape and rules as Claude. Vendor name in the heading is mapped to a capitalized form (`codex` -> `Codex`, `cursor` -> `Cursor`, `gemini` -> `Gemini`); unknown vendors render with the raw name. Codex precedes Cursor; any additional vendors follow in alphabetical order. **Caveat**: today's Codex launchers (`scripts/launch-codex-implement.sh`, `scripts/launch-codex-review.sh`) record only the `total` field and not `input`/`output`, so Codex Input/Output columns will display `0` until those scrapers are extended (out of scope for this PR; see the run-statistics PR description for the follow-up issue link).
+
+The four-column shape is consistent across all tables. Numeric columns are right-aligned (`---:`); text columns are left-aligned (`---`). Cell text passes through a small jq sanitizer (`md_cell`) that escapes `|` (single-backslash GFM escape) and collapses CR/LF to a single space, so well-formedness of the table is preserved even if a step / skill / vendor label contains those characters.
+
+Cache-read and cache-creation totals plus the combined "Claude total" are intentionally **not** rendered in the user-facing markdown; they mix billing rates that distort spend interpretation. Operators who want a single billable proxy can compute `input + cache_read*0.1 + cache_create*1.25 + output` from `token-ledger.sh dump` and the transcripts. Terse mode (`--since-last-mark --terse`) is unchanged in this PR and still prints the cache breakdown.
 
 ## Test Harness
 

--- a/scripts/token-report.sh
+++ b/scripts/token-report.sh
@@ -106,6 +106,12 @@ render_jq() {
         end;
       def n($x): ($x // 0 | tonumber? // 0);
       def fmt($x): ($x | tostring);
+      def md_cell($s):
+        ($s // "" | tostring
+          | gsub("\r\n"; " ")
+          | gsub("\n"; " ")
+          | gsub("\r"; " ")
+          | gsub("\\|"; "\\|"));
       def claude_total($r):
         n($r.message.usage.input_tokens)
         + n($r.message.usage.cache_read_input_tokens)
@@ -155,48 +161,98 @@ render_jq() {
           + " cache_read=" + fmt($ct.cache_read) + " cache_create=" + fmt($ct.cache_create)
           + " output=" + fmt($ct.output) + "); vendor=" + fmt($vt)
           + (if $vt > 0 then " (" + ($vb | map(.vendor + "=" + (.total|tostring)) | join(", ")) + ")" else "" end));
-      def md_header:
-        "| Step | Skill | Claude input | Cache read | Cache create | Output | Claude total | Vendor total |\n"
-        + "|---|---:|---:|---:|---:|---:|---:|---:|";
-      def md_row($step; $skill; $ci; $cr; $cc; $out; $ct; $vt):
-        "| " + $step + " | " + $skill + " | " + ($ci|tostring) + " | " + ($cr|tostring)
-        + " | " + ($cc|tostring) + " | " + ($out|tostring) + " | " + ($ct|tostring)
-        + " | " + ($vt|tostring) + " |";
-      def md_na_row($step; $skill; $vt):
-        "| " + $step + " | " + $skill + " | N/A | N/A | N/A | N/A | N/A | " + ($vt|tostring) + " |";
-      def markdown($marks; $claude; $vendor):
-        [md_header] + (
-          [range(0; $marks|length) as $i
+
+      # --- Shared helpers ---
+
+      # Vendor-name to display heading. Explicit map so headings render
+      # capitalized. Unknown vendors fall through to "### " + raw name to keep
+      # coverage lossless when ledger contains arbitrary vendor strings.
+      def vendor_label($vname):
+        if   $vname == "codex"  then "Codex"
+        elif $vname == "cursor" then "Cursor"
+        elif $vname == "gemini" then "Gemini"
+        else $vname
+        end;
+
+      # Shared 4-column header for the per-vendor tables.
+      def vendor_header($input_label; $output_label):
+        "| Step | Skill | " + $input_label + " | " + $output_label + " |\n"
+        + "| --- | --- | ---: | ---: |";
+
+      # 4-column row. Text cells route through md_cell.
+      def vrow($step; $name; $in; $out):
+        "| " + md_cell($step) + " | " + md_cell($name) + " | "
+        + ($in|tostring) + " | " + ($out|tostring) + " |";
+
+      # Single-array slice helper: the one-array analog of step_slice.
+      def slice1($rows; $start; $end):
+        $rows | map(select(.ts != null and .ts >= $start and ($end == null or .ts < $end)));
+
+      # --- Claude table ---
+
+      # Always emitted because Claude is the primary surface.
+      def claude_table($marks; $claude):
+        ["### Claude", "", vendor_header("Claude Input"; "Claude Output")]
+        + ([range(0; $marks|length) as $i
             | ($marks[$i]) as $m
             | (($marks[$i+1].ts) // null) as $end
-            | (step_slice($claude; $vendor; $m.ts; $end)) as $s
-            | (totals($s.claude)) as $ct
-            | (sumfield($s.vendor; "total")) as $vt
-            | md_row($m.step; "**step total**"; $ct.input; $ct.cache_read; $ct.cache_create; $ct.output; $ct.total; $vt),
-              ($s.claude
+            | (slice1($claude; $m.ts; $end)) as $sl
+            | (totals($sl)) as $st
+            | vrow($m.step; "**step total**"; $st.input; $st.output),
+              ($sl
                 | group_by(.skill)
                 | map({skill: .[0].skill, totals: totals(.)})
                 | .[]
-                | md_row("" ; ("&nbsp;&nbsp;" + .skill); .totals.input; .totals.cache_read; .totals.cache_create; .totals.output; .totals.total; 0)),
-              ($s.vendor
-                | group_by(.vendor)
-                | map({vendor: .[0].vendor, total: sumfield(.; "total")})
-                | .[]
-                | md_na_row("" ; ("&nbsp;&nbsp;vendor:" + .vendor); .total))
+                | vrow(""; .skill; .totals.input; .totals.output))
+           ])
+        + [
+            ($marks[0].ts) as $first
+            | (slice1($claude; $first; null)) as $in_run
+            | (totals($in_run)) as $gt
+            | vrow("**Grand total**"; ""; $gt.input; $gt.output)
           ]
-        ) + [
-          # Filter grand totals to only rows at or after the first mark so the
-          # table reconciles: each step row uses step_slice with mark.ts as the
-          # lower bound, so rows BEFORE the first mark are excluded from every
-          # per-step row and would otherwise appear only in the grand total —
-          # producing a sum-of-step-rows ≠ grand-total mismatch. Filtering here
-          # keeps the grand row consistent with the per-step partition.
-          ($marks[0].ts) as $first
-          | ($claude | map(select(.ts != null and .ts >= $first))) as $claude_in_run
-          | ($vendor | map(select(.ts != null and .ts >= $first))) as $vendor_in_run
-          | (totals($claude_in_run)) as $gt
-          | md_row("**Grand total**"; ""; $gt.input; $gt.cache_read; $gt.cache_create; $gt.output; $gt.total; (sumfield($vendor_in_run; "total")))
-        ] | join("\n");
+        | join("\n");
+
+      # --- Per-vendor table ---
+
+      # Filters $vendor to the requested name and in-run window. Both the
+      # emit/omit decision and totals read from that same filtered set.
+      def vendor_table($vname; $marks; $vendor):
+        ($marks[0].ts) as $first
+        | ($vendor | map(select(.vendor == $vname and .ts != null and .ts >= $first))) as $vrows
+        | if ($vrows | length) == 0 then null
+          else
+            ["### " + vendor_label($vname), "", vendor_header("Input"; "Output")]
+            + ([range(0; $marks|length) as $i
+                | ($marks[$i]) as $m
+                | (($marks[$i+1].ts) // null) as $end
+                | (slice1($vrows; $m.ts; $end)) as $sl
+                | (sumfield($sl; "input")) as $vi
+                | (sumfield($sl; "output")) as $vo
+                | vrow($m.step; "**step total**"; $vi; $vo)
+               ])
+            + [
+                (sumfield($vrows; "input")) as $gi
+                | (sumfield($vrows; "output")) as $go
+                | vrow("**Grand total**"; ""; $gi; $go)
+              ]
+            | join("\n")
+          end;
+
+      # Coverage-lossless vendor enumeration: take distinct vendor names in
+      # the in-run window, then emit codex first, cursor second, and any other
+      # vendors alphabetically.
+      def vendor_names($marks; $vendor):
+        ($marks[0].ts) as $first
+        | ($vendor | map(select(.ts != null and .ts >= $first)) | map(.vendor) | unique) as $present
+        | (["codex", "cursor"] | map(select(. as $v | $present | index($v) != null)))
+        + ($present - ["codex", "cursor"] | sort);
+
+      def markdown($marks; $claude; $vendor):
+        ([claude_table($marks; $claude)]
+         + (vendor_names($marks; $vendor) | map(vendor_table(.; $marks; $vendor)))
+         | map(select(. != null))
+         | join("\n\n"));
 
       ($ledger // []) as $l
       | ($l | map(select(.type == "mark") | {step, ts: (.ts | epoch)}) | map(select(.ts != null))) as $marks

--- a/scripts/token-report.sh
+++ b/scripts/token-report.sh
@@ -166,12 +166,14 @@ render_jq() {
 
       # Vendor-name to display heading. Explicit map so headings render
       # capitalized. Unknown vendors fall through to "### " + raw name to keep
-      # coverage lossless when ledger contains arbitrary vendor strings.
+      # coverage lossless when ledger contains arbitrary vendor strings; the
+      # raw fallback routes through md_cell so a vendor string containing |
+      # or newlines cannot break the heading or inject a fake row separator.
       def vendor_label($vname):
         if   $vname == "codex"  then "Codex"
         elif $vname == "cursor" then "Cursor"
         elif $vname == "gemini" then "Gemini"
-        else $vname
+        else md_cell($vname)
         end;
 
       # Shared 4-column header for the per-vendor tables.


### PR DESCRIPTION
## Summary

- Replace the single mixed 8-column `/implement` token-spend table (`Claude input | Cache read | Cache create | Output | Claude total | Vendor total` + `N/A`-padded vendor rows + `&nbsp;`-indented skill cells) with **one Claude table plus one table per vendor**, all sharing a uniform 4-column shape `Step | Skill | Input | Output`. Eliminates the awkward column-shape mismatch and (per user manual verification of the new shape rendering in Claude Code chat) the prior chat-rendering truncation.
- **Drop `Claude total`**. The old total summed `input + cache_read + cache_create + output`, which combine dramatically different billing rates (cache_read ~10% of normal input, cache_create ~125%) and produced misleading numbers — a recent run's `bump-version` row showed 14,069,742 "Claude total" tokens but only 44 fresh input + 14,856 output (99.7% was cache_read).
- **Sanitize text cells and unknown-vendor headings** via a new `md_cell` jq helper that escapes `|` and collapses CR/LF, so a step / skill / vendor name containing `|` or a newline cannot break the table or inject a fake row separator. Cursor-Security review surfaced and confirmed the unknown-vendor heading path during code review.
- `terse_line` is intentionally **unchanged** — terse-mode breadcrumbs are one-line and consumed by humans tailing the chat, not by markdown renderers.

## Tradeoff (called out per design)

Dropping `cache_read` / `cache_create` entirely loses information (cache reads still cost ~10% of normal input). Operators who want a single billable proxy can derive `input + cache_read*0.1 + cache_create*1.25 + output` from the ledger themselves; the ledger schema (`scripts/token-ledger.sh`) is unchanged.

## Breaking presentation contract

The user-facing table shape is rewritten. External scrapers / regex parsers keyed on the old column headers or cell forms will break:

- Dropped headers: `Cache read`, `Cache create`, `Claude total`, `Vendor total`.
- Dropped cell forms: `&nbsp;&nbsp;<skill>`, `| N/A |`.

The new contract lives in `scripts/token-report.md` Table Shape section. Underlying data is unchanged — the ledger and `--terse` output continue to carry the dropped fields.

## Architecture Diagram

See [tracking issue #1356 anchor comment](https://github.com/character-ai/larch/issues/1356#issuecomment-4394151728) (Architecture + Code Flow diagrams).

## Test plan

- [x] `bash scripts/test-token-report.sh` — 35/35 assertions pass.
- [x] `make test-token-report` — passes.
- [x] `/relevant-checks` — pre-commit + `agent-lint` clean.
- [x] Pipe / newline injection fixtures (mark.step `|`, mark.step newline, skill newline, unknown-vendor `|` + newline) all assert escape / collapse behavior.
- [x] Manual chat-rendering: the new shape renders fully (no truncation) when posted into the tracking issue's anchor comment.

Closes #1356

🤖 Generated with [Claude Code](https://claude.com/claude-code)
