### PR TITLE
test-token-vendor-scrapers: set fake CURSOR_API_KEY in implement-launcher smoke

### DIFF
--- a/scripts/test-token-vendor-scrapers.md
+++ b/scripts/test-token-vendor-scrapers.md
@@ -2,7 +2,7 @@
 
 **Purpose**: Offline regression harness for the Codex and Cursor token scrape snippets used by external launchers.
 
-It covers Codex's last `tokens used` block selection, thousands-separator stripping, non-numeric trailing rejection, Cursor `.usage` extraction and total calculation, malformed JSON fallback, and the Cursor review launcher JSON-sidecar contract where `.result` is written back to `$OUTPUT` as plain reviewer prose while raw JSON remains at `${OUTPUT}.json`.
+It covers Codex's last `tokens used` block selection, thousands-separator stripping, non-numeric trailing rejection, Cursor `.usage` extraction and total calculation, malformed JSON fallback, and the Cursor review launcher JSON-sidecar contract where `.result` is written back to `$OUTPUT` as plain reviewer prose while raw JSON remains at `${OUTPUT}.json`. The Cursor implement-launcher smoke sets a fake non-secret `CURSOR_API_KEY` so auth preflight does not depend on a developer keychain before the PATH-stubbed `cursor` binary runs.
 
 Run via `make test-token-vendor-scrapers` or the shard that includes it.
 

--- a/scripts/test-token-vendor-scrapers.sh
+++ b/scripts/test-token-vendor-scrapers.sh
@@ -147,6 +147,7 @@ STUB_EOF
 
         LARCH_TOKEN_SESSION_ID="$LCI_SESSION" \
         PATH="$LCI_BIN:$PATH" \
+        CURSOR_API_KEY="test-cursor-api-key" \
         RUN_EXTERNAL_AGENT_POLL_INTERVAL=0.05 \
         LARCH_CURSOR_MODEL="stub-model" \
         LARCH_CODEX_MODEL="stub-codex-model" \


### PR DESCRIPTION
## Summary

The Cursor implement-launcher smoke in `scripts/test-token-vendor-scrapers.sh` spawns `launch-cursor-implement.sh` against a PATH-stubbed `cursor` binary. The launcher runs `cursor_auth_preflight` before invoking the stub and, on Darwin with `CURSOR_API_KEY` empty, falls back to checking for a `cursor-user` keychain entry. This made the smoke pass only on developer machines that happened to have logged into Cursor, and fail otherwise for non-test reasons.

Set `CURSOR_API_KEY="test-cursor-api-key"` in the env block so preflight short-circuits via the non-empty-key branch (`lib-cursor-auth.sh:118-120`). The PATH-stubbed `cursor` binary ignores all argv and reads only its manifest from the environment, so the extra `--api-key` argument the launcher now appends is silently discarded.

Sibling `.md` updated with a one-sentence note describing the new fixture behavior.

## Test plan

- [x] Reviewed by larch:code-reviewer (correctness, side-effects, secret hygiene, .md accuracy — all clean).
- [ ] CI green on `make test-token-vendor-scrapers` (and the shard that includes it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)