### PR TITLE
Add .claude/rules/verify-external-tool-invocations.md rule

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "18.0.12",
+  "version": "18.0.13",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 3-reviewer specialist panel (2 Cursor specialists + 1 Codex generic) — extended to 4 with an optional Gemini reviewer when the Gemini CLI is installed and healthy — with 3-voter adjudication; plan review runs a 3-reviewer panel (Claude + Codex + Cursor); design sketches run a 9-agent diverge-then-converge phase in regular mode (1 Claude + 4 Cursor + 4 Codex) or 3 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/.claude/rules/verify-external-tool-invocations.md
+++ b/.claude/rules/verify-external-tool-invocations.md
@@ -1,0 +1,17 @@
+---
+paths:
+  - "scripts/**"
+  - "skills/**"
+  - ".github/workflows/**"
+---
+
+# Verify External Tool Invocations
+
+When any PR adds or modifies an invocation of an external CLI binary (cursor, codex, claude, gitleaks, actionlint, agent-lint, npm, npx, security, gh, etc.):
+
+1. **Run the exact command** with the exact arguments as they appear in the code, on the development machine, before committing.
+2. **Verify the exit code and output** are consistent with the expected behavior (success, expected flags recognized, no "unknown option" or "not available" errors).
+3. If the invocation targets a platform-specific feature (sandbox, keychain, OS-level API), **document the platform requirement** in a comment adjacent to the call.
+4. If the binary is not available locally for testing, **note this explicitly** in the PR description and request manual CI verification before merge.
+
+This rule exists because flag-unavailability failures (e.g. `--sandbox enabled` on hosts without sandbox support, `--prompt` vs `--print` on different CLI versions) produce silent reviewer failures rather than visible errors, making them disproportionately expensive to diagnose.

--- a/.claude/rules/verify-external-tool-invocations.md
+++ b/.claude/rules/verify-external-tool-invocations.md
@@ -9,7 +9,7 @@ paths:
 
 When any PR adds or modifies an invocation of an external CLI binary (cursor, codex, claude, gitleaks, actionlint, agent-lint, npm, npx, security, gh, etc.):
 
-1. **Run the exact command** with the exact arguments as they appear in the code, on the development machine, before committing.
+1. **Run the exact command** with the exact arguments as they appear in the code, on the development machine, before committing. For mutating operations (e.g. `gh pr merge`, `gh issue close`, `gh release create`), use a side-effect-free probe instead: `--help`, `--dry-run`, or a `--version` call that confirms the flag is recognized.
 2. **Verify the exit code and output** are consistent with the expected behavior (success, expected flags recognized, no "unknown option" or "not available" errors).
 3. If the invocation targets a platform-specific feature (sandbox, keychain, OS-level API), **document the platform requirement** in a comment adjacent to the call.
 4. If the binary is not available locally for testing, **note this explicitly** in the PR description and request manual CI verification before merge.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [18.0.13] - 2026-05-08
+
+### Added
+
+- Add .claude/rules/verify-external-tool-invocations.md: rule requiring verification of external CLI invocations (exact flags) before landing PRs that touch scripts, skills, or workflows
+
 ## [18.0.12] - 2026-05-08
 
 ### Fixed


### PR DESCRIPTION
## Summary

Add a new `.claude/rules/verify-external-tool-invocations.md` rule that requires implementers to run and verify external CLI invocations (exact arguments) before landing PRs that touch `scripts/**`, `skills/**`, or `.github/workflows/**`.

The rule was requested in issue #1584 following the `--sandbox enabled` crash (#1583), where an unverified CLI flag caused a hard failure in `launch-cursor-review.sh`.

## Architecture Diagram

Architecture diagram not available.

## Code Flow Diagram

(Code Flow Diagram skipped — quick mode)

## Test Plan

- Run `/relevant-checks` to confirm the rule file passes markdownlint and other linters.

Closes #1584

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)
