### PR TITLE
Resolve #1545: cap bump-version reasoning-fragment output

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "17.1.0",
+  "version": "17.1.1",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 6-reviewer specialist panel (5 Cursor specialists + 1 Codex generic) — extended to 7 with an optional Gemini reviewer when the Gemini CLI is installed and healthy — with 3-voter adjudication; plan review runs a 3-reviewer panel (Claude + Codex + Cursor); design sketches run a 9-agent diverge-then-converge phase in regular mode (1 Claude + 4 Cursor + 4 Codex) or 3 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/.claude/skills/bump-version/SKILL.md
+++ b/.claude/skills/bump-version/SKILL.md
@@ -35,7 +35,7 @@ After `classify-bump.sh` computes its deterministic baseline, the main agent (yo
 
 **You may ONLY escalate severity (PATCH → MINOR → MAJOR). Never downgrade.**
 
-If you escalate, append a paragraph to the reasoning log file explaining why.
+If you escalate, append at most 5 sentences (≤100 words) to the reasoning log file explaining why. State the specific evidence — do not restate the diff or summarize the classifier's bullets. **If you do not escalate, write nothing — do not append to the log, do not summarize the diff, do not narrate your decision.** Escalation is rare; the deterministic classifier is correct in the common case.
 
 ## How it works
 
@@ -49,7 +49,7 @@ If you escalate, append a paragraph to the reasoning log file explaining why.
    - For each modified SKILL.md, reads the old and new full file contents via `git show "$BASE:<path>"` and `git show "HEAD:<path>"`, extracts the first YAML frontmatter block between `---` markers, and compares the `name:` and `argument-hint:` fields. The `argument-hint:` comparison uses token sets: a `--<flag>` present in both old and new is treated as unchanged; only genuine additions or removals contribute to classification.
    - Writes evidence to `${IMPLEMENT_TMPDIR:-${TMPDIR:-/tmp}}/bump-version-reasoning.md` (absolute path also emitted as `REASONING_FILE=<path>` on stdout)
    - Emits `KEY=VALUE` lines on stdout: `CURRENT_VERSION`, `NEW_VERSION`, `BUMP_TYPE`, `REASONING_FILE`
-3. You (main agent) parse the output, read the reasoning log, review the diff, and apply the **escalation-only** caveat review. If you escalate, update `NEW_VERSION` accordingly and append reasoning to the log.
+3. You (main agent) parse the output. **By default, proceed directly to `apply-bump.sh` with the emitted `NEW_VERSION` — no diff review, no commentary, no log append.** Only review the diff for the **escalation-only** caveat when you have specific evidence of a backward-incompatible behavioral change beyond the classifier's reach; if escalating, update `NEW_VERSION` and append the bounded reasoning per the Caveat above.
 4. You invoke `apply-bump.sh --new-version <NEW_VERSION>`, which:
    - First verifies the working tree is clean (fails on any staged or unstaged changes)
    - Backs up `.claude-plugin/plugin.json`
@@ -74,7 +74,7 @@ Parse the output for `CURRENT_VERSION`, `NEW_VERSION`, `BUMP_TYPE`, `REASONING_F
 
 If `BUMP_TYPE=NONE`, report the no-op and exit.
 
-Otherwise, review the reasoning log and the branch diff. Decide whether to escalate. If escalating, compute the new version from `CURRENT_VERSION` + your escalated bump type and append your reasoning to the log file.
+Otherwise, **the default action is to invoke `apply-bump.sh` directly with the script-emitted `NEW_VERSION` — no diff review, no commentary, no log append.** Only review the branch diff when you have specific evidence to suspect a backward-incompatible behavioral change beyond the deterministic classifier's reach. If escalating, compute the new version from `CURRENT_VERSION` + your escalated bump type and append the bounded reasoning per the Caveat above.
 
 Then apply:
 

--- a/.claude/skills/bump-version/SKILL.md
+++ b/.claude/skills/bump-version/SKILL.md
@@ -49,7 +49,7 @@ If you escalate, append at most 5 sentences (≤100 words) to the reasoning log 
    - For each modified SKILL.md, reads the old and new full file contents via `git show "$BASE:<path>"` and `git show "HEAD:<path>"`, extracts the first YAML frontmatter block between `---` markers, and compares the `name:` and `argument-hint:` fields. The `argument-hint:` comparison uses token sets: a `--<flag>` present in both old and new is treated as unchanged; only genuine additions or removals contribute to classification.
    - Writes evidence to `${IMPLEMENT_TMPDIR:-${TMPDIR:-/tmp}}/bump-version-reasoning.md` (absolute path also emitted as `REASONING_FILE=<path>` on stdout)
    - Emits `KEY=VALUE` lines on stdout: `CURRENT_VERSION`, `NEW_VERSION`, `BUMP_TYPE`, `REASONING_FILE`
-3. You (main agent) parse the output. **By default, proceed directly to `apply-bump.sh` with the emitted `NEW_VERSION` — no diff review, no commentary, no log append.** Only review the diff for the **escalation-only** caveat when you have specific evidence of a backward-incompatible behavioral change beyond the classifier's reach; if escalating, update `NEW_VERSION` and append the bounded reasoning per the Caveat above.
+3. You (main agent) parse the output and review the diff for the **escalation-only** caveat (line 34). **Do not write commentary about that review unless you actually escalate** — no log append, no diff summary, no narration. If escalating, update `NEW_VERSION` and append the bounded reasoning per the Caveat above; otherwise proceed directly to `apply-bump.sh` with the emitted `NEW_VERSION`.
 4. You invoke `apply-bump.sh --new-version <NEW_VERSION>`, which:
    - First verifies the working tree is clean (fails on any staged or unstaged changes)
    - Backs up `.claude-plugin/plugin.json`
@@ -74,7 +74,7 @@ Parse the output for `CURRENT_VERSION`, `NEW_VERSION`, `BUMP_TYPE`, `REASONING_F
 
 If `BUMP_TYPE=NONE`, report the no-op and exit.
 
-Otherwise, **the default action is to invoke `apply-bump.sh` directly with the script-emitted `NEW_VERSION` — no diff review, no commentary, no log append.** Only review the branch diff when you have specific evidence to suspect a backward-incompatible behavioral change beyond the deterministic classifier's reach. If escalating, compute the new version from `CURRENT_VERSION` + your escalated bump type and append the bounded reasoning per the Caveat above.
+Otherwise, review the branch diff for the escalation-only caveat (above) and decide whether to escalate. **Do not write commentary about that review unless you actually escalate** — no log append, no diff summary, no narration. If escalating, compute the new version from `CURRENT_VERSION` + your escalated bump type and append the bounded reasoning per the Caveat above; otherwise invoke `apply-bump.sh` directly with the script-emitted `NEW_VERSION`.
 
 Then apply:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [17.1.1] - 2026-05-08
+
+### Changed
+
+- `bump-version`: cap Claude-appended escalation reasoning to ≤100 words / ≤5 sentences and forbid commentary on non-escalation runs to reduce ~23.5k Claude output tokens/run.
+
 ## [17.1.0] - 2026-05-08
 
 ### Added


### PR DESCRIPTION
## Summary
- Capped Claude-appended escalation reasoning in `.claude/skills/bump-version/SKILL.md` to ≤100 words / ≤5 sentences with explicit "if you do not escalate, write nothing" directive — addresses ~23.5k Claude output tokens/run on a deterministic version classifier whose external contract is just `MAJOR`/`MINOR`/`PATCH` plus a short rationale.
- Preserved the escalation-only diff-review contract (line 34) per code review feedback so MAJOR-worthy behavioral changes stay catchable; the cap constrains *output prose*, not diff *reading*.

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- [x] `/relevant-checks` (pre-commit on modified files + agent-lint on full repo) — passed
- [x] Visual confirmation: no markdownlint MD038 violations around backtick code spans
- [x] Confirmed no script files (`classify-bump.sh`, `apply-bump.sh`) modified
- [ ] Acceptance criterion observable post-merge: `bump-version` Claude output tokens drop below 10k/run on a sample of 5 fresh runs

</details>

Closes #1545

Generated with [Claude Code](https://claude.com/claude-code)
