### PR TITLE
Resolve #1496: add bash 3.2 regression test for create-pr.sh empty-array fix

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "17.0.11",
+  "version": "17.0.12",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 6-reviewer specialist panel (5 Cursor specialists + 1 Codex generic) — extended to 7 with an optional Gemini reviewer when the Gemini CLI is installed and healthy — with 3-voter adjudication; plan review runs a 3-reviewer panel (Claude + Codex + Cursor); design sketches run a 9-agent diverge-then-converge phase in regular mode (1 Claude + 4 Cursor + 4 Codex) or 3 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [17.0.12] - 2026-05-08
+
+### Changed
+
+- Resolve #1496: add a bash 3.2 regression test in `scripts/test-create-pr.sh` for the `create-pr.sh` empty-array `set -u` defect. The defensive `${GH_REPO_ARGS[@]+"${GH_REPO_ARGS[@]}"}` expansion itself shipped via PR #1506 (#1464), which threaded `--repo` and parameterized `--base` across the `gh` CLI helpers and as a side-effect guarded all four `GH_REPO_ARGS` expansion sites in `create-pr.sh`. Issue #1496 was filed in parallel to specifically pin the macOS `/bin/bash` (3.2) `set -u` failure scenario. The new test invokes `create-pr.sh` without `--repo` against a stubbed `gh`/`git` and asserts: (a) no `unbound variable` abort on stderr, (b) `PR_STATUS=created` on stdout, (c) no `--repo` argument threaded into the `gh` stub log. The block re-runs under `/bin/bash` when that interpreter is bash 3.x — the actual macOS system shell that triggered the defect — and is a no-op skip on Linux runners shipping bash 4+ as `/bin/bash`. Verified by demonstrating the new test FAILs against the pre-#1506 script under `/bin/bash` 3.2.57 and PASSes against current main.
+
 ## [17.0.11] - 2026-05-08
 
 ### Fixed
@@ -17,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Resolve #1463: combined OOS observations from #1459, #1444, #1434. **A.** `scripts/session-setup.sh` `--write-session-env` path now forwards `--timing-ledger` (mirroring the existing `--token-session-id` / `--claude-source-file` passthrough) when caller-env supplies `LARCH_TIMING_LEDGER`, gated by an inline `is_safe_timing_ledger_path` validation that requires absolute paths under `${TMPDIR:-/tmp}`, `$IMPLEMENT_TMPDIR`, `$DESIGN_TMPDIR`, `$REVIEW_TMPDIR`, or `dirname("$CALLER_ENV")`. Validation failure emits a single stderr warning and skips forwarding (fail-soft); the key is intentionally NOT echoed on session-setup stdout (file-only contract). **B.** `scripts/session-setup.sh` inline GitHub remote URL parser (lines 322-339) now delegates to `scripts/github-remote-repo.sh` after `gh repo view` fails, preserving fail-soft `REPO_UNAVAILABLE=true` semantics. The helper anchors `owner/repo` exactly while the legacy inline regex matched the trailing two segments — a deliberate fail-closed tightening for malformed remotes that the legacy regex would have mis-parsed. **C.** Hook subprocess env-inheritance investigation: existing production wiring binds `session_id` from the hook-event JSON payload (not from inherited LARCH_TOKEN_SESSION_ID), so a one-line breadcrumb cross-reference is added to `skills/implement/scripts/hook-post-design.sh` and `skills/implement/scripts/hook-stop-fail-close.sh` — no behavior change. New regression coverage: `scripts/test-session-setup-repo-fallback.sh` (gh-success / gh-fails-SSH / gh-fails-HTTPS / gh-fails-malformed / gh-fails-no-origin) wired through Makefile `test-harnesses-*`; `skills/implement/scripts/test-implement-review-token-propagation.sh` extended for `LARCH_TIMING_LEDGER` (positive forwarding + negative-stdout + negative-validation cases). Two follow-up OOS issues filed: #1504 (writer-side `--timing-ledger` validation in `scripts/write-session-env.sh`) and #1505 (awk-truncation fix in `scripts/read-session-env-key.sh`).
 
-## [17.0.9] - 2026-05-08
+## [17.0.12] - 2026-05-08
 
 ### Added
 

--- a/scripts/test-create-pr.sh
+++ b/scripts/test-create-pr.sh
@@ -120,4 +120,42 @@ rc=$?
 set -e
 [[ "$rc" -ne 0 ]] || fail "malformed --repo should fail"
 
+# Regression for issue #1496: GH_REPO_ARGS empty array under bash 3.2 + set -u.
+# Pre-fix, all four `gh pr view/create "${GH_REPO_ARGS[@]}"` sites aborted with
+# `unbound variable` on macOS system bash when --repo was not passed. Run the
+# script without --repo and assert (a) it does not abort with that message and
+# (b) every gh subcommand was reached without any --repo prefix.
+repo=$(setup_repo norepo)
+set +e
+(cd "$repo" && GH_LOG="$TMPROOT/norepo-gh.log" GH_MODE=create PATH="$stub_dir:$PATH" "$SCRIPT" --title "Test PR" --body-file body.md) >"$TMPROOT/norepo.out" 2>"$TMPROOT/norepo.err"
+rc=$?
+set -e
+if grep -q 'unbound variable' "$TMPROOT/norepo.err"; then
+    fail "create-pr.sh aborted with 'unbound variable' under bash $BASH_VERSION when --repo omitted (issue #1496)"
+fi
+[[ "$rc" -eq 0 ]] || fail "no-repo path failed unexpectedly: rc=$rc; stderr=$(cat "$TMPROOT/norepo.err")"
+grep -Fxq 'PR_STATUS=created' <"$TMPROOT/norepo.out" || fail "no-repo path did not report created"
+if grep -E '^(pr view|pr create)' "$TMPROOT/norepo-gh.log" | grep -E -- '--repo' >/dev/null; then
+    fail "no-repo path threaded an unexpected --repo argument to gh"
+fi
+
+# Same regression under /bin/bash (bash 3.2 on macOS) when available — exercises
+# the actual interpreter that triggered the reported defect; no-op skip on
+# Linux runners that ship bash 4+ as /bin/bash.
+if [[ -x /bin/bash ]] && /bin/bash --version | grep -qE 'version 3\.[0-9]'; then
+    repo=$(setup_repo norepo32)
+    set +e
+    (cd "$repo" && GH_LOG="$TMPROOT/norepo32-gh.log" GH_MODE=create PATH="$stub_dir:$PATH" /bin/bash "$SCRIPT" --title "Test PR" --body-file body.md) >"$TMPROOT/norepo32.out" 2>"$TMPROOT/norepo32.err"
+    rc=$?
+    set -e
+    if grep -q 'unbound variable' "$TMPROOT/norepo32.err"; then
+        fail "create-pr.sh aborted with 'unbound variable' under /bin/bash 3.2 when --repo omitted (issue #1496)"
+    fi
+    [[ "$rc" -eq 0 ]] || fail "no-repo path failed under /bin/bash 3.2: rc=$rc; stderr=$(cat "$TMPROOT/norepo32.err")"
+    grep -Fxq 'PR_STATUS=created' <"$TMPROOT/norepo32.out" || fail "no-repo path under /bin/bash 3.2 did not report created"
+    if grep -E '^(pr view|pr create)' "$TMPROOT/norepo32-gh.log" | grep -E -- '--repo' >/dev/null; then
+        fail "no-repo path under /bin/bash 3.2 threaded an unexpected --repo argument to gh"
+    fi
+fi
+
 echo "PASS: test-create-pr.sh"


### PR DESCRIPTION
## Summary

- Add a bash 3.2 regression test for `scripts/create-pr.sh`'s empty-array `set -u` defect (issue #1496)
- The defensive `${GH_REPO_ARGS[@]+"${GH_REPO_ARGS[@]}"}` expansion itself shipped in parallel via PR #1506 (issue #1464), which threaded `--repo` and parameterized `--base` and as a side-effect guarded all four `GH_REPO_ARGS` expansion sites
- This PR adds only the regression-coverage piece that #1506 didn't include — pins the bash 3.2 + `set -u` scenario so a future revert of any of the four guarded sites trips the harness

## Architecture Diagram

Architecture diagram not available.

## Code Flow Diagram

(Code Flow Diagram skipped — quick mode)

## Test plan

- [x] New test block in `scripts/test-create-pr.sh` exercises the no-`--repo` path; verified to FAIL on the pre-#1506 script under `/bin/bash 3.2.57` and PASS on current main
- [x] `bash scripts/test-create-pr.sh` passes (modern bash)
- [x] `/bin/bash scripts/test-create-pr.sh` passes (bash 3.2 on macOS)
- [x] `/relevant-checks` (pre-commit + agent-lint) clean
- [x] CI green

Closes #1496

🤖 Generated with [Claude Code](https://claude.com/claude-code)
