### PR TITLE
Resolve #1352: introduce .claude/rules/ + migrate 3 pilot rules

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "15.12.63",
+  "version": "15.12.64",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 6-reviewer specialist panel (5 Cursor specialists + 1 Codex generic) — extended to 7 with an optional Gemini reviewer when the Gemini CLI is installed and healthy — with 3-voter adjudication; plan review runs a 3-reviewer panel (Claude + Codex + Cursor); design sketches run a 9-agent diverge-then-converge phase in regular mode (1 Claude + 4 Cursor + 4 Codex) or 3 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/.claude/rules/script-md-siblings.md
+++ b/.claude/rules/script-md-siblings.md
@@ -1,0 +1,14 @@
+---
+paths: ["scripts/**/*.{sh,py}", "skills/**/scripts/**/*.{sh,py}", "skills/shared/*.md"]
+---
+
+# Script Documentation Siblings
+
+Every `.sh` / `.py` script under `scripts/` and `skills/<name>/scripts/` has a sibling `<basename>.md` next to it (e.g., `scripts/redact-secrets.md` beside `scripts/redact-secrets.sh`) documenting the script's purpose, primary callers, invariants, Makefile wiring, test harness, and edit-in-sync rules. When editing a script, read its sibling `.md` first; update it in the same PR as any behavioral change. Two co-location patterns are permitted, neither is an exemption from the file-existence rule:
+
+- **Primary owns the full contract.** Where a primary script has a sourced-only library (`scripts/lib-*.sh` — no shebang) and/or a regression test harness (`scripts/test-*.sh` for the primary), the primary's `.md` owns the full contract and cites the related files by path. The library and harness still get their own sibling `.md` (typically a one-paragraph stub) so every `.sh` has a sibling for discoverability and audit; the stub points readers to the primary's `.md` rather than restating the contract.
+- **Cross-tree harnesses.** A test harness may live under `scripts/test-*.sh` while its primary lives at `skills/<name>/scripts/<primary>.sh` (e.g. `scripts/test-post-scaffold-hints.sh` testing `skills/create-skill/scripts/post-scaffold-hints.sh`). The primary's `.md` (in its own tree) owns the full contract; the harness in `scripts/` still gets a sibling `.md` stub naming its primary.
+
+For canonical documentation files (`skills/shared/*.md`), update triggers live inside the file itself at the bottom.
+
+This rule's `paths:` intentionally covers nested `skills/**/scripts/**/*.{sh,py}` so future skill script layouts inherit the same sibling-contract invariant.

--- a/.claude/rules/skill-editing-trace.md
+++ b/.claude/rules/skill-editing-trace.md
@@ -1,0 +1,7 @@
+---
+paths: ["skills/**/SKILL.md", "skills/**/scripts/**/*.{sh,py}", "skills/shared/*.md"]
+---
+
+# Skill Editing Trace
+
+**Changing a skill** → start at `skills/<name>/SKILL.md`, then trace every helper in `skills/<name>/scripts/`, `scripts/`, and `skills/shared/`. Behavior is split between prompt and scripts.

--- a/.claude/rules/version-bump-reserved-message.md
+++ b/.claude/rules/version-bump-reserved-message.md
@@ -1,0 +1,3 @@
+# Version Bump Reserved Message
+
+Use `/bump-version` to change `.claude-plugin/plugin.json` version — it owns that commit; `Bump version to X.Y.Z` is a reserved commit message.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -102,6 +102,7 @@ repos:
             .*AGENTS\.md|
             agents/.*\.md|
             \.claude/agents/.*\.md|
+            \.claude/rules/.*\.md|
             \.claude/settings\.json|
             \.claude/settings\.local\.json|
             hooks/hooks\.json|

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,24 +4,18 @@ This repository **is** the larch Claude Code plugin. Editing here modifies what 
 
 ## Repository layout
 
-Plugin ships the entire repo. **Runtime surface**: `skills/`, `agents/`, `hooks/`, `scripts/`, `.claude-plugin/`. Everything else is supplementary (docs, CI config, `.claude/skills/`, dev settings).
+Plugin ships the entire repo. **Runtime surface**: `skills/`, `agents/`, `hooks/`, `scripts/`, `.claude-plugin/`. Everything else is supplementary (docs, CI config, `.claude/skills/`, `.claude/rules/`, dev settings).
 
 ## Editing rules
 
-- Use `/bump-version` to change `.claude-plugin/plugin.json` version — it owns that commit; `Bump version to X.Y.Z` is a reserved commit message.
 - Always respect `scripts/block-submodule-edit.sh`. If a hook blocks a write, investigate and resolve the underlying issue. The guard ships via `hooks/hooks.json` only — `.claude/settings.json` no longer mirrors it, so contributors developing in this repo must load larch as a plugin (`claude --plugin-dir .` or the local marketplace) to pick up the guard.
 - After any change, run `/relevant-checks`.
 - Public `skills/*/SKILL.md` use `${CLAUDE_PLUGIN_ROOT}/…`; dev-only `.claude/skills/*/SKILL.md` use `$PWD/…`.
 - Update `SECURITY.md` when security-relevant behavior changes.
-- **Per-script contracts live beside the script.** Every `.sh` / `.py` script under `scripts/` and `skills/<name>/scripts/` has a sibling `<basename>.md` next to it (e.g., `scripts/redact-secrets.md` beside `scripts/redact-secrets.sh`) documenting the script's purpose, primary callers, invariants, Makefile wiring, test harness, and edit-in-sync rules. When editing a script, read its sibling `.md` first; update it in the same PR as any behavioral change. Two co-location patterns are permitted, neither is an exemption from the file-existence rule:
-  - **Primary owns the full contract.** Where a primary script has a sourced-only library (`scripts/lib-*.sh` — no shebang) and/or a regression test harness (`scripts/test-*.sh` for the primary), the primary's `.md` owns the full contract and cites the related files by path. The library and harness still get their own sibling `.md` (typically a one-paragraph stub) so every `.sh` has a sibling for discoverability and audit; the stub points readers to the primary's `.md` rather than restating the contract.
-  - **Cross-tree harnesses.** A test harness may live under `scripts/test-*.sh` while its primary lives at `skills/<name>/scripts/<primary>.sh` (e.g. `scripts/test-post-scaffold-hints.sh` testing `skills/create-skill/scripts/post-scaffold-hints.sh`). The primary's `.md` (in its own tree) owns the full contract; the harness in `scripts/` still gets a sibling `.md` stub naming its primary.
-
-  For canonical documentation files (`skills/shared/*.md`), update triggers live inside the file itself at the bottom.
+- Path-scoped editing rules for Claude Code live under `.claude/rules/`. Tools that consume only `AGENTS.md` (Codex, Cursor, Gemini) must consult `.claude/rules/script-md-siblings.md`, `.claude/rules/skill-editing-trace.md`, and `.claude/rules/version-bump-reserved-message.md` when editing scripts, `SKILL.md` files, or `.claude-plugin/plugin.json`.
 
 ## Common editing tasks
 
-- **Changing a skill** → start at `skills/<name>/SKILL.md`, then trace every helper in `skills/<name>/scripts/`, `scripts/`, and `skills/shared/`. Behavior is split between prompt and scripts.
 - **Adding/modifying the Code Reviewer archetype** → edit `skills/shared/reviewer-templates.md` (canonical; update triggers in that file), then run `bash scripts/generate-code-reviewer-agent.sh` to regenerate `agents/code-reviewer.md`; CI's `agent-sync` job runs the registry walker (`scripts/check-generators.sh`) to enforce drift across all registered generators. For any other reviewer archetype, follow the general rule: identify the canonical source and mirror updates to any generated outputs.
 - **Changing a shared script** → edit `scripts/<name>.sh`, read its sibling `scripts/<name>.md` for the contract, then grep for callers across `skills/`, `hooks/`, `.claude/settings.json`, `.github/workflows/`, and other scripts.
 - **Changing dev-only skills** → edit under `.claude/skills/bump-version/` or `.claude/skills/relevant-checks/`.
@@ -49,7 +43,7 @@ Plugin ships the entire repo. **Runtime surface**: `skills/`, `agents/`, `hooks/
 ## Conventions
 
 - Shell scripts use `set -euo pipefail` by default. Comment when `-e` is intentionally omitted.
-- Follow recent commit history style. `Bump version to X.Y.Z` is reserved for `/bump-version`.
+- Follow recent commit history style.
 - Run `gh pr create` through the skill, not manually.
 - Run `gh issue create` through `/larch:issue`, not manually. Scripts under `scripts/` and `skills/*/scripts/` (e.g., hooks) may continue to call `gh issue create` directly — the rule targets interactive / assistant-driven issue creation only.
 - Slack env vars are optional; skills degrade gracefully when absent.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [15.12.64] - 2026-05-07
+
+### Added
+
+- Resolve #1352: introduce `larch/.claude/rules/` (Claude Code's modular path-scoped instruction directory) and migrate three pilot rules out of `AGENTS.md` so Claude only loads them when editing the matching paths. New `.claude/rules/script-md-siblings.md` (paths: `scripts/**/*.{sh,py}`, `skills/**/scripts/**/*.{sh,py}`, `skills/shared/*.md`) carries the per-script sibling-contract invariant. New `.claude/rules/skill-editing-trace.md` (paths: `skills/**/SKILL.md`, `skills/**/scripts/**/*.{sh,py}`, `skills/shared/*.md`) carries the "start at SKILL.md, then trace every helper" rule. New `.claude/rules/version-bump-reserved-message.md` is intentionally UNSCOPED (always-on per design plan FINDING_8 — the reserved `Bump version to X.Y.Z` commit subject is a workflow invariant governing commit creation, not a `plugin.json`-edit invariant). New `GEMINI.md` is a one-line `@./AGENTS.md` (13 bytes, Gemini-native @-import; per Round 1 user direction, NOT a symlink). `AGENTS.md` removes the three migrated bullets, adds a single navigation-pointer bullet so Codex/Cursor/Gemini (which do not load Claude Code `.claude/rules/`) can find the rule files, and lists `.claude/rules/` alongside `.claude/skills/` in the Repository-layout supplementary set. `agents/{codex,cursor,gemini}-implementer.md` extend their pre-edit checklist (Style section) to read applicable `.claude/rules/*.md` files when edits touch the matching path scopes. `.pre-commit-config.yaml` adds `\.claude/rules/.*\.md` to the agnix `files:` regex so rules-only commits invoke `agnix --strict` (durable CI coverage replaces the bespoke local YAML check). `larch/.claude/rules/` is dev-only and does NOT ship to consumers (mirrors the existing `.claude/skills/` convention). Token-savings before/after measurement was relaxed by the user during Round 1 design discussion; this PR does not gather that number — operators wanting a number can run a measurement post-merge. The `Cursor / non-Claude-Code` visibility tradeoff is the documented Claude-only scoping the issue explicitly authorized; the AGENTS.md navigation pointer plus the implementer-prompt updates preserve discoverability for external agents.
+
 ## [15.12.63] - 2026-05-07
 
 ### Fixed

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,1 @@
+@./AGENTS.md

--- a/agents/codex-implementer.md
+++ b/agents/codex-implementer.md
@@ -123,6 +123,6 @@ Then atomic-write `<MANIFEST_PATH>` and exit with status 0. The dispatcher inspe
 
 ## Style
 
-Match existing code style. Read CLAUDE.md and AGENTS.md before editing skill prose. Don't over-engineer; the smallest change that fulfills the plan is the right change. Don't add comments explaining what well-named identifiers already say. Don't add error handling for impossible scenarios.
+Match existing code style. Read CLAUDE.md and AGENTS.md before editing skill prose. Also read applicable `.claude/rules/*.md` files when edits touch scripts, `SKILL.md` files, `skills/shared/*.md`, or `.claude-plugin/plugin.json`. Don't over-engineer; the smallest change that fulfills the plan is the right change. Don't add comments explaining what well-named identifiers already say. Don't add error handling for impossible scenarios.
 
 If you finish the plan in fewer files than the plan listed (e.g., one of the files turned out to be unnecessary), say so in `summary_bullets` and reflect the actual touched set in `files_touched`. The dispatcher does NOT cross-check `files_touched` against the actual diff — operators read it as documentation, so accuracy matters even though it is no longer mechanically enforced.

--- a/agents/cursor-implementer.md
+++ b/agents/cursor-implementer.md
@@ -129,6 +129,6 @@ Then atomic-write `<MANIFEST_PATH>` and exit with status 0. The dispatcher inspe
 
 ## Style
 
-Match existing code style. Read CLAUDE.md and AGENTS.md before editing skill prose. Don't over-engineer; the smallest change that fulfills the plan is the right change. Don't add comments explaining what well-named identifiers already say. Don't add error handling for impossible scenarios.
+Match existing code style. Read CLAUDE.md and AGENTS.md before editing skill prose. Also read applicable `.claude/rules/*.md` files when edits touch scripts, `SKILL.md` files, `skills/shared/*.md`, or `.claude-plugin/plugin.json`. Don't over-engineer; the smallest change that fulfills the plan is the right change. Don't add comments explaining what well-named identifiers already say. Don't add error handling for impossible scenarios.
 
 If you finish the plan in fewer files than the plan listed (e.g., one of the files turned out to be unnecessary), say so in `summary_bullets` and reflect the actual touched set in `files_touched`. The dispatcher does NOT cross-check `files_touched` against the actual diff — operators read it as documentation, so accuracy matters even though it is no longer mechanically enforced.

--- a/agents/gemini-implementer.md
+++ b/agents/gemini-implementer.md
@@ -129,6 +129,6 @@ Then atomic-write `<MANIFEST_PATH>` and exit with status 0. The dispatcher inspe
 
 ## Style
 
-Match existing code style. Read CLAUDE.md and AGENTS.md before editing skill prose. Don't over-engineer; the smallest change that fulfills the plan is the right change. Don't add comments explaining what well-named identifiers already say. Don't add error handling for impossible scenarios.
+Match existing code style. Read CLAUDE.md and AGENTS.md before editing skill prose. Also read applicable `.claude/rules/*.md` files when edits touch scripts, `SKILL.md` files, `skills/shared/*.md`, or `.claude-plugin/plugin.json`. Don't over-engineer; the smallest change that fulfills the plan is the right change. Don't add comments explaining what well-named identifiers already say. Don't add error handling for impossible scenarios.
 
 If you finish the plan in fewer files than the plan listed (e.g., one of the files turned out to be unnecessary), say so in `summary_bullets` and reflect the actual touched set in `files_touched`. The dispatcher does NOT cross-check `files_touched` against the actual diff — operators read it as documentation, so accuracy matters even though it is no longer mechanically enforced.


### PR DESCRIPTION
## Summary

- Introduce `larch/.claude/rules/` (Claude Code's modular path-scoped instruction directory) and migrate three pilot rules out of `AGENTS.md` so Claude only loads them when editing the matching paths.
- Add `GEMINI.md` as a one-line `@./AGENTS.md` (13 bytes; Gemini-native @-import per Round 1 user direction). Not a symlink.
- Update `agents/{codex,cursor,gemini}-implementer.md` Style sections to read applicable `.claude/rules/*.md` files when edits touch the matching path scopes (so external agents see the migrated rules).
- Add `\.claude/rules/.*\.md` to the agnix `files:` regex in `.pre-commit-config.yaml` so rules-only commits invoke `agnix --strict`.

## Architecture Diagram

```mermaid
flowchart TD
  subgraph "Claude Code session"
    CC[CLAUDE.md project root]
    CC -- "@import" --> AM[AGENTS.md unconditional rules]
    CC -- "session_start (no paths:)" --> RV[".claude/rules/<br/>version-bump-reserved-message.md"]
    CC -. "path_glob_match" .-> RS[".claude/rules/<br/>script-md-siblings.md"]
    CC -. "path_glob_match" .-> RE[".claude/rules/<br/>skill-editing-trace.md"]
  end
  subgraph "Codex / Cursor / Gemini"
    CX["codex / cursor"] --> AM
    GEM["gemini-cli"] --> GM[GEMINI.md @./AGENTS.md] --> AM
  end
  subgraph "External-agent navigation"
    AM -. "L15 navigation pointer" .-> RS
    AM -. "L15 navigation pointer" .-> RE
    AM -. "L15 navigation pointer" .-> RV
  end
  classDef new fill:#e1f5e1,stroke:#2e7d32,color:#1b5e20
  class RS,RE,RV,GM new
```

## Code Flow Diagram

```mermaid
flowchart LR
  A1["Operator runs<br/>claude / codex / cursor / gemini"]
  A1 -- "Claude Code edit script" --> R1[Read scripts/foo.sh]
  R1 -- "path_glob_match" --> RS[".claude/rules/<br/>script-md-siblings.md"]
  A1 -- "Claude Code edit skill" --> R2[Read skills/x/SKILL.md]
  R2 -- "path_glob_match" --> RE[".claude/rules/<br/>skill-editing-trace.md"]
  A1 -- "session_start any tool" --> RV[".claude/rules/<br/>version-bump-reserved-message.md<br/>(unscoped, always-on)"]
  PCC[".pre-commit-config.yaml<br/>agnix --strict"] --> RV & RS & RE
```

## Test plan

- [x] `pre-commit run --files <changed-files>` (15 files): shellcheck, markdownlint, jsonlint, agent-lint, gitleaks, lint-skill-invocations, lint-literal-counts, agnix all green.
- [x] Repo-wide `agent-lint` (Plugin structure OK).
- [x] Anchored greps confirm migrated phrases removed from `AGENTS.md` while the `.claude/skills/bump-version/SKILL.md` skill-catalog reference is preserved.
- [x] Frontmatter parses: PyYAML loop confirms `script-md-siblings.md` and `skill-editing-trace.md` carry valid `paths:` arrays; `version-bump-reserved-message.md` intentionally has no frontmatter (always-on per design FINDING_8).
- [x] `GEMINI.md` is exactly 13 bytes (`@./AGENTS.md\n`).
- [x] AGENTS.md navigation pointer cites all three rule files.

## Notes

- Token-savings before/after measurement was **relaxed by the user during Round 1 design discussion**; this PR does not gather that number. Operators wanting a number can run a measurement post-merge against an unrelated path-scoped task and amend the issue or file a follow-up.
- Cursor / non-Claude-Code workflows lose direct path-scoped visibility on the three migrated rules — this is the documented Claude-only scoping the issue explicitly authorized. Discoverability for external agents is preserved via the AGENTS.md navigation pointer (line 15) and the `agents/{codex,cursor,gemini}-implementer.md` Style-section update.
- One Cursor-Structure / Cursor-Edge-cases finding suggested adding `paths: [".claude-plugin/plugin.json"]` to `.claude/rules/version-bump-reserved-message.md` for frontmatter parity. Rejected with documented rationale on the tracking issue's anchor comment: the unscoped form is deliberate per accepted /design plan FINDING_8 — the reserved `Bump version to X.Y.Z` commit subject governs commit creation as a workflow invariant, not a `plugin.json`-edit invariant. Path-scoping would silently weaken the rule.

Closes #1352

🤖 Generated with [Claude Code](https://claude.com/claude-code)
