### PR TITLE
Resolve #1430: silence retry harness tmpdir cleanup warning

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "15.13.8",
+  "version": "15.13.9",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 6-reviewer specialist panel (5 Cursor specialists + 1 Codex generic) — extended to 7 with an optional Gemini reviewer when the Gemini CLI is installed and healthy — with 3-voter adjudication; plan review runs a 3-reviewer panel (Claude + Codex + Cursor); design sketches run a 9-agent diverge-then-converge phase in regular mode (1 Claude + 4 Cursor + 4 Codex) or 3 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [15.13.9] - 2026-05-08
+
+### Fixed
+
+- Resolve #1430: silence the cosmetic `rm: <TMPROOT>: Permission denied` stderr emitted by the EXIT trap in `scripts/test-collect-agent-retry.sh` during `make test-harnesses-1`. The warning was a transient macOS-APFS race: a backgrounded retry subshell (spawned by `scripts/collect-agent-results.sh` and chained via `wait_for_reviewers.sh`) could still hold a per-case workdir as cwd when the harness's EXIT trap fired. All TMPROOT contents are user-owned with normal permissions and a manual `rm -rf` succeeds; cleanup is best-effort tmpdir disposal that the OS reaps regardless. Trap now redirects rm stderr to `/dev/null` with a 4-line comment recording the rationale (review-round-1 follow-up). 121/121 test assertions still pass.
+
 ## [15.13.8] - 2026-05-08
 
 ### Changed

--- a/scripts/test-collect-agent-retry.sh
+++ b/scripts/test-collect-agent-retry.sh
@@ -16,7 +16,7 @@ export WAIT_FOR_REVIEWERS_POLL_INTERVAL=0.05
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 COLLECTOR="$REPO_ROOT/scripts/collect-agent-results.sh"
 TMPROOT="$(mktemp -d "${TMPDIR:-/tmp}/test-collect-agent-retry-XXXXXX")"
-trap 'rm -rf "$TMPROOT"' EXIT
+trap 'rm -rf "$TMPROOT" 2>/dev/null' EXIT
 
 PASS=0
 FAIL=0

--- a/scripts/test-collect-agent-retry.sh
+++ b/scripts/test-collect-agent-retry.sh
@@ -16,6 +16,10 @@ export WAIT_FOR_REVIEWERS_POLL_INTERVAL=0.05
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 COLLECTOR="$REPO_ROOT/scripts/collect-agent-results.sh"
 TMPROOT="$(mktemp -d "${TMPDIR:-/tmp}/test-collect-agent-retry-XXXXXX")"
+# Suppress rm stderr: backgrounded retry subshells (collect-agent-results.sh)
+# can still hold a per-case workdir as cwd when this trap fires, producing a
+# transient "Permission denied" on macOS APFS. Cleanup is best-effort; the OS
+# reaps stale dirs under TMPDIR.
 trap 'rm -rf "$TMPROOT" 2>/dev/null' EXIT
 
 PASS=0


### PR DESCRIPTION
## Summary

- Keep the retry harness output focused on assertion failures by silencing a known best-effort tmpdir cleanup race.
- Add a 4-line comment above the EXIT trap explaining the suppressed-stderr rationale (review round 1 fold-inline of the only finding raised: "blanket `2>/dev/null` hides all cleanup diagnostics").

## Architecture Diagram

Architecture diagram not available.

## Code Flow Diagram

(Code Flow Diagram skipped — quick mode)

## Test plan

- [x] `bash scripts/test-collect-agent-retry.sh` — 121/121 pass with no stderr noise on cleanup.
- [x] `/relevant-checks` — pre-commit + agent-lint clean.

Closes #1430

🤖 Generated with [Claude Code](https://claude.com/claude-code)
