### PR TITLE
Resolve #1557: token-ledger sub-phase marks for /design plan-review and /review voting

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "18.0.0",
+  "version": "18.0.1",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 3-reviewer specialist panel (2 Cursor specialists + 1 Codex generic) — extended to 4 with an optional Gemini reviewer when the Gemini CLI is installed and healthy — with 3-voter adjudication; plan review runs a 3-reviewer panel (Claude + Codex + Cursor); design sketches run a 9-agent diverge-then-converge phase in regular mode (1 Claude + 4 Cursor + 4 Codex) or 3 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `/design` Step 3 plan-review and `/review` Step 3 voting-cycle sub-phases now emit `token-ledger.sh mark` calls alongside the existing `timing-ledger.sh` marks. The `scripts/token-report.sh` markdown table renders these as adjacent flat-segment rows under the parent `Step 1 — design plan` / `Step 5 — code review` segments — measurement prerequisite for #1550 (Haiku-routing ROI gate). Closes #1557.
 
-
 ## [18.0.0] - 2026-05-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [18.0.1] - 2026-05-08
+
+### Changed
+
+- `/design` Step 3 plan-review and `/review` Step 3 voting-cycle sub-phases now emit `token-ledger.sh mark` calls alongside the existing `timing-ledger.sh` marks. The `scripts/token-report.sh` markdown table renders these as adjacent flat-segment rows under the parent `Step 1 — design plan` / `Step 5 — code review` segments — measurement prerequisite for #1550 (Haiku-routing ROI gate). Closes #1557.
+
+
 ## [18.0.0] - 2026-05-08
 
 ### Added

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -445,7 +445,10 @@ Write the plan to `$DESIGN_TMPDIR/plan.txt` with basename exactly `plan.txt`. If
 
 ```bash
 SESSION_ENV_PATH="$SESSION_ENV_PATH" LARCH_TIMING_SKILL=design "${CLAUDE_PLUGIN_ROOT}/scripts/timing-ledger.sh" mark "design Step 3 — plan review" || true
-SESSION_ENV_PATH="$SESSION_ENV_PATH" "${CLAUDE_PLUGIN_ROOT}/scripts/token-ledger.sh" mark "Step 1 — design Step 3 plan review" || true
+LARCH_TOKEN_SESSION_ID=$("${CLAUDE_PLUGIN_ROOT}/scripts/read-session-env-key.sh" --file "$SESSION_ENV_PATH" --key LARCH_TOKEN_SESSION_ID --default "")
+LARCH_CLAUDE_SOURCE_FILE=$("${CLAUDE_PLUGIN_ROOT}/scripts/read-session-env-key.sh" --file "$SESSION_ENV_PATH" --key LARCH_CLAUDE_SOURCE_FILE --default "")
+export LARCH_TOKEN_SESSION_ID LARCH_CLAUDE_SOURCE_FILE
+"${CLAUDE_PLUGIN_ROOT}/scripts/token-ledger.sh" mark "Step 1 — design Step 3 plan review" || true
 ```
 
 **IMPORTANT: Plan review MUST ALWAYS run with all 8 reviewers (4 Codex specialists + 4 Cursor specialists: Architecture/Standards, Edge-cases/Failure-modes, Innovation/Exploration, Pragmatism/Safety). Never skip or abbreviate this step regardless of how straightforward the plan appears — even when all sketch agents agreed, the plan is short, or the change seems trivial. Reviewers validate against the actual codebase state, catching issues that sketch-phase reasoning alone cannot detect. When Cursor is unavailable, each Cursor archetype slot falls back to Codex; when Codex is unavailable, each Codex archetype slot falls back to Cursor; when both are unavailable, each falls back to a Claude subagent.**
@@ -548,7 +551,10 @@ If **all reviewers** report no in-scope issues and no out-of-scope observations,
 
 ```bash
 SESSION_ENV_PATH="$SESSION_ENV_PATH" LARCH_TIMING_SKILL=design "${CLAUDE_PLUGIN_ROOT}/scripts/timing-ledger.sh" mark "design Step 3.5 — discussion r2" || true
-SESSION_ENV_PATH="$SESSION_ENV_PATH" "${CLAUDE_PLUGIN_ROOT}/scripts/token-ledger.sh" mark "Step 1 — design Step 3.5 discussion r2" || true
+LARCH_TOKEN_SESSION_ID=$("${CLAUDE_PLUGIN_ROOT}/scripts/read-session-env-key.sh" --file "$SESSION_ENV_PATH" --key LARCH_TOKEN_SESSION_ID --default "")
+LARCH_CLAUDE_SOURCE_FILE=$("${CLAUDE_PLUGIN_ROOT}/scripts/read-session-env-key.sh" --file "$SESSION_ENV_PATH" --key LARCH_CLAUDE_SOURCE_FILE --default "")
+export LARCH_TOKEN_SESSION_ID LARCH_CLAUDE_SOURCE_FILE
+"${CLAUDE_PLUGIN_ROOT}/scripts/token-ledger.sh" mark "Step 1 — design Step 3.5 discussion r2" || true
 ```
 
 Print: `> **🔶 3.5: discussion r2**`
@@ -561,7 +567,10 @@ Print: `> **🔶 3.5: discussion r2**`
 
 ```bash
 SESSION_ENV_PATH="$SESSION_ENV_PATH" LARCH_TIMING_SKILL=design "${CLAUDE_PLUGIN_ROOT}/scripts/timing-ledger.sh" mark "design Step 3b — arch diagram" || true
-SESSION_ENV_PATH="$SESSION_ENV_PATH" "${CLAUDE_PLUGIN_ROOT}/scripts/token-ledger.sh" mark "Step 1 — design Step 3b arch diagram" || true
+LARCH_TOKEN_SESSION_ID=$("${CLAUDE_PLUGIN_ROOT}/scripts/read-session-env-key.sh" --file "$SESSION_ENV_PATH" --key LARCH_TOKEN_SESSION_ID --default "")
+LARCH_CLAUDE_SOURCE_FILE=$("${CLAUDE_PLUGIN_ROOT}/scripts/read-session-env-key.sh" --file "$SESSION_ENV_PATH" --key LARCH_CLAUDE_SOURCE_FILE --default "")
+export LARCH_TOKEN_SESSION_ID LARCH_CLAUDE_SOURCE_FILE
+"${CLAUDE_PLUGIN_ROOT}/scripts/token-ledger.sh" mark "Step 1 — design Step 3b arch diagram" || true
 ```
 
 Print: `> **🔶 3b: arch diagram**`

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -445,6 +445,7 @@ Write the plan to `$DESIGN_TMPDIR/plan.txt` with basename exactly `plan.txt`. If
 
 ```bash
 SESSION_ENV_PATH="$SESSION_ENV_PATH" LARCH_TIMING_SKILL=design "${CLAUDE_PLUGIN_ROOT}/scripts/timing-ledger.sh" mark "design Step 3 — plan review" || true
+SESSION_ENV_PATH="$SESSION_ENV_PATH" "${CLAUDE_PLUGIN_ROOT}/scripts/token-ledger.sh" mark "Step 1 — design Step 3 plan review" || true
 ```
 
 **IMPORTANT: Plan review MUST ALWAYS run with all 8 reviewers (4 Codex specialists + 4 Cursor specialists: Architecture/Standards, Edge-cases/Failure-modes, Innovation/Exploration, Pragmatism/Safety). Never skip or abbreviate this step regardless of how straightforward the plan appears — even when all sketch agents agreed, the plan is short, or the change seems trivial. Reviewers validate against the actual codebase state, catching issues that sketch-phase reasoning alone cannot detect. When Cursor is unavailable, each Cursor archetype slot falls back to Codex; when Codex is unavailable, each Codex archetype slot falls back to Cursor; when both are unavailable, each falls back to a Claude subagent.**
@@ -547,6 +548,7 @@ If **all reviewers** report no in-scope issues and no out-of-scope observations,
 
 ```bash
 SESSION_ENV_PATH="$SESSION_ENV_PATH" LARCH_TIMING_SKILL=design "${CLAUDE_PLUGIN_ROOT}/scripts/timing-ledger.sh" mark "design Step 3.5 — discussion r2" || true
+SESSION_ENV_PATH="$SESSION_ENV_PATH" "${CLAUDE_PLUGIN_ROOT}/scripts/token-ledger.sh" mark "Step 1 — design Step 3.5 discussion r2" || true
 ```
 
 Print: `> **🔶 3.5: discussion r2**`
@@ -559,6 +561,7 @@ Print: `> **🔶 3.5: discussion r2**`
 
 ```bash
 SESSION_ENV_PATH="$SESSION_ENV_PATH" LARCH_TIMING_SKILL=design "${CLAUDE_PLUGIN_ROOT}/scripts/timing-ledger.sh" mark "design Step 3b — arch diagram" || true
+SESSION_ENV_PATH="$SESSION_ENV_PATH" "${CLAUDE_PLUGIN_ROOT}/scripts/token-ledger.sh" mark "Step 1 — design Step 3b arch diagram" || true
 ```
 
 Print: `> **🔶 3b: arch diagram**`

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -228,6 +228,7 @@ At the top of each Step 3 round iteration's bash block (before `### 3a — Colle
 
 ```bash
 SESSION_ENV_PATH="$SESSION_ENV_PATH" LARCH_TIMING_SKILL=review "${CLAUDE_PLUGIN_ROOT}/scripts/timing-ledger.sh" mark "review Step 3 round ${round_num} — review cycle" || true
+SESSION_ENV_PATH="$SESSION_ENV_PATH" "${CLAUDE_PLUGIN_ROOT}/scripts/token-ledger.sh" mark "Step 5 — review Step 3 round ${round_num} voting cycle" || true
 ```
 
 Use the round counter already tracked by the round state machine.
@@ -326,6 +327,7 @@ If `round_substantial=true`, increment the round number. IMMEDIATELY re-execute 
 
 ```bash
 SESSION_ENV_PATH="$SESSION_ENV_PATH" LARCH_TIMING_SKILL=review "${CLAUDE_PLUGIN_ROOT}/scripts/timing-ledger.sh" mark "review Step 4 — final summary" || true
+SESSION_ENV_PATH="$SESSION_ENV_PATH" "${CLAUDE_PLUGIN_ROOT}/scripts/token-ledger.sh" mark "Step 5 — review Step 4 final summary" || true
 ```
 
 ### 4a — Print summary (both modes)

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -228,7 +228,10 @@ At the top of each Step 3 round iteration's bash block (before `### 3a — Colle
 
 ```bash
 SESSION_ENV_PATH="$SESSION_ENV_PATH" LARCH_TIMING_SKILL=review "${CLAUDE_PLUGIN_ROOT}/scripts/timing-ledger.sh" mark "review Step 3 round ${round_num} — review cycle" || true
-SESSION_ENV_PATH="$SESSION_ENV_PATH" "${CLAUDE_PLUGIN_ROOT}/scripts/token-ledger.sh" mark "Step 5 — review Step 3 round ${round_num} voting cycle" || true
+LARCH_TOKEN_SESSION_ID=$("${CLAUDE_PLUGIN_ROOT}/scripts/read-session-env-key.sh" --file "$SESSION_ENV_PATH" --key LARCH_TOKEN_SESSION_ID --default "")
+LARCH_CLAUDE_SOURCE_FILE=$("${CLAUDE_PLUGIN_ROOT}/scripts/read-session-env-key.sh" --file "$SESSION_ENV_PATH" --key LARCH_CLAUDE_SOURCE_FILE --default "")
+export LARCH_TOKEN_SESSION_ID LARCH_CLAUDE_SOURCE_FILE
+"${CLAUDE_PLUGIN_ROOT}/scripts/token-ledger.sh" mark "Step 5 — review Step 3 round ${round_num} voting cycle" || true
 ```
 
 Use the round counter already tracked by the round state machine.
@@ -327,7 +330,10 @@ If `round_substantial=true`, increment the round number. IMMEDIATELY re-execute 
 
 ```bash
 SESSION_ENV_PATH="$SESSION_ENV_PATH" LARCH_TIMING_SKILL=review "${CLAUDE_PLUGIN_ROOT}/scripts/timing-ledger.sh" mark "review Step 4 — final summary" || true
-SESSION_ENV_PATH="$SESSION_ENV_PATH" "${CLAUDE_PLUGIN_ROOT}/scripts/token-ledger.sh" mark "Step 5 — review Step 4 final summary" || true
+LARCH_TOKEN_SESSION_ID=$("${CLAUDE_PLUGIN_ROOT}/scripts/read-session-env-key.sh" --file "$SESSION_ENV_PATH" --key LARCH_TOKEN_SESSION_ID --default "")
+LARCH_CLAUDE_SOURCE_FILE=$("${CLAUDE_PLUGIN_ROOT}/scripts/read-session-env-key.sh" --file "$SESSION_ENV_PATH" --key LARCH_CLAUDE_SOURCE_FILE --default "")
+export LARCH_TOKEN_SESSION_ID LARCH_CLAUDE_SOURCE_FILE
+"${CLAUDE_PLUGIN_ROOT}/scripts/token-ledger.sh" mark "Step 5 — review Step 4 final summary" || true
 ```
 
 ### 4a — Print summary (both modes)


### PR DESCRIPTION
## Summary

Add `token-ledger.sh mark` calls inside `/design` Step 3 plan-review and `/review` Step 3 voting-cycle sub-phases (alongside the existing `timing-ledger.sh` marks) so `scripts/token-report.sh` attributes Claude tokens to those sub-phases as flat-segment rows under the parent `Step 1 — design plan` / `Step 5 — code review` segments. Each new `token-ledger.sh mark` call is preceded by a `read-session-env-key.sh` rehydration of `LARCH_TOKEN_SESSION_ID` and `LARCH_CLAUDE_SOURCE_FILE` from `$SESSION_ENV_PATH`, matching the existing pattern in `skills/implement/SKILL.md` so nested `/design` and `/review` marks land in the parent `/implement` ledger instead of a cwd-hash fallback.

5 mark insertion sites:
- `skills/design/SKILL.md`: Step 3 (plan review), Step 3.5 (discussion r2), Step 3b (arch diagram).
- `skills/review/SKILL.md`: Step 3 round-N (voting cycle), Step 4 (final summary).

This is the measurement prerequisite for #1550 (route Claude voter/judge to Haiku 4.5). Without sub-phase token attribution the issue's ROI gate (≥10% / <5% / 5–10% A/B) cannot be evaluated against data.

## Architecture Diagram

Architecture diagram not available.

## Code Flow Diagram

(Code Flow Diagram skipped — quick mode)

## Test plan

- `/relevant-checks` after both impl and review-fix commits — confirmed pre-commit hooks (markdownlint, shellcheck, agent-lint, etc.) and full-repo agent-lint pass on the modified SKILL.md files.
- Post-merge: operator runs one full (non-quick) `/implement` on a representative task; `scripts/token-report.sh` should show new sibling rows like `Step 1 — design Step 3 plan review` and `Step 5 — review Step 3 round 1 voting cycle`. Compute and post on #1557: plan-review tokens / total Claude tokens (%), voting tokens / total Claude tokens (%), combined / blended `/implement` cost (%).

Closes #1557

🤖 Generated with [Claude Code](https://claude.com/claude-code)
