### PR TITLE
Resolve #1475: align absent-sentinel for plugin.json check (fixes --coder=codex/cursor/gemini false-positive bail)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "17.0.0",
+  "version": "17.0.1",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 6-reviewer specialist panel (5 Cursor specialists + 1 Codex generic) — extended to 7 with an optional Gemini reviewer when the Gemini CLI is installed and healthy — with 3-voter adjudication; plan review runs a 3-reviewer panel (Claude + Codex + Cursor); design sketches run a 9-agent diverge-then-converge phase in regular mode (1 Claude + 4 Cursor + 4 Codex) or 3 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [17.0.1] - 2026-05-07
+
+### Fixed
+
+- Resolve #1475: align the absent-sentinel encoding for the `.claude-plugin/plugin.json` baseline check in `skills/implement/scripts/step2-implement.sh`. The Step 1 baseline write now uses an empty file (`: > "$file.tmp"`) when `plugin.json` is absent, and the Step 6b post-implementer comparison uses `CURRENT_PLUGIN_JSON=""` for the same absent state. Previously the baseline used `printf '\n'` while the post-check used `$'\n'`, which compared unequal because `$(cat …)` strips trailing newlines per POSIX. The mismatch caused a deterministic false-positive `protected-path-modified` bail for `--coder=codex` (default), `--coder=cursor`, and `--coder=gemini` in any consumer repo lacking `.claude-plugin/plugin.json`. New Test 13 in `skills/implement/scripts/test-step2-dispatch.sh` covers the absent-then-still-absent case end-to-end with a stub Codex spawn → manifest → Step 6/7 → dispatcher-side commit flow, asserting `STATUS=complete` plus `ORCHESTRATOR_EDIT_AUTHORITY=forbidden` + `MANIFEST=` per NEVER #10. Test 12 entry added to `test-step2-dispatch.md` to close the previously latent 11→13 numbering gap.
+
 ## [17.0.0] - 2026-05-07
 
 ### Changed

--- a/skills/implement/scripts/step2-implement.sh
+++ b/skills/implement/scripts/step2-implement.sh
@@ -330,7 +330,10 @@ if [[ ! -f "$PLUGIN_JSON_BASELINE_FILE" ]]; then
     if [[ -f "$REPO_ROOT/.claude-plugin/plugin.json" ]]; then
         git -C "$REPO_ROOT" hash-object "$REPO_ROOT/.claude-plugin/plugin.json" > "$PLUGIN_JSON_BASELINE_FILE.tmp"
     else
-        printf '\n' > "$PLUGIN_JSON_BASELINE_FILE.tmp"
+        # Empty file is the canonical absent-sentinel — matches the "" produced by
+        # the post-implementer absent branch in Step 6b, and round-trips cleanly
+        # through `$(cat …)` below (no trailing-newline stripping mismatch). #1475.
+        : > "$PLUGIN_JSON_BASELINE_FILE.tmp"
     fi
     mv "$PLUGIN_JSON_BASELINE_FILE.tmp" "$PLUGIN_JSON_BASELINE_FILE"
 fi
@@ -506,11 +509,9 @@ if [[ "$STATUS" != "bailed" ]]; then
         emit_bailed "branch-changed"
     fi
 
-    # 6b: .claude-plugin/plugin.json unchanged.
-    # When plugin.json is absent the baseline file at line 333 holds a literal
-    # newline, but `$(cat …)` at line 337 strips trailing newlines per POSIX, so
-    # PLUGIN_JSON_BASELINE becomes "" (empty). Match that here with "" instead
-    # of $'\n' so absent-then-still-absent compares equal — closes #1475.
+    # 6b: .claude-plugin/plugin.json unchanged. Both branches use "" as the
+    # canonical absent-sentinel, matching the empty baseline file written in
+    # Step 1's first-write block above — closes #1475.
     if [[ -f "$REPO_ROOT/.claude-plugin/plugin.json" ]]; then
         CURRENT_PLUGIN_JSON=$(git -C "$REPO_ROOT" hash-object "$REPO_ROOT/.claude-plugin/plugin.json")
     else

--- a/skills/implement/scripts/step2-implement.sh
+++ b/skills/implement/scripts/step2-implement.sh
@@ -507,10 +507,14 @@ if [[ "$STATUS" != "bailed" ]]; then
     fi
 
     # 6b: .claude-plugin/plugin.json unchanged.
+    # When plugin.json is absent the baseline file at line 333 holds a literal
+    # newline, but `$(cat …)` at line 337 strips trailing newlines per POSIX, so
+    # PLUGIN_JSON_BASELINE becomes "" (empty). Match that here with "" instead
+    # of $'\n' so absent-then-still-absent compares equal — closes #1475.
     if [[ -f "$REPO_ROOT/.claude-plugin/plugin.json" ]]; then
         CURRENT_PLUGIN_JSON=$(git -C "$REPO_ROOT" hash-object "$REPO_ROOT/.claude-plugin/plugin.json")
     else
-        CURRENT_PLUGIN_JSON=$'\n'
+        CURRENT_PLUGIN_JSON=""
     fi
     if [[ "$CURRENT_PLUGIN_JSON" != "$PLUGIN_JSON_BASELINE" ]]; then
         emit_bailed "protected-path-modified"

--- a/skills/implement/scripts/test-step2-dispatch.md
+++ b/skills/implement/scripts/test-step2-dispatch.md
@@ -2,7 +2,7 @@
 
 **Purpose**: Offline regression harness for `skills/implement/scripts/step2-implement.sh` covering the dispatcher branches that do not require spawning an external implementer. Runs in <1s with no `codex`/`cursor`/`gemini` binary and no network.
 
-**Coverage** (37 assertions):
+**Coverage**:
 1. `--coder claude` emits `STATUS=claude_fallback` and `ORCHESTRATOR_EDIT_AUTHORITY=allowed` (and no other KV keys — no `MANIFEST=`, no `TRANSCRIPT=`, etc.), and writes no baseline files.
 1b. Default coder (no flag) is codex — verified via non-git cwd exit 2 with the git-tree message (the claude default would early-return `STATUS=claude_fallback` instead).
 1c. Legacy `--codex-available false` still emits `STATUS=claude_fallback` and prints a deprecation warning to stderr.
@@ -32,6 +32,7 @@
 10. Second invocation against a tmpdir whose `step2-spawn-coder.txt` recorded a different coder (`codex` pre-seeded; invocation passes `--coder=cursor --cursor-healthy true`) emits `STATUS=bailed REASON=coder-mismatch-tmpdir-reuse TOOL=cursor`. The pre-seeded sentinel value MUST be unchanged on bail, and the `cursor-resume-count.txt` MUST NOT have been written — pins the cross-coder guard's "fail before any per-tool state mutation" ordering. Also asserts `ORCHESTRATOR_EDIT_AUTHORITY=forbidden` on this bail path.
 10b. Gemini variant of the same cross-coder guard (`cursor` pre-seeded; invocation passes `--coder=gemini --gemini-healthy true`) emits `TOOL=gemini`, leaves the sentinel unchanged, and does not write `gemini-resume-count.txt`.
 11. `ORCHESTRATOR_EDIT_AUTHORITY` pair invariant: on every reachable exit-0 outcome the dispatcher emits exactly one `ORCHESTRATOR_EDIT_AUTHORITY=` line, with `allowed` iff `STATUS=claude_fallback` and `forbidden` on every external-implementer outcome. Test 11a re-runs the `--coder claude` claude_fallback path and asserts `AUTH=allowed`; test 11b re-runs the resume-cap bail (`--coder codex --answers` with pre-seeded `codex-resume-count.txt=5`) and asserts `AUTH=forbidden`. Tests 1, 1c, 3b, 3b2, 3b3, 3b5, 3b6, 5, 7, and 10 also pin the AUTH key on their respective branches; this is the central mechanical gate that lets `SKILL.md` Step 2 enforce NEVER #10 (`ORCHESTRATOR_EDIT_AUTHORITY=allowed` ⇔ `STATUS=claude_fallback`).
+13. `.claude-plugin/plugin.json` absent-then-still-absent regression (issue #1475): in a scratch git repo without `plugin.json`, a stub Codex that performs a benign edit on a non-protected file and writes a valid `status=complete` manifest must reach `STATUS=complete` — not bail with `REASON=protected-path-modified`. Pins the Step 6b absent-sentinel-equality fix at `step2-implement.sh` line ~516 (`CURRENT_PLUGIN_JSON=""`).
 
 All `--coder codex` invocations that proceed past argument parsing are run with cwd pinned to `$REPO_ROOT` so the dispatcher's git resolution targets the harness's own git tree. Cursor and Gemini health-gate tests also use `cd "$REPO_ROOT"` unless the assertion specifically covers outside-git ordering.
 
@@ -40,7 +41,7 @@ All `--coder codex` invocations that proceed past argument parsing are run with 
 - Path normalization (`..` / leading `/` / `.claude-plugin/plugin.json` / submodule paths).
 - Sanitization via `scripts/redact-secrets.sh`.
 - Single-retry on transient launcher failure with clean-state guard.
-- `branch-changed` / `protected-path-modified` / `submodule-dirty` / `cursor-modified-history` post-implementer checks.
+- `branch-changed` / `submodule-dirty` / `cursor-modified-history` post-implementer checks.
 - Dispatcher-side commit (`git add -A && git commit -F …`) and `commit-failed` recovery.
 
 **Invariants**:

--- a/skills/implement/scripts/test-step2-dispatch.md
+++ b/skills/implement/scripts/test-step2-dispatch.md
@@ -1,6 +1,6 @@
 # test-step2-dispatch.sh
 
-**Purpose**: Offline regression harness for `skills/implement/scripts/step2-implement.sh` covering the dispatcher branches that do not require spawning an external implementer. Runs in <1s with no `codex`/`cursor`/`gemini` binary and no network.
+**Purpose**: Offline regression harness for `skills/implement/scripts/step2-implement.sh`. Most tests cover dispatcher branches that do not require spawning a real external implementer; a small number (Test 12, Test 13) inject a stub `codex` binary on PATH to exercise the spawn → manifest → Step 6/7 → dispatcher-side commit flow. Runs in <1s with no real `codex`/`cursor`/`gemini` binary and no network.
 
 **Coverage**:
 1. `--coder claude` emits `STATUS=claude_fallback` and `ORCHESTRATOR_EDIT_AUTHORITY=allowed` (and no other KV keys — no `MANIFEST=`, no `TRANSCRIPT=`, etc.), and writes no baseline files.
@@ -32,7 +32,8 @@
 10. Second invocation against a tmpdir whose `step2-spawn-coder.txt` recorded a different coder (`codex` pre-seeded; invocation passes `--coder=cursor --cursor-healthy true`) emits `STATUS=bailed REASON=coder-mismatch-tmpdir-reuse TOOL=cursor`. The pre-seeded sentinel value MUST be unchanged on bail, and the `cursor-resume-count.txt` MUST NOT have been written — pins the cross-coder guard's "fail before any per-tool state mutation" ordering. Also asserts `ORCHESTRATOR_EDIT_AUTHORITY=forbidden` on this bail path.
 10b. Gemini variant of the same cross-coder guard (`cursor` pre-seeded; invocation passes `--coder=gemini --gemini-healthy true`) emits `TOOL=gemini`, leaves the sentinel unchanged, and does not write `gemini-resume-count.txt`.
 11. `ORCHESTRATOR_EDIT_AUTHORITY` pair invariant: on every reachable exit-0 outcome the dispatcher emits exactly one `ORCHESTRATOR_EDIT_AUTHORITY=` line, with `allowed` iff `STATUS=claude_fallback` and `forbidden` on every external-implementer outcome. Test 11a re-runs the `--coder claude` claude_fallback path and asserts `AUTH=allowed`; test 11b re-runs the resume-cap bail (`--coder codex --answers` with pre-seeded `codex-resume-count.txt=5`) and asserts `AUTH=forbidden`. Tests 1, 1c, 3b, 3b2, 3b3, 3b5, 3b6, 5, 7, and 10 also pin the AUTH key on their respective branches; this is the central mechanical gate that lets `SKILL.md` Step 2 enforce NEVER #10 (`ORCHESTRATOR_EDIT_AUTHORITY=allowed` ⇔ `STATUS=claude_fallback`).
-13. `.claude-plugin/plugin.json` absent-then-still-absent regression (issue #1475): in a scratch git repo without `plugin.json`, a stub Codex that performs a benign edit on a non-protected file and writes a valid `status=complete` manifest must reach `STATUS=complete` — not bail with `REASON=protected-path-modified`. Pins the Step 6b absent-sentinel-equality fix at `step2-implement.sh` line ~516 (`CURRENT_PLUGIN_JSON=""`).
+12. Canonical `--tmpdir`/`session-id` overwrites stale token-session env before the launcher subprocess runs. Test 12a writes a fresh `session-id` to a clean tmpdir, sets a stale `LARCH_TOKEN_SESSION_ID` in the dispatcher's environment, and asserts the stub Codex sees the tmpdir's `session-id` (not the stale env value). Test 12b re-runs against a separate tmpdir with no inherited env to confirm each tmpdir exports its own session id. Both use the stub Codex pattern (PATH override) shared with Test 13.
+13. `.claude-plugin/plugin.json` absent-then-still-absent regression (issue #1475): in a scratch git repo without `plugin.json`, a stub Codex that performs a benign edit on a non-protected file and writes a valid `status=complete` manifest must reach `STATUS=complete` (not bail with `REASON=protected-path-modified`), AND emit `ORCHESTRATOR_EDIT_AUTHORITY=forbidden` plus `MANIFEST=` per NEVER #10. Pins the Step 6b absent-sentinel-equality fix where both the baseline write and the post-implementer comparison use the empty-string canonical sentinel for "absent".
 
 All `--coder codex` invocations that proceed past argument parsing are run with cwd pinned to `$REPO_ROOT` so the dispatcher's git resolution targets the harness's own git tree. Cursor and Gemini health-gate tests also use `cd "$REPO_ROOT"` unless the assertion specifically covers outside-git ordering.
 
@@ -41,8 +42,8 @@ All `--coder codex` invocations that proceed past argument parsing are run with 
 - Path normalization (`..` / leading `/` / `.claude-plugin/plugin.json` / submodule paths).
 - Sanitization via `scripts/redact-secrets.sh`.
 - Single-retry on transient launcher failure with clean-state guard.
-- `branch-changed` / `submodule-dirty` / `cursor-modified-history` post-implementer checks.
-- Dispatcher-side commit (`git add -A && git commit -F …`) and `commit-failed` recovery.
+- `branch-changed` / `submodule-dirty` / `cursor-modified-history` post-implementer checks. (Test 13 covers only the Step 6b absent-`plugin.json` sentinel case from issue #1475; Step 7a path-validation `protected-path-modified` paths and the other Step 6 post-implementer rejections remain out of scope here.)
+- `commit-failed` recovery on the dispatcher-side commit. (Test 13 exercises the happy path of `git add -A && git commit -F …` end-to-end via stub Codex; failure-recovery branches remain out of scope.)
 
 **Invariants**:
 - Tests run against the live dispatcher in the repo, not a copy.

--- a/skills/implement/scripts/test-step2-dispatch.sh
+++ b/skills/implement/scripts/test-step2-dispatch.sh
@@ -25,6 +25,9 @@
 #   - First codex invocation writes step2-spawn-coder.txt with the resolved coder.
 #   - Second invocation against same tmpdir with mismatched --coder → STATUS=bailed
 #     REASON=coder-mismatch-tmpdir-reuse TOOL=<current-tool>.
+#   - In a scratch git repo without .claude-plugin/plugin.json, a stub-Codex
+#     run that touches only non-protected files reaches STATUS=complete
+#     (no false-positive REASON=protected-path-modified — issue #1475).
 #
 # External-implementer spawning paths (manifest validation, dispatcher-side commit,
 # sanitization, launcher-retry) are covered by separate launcher / end-to-end tests;
@@ -594,6 +597,77 @@ if [[ "$OUT_12B" == *"STATUS=bailed"* ]] && [[ "$(cat "$TOKEN12B")" == "fresh-st
     pass
 else
     fail 12b "second tmpdir should export its own session id, out=$OUT_12B token=$(cat "$TOKEN12B" 2>/dev/null)"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 13: in a git repo WITHOUT .claude-plugin/plugin.json, a successful
+# implementer run that does NOT touch plugin.json must reach STATUS=complete
+# (not bail with REASON=protected-path-modified). Regression coverage for
+# issue #1475 — absent-then-still-absent must compare equal in Step 6b.
+# ---------------------------------------------------------------------------
+TMP13="$SCRATCH/test13"; mkdir -p "$TMP13"
+printf 'fresh-step2-13\n' > "$TMP13/session-id"
+
+# Scratch git repo with no .claude-plugin/plugin.json.
+SCRATCH_REPO="$SCRATCH/scratch-repo-13"
+mkdir -p "$SCRATCH_REPO"
+git -C "$SCRATCH_REPO" init -q -b main
+git -C "$SCRATCH_REPO" config user.email "test@example.com"
+git -C "$SCRATCH_REPO" config user.name "Test"
+echo "initial" > "$SCRATCH_REPO/README.md"
+git -C "$SCRATCH_REPO" add README.md
+git -C "$SCRATCH_REPO" commit -q -m "init"
+[[ ! -e "$SCRATCH_REPO/.claude-plugin/plugin.json" ]] || \
+    fail 13 "scratch repo precondition: plugin.json should not exist"
+
+# Stub codex: modify a benign file in the working tree and write a
+# status=complete manifest. Does NOT touch .claude-plugin/plugin.json.
+STUB13="$SCRATCH/stub-bin-13"; mkdir -p "$STUB13"
+cat > "$STUB13/codex" <<'STUB13_CODEX'
+#!/usr/bin/env bash
+set -euo pipefail
+: "${STEP2_MANIFEST_PATH:?}"
+output_path=""
+last=""
+for arg in "$@"; do
+    if [[ "$last" == "--output-last-message" ]]; then
+        output_path="$arg"
+    fi
+    last="$arg"
+done
+[[ -n "$output_path" ]] && printf 'stub transcript\n' > "$output_path"
+# Modify a benign tracked file. Working tree is the dispatcher's cwd.
+echo "edited by stub" >> "$PWD/README.md"
+cat > "$STEP2_MANIFEST_PATH.tmp" <<JSON
+{
+  "schema_version": "1",
+  "status": "complete",
+  "files_touched": [{"path": "README.md"}],
+  "commit_message": "stub: edit README",
+  "summary_bullets": ["edited README"],
+  "tests_added_or_modified": [],
+  "todos_left": [],
+  "oos_observations": []
+}
+JSON
+mv "$STEP2_MANIFEST_PATH.tmp" "$STEP2_MANIFEST_PATH"
+printf 'stub codex stdout\n'
+STUB13_CODEX
+chmod +x "$STUB13/codex"
+
+OUT_13=$(cd "$SCRATCH_REPO" && \
+    PATH="$STUB13:$PATH" \
+    RUN_EXTERNAL_AGENT_POLL_INTERVAL=0.05 \
+    STEP2_MANIFEST_PATH="$TMP13/manifest.json" \
+    LARCH_CODEX_MODEL=stub-codex-model \
+    "$DISPATCHER" --tmpdir "$TMP13" --plan-file "$PLAN" --feature-file "$FEATURE" \
+        --auto-mode false --coder codex 2>&1)
+
+if [[ "$OUT_13" == *"STATUS=complete"* ]] \
+   && [[ "$OUT_13" != *"REASON=protected-path-modified"* ]]; then
+    pass
+else
+    fail 13 "absent plugin.json + benign edit should reach STATUS=complete (no protected-path-modified false positive); got: $OUT_13"
 fi
 
 # ---------------------------------------------------------------------------

--- a/skills/implement/scripts/test-step2-dispatch.sh
+++ b/skills/implement/scripts/test-step2-dispatch.sh
@@ -316,7 +316,7 @@ git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD > "$TMP5/step2-spawn-branch.txt"
 if [[ -f "$REPO_ROOT/.claude-plugin/plugin.json" ]]; then
     git -C "$REPO_ROOT" hash-object "$REPO_ROOT/.claude-plugin/plugin.json" > "$TMP5/step2-plugin-json-baseline.txt"
 else
-    printf '\n' > "$TMP5/step2-plugin-json-baseline.txt"
+    : > "$TMP5/step2-plugin-json-baseline.txt"
 fi
 echo "5" > "$TMP5/codex-resume-count.txt"
 ANSWERS="$SCRATCH/answers.json"
@@ -357,7 +357,7 @@ git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD > "$TMP7/step2-spawn-branch.txt"
 if [[ -f "$REPO_ROOT/.claude-plugin/plugin.json" ]]; then
     git -C "$REPO_ROOT" hash-object "$REPO_ROOT/.claude-plugin/plugin.json" > "$TMP7/step2-plugin-json-baseline.txt"
 else
-    printf '\n' > "$TMP7/step2-plugin-json-baseline.txt"
+    : > "$TMP7/step2-plugin-json-baseline.txt"
 fi
 echo "garbage" > "$TMP7/codex-resume-count.txt"
 OUT=$(cd "$REPO_ROOT" && "$DISPATCHER" --tmpdir "$TMP7" --plan-file "$PLAN" --feature-file "$FEATURE" \
@@ -405,7 +405,7 @@ git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD > "$TMP9/step2-spawn-branch.txt"
 if [[ -f "$REPO_ROOT/.claude-plugin/plugin.json" ]]; then
     git -C "$REPO_ROOT" hash-object "$REPO_ROOT/.claude-plugin/plugin.json" > "$TMP9/step2-plugin-json-baseline.txt"
 else
-    printf '\n' > "$TMP9/step2-plugin-json-baseline.txt"
+    : > "$TMP9/step2-plugin-json-baseline.txt"
 fi
 echo "5" > "$TMP9/codex-resume-count.txt"
 OUT=$(cd "$REPO_ROOT" && "$DISPATCHER" --tmpdir "$TMP9" --plan-file "$PLAN" --feature-file "$FEATURE" \
@@ -429,7 +429,7 @@ git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD > "$TMP10/step2-spawn-branch.txt
 if [[ -f "$REPO_ROOT/.claude-plugin/plugin.json" ]]; then
     git -C "$REPO_ROOT" hash-object "$REPO_ROOT/.claude-plugin/plugin.json" > "$TMP10/step2-plugin-json-baseline.txt"
 else
-    printf '\n' > "$TMP10/step2-plugin-json-baseline.txt"
+    : > "$TMP10/step2-plugin-json-baseline.txt"
 fi
 echo "codex" > "$TMP10/step2-spawn-coder.txt"
 OUT=$(cd "$REPO_ROOT" && "$DISPATCHER" --tmpdir "$TMP10" --plan-file "$PLAN" --feature-file "$FEATURE" \
@@ -466,7 +466,7 @@ git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD > "$TMP10B/step2-spawn-branch.tx
 if [[ -f "$REPO_ROOT/.claude-plugin/plugin.json" ]]; then
     git -C "$REPO_ROOT" hash-object "$REPO_ROOT/.claude-plugin/plugin.json" > "$TMP10B/step2-plugin-json-baseline.txt"
 else
-    printf '\n' > "$TMP10B/step2-plugin-json-baseline.txt"
+    : > "$TMP10B/step2-plugin-json-baseline.txt"
 fi
 echo "cursor" > "$TMP10B/step2-spawn-coder.txt"
 OUT=$(cd "$REPO_ROOT" && "$DISPATCHER" --tmpdir "$TMP10B" --plan-file "$PLAN" --feature-file "$FEATURE" \
@@ -515,7 +515,7 @@ git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD > "$TMP11B/step2-spawn-branch.tx
 if [[ -f "$REPO_ROOT/.claude-plugin/plugin.json" ]]; then
     git -C "$REPO_ROOT" hash-object "$REPO_ROOT/.claude-plugin/plugin.json" > "$TMP11B/step2-plugin-json-baseline.txt"
 else
-    printf '\n' > "$TMP11B/step2-plugin-json-baseline.txt"
+    : > "$TMP11B/step2-plugin-json-baseline.txt"
 fi
 echo "5" > "$TMP11B/codex-resume-count.txt"
 OUT_B=$(cd "$REPO_ROOT" && "$DISPATCHER" --tmpdir "$TMP11B" --plan-file "$PLAN" --feature-file "$FEATURE" \
@@ -664,10 +664,13 @@ OUT_13=$(cd "$SCRATCH_REPO" && \
         --auto-mode false --coder codex 2>&1)
 
 if [[ "$OUT_13" == *"STATUS=complete"* ]] \
-   && [[ "$OUT_13" != *"REASON=protected-path-modified"* ]]; then
+   && [[ "$OUT_13" != *"REASON=protected-path-modified"* ]] \
+   && [[ "$OUT_13" == *"ORCHESTRATOR_EDIT_AUTHORITY=forbidden"* ]] \
+   && [[ "$OUT_13" != *"ORCHESTRATOR_EDIT_AUTHORITY=allowed"* ]] \
+   && [[ "$OUT_13" == *"MANIFEST="* ]]; then
     pass
 else
-    fail 13 "absent plugin.json + benign edit should reach STATUS=complete (no protected-path-modified false positive); got: $OUT_13"
+    fail 13 "absent plugin.json + benign edit should reach STATUS=complete with AUTH=forbidden + MANIFEST= (no protected-path-modified false positive); got: $OUT_13"
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Align the absent-sentinel encoding for the `.claude-plugin/plugin.json` baseline check in `skills/implement/scripts/step2-implement.sh`. Step 1 baseline write uses `: >` (empty file) and Step 6b post-check uses `CURRENT_PLUGIN_JSON=""` — both branches now yield `""` for "plugin.json absent", eliminating the trailing-newline mismatch via `$(cat …)` that produced false-positive `protected-path-modified` bails on `--coder=codex` (default), `--coder=cursor`, and `--coder=gemini` in consumer repos lacking `.claude-plugin/plugin.json`.
- Add Test 13 to `skills/implement/scripts/test-step2-dispatch.sh` covering the absent-then-still-absent regression end-to-end with a stub Codex spawn → manifest → Step 6/7 → dispatcher-side commit flow; asserts `STATUS=complete` plus `ORCHESTRATOR_EDIT_AUTHORITY=forbidden` + `MANIFEST=` per NEVER #10. Verified to fail without the fix and pass with it.
- Add Test 12 entry to `test-step2-dispatch.md` to close a pre-existing latent 11→13 numbering gap; update purpose text and out-of-scope list to reflect Test 12/13 stub-Codex coverage of the spawn → manifest → commit happy path.

## Architecture Diagram

Architecture diagram not available.

## Code Flow Diagram

(Code Flow Diagram skipped — quick mode)

## Test plan

- [x] `bash skills/implement/scripts/test-step2-dispatch.sh` — `40/40` assertions pass.
- [x] Verified Test 13 fails when the fix is reverted (regression coverage proven).
- [x] `/relevant-checks` — pre-commit + agent-lint pass.
- [ ] CI green on PR.

Closes #1475

🤖 Generated with [Claude Code](https://claude.com/claude-code)
