### PR TITLE
Fix inverted skip-probe logic in session-setup.sh (v20.0.7)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "20.0.7",
+  "version": "20.0.8",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 3-reviewer specialist panel (2 Cursor specialists + 1 Codex generic) with 3-voter adjudication; plan review runs a 4-reviewer diagonal panel (2 Cursor: Arch, Edge + 2 Codex: Innovation, Pragmatic); design sketches run a 4-agent diverge-then-converge phase in regular mode (2 Cursor + 2 Codex) or 2 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Reviewer dirty-tree changes are now automatically logged and discarded instead of prompting the operator with a restore/stash/bail `AskUserQuestion`. When a Cursor, Codex, or Claude reviewer leaves uncommitted changes in the working tree, the orchestrator logs which reviewer caused it (to `execution-issues.md` under `Warnings` in `/implement` runs, or to the transcript in standalone `/review` runs) and immediately discards the changes via scoped `git restore` / `git clean` — no stash is created and `git stash list` remains clean. This replaces the three-option recovery prompt introduced by #1437. Updated: `skills/implement/SKILL.md` (Step 5.3.b quick mode, Step 5 normal mode, `--auto` flag description), `skills/review/SKILL.md` (Step 3a, line 22), `skills/review/references/heavy-worker.md`, `docs/external-reviewers.md`, `SECURITY.md`
 
-## [20.0.7] - 2026-05-09
+## [20.0.8] - 2026-05-09
 
 ### Changed
 

--- a/scripts/session-setup.md
+++ b/scripts/session-setup.md
@@ -21,7 +21,7 @@ advisory; write failures warn on stderr and do not abort setup.
 
 - `--check-reviewers` probes the legacy Codex+Cursor set.
 - `--check-gemini-reviewer` is opt-in and only meaningful with `--check-reviewers` for the probe workflow; it passes `--include-gemini` to `check-reviewers.sh`. The flag also gates `GEMINI_HEALTHY` emission in the `--write-health` sidecar on the passthrough path: when set with empty `FINAL_GEMINI_HEALTHY`, the sidecar emits `GEMINI_HEALTHY=false` (fail-closed) rather than omitting the key. See `scripts/test-session-setup-health-defaults.sh` scenario 2 for the regression fixture.
-- Caller-env `CODEX_HEALTHY=false`, `CURSOR_HEALTHY=false`, or `GEMINI_HEALTHY=false` auto-skips the corresponding probe.
+- A non-empty caller-env `CODEX_HEALTHY`, `CURSOR_HEALTHY`, or `GEMINI_HEALTHY` (either `true` or `false`) auto-skips the corresponding probe; an empty or absent value runs the probe.
 - Gemini health failures use skip-style wording: Gemini is omitted for the session rather than replaced by Claude.
 - When Gemini probing is enabled, `session-setup.sh` passes `--artifact-dir "$SESSION_TMPDIR"` to `check-reviewers.sh` so `gemini-tool-drift.txt` persists for the session lifetime instead of disappearing with the probe tmpdir.
 - `GEMINI_TOOL_DRIFT_WARNING=` keys are re-emitted on stdout and summarized as a stderr banner. `GEMINI_TOOL_DRIFT_ARTIFACT=` is passed through when present.

--- a/scripts/session-setup.sh
+++ b/scripts/session-setup.sh
@@ -326,14 +326,15 @@ fi
 
 # --- 4. Reviewer health: either probe (--check-reviewers) or passthrough from caller-env ---
 if [[ "$CHECK_REVIEWERS" == "true" ]]; then
-    # Auto-set skip-probe flags from caller-env health values
-    if [[ "$CALLER_CODEX_HEALTHY" == "false" ]]; then
+    # Auto-set skip-probe flags from caller-env health values.
+    # Skip whenever caller already provided a value (true or false); probe only when empty.
+    if [[ -n "$CALLER_CODEX_HEALTHY" ]]; then
         SKIP_CODEX_PROBE=true
     fi
-    if [[ "$CALLER_CURSOR_HEALTHY" == "false" ]]; then
+    if [[ -n "$CALLER_CURSOR_HEALTHY" ]]; then
         SKIP_CURSOR_PROBE=true
     fi
-    if [[ "$CALLER_GEMINI_HEALTHY" == "false" ]]; then
+    if [[ -n "$CALLER_GEMINI_HEALTHY" ]]; then
         SKIP_GEMINI_PROBE=true
     fi
 

--- a/scripts/session-setup.sh
+++ b/scripts/session-setup.sh
@@ -396,6 +396,19 @@ if [[ "$CHECK_REVIEWERS" == "true" ]]; then
         esac
     done <<< "$REVIEWER_OUTPUT"
 
+    # When a probe was skipped because the caller provided a known health value,
+    # override check-reviewers.sh's initial 'false' with the caller's value so
+    # the skip is transparent to downstream consumers.
+    if [[ "$SKIP_CODEX_PROBE" == "true" && -n "$CALLER_CODEX_HEALTHY" ]]; then
+        PROBED_CODEX_HEALTHY="$CALLER_CODEX_HEALTHY"
+    fi
+    if [[ "$SKIP_CURSOR_PROBE" == "true" && -n "$CALLER_CURSOR_HEALTHY" ]]; then
+        PROBED_CURSOR_HEALTHY="$CALLER_CURSOR_HEALTHY"
+    fi
+    if [[ "$SKIP_GEMINI_PROBE" == "true" && -n "$CALLER_GEMINI_HEALTHY" ]]; then
+        PROBED_GEMINI_HEALTHY="$CALLER_GEMINI_HEALTHY"
+    fi
+
     [[ -n "$PROBED_CODEX_AVAILABLE" ]] && echo "CODEX_AVAILABLE=$PROBED_CODEX_AVAILABLE"
     [[ -n "$PROBED_CURSOR_AVAILABLE" ]] && echo "CURSOR_AVAILABLE=$PROBED_CURSOR_AVAILABLE"
     [[ -n "$PROBED_GEMINI_AVAILABLE" ]] && echo "GEMINI_AVAILABLE=$PROBED_GEMINI_AVAILABLE"

--- a/scripts/test-session-setup-health-defaults.sh
+++ b/scripts/test-session-setup-health-defaults.sh
@@ -140,6 +140,25 @@ if run_session_setup "explicit-false" "$ENV4" "$HEALTH4"; then
         "explicit caller-env false: GEMINI passes through"
 fi
 
+# ---------------------------------------------------------------------------
+# Test 5 — --check-reviewers with caller-env true: health sidecar must echo
+# caller value, not check-reviewers.sh's initial 'false'. Regression for the
+# inverted skip-probe fix (== "false" → -n check).
+# ---------------------------------------------------------------------------
+ENV5="$SANDBOX/env5.txt"
+HEALTH5="$SANDBOX/health5.txt"
+cat > "$ENV5" <<'EOF'
+CODEX_HEALTHY=true
+CURSOR_HEALTHY=true
+EOF
+if run_session_setup "check-reviewers-caller-true" "$ENV5" "$HEALTH5" \
+    --check-reviewers; then
+    assert_health_value "$HEALTH5" "CODEX_HEALTHY" "true" \
+        "--check-reviewers + caller true: CODEX passes through"
+    assert_health_value "$HEALTH5" "CURSOR_HEALTHY" "true" \
+        "--check-reviewers + caller true: CURSOR passes through"
+fi
+
 echo
 echo "Results: $PASS passed, $FAIL failed"
 [[ $FAIL -eq 0 ]] || exit 1

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -89,7 +89,7 @@ Run the shared session setup script. This handles temp directory creation, revie
 ${CLAUDE_PLUGIN_ROOT}/scripts/session-setup.sh --prefix claude-review --skip-preflight --skip-branch-check --skip-repo-check --check-reviewers --check-gemini-reviewer [--caller-env "$SESSION_ENV_PATH"] [--skip-codex-probe] [--skip-cursor-probe] [--skip-gemini-probe] [--write-health "${SESSION_ENV_PATH}.health"]
 ```
 
-Only include `--caller-env "$SESSION_ENV_PATH"` and `--write-health "${SESSION_ENV_PATH}.health"` if `SESSION_ENV_PATH` is non-empty. If `SESSION_ENV_PATH` provides `CODEX_HEALTHY=false`, `CURSOR_HEALTHY=false`, or `GEMINI_HEALTHY=false`, the script auto-sets the corresponding `--skip-codex-probe` / `--skip-cursor-probe` / `--skip-gemini-probe` flag.
+Only include `--caller-env "$SESSION_ENV_PATH"` and `--write-health "${SESSION_ENV_PATH}.health"` if `SESSION_ENV_PATH` is non-empty. If `SESSION_ENV_PATH` provides a non-empty `CODEX_HEALTHY`, `CURSOR_HEALTHY`, or `GEMINI_HEALTHY` value (either `true` or `false`), the script auto-sets the corresponding `--skip-codex-probe` / `--skip-cursor-probe` / `--skip-gemini-probe` flag and propagates the caller value.
 
 If the script exits non-zero, print the error and abort.
 

--- a/skills/shared/external-reviewers.md
+++ b/skills/shared/external-reviewers.md
@@ -13,7 +13,7 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/session-setup.sh --prefix <name> [--skip-preflight
 
 The `--check-reviewers` flag runs `check-reviewers.sh --probe` internally and emits `CODEX_AVAILABLE`, `CURSOR_AVAILABLE`, `CODEX_HEALTHY`, `CURSOR_HEALTHY` on stdout. `--check-gemini-reviewer` opts into Gemini probing and adds `GEMINI_AVAILABLE` / `GEMINI_HEALTHY`; `/implement` and `/review` continue to pass it because those keys are consumed by `/implement --coder=gemini` dispatch gating and by cross-skill health propagation, even though the Gemini reviewer launcher is not currently invoked. Skills that need neither Gemini implementer dispatch nor cross-skill `GEMINI_HEALTHY` propagation may omit the flag.
 
-**Session-env override**: If `--caller-env` provides `CODEX_HEALTHY=false`, `CURSOR_HEALTHY=false`, or `GEMINI_HEALTHY=false`, the script auto-sets the corresponding `--skip-codex-probe` / `--skip-cursor-probe` / `--skip-gemini-probe` flag internally — you do not need to pass these explicitly when using `--caller-env`.
+**Session-env override**: If `--caller-env` provides a non-empty `CODEX_HEALTHY`, `CURSOR_HEALTHY`, or `GEMINI_HEALTHY` value (either `true` or `false`), the script auto-sets the corresponding `--skip-codex-probe` / `--skip-cursor-probe` / `--skip-gemini-probe` flag internally and propagates the caller value — you do not need to pass these explicitly when using `--caller-env`.
 
 Set mental flags `codex_available` and `cursor_available` based on the output:
 - If `CODEX_AVAILABLE=false`: `codex_available=false`. Print: `**⚠ Codex not available (binary not found). Proceeding without Codex reviewer.**`


### PR DESCRIPTION
## Summary

- Fix inverted condition in `session-setup.sh` skip-probe block: `== "false"` → `-n` so probes skip when the caller provides *any* health value (not just unhealthy).
- Add caller-value override after parsing `check-reviewers.sh` output to propagate the caller's health value through the `--check-reviewers` probe path.
- Add regression test (Test 5) to `test-session-setup-health-defaults.sh` covering `--check-reviewers` + caller-env `CODEX_HEALTHY=true`.
- Fix doc drift in `skills/shared/external-reviewers.md` and `skills/review/SKILL.md`.

## Architecture Diagram

Architecture diagram not available.

## Code Flow Diagram

(Code Flow Diagram skipped — quick mode)

## Test plan

- [ ] `/relevant-checks` passes (pre-commit + agent-lint)
- [ ] `make test-session-setup-health-defaults` passes (Test 5 covers the regression)
- [ ] CI green

Closes #1719

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)
