### PR TITLE
Cache node_modules in lint CI job to skip npm ci on cache hits

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "18.0.7",
+  "version": "18.0.8",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 3-reviewer specialist panel (2 Cursor specialists + 1 Codex generic) — extended to 4 with an optional Gemini reviewer when the Gemini CLI is installed and healthy — with 3-voter adjudication; plan review runs a 3-reviewer panel (Claude + Codex + Cursor); design sketches run a 9-agent diverge-then-converge phase in regular mode (1 Claude + 4 Cursor + 4 Codex) or 3 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,12 +81,12 @@ jobs:
         id: node-modules-cache
         with:
           path: node_modules
-          # Mirror the lockfile-keyed pattern from setup-node and the
-          # puppeteer cache so a lockfile bump invalidates this entry.
-          # On a hit, npm ci is skipped entirely (~12s saved per run).
-          # Closes #1576.
-          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          # Key on both package.json and package-lock.json so a
+          # dependency-manifest change that doesn't update the lockfile
+          # still invalidates this cache (closes #1576).
+          key: node-modules-${{ runner.os }}-${{ hashFiles('package.json', 'package-lock.json') }}
       - uses: actions/cache@v5
+        id: puppeteer-cache
         with:
           path: ~/.cache/puppeteer
           # Mirror the cache-dependency-path key on the lockfile so the
@@ -107,9 +107,10 @@ jobs:
         # restores ~/.cache/puppeteer between runs so cold downloads
         # only happen when package-lock.json changes.
         #
-        # Skipped on node-modules-cache hit so npm ci does not
-        # re-extract packages that are already present (closes #1576).
-        if: steps.node-modules-cache.outputs.cache-hit != 'true'
+        # Skipped only when BOTH node_modules and Puppeteer caches hit:
+        # a node_modules hit with a puppeteer miss would leave Chromium
+        # absent and break the mermaid lint step (closes #1576).
+        if: steps.node-modules-cache.outputs.cache-hit != 'true' || steps.puppeteer-cache.outputs.cache-hit != 'true'
         run: npm ci
       - name: Lint Mermaid fences (changed only)
         run: scripts/lint-mermaid-fences.sh --changed-only

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,6 +78,15 @@ jobs:
           # npm cache (closes #1426 follow-up FINDING_1).
           cache-dependency-path: package-lock.json
       - uses: actions/cache@v5
+        id: node-modules-cache
+        with:
+          path: node_modules
+          # Mirror the lockfile-keyed pattern from setup-node and the
+          # puppeteer cache so a lockfile bump invalidates this entry.
+          # On a hit, npm ci is skipped entirely (~12s saved per run).
+          # Closes #1576.
+          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+      - uses: actions/cache@v5
         with:
           path: ~/.cache/puppeteer
           # Mirror the cache-dependency-path key on the lockfile so the
@@ -97,6 +106,10 @@ jobs:
         # Puppeteer's Chromium download. The puppeteer cache above
         # restores ~/.cache/puppeteer between runs so cold downloads
         # only happen when package-lock.json changes.
+        #
+        # Skipped on node-modules-cache hit so npm ci does not
+        # re-extract packages that are already present (closes #1576).
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
         run: npm ci
       - name: Lint Mermaid fences (changed only)
         run: scripts/lint-mermaid-fences.sh --changed-only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Cache `node_modules` in the lint CI job so `npm ci` is skipped entirely when `package-lock.json` and `package.json` are unchanged, saving ~12s per run. `npm ci` now runs only when either the `node_modules` or Puppeteer cache misses.
 
-
 ## [18.0.7] - 2026-05-08
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [18.0.8] - 2026-05-08
+
+### Changed
+
+- Cache `node_modules` in the lint CI job so `npm ci` is skipped entirely when `package-lock.json` and `package.json` are unchanged, saving ~12s per run. `npm ci` now runs only when either the `node_modules` or Puppeteer cache misses.
+
+
 ## [18.0.7] - 2026-05-08
 
 ### Changed


### PR DESCRIPTION
## Summary
- Add `actions/cache@v5` step for `node_modules` (keyed on `package.json` + `package-lock.json` hash) between the npm setup and Puppeteer cache steps in the `lint` job.
- Make `npm ci` conditional: skip it only when **both** the `node_modules` cache **and** the Puppeteer Chromium cache hit. A `node_modules` cache hit with a Puppeteer cache miss would otherwise leave Chromium absent and break the mermaid lint step.
- On a full cache hit (~12s savings per run); on a cache miss `npm ci` still runs with the warm npm registry cache.

## Architecture Diagram
Architecture diagram not available.

## Code Flow Diagram
(Code Flow Diagram skipped — quick mode)

## Test plan
- CI passes after this PR lands.
- On a second CI run with no lockfile change, the "Install Mermaid CLI" step is skipped (cache hit visible in CI logs, saving ~12s).

Closes #1576

🤖 Generated with [Claude Code](https://claude.com/claude-code)
