### PR TITLE
Compress /design heavy-worker.md to 2 KB digest (v20.2.4)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "20.2.3",
+  "version": "20.2.4",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 7-reviewer specialist panel (5 Cursor specialists + 1 Codex generic + 1 Claude generic) with 2-voter adjudication (Cursor + Codex primary; Claude conditional tie-breaker on 1Y/1N); plan review runs a 4-reviewer diagonal panel (2 Cursor: Arch, Edge + 2 Codex: Innovation, Pragmatic); design sketches run a 4-agent diverge-then-converge phase in regular mode (2 Cursor + 2 Codex) or 2 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Reviewer dirty-tree changes are now automatically logged and discarded instead of prompting the operator with a restore/stash/bail `AskUserQuestion`. When a Cursor, Codex, or Claude reviewer leaves uncommitted changes in the working tree, the orchestrator logs which reviewer caused it (to `execution-issues.md` under `Warnings` in `/implement` runs, or to the transcript in standalone `/review` runs) and immediately discards the changes via scoped `git restore` / `git clean` — no stash is created and `git stash list` remains clean. This replaces the three-option recovery prompt introduced by #1437. Updated: `skills/implement/SKILL.md` (Step 5.3.b quick mode, Step 5 normal mode, `--auto` flag description), `skills/review/SKILL.md` (Step 3a, line 22), `skills/review/references/heavy-worker.md`, `docs/external-reviewers.md`, `SECURITY.md`
 
+## [20.2.4] - 2026-05-09
+
+### Changed
+
+- Compress `/design` `heavy-worker.md` (8 KB) to a 2 KB digest at `heavy-worker.digest.md`; full doc loads only on the subagent dispatch path, reducing parent orchestrator context by ~6 KB per `/design` invocation
+
 ## [20.2.3] - 2026-05-09
 
 ### Changed

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -400,7 +400,7 @@ Otherwise, read `$DESIGN_TMPDIR/approach-synthesis.txt` — this provides `{SYNT
 
 Execute steps 6 through the final `✅ 2a.5: dialectic — …` print directive as documented in `${CLAUDE_PLUGIN_ROOT}/skills/design/references/dialectic-execution.md` (loaded via the MANDATORY directive above). That file is the single normative source for dialectic-execution mechanics. The final `Write $DESIGN_TMPDIR/dialectic-resolutions.md` sub-step (including the per-disposition field rules) lives inside that reference; print the `## Dialectic Resolutions` header at the end and the `✅ 2a.5: dialectic — <V> voted, <F> fallback, <S> bucket-skipped, <O> over-cap (<elapsed>)` print directive (omit a count if zero).
 
-After each dialectic collection boundary (debate results and judge results), follow the dirty-tree probe contract in `references/heavy-worker.md`: consult launcher sidecars, run `check-mid-run-dirty-tree.sh --mode checkpoint`, and ask for recovery on dirty/unknown regardless of `auto_mode`, deduped by `$DESIGN_TMPDIR/.dirty-tree-prompted-<boundary>`.
+After each dialectic collection boundary (debate results and judge results), follow the dirty-tree probe contract in `references/heavy-worker.digest.md`: consult launcher sidecars, run `check-mid-run-dirty-tree.sh --mode checkpoint`, and ask for recovery on dirty/unknown regardless of `auto_mode`, deduped by `$DESIGN_TMPDIR/.dirty-tree-prompted-<boundary>`.
 
 ## Step 2b — Design the Implementation Plan
 

--- a/skills/design/references/heavy-worker.digest.md
+++ b/skills/design/references/heavy-worker.digest.md
@@ -6,6 +6,8 @@
 
 **Contract**: Runs token-heavy design machinery (sketches → dialectic → plan → plan review) in an isolated Agent-tool subagent context. Writes raw artifacts under `$DESIGN_TMPDIR/` only. Does NOT write `manifest.env` — parent `/design` Step 5 writes that after Steps 3.5/3b/4.
 
+**When to load**: by the parent `/design` orchestrator when consulting the dirty-tree probe contract (Step 2a.5 collection boundaries). Load the full `heavy-worker.md` when dispatching a subagent.
+
 ## Inputs
 
 Pass explicitly to the subagent: `DESIGN_TMPDIR`, `IMPLEMENT_TMPDIR`, `SESSION_ENV_PATH`, `FEATURE_DESCRIPTION`, `quick_mode`, `auto_mode`, current branch info, reviewer health flags (`codex_available`, `cursor_available`, `CODEX_HEALTHY`, `CURSOR_HEALTHY`).

--- a/skills/design/references/heavy-worker.digest.md
+++ b/skills/design/references/heavy-worker.digest.md
@@ -1,0 +1,30 @@
+# Design Heavy Worker Reference — Digest
+
+**Consumer**: `/design` heavy-phase Agent-tool subagent dispatched when `--subagent` AND `quick_mode=false`.
+
+> **If dispatching a subagent, read the full `heavy-worker.md` before proceeding.**
+
+**Contract**: Runs token-heavy design machinery (sketches → dialectic → plan → plan review) in an isolated Agent-tool subagent context. Writes raw artifacts under `$DESIGN_TMPDIR/` only. Does NOT write `manifest.env` — parent `/design` Step 5 writes that after Steps 3.5/3b/4.
+
+## Inputs
+
+Pass explicitly to the subagent: `DESIGN_TMPDIR`, `IMPLEMENT_TMPDIR`, `SESSION_ENV_PATH`, `FEATURE_DESCRIPTION`, `quick_mode`, `auto_mode`, current branch info, reviewer health flags (`codex_available`, `cursor_available`, `CODEX_HEALTHY`, `CURSOR_HEALTHY`).
+
+## Artifact Contract
+
+Subagent writes under `$DESIGN_TMPDIR/`:
+
+- **Required non-empty**: `approach-synthesis.txt`, `plan.txt`, `voting-tally.md`
+- **Required, may be empty**: `contested-decisions.md`, `oos.md`, `rejected-findings.md`, `accepted-plan-findings.md`
+- **Conditional**: `dialectic-resolutions.md` (empty file when dialectic skipped), `architecture-diagram.md` (`auto_mode=true` only), `dirty-tree-detected.env` (on dirty-tree at any collection boundary)
+
+**Return sentinel** (only content in the Agent-tool return text): `DESIGN_HEAVY=complete` on success; `DESIGN_HEAVY=failed REASON=<token>` on failure. No plan/prose in return text — artifacts stay in files.
+
+## Key Invariants
+
+- **SendMessage dependency**: without `SendMessage`, any subagent yield becomes a fatal stall — pass `--inline` to avoid subagent dispatch.
+- **Dirty-tree recovery**: on `DESIGN_HEAVY=failed REASON=dirty-tree`, read `$DESIGN_TMPDIR/dirty-tree-detected.env` (`STATUS`, `STAGE`, `RECOVERY_REQUIRED=true`) and prompt for recovery — not suppressed by `--auto`.
+
+## Mid-Run Dirty-Tree Probe Contract
+
+After each external collection boundary (sketch, dialectic-debate, dialectic-judge, plan-review), consult launcher `${OUTPUT}.dirty-tree` sidecars and run `${CLAUDE_PLUGIN_ROOT}/scripts/check-mid-run-dirty-tree.sh --mode checkpoint`. On `STATUS=dirty` or `STATUS=unknown`: write `$DESIGN_TMPDIR/dirty-tree-detected.env` with `STATUS=<status>`, `STAGE=<boundary>`, `RECOVERY_REQUIRED=true`, then return `DESIGN_HEAVY=failed REASON=dirty-tree`.

--- a/skills/design/references/heavy-worker.digest.md
+++ b/skills/design/references/heavy-worker.digest.md
@@ -27,4 +27,4 @@ Subagent writes under `$DESIGN_TMPDIR/`:
 
 ## Mid-Run Dirty-Tree Probe Contract
 
-After each external collection boundary (sketch, dialectic-debate, dialectic-judge, plan-review), consult launcher `${OUTPUT}.dirty-tree` sidecars and run `${CLAUDE_PLUGIN_ROOT}/scripts/check-mid-run-dirty-tree.sh --mode checkpoint`. On `STATUS=dirty` or `STATUS=unknown`: write `$DESIGN_TMPDIR/dirty-tree-detected.env` with `STATUS=<status>`, `STAGE=<boundary>`, `RECOVERY_REQUIRED=true`, then return `DESIGN_HEAVY=failed REASON=dirty-tree`.
+After each external collection boundary (sketch, dialectic-debate, dialectic-judge, plan-review), consult launcher `${OUTPUT}.dirty-tree` sidecars and run `${CLAUDE_PLUGIN_ROOT}/scripts/check-mid-run-dirty-tree.sh --mode checkpoint`. On `STATUS=dirty` or `STATUS=unknown`: write `$DESIGN_TMPDIR/dirty-tree-detected.env` with `STATUS=<status>`, `STAGE=<boundary>`, `RECOVERY_REQUIRED=true`, then return `DESIGN_HEAVY=failed REASON=dirty-tree`. Dedup per boundary via `$DESIGN_TMPDIR/.dirty-tree-prompted-<boundary>`.


### PR DESCRIPTION
## Summary

Introduces `skills/design/references/heavy-worker.digest.md` — a ~2 KB summary of the existing `heavy-worker.md` (8 KB). The parent `/design` orchestrator now references the digest instead of the full document when following the dirty-tree probe contract (SKILL.md line 403); the dispatched subagent still reads the full `heavy-worker.md`. Net reduction: ~6 KB per `/design` invocation from the parent's context.

## Architecture Diagram

Architecture diagram not available.

## Code Flow Diagram

(Code Flow Diagram skipped — quick mode)

## Test plan

- `relevant-checks` passed (pre-commit hooks + agent-lint)
- Digest file is 2409 bytes (~2 KB); original heavy-worker.md is 8249 bytes (~8 KB)
- SKILL.md line 403 now references `heavy-worker.digest.md` (grep confirms)
- heavy-worker.md and SKILL.md line 253 subagent instruction unchanged

Closes #1738
Closes #1654

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
