### PR TITLE
fix(simplicity-classification): strongly bias toward SIMPLE, add COMPLEXITY to Step 4 breadcrumb

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "20.5.2",
+  "version": "20.5.3",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 7-reviewer specialist panel (5 Cursor specialists + 1 Codex generic + 1 Claude generic) with 2-voter adjudication (Cursor + Codex primary; Claude conditional tie-breaker on 1Y/1N); plan review runs a 4-reviewer diagonal panel (2 Cursor: Arch, Edge + 2 Codex: Innovation, Pragmatic); design sketches run a 4-agent diverge-then-converge phase in regular mode (2 Cursor + 2 Codex) or 2 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Reviewer dirty-tree changes are now automatically logged and discarded instead of prompting the operator with a restore/stash/bail `AskUserQuestion`. When a Cursor, Codex, or Claude reviewer leaves uncommitted changes in the working tree, the orchestrator logs which reviewer caused it (to `execution-issues.md` under `Warnings` in `/implement` runs, or to the transcript in standalone `/review` runs) and immediately discards the changes via scoped `git restore` / `git clean` — no stash is created and `git stash list` remains clean. This replaces the three-option recovery prompt introduced by #1437. Updated: `skills/implement/SKILL.md` (Step 5.3.b quick mode, Step 5 normal mode, `--auto` flag description), `skills/review/SKILL.md` (Step 3a, line 22), `skills/review/references/heavy-worker.md`, `docs/external-reviewers.md`, `SECURITY.md`
 
+## [20.5.3] - 2026-05-10
+
+### Changed
+
+- /implement simplicity classification now strongly defaults to SIMPLE; HARD requires genuinely uncertain approach or major new shared abstraction; explicit NOT-sufficient list (multi-file mechanical edits, pre-resolved decisions, parity/test requirements)
+- `/fix-issue` Step 4 now evaluates and verbalizes COMPLEXITY (`SIMPLE` or `HARD`) in the breadcrumb when `INTENT=PR`, including `(forced by --hard)` suffix when `hard_mode=true`
+
+### Fixed
+
+- `skills/fix-issue/references/triage-classification.md`: corrects "default to HARD when uncertain" → "default to SIMPLE when uncertain" and tightens Dimension 2 HARD criteria
+
 ## [20.5.2] - 2026-05-10
 
 ### Added

--- a/skills/fix-issue/SKILL.md
+++ b/skills/fix-issue/SKILL.md
@@ -185,10 +185,11 @@ Print `> **🔶 4: classify**`
 The triage-classification reference loaded at Step 3 (digest or full `triage-classification.md`) owns the decision rules for both dimensions — do not re-load it here. If only the digest was loaded and a classification edge case is genuinely uncertain, load full `triage-classification.md` at this step.
 
 - **Intent** (`PR` vs `NON_PR`): does this issue prescribe work whose natural output is a pull request, or something else (new issues, a written report)? Default to `PR` only when the issue is genuinely ambiguous; when the issue text explicitly forbids a PR or mandates research/issues as the deliverable, pick `NON_PR` regardless of the default.
+- **Complexity** (`SIMPLE` vs `HARD`, only when `INTENT=PR`): default to `SIMPLE`; classify as `HARD` only when the approach is genuinely uncertain or the work introduces a major new shared abstraction. When `hard_mode=true`, skip the evaluation and set `COMPLEXITY=HARD` directly. See the triage-classification reference for the full decision rules.
 
-Set `INTENT` per those rules using the issue details and Step 3's codebase exploration.
+Set `INTENT` (and `COMPLEXITY` when `INTENT=PR`) per those rules using the issue details and Step 3's codebase exploration.
 
-Print `✅ 4: classify — INTENT=**$INTENT** (<elapsed>)`. The `**...**` bold around `$INTENT` is required — it makes the classification value visually prominent in the Claude Code transcript.
+When `INTENT=PR`: print `✅ 4: classify — INTENT=**$INTENT** COMPLEXITY=**$COMPLEXITY** (<elapsed>)` — or `COMPLEXITY=**$COMPLEXITY** (forced by --hard)` when `hard_mode=true`. When `INTENT=NON_PR`: print `✅ 4: classify — INTENT=**$INTENT** (<elapsed>)`. The `**...**` bold around both `$INTENT` and `$COMPLEXITY` (when printed) is required — it makes the classification values visually prominent in the Claude Code transcript.
 
 ## Step 5 — Execute
 

--- a/skills/fix-issue/SKILL.md
+++ b/skills/fix-issue/SKILL.md
@@ -189,7 +189,7 @@ The triage-classification reference loaded at Step 3 (digest or full `triage-cla
 
 Set `INTENT` (and `COMPLEXITY` when `INTENT=PR`) per those rules using the issue details and Step 3's codebase exploration.
 
-When `INTENT=PR`: print `✅ 4: classify — INTENT=**$INTENT** COMPLEXITY=**$COMPLEXITY** (<elapsed>)` — or `COMPLEXITY=**$COMPLEXITY** (forced by --hard)` when `hard_mode=true`. When `INTENT=NON_PR`: print `✅ 4: classify — INTENT=**$INTENT** (<elapsed>)`. The `**...**` bold around both `$INTENT` and `$COMPLEXITY` (when printed) is required — it makes the classification values visually prominent in the Claude Code transcript.
+When `INTENT=PR` and `hard_mode=false`: print `✅ 4: classify — INTENT=**$INTENT** COMPLEXITY=**$COMPLEXITY** (<elapsed>)`. When `INTENT=PR` and `hard_mode=true`: print `✅ 4: classify — INTENT=**$INTENT** COMPLEXITY=**$COMPLEXITY** (forced by --hard) (<elapsed>)`. When `INTENT=NON_PR`: print `✅ 4: classify — INTENT=**$INTENT** (<elapsed>)`. The `**...**` bold around both `$INTENT` and `$COMPLEXITY` (when printed) is required — it makes the classification values visually prominent in the Claude Code transcript.
 
 ## Step 5 — Execute
 

--- a/skills/fix-issue/references/triage-classification.digest.md
+++ b/skills/fix-issue/references/triage-classification.digest.md
@@ -31,6 +31,6 @@ SKILL.md Step 3 then invokes `issue-lifecycle.sh close --close-class <value>`, `
 - `NON_PR`: research/review → issues or written report. Pick when the issue explicitly forbids a PR or mandates research/issues as the deliverable.
 
 **Dimension 2 — Complexity** (only when `INTENT=PR`):
-- `SIMPLE`: ≤2 files, obvious solution, no architectural decisions. Default when uncertain.
-- `HARD`: everything else (multi-file, new features, architectural decisions, unclear root cause).
+- `SIMPLE`: Approach is clear from the issue or codebase patterns; implementation is mostly mechanical. **Default when uncertain.** Multi-file changes are fine when edits follow a clear pattern.
+- `HARD`: The correct approach is genuinely uncertain (reasonable engineers would debate it), or the work introduces a major new shared abstraction. Multi-file changes and "some architectural considerations" alone are NOT sufficient.
 - `--hard` short-circuit: forces `COMPLEXITY=HARD` when `hard_mode=true` and `INTENT=PR`.

--- a/skills/fix-issue/references/triage-classification.md
+++ b/skills/fix-issue/references/triage-classification.md
@@ -2,7 +2,7 @@
 
 **Consumer**: `/fix-issue` Steps 3 (Triage) and 4 (Classify Intent and Complexity).
 
-**Contract**: Authoritative detail for the triage checks, the not-material closure flow, the intent dimension (PR vs NON_PR) with its "default to PR only when genuinely ambiguous" rule, and the complexity dimension (SIMPLE vs HARD, evaluated only when `INTENT=PR`) with its "default to HARD when uncertain" rule. SKILL.md carries the step-level breadcrumbs, the `issue-lifecycle.sh close` invocations, and the `Print ✅ 4: classify — INTENT=**$INTENT** [COMPLEXITY=🟨 **$COMPLEXITY** 🟨]` line (bold is required for `INTENT`; yellow-square markers plus bold are required for `COMPLEXITY` so the classification values stand out at a glance); this file carries the judgment-heavy detail that would bloat the main-file knowledge delta.
+**Contract**: Authoritative detail for the triage checks, the not-material closure flow, the intent dimension (PR vs NON_PR) with its "default to PR only when genuinely ambiguous" rule, and the complexity dimension (SIMPLE vs HARD, evaluated only when `INTENT=PR`) with its "default to SIMPLE when uncertain" rule. SKILL.md carries the step-level breadcrumbs, the `issue-lifecycle.sh close` invocations, and the Step 4 breadcrumb (including `COMPLEXITY=**$COMPLEXITY**` when `INTENT=PR`); this file carries the judgment-heavy detail that would bloat the main-file knowledge delta.
 
 **When to load**: before executing Step 3 (Triage) OR Step 4 (Classify). Load once — the two step-bodies consume the same detail. **Do NOT load** in any other step — Steps 0 / 1 / 2 / 5 / 6 / 7 / 8 do not consume this content. **Do NOT load** on any path that has already branched to Step 8 — concrete examples: Step 0 `find-lock-issue.sh` exit 1 / 2 / 3 (no eligible issue, error, or lock-failed-after-eligibility-pass), Step 1 setup abort (`REPO_UNAVAILABLE=true`). Steps 3 and 4 do not run on those paths.
 
@@ -52,10 +52,10 @@ Does this issue prescribe work that should produce a pull request?
 
 ### Dimension 2 — Complexity (evaluated only when `INTENT=PR`)
 
-- **SIMPLE**: Isolated fix in 2 or fewer files. Obvious solution with no architectural decisions needed. Examples: typo fix, small bug with clear root cause, config change. **Default when uncertain.**
-- **HARD**: Multi-file changes, new features, architectural decisions, or genuinely complex root cause. Use `--hard` to force this path.
+- **SIMPLE**: The approach is clear from the issue description or codebase patterns, and the implementation is mostly mechanical. **Default when uncertain.** Multi-file changes are fine when the individual edits follow a clear pattern.
+- **HARD**: The correct approach is genuinely uncertain — reasonable engineers would debate it — or the work introduces a major new shared abstraction. Use `--hard` to force this path.
 
-**Default to SIMPLE when uncertain.** Most issues are isolated fixes; the SIMPLE path is faster and sufficient for the majority of cases. Use HARD for genuinely multi-file or architecturally complex work.
+**Default to SIMPLE when uncertain.** The bar for HARD is high: reserve it for tasks where design ceremony (competing sketches, trade-off voting) would produce meaningfully better outcomes than implementing the obvious approach. Multi-file changes, "some architectural considerations," and new helper scripts or functions are NOT sufficient for HARD on their own.
 
 **`--hard` short-circuit (overrides the HARD-vs-SIMPLE evaluation on the PR path).** When the operator passed `--hard` to `/fix-issue` (`hard_mode=true`) AND `INTENT=PR`, set `COMPLEXITY=HARD` without running the SIMPLE-vs-HARD decision rules above — the operator has explicitly opted into the HARD pipeline. SKILL.md Step 4 owns the short-circuit logic and the augmented breadcrumb (the `(forced by --hard)` suffix); this reference describes the same rule on the decision-detail side. The short-circuit does NOT apply when `INTENT=NON_PR` (complexity is not meaningful there).
 

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -795,14 +795,20 @@ Otherwise (no reusable manifest), continue with the normal-mode flow below (simp
 
 **Simplicity classification**: when the preamble condition holds, classify the task before invoking `/design`. Use `FEATURE_DESCRIPTION` plus a light codebase scan (Read / Grep / Glob of the obvious target files) to decide whether the work is SIMPLE.
 
-A task qualifies as SIMPLE only when all of these are true:
-- Contained scope: the change is well-scoped with no cascading architectural implications. Size in lines or file count is NOT the primary indicator — a change touching many files can still be trivial, and a single-file change can be genuinely complex.
-- No architectural decisions: the approach follows an existing pattern without needing competing sketches, trade-off analysis, or API/UX design choices.
-- No new abstractions: the work does not introduce a framework, shared helper, workflow contract, data model, or long-lived extension point.
-- Obvious verification path: `/relevant-checks`, a focused existing test, a dry-run, or direct grep/readback is enough to validate the change.
-- Low controversy: both the overall approach and individual implementation decisions are unambiguous. Competing valid approaches, non-obvious correctness judgments, or design decisions that reasonable engineers would debate are all indicators of HARD.
+**Default to SIMPLE.** A task is HARD only when running `/design` — with competing sketches, a voting panel, and a full reviewer suite — would produce meaningfully better outcomes than just implementing the obvious approach. That bar is high.
 
-When in doubt, default to SIMPLE — the cost of misclassifying a hard task as SIMPLE is a lighter review process; unnecessary ceremony on a simple task is worse.
+A task is HARD when at least one of these is true:
+- The correct approach is genuinely uncertain: reasonable engineers would propose substantially different architectures, and the choice between them has meaningful long-term consequences.
+- The work introduces a major new shared abstraction whose interface must be carefully designed (e.g., a new cross-skill workflow contract, data model, or protocol — NOT just a new helper function or script).
+- A mistake would be very hard to detect or revert, or would silently corrupt data or break a non-obvious invariant.
+
+Explicitly NOT sufficient for HARD:
+- Multi-file changes (even 20+ files), when the individual edits follow a clear pattern described in the issue.
+- "Architectural decisions" that the issue body or existing codebase patterns already resolve.
+- Needing to add tests or follow parity rules — these are known requirements, not ambiguous design choices.
+- Mechanical edits across many call sites (e.g., renaming a flag, removing a prose string from N launchers).
+
+When in doubt, classify SIMPLE — the cost of a lighter review on a genuinely hard task is manageable; unnecessary design ceremony on a simple task is pure waste and significantly delays delivery.
 
 When the task is SIMPLE: print `**⚡ 1: design plan — task classified as SIMPLE; auto-switching to quick workflow.**`, record `"${CLAUDE_PLUGIN_ROOT}/scripts/timing-ledger.sh" workflow-path "SIMPLE" || true`, set `quick_mode=true`, and re-enter the Quick mode branch above (`### Quick mode (quick_mode=true)`). From there, handle branch creation, produce the inline plan, write `plan.txt` + `voting-tally.md`, and proceed to Step 2 exactly as ordinary quick mode does.
 


### PR DESCRIPTION
## Summary

- **Stronger SIMPLE default in `/implement`**: rewrites the simplicity classification from an all-must-be-true SIMPLE checklist to an explicit high-bar HARD definition with a NOT-sufficient list; multi-file mechanical edits, pre-resolved architectural decisions, and parity/test requirements no longer classify as HARD
- **Fixes wrong default in `/fix-issue` triage-classification**: corrects "default to HARD when uncertain" → "default to SIMPLE when uncertain" in the contract line, and tightens Dimension 2 HARD criteria to match
- **Adds COMPLEXITY verbalization to Step 4 breadcrumb**: `/fix-issue` Step 4 now explicitly evaluates and prints COMPLEXITY (`SIMPLE`/`HARD`) in the transcript when `INTENT=PR`, fixing the "implicit HARD classification not verbalized" bug

## Architecture Diagram

Architecture diagram not available.

## Code Flow Diagram

(Code Flow Diagram skipped — quick mode)

## Test plan

- [ ] Run `/relevant-checks` on all modified files (pre-commit + agent-lint)
- [ ] Verify new simplicity classification text: SIMPLE is clearly the default; HARD requires genuinely uncertain approach
- [ ] Verify Step 4 breadcrumb instructions include COMPLEXITY when INTENT=PR
- [ ] Verify no `≤2 files` restriction in digest SIMPLE description

Closes #1752

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
