### PR TITLE
perf(merge-pr): batch gh pr view calls for mergeStateStatus + headRefOid (v20.4.3)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "20.4.2",
+  "version": "20.4.3",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 7-reviewer specialist panel (5 Cursor specialists + 1 Codex generic + 1 Claude generic) with 2-voter adjudication (Cursor + Codex primary; Claude conditional tie-breaker on 1Y/1N); plan review runs a 4-reviewer diagonal panel (2 Cursor: Arch, Edge + 2 Codex: Innovation, Pragmatic); design sketches run a 4-agent diverge-then-converge phase in regular mode (2 Cursor + 2 Codex) or 2 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Reviewer dirty-tree changes are now automatically logged and discarded instead of prompting the operator with a restore/stash/bail `AskUserQuestion`. When a Cursor, Codex, or Claude reviewer leaves uncommitted changes in the working tree, the orchestrator logs which reviewer caused it (to `execution-issues.md` under `Warnings` in `/implement` runs, or to the transcript in standalone `/review` runs) and immediately discards the changes via scoped `git restore` / `git clean` — no stash is created and `git stash list` remains clean. This replaces the three-option recovery prompt introduced by #1437. Updated: `skills/implement/SKILL.md` (Step 5.3.b quick mode, Step 5 normal mode, `--auto` flag description), `skills/review/SKILL.md` (Step 3a, line 22), `skills/review/references/heavy-worker.md`, `docs/external-reviewers.md`, `SECURITY.md`
 
+## [20.4.3] - 2026-05-09
+
+### Changed
+
+- Batch `mergeStateStatus` and `headRefOid` into one `gh pr view --json` call in `merge-pr.sh`, eliminating one API round-trip per merge invocation.
+
 ## [20.4.2] - 2026-05-09
 
 ### Fixed

--- a/scripts/merge-pr.md
+++ b/scripts/merge-pr.md
@@ -21,7 +21,7 @@ Emits `MERGE_RESULT=...` and `ERROR=...` on stdout via an EXIT trap. Exits 0 unc
 | `version_already_published` | Same-version race gate found a literal bump commit in `origin/main..HEAD` and `origin/main` already publishes that same `.claude-plugin/plugin.json` version. Caller should bail so the branch can rebase and re-bump. |
 | `admin_failed` | Default-mode `--admin` attempt failed and the plain fallback also failed. Hard error. |
 | `policy_denied` | CI re-verified green + branch fresh (admin-eligible); `--no-admin-fallback` is set, so `--admin` was NOT invoked, and the plain merge attempt failed. Caller should bail to manual reviewer-approval flow. |
-| `error` | Catch-all unexpected failure. Also covers the case where `gh pr view --json mergeStateStatus` returns empty (API/network/`gh` failure) or `UNKNOWN` — the script cannot determine merge state, so it short-circuits with `error` rather than mis-routing to `main_advanced`. |
+| `error` | Catch-all unexpected failure. Also covers the case where `gh pr view --json mergeStateStatus,headRefOid` returns empty (API/network/`gh` failure) or `UNKNOWN` mergeStateStatus — the script cannot determine merge state, so it short-circuits with `error` rather than mis-routing to `main_advanced`. |
 
 ## --no-admin-fallback
 
@@ -42,11 +42,15 @@ Both gates are checked **before** any merge attempt: default-mode `--admin`, def
 
 After CI and merge-state checks pass, the script also runs a same-version bump race gate before any merge attempt:
 
-1. It verifies `git rev-parse HEAD` equals `gh pr view --json headRefOid` for the PR. This precondition ensures the local worktree state being inspected is the PR head GitHub would merge.
+1. It verifies `git rev-parse HEAD` equals the `headRefOid` fetched via the same upfront `gh pr view --json mergeStateStatus,headRefOid` compound call (see "Batched discovery" below). This precondition ensures the local worktree state being inspected is the PR head GitHub would merge.
 2. It refreshes `origin/main` and scans commit subjects in `origin/main..HEAD` for the newest literal `Bump version to X.Y.Z` subject. This branch-range scan catches a bump commit even when a follow-up `Fix CI failure` commit is on top.
 3. If the branch contains a bump commit, the origin-side version check reads `origin/main:.claude-plugin/plugin.json` content, not origin-side commit subjects. Squash-merge titles therefore cannot hide the already-published version.
 4. Every parsed version must satisfy `^[0-9]+\.[0-9]+\.[0-9]+$`. Fetch failure, unreadable or malformed origin `plugin.json`, missing/null version, local/remote OID mismatch, and malformed versions fail closed via `MERGE_RESULT=error`.
 5. If origin publishes the same version as the branch bump, the script emits `MERGE_RESULT=version_already_published` and `ERROR=origin/main HEAD already bumped to X.Y.Z; rebase and re-bump`. If origin publishes a different version and `origin/main` is no longer an ancestor of `HEAD`, the script emits `MERGE_RESULT=main_advanced`.
+
+## Batched discovery
+
+At startup the script issues one compound `gh pr view --json mergeStateStatus,headRefOid` call that populates both `MERGE_STATE` and `PR_HEAD_OID`. This avoids a second API round-trip later for the same-version bump race gate's OID precondition. Both fields are parsed from the JSON result via `jq -r '.<field> // ""'`. Failure handling is unchanged: an empty result (gh error or network failure) still routes through the existing empty/UNKNOWN short-circuit paths.
 
 ## Non-responsibilities
 

--- a/scripts/merge-pr.sh
+++ b/scripts/merge-pr.sh
@@ -71,8 +71,10 @@ emit_output() {
 }
 trap 'emit_output' EXIT
 
-# --- Read merge state before any merge attempt ---
-MERGE_STATE=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json mergeStateStatus -q '.mergeStateStatus' 2>/dev/null || echo "")
+# --- Fetch PR metadata (mergeStateStatus + headRefOid) in one compound call ---
+PR_INFO=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json mergeStateStatus,headRefOid 2>/dev/null || echo "")
+MERGE_STATE=$(echo "$PR_INFO" | jq -r '.mergeStateStatus // ""' 2>/dev/null || echo "")
+PR_HEAD_OID=$(echo "$PR_INFO" | jq -r '.headRefOid // ""' 2>/dev/null || echo "")
 
 if [[ "$MERGE_STATE" == "BEHIND" ]]; then
     MERGE_RESULT="main_advanced"
@@ -88,7 +90,7 @@ fi
 # so the orchestrator bails to its error-handling path.
 if [[ -z "$MERGE_STATE" ]] || [[ "$MERGE_STATE" == "UNKNOWN" ]]; then
     MERGE_RESULT="error"
-    ERROR="could not read mergeStateStatus from gh pr view (state=\"$MERGE_STATE\")"
+    ERROR="could not read mergeStateStatus from gh pr view --json mergeStateStatus,headRefOid (state=\"$MERGE_STATE\")"
     exit 0
 fi
 
@@ -142,7 +144,6 @@ if [[ "$MERGE_STATE" != "CLEAN" ]] && [[ "$MERGE_STATE" != "UNSTABLE" ]] && [[ "
 fi
 
 # --- Same-version bump race gate ---
-PR_HEAD_OID=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRefOid -q '.headRefOid' 2>/dev/null || echo "")
 if [[ -z "$PR_HEAD_OID" ]]; then
     MERGE_RESULT="error"
     ERROR="could not resolve PR head OID via gh pr view"

--- a/scripts/test-merge-pr.md
+++ b/scripts/test-merge-pr.md
@@ -37,8 +37,7 @@ Each sub-test gets a fresh tmpdir under `$TMPDIR_BASE` containing:
 
 The stub responds to the production call shapes used by `merge-pr.sh`:
 
-- `gh pr view ... --json mergeStateStatus -q .mergeStateStatus` returns `$GH_MERGE_STATE` (default: `CLEAN`).
-- `gh pr view ... --json headRefOid -q .headRefOid` returns `$STUB_PR_HEAD_OID` (default: `aaaa1111`).
+- `gh pr view ... --json mergeStateStatus,headRefOid` returns a JSON object `{"mergeStateStatus":"<GH_MERGE_STATE>","headRefOid":"<STUB_PR_HEAD_OID>"}`. When `GH_MERGE_STATE=__EMPTY__`, `mergeStateStatus` is `null` so that `jq // ""` yields an empty string (matching the empty-state test). Defaults: `GH_MERGE_STATE=CLEAN`, `STUB_PR_HEAD_OID=aaaa1111`.
 - `gh pr checks ... --json name,state,bucket,link` returns `$GH_CHECKS_JSON` (default: one passing check).
 - `gh pr merge ... --squash [--admin]` exits with `$GH_ADMIN_EXIT` / `$GH_PLAIN_EXIT` and emits `$GH_ADMIN_OUTPUT` / `$GH_PLAIN_OUTPUT`.
 

--- a/scripts/test-merge-pr.sh
+++ b/scripts/test-merge-pr.sh
@@ -44,16 +44,13 @@ fi
 
 case "$2" in
     view)
-        if [[ "$*" == *"--json headRefOid"* ]]; then
-            printf '%s\n' "${STUB_PR_HEAD_OID:-aaaa1111}"
-            exit 0
-        fi
-        # __EMPTY__ sentinel renders an empty mergeStateStatus line (otherwise
-        # bash's `:-` would treat the empty value as "use default").
+        # Compound call: returns JSON with both mergeStateStatus and headRefOid.
+        # __EMPTY__ sentinel → null mergeStateStatus so jq // "" yields "".
+        HEAD_OID="${STUB_PR_HEAD_OID:-aaaa1111}"
         if [[ "${GH_MERGE_STATE:-CLEAN}" == "__EMPTY__" ]]; then
-            printf ''
+            printf '{"mergeStateStatus":null,"headRefOid":"%s"}\n' "$HEAD_OID"
         else
-            printf '%s\n' "${GH_MERGE_STATE:-CLEAN}"
+            printf '{"mergeStateStatus":"%s","headRefOid":"%s"}\n' "${GH_MERGE_STATE:-CLEAN}" "$HEAD_OID"
         fi
         ;;
     checks)
@@ -247,9 +244,8 @@ run_case "admin_success" \
 assert_stdout_contains "admin_success" "MERGE_RESULT=admin_merged" "A: admin success emits admin_merged"
 assert_command_count "admin_success" "gh.log" "pr merge 123 --repo owner/repo --squash --admin" "1" "A: exactly one --admin merge command"
 assert_command_count "admin_success" "gh.log" "pr merge 123 --repo owner/repo --squash" "0" "A: no plain fallback after admin success"
-assert_line_order "admin_success" "trace.log" "gh pr view 123 --repo owner/repo --json mergeStateStatus -q .mergeStateStatus" "gh pr merge 123 --repo owner/repo --squash --admin" "A: merge state is read before admin merge"
+assert_line_order "admin_success" "trace.log" "gh pr view 123 --repo owner/repo --json mergeStateStatus,headRefOid" "gh pr merge 123 --repo owner/repo --squash --admin" "A: merge state and head OID are read before admin merge (compound call)"
 assert_line_order "admin_success" "trace.log" "gh pr checks 123 --repo owner/repo --json name,state,bucket,link" "gh pr merge 123 --repo owner/repo --squash --admin" "A: checks are read before admin merge"
-assert_line_order "admin_success" "trace.log" "gh pr view 123 --repo owner/repo --json headRefOid -q .headRefOid" "gh pr merge 123 --repo owner/repo --squash --admin" "A: PR head OID is read before admin merge"
 assert_line_order "admin_success" "trace.log" "git fetch origin main --quiet" "gh pr merge 123 --repo owner/repo --squash --admin" "A: origin/main refresh happens before admin merge"
 assert_line_order "admin_success" "trace.log" "git log --format=%s origin/main..HEAD" "gh pr merge 123 --repo owner/repo --squash --admin" "A: branch-range scan happens before admin merge"
 


### PR DESCRIPTION
## Summary

- Batched the two sequential `gh pr view` calls in `scripts/merge-pr.sh` (`--json mergeStateStatus` and `--json headRefOid`) into a single compound `gh pr view --json mergeStateStatus,headRefOid` call, eliminating one API round-trip per merge invocation.
- Updated the offline test stub in `scripts/test-merge-pr.sh` to return a JSON object for the compound call, and updated the trace assertions to match the new call format.
- Documented the batched discovery pattern in `scripts/merge-pr.md` and updated the fixture contract in `scripts/test-merge-pr.md`.

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- Run `bash scripts/test-merge-pr.sh` — all 60 assertions pass (verified locally).
- Run `make lint` (shellcheck + test harness chain).

</details>

Closes #1734

Generated with [Claude Code](https://claude.com/claude-code)
