### PR TITLE
Resolve #1433: atomic archive publish in compose-review-findings.sh

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "15.13.9",
+  "version": "15.13.10",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 6-reviewer specialist panel (5 Cursor specialists + 1 Codex generic) — extended to 7 with an optional Gemini reviewer when the Gemini CLI is installed and healthy — with 3-voter adjudication; plan review runs a 3-reviewer panel (Claude + Codex + Cursor); design sketches run a 9-agent diverge-then-converge phase in regular mode (1 Claude + 4 Cursor + 4 Codex) or 3 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [15.13.10] - 2026-05-07
+
+### Fixed
+
+- Resolve #1433: close the partial-content observability window in `scripts/compose-review-findings.sh`'s archive publish path. The previous `cp "$TMP_JSONL" "$ARCHIVE_PATH"` could expose a half-written `docs/review-archive/issue-<N>.jsonl` to readers if interrupted mid-write. Replaced with a same-directory staged write — `mktemp "${ARCHIVE_PATH}.XXXXXX"` inside `$ARCHIVE_DIR`, copy `$TMP_JSONL` in, then `mv -f` to publish — which guarantees an atomic rename on POSIX same-filesystem semantics (the prior bare `mv -f` from `$TMP_JSONL` could fall back to copy+unlink across filesystems and reintroduce the same window). Failure paths in both staging and publish remove the tempfile before `fail`. Harness `scripts/test-compose-review-findings.sh` case (e) now asserts the archive directory contains only the published JSONL after a successful run, pinning the no-leftover-staging-tempfile invariant.
+
 ## [15.13.9] - 2026-05-08
 
 ### Fixed

--- a/scripts/compose-review-findings.md
+++ b/scripts/compose-review-findings.md
@@ -9,7 +9,9 @@ When the inline payload exceeds a configurable byte threshold (default
 30 000 bytes, set per issue #1402's design clarification), switch to
 **archive-pointer mode**: write a `docs/review-archive/issue-<N>.jsonl`
 file with one JSON object per finding and replace the inline section body
-with a small pointer + count summary.
+with a small pointer + count summary. Archive files are staged as
+same-directory tempfiles and then published with `mv -f` so readers never
+observe a partially copied final `issue-<N>.jsonl`.
 
 This is the load-bearing helper for issue #1402's `review-findings-full`
 section. The existing `plan-review-tally` and `code-review-tally`

--- a/scripts/compose-review-findings.sh
+++ b/scripts/compose-review-findings.sh
@@ -358,7 +358,15 @@ if [ "$INLINE_BYTES" -gt "$ARCHIVE_THRESHOLD" ] && [ "$FINDINGS_TOTAL" -gt 0 ]; 
     MODE="archive"
     ARCHIVE_PATH="$ARCHIVE_DIR/issue-${ISSUE}.jsonl"
     mkdir -p "$ARCHIVE_DIR" 2>/dev/null || fail "cannot create archive directory: $ARCHIVE_DIR"
-    cp "$TMP_JSONL" "$ARCHIVE_PATH" || fail "failed to write archive: $ARCHIVE_PATH"
+    ARCHIVE_TMP="$(mktemp "${ARCHIVE_PATH}.XXXXXX")" || fail "cannot create temp archive file: $ARCHIVE_PATH"
+    if ! cp "$TMP_JSONL" "$ARCHIVE_TMP"; then
+        rm -f "$ARCHIVE_TMP"
+        fail "failed to stage archive: $ARCHIVE_PATH"
+    fi
+    if ! mv -f "$ARCHIVE_TMP" "$ARCHIVE_PATH"; then
+        rm -f "$ARCHIVE_TMP"
+        fail "failed to publish archive: $ARCHIVE_PATH"
+    fi
     ARCHIVE_BYTES=$(wc -c < "$ARCHIVE_PATH" | tr -d ' ')
 
     # Replace the inline body with a pointer + count summary; the existing

--- a/scripts/test-compose-review-findings.sh
+++ b/scripts/test-compose-review-findings.sh
@@ -10,7 +10,8 @@
 #       header with synthetic id REJ_P1
 #   (d) rejected code-review parsing → finding emitted under [Code Review]
 #       header with synthetic id REJ_C1
-#   (e) inline ↔ archive switchover at the configured threshold
+#   (e) inline ↔ archive switchover at the configured threshold, with no
+#       leftover same-directory archive tempfile
 #   (f) archive content shape (JSONL — one record per line, valid JSON)
 #   (g) category derivation maps reviewer-name fragments to canonical tags
 #   (h) JSON escaping handles control bytes, carriage returns, quotes, and newlines
@@ -156,6 +157,10 @@ stdout_e=$("$COMPOSE" \
 grep -qxF 'MODE=archive' <<<"$stdout_e" || fail "(e) expected MODE=archive; got: $stdout_e"
 grep -qxF "ARCHIVE_PATH=$TMP/e-archive/issue-99.jsonl" <<<"$stdout_e" || fail "(e) archive path missing"
 [ -f "$TMP/e-archive/issue-99.jsonl" ] || fail "(e) archive file not created"
+archive_entries=("$TMP/e-archive"/*)
+if [ "${#archive_entries[@]}" -ne 1 ] || [ "${archive_entries[0]}" != "$TMP/e-archive/issue-99.jsonl" ]; then
+    fail "(e) archive directory should contain only the published JSONL"
+fi
 grep -q 'Inline payload exceeded' "$out_e" || fail "(e) pointer text missing"
 grep -q 'Archive path' "$out_e" || fail "(e) archive path bullet missing"
 [ "$FAILS" -eq 0 ] && pass "(e) archive switchover"


### PR DESCRIPTION
## Summary

- Close the partial-content visibility window when review findings switch to archive mode
- Pin archive switchover coverage so successful writes leave no staging files behind
- Document the atomic archive publication contract for the compose helper

## Architecture Diagram

Architecture diagram not available.

## Code Flow Diagram

(Code Flow Diagram skipped — quick mode)

## Test plan

- [x] `bash scripts/test-compose-review-findings.sh` — all 12 cases pass, including the new "no leftover staging tempfile" assertion in case (e)
- [x] `/relevant-checks` — pre-commit (shellcheck, markdownlint, jsonlint, agent-lint, gitleaks, lint-skill-invocation, lint-literal-counts) + full-repo agent-lint clean

Closes #1433

🤖 Generated with [Claude Code](https://claude.com/claude-code)
