### PR TITLE
Resolve #1416: combined design-phase OOS follow-ups (root .gitattributes + slug-count drift fix)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "15.13.4",
+  "version": "15.13.5",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 6-reviewer specialist panel (5 Cursor specialists + 1 Codex generic) — extended to 7 with an optional Gemini reviewer when the Gemini CLI is installed and healthy — with 3-voter adjudication; plan review runs a 3-reviewer panel (Claude + Codex + Cursor); design sketches run a 9-agent diverge-then-converge phase in regular mode (1 Claude + 4 Cursor + 4 Codex) or 3 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,19 @@
+# Default: detect text files automatically and normalize EOL to LF in the
+# repository. This makes line-ending behavior independent of contributor
+# editor settings or `git`'s `core.autocrlf`, replacing the previous
+# one-shot raw-byte CRLF gate (gate 7 in the polish PR).
+
+* text=auto eol=lf
+
+# Explicit text rules for the common extensions in this repo. These pin
+# `eol=lf` regardless of `core.autocrlf` and prevent CRLF from sneaking
+# into text content via Windows editors or copy-paste from CRLF sources.
+*.md     text eol=lf
+*.sh     text eol=lf
+*.py     text eol=lf
+*.yaml   text eol=lf
+*.yml    text eol=lf
+*.json   text eol=lf
+*.tsv    text eol=lf
+*.toml   text eol=lf
+*.txt    text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,6 @@
 # Default: detect text files automatically and normalize EOL to LF in the
 # repository. This makes line-ending behavior independent of contributor
-# editor settings or `git`'s `core.autocrlf`, replacing the previous
-# one-shot raw-byte CRLF gate (gate 7 in the polish PR).
+# editor settings or `git`'s `core.autocrlf`.
 
 * text=auto eol=lf
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [15.13.5] - 2026-05-07
+
+### Changed
+
+- Resolve #1416: combined design-phase OOS follow-ups from #1410 and #1411. New root `.gitattributes` enforces LF EOL across the repo (default `* text=auto eol=lf` plus explicit `text eol=lf` for `*.md`, `*.sh`, `*.py`, `*.yaml`, `*.yml`, `*.json`, `*.tsv`, `*.toml`, `*.txt`) so CRLF normalization no longer depends on contributor editor settings or `git`'s `core.autocrlf`. `scripts/anchor-section-markers.md` test-harness bullet drops the stale "9-slug" literal in favor of referring to the `SECTION_MARKERS` array by symbol; the array now has 10 slugs (the `timing-report` slug was added). Also folded inline as same-class doc drift: `scripts/test-assemble-anchor.sh` header comment dropped its stale "8 empty marker pairs … (23 lines total)" literal counts in favor of a by-symbol reference to `SECTION_MARKERS`, per `.claude/rules/drift-prone-prose-in-docs.md` "Don't write hardcoded counts in prose".
+
 ## [15.13.4] - 2026-05-08
 
 ### Changed

--- a/scripts/anchor-section-markers.md
+++ b/scripts/anchor-section-markers.md
@@ -43,7 +43,7 @@ The `COLLAPSE_PRIORITY` array lives inline in `scripts/tracking-issue-write.sh` 
 ## Test harness
 
 Covered indirectly by:
-- `scripts/test-assemble-anchor.sh` — fixture-based validation that assemble-anchor.sh emits the full 9-slug marker set in SECTION_MARKERS order.
+- `scripts/test-assemble-anchor.sh` — fixture-based validation that assemble-anchor.sh emits the full SECTION_MARKERS marker set in declaration order.
 - `scripts/test-tracking-issue-write.sh` — existing harness validates truncation + the SECTION_MARKERS ⊆ COLLAPSE_PRIORITY invariant (Phase 5 addition).
 
 No direct harness — the file exposes only a constant array.

--- a/scripts/test-assemble-anchor.sh
+++ b/scripts/test-assemble-anchor.sh
@@ -2,9 +2,10 @@
 # test-assemble-anchor.sh — regression harness for scripts/assemble-anchor.sh.
 #
 # Covers 18 assertion categories:
-#   (a) Empty sections directory → 8 empty marker pairs + run-statistics
-#       minimal table + first-line marker + seed-only visible placeholder
-#       line on line 2 (23 lines total).
+#   (a) Empty sections directory → one empty marker pair per SECTION_MARKERS
+#       slug + run-statistics minimal table + first-line marker +
+#       seed-only visible placeholder line on line 2 (line count derived
+#       from SECTION_MARKERS at runtime — see expected_lines_a below).
 #   (a2) Empty sections directory → placeholder literal present (regression
 #       guard for the seed-only visibility fix).
 #   (a3) Partial fragments (one slug populated) → placeholder is suppressed


### PR DESCRIPTION
## Summary

- Added a root `.gitattributes` enforcing LF normalization across the repo (default `* text=auto eol=lf` plus explicit `text eol=lf` for `*.md`, `*.sh`, `*.py`, `*.yaml`, `*.yml`, `*.json`, `*.tsv`, `*.toml`, `*.txt`) so CRLF behavior no longer depends on contributor editor settings or `git`'s `core.autocrlf` (#1410).
- Dropped the stale "9-slug" literal count from `scripts/anchor-section-markers.md` — the test-harness bullet now refers to the `SECTION_MARKERS` array by symbol; the array currently has 10 slugs after `timing-report` was added (#1411).
- Folded inline as same-class doc drift (review round 1, rule 1): removed stale "8 empty marker pairs … (23 lines total)" literal counts from the `scripts/test-assemble-anchor.sh` header comment in favor of a by-symbol reference, per `.claude/rules/drift-prone-prose-in-docs.md`.

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] `/relevant-checks` (pre-commit + agent-lint) clean post-implementation
- [x] `/relevant-checks` clean post-review-fixes
- [ ] CI green on the PR (markdownlint, shellcheck, agent-lint, agent-sync, lint, test-harnesses)

</details>

Closes #1416

Generated with [Claude Code](https://claude.com/claude-code)
