### PR TITLE
fix(implement): suppress rebase-skip log, static codex sidecar, trim bump-version prose (v24.1.2)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "24.1.1",
+  "version": "24.1.2",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 7-reviewer specialist panel (5 Cursor specialists + 1 Codex generic + 1 Claude generic) with 2-voter adjudication (Cursor + Codex primary; Claude conditional tie-breaker on 1Y/1N); plan review runs a 4-reviewer diagonal panel (2 Cursor: Arch, Edge + 2 Codex: Innovation, Pragmatic); design sketches run a 4-agent diverge-then-converge phase in regular mode (2 Cursor + 2 Codex) or 2 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Reviewer dirty-tree changes are now automatically logged and discarded instead of prompting the operator with a restore/stash/bail `AskUserQuestion`. When a Cursor, Codex, or Claude reviewer leaves uncommitted changes in the working tree, the orchestrator logs which reviewer caused it (to `execution-issues.md` under `Warnings` in `/implement` runs, or to the transcript in standalone `/review` runs) and immediately discards the changes via scoped `git restore` / `git clean` — no stash is created and `git stash list` remains clean. This replaces the three-option recovery prompt introduced by #1437. Updated: `skills/implement/SKILL.md` (Step 5.3.b quick mode, Step 5 normal mode, `--auto` flag description), `skills/review/SKILL.md` (Step 3a, line 22), `skills/review/references/heavy-worker.md`, `docs/external-reviewers.md`, `SECURITY.md`
 
+## [24.1.2] - 2026-05-11
+
+### Fixed
+
+- suppress Rebase Checkpoint Macro M1 log line on no-op rebase (SKIPPED paths)
+- skip dirty-tree sidecar scan in Codex EXIT trap when --sandbox read-only is confirmed
+- remove inline bump-version description prose from HAS_BUMP=false warning in /implement
+
 ## [24.1.1] - 2026-05-11
 
 ### Changed

--- a/scripts/launch-review.md
+++ b/scripts/launch-review.md
@@ -23,9 +23,10 @@ Gemini remains generic-only and rejects specialist flags.
 - Codex receives a compact read-only hardening preamble through
   per-invocation `CODEX_HOME/config.toml`; Cursor receives the same compact
   prohibition in the wrapped prompt plus a `--mode plan` enforcement note.
-- Codex sets `CODEX_SANDBOX_MODE=read-only` and skips the dirty-tree-sidecar
-  EXIT trap scan — `--sandbox read-only` blocks writes at the syscall level,
-  making the after-the-fact scan redundant. Cursor still runs the scan.
+- Codex sets `CODEX_SANDBOX_MODE=read-only` and emits a static
+  `STATUS=clean MODE=baseline REASON=codex-sandbox-read-only` sidecar without
+  running the scan — `--sandbox read-only` blocks writes at the syscall level,
+  making the after-the-fact scan redundant. Cursor still runs the full scan.
 
 ## Primary Callers
 

--- a/scripts/launch-review.md
+++ b/scripts/launch-review.md
@@ -23,6 +23,9 @@ Gemini remains generic-only and rejects specialist flags.
 - Codex receives a compact read-only hardening preamble through
   per-invocation `CODEX_HOME/config.toml`; Cursor receives the same compact
   prohibition in the wrapped prompt plus a `--mode plan` enforcement note.
+- Codex sets `CODEX_SANDBOX_MODE=read-only` and skips the dirty-tree-sidecar
+  EXIT trap scan — `--sandbox read-only` blocks writes at the syscall level,
+  making the after-the-fact scan redundant. Cursor still runs the scan.
 
 ## Primary Callers
 

--- a/scripts/launch-review.sh
+++ b/scripts/launch-review.sh
@@ -204,6 +204,7 @@ CODEX_HOME_DIR=""
 DIRTY_TREE_WRITTEN=false
 UNTRACKED_BASELINE="${OUTPUT}.untracked-baseline"
 DIRTY_TREE_SIDECAR="${OUTPUT}.dirty-tree"
+CODEX_SANDBOX_MODE=read-only
 
 # _write_dirty_tree_sidecar is provided by lib-dirty-tree-sidecar.sh
 # (sourced above) and reads/writes the OUTPUT, DIRTY_TREE_WRITTEN,
@@ -216,7 +217,9 @@ _codex_exit_dispatcher() {
     _emit_timing_record "$rc"
     [[ -n "$MODEL_ARGS_TMP" ]] && rm -f "$MODEL_ARGS_TMP"
     [[ -n "$CODEX_HOME_DIR" ]] && rm -rf "$CODEX_HOME_DIR"
-    _write_dirty_tree_sidecar
+    # Skip dirty-tree sidecar when sandbox is read-only: the syscall block
+    # already prevents writes, making the after-the-fact scan redundant.
+    [[ "${CODEX_SANDBOX_MODE:-}" == "read-only" ]] || _write_dirty_tree_sidecar
     codex_launcher_promote_inner_done "$OUTPUT"
     exit "$rc"
 }
@@ -297,9 +300,9 @@ fi
 # `--sandbox read-only` (replacing the prior `--full-auto`'s workspace-write)
 # so the CLI itself rejects model-issued shell writes; the instructions
 # field is the prompt-level reinforcement so the model also reasons about
-# its read-only role. The launcher's existing dirty-tree-sidecar machinery
-# (snapshot-untracked.sh untracked-files baseline + _write_dirty_tree_sidecar
-# EXIT trap) remains the after-the-fact detector.
+# its read-only role. The dirty-tree-sidecar EXIT trap is suppressed for
+# Codex because --sandbox read-only already blocks writes at the syscall
+# level, making the after-the-fact scan redundant.
 #
 # Retry-replay safety: ${OUTPUT}.prompt is consumed by collect-agent-results.sh
 # empty-output retries via `--prompt-file`. Because the static hardening

--- a/scripts/launch-review.sh
+++ b/scripts/launch-review.sh
@@ -217,9 +217,17 @@ _codex_exit_dispatcher() {
     _emit_timing_record "$rc"
     [[ -n "$MODEL_ARGS_TMP" ]] && rm -f "$MODEL_ARGS_TMP"
     [[ -n "$CODEX_HOME_DIR" ]] && rm -rf "$CODEX_HOME_DIR"
-    # Skip dirty-tree sidecar when sandbox is read-only: the syscall block
-    # already prevents writes, making the after-the-fact scan redundant.
-    [[ "${CODEX_SANDBOX_MODE:-}" == "read-only" ]] || _write_dirty_tree_sidecar
+    # When sandbox is read-only the syscall block prevents writes, so emit a
+    # static clean sidecar (maintains consumer contract) without scanning.
+    if [[ "${CODEX_SANDBOX_MODE:-}" == "read-only" ]]; then
+        if [[ -n "${DIRTY_TREE_SIDECAR:-}" && "$DIRTY_TREE_WRITTEN" == "false" ]]; then
+            printf 'STATUS=clean\nMODE=baseline\nREASON=codex-sandbox-read-only\n' \
+                > "$DIRTY_TREE_SIDECAR" 2>/dev/null || true
+            DIRTY_TREE_WRITTEN=true
+        fi
+    else
+        _write_dirty_tree_sidecar
+    fi
     codex_launcher_promote_inner_done "$OUTPUT"
     exit "$rc"
 }
@@ -300,9 +308,9 @@ fi
 # `--sandbox read-only` (replacing the prior `--full-auto`'s workspace-write)
 # so the CLI itself rejects model-issued shell writes; the instructions
 # field is the prompt-level reinforcement so the model also reasons about
-# its read-only role. The dirty-tree-sidecar EXIT trap is suppressed for
-# Codex because --sandbox read-only already blocks writes at the syscall
-# level, making the after-the-fact scan redundant.
+# its read-only role. The dirty-tree-sidecar EXIT trap still emits a sidecar
+# for Codex, but writes a static STATUS=clean record instead of running the
+# scan — --sandbox read-only enforces write isolation at the syscall level.
 #
 # Retry-replay safety: ${OUTPUT}.prompt is consumed by collect-agent-results.sh
 # empty-output retries via `--prompt-file`. Because the static hardening

--- a/scripts/test-implement-rebase-macro.sh
+++ b/scripts/test-implement-rebase-macro.sh
@@ -8,7 +8,7 @@
 #  (F) Macro header line number is BETWEEN `### Verbosity Control` and `## Step 0`.
 #  (G) Macro section body contains the keep-on-conflict rebase-push.sh invocation, the
 #      early_rebase conflict-resolution dispatch, and the non-conflict bail line.
-#  (H) Exactly 1 `rebase-push.sh --no-push --skip-if-pushed --keep-on-conflict` occurrence (only the macro M2 uses
+#  (H) Exactly 1 `rebase-push.sh --no-push --skip-if-pushed --keep-on-conflict` occurrence (only the macro M1 uses
 #      that flag combo; Step 1.m, Step 8b, and the Rebase + Re-bump Sub-procedure use `--no-push`
 #      alone). Also asserts the 7.r Apply invocation is inside the Step 7 slice and that all
 #      three `--no-push`-only call sites (Step 1.m + Step 8b + Sub-procedure) remain.
@@ -148,7 +148,7 @@ rm -f "$macro_body_tmp"
 # ---------------------------------------------------------------------------
 rebase_push_skip_count=$(grep -cF '${CLAUDE_PLUGIN_ROOT}/scripts/rebase-push.sh --no-push --skip-if-pushed --keep-on-conflict' "$SKILL_MD" || true)
 [[ "$rebase_push_skip_count" == "1" ]] \
-  || fail "(H) expected exactly 1 'rebase-push.sh --no-push --skip-if-pushed --keep-on-conflict' occurrence (macro M2 only), found $rebase_push_skip_count — residual inline rebase block may have survived the refactor"
+  || fail "(H) expected exactly 1 'rebase-push.sh --no-push --skip-if-pushed --keep-on-conflict' occurrence (macro M1 only), found $rebase_push_skip_count — residual inline rebase block may have survived the refactor"
 
 # Sanity check: all three non-macro --no-push call sites must still exist:
 #   - Step 1.m in SKILL.md (pre-Step-1 main freshness)

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -87,22 +87,20 @@ Standardizes the four post-step rebase checkpoints (Steps 1.r, 4.r, 7.r, 7a.r). 
 
 **Invocation form** (exact, one line per call site): `Apply the Rebase Checkpoint Macro with <step-prefix>=<X> and <short-name>=<Y>.`
 
-**Procedure** (M1-M4 labels avoid collision with outer Step 0-18 numbering):
+**Procedure** (M1-M3 labels avoid collision with outer Step 0-18 numbering):
 
-- **M1 — Print start line**: `🔃 <step-prefix>: <short-name> | rebase`
-
-- **M2 — Run rebase**:
+- **M1 — Run rebase**:
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/scripts/rebase-push.sh --no-push --skip-if-pushed --keep-on-conflict [--base-remote upstream --base-ref main when forked_target=true]
 ```
   Capture stdout and exit code as `rc`.
 
-- **M3 — On non-zero exit**, branch on `rc`:
-  - **Exit 1** (rebase conflict): print `🔃 <step-prefix>: <short-name> | rebase — conflict detected, invoking Conflict Resolution Procedure (caller_kind=early_rebase)`. Parse `CONFLICT_FILES=<comma-separated list>` from M2's captured stdout; `--keep-on-conflict` leaves the rebase in progress so this list is authoritative for Phase 1. (If the line is missing — defensive only — fall back to `git diff --name-only --diff-filter=U` to enumerate the in-progress rebase's unmerged paths.) **MANDATORY — READ ENTIRE FILE** before executing the Conflict Resolution Procedure: `${CLAUDE_PLUGIN_ROOT}/skills/implement/references/conflict-resolution.md`. Invoke the Conflict Resolution Procedure with `caller_kind=early_rebase` and the parsed `CONFLICT_FILES`. On success, continue to M4. On hard failure, the procedure runs `${CLAUDE_PLUGIN_ROOT}/scripts/git-rebase-abort.sh`, sets `STALL_TRACKING=true` (signals Step 18 to rename the tracking issue to `[STALLED]` — see "Title-prefix lifecycle" below), and skips to Step 18.
+- **M2 — On non-zero exit**, branch on `rc`:
+  - **Exit 1** (rebase conflict): print `🔃 <step-prefix>: <short-name> | rebase — conflict detected, invoking Conflict Resolution Procedure (caller_kind=early_rebase)`. Parse `CONFLICT_FILES=<comma-separated list>` from M1's captured stdout; `--keep-on-conflict` leaves the rebase in progress so this list is authoritative for Phase 1. (If the line is missing — defensive only — fall back to `git diff --name-only --diff-filter=U` to enumerate the in-progress rebase's unmerged paths.) **MANDATORY — READ ENTIRE FILE** before executing the Conflict Resolution Procedure: `${CLAUDE_PLUGIN_ROOT}/skills/implement/references/conflict-resolution.md`. Invoke the Conflict Resolution Procedure with `caller_kind=early_rebase` and the parsed `CONFLICT_FILES`. On success, continue to M3. On hard failure, the procedure runs `${CLAUDE_PLUGIN_ROOT}/scripts/git-rebase-abort.sh`, sets `STALL_TRACKING=true` (signals Step 18 to rename the tracking issue to `[STALLED]` — see "Title-prefix lifecycle" below), and skips to Step 18.
   - **Exit 3** (non-conflict rebase failure — fetch error, detached HEAD, etc.; `REBASE_ERROR=...` printed on stderr): print `**⚠ Rebase onto main failed (non-conflict): $REBASE_ERROR. Bailing to cleanup.**`, set `STALL_TRACKING=true`, and skip to Step 18.
   - **Other non-zero exit**: print `**⚠ Rebase onto main failed unexpectedly (exit $rc). Bailing to cleanup.**`, set `STALL_TRACKING=true`, and skip to Step 18.
 
-- **M4 — On success**, branch on stdout (check `SKIPPED_ALREADY_PUSHED` BEFORE `SKIPPED_ALREADY_FRESH` — `rebase-push.sh` exits early on already-pushed before fetch):
+- **M3 — On success**, branch on stdout (check `SKIPPED_ALREADY_PUSHED` BEFORE `SKIPPED_ALREADY_FRESH` — `rebase-push.sh` exits early on already-pushed before fetch):
   - If stdout contains `SKIPPED_ALREADY_PUSHED=true`: silently continue.
   - If stdout contains `SKIPPED_ALREADY_FRESH=true`: silently continue.
   - Otherwise, print: `✅ <step-prefix>: <short-name> | rebase status=complete elapsed=<elapsed>`
@@ -711,7 +709,7 @@ When `forked_target=true`, append `--base-remote upstream --base-ref main` to th
 
 When Step 0 ran with `continue_from_current=false`, its default preflight already fetched and rebased `main`, so this Step 1.m call should normally short-circuit with `SKIPPED_ALREADY_FRESH=true`. Keep the macro here for the `continue_from_current=true` path and for idempotent protection if Step 0's freshness work was already satisfied.
 
-On non-zero exit, print `**⚠ Failed to ensure local main is fresh. Bailing to cleanup.**`, set `STALL_TRACKING=true` (parallels Rebase Checkpoint Macro M3 and Step 12d — signals Step 18 to rename the tracking issue to `[STALLED]` when Step 0.5 Branch 4 has already created one), and skip to Step 18. On success: if stdout contains `SKIPPED_ALREADY_FRESH=true`, silently continue; otherwise print `✅ 1.m: design plan | update main status=complete outcome=rebased elapsed=<elapsed>`, where the rebase base is `upstream/main` under fork mode and `origin/main` otherwise.
+On non-zero exit, print `**⚠ Failed to ensure local main is fresh. Bailing to cleanup.**`, set `STALL_TRACKING=true` (parallels Rebase Checkpoint Macro M2 and Step 12d — signals Step 18 to rename the tracking issue to `[STALLED]` when Step 0.5 Branch 4 has already created one), and skip to Step 18. On success: if stdout contains `SKIPPED_ALREADY_FRESH=true`, silently continue; otherwise print `✅ 1.m: design plan | update main status=complete outcome=rebased elapsed=<elapsed>`, where the rebase base is `upstream/main` under fork mode and `origin/main` otherwise.
 
 ### Quick mode (`quick_mode=true`)
 
@@ -1501,7 +1499,7 @@ If `forked_target=true`: print `⏩ 8: version bump status=skip reason=forked-dr
 
 Parse `HAS_BUMP`, `COMMITS_BEFORE`, `STATUS` (`ok|missing_main_ref|git_error` per #172). If `STATUS != ok`, the pre-mode count is untrustworthy — log `**⚠ 8: version bump — pre-check STATUS=$STATUS, commit count may be unreliable. Continuing.**` to `Warnings` and proceed. Step 8 is pre-PR and permissive; last-chance enforcement is in the Rebase + Re-bump Sub-procedure step 4 invoked by Step 12 (step12 family), which hard-bails on non-`ok` STATUS from either pre- or post-check.
 
-**If `HAS_BUMP=false`**: print `**⚠ VERSION BUMP SKIPPED: No /bump-version skill found at .claude/skills/bump-version/SKILL.md. To enable automatic version bumps, create a /bump-version skill in this repo. The skill should determine the current version, classify the bump type, compute the new version, edit the version file, and commit.**`, set `HAS_BUMP=false` in postbump-state, skip `/bump-version`, and jump to the `postbump` invocation. Phase 2 skips because there is no bump commit to amend; Phase 3 still refreshes before PR creation.
+**If `HAS_BUMP=false`**: print `**⚠ VERSION BUMP SKIPPED: No /bump-version skill found at .claude/skills/bump-version/SKILL.md. To enable automatic version bumps, create a /bump-version skill in this repo.**`, set `HAS_BUMP=false` in postbump-state, skip `/bump-version`, and jump to the `postbump` invocation. Phase 2 skips because there is no bump commit to amend; Phase 3 still refreshes before PR creation.
 
 **If `HAS_BUMP=true`**:
 

--- a/skills/implement/references/conflict-resolution.md
+++ b/skills/implement/references/conflict-resolution.md
@@ -104,7 +104,7 @@ If the reviewer panel finds no issues or all findings are addressed: proceed to 
 ## Phase 4 — Continue Rebase
 
 For `caller_kind=early_rebase`, run `${CLAUDE_PLUGIN_ROOT}/scripts/rebase-push.sh --continue --no-push --keep-on-conflict` and handle exit codes:
-- **Exit 0**: Local-only rebase succeeded. Return to the Rebase Checkpoint Macro's success path (M4). Do NOT invoke the Rebase + Re-bump Sub-procedure and do NOT push.
+- **Exit 0**: Local-only rebase succeeded. Return to the Rebase Checkpoint Macro's success path (M3). Do NOT invoke the Rebase + Re-bump Sub-procedure and do NOT push.
 - **Exit 1**: A later commit in the rebase conflicted. Loop back to **Phase 1** for the new conflict (the Conflict Resolution Procedure starts again for the new set of `CONFLICT_FILES`).
 - **Exit 3**: Check the `REBASE_ERROR` output. If it indicates an empty or already-applied commit (e.g., "nothing to commit", "No changes"), run `${CLAUDE_PLUGIN_ROOT}/scripts/git-rebase-skip.sh` (if it exits non-zero, run `${CLAUDE_PLUGIN_ROOT}/scripts/git-rebase-abort.sh`, set `STALL_TRACKING=true`, and **bail out** to Step 18) and then `${CLAUDE_PLUGIN_ROOT}/scripts/rebase-push.sh --continue --no-push --keep-on-conflict` again (handle the same exit codes). Otherwise, run `${CLAUDE_PLUGIN_ROOT}/scripts/git-rebase-abort.sh`, set `STALL_TRACKING=true`, and **bail out** to Step 18.
 

--- a/skills/implement/references/conflict-resolution.md
+++ b/skills/implement/references/conflict-resolution.md
@@ -18,7 +18,7 @@ When `rebase-push.sh` exits with code 1, the rebase is paused with conflicts. Th
 
 ## Phase 1 — Conflict Classification and Resolution
 
-The caller supplies `CONFLICT_FILES` as a comma-separated list. For Step 12 family callers it is the `CONFLICT_FILES=...` line on the conflict-fallback `rebase-push.sh` invocation's stdout. For `caller_kind=early_rebase` it is the `CONFLICT_FILES=...` line on the macro M2 `rebase-push.sh --no-push --skip-if-pushed --keep-on-conflict` invocation's stdout, captured by the macro before invoking this procedure. If the caller did not capture the list (defensive only), enumerate the in-progress rebase's unmerged paths via `git diff --name-only --diff-filter=U`.
+The caller supplies `CONFLICT_FILES` as a comma-separated list. For Step 12 family callers it is the `CONFLICT_FILES=...` line on the conflict-fallback `rebase-push.sh` invocation's stdout. For `caller_kind=early_rebase` it is the `CONFLICT_FILES=...` line on the macro M1 `rebase-push.sh --no-push --skip-if-pushed --keep-on-conflict` invocation's stdout, captured by the macro before invoking this procedure. If the caller did not capture the list (defensive only), enumerate the in-progress rebase's unmerged paths via `git diff --name-only --diff-filter=U`.
 
 For each file in `CONFLICT_FILES`:
 


### PR DESCRIPTION
## Summary
- Removed M1 (unconditional start log) from the Rebase Checkpoint Macro — SKIPPED paths now silently continue, matching the existing verbosity suppression rule
- Added static `STATUS=clean` sidecar write for Codex in `_codex_exit_dispatcher` instead of the full scan — `--sandbox read-only` enforces write isolation at the syscall level
- Removed inline bump-version description from the `HAS_BUMP=false` warning in `/implement` — classification logic belongs in the bump-version SKILL.md

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- `/relevant-checks` passes (pre-commit + agent-lint)
- `scripts/test-implement-rebase-macro.sh` assertions pass (call-site registry unchanged; macro M1/M2/M3 labels consistent)
- `scripts/test-launch-review.sh` Codex dirty-tree assertions pass (static `STATUS=clean MODE=baseline` sidecar satisfies the harness)
- Manual inspection: rebase checkpoint on a clean branch produces no orphaned `🔃` log lines

</details>

Closes #1844

Generated with [Claude Code](https://claude.com/claude-code)
