### PR TITLE
Resolve #1377: land 3 path-scoped rules from hook/CI mining

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "15.12.71",
+  "version": "15.12.72",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 6-reviewer specialist panel (5 Cursor specialists + 1 Codex generic) — extended to 7 with an optional Gemini reviewer when the Gemini CLI is installed and healthy — with 3-voter adjudication; plan review runs a 3-reviewer panel (Claude + Codex + Cursor); design sketches run a 9-agent diverge-then-converge phase in regular mode (1 Claude + 4 Cursor + 4 Codex) or 3 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/.claude/rules/markdown-no-space-in-code-span.md
+++ b/.claude/rules/markdown-no-space-in-code-span.md
@@ -9,9 +9,9 @@ Inside a backtick code span, the content must not start or end with whitespace. 
 When you need to render a literal that begins or ends with a space (for example, an exact-match prefix grammar):
 
 - **Drop the surrounding code span** when the content is already a recognizable token in context: write `Umbrella:` (no trailing space) instead of trying to encode a trailing space inside the span.
-- **HTML entities are not a workaround.** `&nbsp;` rendered inside a code span still trips MD038 when adjacent to a real space. Move the literal space outside the span instead — write the inner token without whitespace and put the space in the surrounding prose.
+- **HTML entities are not a workaround.** Encoding the boundary whitespace as `&nbsp;` inside the code span generally does not satisfy MD038 — the rule operates on the source-text whitespace, not the rendered HTML. Move the literal space outside the span instead — write the inner token without whitespace and put the space in the surrounding prose.
 - **Code fence** for multi-token / multi-line literals where exact whitespace matters; fences are exempt from MD038.
-- **Backslash-escape the rendering boundary**: write the span without the literal whitespace and clarify in surrounding prose ("the prefix `Umbrella:` followed by a single space").
+- **Describe boundary spacing in prose** rather than encoding it inside the span: write the span without the literal whitespace and qualify in surrounding text ("the prefix `Umbrella:` followed by a single space").
 
 This rule covers all `.md` files. The most common violations historically are in `CHANGELOG.md` entries that quote prefix grammars verbatim and `SKILL.md` files that document literal markers.
 

--- a/.claude/rules/markdown-no-space-in-code-span.md
+++ b/.claude/rules/markdown-no-space-in-code-span.md
@@ -1,0 +1,18 @@
+---
+paths: ["**/*.md"]
+---
+
+# Markdown Code Spans — No Inner Whitespace
+
+Inside a backtick code span, the content must not start or end with whitespace. The `markdownlint` MD038 rule (enabled by default, see `.markdownlint.json`) blocks the lint CI job when violated; MD037 covers the same pattern for `*emphasis*` / `_emphasis_` boundaries.
+
+When you need to render a literal that begins or ends with a space (for example, an exact-match prefix grammar):
+
+- **Drop the surrounding code span** when the content is already a recognizable token in context: write `Umbrella:` (no trailing space) instead of trying to encode a trailing space inside the span.
+- **HTML entities are not a workaround.** `&nbsp;` rendered inside a code span still trips MD038 when adjacent to a real space. Move the literal space outside the span instead — write the inner token without whitespace and put the space in the surrounding prose.
+- **Code fence** for multi-token / multi-line literals where exact whitespace matters; fences are exempt from MD038.
+- **Backslash-escape the rendering boundary**: write the span without the literal whitespace and clarify in surrounding prose ("the prefix `Umbrella:` followed by a single space").
+
+This rule covers all `.md` files. The most common violations historically are in `CHANGELOG.md` entries that quote prefix grammars verbatim and `SKILL.md` files that document literal markers.
+
+Related: `MD001/heading-increment` (no h1 → h3 jumps) is the same hygiene class — when adding a section, increment by exactly one level from the surrounding context.

--- a/.claude/rules/no-direct-submodule-edits.md
+++ b/.claude/rules/no-direct-submodule-edits.md
@@ -1,0 +1,11 @@
+---
+paths: ["**/*"]
+---
+
+# No Direct Edits Inside Submodules
+
+Files inside a checked-out git submodule of this superproject are off-limits to `Edit` and `Write`. The PreToolUse hook `scripts/block-submodule-edit.sh` (registered in `hooks/hooks.json`) emits a `permissionDecision: deny` and aborts the tool call.
+
+If you need to change submodule content, file a PR in the submodule's own repo, then bump the pinned commit in this superproject via a normal `git submodule update` workflow.
+
+Detection: the guard walks from the target file up to the first containing git repo and verifies via `rev-parse --show-superproject-working-tree` that the containing repo is a true submodule of the current superproject. Symlinks are resolved (bounded depth 40) before classification (#166); `cd` into a submodule does not bypass the guard because the hook anchors on `CLAUDE_PROJECT_DIR` (#150).

--- a/.claude/rules/no-direct-submodule-edits.md
+++ b/.claude/rules/no-direct-submodule-edits.md
@@ -6,6 +6,6 @@ paths: ["**/*"]
 
 Files inside a checked-out git submodule of this superproject are off-limits to `Edit` and `Write`. The PreToolUse hook `scripts/block-submodule-edit.sh` (registered in `hooks/hooks.json`) emits a `permissionDecision: deny` and aborts the tool call.
 
-If you need to change submodule content, file a PR in the submodule's own repo, then bump the pinned commit in this superproject via a normal `git submodule update` workflow.
+If you need to change submodule content, file a PR in the submodule's own repo. Once that lands, bump the superproject's pinned commit by checking out the desired SHA inside the submodule's checkout, then in the superproject running `git add <submodule-path>` and committing — `git submodule update` only checks out the SHA already recorded by the superproject and does not advance the pin.
 
 Detection: the guard walks from the target file up to the first containing git repo and verifies via `rev-parse --show-superproject-working-tree` that the containing repo is a true submodule of the current superproject. Symlinks are resolved (bounded depth 40) before classification (#166); `cd` into a submodule does not bypass the guard because the hook anchors on `CLAUDE_PROJECT_DIR` (#150).

--- a/.claude/rules/skill-md-description-trigger.md
+++ b/.claude/rules/skill-md-description-trigger.md
@@ -1,0 +1,13 @@
+---
+paths: ["skills/**/SKILL.md", ".claude/skills/**/SKILL.md"]
+---
+
+# SKILL.md Description Must Carry a Trigger
+
+The `description:` field in a SKILL.md frontmatter must include explicit trigger or usage context — `Use when …`, `Trigger when …`, `When to use …`, or equivalent — naming a concrete situation in which the skill should be invoked. A bare summary of what the skill does is rejected by `agent-lint` (`S017/desc-no-trigger`, run via pre-commit and the dedicated `agent-lint` CI job).
+
+Good: `description: Use when implementing a feature with auto-merge. Shortcut for /implement --merge.`
+
+Bad: `description: Implements a feature and auto-merges.`
+
+For the full design rubric (knowledge delta, structure, style), see `skills/shared/skill-design-principles.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [15.12.72] - 2026-05-07
+
+### Added
+
+- Resolve #1377: land three path-scoped `.claude/rules/` files mined from recurring CI failures and the active blocking hook. `.claude/rules/markdown-no-space-in-code-span.md` (paths `["**/*.md"]`) shadows the pre-commit `markdownlint` MD038/MD037/MD001 hygiene class — the largest CI-failure cluster in the mining window (>= 11 distinct PRs across 6 weeks). `.claude/rules/skill-md-description-trigger.md` (paths `["skills/**/SKILL.md", ".claude/skills/**/SKILL.md"]`) shadows `agent-lint S017/desc-no-trigger` so the description-trigger requirement is loaded at SKILL.md edit time without needing to load the full `skills/shared/skill-design-principles.md` rubric. `.claude/rules/no-direct-submodule-edits.md` (paths `["**/*"]`) shadows the `scripts/block-submodule-edit.sh` PreToolUse hook so the agent does not attempt edits the hook would deny at write time. AGENTS.md's existing scale-free `paths:` matching guidance covers the new files automatically; no AGENTS.md edit needed. Mining method, cluster→rule mapping, and rejected-candidate reasoning are recorded on the tracking issue (#1377).
+
 ## [15.12.71] - 2026-05-07
 
 ### Changed


### PR DESCRIPTION
## Summary

- Land the three path-scoped `.claude/rules/` files mined in issue #1377 from recurring CI failures and the active blocking hook: `markdown-no-space-in-code-span.md` (MD038/MD037/MD001 hygiene class), `skill-md-description-trigger.md` (`agent-lint S017/desc-no-trigger`), and `no-direct-submodule-edits.md` (`scripts/block-submodule-edit.sh` PreToolUse hook).
- AGENTS.md's existing scale-free `paths:` matching guidance covers the new files automatically; no AGENTS.md edit needed.
- Cluster→rule mapping, mining method, counts, and rejected-candidate reasoning are recorded on the tracking issue (#1377).

## Architecture Diagram

Architecture diagram not available.

## Code Flow Diagram

(Code Flow Diagram skipped — quick mode)

## Test plan

- [x] `/relevant-checks` clean (pre-commit on changed files + agent-lint on full repo)
- [x] markdownlint accepts the new files (rule 1's body discusses MD038 — care taken to keep its own code spans MD038-clean)
- [x] Each new rule's `paths:` frontmatter parses correctly

Closes #1377

🤖 Generated with [Claude Code](https://claude.com/claude-code)
