### PR TITLE
Voter ballot-only output: YES requires no rationale (v20.0.2)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "20.0.3",
+  "version": "20.0.4",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 3-reviewer specialist panel (2 Cursor specialists + 1 Codex generic) with 3-voter adjudication; plan review runs a 4-reviewer diagonal panel (2 Cursor: Arch, Edge + 2 Codex: Innovation, Pragmatic); design sketches run a 4-agent diverge-then-converge phase in regular mode (2 Cursor + 2 Codex) or 2 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Reviewer dirty-tree changes are now automatically logged and discarded instead of prompting the operator with a restore/stash/bail `AskUserQuestion`. When a Cursor, Codex, or Claude reviewer leaves uncommitted changes in the working tree, the orchestrator logs which reviewer caused it (to `execution-issues.md` under `Warnings` in `/implement` runs, or to the transcript in standalone `/review` runs) and immediately discards the changes via scoped `git restore` / `git clean` — no stash is created and `git stash list` remains clean. This replaces the three-option recovery prompt introduced by #1437. Updated: `skills/implement/SKILL.md` (Step 5.3.b quick mode, Step 5 normal mode, `--auto` flag description), `skills/review/SKILL.md` (Step 3a, line 22), `skills/review/references/heavy-worker.md`, `docs/external-reviewers.md`, `SECURITY.md`
 
-## [20.0.3] - 2026-05-09
+## [20.0.4] - 2026-05-09
 
 ### Changed
 

--- a/docs/voting-process.md
+++ b/docs/voting-process.md
@@ -55,12 +55,12 @@ OOS_1: [OUT_OF_SCOPE] Code — <description of pre-existing issue>
 
 ## Voter Output Format
 
-Each voter outputs one line per finding:
+Each voter outputs one line per finding. YES votes require no reason; NO and EXONERATE votes require a one-line reason:
 
 ```text
-FINDING_1: YES — <one-line rationale>
-FINDING_2: NO — <one-line rationale>
-FINDING_3: EXONERATE — <one-line rationale>
+FINDING_1: YES
+FINDING_2: NO — <one-line reason>
+FINDING_3: EXONERATE — <one-line reason>
 ```
 
 ## Voting Flow

--- a/skills/shared/voting-protocol.md
+++ b/skills/shared/voting-protocol.md
@@ -24,7 +24,7 @@ Include the reviewer attribution so voters have context, but instruct voters to 
 
 ## Voter Output Format
 
-Each voter must output one line per ballot item, **using the same ID that appears on the ballot** — `FINDING_N` for in-scope items and `OOS_N` for out-of-scope items. YES votes require no rationale; NO and EXONERATE votes require a one-line reason:
+Each voter must output one line per ballot item, **using the same ID that appears on the ballot** — `FINDING_N` for in-scope items and `OOS_N` for out-of-scope items. YES votes require no reason; NO and EXONERATE votes require a one-line reason:
 
 ```
 FINDING_1: YES
@@ -32,6 +32,7 @@ FINDING_2: NO — <one-line reason>
 FINDING_3: EXONERATE — <one-line reason>
 OOS_1: YES
 OOS_2: NO — <one-line reason>
+OOS_3: EXONERATE — <one-line reason>
 ...
 ```
 

--- a/skills/shared/voting-protocol.md
+++ b/skills/shared/voting-protocol.md
@@ -24,14 +24,14 @@ Include the reviewer attribution so voters have context, but instruct voters to 
 
 ## Voter Output Format
 
-Each voter must output one line per ballot item, **using the same ID that appears on the ballot** — `FINDING_N` for in-scope items and `OOS_N` for out-of-scope items:
+Each voter must output one line per ballot item, **using the same ID that appears on the ballot** — `FINDING_N` for in-scope items and `OOS_N` for out-of-scope items. YES votes require no rationale; NO and EXONERATE votes require a one-line reason:
 
 ```
-FINDING_1: YES — <one-line rationale>
-FINDING_2: NO — <one-line rationale>
-FINDING_3: EXONERATE — <one-line rationale>
-OOS_1: YES — <one-line rationale>
-OOS_2: NO — <one-line rationale>
+FINDING_1: YES
+FINDING_2: NO — <one-line reason>
+FINDING_3: EXONERATE — <one-line reason>
+OOS_1: YES
+OOS_2: NO — <one-line reason>
 ...
 ```
 
@@ -79,17 +79,17 @@ Be scrupulous — only vote YES for findings that genuinely improve the {REVIEW_
 {BALLOT}
 
 For each ballot item, output exactly one line using the same ID from the ballot (FINDING_N or OOS_N):
-FINDING_N: YES — <one-line rationale>
+FINDING_N: YES
 or
-FINDING_N: NO — <one-line rationale>
+FINDING_N: NO — <one-line reason>
 or
-FINDING_N: EXONERATE — <one-line rationale>
+FINDING_N: EXONERATE — <one-line reason>
 or
-OOS_N: YES — <one-line rationale>
+OOS_N: YES
 or
-OOS_N: NO — <one-line rationale>
+OOS_N: NO — <one-line reason>
 or
-OOS_N: EXONERATE — <one-line rationale>
+OOS_N: EXONERATE — <one-line reason>
 
 You must vote on every item. Do NOT skip any. Do NOT modify files.
 ```


### PR DESCRIPTION
## Summary

Constrain voter ballot output: YES votes no longer require a rationale — voters output bare `FINDING_N: YES`. NO and EXONERATE votes still require a one-line reason. Applies to both in-scope findings and OOS items.

This reduces voter token usage by eliminating unnecessary rationale on accepted findings and is a cross-vendor consensus change (Claude C32, Codex IDEA_11/12, Cursor IDEA_47).

## Architecture Diagram

Architecture diagram not available.

## Code Flow Diagram

(Code Flow Diagram skipped — quick mode)

## Test plan

- `make lint` passes (checked)
- Grep `skills/shared/voting-protocol.md` and `docs/voting-process.md` to confirm new bare-YES format

Closes #1702
