### PR TITLE
feat: move Step Name Registry tables to per-skill TSV files (v20.6.5)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "20.6.5",
+  "version": "20.6.6",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 7-reviewer specialist panel (5 Cursor specialists + 1 Codex generic + 1 Claude generic) with 2-voter adjudication (Cursor + Codex primary; Claude conditional tie-breaker on 1Y/1N); plan review runs a 4-reviewer diagonal panel (2 Cursor: Arch, Edge + 2 Codex: Innovation, Pragmatic); design sketches run a 4-agent diverge-then-converge phase in regular mode (2 Cursor + 2 Codex) or 2 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Reviewer dirty-tree changes are now automatically logged and discarded instead of prompting the operator with a restore/stash/bail `AskUserQuestion`. When a Cursor, Codex, or Claude reviewer leaves uncommitted changes in the working tree, the orchestrator logs which reviewer caused it (to `execution-issues.md` under `Warnings` in `/implement` runs, or to the transcript in standalone `/review` runs) and immediately discards the changes via scoped `git restore` / `git clean` — no stash is created and `git stash list` remains clean. This replaces the three-option recovery prompt introduced by #1437. Updated: `skills/implement/SKILL.md` (Step 5.3.b quick mode, Step 5 normal mode, `--auto` flag description), `skills/review/SKILL.md` (Step 3a, line 22), `skills/review/references/heavy-worker.md`, `docs/external-reviewers.md`, `SECURITY.md`
 
+## [20.6.6] - 2026-05-10
+
+### Changed
+
+- Move Step Name Registry tables from each orchestrator skill's SKILL.md into per-skill `scripts/step-name-registry.tsv` files; add MANDATORY load directives; update `progress-reporting.md` and fix-issue test harness
+
 ## [20.6.5] - 2026-05-10
 
 ### Fixed

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -34,21 +34,7 @@ The feature to design is described by the remainder of `$ARGUMENTS` after flags 
 - Print a **completion line** only when it carries informational payload. Only the final step (Step 5) prints an unconditional completion announcement.
 - When `STEP_NUM_PREFIX` is non-empty, prepend it to step numbers: `{STEP_NUM_PREFIX}{local_step}`. When `STEP_PATH_PREFIX` is non-empty, prepend it to breadcrumb paths: `{STEP_PATH_PREFIX} | {step_short_name}`. **This rule overrides the literal step numbers and names in `Print:` directives and examples throughout this file.** Examples shown below assume standalone mode; when nested, prepend the parent context.
 
-Step Name Registry:
-| Step | Short Name |
-|------|------------|
-| 0 | setup |
-| 1 | branch |
-| 1c | questions |
-| 1d | discussion r1 |
-| 2a | sketches |
-| 2a.5 | dialectic |
-| 2b | full plan |
-| 3 | plan review |
-| 3.5 | discussion r2 |
-| 3b | arch diagram |
-| 4 | rejected findings |
-| 5 | cleanup |
+**MANDATORY at session start**: Read `${CLAUDE_PLUGIN_ROOT}/skills/design/scripts/step-name-registry.tsv` to get the Step Name Registry (step number → short name mapping for progress breadcrumbs).
 
 ### Verbosity Control
 

--- a/skills/design/scripts/step-name-registry.tsv
+++ b/skills/design/scripts/step-name-registry.tsv
@@ -1,0 +1,13 @@
+step	name
+0	setup
+1	branch
+1c	questions
+1d	discussion r1
+2a	sketches
+2a.5	dialectic
+2b	full plan
+3	plan review
+3.5	discussion r2
+3b	arch diagram
+4	rejected findings
+5	cleanup

--- a/skills/fix-issue/SKILL.md
+++ b/skills/fix-issue/SKILL.md
@@ -39,18 +39,7 @@ Before processing each invocation, hold these four questions.
 
 Follow the formatting rules in `${CLAUDE_PLUGIN_ROOT}/skills/shared/progress-reporting.md`.
 
-Step Name Registry:
-
-| Step | Short Name |
-|------|-----------|
-| 0 | find & lock |
-| 1 | setup |
-| 2 | read details |
-| 3 | triage |
-| 4 | classify |
-| 5 | execute |
-| 6 | close issue |
-| 8 | cleanup |
+**MANDATORY at session start**: Read `${CLAUDE_PLUGIN_ROOT}/skills/fix-issue/scripts/step-name-registry.tsv` to get the Step Name Registry (step number → short name mapping for progress breadcrumbs).
 
 **MANDATORY at session start — READ ENTIRE FILE**: `${CLAUDE_PLUGIN_ROOT}/skills/shared/orchestrator-never.md`. Contains cross-skill NEVER rules that apply to this skill in addition to the skill-specific Anti-patterns below.
 

--- a/skills/fix-issue/scripts/step-name-registry.tsv
+++ b/skills/fix-issue/scripts/step-name-registry.tsv
@@ -1,0 +1,9 @@
+step	name
+0	find & lock
+1	setup
+2	read details
+3	triage
+4	classify
+5	execute
+6	close issue
+8	cleanup

--- a/skills/fix-issue/scripts/test-fix-issue-step-order.md
+++ b/skills/fix-issue/scripts/test-fix-issue-step-order.md
@@ -24,4 +24,6 @@ The harness uses an accumulator pattern (`fail=1` set on each failure, exit at e
 
 The harness is wired into `make lint` via the `test-fix-issue-step-order` target in `Makefile`. It is added to `agent-lint.toml`'s `exclude` list alongside this sibling contract because agent-lint's dead-script and S030/orphaned-skill-files rules do not follow Makefile-only references.
 
+TSV encoding: the file must be UTF-8 with LF line endings and no BOM. The awk `$2` comparison will include `\r` if CRLF endings slip in, causing false CI failures.
+
 Edit-in-sync: if the Step Name Registry rows in `step-name-registry.tsv` change (assertions 1, 2, 8, 9), the section headings rename, anti-pattern #1 reverts, any find & lock breadcrumb literal moves, the find-lock-issue.sh invocation form changes, the setup-script invocation form changes, or the file-preamble anti-halt phrase `child Bash tool calls into the canonical` is reworded, update both this harness and this contract in the same PR. The block-extraction boundaries are pinned to the exact heading literals `## Step 0 — Find and Lock`, `## Step 1 — Setup`, and `## Step 2` (prefix); a Step 2 heading rename is the most likely silent breakage and is itself caught by assertion (3) / (4) on the start side, but the Step 2 prefix boundary should be re-pinned in the same PR if Step 2's heading changes.

--- a/skills/fix-issue/scripts/test-fix-issue-step-order.md
+++ b/skills/fix-issue/scripts/test-fix-issue-step-order.md
@@ -1,18 +1,18 @@
 # skills/fix-issue/scripts/test-fix-issue-step-order.sh — contract
 
-`skills/fix-issue/scripts/test-fix-issue-step-order.sh` is the regression harness pinning the `/fix-issue` Step 0 = find & lock, Step 1 = setup structure established by the fold-find-and-lock refactor (closes #496). It is offline, hermetic, and runs against the on-disk `skills/fix-issue/SKILL.md` at harness invocation time — typically the commit checked out in CI, but local developer runs see the working tree. No network, no git state change, no mocks. The harness guards against accidental reversion of the fold or stale renumbering of the breadcrumbs. (Throughout this contract, "preamble" means the YAML front matter, the H1 title, and any body text that appears before the first flush-left line matching `^##` followed by a space (the harness uses a strict line-anchored prefix; CommonMark-style indented level-2 ATX is deliberately not matched, since SKILL.md headings are always flush-left) — not just YAML.)
+`skills/fix-issue/scripts/test-fix-issue-step-order.sh` is the regression harness pinning the `/fix-issue` Step 0 = find & lock, Step 1 = setup structure established by the fold-find-and-lock refactor (closes #496). It is offline, hermetic, and runs against the on-disk `skills/fix-issue/SKILL.md` and `skills/fix-issue/scripts/step-name-registry.tsv` at harness invocation time — typically the commit checked out in CI, but local developer runs see the working tree. No network, no git state change, no mocks. The harness guards against accidental reversion of the fold or stale renumbering of the breadcrumbs. (Throughout this contract, "preamble" means the YAML front matter, the H1 title, and any body text that appears before the first flush-left line matching `^##` followed by a space (the harness uses a strict line-anchored prefix; CommonMark-style indented level-2 ATX is deliberately not matched, since SKILL.md headings are always flush-left) — not just YAML.)
 
-Thirteen assertions against `skills/fix-issue/SKILL.md` — ten textual literal pins (1-9, 13) plus three operational ordering pins (10-12) via awk-scoped block extraction:
+Thirteen assertions — ten textual literal pins (1-9, 13) plus three operational ordering pins (10-12) via awk-scoped block extraction. Assertions (1), (2), (8), and (9) target `step-name-registry.tsv`; the remaining assertions target `SKILL.md`.
 
-1. Step Name Registry contains `| 0 | find & lock |`.
-2. Step Name Registry contains `| 1 | setup |`.
+1. `step-name-registry.tsv` contains row with `step=0, name=find & lock` (checked via `awk -F'\t'` exact column match).
+2. `step-name-registry.tsv` contains row with `step=1, name=setup` (same).
 3. Section heading `## Step 0 — Find and Lock` present.
 4. Section heading `## Step 1 — Setup` present.
 5. Anti-pattern #1 contains `treat Step 0 as structural`.
 6. Find & lock success breadcrumb literal `✅ 0: find & lock` present.
 7. Find & lock failure breadcrumb literal `⚠ 0: find & lock` present.
-8. No stale `| 1 | lock |` step-name-registry row remains (narrowed from bare `1: lock` substring to avoid false positives on unrelated text — see #889).
-9. No stale `| 2 | lock |` step-name-registry row remains (same narrowing).
+8. No stale `step=1, name=lock` row in `step-name-registry.tsv` (checked via `awk -F'\t'` exact column match to avoid false positives — see #889).
+9. No stale `step=2, name=lock` row in `step-name-registry.tsv` (same narrowing).
 10. The Step 0 block contains the `find-lock-issue.sh` invocation.
 11. The Step 0 block does NOT contain `session-setup.sh` (operational ordering).
 12. The Step 1 block contains `session-setup.sh --prefix claude-fix-issue --skip-branch-check`.
@@ -24,4 +24,4 @@ The harness uses an accumulator pattern (`fail=1` set on each failure, exit at e
 
 The harness is wired into `make lint` via the `test-fix-issue-step-order` target in `Makefile`. It is added to `agent-lint.toml`'s `exclude` list alongside this sibling contract because agent-lint's dead-script and S030/orphaned-skill-files rules do not follow Makefile-only references.
 
-Edit-in-sync: if the Step Name Registry order changes, the section headings rename, anti-pattern #1 reverts, any find & lock breadcrumb literal moves, the find-lock-issue.sh invocation form changes, the setup-script invocation form changes, or the file-preamble anti-halt phrase `child Bash tool calls into the canonical` is reworded, update both this harness and this contract in the same PR. The block-extraction boundaries are pinned to the exact heading literals `## Step 0 — Find and Lock`, `## Step 1 — Setup`, and `## Step 2` (prefix); a Step 2 heading rename is the most likely silent breakage and is itself caught by assertion (3) / (4) on the start side, but the Step 2 prefix boundary should be re-pinned in the same PR if Step 2's heading changes.
+Edit-in-sync: if the Step Name Registry rows in `step-name-registry.tsv` change (assertions 1, 2, 8, 9), the section headings rename, anti-pattern #1 reverts, any find & lock breadcrumb literal moves, the find-lock-issue.sh invocation form changes, the setup-script invocation form changes, or the file-preamble anti-halt phrase `child Bash tool calls into the canonical` is reworded, update both this harness and this contract in the same PR. The block-extraction boundaries are pinned to the exact heading literals `## Step 0 — Find and Lock`, `## Step 1 — Setup`, and `## Step 2` (prefix); a Step 2 heading rename is the most likely silent breakage and is itself caught by assertion (3) / (4) on the start side, but the Step 2 prefix boundary should be re-pinned in the same PR if Step 2's heading changes.

--- a/skills/fix-issue/scripts/test-fix-issue-step-order.sh
+++ b/skills/fix-issue/scripts/test-fix-issue-step-order.sh
@@ -3,22 +3,24 @@
 # /fix-issue Step 0 = find & lock, Step 1 = setup ordering established
 # by the fold-find-and-lock refactor (closes #496).
 #
-# Asserts that skills/fix-issue/SKILL.md carries the load-bearing
-# literals the new step ordering depends on. The skill is prose;
+# Asserts that skills/fix-issue/SKILL.md and the companion
+# skills/fix-issue/scripts/step-name-registry.tsv carry the load-bearing
+# literals the step ordering depends on. The skill is prose;
 # this harness is a CI guard against accidental reversion of the
 # fold or stale renumbering.
 #
-# Thirteen assertions against skills/fix-issue/SKILL.md (ten textual literal
-# pins + three operational ordering pins via awk-scoped block extraction):
-#   (1) Step Name Registry contains "| 0 | find & lock |" row.
-#   (2) Step Name Registry contains "| 1 | setup |" row.
-#   (3) Section heading "## Step 0 — Find and Lock" present.
-#   (4) Section heading "## Step 1 — Setup" present.
+# Thirteen assertions — ten textual literal pins (1-9, 13) plus three
+# operational ordering pins (10-12) via awk-scoped block extraction.
+# Assertions (1), (2), (8), and (9) target the TSV; the rest target SKILL.md:
+#   (1) step-name-registry.tsv has step=0, name="find & lock".
+#   (2) step-name-registry.tsv has step=1, name="setup".
+#   (3) Section heading "## Step 0 — Find and Lock" present in SKILL.md.
+#   (4) Section heading "## Step 1 — Setup" present in SKILL.md.
 #   (5) Anti-pattern #1 contains "treat Step 0 as structural".
 #   (6) Find & lock success breadcrumb literal "✅ 0: find & lock" present.
 #   (7) Find & lock failure breadcrumb literal "⚠ 0: find & lock" present.
-#   (8) No stale "| 1 | lock |" step-name-registry row remains.
-#   (9) No stale "| 2 | lock |" step-name-registry row remains.
+#   (8) No stale step=1, name="lock" row in step-name-registry.tsv.
+#   (9) No stale step=2, name="lock" row in step-name-registry.tsv.
 #  (10) Step 0 (Find and Lock) block contains the find-lock-issue.sh invocation.
 #  (11) Step 0 block does NOT contain `session-setup.sh` (operational ordering).
 #  (12) Step 1 (Setup) block contains the session-setup.sh invocation.
@@ -58,9 +60,15 @@ set -euo pipefail
 
 REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
 SKILL_MD="$REPO_ROOT/skills/fix-issue/SKILL.md"
+REGISTRY_TSV="$REPO_ROOT/skills/fix-issue/scripts/step-name-registry.tsv"
 
 if [[ ! -f "$SKILL_MD" ]]; then
     echo "FAIL: SKILL.md not found at $SKILL_MD" >&2
+    exit 1
+fi
+
+if [[ ! -f "$REGISTRY_TSV" ]]; then
+    echo "FAIL: step-name-registry.tsv not found at $REGISTRY_TSV" >&2
     exit 1
 fi
 
@@ -84,9 +92,29 @@ assert_not_contains() {
     fi
 }
 
-# (1)-(2) Step Name Registry rows
-assert_contains '| 0 | find & lock |' '(1) Step Name Registry has "0 | find & lock"'
-assert_contains '| 1 | setup |' '(2) Step Name Registry has "1 | setup"'
+assert_tsv_row() {
+    local step="$1"
+    local name="$2"
+    local description="$3"
+    if ! awk -F'\t' -v s="$step" -v n="$name" 'NR>1 && $1==s && $2==n {found=1} END {exit !found}' "$REGISTRY_TSV"; then
+        echo "FAIL: $description (TSV row step=$step name=$name not found)" >&2
+        fail=1
+    fi
+}
+
+assert_tsv_no_row() {
+    local step="$1"
+    local name="$2"
+    local description="$3"
+    if awk -F'\t' -v s="$step" -v n="$name" 'NR>1 && $1==s && $2==n {found=1} END {exit !found}' "$REGISTRY_TSV"; then
+        echo "FAIL: $description (TSV row step=$step name=$name unexpectedly found)" >&2
+        fail=1
+    fi
+}
+
+# (1)-(2) Step Name Registry rows — now in TSV, not inline in SKILL.md
+assert_tsv_row '0' 'find & lock' '(1) step-name-registry.tsv has "0 -> find & lock"'
+assert_tsv_row '1' 'setup' '(2) step-name-registry.tsv has "1 -> setup"'
 
 # (3)-(4) Section headings
 assert_contains '## Step 0 — Find and Lock' '(3) section "Step 0 — Find and Lock" present'
@@ -99,9 +127,9 @@ assert_contains 'treat Step 0 as structural' '(5) anti-pattern #1 says "treat St
 assert_contains '✅ 0: find & lock' '(6) find & lock success breadcrumb uses "0: find & lock"'
 assert_contains '⚠ 0: find & lock' '(7) find & lock failure breadcrumb uses "0: find & lock"'
 
-# (8)-(9) No stale "lock" step-name-registry rows from the pre-fold structure
-assert_not_contains '| 1 | lock |' '(8) no stale "| 1 | lock |" registry row'
-assert_not_contains '| 2 | lock |' '(9) no stale "| 2 | lock |" registry row'
+# (8)-(9) No stale "lock" step-name-registry rows from the pre-fold structure (checked in TSV)
+assert_tsv_no_row '1' 'lock' '(8) no stale "1 -> lock" registry row in TSV'
+assert_tsv_no_row '2' 'lock' '(9) no stale "2 -> lock" registry row in TSV'
 
 # (10)-(12) Operational-ordering assertions on awk-scoped step blocks.
 # These guard against a future edit that keeps the headings/registry/

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -69,37 +69,7 @@ Each rule states WHY; per-site reminders reference by anchor name.
 
 Every step MUST print breadcrumb status lines per `${CLAUDE_PLUGIN_ROOT}/skills/shared/progress-reporting.md`. Print a start line (`> **🔶 2: implementation**`) on entry; print a completion line only when it carries informational payload (Step 18 is the only unconditional completion). Long-running steps print intermediate progress (`⏳ 12: CI+merge loop — CI running (2m elapsed), main unchanged`).
 
-Step Name Registry:
-| Step | Short Name |
-|------|------------|
-| 0 | setup |
-| 0.5 | tracking issue |
-| 1 | design plan |
-| 1.m | update main |
-| 1.r | rebase |
-| 2 | implementation |
-| 3 | checks (1) |
-| 4 | commit (impl) |
-| 4.r | rebase |
-| 5 | code review |
-| 6 | checks (2) |
-| 7 | commit (review) |
-| 7.r | rebase |
-| 7a | code flow |
-| 7a.r | rebase |
-| 8 | version bump |
-| 8a | changelog |
-| 8b | rebase |
-| 9a.1 | OOS issues |
-| 9 | create PR |
-| 10 | CI monitor |
-| 11 | execution-issues |
-| 12 | CI+merge loop |
-| 14 | local cleanup |
-| 15 | verify main |
-| 16 | rejected findings |
-| 17 | final report |
-| 18 | cleanup |
+**MANDATORY at session start**: Read `${CLAUDE_PLUGIN_ROOT}/skills/implement/scripts/step-name-registry.tsv` to get the Step Name Registry (step number → short name mapping for progress breadcrumbs).
 
 ### Verbosity Control
 

--- a/skills/implement/scripts/step-name-registry.tsv
+++ b/skills/implement/scripts/step-name-registry.tsv
@@ -1,0 +1,29 @@
+step	name
+0	setup
+0.5	tracking issue
+1	design plan
+1.m	update main
+1.r	rebase
+2	implementation
+3	checks (1)
+4	commit (impl)
+4.r	rebase
+5	code review
+6	checks (2)
+7	commit (review)
+7.r	rebase
+7a	code flow
+7a.r	rebase
+8	version bump
+8a	changelog
+8b	rebase
+9a.1	OOS issues
+9	create PR
+10	CI monitor
+11	execution-issues
+12	CI+merge loop
+14	local cleanup
+15	verify main
+16	rejected findings
+17	final report
+18	cleanup

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -105,20 +105,7 @@ Defense in depth: stdout parsing of `ISSUES_*` is the primary post-`/issue` mech
 - Print a **start line** when entering a step: e.g., `> **🔶 1: research**`
 - Print a **completion line** when done: e.g., `✅ 1: research — synthesis complete, 4 lanes (3m12s)`
 
-Step Name Registry:
-| Step | Short Name |
-|------|------------|
-| 0 | setup |
-| 1 | research |
-| 1.1 | planner |
-| 1.1.c | interactive-review |
-| 1.2 | lane-assign |
-| 2 | validation |
-| 2.5 | citation-validation |
-| 2.6 | critique loop |
-| 3 | report |
-| 3.5 | auto-issue |
-| 4 | cleanup |
+**MANDATORY at session start**: Read `${CLAUDE_PLUGIN_ROOT}/skills/research/scripts/step-name-registry.tsv` to get the Step Name Registry (step number → short name mapping for progress breadcrumbs).
 
 **MANDATORY at session start — READ ENTIRE FILE**: `${CLAUDE_PLUGIN_ROOT}/skills/shared/orchestrator-never.md`. Contains cross-skill NEVER rules that apply to this skill in addition to the skill-specific Anti-patterns below.
 

--- a/skills/research/scripts/step-name-registry.tsv
+++ b/skills/research/scripts/step-name-registry.tsv
@@ -1,0 +1,12 @@
+step	name
+0	setup
+1	research
+1.1	planner
+1.1.c	interactive-review
+1.2	lane-assign
+2	validation
+2.5	citation-validation
+2.6	critique loop
+3	report
+3.5	auto-issue
+4	cleanup

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -47,15 +47,7 @@ Mode is determined by the parser state machine (fail-closed, evaluated in order)
 - Print a **completion line** only when it carries informational payload. Pure "step complete" announcements without payload are not needed.
 - When `STEP_NUM_PREFIX` is non-empty, prepend it to step numbers. When `STEP_PATH_PREFIX` is non-empty, prepend it to breadcrumb paths. **This rule overrides the literal step numbers and names in `Print:` directives and examples throughout this file.** Examples shown below assume standalone mode; when nested, prepend the parent context.
 
-Step Name Registry:
-| Step | Short Name |
-|------|------------|
-| 0 | setup |
-| 1 | gather context |
-| 2 | launch reviewers |
-| 3 | review cycle |
-| 4 | final summary |
-| 5 | cleanup |
+**MANDATORY at session start**: Read `${CLAUDE_PLUGIN_ROOT}/skills/review/scripts/step-name-registry.tsv` to get the Step Name Registry (step number → short name mapping for progress breadcrumbs).
 
 ### Reviewer status table
 

--- a/skills/review/scripts/step-name-registry.tsv
+++ b/skills/review/scripts/step-name-registry.tsv
@@ -1,0 +1,7 @@
+step	name
+0	setup
+1	gather context
+2	launch reviewers
+3	review cycle
+4	final summary
+5	cleanup

--- a/skills/shared/progress-reporting.md
+++ b/skills/shared/progress-reporting.md
@@ -1,6 +1,6 @@
 # Progress Reporting Contract
 
-Shared formatting rules for step progress output across all larch skills. Each skill maintains its own **Step Name Registry** (mapping step numbers to short names) and references this contract for formatting.
+Shared formatting rules for step progress output across all larch skills. Each skill maintains its own **Step Name Registry** (mapping step numbers to short names) in `skills/<name>/scripts/step-name-registry.tsv` (tab-separated, `step` and `name` columns, header row first). Skills load this file via a MANDATORY directive at session start and reference it for breadcrumb name resolution.
 
 ## Breadcrumb Format
 

--- a/skills/shared/progress-reporting.md
+++ b/skills/shared/progress-reporting.md
@@ -1,6 +1,6 @@
 # Progress Reporting Contract
 
-Shared formatting rules for step progress output across all larch skills. Each skill maintains its own **Step Name Registry** (mapping step numbers to short names) in `skills/<name>/scripts/step-name-registry.tsv` (tab-separated, `step` and `name` columns, header row first). Skills load this file via a MANDATORY directive at session start and reference it for breadcrumb name resolution.
+Shared formatting rules for step progress output across all larch skills. Each **orchestrator skill** (design, implement, review, fix-issue, research) maintains its own **Step Name Registry** (mapping step numbers to short names) in `skills/<name>/scripts/step-name-registry.tsv` (tab-separated, `step` and `name` columns, header row first, UTF-8 LF). These skills load the file via a MANDATORY directive at session start and reference it for breadcrumb name resolution.
 
 ## Breadcrumb Format
 


### PR DESCRIPTION
## Summary

- Move Step Name Registry tables (step number → short name mappings) out of each orchestrator skill's `SKILL.md` into per-skill `scripts/step-name-registry.tsv` files
- Replace inline tables with MANDATORY load directives in fix-issue, implement, design, review, and research SKILL.md files
- Update `skills/shared/progress-reporting.md` to document the TSV convention (scoped to orchestrator skills)
- Update `skills/fix-issue/scripts/test-fix-issue-step-order.sh` — assertions (1), (2), (8), (9) now check the TSV via `awk -F'\t'` exact column match

## Architecture Diagram

Architecture diagram not available.

## Code Flow Diagram

(Code Flow Diagram skipped — quick mode)

## Test plan

- [x] `bash skills/fix-issue/scripts/test-fix-issue-step-order.sh` — all 13 assertions pass
- [x] `/relevant-checks` passes at Step 3 and Step 6

Closes #1773

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
