### PR TITLE
Resolve #1369: add Honesty section to AGENTS.md

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "15.12.64",
+  "version": "15.12.65",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 6-reviewer specialist panel (5 Cursor specialists + 1 Codex generic) — extended to 7 with an optional Gemini reviewer when the Gemini CLI is installed and healthy — with 3-voter adjudication; plan review runs a 3-reviewer panel (Claude + Codex + Cursor); design sketches run a 9-agent diverge-then-converge phase in regular mode (1 Claude + 4 Cursor + 4 Codex) or 3 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,15 @@ Plugin ships the entire repo. **Runtime surface**: `skills/`, `agents/`, `hooks/
 - Slack env vars are optional; skills degrade gracefully when absent.
 - **Don't spawn a Monitor or a Bash `run_in_background` polling loop (`for`/`while`/`until` + `sleep`) to watch another `run_in_background` job finish — and don't reach for `ScheduleWakeup` as a third polling mechanism either.** The Bash tool already emits a `<task-notification>` with `status=completed` (or `failed`) when the original process exits — both forms of poller would just deliver the same signal twice, and a stale poller can keep the session alive long after the watched job has reported. `ScheduleWakeup` is worse than a poller in this role: a non-sentinel `prompt` re-fires on wakeup as a `/loop` input and (per the tool's "pass the same `/loop` prompt back each turn" guidance) perpetuates a `/loop`-style chain that survives past the watched step and into post-completion turns. If you genuinely need a wakeup, rely on the task notification. Use Monitor only for tailing logs, polling *external* state, or per-occurrence event streams; for one-shot "wait until done," rely on the Bash notification. (`/implement` ratchets this stricter — see `skills/implement/SKILL.md` NEVER #9, which forbids `ScheduleWakeup` anywhere in the orchestrator.)
 
+## Honesty
+
+- **Don't fabricate.** If you do not know a file path, function name, line number, command output, or test result, say so.
+- **Don't overstate completion.** Report what you actually did, not what you intended; "done" means verified done.
+- **Don't paper over failures.** Surface failed commands, failed tests, and unexpected results directly.
+- **Trust but verify your own claims.** Before reporting a tool-call result, confirm the tool actually returned it, and do not claim results from tools you did not run.
+- **Distinguish observation from inference.** Mark guesses, assumptions, and likely explanations as such.
+- **Value honesty over agreeableness.** Push back on wrong premises or flawed plans, following `KARPATHY_CLAUDE.md` §1 "Think Before Coding" rather than duplicating that guidance here.
+
 ## Answering questions about this repo
 
 For Q&A about this repository, default to direct file reads instead of dispatching Explore, Agent, or Plan.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [15.12.65] - 2026-05-07
+
+### Added
+
+- Resolve #1369: add a top-level `## Honesty` section to `AGENTS.md` so every agent (Claude session, Codex/Cursor/Gemini implementer, reviewer) loads honesty rules at session start. Six bullets cover: don't fabricate (paths/functions/line numbers/command output/test results), don't overstate completion ("done" means verified done), don't paper over failures, trust-but-verify own claims (confirm tool returned what's claimed before reporting), distinguish observation from inference (mark guesses as guesses), and value honesty over agreeableness (cross-references `KARPATHY_CLAUDE.md` §1 "Think Before Coding" instead of duplicating its push-back guidance). Section is unconditional content at ~9 lines so the per-session token cost stays minimal. Out of scope: enforcement mechanisms (lint rules, hooks, reviewer checks) and per-skill honesty rules.
+
 ## [15.12.64] - 2026-05-07
 
 ### Added

--- a/scripts/gemini-known-tools.txt
+++ b/scripts/gemini-known-tools.txt
@@ -11,4 +11,3 @@ search_file_content
 web_fetch
 web_search
 write_file
-run-shell-command-id

--- a/scripts/gemini-known-tools.txt
+++ b/scripts/gemini-known-tools.txt
@@ -11,3 +11,4 @@ search_file_content
 web_fetch
 web_search
 write_file
+run-shell-command-id


### PR DESCRIPTION
## Summary

- Add a new top-level `## Honesty` section to `AGENTS.md` (Resolve #1369) so every agent (Claude session, Codex/Cursor/Gemini implementer, reviewer) loads honesty rules at session start.
- Six rules: no fabrication, no overstated completion, no papered-over failures, trust-but-verify own claims, distinguish observation from inference, honesty over agreeableness (cross-references `KARPATHY_CLAUDE.md` §1 to avoid duplicating its push-back guidance).
- ~9 lines added, no executable surface changed; PATCH bump to 15.12.65.

## Architecture Diagram

Architecture diagram not available.

## Code Flow Diagram

(Code Flow Diagram skipped — quick mode)

## Test plan

- [x] /relevant-checks passes (pre-commit + agent-lint).
- [x] Read `AGENTS.md` back: `## Honesty` section present, all six rule categories covered, KARPATHY_CLAUDE.md cross-reference present, total under ~30 lines.
- [x] `git diff main...HEAD` confirms only `AGENTS.md` and the version-bump files (`.claude-plugin/plugin.json`, `CHANGELOG.md`) changed; no unintended file edits.
- [ ] CI green on this PR.

Closes #1369

🤖 Generated with [Claude Code](https://claude.com/claude-code)
