### PR TITLE
Fix SIGPIPE/pipefail flaky anti-pattern in test scripts (v19.1.1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "19.1.0",
+  "version": "19.1.1",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 3-reviewer specialist panel (2 Cursor specialists + 1 Codex generic) with 3-voter adjudication; plan review runs a 4-reviewer diagonal panel (2 Cursor: Arch, Edge + 2 Codex: Innovation, Pragmatic); design sketches run a 4-agent diverge-then-converge phase in regular mode (2 Cursor + 2 Codex) or 2 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [19.1.1] - 2026-05-09
+
+### Fixed
+
+- Fix SIGPIPE/pipefail flakiness in test scripts: replace `producer|head`/`grep|grep -qF` pipelines with `grep -m 1` and here-strings to prevent transient CI failures on Linux
+
 ## [19.1.0] - 2026-05-09
 
 ### Added

--- a/scripts/test-assemble-anchor.sh
+++ b/scripts/test-assemble-anchor.sh
@@ -304,8 +304,8 @@ grep -qxF '```mermaid' "$output_b" \
     || fail "(b) missing diagrams mermaid fence"
 
 # Verify the order: diagrams (index 3) must appear before version-bump-reasoning (index 4).
-diagrams_line=$(grep -n '<!-- section:diagrams -->' "$output_b" | head -n 1 | cut -d: -f1)
-vbr_line=$(grep -n '<!-- section:version-bump-reasoning -->' "$output_b" | head -n 1 | cut -d: -f1)
+diagrams_line=$(grep -m 1 -n '<!-- section:diagrams -->' "$output_b" | cut -d: -f1)
+vbr_line=$(grep -m 1 -n '<!-- section:version-bump-reasoning -->' "$output_b" | cut -d: -f1)
 [ "$diagrams_line" -lt "$vbr_line" ] \
     || fail "(b) expected diagrams ($diagrams_line) before version-bump-reasoning ($vbr_line)"
 
@@ -439,10 +439,10 @@ mkdir -p "$sections_b4"
 output_b4="$tmpdir/out-b4.md"
 "$ASSEMBLE_ANCHOR" --sections-dir "$sections_b4" --issue 502 --output "$output_b4" > /dev/null
 
-version_line_num=$(grep -nF '| larch plugin version | 9.8.7 |' "$output_b4" | head -n 1 | cut -d: -f1)
-model_line_num=$(grep -nF '| Claude model | unknown |' "$output_b4" | head -n 1 | cut -d: -f1)
-effort_line_num=$(grep -nF '| effort level | unknown |' "$output_b4" | head -n 1 | cut -d: -f1)
-close_line_num=$(grep -nF '<!-- section-end:run-statistics -->' "$output_b4" | head -n 1 | cut -d: -f1)
+version_line_num=$(grep -m 1 -nF '| larch plugin version | 9.8.7 |' "$output_b4" | cut -d: -f1)
+model_line_num=$(grep -m 1 -nF '| Claude model | unknown |' "$output_b4" | cut -d: -f1)
+effort_line_num=$(grep -m 1 -nF '| effort level | unknown |' "$output_b4" | cut -d: -f1)
+close_line_num=$(grep -m 1 -nF '<!-- section-end:run-statistics -->' "$output_b4" | cut -d: -f1)
 [ -n "$version_line_num" ] || fail "(b4) missing injected plugin-version row"
 [ -n "$model_line_num" ] || fail "(b4) missing injected Claude-model row"
 [ -n "$effort_line_num" ] || fail "(b4) missing injected effort-level row"

--- a/scripts/test-ci-wait-exit-trap.sh
+++ b/scripts/test-ci-wait-exit-trap.sh
@@ -202,7 +202,7 @@ EXPECTED_KEYS=("ACTION=" "CI_STATUS=" "BEHIND_COUNT=" "FAILED_RUN_ID=" "BAIL_REA
 ALL_KEYS_PRESENT=true
 LAST_LINE_NUM=0
 for key in "${EXPECTED_KEYS[@]}"; do
-    LINE_NUM="$(echo "$B_STDOUT" | grep -n -F "$key" | head -1 | cut -d: -f1)"
+    LINE_NUM="$(grep -m 1 -n -F "$key" <<< "$B_STDOUT" | cut -d: -f1)"
     if [ -z "$LINE_NUM" ]; then
         ALL_KEYS_PRESENT=false
         fail "B: expected stdout key '$key' not found"

--- a/scripts/test-collect-agent-bash32.sh
+++ b/scripts/test-collect-agent-bash32.sh
@@ -121,7 +121,7 @@ else
             ok "case 2: empty VAL_ARGS under /bin/bash 3.x, STATUS=OK, clean stderr"
         fi
     else
-        ACTUAL_STATUS="$(echo "$OUT2" | grep '^STATUS=' | head -1)"
+        ACTUAL_STATUS="$(grep -m 1 '^STATUS=' <<< "$OUT2")"
         if grep -q 'unbound variable' "$TMPROOT/case2.stderr"; then
             fail "case 2: bash 3.2 unbound-variable hazard fired — issue #511 regressed (got: $ACTUAL_STATUS)"
         else
@@ -146,7 +146,7 @@ else
     if echo "$OUT3a" | grep -q '^STATUS=OK$'; then
         ok "case 3 positive: NO_ISSUES_FOUND fixture under --validation-mode → STATUS=OK"
     else
-        ACTUAL_STATUS_A="$(echo "$OUT3a" | grep '^STATUS=' | head -1)"
+        ACTUAL_STATUS_A="$(grep -m 1 '^STATUS=' <<< "$OUT3a")"
         fail "case 3 positive: NO_ISSUES_FOUND under --validation-mode did not return OK (got: $ACTUAL_STATUS_A) — flag forwarding broken"
     fi
 
@@ -165,7 +165,7 @@ else
             ok "case 3 negative: NO_ISSUES_FOUND without --validation-mode → STATUS=NOT_SUBSTANTIVE (200-word floor)"
         fi
     else
-        ACTUAL_STATUS_B="$(echo "$OUT3b" | grep '^STATUS=' | head -1)"
+        ACTUAL_STATUS_B="$(grep -m 1 '^STATUS=' <<< "$OUT3b")"
         fail "case 3 negative: same fixture without --validation-mode did not reject (got: $ACTUAL_STATUS_B) — flag is not actually changing behavior"
     fi
 fi

--- a/scripts/test-tracking-issue-write.sh
+++ b/scripts/test-tracking-issue-write.sh
@@ -802,7 +802,7 @@ invariant_out=$(bash -c "
     set -euo pipefail
     source '$REPO_ROOT/scripts/anchor-section-markers.sh'
     # COLLAPSE_PRIORITY lives inline in tracking-issue-write.sh; grep it out.
-    cp_line=\$(grep -E '^COLLAPSE_PRIORITY=\\(' '$WRITE' | head -n 1)
+    cp_line=\$(grep -m 1 -E '^COLLAPSE_PRIORITY=\\(' '$WRITE')
     if [ -z \"\$cp_line\" ]; then
         echo 'ERROR=COLLAPSE_PRIORITY= declaration not found in tracking-issue-write.sh'
         exit 1
@@ -836,8 +836,9 @@ else
     FAILED_TESTS+=("(i) SECTION_MARKERS ⊆ COLLAPSE_PRIORITY invariant")
     echo "  FAIL: (i) $invariant_out" >&2
 fi
+_cp_content=$(grep -E '^COLLAPSE_PRIORITY=\(' "$WRITE" || true)
 if bash -c "source '$REPO_ROOT/scripts/anchor-section-markers.sh'; printf '%s\n' \"\${SECTION_MARKERS[@]}\"" | grep -qxF 'timing-report' \
-    && grep -E '^COLLAPSE_PRIORITY=\(' "$WRITE" | grep -qF 'timing-report'; then
+    && [[ "$_cp_content" == *"timing-report"* ]]; then
     PASS=$((PASS + 1))
     echo "  ok: (i2) timing-report present in SECTION_MARKERS and COLLAPSE_PRIORITY"
 else
@@ -846,7 +847,7 @@ else
     echo "  FAIL: (i2) timing-report missing from SECTION_MARKERS or COLLAPSE_PRIORITY" >&2
 fi
 if bash -c "source '$REPO_ROOT/scripts/anchor-section-markers.sh'; printf '%s\n' \"\${SECTION_MARKERS[@]}\"" | grep -qxF 'token-report' \
-    && grep -E '^COLLAPSE_PRIORITY=\(' "$WRITE" | grep -qF 'token-report'; then
+    && [[ "$_cp_content" == *"token-report"* ]]; then
     PASS=$((PASS + 1))
     echo "  ok: (i3) token-report present in SECTION_MARKERS and COLLAPSE_PRIORITY"
 else


### PR DESCRIPTION
## Summary

Fix SIGPIPE/pipefail flaky anti-pattern in 4 test scripts. Under `set -euo pipefail` on Linux, `producer | early-exit-consumer` pipelines cause the producer to receive SIGPIPE (exit 141) when the consumer exits early, and `pipefail` promotes this to a pipeline failure — causing transient CI failures.

**Changes:**
- `scripts/test-tracking-issue-write.sh` — `grep -E | head -n 1` → `grep -m 1 -E`; capture COLLAPSE_PRIORITY content in variable, replace `grep | grep -qF` with `[[ "$var" == *pattern* ]]`
- `scripts/test-assemble-anchor.sh` — `grep -n | head -n 1 | cut` → `grep -m 1 -n | cut`
- `scripts/test-ci-wait-exit-trap.sh` — `echo | grep | head | cut` → `grep -m 1 ... <<< "$VAR" | cut`
- `scripts/test-collect-agent-bash32.sh` — `echo | grep | head` → `grep -m 1 ... <<< "$VAR"`

## Architecture Diagram

Architecture diagram not available.

## Code Flow Diagram

(Code Flow Diagram skipped — quick mode)

## Test plan

- `/relevant-checks` (pre-commit + agent-lint) passes
- These test scripts can be run locally on Linux to verify no SIGPIPE exits

Closes #1691

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
