### PR TITLE
Resolve #1577: fix CHANGELOG double blank line in write_changelog_entry

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "18.0.9",
+  "version": "18.0.10",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 3-reviewer specialist panel (2 Cursor specialists + 1 Codex generic) — extended to 4 with an optional Gemini reviewer when the Gemini CLI is installed and healthy — with 3-voter adjudication; plan review runs a 3-reviewer panel (Claude + Codex + Cursor); design sketches run a 9-agent diverge-then-converge phase in regular mode (1 Claude + 4 Cursor + 4 Codex) or 3 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [18.0.10] - 2026-05-08
+
+### Changed
+
+- Fix recurrent double blank line after CHANGELOG entry by fixing separator logic in write_changelog_entry and changelog_categories_to_markdown
+
 ## [18.0.9] - 2026-05-08
 
 ### Added

--- a/scripts/implement-finalize.sh
+++ b/scripts/implement-finalize.sh
@@ -502,6 +502,7 @@ write_changelog_entry() {
             skipping = 0
             in_unreleased = 0
             match_count = 0
+            entry_from_version_match = 0
         }
         FNR == NR {
             if (/^## \[Unreleased\]/) has_unreleased = 1
@@ -516,11 +517,13 @@ write_changelog_entry() {
             if (!inserted) {
                 for (i = 1; i <= en; i++) print e[i]
                 inserted = 1
+                entry_from_version_match = 1
             }
             skipping = 1
             next
         }
         skipping && /^## \[/ {
+            if (entry_from_version_match) print ""
             skipping = 0
         }
         skipping {

--- a/scripts/implement-finalize.sh
+++ b/scripts/implement-finalize.sh
@@ -435,13 +435,13 @@ changelog_categories_to_markdown() {
     for category in Added Changed Fixed Removed Security; do
         file="$dir/$category"
         [ -s "$file" ] || continue
+        [ "$had_any" = "true" ] && printf '\n' >> "$out"
         had_any=true
         printf '### %s\n\n' "$category" >> "$out"
         while IFS= read -r title || [ -n "$title" ]; do
             [ -n "$title" ] || continue
             printf -- '- %s\n' "$title" >> "$out"
         done < "$file"
-        printf '\n' >> "$out"
     done
     [ "$had_any" = "true" ]
 }
@@ -556,6 +556,7 @@ write_changelog_entry() {
         }
         !inserted && /^## \[/ {
             for (i = 1; i <= en; i++) print e[i]
+            print ""
             inserted = 1
         }
         { print }

--- a/scripts/test-implement-finalize.sh
+++ b/scripts/test-implement-finalize.sh
@@ -44,6 +44,12 @@ assert_file_contains() {
     assert_contains "$needle" "$content" "$label"
 }
 
+assert_file_not_contains() {
+    local needle=$1 path=$2 label=$3 content
+    content=$(cat "$path" 2>/dev/null || true)
+    assert_not_contains "$needle" "$content" "$label"
+}
+
 assert_rc() {
     local actual=$1 expected=$2 label=$3
     if [ "$actual" -eq "$expected" ]; then
@@ -728,6 +734,9 @@ assert_file_contains "--repo" "$SANDBOX/refresh-anchor-argv.txt" "postbump: anch
 assert_file_contains "IMPLEMENT_TMPDIR=$SANDBOX/tmp" "$SANDBOX/refresh-anchor-env.txt" "postbump: exports IMPLEMENT_TMPDIR to children"
 assert_file_contains "## [17.0.4] -" "$SANDBOX/repo/CHANGELOG.md" "postbump: changelog contains new version"
 assert_file_contains "### Changed" "$SANDBOX/repo/CHANGELOG.md" "postbump: flat bullets default to Changed"
+awk 'prev_blank && /^$/ { print "DOUBLE_BLANK"; exit } /^$/ { prev_blank=1; next } { prev_blank=0 }' \
+    "$SANDBOX/repo/CHANGELOG.md" > "$SANDBOX/blank-check.txt"
+assert_file_not_contains "DOUBLE_BLANK" "$SANDBOX/blank-check.txt" "postbump: changelog has no consecutive blank lines"
 
 # FINDING_1 regression: Unreleased section bullets must be preserved, not consumed.
 cat > "$SANDBOX/repo/CHANGELOG.md" <<'CHANGELOG_UNRELEASED'

--- a/scripts/test-implement-finalize.sh
+++ b/scripts/test-implement-finalize.sh
@@ -824,6 +824,34 @@ assert_file_contains "### Fixed" "$SANDBOX/repo/CHANGELOG.md" "postbump: fallbac
 assert_file_contains "### Added" "$SANDBOX/repo/CHANGELOG.md" "postbump: fallback categorized Added"
 assert_file_contains "### Changed" "$SANDBOX/repo/CHANGELOG.md" "postbump: fallback bare bullet defaults Changed"
 
+# Regression: when target version header already exists (replacement path), no double blank before next header.
+cat > "$SANDBOX/repo/CHANGELOG.md" <<'CHANGELOG_REPLACE'
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [17.0.4] - 2026-05-01
+
+### Fixed
+
+- old content to be replaced.
+
+## [17.0.3] - 2026-04-30
+
+### Changed
+
+- Prior change.
+CHANGELOG_REPLACE
+write_postbump_state "$POSTBUMP_STATE"
+OUT=$(run_subject postbump --state-file "$POSTBUMP_STATE" --implement-tmpdir "$SANDBOX/tmp")
+assert_contains "CHANGELOG_STATUS=updated" "$OUT" "postbump: replacement path updates changelog"
+awk 'prev_blank && /^$/ { print "DOUBLE_BLANK"; exit } /^$/ { prev_blank=1; next } { prev_blank=0 }' \
+    "$SANDBOX/repo/CHANGELOG.md" > "$SANDBOX/blank-check-replace.txt"
+assert_file_not_contains "DOUBLE_BLANK" "$SANDBOX/blank-check-replace.txt" "postbump: replacement path has no consecutive blank lines"
+
 cp "$SANDBOX/original-CHANGELOG.md" "$SANDBOX/repo/CHANGELOG.md"
 write_postbump_state "$POSTBUMP_STATE" BUMP_TYPE=NONE
 OUT=$(run_subject postbump --state-file "$POSTBUMP_STATE" --implement-tmpdir "$SANDBOX/tmp")


### PR DESCRIPTION
## Summary

- Fix recurrent double blank line in CHANGELOG entries by refactoring `changelog_categories_to_markdown` to emit the inter-category separator blank before the next header (not after the previous one), so entries no longer have a trailing blank line
- Add `entry_from_version_match` flag in `write_changelog_entry` awk so the version-replacement path correctly emits a blank separator only when the entry was printed by the version-match block itself
- Add `assert_file_not_contains` helper and two regression tests (standard insertion path + version replacement path) to the postbump harness

## Test plan

- [x] `make test-implement-finalize` → 156 passed, 0 failed
- [x] Pre-commit linters (`shellcheck`, `agent-lint`, `detect-secrets`) on changed files → all pass

Closes #1577

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
