### PR TITLE
Add severity-gated prose cap to reviewer prompts (v20.0.8)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "20.0.8",
+  "version": "20.0.9",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 3-reviewer specialist panel (2 Cursor specialists + 1 Codex generic) with 3-voter adjudication; plan review runs a 4-reviewer diagonal panel (2 Cursor: Arch, Edge + 2 Codex: Innovation, Pragmatic); design sketches run a 4-agent diverge-then-converge phase in regular mode (2 Cursor + 2 Codex) or 2 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",
@@ -31,7 +31,7 @@
     "codex_model": {
       "title": "Codex Model",
       "type": "string",
-      "description": "Model for Codex launches — review, implementation, sketches, voting (e.g., o3). Also accepted via LARCH_CODEX_MODEL env var. When unset, defaults to gpt-5.5.",
+      "description": "Model for Codex launches \u2014 review, implementation, sketches, voting (e.g., o3). Also accepted via LARCH_CODEX_MODEL env var. When unset, defaults to gpt-5.5.",
       "sensitive": false
     },
     "gemini_model": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Reviewer dirty-tree changes are now automatically logged and discarded instead of prompting the operator with a restore/stash/bail `AskUserQuestion`. When a Cursor, Codex, or Claude reviewer leaves uncommitted changes in the working tree, the orchestrator logs which reviewer caused it (to `execution-issues.md` under `Warnings` in `/implement` runs, or to the transcript in standalone `/review` runs) and immediately discards the changes via scoped `git restore` / `git clean` — no stash is created and `git stash list` remains clean. This replaces the three-option recovery prompt introduced by #1437. Updated: `skills/implement/SKILL.md` (Step 5.3.b quick mode, Step 5 normal mode, `--auto` flag description), `skills/review/SKILL.md` (Step 3a, line 22), `skills/review/references/heavy-worker.md`, `docs/external-reviewers.md`, `SECURITY.md`
 
-## [20.0.8] - 2026-05-09
+## [20.0.9] - 2026-05-09
+
+### Changed
+
+- Add severity-gated prose length cap to all reviewer prompts: **Important** and **Latent** findings up to 4–5 sentences; **Nit** findings 1–2 sentences; no cap on finding count.
+
+## [20.0.7] - 2026-05-09
 
 ### Changed
 

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -148,10 +148,10 @@ Report at most 5 Nits. If more exist, summarize as a count plus categories (e.g.
 ### Prose length cap
 
 Keep each finding concise — verbosity dilutes signal.
-- **Important** findings: up to 4 sentences (problem, location, impact, suggested fix).
-- **Nit** and **Latent** findings: 1–2 sentences maximum.
+- **Important** and **Latent** findings: up to 4 sentences — one each for problem, location, concrete impact/scenario, and suggested fix. Never trim the mandatory concrete failing scenario to meet the cap; allow up to 5 sentences when the scenario cannot be compressed further.
+- **Nit** findings: 1–2 sentences maximum.
 
-No cap on the number of findings — report every issue you identify.
+No cap on finding count; the 5-Nit cap in § Severity still applies to **Nit** findings.
 
 ### In-Scope Findings
 A numbered list of issues that should be fixed in this PR. For each finding:

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -145,6 +145,14 @@ If no such scenario or path exists, demote to `**Nit**` or omit.
 
 Report at most 5 Nits. If more exist, summarize as a count plus categories (e.g., "Additional: 3 naming, 2 formatting").
 
+### Prose length cap
+
+Keep each finding concise — verbosity dilutes signal.
+- **Important** findings: up to 4 sentences (problem, location, impact, suggested fix).
+- **Nit** and **Latent** findings: 1–2 sentences maximum.
+
+No cap on the number of findings — report every issue you identify.
+
 ### In-Scope Findings
 A numbered list of issues that should be fixed in this PR. For each finding:
 - **Severity**: one of `**Important**` / `**Nit**` / `**Latent**` (required prefix)

--- a/agents/reviewer-correctness-edges.md
+++ b/agents/reviewer-correctness-edges.md
@@ -55,8 +55,8 @@ Tag each finding with its focus area (one of `code-quality` / `risk-integration`
 ### Prose length cap
 
 Keep each finding concise — verbosity dilutes signal.
-- **Important** findings: up to 4 sentences (problem, location, impact, suggested fix).
-- **Nit** and **Latent** findings: 1–2 sentences maximum.
+- **Important** and **Latent** findings: up to 4 sentences — one each for problem, location, concrete impact/scenario, and suggested fix. Never trim the mandatory concrete failing scenario to meet the cap; allow up to 5 sentences when the scenario cannot be compressed further.
+- **Nit** findings: 1–2 sentences maximum.
 
 No cap on the number of findings — report every issue you identify.
 

--- a/agents/reviewer-correctness-edges.md
+++ b/agents/reviewer-correctness-edges.md
@@ -52,6 +52,14 @@ Briefly scan for security vulnerabilities (injection, secret leakage), code-reus
 
 Tag each finding with its focus area (one of `code-quality` / `risk-integration` / `correctness` / `architecture` / `security`). Return findings in two sections:
 
+### Prose length cap
+
+Keep each finding concise — verbosity dilutes signal.
+- **Important** findings: up to 4 sentences (problem, location, impact, suggested fix).
+- **Nit** and **Latent** findings: 1–2 sentences maximum.
+
+No cap on the number of findings — report every issue you identify.
+
 ### In-Scope Findings
 Numbered list. Each finding: severity (`**Important**` / `**Nit**` / `**Latent**`), focus-area tag, file:line, what the issue is, suggested fix.
 

--- a/agents/reviewer-correctness.md
+++ b/agents/reviewer-correctness.md
@@ -42,8 +42,8 @@ Tag each finding with its focus area (one of `code-quality` / `risk-integration`
 ### Prose length cap
 
 Keep each finding concise — verbosity dilutes signal.
-- **Important** findings: up to 4 sentences (problem, location, impact, suggested fix).
-- **Nit** and **Latent** findings: 1–2 sentences maximum.
+- **Important** and **Latent** findings: up to 4 sentences — one each for problem, location, concrete impact/scenario, and suggested fix. Never trim the mandatory concrete failing scenario to meet the cap; allow up to 5 sentences when the scenario cannot be compressed further.
+- **Nit** findings: 1–2 sentences maximum.
 
 No cap on the number of findings — report every issue you identify.
 

--- a/agents/reviewer-correctness.md
+++ b/agents/reviewer-correctness.md
@@ -39,6 +39,14 @@ Briefly scan for security vulnerabilities (injection, secret leakage) and breaki
 
 Tag each finding with its focus area (one of `code-quality` / `risk-integration` / `correctness` / `architecture` / `security`). Return findings in two sections:
 
+### Prose length cap
+
+Keep each finding concise — verbosity dilutes signal.
+- **Important** findings: up to 4 sentences (problem, location, impact, suggested fix).
+- **Nit** and **Latent** findings: 1–2 sentences maximum.
+
+No cap on the number of findings — report every issue you identify.
+
 ### In-Scope Findings
 Numbered list. Each finding: severity (`**Important**` / `**Nit**` / `**Latent**`), focus-area tag, file:line, what the issue is, suggested fix.
 

--- a/agents/reviewer-edge-cases.md
+++ b/agents/reviewer-edge-cases.md
@@ -40,8 +40,8 @@ Tag each finding with its focus area (one of `code-quality` / `risk-integration`
 ### Prose length cap
 
 Keep each finding concise — verbosity dilutes signal.
-- **Important** findings: up to 4 sentences (problem, location, impact, suggested fix).
-- **Nit** and **Latent** findings: 1–2 sentences maximum.
+- **Important** and **Latent** findings: up to 4 sentences — one each for problem, location, concrete impact/scenario, and suggested fix. Never trim the mandatory concrete failing scenario to meet the cap; allow up to 5 sentences when the scenario cannot be compressed further.
+- **Nit** findings: 1–2 sentences maximum.
 
 No cap on the number of findings — report every issue you identify.
 

--- a/agents/reviewer-edge-cases.md
+++ b/agents/reviewer-edge-cases.md
@@ -37,6 +37,14 @@ Briefly scan for security vulnerabilities (injection, secret leakage) and obviou
 
 Tag each finding with its focus area (one of `code-quality` / `risk-integration` / `correctness` / `architecture` / `security`). Return findings in two sections:
 
+### Prose length cap
+
+Keep each finding concise — verbosity dilutes signal.
+- **Important** findings: up to 4 sentences (problem, location, impact, suggested fix).
+- **Nit** and **Latent** findings: 1–2 sentences maximum.
+
+No cap on the number of findings — report every issue you identify.
+
 ### In-Scope Findings
 Numbered list. Each finding: severity (`**Important**` / `**Nit**` / `**Latent**`), focus-area tag, file:line, what the issue is, suggested fix.
 

--- a/agents/reviewer-security-structure-tests.md
+++ b/agents/reviewer-security-structure-tests.md
@@ -60,8 +60,8 @@ Tag each finding with its focus area (one of `code-quality` / `risk-integration`
 ### Prose length cap
 
 Keep each finding concise — verbosity dilutes signal.
-- **Important** findings: up to 4 sentences (problem, location, impact, suggested fix).
-- **Nit** and **Latent** findings: 1–2 sentences maximum.
+- **Important** and **Latent** findings: up to 4 sentences — one each for problem, location, concrete impact/scenario, and suggested fix. Never trim the mandatory concrete failing scenario to meet the cap; allow up to 5 sentences when the scenario cannot be compressed further.
+- **Nit** findings: 1–2 sentences maximum.
 
 No cap on the number of findings — report every issue you identify.
 

--- a/agents/reviewer-security-structure-tests.md
+++ b/agents/reviewer-security-structure-tests.md
@@ -57,6 +57,14 @@ Briefly scan for correctness bugs (nil dereference, off-by-one, race conditions)
 
 Tag each finding with its focus area (one of `code-quality` / `risk-integration` / `correctness` / `architecture` / `security`). Return findings in two sections:
 
+### Prose length cap
+
+Keep each finding concise — verbosity dilutes signal.
+- **Important** findings: up to 4 sentences (problem, location, impact, suggested fix).
+- **Nit** and **Latent** findings: 1–2 sentences maximum.
+
+No cap on the number of findings — report every issue you identify.
+
 ### In-Scope Findings
 Numbered list. Each finding: severity (`**Important**` / `**Nit**` / `**Latent**`), focus-area tag, file:line, what the issue is, suggested fix.
 

--- a/agents/reviewer-security.md
+++ b/agents/reviewer-security.md
@@ -39,6 +39,14 @@ Briefly scan for correctness bugs (nil dereference, logic errors) and breaking c
 
 Tag each finding with its focus area (one of `code-quality` / `risk-integration` / `correctness` / `architecture` / `security`). Return findings in two sections:
 
+### Prose length cap
+
+Keep each finding concise — verbosity dilutes signal.
+- **Important** findings: up to 4 sentences (problem, location, impact, suggested fix).
+- **Nit** and **Latent** findings: 1–2 sentences maximum.
+
+No cap on the number of findings — report every issue you identify.
+
 ### In-Scope Findings
 Numbered list. Each finding: severity (`**Important**` / `**Nit**` / `**Latent**`), focus-area tag, file:line, what the issue is, suggested fix.
 

--- a/agents/reviewer-security.md
+++ b/agents/reviewer-security.md
@@ -42,8 +42,8 @@ Tag each finding with its focus area (one of `code-quality` / `risk-integration`
 ### Prose length cap
 
 Keep each finding concise — verbosity dilutes signal.
-- **Important** findings: up to 4 sentences (problem, location, impact, suggested fix).
-- **Nit** and **Latent** findings: 1–2 sentences maximum.
+- **Important** and **Latent** findings: up to 4 sentences — one each for problem, location, concrete impact/scenario, and suggested fix. Never trim the mandatory concrete failing scenario to meet the cap; allow up to 5 sentences when the scenario cannot be compressed further.
+- **Nit** findings: 1–2 sentences maximum.
 
 No cap on the number of findings — report every issue you identify.
 

--- a/agents/reviewer-structure.md
+++ b/agents/reviewer-structure.md
@@ -37,8 +37,8 @@ Tag each finding with its focus area (one of `code-quality` / `risk-integration`
 ### Prose length cap
 
 Keep each finding concise — verbosity dilutes signal.
-- **Important** findings: up to 4 sentences (problem, location, impact, suggested fix).
-- **Nit** and **Latent** findings: 1–2 sentences maximum.
+- **Important** and **Latent** findings: up to 4 sentences — one each for problem, location, concrete impact/scenario, and suggested fix. Never trim the mandatory concrete failing scenario to meet the cap; allow up to 5 sentences when the scenario cannot be compressed further.
+- **Nit** findings: 1–2 sentences maximum.
 
 No cap on the number of findings — report every issue you identify.
 

--- a/agents/reviewer-structure.md
+++ b/agents/reviewer-structure.md
@@ -34,6 +34,14 @@ Briefly scan for critical correctness bugs (nil dereference, off-by-one, race co
 
 Tag each finding with its focus area (one of `code-quality` / `risk-integration` / `correctness` / `architecture` / `security`). Return findings in two sections:
 
+### Prose length cap
+
+Keep each finding concise — verbosity dilutes signal.
+- **Important** findings: up to 4 sentences (problem, location, impact, suggested fix).
+- **Nit** and **Latent** findings: 1–2 sentences maximum.
+
+No cap on the number of findings — report every issue you identify.
+
 ### In-Scope Findings
 Numbered list. Each finding: severity (`**Important**` / `**Nit**` / `**Latent**`), focus-area tag, file:line, what the issue is, suggested fix.
 

--- a/agents/reviewer-testing.md
+++ b/agents/reviewer-testing.md
@@ -38,8 +38,8 @@ Tag each finding with its focus area (one of `code-quality` / `risk-integration`
 ### Prose length cap
 
 Keep each finding concise — verbosity dilutes signal.
-- **Important** findings: up to 4 sentences (problem, location, impact, suggested fix).
-- **Nit** and **Latent** findings: 1–2 sentences maximum.
+- **Important** and **Latent** findings: up to 4 sentences — one each for problem, location, concrete impact/scenario, and suggested fix. Never trim the mandatory concrete failing scenario to meet the cap; allow up to 5 sentences when the scenario cannot be compressed further.
+- **Nit** findings: 1–2 sentences maximum.
 
 No cap on the number of findings — report every issue you identify.
 

--- a/agents/reviewer-testing.md
+++ b/agents/reviewer-testing.md
@@ -35,6 +35,14 @@ Briefly scan for correctness bugs (nil dereference, logic errors) and security v
 
 Tag each finding with its focus area (one of `code-quality` / `risk-integration` / `correctness` / `architecture` / `security`). Return findings in two sections:
 
+### Prose length cap
+
+Keep each finding concise — verbosity dilutes signal.
+- **Important** findings: up to 4 sentences (problem, location, impact, suggested fix).
+- **Nit** and **Latent** findings: 1–2 sentences maximum.
+
+No cap on the number of findings — report every issue you identify.
+
 ### In-Scope Findings
 Numbered list. Each finding: severity (`**Important**` / `**Nit**` / `**Latent**`), focus-area tag, file:line, what the issue is, suggested fix.
 

--- a/skills/shared/reviewer-templates.md
+++ b/skills/shared/reviewer-templates.md
@@ -188,6 +188,14 @@ If no such scenario or path exists, demote to `**Nit**` or omit.
 
 Report at most 5 Nits. If more exist, summarize as a count plus categories (e.g., "Additional: 3 naming, 2 formatting").
 
+### Prose length cap
+
+Keep each finding concise — verbosity dilutes signal.
+- **Important** findings: up to 4 sentences (problem, location, impact, suggested fix).
+- **Nit** and **Latent** findings: 1–2 sentences maximum.
+
+No cap on the number of findings — report every issue you identify.
+
 ### In-Scope Findings
 A numbered list of issues that should be fixed in this PR. For each finding:
 - **Severity**: one of `**Important**` / `**Nit**` / `**Latent**` (required prefix)

--- a/skills/shared/reviewer-templates.md
+++ b/skills/shared/reviewer-templates.md
@@ -191,10 +191,10 @@ Report at most 5 Nits. If more exist, summarize as a count plus categories (e.g.
 ### Prose length cap
 
 Keep each finding concise — verbosity dilutes signal.
-- **Important** findings: up to 4 sentences (problem, location, impact, suggested fix).
-- **Nit** and **Latent** findings: 1–2 sentences maximum.
+- **Important** and **Latent** findings: up to 4 sentences — one each for problem, location, concrete impact/scenario, and suggested fix. Never trim the mandatory concrete failing scenario to meet the cap; allow up to 5 sentences when the scenario cannot be compressed further.
+- **Nit** findings: 1–2 sentences maximum.
 
-No cap on the number of findings — report every issue you identify.
+No cap on finding count; the 5-Nit cap in § Severity still applies to **Nit** findings.
 
 ### In-Scope Findings
 A numbered list of issues that should be fixed in this PR. For each finding:


### PR DESCRIPTION
## Summary

Add a severity-gated prose length cap to all reviewer prompts — keeps findings concise without losing required proof.

- **Important** / **Latent** findings: up to 4 sentences (problem, location, impact/scenario, fix); 5 sentences allowed when the mandatory concrete failing scenario cannot be compressed further
- **Nit** findings: 1–2 sentences maximum
- No cap on the number of findings — report every issue you identify
- The existing 5-Nit-cap-with-summary rule in the canonical archetype is preserved and cross-referenced

Applied to: `skills/shared/reviewer-templates.md` (canonical source), regenerated `agents/code-reviewer.md`, and all 7 hand-maintained specialist reviewer agents.

## Architecture Diagram

Architecture diagram not available.

## Code Flow Diagram

(Code Flow Diagram skipped — quick mode)

## Test plan

- `bash scripts/generate-code-reviewer-agent.sh --check` verifies template↔agent sync
- `make relevant-checks` (pre-commit + agent-lint) passes
- Visual inspection of `### Prose length cap` block in each reviewer agent file

Closes #1699

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)
