### PR TITLE
Replace long worked examples with compact key schemas in SKILL.md files (v18.4.7)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "18.4.10",
+  "version": "18.4.11",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 3-reviewer specialist panel (2 Cursor specialists + 1 Codex generic) with 3-voter adjudication; plan review runs a 4-reviewer diagonal panel (2 Cursor: Arch, Edge + 2 Codex: Innovation, Pragmatic); design sketches run a 4-agent diverge-then-converge phase in regular mode (2 Cursor + 2 Codex) or 2 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [18.4.11] - 2026-05-09
+
+### Changed
+
+- Replace 20-line worked examples in skills/implement, skills/research, and skills/create-skill SKILL.md files with compact key schemas and bullet-name formats, reducing token overhead on every orchestrator invocation
+
 ## [18.4.10] - 2026-05-09
 
 ### Changed

--- a/skills/create-skill/SKILL.md
+++ b/skills/create-skill/SKILL.md
@@ -173,32 +173,14 @@ Construct a concise feature description for `/im`:
 - Template: `multi-step` if `MULTI_STEP=true`, else `minimal`.
 - Feature-spec file path: `<RAW_DESC_FILE_PATH>` is the **resolved absolute path** of `$RAW_DESC_FILE` (e.g. `/tmp/create-skill-raw-desc-XXXXXX.txt`) captured at Step 1.4 — substitute the actual filesystem path here, NOT the literal variable name `$RAW_DESC_FILE`. The renderer's `--feature-spec-file` flag (#568) reads this file's content (raw passthrough — multi-line preserved) and emits it as the body's opening paragraph. Without this substitution, the implementing agent would invoke `render-skill-md.sh --feature-spec-file "$RAW_DESC_FILE"` literally and the file-existence check would fail with `ERROR=Cannot read --feature-spec-file: $RAW_DESC_FILE`.
 
-Feature description template (fill placeholders from the parsed values; note `<FRONTMATTER_DESCRIPTION>` is the validated single-line frontmatter from Step 1.5/1.6 and `<FEATURE_SPEC>` is the original raw description carried as a feature brief — these are TWO DISTINCT slots):
+Feature description template (fill placeholders; `<FRONTMATTER_DESCRIPTION>` and `<FEATURE_SPEC>` are TWO DISTINCT slots):
 
-```
-Scaffold new skill /<NAME> at <TARGET_DIR>. Frontmatter description: "<FRONTMATTER_DESCRIPTION>". Path mode: <plugin-dev|consumer>. Template: <minimal|multi-step>.
-
-Feature spec for the new skill (verbatim user input — multi-line allowed):
-<FEATURE_SPEC>
-
-Use ${CLAUDE_PLUGIN_ROOT}/skills/create-skill/scripts/render-skill-md.sh to write the scaffold:
-  render-skill-md.sh --name "<NAME>" --description "<FRONTMATTER_DESCRIPTION>" \
-    --target-dir "<TARGET_DIR>" \
-    --local-token "<LOCAL_TOKEN>" --plugin-token "${CLAUDE_PLUGIN_ROOT}" \
-    --multi-step <MULTI_STEP> \
-    --feature-spec-file "<RAW_DESC_FILE_PATH>"
-
-After scaffolding, run ${CLAUDE_PLUGIN_ROOT}/skills/create-skill/scripts/post-scaffold-hints.sh --target-dir "<TARGET_DIR>" --plugin <PLUGIN>. The hints script is the single source of truth for the post-scaffold doc-sync checklist — execute every reminder it emits verbatim (including README Skills catalog row + the docs/configuration-and-permissions.md "Strict-permissions consumers — Skill permission entries" subsection pointer, .claude/settings.json dual-form Skill permission entries with `sort -u`, docs/workflow-lifecycle.md orchestration/delegation/standalone updates, docs/agents.md, docs/review-agents.md, AGENTS.md Canonical sources, and any additional lines the hints script prints). Include the hints output verbatim in the PR body under a "Post-scaffold sync checklist" section.
-
-The renderer mechanically scaffolds the body from `--feature-spec-file`'s content (the raw `<FEATURE_SPEC>` written to `<RAW_DESC_FILE_PATH>` at Step 1.4); use <FRONTMATTER_DESCRIPTION> ONLY for the YAML frontmatter `description:` field via `render-skill-md.sh --description`. On the verbatim path the two slots carry the same string; on the synthesis path <FRONTMATTER_DESCRIPTION> is a one-line `Use when…` distillation of <FEATURE_SPEC>, both validated. The implementing agent then evolves the scaffolded body into the real skill — the renderer-provided opening paragraph is a starting point, not the final body.
-
-The full CLI grammar, body-vs-frontmatter contract, output-channel split (`RENDERED=` on stdout / `ERROR=` on stderr), backward-compat semantics, and edit-in-sync rules for `render-skill-md.sh` live in the sibling contract at `${CLAUDE_PLUGIN_ROOT}/skills/create-skill/scripts/render-skill-md.md`.
-
-MUST read ${CLAUDE_PLUGIN_ROOT}/skills/shared/skill-design-principles.md (full file) before writing any code. Section III mechanical rules A/B/C below override Section IV writing-style guidance on conflict:
-  A. Content and logic live in .sh scripts — shared at ${CLAUDE_PLUGIN_ROOT}/scripts/ when reusable, private at ${CLAUDE_PLUGIN_ROOT}/skills/<NAME>/scripts/ otherwise. Grep existing scripts/ before creating a new one.
-  B. No direct Bash-tool commands in SKILL.md — every shell command is a .sh wrapper call; no inline pipelines, loops, or multi-line `bash -c`.
-  C. No consecutive Bash-tool calls per step — combine multi-action steps into one coordinator .sh that invokes the individual scripts internally.
-```
+- Opening line: `Scaffold new skill /<NAME> at <TARGET_DIR>. Frontmatter description: "<FRONTMATTER_DESCRIPTION>". Path mode: <plugin-dev|consumer>. Template: <minimal|multi-step>.`
+- `Feature spec for the new skill (verbatim user input — multi-line allowed):` followed by `<FEATURE_SPEC>`
+- `render-skill-md.sh` invocation: `--name "<NAME>" --description "<FRONTMATTER_DESCRIPTION>" --target-dir "<TARGET_DIR>" --local-token "<LOCAL_TOKEN>" --plugin-token "${CLAUDE_PLUGIN_ROOT}" --multi-step <MULTI_STEP> --feature-spec-file "<RAW_DESC_FILE_PATH>"`
+- After scaffolding, run `post-scaffold-hints.sh --target-dir "<TARGET_DIR>" --plugin <PLUGIN>` and execute every hint verbatim (README catalog row, docs/configuration-and-permissions.md Strict-permissions entry, .claude/settings.json dual-form entries with `sort -u`, docs/workflow-lifecycle.md, docs/agents.md, docs/review-agents.md, AGENTS.md Canonical sources). Include hints output in the PR body under "Post-scaffold sync checklist".
+- Note: renderer uses `<FRONTMATTER_DESCRIPTION>` ONLY for the `description:` frontmatter field; on the synthesis path it is a one-line `Use when…` distillation of `<FEATURE_SPEC>`. Contract in `render-skill-md.md`.
+- `MUST read ${CLAUDE_PLUGIN_ROOT}/skills/shared/skill-design-principles.md` (full file). Section III mechanical rules A/B/C (scripts-not-SKILL.md, no inline Bash, no consecutive Bash calls) override Section IV on conflict.
 
 Print: `**Create-skill /<NAME> (<plugin-dev|consumer>, <minimal|multi-step>) — delegating to /im --quick --auto [--slack]**` (omit `--slack` when `SLACK=false`). `/im` auto-merges; `--merge` on `/create-skill` is a backward-compat no-op and is not forwarded.
 

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -1904,28 +1904,15 @@ else
   CLONE_TAG_FULL=${CLONE_TAG_FULL:0:32}
   [ -n "$CLONE_TAG_FULL" ] || CLONE_TAG_FULL="_"
 fi
-cat > "$IMPLEMENT_TMPDIR/finalize-state.sh" <<EOF
-BRANCH_NAME=$BRANCH_NAME
-PR_NUMBER=$PR_NUMBER
-PR_TITLE=$PR_TITLE
-PR_URL=$PR_URL
-ISSUE_NUMBER=$ISSUE_NUMBER
-REPO=$REPO
-DRAFT=$draft
-MERGE=$merge
-SLACK_ENABLED=$slack_enabled
-SLACK_AVAILABLE=$slack_available
-DEFERRED=$deferred
-REPO_UNAVAILABLE=$repo_unavailable
-PR_CLOSED=${pr_closed:-false}
-DESIGN_ONLY_DONE=${DESIGN_ONLY_DONE:-false}
-BAIL_NEEDS_USER_INPUT=${BAIL_NEEDS_USER_INPUT:-false}
-STALL_TRACKING=${STALL_TRACKING:-false}
-STALL_STEP=${STALL_STEP:-}
-DONE_RENAME_APPLIED=${DONE_RENAME_APPLIED:-false}
-EXPECTED_SESSION_ID=$(cat "$IMPLEMENT_TMPDIR/session-id" 2>/dev/null || echo "")
-EXPECTED_TMPDIR_BASENAME_PREFIX=claude-implement-${CLONE_TAG_FULL}-
-EOF
+# Write $IMPLEMENT_TMPDIR/finalize-state.sh (one KEY=VALUE per line, awk-read by postmerge):
+# BRANCH_NAME  PR_NUMBER  PR_TITLE  PR_URL  ISSUE_NUMBER  REPO
+# DRAFT  MERGE  SLACK_ENABLED  SLACK_AVAILABLE  DEFERRED  REPO_UNAVAILABLE
+# PR_CLOSED=${pr_closed:-false}  DESIGN_ONLY_DONE=${DESIGN_ONLY_DONE:-false}
+# BAIL_NEEDS_USER_INPUT=${BAIL_NEEDS_USER_INPUT:-false}
+# STALL_TRACKING=${STALL_TRACKING:-false}  STALL_STEP=${STALL_STEP:-}
+# DONE_RENAME_APPLIED=${DONE_RENAME_APPLIED:-false}
+# EXPECTED_SESSION_ID=$(cat "$IMPLEMENT_TMPDIR/session-id" 2>/dev/null || echo "")
+# EXPECTED_TMPDIR_BASENAME_PREFIX=claude-implement-${CLONE_TAG_FULL}-
 printf '%s' "${FINAL_BAIL_REASON:-}" > "$IMPLEMENT_TMPDIR/final-bail-reason.txt"
 ```
 
@@ -1947,8 +1934,6 @@ If `forked_target=true`: print `⏭️ 14: local cleanup — skipped (--forked d
 
 Use the finalizer state from Step 13.5, then delegate Step 14 and Step 15 mechanical work to `implement-finalize.sh postmerge`. The state file is plain `KEY=value` text and is never sourced; the script reads it with `awk`. Mechanical SSOT: `${CLAUDE_PLUGIN_ROOT}/scripts/implement-finalize.md` § `postmerge`.
 
-`CLONE_TAG_FULL` is computed inline using the same four-step algorithm as Step 13.5 (see Step 13.5 prose for the rationale and #1563); the heredoc references it on the `EXPECTED_TMPDIR_BASENAME_PREFIX` line.
-
 ```bash
 if [ -n "${CLONE_TAG:-}" ]; then
   CLONE_TAG_FULL="$CLONE_TAG"
@@ -1958,28 +1943,10 @@ else
   CLONE_TAG_FULL=${CLONE_TAG_FULL:0:32}
   [ -n "$CLONE_TAG_FULL" ] || CLONE_TAG_FULL="_"
 fi
-cat > "$IMPLEMENT_TMPDIR/finalize-state.sh" <<EOF
-BRANCH_NAME=$BRANCH_NAME
-PR_NUMBER=$PR_NUMBER
-PR_TITLE=$PR_TITLE
-PR_URL=$PR_URL
-ISSUE_NUMBER=$ISSUE_NUMBER
-REPO=$REPO
-DRAFT=$draft
-MERGE=$merge
-SLACK_ENABLED=$slack_enabled
-SLACK_AVAILABLE=$slack_available
-DEFERRED=$deferred
-REPO_UNAVAILABLE=$repo_unavailable
-PR_CLOSED=${pr_closed:-false}
-DESIGN_ONLY_DONE=${DESIGN_ONLY_DONE:-false}
-BAIL_NEEDS_USER_INPUT=${BAIL_NEEDS_USER_INPUT:-false}
-STALL_TRACKING=${STALL_TRACKING:-false}
-STALL_STEP=${STALL_STEP:-}
-DONE_RENAME_APPLIED=${DONE_RENAME_APPLIED:-false}
-EXPECTED_SESSION_ID=$(cat "$IMPLEMENT_TMPDIR/session-id" 2>/dev/null || echo "")
-EXPECTED_TMPDIR_BASENAME_PREFIX=claude-implement-${CLONE_TAG_FULL}-
-EOF
+# Re-write $IMPLEMENT_TMPDIR/finalize-state.sh with the same 20-key schema as Step 13.5,
+# using updated values for current Step 14 state (PR_NUMBER/PR_URL/PR_TITLE from Step 9b,
+# PR_CLOSED/DONE_RENAME_APPLIED from Step 12, STALL_TRACKING/STALL_STEP from Step 12d, etc.)
+# EXPECTED_TMPDIR_BASENAME_PREFIX=claude-implement-${CLONE_TAG_FULL}-
 printf '%s' "${FINAL_BAIL_REASON:-}" > "$IMPLEMENT_TMPDIR/final-bail-reason.txt"
 
 ${CLAUDE_PLUGIN_ROOT}/scripts/implement-finalize.sh postmerge \
@@ -2099,31 +2066,11 @@ export LARCH_TOKEN_SESSION_ID LARCH_CLAUDE_SOURCE_FILE
 
 If `DESIGN_ONLY_DONE=true`: print `✅ 17: final report — design-only complete; tracking issue contains plan, review tally, diagrams, and OOS status (<elapsed>)`.
 
-If `forked_target=true` and `DESIGN_ONLY_DONE` is not true: print:
-
-```markdown
-## Fork CI Dry-Run Complete
-
-Fork PR: <PR_URL>
-
-To open the upstream PR when CI is green on the fork, use these values:
-
-UPSTREAM_REPO: <UPSTREAM_REPO>
-FORK_OWNER:    <FORK_OWNER>
-BRANCH:        <BRANCH_NAME>
-BASE_REF:      <upstream default branch, falling back to main>
-
-Command template:
-
-gh pr create --repo "$UPSTREAM_REPO" --base "$BASE_REF" --head "$FORK_OWNER:$BRANCH_NAME"
-
-Caveats for fork CI fidelity:
-- Actions must be enabled on the fork repo for any workflow to run.
-- Workflows that consume upstream secrets will fail or skip in the fork.
-- Workflows guarded by `if: github.repository == 'owner/upstream-repo'` will skip on forks.
-- Green on the fork does not guarantee green on the upstream PR; treat this as a dry run only.
-- If `FORK_CI_NO_CHECKS=true`, no checks were observed after the grace period, so the fork produced no CI signal.
-```
+If `forked_target=true` and `DESIGN_ONLY_DONE` is not true: print a fork CI dry-run report with:
+- `## Fork CI Dry-Run Complete` header, then `Fork PR: <PR_URL>`
+- Upstream PR values: `UPSTREAM_REPO`, `FORK_OWNER`, `BRANCH`, `BASE_REF` (upstream default branch, fallback main)
+- `gh pr create` command template substituting those four values
+- Caveats (5 bullets): Actions must be enabled; secrets skip; `github.repository` guard skips; green on fork ≠ green upstream; `FORK_CI_NO_CHECKS=true` means no CI signal observed
 
 If `UPSTREAM_DESIGN_ISSUE` is set, append: `You may include Closes #<UPSTREAM_DESIGN_ISSUE> in the upstream PR body when you compose it manually.` If accepted-OOS items were skipped by Step 9a.1, append them under `## Out-of-Scope Observations` as text only. **Precedence**: `DESIGN_ONLY_DONE=true` wins over fork-mode report; never print fork-CI / fork-PR language on design-only completion.
 

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -1893,7 +1893,7 @@ export LARCH_TOKEN_SESSION_ID LARCH_CLAUDE_SOURCE_FILE
 
 Write `$IMPLEMENT_TMPDIR/finalize-state.sh` before any post-PR cleanup/Slack/teardown branch. This always-run state file is required even when `merge=false`, `draft=true`, `forked_target=true`, or Step 12 bailed before local cleanup.
 
-`EXPECTED_TMPDIR_BASENAME_PREFIX` MUST mirror exactly what `session-setup.sh` and `scripts/implement-finalize.sh::clone_basename_prefix` produce, or Step 18's `verify_cleanup_target` sanity-check will refuse rm-rf and leak the session tmpdir. The four required steps — basename, sanitize via `tr` (NOT a one-pipe form, which bakes basename's trailing newline into a stray `_`; see #1563), truncate to 32 chars, empty-fallback to `_` — are computed inline before the heredoc into `CLONE_TAG_FULL`, then referenced by the heredoc. The `${CLONE_TAG:-…}` operator-override semantics are preserved on the first line.
+`EXPECTED_TMPDIR_BASENAME_PREFIX` MUST mirror exactly what `session-setup.sh` and `scripts/implement-finalize.sh::clone_basename_prefix` produce, or Step 18's `verify_cleanup_target` sanity-check will refuse rm-rf and leak the session tmpdir. The four required steps — basename, sanitize via `tr` (NOT a one-pipe form, which bakes basename's trailing newline into a stray `_`; see #1563), truncate to 32 chars, empty-fallback to `_` — are computed inline into `CLONE_TAG_FULL` before writing the state file. The `${CLONE_TAG:-…}` operator-override semantics are preserved on the first line.
 
 ```bash
 if [ -n "${CLONE_TAG:-}" ]; then
@@ -1904,17 +1904,20 @@ else
   CLONE_TAG_FULL=${CLONE_TAG_FULL:0:32}
   [ -n "$CLONE_TAG_FULL" ] || CLONE_TAG_FULL="_"
 fi
-# Write $IMPLEMENT_TMPDIR/finalize-state.sh (one KEY=VALUE per line, awk-read by postmerge):
-# BRANCH_NAME  PR_NUMBER  PR_TITLE  PR_URL  ISSUE_NUMBER  REPO
-# DRAFT  MERGE  SLACK_ENABLED  SLACK_AVAILABLE  DEFERRED  REPO_UNAVAILABLE
-# PR_CLOSED=${pr_closed:-false}  DESIGN_ONLY_DONE=${DESIGN_ONLY_DONE:-false}
-# BAIL_NEEDS_USER_INPUT=${BAIL_NEEDS_USER_INPUT:-false}
-# STALL_TRACKING=${STALL_TRACKING:-false}  STALL_STEP=${STALL_STEP:-}
-# DONE_RENAME_APPLIED=${DONE_RENAME_APPLIED:-false}
-# EXPECTED_SESSION_ID=$(cat "$IMPLEMENT_TMPDIR/session-id" 2>/dev/null || echo "")
-# EXPECTED_TMPDIR_BASENAME_PREFIX=claude-implement-${CLONE_TAG_FULL}-
-printf '%s' "${FINAL_BAIL_REASON:-}" > "$IMPLEMENT_TMPDIR/final-bail-reason.txt"
 ```
+
+Write `$IMPLEMENT_TMPDIR/finalize-state.sh` (one `KEY=VALUE` per line, awk-read by `postmerge`) with these 20 keys:
+
+- `BRANCH_NAME`, `PR_NUMBER`, `PR_TITLE`, `PR_URL`, `ISSUE_NUMBER`, `REPO`
+- `DRAFT`, `MERGE`, `SLACK_ENABLED`, `SLACK_AVAILABLE`, `DEFERRED`, `REPO_UNAVAILABLE`
+- `PR_CLOSED` (`${pr_closed:-false}`), `DESIGN_ONLY_DONE` (`${DESIGN_ONLY_DONE:-false}`)
+- `BAIL_NEEDS_USER_INPUT` (`${BAIL_NEEDS_USER_INPUT:-false}`)
+- `STALL_TRACKING` (`${STALL_TRACKING:-false}`), `STALL_STEP` (`${STALL_STEP:-}`)
+- `DONE_RENAME_APPLIED` (`${DONE_RENAME_APPLIED:-false}`)
+- `EXPECTED_SESSION_ID` — `$(cat "$IMPLEMENT_TMPDIR/session-id" 2>/dev/null || echo "")`
+- `EXPECTED_TMPDIR_BASENAME_PREFIX=claude-implement-${CLONE_TAG_FULL}-`
+
+Then: `printf '%s' "${FINAL_BAIL_REASON:-}" > "$IMPLEMENT_TMPDIR/final-bail-reason.txt"`
 
 If `forked_target=true`, leave `ISSUE_NUMBER` blank and keep `REPO=$FORK_REPO` as resolved by session setup.
 
@@ -1943,10 +1946,13 @@ else
   CLONE_TAG_FULL=${CLONE_TAG_FULL:0:32}
   [ -n "$CLONE_TAG_FULL" ] || CLONE_TAG_FULL="_"
 fi
-# Re-write $IMPLEMENT_TMPDIR/finalize-state.sh with the same 20-key schema as Step 13.5,
-# using updated values for current Step 14 state (PR_NUMBER/PR_URL/PR_TITLE from Step 9b,
-# PR_CLOSED/DONE_RENAME_APPLIED from Step 12, STALL_TRACKING/STALL_STEP from Step 12d, etc.)
-# EXPECTED_TMPDIR_BASENAME_PREFIX=claude-implement-${CLONE_TAG_FULL}-
+```
+
+Re-write `$IMPLEMENT_TMPDIR/finalize-state.sh` with the same 20-key schema as Step 13.5, using updated values for current Step 14 state (e.g., `PR_NUMBER`/`PR_URL`/`PR_TITLE` from Step 9b, `PR_CLOSED`/`DONE_RENAME_APPLIED` from Step 12, `STALL_TRACKING`/`STALL_STEP` from Step 12d). The `EXPECTED_TMPDIR_BASENAME_PREFIX=claude-implement-${CLONE_TAG_FULL}-` line uses the freshly computed `CLONE_TAG_FULL`. See Step 13.5 key list for all 20 keys.
+
+Then:
+
+```bash
 printf '%s' "${FINAL_BAIL_REASON:-}" > "$IMPLEMENT_TMPDIR/final-bail-reason.txt"
 
 ${CLAUDE_PLUGIN_ROOT}/scripts/implement-finalize.sh postmerge \

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -155,24 +155,11 @@ The four research lanes use the **Codex pre-launch status** (each lane is Codex-
 
 The heredoc body uses a **quoted delimiter** (`<<'EOF'`) so that any residual shell metacharacters in a substituted reason value are preserved verbatim.
 
-```bash
-cat > "$RESEARCH_TMPDIR/lane-status.txt" <<'EOF'
-RESEARCH_ARCH_STATUS=<codex pre-launch status>
-RESEARCH_ARCH_REASON=<codex sanitized reason or empty>
-RESEARCH_EDGE_STATUS=<codex pre-launch status>
-RESEARCH_EDGE_REASON=<codex sanitized reason or empty>
-RESEARCH_EXT_STATUS=<codex pre-launch status>
-RESEARCH_EXT_REASON=<codex sanitized reason or empty>
-RESEARCH_SEC_STATUS=<codex pre-launch status>
-RESEARCH_SEC_REASON=<codex sanitized reason or empty>
-VALIDATION_CODE_STATUS=ok
-VALIDATION_CODE_REASON=
-VALIDATION_CURSOR_STATUS=<cursor pre-launch status>
-VALIDATION_CURSOR_REASON=<cursor sanitized reason or empty>
-VALIDATION_CODEX_STATUS=<codex pre-launch status>
-VALIDATION_CODEX_REASON=<codex sanitized reason or empty>
-EOF
-```
+Write `$RESEARCH_TMPDIR/lane-status.txt` (shell key=value, quoted `<<'EOF'` delimiter; 14 keys):
+- `RESEARCH_{ARCH,EDGE,EXT,SEC}_STATUS` — codex pre-launch status for each lane
+- `RESEARCH_{ARCH,EDGE,EXT,SEC}_REASON` — sanitized reason or empty
+- `VALIDATION_CODE_STATUS=ok`, `VALIDATION_CODE_REASON=` (always constant)
+- `VALIDATION_{CURSOR,CODEX}_{STATUS,REASON}` — per pre-launch probe result
 
 ### 0c — Record Research Context
 
@@ -268,43 +255,17 @@ Parse the seven output lines via prefix-strip (NOT `cut -d=`, since rendered val
 
 If the helper exits non-zero, substitute the placeholder line `_Lane attribution unavailable._` for every header row and log: `**⚠ 3: report — render-lane-status failed; lane attribution unavailable.**`.
 
-Print the final research report under a `## Research Report` header with the following structure:
-
-```markdown
-## Research Report
-
-**Research question**: <RESEARCH_QUESTION>
-**Codebase context**: Branch `<CURRENT_BRANCH>`, commit `<HEAD_SHA>`
-
-**Research phase** (4 lanes):
-- <RESEARCH_ARCH_HEADER>
-- <RESEARCH_EDGE_HEADER>
-- <RESEARCH_EXT_HEADER>
-- <RESEARCH_SEC_HEADER>
-
-**Validation phase** (3 reviewers):
-- <VALIDATION_CODE_HEADER>
-- <VALIDATION_CURSOR_HEADER>
-- <VALIDATION_CODEX_HEADER>
-
-### Findings Summary
-<synthesized and validated findings, organized by topic>
-
-### Risk Assessment
-<Low/Medium/High with rationale, or N/A if not applicable to this research question>
-
-### Difficulty Estimate
-<S/M/L/XL with rationale, or N/A if not applicable>
-
-### Feasibility Verdict
-<assessment of feasibility with rationale, or N/A if not applicable>
-
-### Key Files and Areas
-<list of the most relevant files/modules/areas identified during research>
-
-### Open Questions
-<any unresolved questions or areas that need further investigation>
-```
+Print the final research report under a `## Research Report` header. Required sections (in order):
+- `**Research question**:` — `<RESEARCH_QUESTION>`
+- `**Codebase context**:` — branch and commit
+- `**Research phase** (4 lanes):` — one bullet per `<X_ARCH/EDGE/EXT/SEC_HEADER>`
+- `**Validation phase** (3 reviewers):` — one bullet per `<VALIDATION_CODE/CURSOR/CODEX_HEADER>`
+- `### Findings Summary` — synthesized validated findings by topic
+- `### Risk Assessment` — Low/Medium/High + rationale, or N/A
+- `### Difficulty Estimate` — S/M/L/XL + rationale, or N/A
+- `### Feasibility Verdict` — feasibility + rationale, or N/A
+- `### Key Files and Areas` — relevant files/modules/areas
+- `### Open Questions` — unresolved questions or areas needing further investigation
 
 When any external research lane ran as a Claude-fallback (`N_FALLBACK >= 1` per the §1.5 banner preamble in `${CLAUDE_PLUGIN_ROOT}/skills/research/references/research-phase.md`), Step 1.5 prepends a reduced-diversity banner under `## Research Synthesis`. The banner is computed by the canonical executable helper `${CLAUDE_PLUGIN_ROOT}/skills/research/scripts/compute-research-banner.sh` (contract in sibling `${CLAUDE_PLUGIN_ROOT}/skills/research/scripts/compute-research-banner.md`); the orchestrator forks the helper with the lane-status.txt path and prepends the helper's stdout to the synthesis subagent's body before writing `research-report.txt`. The banner contract is guarded by `${CLAUDE_PLUGIN_ROOT}/skills/research/scripts/test-research-banner.sh` (contract in sibling `${CLAUDE_PLUGIN_ROOT}/skills/research/scripts/test-research-banner.md`). Example degraded-path preview (one Codex angle fell back):
 

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -153,13 +153,12 @@ Sanitize each `*_PROBE_ERROR` value before writing: strip embedded `=` and `|` c
 
 The four research lanes use the **Codex pre-launch status** (each lane is Codex-first; the per-lane fallback is Claude `Agent`). The `VALIDATION_CODE_*` slot uses pre-launch status `ok` (Claude code-reviewer subagent has no fallback path); `VALIDATION_CURSOR_*` and `VALIDATION_CODEX_*` use the Cursor/Codex pre-launch statuses respectively.
 
-The heredoc body uses a **quoted delimiter** (`<<'EOF'`) so that any residual shell metacharacters in a substituted reason value are preserved verbatim.
+Write `$RESEARCH_TMPDIR/lane-status.txt` using a quoted-delimiter heredoc (`<<'EOF'`) so that shell metacharacters in sanitized reason values are preserved verbatim. 14 keys (one `KEY=VALUE` per line):
 
-Write `$RESEARCH_TMPDIR/lane-status.txt` (shell key=value, quoted `<<'EOF'` delimiter; 14 keys):
-- `RESEARCH_{ARCH,EDGE,EXT,SEC}_STATUS` — codex pre-launch status for each lane
-- `RESEARCH_{ARCH,EDGE,EXT,SEC}_REASON` — sanitized reason or empty
+- `RESEARCH_ARCH_STATUS`, `RESEARCH_EDGE_STATUS`, `RESEARCH_EXT_STATUS`, `RESEARCH_SEC_STATUS` — codex pre-launch status for each lane
+- `RESEARCH_ARCH_REASON`, `RESEARCH_EDGE_REASON`, `RESEARCH_EXT_REASON`, `RESEARCH_SEC_REASON` — sanitized reason or empty
 - `VALIDATION_CODE_STATUS=ok`, `VALIDATION_CODE_REASON=` (always constant)
-- `VALIDATION_{CURSOR,CODEX}_{STATUS,REASON}` — per pre-launch probe result
+- `VALIDATION_CURSOR_STATUS`, `VALIDATION_CURSOR_REASON`, `VALIDATION_CODEX_STATUS`, `VALIDATION_CODEX_REASON` — per pre-launch probe result
 
 ### 0c — Record Research Context
 
@@ -258,8 +257,8 @@ If the helper exits non-zero, substitute the placeholder line `_Lane attribution
 Print the final research report under a `## Research Report` header. Required sections (in order):
 - `**Research question**:` — `<RESEARCH_QUESTION>`
 - `**Codebase context**:` — branch and commit
-- `**Research phase** (4 lanes):` — one bullet per `<X_ARCH/EDGE/EXT/SEC_HEADER>`
-- `**Validation phase** (3 reviewers):` — one bullet per `<VALIDATION_CODE/CURSOR/CODEX_HEADER>`
+- `**Research phase** (4 lanes):` — one bullet each for `<RESEARCH_ARCH_HEADER>`, `<RESEARCH_EDGE_HEADER>`, `<RESEARCH_EXT_HEADER>`, `<RESEARCH_SEC_HEADER>`
+- `**Validation phase** (3 reviewers):` — one bullet each for `<VALIDATION_CODE_HEADER>`, `<VALIDATION_CURSOR_HEADER>`, `<VALIDATION_CODEX_HEADER>`
 - `### Findings Summary` — synthesized validated findings by topic
 - `### Risk Assessment` — Low/Medium/High + rationale, or N/A
 - `### Difficulty Estimate` — S/M/L/XL + rationale, or N/A


### PR DESCRIPTION
## Summary

- Replace 20-line worked examples in `skills/implement/SKILL.md`, `skills/research/SKILL.md`, and `skills/create-skill/SKILL.md` with compact bullet key-name schemas, reducing token overhead on every orchestrator invocation
- `skills/implement/SKILL.md` Step 13.5 and Step 14: heredoc key lists moved out of bash comment blocks into prose bullet schemas (keeping the CLONE_TAG_FULL computation in bash per CI assertion 31a-31e requiring >= 2 occurrences)
- `skills/implement/SKILL.md` Step 17: Fork CI report template replaced with 5-bullet schema
- `skills/research/SKILL.md`: lane-status.txt heredoc (14 keys) and Research Report template both replaced with explicit key-name bullet schemas; fixed brace-expansion notation to use literal key names
- `skills/create-skill/SKILL.md`: feature description template replaced with 6-bullet schema

## Architecture Diagram

Architecture diagram not available.

## Code Flow Diagram

(Code Flow Diagram skipped — quick mode)

## Test plan

- [ ] `/relevant-checks` passes (pre-commit on modified files + agent-lint on full repo) — ✅ verified
- [ ] CI assertion 31a-31e: CLONE_TAG_FULL algorithm lines appear >= 2 times in `skills/implement/SKILL.md` — ✅ verified (2 each)
- [ ] No code blocks > 15 lines remain in changed SKILL.md files — ✅ verified

Closes #1625

🤖 Generated with [Claude Code](https://claude.com/claude-code)
