### PR TITLE
Extract shared ScheduleWakeup NEVER rule to orchestrator-never.md (v20.2.2)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "20.2.2",
+  "version": "20.2.3",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 7-reviewer specialist panel (5 Cursor specialists + 1 Codex generic + 1 Claude generic) with 2-voter adjudication (Cursor + Codex primary; Claude conditional tie-breaker on 1Y/1N); plan review runs a 4-reviewer diagonal panel (2 Cursor: Arch, Edge + 2 Codex: Innovation, Pragmatic); design sketches run a 4-agent diverge-then-converge phase in regular mode (2 Cursor + 2 Codex) or 2 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Reviewer dirty-tree changes are now automatically logged and discarded instead of prompting the operator with a restore/stash/bail `AskUserQuestion`. When a Cursor, Codex, or Claude reviewer leaves uncommitted changes in the working tree, the orchestrator logs which reviewer caused it (to `execution-issues.md` under `Warnings` in `/implement` runs, or to the transcript in standalone `/review` runs) and immediately discards the changes via scoped `git restore` / `git clean` — no stash is created and `git stash list` remains clean. This replaces the three-option recovery prompt introduced by #1437. Updated: `skills/implement/SKILL.md` (Step 5.3.b quick mode, Step 5 normal mode, `--auto` flag description), `skills/review/SKILL.md` (Step 3a, line 22), `skills/review/references/heavy-worker.md`, `docs/external-reviewers.md`, `SECURITY.md`
 
+## [20.2.3] - 2026-05-09
+
+### Changed
+
+- Extract shared "NEVER improvise ScheduleWakeup" anti-pattern rule to `skills/shared/orchestrator-never.md`; load it via a `MANDATORY at session start` directive in `fix-issue/SKILL.md` and `research/SKILL.md`, replacing verbose per-skill inline paragraphs with short pointers. Update `scripts/test-anti-improvised-wakeup.sh` to check the shared file and per-skill MANDATORY wiring instead of individual SKILL.md tokens (tighter token: `'MANDATORY at session start'`).
+
 ## [20.2.2] - 2026-05-09
 
 ### Fixed

--- a/scripts/test-anti-improvised-wakeup.md
+++ b/scripts/test-anti-improvised-wakeup.md
@@ -1,6 +1,6 @@
 # scripts/test-anti-improvised-wakeup.sh — contract
 
-`scripts/test-anti-improvised-wakeup.sh` is a freestanding regression harness that pins the project-wide guard against improvised `ScheduleWakeup` calls outside skill-script direction. It asserts the shared project token in `AGENTS.md`, `skills/fix-issue/SKILL.md`, and `skills/research/SKILL.md`, and also asserts the stricter legacy `/implement` NEVER #9 token in `skills/implement/SKILL.md`.
+`scripts/test-anti-improvised-wakeup.sh` is a freestanding regression harness that pins the project-wide guard against improvised `ScheduleWakeup` calls outside skill-script direction. It asserts three contracts: (A) the shared project token in `AGENTS.md` and `skills/shared/orchestrator-never.md`; (B) the MANDATORY directive wiring token in each per-skill SKILL.md that delegates to the shared file (`skills/fix-issue/SKILL.md` and `skills/research/SKILL.md`); (C) the stricter legacy `/implement` NEVER #9 token in `skills/implement/SKILL.md`.
 
 Primary callers are the `test-anti-improvised-wakeup` Makefile target and `make lint` via `test-harnesses-1`. The harness is intentionally literal-only: it uses `grep -Fq` against repository files and does not execute or parse skill content.
 

--- a/scripts/test-anti-improvised-wakeup.sh
+++ b/scripts/test-anti-improvised-wakeup.sh
@@ -26,7 +26,7 @@ REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
 
 PROJECT_TOKEN='NEVER improvise ScheduleWakeup outside skill-script direction'
 IMPLEMENT_LEGACY_TOKEN="NEVER call \`ScheduleWakeup\` anywhere in the \`/implement\` orchestrator"
-MANDATORY_TOKEN='orchestrator-never.md'
+MANDATORY_TOKEN='MANDATORY at session start'
 
 PROJECT_ANCHORS=(
   "AGENTS.md"

--- a/scripts/test-anti-improvised-wakeup.sh
+++ b/scripts/test-anti-improvised-wakeup.sh
@@ -2,11 +2,13 @@
 # test-anti-improvised-wakeup.sh — Regression harness for the project-wide
 # guard against improvised ScheduleWakeup calls outside skill-script direction.
 #
-# Asserts two contracts:
+# Asserts three contracts:
 #
-#   (A) The project token appears in each project-wide / per-skill anchor that
-#       must forbid improvised ScheduleWakeup continuation.
-#   (B) The legacy /implement-specific token remains present in
+#   (A) The project token appears in the project-wide anchors:
+#       AGENTS.md and skills/shared/orchestrator-never.md.
+#   (B) The per-skill MANDATORY directive wiring is present in each skill
+#       that delegates to the shared file.
+#   (C) The legacy /implement-specific token remains present in
 #       skills/implement/SKILL.md, preserving its stricter NEVER #9 ratchet.
 #
 # Invoked via:  bash scripts/test-anti-improvised-wakeup.sh
@@ -24,13 +26,18 @@ REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
 
 PROJECT_TOKEN='NEVER improvise ScheduleWakeup outside skill-script direction'
 IMPLEMENT_LEGACY_TOKEN="NEVER call \`ScheduleWakeup\` anywhere in the \`/implement\` orchestrator"
+MANDATORY_TOKEN='orchestrator-never.md'
 
 PROJECT_ANCHORS=(
   "AGENTS.md"
+  "skills/shared/orchestrator-never.md"
+)
+IMPLEMENT_LEGACY_ANCHOR="skills/implement/SKILL.md"
+
+MANDATORY_ANCHORS=(
   "skills/fix-issue/SKILL.md"
   "skills/research/SKILL.md"
 )
-IMPLEMENT_LEGACY_ANCHOR="skills/implement/SKILL.md"
 
 FAIL_COUNT=0
 PASS_COUNT=0
@@ -59,6 +66,12 @@ check_token_present() {
 echo "--- Project-wide improvised ScheduleWakeup guard ---"
 for rel in "${PROJECT_ANCHORS[@]}"; do
   check_token_present "$rel" "$PROJECT_TOKEN" "project token"
+done
+
+echo ""
+echo "--- Per-skill MANDATORY directive wiring ---"
+for rel in "${MANDATORY_ANCHORS[@]}"; do
+  check_token_present "$rel" "$MANDATORY_TOKEN" "MANDATORY directive token"
 done
 
 echo ""

--- a/skills/fix-issue/SKILL.md
+++ b/skills/fix-issue/SKILL.md
@@ -52,6 +52,8 @@ Step Name Registry:
 | 6 | close issue |
 | 8 | cleanup |
 
+**MANDATORY at session start — READ ENTIRE FILE**: `${CLAUDE_PLUGIN_ROOT}/skills/shared/orchestrator-never.md`. Contains cross-skill NEVER rules that apply to this skill in addition to the skill-specific Anti-patterns below.
+
 ## Anti-patterns
 
 Each rule states **Why** (the specific consequence of breaking the rule) and **How to apply** (where the invariant is load-bearing). Rules marked **CI-backed: yes** are mechanically enforced by `skills/fix-issue/scripts/test-fix-issue-bail-detection.sh` via an `awk` extraction over the `### 5a` block (under Step 5 — Execute); the remaining rules are editorial invariants that depend on the SKILL.md text being unambiguous.
@@ -68,7 +70,7 @@ Each rule states **Why** (the specific consequence of breaking the rule) and **H
 
 7. **NEVER auto-pick umbrellas in the no-arg find-lock-issue scan.** **Why**: the umbrella-PR design dialectic (DECISION_1, voted 2-1 ANTI_THESIS) chose explicit-target-only umbrella handling. Folding umbrella handling into the bulk sweep multiplies decision-surface complexity (umbrella resolution is a distinct state machine with non-GO locking, child-pick semantics, and finalization paths) and increases operator surprise (umbrellas can be passive long-lived planning trackers). **How to apply**: `umbrella-handler.sh` is invoked ONLY in the explicit-issue path of `find-lock-issue.sh`. Operators who want umbrella-tracked work to drain must explicitly pass the umbrella number (e.g., `/fix-issue <umbrella#>` once per dispatch cycle). **CI-backed**: yes — `test-find-lock-issue.sh` carries an `auto-pick-skips-umbrella` regression fixture.
 
-8. **NEVER improvise ScheduleWakeup outside skill-script direction.** **Why**: `/fix-issue` is single-iteration by contract — its terminal `✅ 8: cleanup — fix-issue complete!` line ends its transcript. The orchestrator (Claude) was observed calling `ScheduleWakeup` on its own initiative after Step 8 to fire another `/fix-issue` iteration, outside any of `/fix-issue`'s own steps. Recurring behavior is owned by `/loop`'s `<<autonomous-loop-dynamic>>` sentinel mechanism, not by orchestrator improvisation in `/fix-issue`'s terminal turn. **How to apply**: this skill has no step that calls `ScheduleWakeup`; do not call it anywhere from Step 0 through Step 8 or after Step 8 completes. See AGENTS.md for the project-wide rule that this entry mirrors. **CI-backed**: yes — `scripts/test-anti-improvised-wakeup.sh` pins the literal at this site.
+8. **NEVER improvise ScheduleWakeup outside skill-script direction.** See `${CLAUDE_PLUGIN_ROOT}/skills/shared/orchestrator-never.md` (loaded via MANDATORY above). **CI-backed**: yes — `scripts/test-anti-improvised-wakeup.sh` pins the literal in the shared file.
 
 ## Step 0 — Find and Lock
 

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -120,9 +120,11 @@ Step Name Registry:
 | 3.5 | auto-issue |
 | 4 | cleanup |
 
+**MANDATORY at session start — READ ENTIRE FILE**: `${CLAUDE_PLUGIN_ROOT}/skills/shared/orchestrator-never.md`. Contains cross-skill NEVER rules that apply to this skill in addition to the skill-specific Anti-patterns below.
+
 ## Anti-patterns
 
-1. **NEVER improvise ScheduleWakeup outside skill-script direction.** **Why**: `/research` is single-iteration by contract — its terminal `## Step 4 — Cleanup and Final Warnings` block ends the run. Calling `ScheduleWakeup` after the cleanup, or narrating "next iteration" / "loop sleeping until ..." prose, is orchestrator improvisation outside any of `/research`'s steps. Recurring behavior is owned by `/loop`'s `<<autonomous-loop-dynamic>>` sentinel mechanism, not by improvised wakeup chains in this skill. **How to apply**: this skill has no step that calls `ScheduleWakeup`; do not call it from anywhere in the run. See AGENTS.md for the project-wide rule that this entry mirrors. **CI-backed**: yes — `scripts/test-anti-improvised-wakeup.sh` pins the literal at this site.
+1. **NEVER improvise ScheduleWakeup outside skill-script direction.** See `${CLAUDE_PLUGIN_ROOT}/skills/shared/orchestrator-never.md` (loaded via MANDATORY above). **CI-backed**: yes — `scripts/test-anti-improvised-wakeup.sh` pins the literal in the shared file.
 
 ## Step 0 — Session Setup
 

--- a/skills/shared/orchestrator-never.md
+++ b/skills/shared/orchestrator-never.md
@@ -1,0 +1,5 @@
+# Orchestrator NEVER List
+
+Cross-skill anti-pattern rules for all single-iteration larch orchestrators. Load once per session via the MANDATORY directive in each skill's SKILL.md.
+
+1. **NEVER improvise ScheduleWakeup outside skill-script direction.** **Why**: single-iteration skills end at their terminal `✅` line. The orchestrator calling `ScheduleWakeup` on its own initiative, or narrating "next iteration" / "loop sleeping until ..." prose, is improvisation outside the skill's steps. Recurring behavior is owned exclusively by `/loop`'s `<<autonomous-loop-dynamic>>` sentinel mechanism — never by orchestrator improvisation in a child skill's terminal turn. **How to apply**: do not call `ScheduleWakeup` from any skill that does not have a numbered step directing the call. See AGENTS.md for the project-wide rule. **CI-backed**: yes — `scripts/test-anti-improvised-wakeup.sh` pins the literal at this site.


### PR DESCRIPTION
## Summary

- Extract shared "NEVER improvise ScheduleWakeup" rule to `skills/shared/orchestrator-never.md`
- Add `MANDATORY at session start` directive in `fix-issue/SKILL.md` and `research/SKILL.md`; collapse verbose inline NEVER bullets to short pointers
- Update `scripts/test-anti-improvised-wakeup.sh` to check the shared file + per-skill MANDATORY wiring (tighter token: `'MANDATORY at session start'`)

## Architecture Diagram

Architecture diagram not available.

## Code Flow Diagram

Code flow diagram not available.

## Test plan

- `bash scripts/test-anti-improvised-wakeup.sh` — 5/5 pass (2 project anchors + 2 MANDATORY-wiring + 1 implement legacy ratchet)
- `make lint` / `/relevant-checks` — passes

Closes #1682

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
