### PR TITLE
Resolve #1486: snapshot-untracked.sh — don't rm $OUTPUT on unknown flag

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "17.0.10",
+  "version": "17.0.11",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 6-reviewer specialist panel (5 Cursor specialists + 1 Codex generic) — extended to 7 with an optional Gemini reviewer when the Gemini CLI is installed and healthy — with 3-voter adjudication; plan review runs a 3-reviewer panel (Claude + Codex + Cursor); design sketches run a 9-agent diverge-then-converge phase in regular mode (1 Claude + 4 Cursor + 4 Codex) or 3 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [17.0.11] - 2026-05-08
+
+### Fixed
+
+- Resolve #1486: `scripts/snapshot-untracked.sh` no longer deletes the user-controlled `$OUTPUT` path on argument-parsing errors. The unknown-flag arm previously ran `rm -f "$OUTPUT" "${OUTPUT}.tmp"` — a typo'd later flag after a valid `--output <path>` would silently delete that path. The arm now logs to stderr and exits 0 without touching the output. Folded inline (rule 2): `${2:?--output requires a value}` replaced with an explicit guard that exits 0 instead of 1 on missing `--output` value, preserving the always-exit-0 contract. Header in `scripts/snapshot-untracked.sh`, sibling `scripts/snapshot-untracked.md`, and `skills/implement/SKILL.md` Step 5 narrowed from "any failure" to "operation failure" (git/sort/mv) vs. "argument-parsing failure" so the split contract is documented in all three places.
+
 ## [17.0.10] - 2026-05-08
 
 ### Changed

--- a/scripts/snapshot-untracked.md
+++ b/scripts/snapshot-untracked.md
@@ -4,7 +4,8 @@
 
 **Invariants**:
 - Always exits 0 — callers must never abort on snapshot failure
-- On any failure, removes both temp file and output file so `check-review-changes.sh` sees `UNTRACKED_BASELINE=missing` (issue #651 guard)
+- On any *operation* failure (git / sort / mv), removes both temp file and output file so `check-review-changes.sh` sees `UNTRACKED_BASELINE=missing` (issue #651 guard)
+- Unknown CLI flags and missing `--output` log a diagnostic to stderr and exit 0 *without* touching `$OUTPUT` — argument-parsing errors must not delete user-controlled paths
 - Default output is sorted and newline-delimited for `check-review-changes.sh`; `--nul` switches to sorted NUL-delimited output for `check-mid-run-dirty-tree.sh`
 - Uses `set -o pipefail` so `git ls-files` failures propagate through the pipe
 - Atomic write via temp file + `mv -f`

--- a/scripts/snapshot-untracked.sh
+++ b/scripts/snapshot-untracked.sh
@@ -20,7 +20,7 @@ while [[ $# -gt 0 ]]; do
     case "$1" in
         --output) OUTPUT="${2:?--output requires a value}"; shift 2 ;;
         --nul) NUL_MODE=true; shift ;;
-        *) echo "snapshot-untracked.sh: unknown flag: $1" >&2; rm -f "$OUTPUT" "${OUTPUT}.tmp" 2>/dev/null; exit 0 ;;
+        *) echo "snapshot-untracked.sh: unknown flag: $1" >&2; exit 0 ;;
     esac
 done
 

--- a/scripts/snapshot-untracked.sh
+++ b/scripts/snapshot-untracked.sh
@@ -5,9 +5,13 @@
 #   snapshot-untracked.sh --output <file> [--nul]
 #
 # On success, writes a sorted list of untracked paths to <file> via atomic rename.
-# On ANY failure (git, sort, mv), removes both the temp file and <file> so the
-# downstream consumer (check-review-changes.sh) sees UNTRACKED_BASELINE=missing
-# and degrades gracefully (issue #651).
+# On any OPERATION failure (git, sort, mv), removes both the temp file and <file>
+# so the downstream consumer (check-review-changes.sh) sees
+# UNTRACKED_BASELINE=missing and degrades gracefully (issue #651).
+#
+# On argument-parsing failure (unknown flag, missing --output), logs to stderr
+# and exits 0 WITHOUT touching <file> — argument errors must not delete
+# user-controlled paths (issue #1486).
 #
 # Always exits 0 — callers must never abort on snapshot failure.
 
@@ -18,7 +22,14 @@ NUL_MODE=false
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --output) OUTPUT="${2:?--output requires a value}"; shift 2 ;;
+        --output)
+            if [[ $# -lt 2 || -z "${2:-}" ]]; then
+                echo "snapshot-untracked.sh: --output requires a value" >&2
+                exit 0
+            fi
+            OUTPUT="$2"
+            shift 2
+            ;;
         --nul) NUL_MODE=true; shift ;;
         *) echo "snapshot-untracked.sh: unknown flag: $1" >&2; exit 0 ;;
     esac

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -1080,7 +1080,7 @@ The snapshot is captured via a dedicated script that handles `pipefail`, atomic 
 ${CLAUDE_PLUGIN_ROOT}/scripts/snapshot-untracked.sh --output "$IMPLEMENT_TMPDIR/pre-review-untracked.txt"
 ```
 
-Best-effort: the script always exits 0; on any failure it removes both temp and baseline files so `check-review-changes.sh` sees `UNTRACKED_BASELINE=missing` and degrades gracefully (issue #651).
+Best-effort: the script always exits 0; on any *operation* failure (git / sort / mv) it removes both temp and baseline files so `check-review-changes.sh` sees `UNTRACKED_BASELINE=missing` and degrades gracefully (issue #651). Argument-parsing failures (unknown flag, missing `--output`) log to stderr and exit 0 *without* touching the baseline path — see `scripts/snapshot-untracked.md` for the full contract.
 
 ### Quick mode (`quick_mode=true`)
 


### PR DESCRIPTION
## Summary

- `scripts/snapshot-untracked.sh` unknown-flag arm no longer deletes `$OUTPUT` — argument-parsing errors must not destroy user-controlled paths.
- Folded inline: replaced `${2:?--output requires a value}` with an explicit guard so missing `--output` value exits 0 instead of 1, preserving the always-exit-0 contract.
- Narrowed "any failure" wording in `scripts/snapshot-untracked.sh` header, `scripts/snapshot-untracked.md`, and `skills/implement/SKILL.md` Step 5 to distinguish operation failures (git/sort/mv) from argument-parsing failures.

## Architecture Diagram

Architecture diagram not available.

## Code Flow Diagram

(Code Flow Diagram skipped — quick mode)

## Test plan

- [x] Offline behavioral verification: unknown flag (`--bogus`) preserves `--output` path; missing `--output` value exits 0; happy path writes snapshot.
- [x] `/relevant-checks` (pre-commit + agent-lint) — passed.

Closes #1486

🤖 Generated with [Claude Code](https://claude.com/claude-code)
