### PR TITLE
Resolve #1604: cap-hit assertions for implement/review launchers and collector (v18.4.2)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "18.4.1",
+  "version": "18.4.2",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 3-reviewer specialist panel (2 Cursor specialists + 1 Codex generic) with 3-voter adjudication; plan review runs an 8-reviewer panel (4 Codex archetypes + 4 Cursor archetypes: Architecture/Standards, Edge-cases/Failure-modes, Innovation/Exploration, Pragmatism/Safety); design sketches run a 4-agent diverge-then-converge phase in regular mode (2 Cursor + 2 Codex) or 2 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [18.4.2] - 2026-05-09
+
+### Changed
+
+- Add cap-hit assertions to 7 test harnesses (codex/cursor/gemini implement launchers, step2 dispatcher, codex/cursor review launchers, collect-agent-results.sh)
+
 ## [18.4.1] - 2026-05-09
 
 ### Changed

--- a/scripts/test-collect-agent-retry.sh
+++ b/scripts/test-collect-agent-retry.sh
@@ -739,6 +739,22 @@ else
     ok "case Z env sanitized — hook sentinel did not fire"
 fi
 
+# Case cap_hit: output file whose first line is STATUS=cap_hit is classified
+# as STATUS=cap_hit HEALTHY=true by collect-agent-results.sh and does NOT
+# trigger a retry (no .meta file required, no retry output created).
+OUT_CAP="$TMPROOT/cap-hit.txt"
+HEALTH_CAP="$TMPROOT/cap-hit.health"
+printf 'STATUS=cap_hit\nSTATUS=cap_hit TOTAL=9999 CAP=1 STEP=cursor-review\n' > "$OUT_CAP"
+printf '0\n' > "${OUT_CAP}.done"
+RESULT_CAP=$(run_collector bash "$OUT_CAP" "$HEALTH_CAP")
+assert_line "cap_hit status" "STATUS=cap_hit" "$RESULT_CAP"
+assert_line "cap_hit healthy" "HEALTHY=true" "$RESULT_CAP"
+if [[ -e "${OUT_CAP%.txt}-retry.txt" ]]; then
+    fail "cap_hit should not generate a retry output"
+else
+    ok "cap_hit no retry output"
+fi
+
 echo ""
 echo "Summary: $PASS passed, $FAIL failed, $SKIP skipped"
 if (( FAIL > 0 )); then

--- a/scripts/test-launch-codex-review.sh
+++ b/scripts/test-launch-codex-review.sh
@@ -438,7 +438,11 @@ if command -v shasum >/dev/null 2>&1; then
 else
     CH_SLUG=$(printf '%s' "$CH_SESSION" | sha256sum | awk '{print $1}')
 fi
-CH_LEDGER="${TMPDIR:-/tmp}/larch-tokens-${CH_SLUG}.jsonl"
+# Use a subprocess to discover the TMPDIR that check-step-token-budget.sh will
+# see (this test overrides $TMPDIR locally without exporting it, so the ledger
+# must land in the subprocess-visible temp root, not the test's local override).
+_CH_TMPROOT=$(bash -c 'printf "%s" "${TMPDIR:-/tmp}"')
+CH_LEDGER="${_CH_TMPROOT}/larch-tokens-${CH_SLUG}.jsonl"
 printf '{"type":"vendor","vendor":"codex","total":9999}\n' > "$CH_LEDGER"
 
 CH_OUTPUT="$TMPDIR/cap-hit-codex-review.txt"

--- a/scripts/test-launch-codex-review.sh
+++ b/scripts/test-launch-codex-review.sh
@@ -429,6 +429,41 @@ else
     pass
 fi
 
+# Cap-hit path: when LARCH_TOKEN_BUDGET_CAP_REVIEW=1 and the token ledger
+# shows vendor spend >= 1, the launcher writes STATUS=cap_hit to the output
+# file and exits 0 without invoking the underlying Codex binary.
+CH_SESSION="cap-hit-codex-review-$$-$RANDOM"
+if command -v shasum >/dev/null 2>&1; then
+    CH_SLUG=$(printf '%s' "$CH_SESSION" | shasum -a 256 | awk '{print $1}')
+else
+    CH_SLUG=$(printf '%s' "$CH_SESSION" | sha256sum | awk '{print $1}')
+fi
+CH_LEDGER="${TMPDIR:-/tmp}/larch-tokens-${CH_SLUG}.jsonl"
+printf '{"type":"vendor","vendor":"codex","total":9999}\n' > "$CH_LEDGER"
+
+CH_OUTPUT="$TMPDIR/cap-hit-codex-review.txt"
+CH_COUNT="$TMPDIR/cap-hit-codex-count.txt"
+
+PATH="$STUB_BIN:$PATH" \
+    CODEX_STUB_ARGV_LOG="$TMPDIR/cap-hit-codex-argv.txt" \
+    CODEX_STUB_COUNT_FILE="$CH_COUNT" \
+    LARCH_CODEX_MODEL="stub-model" \
+    LARCH_TOKEN_SESSION_ID="$CH_SESSION" \
+    LARCH_TOKEN_BUDGET_CAP_REVIEW=1 \
+    "$LAUNCHER" --output "$CH_OUTPUT" --timeout 5 --prompt "cap hit review" >/dev/null 2>&1
+rm -f "$CH_LEDGER"
+
+if [[ -f "$CH_OUTPUT" ]] && [[ "$(head -1 "$CH_OUTPUT")" == "STATUS=cap_hit" ]]; then
+    pass
+else
+    fail "cap-hit output first line must be STATUS=cap_hit; got: $(head -1 "$CH_OUTPUT" 2>/dev/null)"
+fi
+if [[ ! -f "$CH_COUNT" ]]; then
+    pass
+else
+    fail "cap-hit path must not invoke the underlying Codex binary (count file written)"
+fi
+
 if (( FAIL > 0 )); then
     printf 'FAIL: test-launch-codex-review.sh - %s failed, %s passed\n' "$FAIL" "$PASS" >&2
     printf '  %s\n' "${FAILURES[@]}" >&2

--- a/scripts/test-launch-cursor-review.sh
+++ b/scripts/test-launch-cursor-review.sh
@@ -798,7 +798,11 @@ if command -v shasum >/dev/null 2>&1; then
 else
     CH_SLUG=$(printf '%s' "$CH_SESSION" | sha256sum | awk '{print $1}')
 fi
-CH_LEDGER="${TMPDIR:-/tmp}/larch-tokens-${CH_SLUG}.jsonl"
+# Use a subprocess to discover the TMPDIR that check-step-token-budget.sh will
+# see (this test overrides $TMPDIR locally without exporting it, so the ledger
+# must land in the subprocess-visible temp root, not the test's local override).
+_CH_TMPROOT=$(bash -c 'printf "%s" "${TMPDIR:-/tmp}"')
+CH_LEDGER="${_CH_TMPROOT}/larch-tokens-${CH_SLUG}.jsonl"
 printf '{"type":"vendor","vendor":"cursor","total":9999}\n' > "$CH_LEDGER"
 
 CH_OUTPUT="$TMPDIR/cap-hit-cursor-review.txt"

--- a/scripts/test-launch-cursor-review.sh
+++ b/scripts/test-launch-cursor-review.sh
@@ -789,6 +789,39 @@ else
     pass
 fi
 
+# Cap-hit path: when LARCH_TOKEN_BUDGET_CAP_REVIEW=1 and the token ledger
+# shows vendor spend >= 1, the launcher writes STATUS=cap_hit to the output
+# file and exits 0 without invoking the underlying Cursor binary.
+CH_SESSION="cap-hit-cursor-review-$$-$RANDOM"
+if command -v shasum >/dev/null 2>&1; then
+    CH_SLUG=$(printf '%s' "$CH_SESSION" | shasum -a 256 | awk '{print $1}')
+else
+    CH_SLUG=$(printf '%s' "$CH_SESSION" | sha256sum | awk '{print $1}')
+fi
+CH_LEDGER="${TMPDIR:-/tmp}/larch-tokens-${CH_SLUG}.jsonl"
+printf '{"type":"vendor","vendor":"cursor","total":9999}\n' > "$CH_LEDGER"
+
+CH_OUTPUT="$TMPDIR/cap-hit-cursor-review.txt"
+CH_PID_FILE="$TMPDIR/cap-hit-cursor-pid.txt"
+
+PATH="$STUB_BIN:$PATH" \
+    CURSOR_STUB_PID_FILE="$CH_PID_FILE" \
+    LARCH_TOKEN_SESSION_ID="$CH_SESSION" \
+    LARCH_TOKEN_BUDGET_CAP_REVIEW=1 \
+    "$LAUNCHER" --output "$CH_OUTPUT" --timeout 5 --prompt "cap hit review" >/dev/null 2>&1
+rm -f "$CH_LEDGER"
+
+if [[ -f "$CH_OUTPUT" ]] && [[ "$(head -1 "$CH_OUTPUT")" == "STATUS=cap_hit" ]]; then
+    pass
+else
+    fail "cap-hit output first line must be STATUS=cap_hit; got: $(head -1 "$CH_OUTPUT" 2>/dev/null)"
+fi
+if [[ ! -f "$CH_PID_FILE" ]]; then
+    pass
+else
+    fail "cap-hit path must not invoke the underlying Cursor binary (pid file written)"
+fi
+
 if [[ "$FAIL" -ne 0 ]]; then
     printf 'FAIL: test-launch-cursor-review.sh - %s failed, %s passed\n' "$FAIL" "$PASS" >&2
     printf '  %s\n' "${FAIL_DETAILS[@]}" >&2

--- a/skills/implement/scripts/test-codex-implementer.sh
+++ b/skills/implement/scripts/test-codex-implementer.sh
@@ -593,6 +593,53 @@ else
     fail 13b "flag-like timing-task-kind should exit 2 with non-empty-non-flag-like message, got $EXIT: $(cat "$T13b_OUT")"
 fi
 
+# Test cap-hit: when the per-step token budget cap is exceeded, the launcher
+# exits immediately with LAUNCHER_EXIT=0 MANIFEST_WRITTEN=false STATUS=cap_hit
+# without invoking the underlying Codex binary.
+CH_SESSION="cap-hit-codex-$$-$RANDOM"
+if command -v shasum >/dev/null 2>&1; then
+    CH_SLUG=$(printf '%s' "$CH_SESSION" | shasum -a 256 | awk '{print $1}')
+else
+    CH_SLUG=$(printf '%s' "$CH_SESSION" | sha256sum | awk '{print $1}')
+fi
+CH_LEDGER="${TMPDIR:-/tmp}/larch-tokens-${CH_SLUG}.jsonl"
+printf '{"type":"vendor","vendor":"codex","total":9999}\n' > "$CH_LEDGER"
+
+CH_ARGV="$SCRATCH/cap-hit-codex-argv.txt"
+CH_OUT=$(cd "$REPO_ROOT" && \
+    PATH="$STUB_BIN:$PATH" \
+    STUB_ARGV_FILE="$CH_ARGV" \
+    STUB_PROMPT_FILE="$SCRATCH/cap-hit-codex-prompt.txt" \
+    STUB_LAST_ARG_FILE="$SCRATCH/cap-hit-codex-last-arg.txt" \
+    STUB_SEPARATOR_INDEX_FILE="$SCRATCH/cap-hit-codex-sep.txt" \
+    STUB_MANIFEST_PATH="$SCRATCH/cap-hit-codex-manifest.json" \
+    LARCH_TOKEN_SESSION_ID="$CH_SESSION" \
+    LARCH_TOKEN_BUDGET_CAP_IMPLEMENT=1 \
+    LARCH_CODEX_MODEL="stub-codex-model" \
+    "$LAUNCHER" \
+        --transcript-path "$SCRATCH/cap-hit-codex-transcript.txt" \
+        --sidecar-log "$SCRATCH/cap-hit-codex-sidecar.log" \
+        --manifest-path "$SCRATCH/cap-hit-codex-manifest.json" \
+        --qa-pending-path "$SCRATCH/cap-hit-codex-qa.json" \
+        --plan-file "$PLAN" \
+        --feature-file "$FEATURE" \
+        --agent-prompt "$AGENT_PROMPT" \
+        --timeout 30)
+rm -f "$CH_LEDGER"
+
+if printf '%s\n' "$CH_OUT" | grep -Fxq 'LAUNCHER_EXIT=0' && \
+   printf '%s\n' "$CH_OUT" | grep -Fxq 'MANIFEST_WRITTEN=false' && \
+   printf '%s\n' "$CH_OUT" | grep -Fxq 'STATUS=cap_hit'; then
+    pass
+else
+    fail "cap-hit-kv" "cap_hit path must emit LAUNCHER_EXIT=0 MANIFEST_WRITTEN=false STATUS=cap_hit; got: $CH_OUT"
+fi
+if [[ ! -f "$CH_ARGV" ]]; then
+    pass
+else
+    fail "cap-hit-no-invoke" "cap_hit path must not invoke the underlying Codex binary"
+fi
+
 TOTAL=$((PASS_COUNT + FAIL_COUNT))
 if (( FAIL_COUNT == 0 )); then
     echo "PASS: test-codex-implementer.sh — $PASS_COUNT/$TOTAL assertions"

--- a/skills/implement/scripts/test-cursor-implementer.sh
+++ b/skills/implement/scripts/test-cursor-implementer.sh
@@ -684,6 +684,53 @@ else
     fail K4b "flag-like timing-task-kind should exit 2 with non-empty-non-flag-like message, got rc=$K4b_RC: $K4b_OUT"
 fi
 
+# Test cap-hit: when the per-step token budget cap is exceeded, the launcher
+# exits immediately with LAUNCHER_EXIT=0 MANIFEST_WRITTEN=false STATUS=cap_hit
+# without invoking the underlying Cursor binary.
+CH_SESSION="cap-hit-cursor-$$-$RANDOM"
+if command -v shasum >/dev/null 2>&1; then
+    CH_SLUG=$(printf '%s' "$CH_SESSION" | shasum -a 256 | awk '{print $1}')
+else
+    CH_SLUG=$(printf '%s' "$CH_SESSION" | sha256sum | awk '{print $1}')
+fi
+CH_LEDGER="${TMPDIR:-/tmp}/larch-tokens-${CH_SLUG}.jsonl"
+printf '{"type":"vendor","vendor":"cursor","total":9999}\n' > "$CH_LEDGER"
+
+CH_ARGV="$SCRATCH/cap-hit-cursor-argv.txt"
+CH_OUT=$(cd "$REPO_ROOT" && \
+    PATH="$STUB_BIN:$PATH" \
+    STUB_ARGV_FILE="$CH_ARGV" \
+    STUB_PROMPT_FILE="$SCRATCH/cap-hit-cursor-prompt.txt" \
+    STUB_LAST_ARG_FILE="$SCRATCH/cap-hit-cursor-last-arg.txt" \
+    STUB_SEPARATOR_INDEX_FILE="$SCRATCH/cap-hit-cursor-sep.txt" \
+    STUB_MANIFEST_PATH="$SCRATCH/cap-hit-cursor-manifest.json" \
+    LARCH_TOKEN_SESSION_ID="$CH_SESSION" \
+    LARCH_TOKEN_BUDGET_CAP_IMPLEMENT=1 \
+    LARCH_CURSOR_MODEL="stub-cursor-model" \
+    "$LAUNCHER" \
+        --transcript-path "$SCRATCH/cap-hit-cursor-transcript.txt" \
+        --sidecar-log "$SCRATCH/cap-hit-cursor-sidecar.log" \
+        --manifest-path "$SCRATCH/cap-hit-cursor-manifest.json" \
+        --qa-pending-path "$SCRATCH/cap-hit-cursor-qa.json" \
+        --plan-file "$PLAN" \
+        --feature-file "$FEATURE" \
+        --agent-prompt "$AGENT_PROMPT" \
+        --timeout 30)
+rm -f "$CH_LEDGER"
+
+if printf '%s\n' "$CH_OUT" | grep -Fxq 'LAUNCHER_EXIT=0' && \
+   printf '%s\n' "$CH_OUT" | grep -Fxq 'MANIFEST_WRITTEN=false' && \
+   printf '%s\n' "$CH_OUT" | grep -Fxq 'STATUS=cap_hit'; then
+    pass
+else
+    fail "cap-hit-kv" "cap_hit path must emit LAUNCHER_EXIT=0 MANIFEST_WRITTEN=false STATUS=cap_hit; got: $CH_OUT"
+fi
+if [[ ! -f "$CH_ARGV" ]]; then
+    pass
+else
+    fail "cap-hit-no-invoke" "cap_hit path must not invoke the underlying Cursor binary"
+fi
+
 TOTAL=$((PASS_COUNT + FAIL_COUNT))
 if (( FAIL_COUNT == 0 )); then
     echo "PASS: test-cursor-implementer.sh — $PASS_COUNT/$TOTAL assertions"

--- a/skills/implement/scripts/test-gemini-implementer.sh
+++ b/skills/implement/scripts/test-gemini-implementer.sh
@@ -458,6 +458,51 @@ else
     fail 10b "flag-like timing-task-kind should exit 2 with non-empty-non-flag-like message, got rc=$T10b_RC: $T10b_OUT"
 fi
 
+# Test cap-hit: when the per-step token budget cap is exceeded, the launcher
+# exits immediately with LAUNCHER_EXIT=0 MANIFEST_WRITTEN=false STATUS=cap_hit
+# without invoking the underlying Gemini binary.
+CH_SESSION="cap-hit-gemini-$$-$RANDOM"
+if command -v shasum >/dev/null 2>&1; then
+    CH_SLUG=$(printf '%s' "$CH_SESSION" | shasum -a 256 | awk '{print $1}')
+else
+    CH_SLUG=$(printf '%s' "$CH_SESSION" | sha256sum | awk '{print $1}')
+fi
+CH_LEDGER="${TMPDIR:-/tmp}/larch-tokens-${CH_SLUG}.jsonl"
+printf '{"type":"vendor","vendor":"gemini","total":9999}\n' > "$CH_LEDGER"
+
+CH_ARGV="$SCRATCH/cap-hit-gemini-argv.txt"
+CH_OUT=$(cd "$REPO_ROOT" && \
+    PATH="$STUB_BIN:$PATH" \
+    STUB_ARGV_FILE="$CH_ARGV" \
+    STUB_PROMPT_FILE="$SCRATCH/cap-hit-gemini-prompt.txt" \
+    STUB_MANIFEST_PATH="$SCRATCH/cap-hit-gemini-manifest.json" \
+    LARCH_TOKEN_SESSION_ID="$CH_SESSION" \
+    LARCH_TOKEN_BUDGET_CAP_IMPLEMENT=1 \
+    LARCH_GEMINI_MODEL="stub-gemini-model" \
+    "$LAUNCHER" \
+        --transcript-path "$SCRATCH/cap-hit-gemini-transcript.txt" \
+        --sidecar-log "$SCRATCH/cap-hit-gemini-sidecar.log" \
+        --manifest-path "$SCRATCH/cap-hit-gemini-manifest.json" \
+        --qa-pending-path "$SCRATCH/cap-hit-gemini-qa.json" \
+        --plan-file "$PLAN" \
+        --feature-file "$FEATURE" \
+        --agent-prompt "$AGENT_PROMPT" \
+        --timeout 30)
+rm -f "$CH_LEDGER"
+
+if printf '%s\n' "$CH_OUT" | grep -Fxq 'LAUNCHER_EXIT=0' && \
+   printf '%s\n' "$CH_OUT" | grep -Fxq 'MANIFEST_WRITTEN=false' && \
+   printf '%s\n' "$CH_OUT" | grep -Fxq 'STATUS=cap_hit'; then
+    pass
+else
+    fail "cap-hit-kv" "cap_hit path must emit LAUNCHER_EXIT=0 MANIFEST_WRITTEN=false STATUS=cap_hit; got: $CH_OUT"
+fi
+if [[ ! -f "$CH_ARGV" ]]; then
+    pass
+else
+    fail "cap-hit-no-invoke" "cap_hit path must not invoke the underlying Gemini binary"
+fi
+
 TOTAL=$((PASS_COUNT + FAIL_COUNT))
 if (( FAIL_COUNT == 0 )); then
     echo "PASS: test-gemini-implementer.sh — $PASS_COUNT/$TOTAL assertions"

--- a/skills/implement/scripts/test-step2-dispatch.sh
+++ b/skills/implement/scripts/test-step2-dispatch.sh
@@ -674,6 +674,41 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Test 14: cap-hit path. When LARCH_TOKEN_BUDGET_CAP_IMPLEMENT=1 and the
+# token ledger shows vendor spend >= 1, the launcher short-circuits with
+# STATUS=cap_hit on stdout. The dispatcher must surface STATUS=bailed
+# REASON=cap_hit ORCHESTRATOR_EDIT_AUTHORITY=forbidden without retrying.
+# No stub coder binary is needed — the launcher exits before spawning one.
+# ---------------------------------------------------------------------------
+TMP14="$SCRATCH/test14"; mkdir -p "$TMP14"
+CH14_SESSION="cap-hit-step2-$$-$RANDOM"
+if command -v shasum >/dev/null 2>&1; then
+    CH14_SLUG=$(printf '%s' "$CH14_SESSION" | shasum -a 256 | awk '{print $1}')
+else
+    CH14_SLUG=$(printf '%s' "$CH14_SESSION" | sha256sum | awk '{print $1}')
+fi
+CH14_LEDGER="${TMPDIR:-/tmp}/larch-tokens-${CH14_SLUG}.jsonl"
+printf '{"type":"vendor","vendor":"codex","total":9999}\n' > "$CH14_LEDGER"
+
+OUT_14=$(cd "$REPO_ROOT" && \
+    RUN_EXTERNAL_AGENT_POLL_INTERVAL=0.05 \
+    LARCH_TOKEN_SESSION_ID="$CH14_SESSION" \
+    LARCH_TOKEN_BUDGET_CAP_IMPLEMENT=1 \
+    LARCH_CODEX_MODEL=stub-codex-model \
+    "$DISPATCHER" --tmpdir "$TMP14" --plan-file "$PLAN" --feature-file "$FEATURE" \
+        --auto-mode false --coder codex 2>&1)
+rm -f "$CH14_LEDGER"
+
+if [[ "$OUT_14" == *"STATUS=bailed"* ]] \
+   && [[ "$OUT_14" == *"REASON=cap_hit"* ]] \
+   && [[ "$OUT_14" == *"ORCHESTRATOR_EDIT_AUTHORITY=forbidden"* ]] \
+   && [[ "$OUT_14" != *"ORCHESTRATOR_EDIT_AUTHORITY=allowed"* ]]; then
+    pass
+else
+    fail 14 "cap_hit path should emit STATUS=bailed REASON=cap_hit AUTH=forbidden; got: $OUT_14"
+fi
+
+# ---------------------------------------------------------------------------
 # Summary.
 # ---------------------------------------------------------------------------
 TOTAL=$((PASS_COUNT + FAIL_COUNT))


### PR DESCRIPTION
## Summary

- Add cap-hit assertions to 7 test harnesses covering the token budget cap short-circuit path in implement launchers, step2 dispatcher, review launchers, and `collect-agent-results.sh`
- Each test injects a fake JSONL vendor ledger (total=9999) to trigger `check-step-token-budget.sh` without modifying shared scripts, asserts correct KV output and no underlying coder invocation

## Architecture Diagram

Architecture diagram not available.

## Code Flow Diagram

(Code Flow Diagram skipped — quick mode)

## Test plan

- [ ] `make test-codex-implementer` — passes with 27/27 assertions (2 new cap-hit assertions)
- [ ] `make test-cursor-implementer` — passes with 33/33 assertions (2 new cap-hit assertions)
- [ ] `make test-gemini-implementer` — passes with 28/28 assertions (2 new cap-hit assertions)
- [ ] `make test-step2-dispatch` — passes with 41/41 assertions (1 new cap-hit assertion)
- [ ] `make test-launch-codex-review` — passes with 69/69 assertions (2 new cap-hit assertions)
- [ ] `make test-launch-cursor-review` — passes with 149/149 assertions (2 new cap-hit assertions)
- [ ] `make test-collect-agent-retry` — passes with 127/127 assertions (3 new cap-hit assertions)
- [ ] `make lint` (pre-commit + shellcheck + agent-lint) — all pass

Closes #1604

🤖 Generated with [Claude Code](https://claude.ai/code)
