### PR TITLE
Emit reviewer status table at round launch and round-complete only (v20.0.13)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "20.0.13",
+  "version": "20.0.14",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 7-reviewer specialist panel (5 Cursor specialists + 1 Codex generic + 1 Claude generic) with 2-voter adjudication (Cursor + Codex primary; Claude conditional tie-breaker on 1Y/1N); plan review runs a 4-reviewer diagonal panel (2 Cursor: Arch, Edge + 2 Codex: Innovation, Pragmatic); design sketches run a 4-agent diverge-then-converge phase in regular mode (2 Cursor + 2 Codex) or 2 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Reviewer dirty-tree changes are now automatically logged and discarded instead of prompting the operator with a restore/stash/bail `AskUserQuestion`. When a Cursor, Codex, or Claude reviewer leaves uncommitted changes in the working tree, the orchestrator logs which reviewer caused it (to `execution-issues.md` under `Warnings` in `/implement` runs, or to the transcript in standalone `/review` runs) and immediately discards the changes via scoped `git restore` / `git clean` — no stash is created and `git stash list` remains clean. This replaces the three-option recovery prompt introduced by #1437. Updated: `skills/implement/SKILL.md` (Step 5.3.b quick mode, Step 5 normal mode, `--auto` flag description), `skills/review/SKILL.md` (Step 3a, line 22), `skills/review/references/heavy-worker.md`, `docs/external-reviewers.md`, `SECURITY.md`
 
+## [20.0.14] - 2026-05-09
+
+### Fixed
+
+- Emit reviewer status table only at round launch (all pending) and at round-complete (after `collect-agent-results.sh` returns), not on every individual status change (#1703)
+
 ## [20.0.13] - 2026-05-09
 
 ### Fixed

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -55,15 +55,13 @@ Step Name Registry:
 
 ### Reviewer status table
 
-After launching all reviewers (Step 2), maintain a mental tracker of each reviewer's status. Print a compact table after EACH status change:
+After launching all reviewers (Step 2), maintain a mental tracker of each reviewer's status. Print a compact table at two points per round only: (1) after launching all reviewers (all ⏳ or ⊘), and (2) after `collect-agent-results.sh` returns (all external reviewers resolved):
 
 ```
 📊 Reviewers: | Structure: ✅ 3m12s | Correctness: ⏳ | Testing: ⏳ | Security: ⏳ | Edge-cases: ⏳ | Codex: ⏳ | Claude-Generic: ✅ 2m30s |
 ```
 
 Icons: ✅ done (with elapsed time since launch), ⏳ pending/in-progress, ❌ failed/timeout (with elapsed time since launch), ⊘ skipped (unavailable for replacement-style reviewers only). See `${CLAUDE_PLUGIN_ROOT}/skills/shared/progress-reporting.md` for elapsed time and step start formatting rules.
-
-**Status table updates**: (1) Print initial table after launching all reviewers (all ⏳ or ⊘). (2) Update after `collect-agent-results.sh` returns (all external reviewers resolved).
 
 Use empty `description` parameter on Bash tool calls and terse 3-5 word descriptions on Agent tool calls. Do not produce explanatory prose between tool call outputs — only print: step breadcrumb lines (start `🔶`, completion `✅`, skip `⏩`), all warning/error lines (`**⚠ ...`), structured summaries (voting tallies, scoreboards, round summaries, findings lists, final summary), and the reviewer status table.
 


### PR DESCRIPTION
## Summary

- Replace contradictory "after EACH status change" instruction in `skills/review/SKILL.md` with the correct two-point rule: print at round launch (all ⏳/⊘) and at round-complete (after `collect-agent-results.sh` returns)
- Remove the now-redundant `**Status table updates**` sentence that restated the same rule

## Architecture Diagram

Architecture diagram not available.

## Code Flow Diagram

(Code Flow Diagram skipped — quick mode)

## Test plan

- `pre-commit` on modified file passes
- `agent-lint` on full repo passes
- Reviewers in `/review` now emit the status table exactly twice per round instead of on every individual status change

Closes #1703

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)
