### PR TITLE
Add Claude generic reviewer positive anchor to quick-mode docs sync test (v18.4.5)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "18.4.4",
+  "version": "18.4.5",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 3-reviewer specialist panel (2 Cursor specialists + 1 Codex generic) with 3-voter adjudication; plan review runs an 8-reviewer panel (4 Codex archetypes + 4 Cursor archetypes: Architecture/Standards, Edge-cases/Failure-modes, Innovation/Exploration, Pragmatism/Safety); design sketches run a 4-agent diverge-then-converge phase in regular mode (2 Cursor + 2 Codex) or 2 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [18.4.5] - 2026-05-09
+
+### Fixed
+
+- Add missing "Claude generic" positive anchor to test-quick-mode-docs-sync.sh POS_MARKERS so CI enforces the Claude generic reviewer slot across all public quick-mode docs
+
 ## [18.4.3] - 2026-05-09
 
 ### Changed

--- a/scripts/test-quick-mode-docs-sync.md
+++ b/scripts/test-quick-mode-docs-sync.md
@@ -20,7 +20,7 @@ Without this harness, drift between the canonical quick-mode contract and its pu
 
 ### Positive anchors (required in every target)
 
-Each target file MUST contain all six markers:
+Each target file MUST contain all seven markers:
 
 | Marker | Casing | Rationale |
 |--------|--------|-----------|
@@ -30,8 +30,9 @@ Each target file MUST contain all six markers:
 | `rounds 1-3` | **case-insensitive** `grep -iF` | Pins the rounds-1-3 vs rounds-4+ split. Insensitive because `docs/review-agents.md` uses both `Rounds 1-3` (table cell) and `rounds 1-3` (Note A prose). Added per #1002. |
 | `5 Cursor specialists` | case-sensitive `grep -F` | Pins the specialist count in rounds 1-3. Together with the markers below, encodes the multi-lane topology so a future change that drops the specialist panel from rounds 1-3 fails CI. Added per #1002. |
 | `generic Codex` | case-sensitive `grep -F` | Pins the generic Codex slot — present both in rounds 1-3 (specialists + generic Codex) and as a fallback link in the rounds-4+ chain. Added per #1002. |
+| `Claude generic` | case-sensitive `grep -F` | Pins the always-present Claude generic reviewer slot in rounds 1-3. Added per #1621. |
 
-The last three markers encode the rounds-1-3 vs rounds-4+ topology described in the canonical Step 5 contract. Without them, a SKILL.md edit that re-shuffled the multi-lane structure (e.g. removing the generic Codex from rounds 1-3, or merging rounds 1-3 with rounds 4+) could ship without the public docs being updated.
+The last four markers encode the rounds-1-3 vs rounds-4+ topology described in the canonical Step 5 contract. Without them, a SKILL.md edit that re-shuffled the multi-lane structure (e.g. removing the generic Codex from rounds 1-3, or merging rounds 1-3 with rounds 4+) could ship without the public docs being updated.
 
 ### Negative checks (forbidden in public docs only)
 

--- a/scripts/test-quick-mode-docs-sync.sh
+++ b/scripts/test-quick-mode-docs-sync.sh
@@ -33,7 +33,10 @@
 #        - "generic Codex"               (case-sensitive, grep -F — pins the
 #                                         generic Codex slot in rounds 1-3 and
 #                                         the rounds-4+ generic reviewer chain)
-#      The last three encode the rounds-1-3 vs rounds-4+ topology so future
+#        - "Claude generic"              (case-sensitive, grep -F — pins the
+#                                         always-present Claude generic reviewer
+#                                         slot in rounds 1-3)
+#      The last four encode the rounds-1-3 vs rounds-4+ topology so future
 #      Step 5 quick-mode reviewer-composition changes that don't propagate to
 #      every public surface fail CI (closes #1002).
 #
@@ -97,6 +100,7 @@ readonly POS_MARKERS=(
   "rounds 1-3|insensitive"
   "5 Cursor specialists|sensitive"
   "generic Codex|sensitive"
+  "Claude generic|sensitive"
 )
 
 # Stale phrases (forbidden in public docs; SKILL.md exempt).
@@ -298,7 +302,7 @@ This is a fixture describing quick-mode behavior.
 The review loop runs up to 7 rounds.
 Reviewer selection per round follows Cursor → Codex → Claude fallback.
 The loop has no voting panel — main agent accepts or rejects each finding.
-Rounds 1-3 launch 5 Cursor specialists in parallel plus a generic Codex reviewer.
+Rounds 1-3 launch 5 Cursor specialists in parallel plus a generic Codex reviewer and a Claude generic reviewer.
 Rounds 4+ use a single generic reviewer per round.
 EOF
 
@@ -313,7 +317,7 @@ Stale-phrase fixture: contains every positive marker so only the stale phrase ca
 The review loop runs up to 7 rounds.
 Reviewer selection per round follows Cursor → Codex → Claude fallback.
 The loop has no voting panel — main agent accepts or rejects each finding.
-Rounds 1-3 launch 5 Cursor specialists in parallel plus a generic Codex reviewer.
+Rounds 1-3 launch 5 Cursor specialists in parallel plus a generic Codex reviewer and a Claude generic reviewer.
 Stale phrase intentionally embedded: simplified code review (1 Claude Code Reviewer subagent, 1 round).
 EOF
 


### PR DESCRIPTION
## Summary

Add the missing `"Claude generic|sensitive"` positive anchor to `test-quick-mode-docs-sync.sh` so CI enforces that every public quick-mode doc mentions the always-present Claude generic reviewer slot in rounds 1-3.

## Changes

- `POS_MARKERS`: adds `"Claude generic|sensitive"` after `"generic Codex|sensitive"`
- Header comment: updates "last three" → "last four" topology markers
- Self-test `good` fixture: adds "Claude generic reviewer" text so the fixture passes all 7 anchors
- Self-test `bad` fixture: same addition, preserving the "exactly 1 failure from stale phrase" invariant
- `test-quick-mode-docs-sync.md`: "all six markers" → "all seven markers"; adds `Claude generic` table row

## Architecture Diagram

Architecture diagram not available.

## Code Flow Diagram

(Code Flow Diagram skipped — quick mode)

## Test plan

- `bash scripts/test-quick-mode-docs-sync.sh` exits 0
- `bash scripts/test-quick-mode-docs-sync.sh --self-test` exits 0

Closes #1621

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)
