### PR TITLE
Suppress prose scoreboard in nested /review runs; print counts only (v20.0.2)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "20.0.1",
+  "version": "20.0.2",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 3-reviewer specialist panel (2 Cursor specialists + 1 Codex generic) with 3-voter adjudication; plan review runs a 4-reviewer diagonal panel (2 Cursor: Arch, Edge + 2 Codex: Innovation, Pragmatic); design sketches run a 4-agent diverge-then-converge phase in regular mode (2 Cursor + 2 Codex) or 2 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Reviewer dirty-tree changes are now automatically logged and discarded instead of prompting the operator with a restore/stash/bail `AskUserQuestion`. When a Cursor, Codex, or Claude reviewer leaves uncommitted changes in the working tree, the orchestrator logs which reviewer caused it (to `execution-issues.md` under `Warnings` in `/implement` runs, or to the transcript in standalone `/review` runs) and immediately discards the changes via scoped `git restore` / `git clean` — no stash is created and `git stash list` remains clean. This replaces the three-option recovery prompt introduced by #1437. Updated: `skills/implement/SKILL.md` (Step 5.3.b quick mode, Step 5 normal mode, `--auto` flag description), `skills/review/SKILL.md` (Step 3a, line 22), `skills/review/references/heavy-worker.md`, `docs/external-reviewers.md`, `SECURITY.md`
 
+## [20.0.2] - 2026-05-09
+
+### Changed
+
+- Suppress full prose scoreboard in nested /review runs (SESSION_ENV_PATH non-empty); print only count summary instead
+
 ## [20.0.1] - 2026-05-09
 
 ### Changed

--- a/skills/shared/voting-protocol.md
+++ b/skills/shared/voting-protocol.md
@@ -176,7 +176,12 @@ If a deduplicated finding was proposed by multiple reviewers (merged during dedu
 
 ## Scoreboard
 
-After voting, print a scoreboard to the session:
+After voting, print the scoreboard. Branch on `SESSION_ENV_PATH`:
+
+- **When `SESSION_ENV_PATH` is empty (standalone run)**: print the full scoreboard table to the session.
+- **When `SESSION_ENV_PATH` is non-empty (nested run under `/implement`)**: print only a one-line count summary of the form `Round <N>: <A> accepted, <R> rejected, <E> exonerated` (in-scope findings only; neutral findings omitted). The full scoreboard is written to the artifact file (`review-round-summary.md` or equivalent) by the surrounding workflow and is accessible to the parent orchestrator from there.
+
+Full scoreboard format (used in standalone mode):
 
 ```
 ## Reviewer Competition Scoreboard

--- a/skills/shared/voting-protocol.md
+++ b/skills/shared/voting-protocol.md
@@ -179,7 +179,7 @@ If a deduplicated finding was proposed by multiple reviewers (merged during dedu
 After voting, print the scoreboard. Branch on `SESSION_ENV_PATH`:
 
 - **When `SESSION_ENV_PATH` is empty (standalone run)**: print the full scoreboard table to the session.
-- **When `SESSION_ENV_PATH` is non-empty (nested run under `/implement`)**: print only a one-line count summary of the form `Round <N>: <A> accepted, <R> rejected, <E> exonerated` (in-scope findings only; neutral findings omitted). The full scoreboard is written to the artifact file (`review-round-summary.md` or equivalent) by the surrounding workflow and is accessible to the parent orchestrator from there.
+- **When `SESSION_ENV_PATH` is non-empty (nested run under `/implement`)**: print only a one-line count summary of the form `Round <N>: <A> accepted, <R> rejected, <E> exonerated` (in-scope findings only; neutral findings omitted). The full scoreboard is available in the workflow's file artifacts (e.g., `review-round-summary.md` written by the review heavy worker in subagent mode, `voting-tally.md` for plan review) for parent access.
 
 Full scoreboard format (used in standalone mode):
 


### PR DESCRIPTION
## Summary

Suppress the full prose Reviewer Competition Scoreboard in nested `/review` runs (SESSION_ENV_PATH non-empty). Instead of the full markdown table after each voting round, print only a one-line count summary: `Round N: A accepted, R rejected, E exonerated`. The full scoreboard remains in the workflow's artifact files (e.g., `review-round-summary.md` in subagent mode, `voting-tally.md` for plan review) for parent access.

Design's `dialectic-execution.md` already handles this correctly (line 90). This change brings `/review`'s per-round voting scoreboard into parity.

## Architecture Diagram

Architecture diagram not available.

## Code Flow Diagram

(Code Flow Diagram skipped — quick mode)

## Test plan

- Pre-commit markdown lint passed
- agent-lint passed via `/relevant-checks`
- Standalone `/review` invocations unaffected (SESSION_ENV_PATH empty)
- Nested `/review` invocations under `/implement` will print only count summaries per voting round

Closes #1704

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)
