### PR TITLE
feat(implement): token/timing instrumentation cleanup — remove per-step reports, gate verbose table

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "24.1.4",
+  "version": "24.1.5",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 7-reviewer specialist panel (5 Cursor specialists + 1 Codex generic + 1 Claude generic) with 2-voter adjudication (Cursor + Codex primary; Claude conditional tie-breaker on 1Y/1N); plan review runs a 4-reviewer diagonal panel (2 Cursor: Arch, Edge + 2 Codex: Innovation, Pragmatic); design sketches run a 4-agent diverge-then-converge phase in regular mode (2 Cursor + 2 Codex) or 2 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Reviewer dirty-tree changes are now automatically logged and discarded instead of prompting the operator with a restore/stash/bail `AskUserQuestion`. When a Cursor, Codex, or Claude reviewer leaves uncommitted changes in the working tree, the orchestrator logs which reviewer caused it (to `execution-issues.md` under `Warnings` in `/implement` runs, or to the transcript in standalone `/review` runs) and immediately discards the changes via scoped `git restore` / `git clean` — no stash is created and `git stash list` remains clean. This replaces the three-option recovery prompt introduced by #1437. Updated: `skills/implement/SKILL.md` (Step 5.3.b quick mode, Step 5 normal mode, `--auto` flag description), `skills/review/SKILL.md` (Step 3a, line 22), `skills/review/references/heavy-worker.md`, `docs/external-reviewers.md`, `SECURITY.md`
 
+## [24.1.5] - 2026-05-11
+
+### Changed
+
+- Remove per-step `token-report --since-last-mark --terse` calls from `/implement`; add `--summary` flag to `token-report.sh`/`timing-report.sh` for grand-total one-liner
+- Gate `/implement` Step 17 full token/timing table behind `LARCH_VERBOSE_TOKENS=true`; default chat output is now a brief summary line
+
 ## [24.1.3] - 2026-05-11
 
 ### Fixed

--- a/docs/configuration-and-permissions.md
+++ b/docs/configuration-and-permissions.md
@@ -248,6 +248,10 @@ Per-million-token cost rate (USD) used by `/research`'s Step 4 token report (`##
 
 **Scope**: Token telemetry covers Claude subagent (Agent-tool) invocations only. Claude inline (orchestrator) and external lanes (Cursor/Codex) are unmeasurable and excluded from both the totals and the cost column. The report labels itself "Claude tokens only; external lanes excluded" so operators see the coverage honestly. See [`scripts/token-tally.md`](../scripts/token-tally.md) for the helper contract.
 
+### `LARCH_VERBOSE_TOKENS`
+
+When set to `true`, `/implement` Step 17 prints the full per-step token/timing table to chat (the same output as before v25). When unset or set to any other value (the default), Step 17 prints a single grand-total summary line (`Total: claude=N tokens ...; vendor=N` / `Total: elapsed=HH:MM:SS ...`) instead. The full breakdown is always written to the tracking-issue anchor comment via `--append-token-report` in Step 18 regardless of this setting.
+
 ### `LARCH_BUMP_FILES`
 
 Colon-separated list of bump files that `scripts/drop-bump-commit.sh` Guard 4 accepts as the allowed non-changelog file set. Uses **replacement semantics**: when set, this list replaces the built-in default (`.claude-plugin/plugin.json`) — it is NOT additive. `CHANGELOG.md` is always allowed regardless of this setting (never required, always optional).

--- a/scripts/test-implement-structure.sh
+++ b/scripts/test-implement-structure.sh
@@ -194,38 +194,6 @@ fail() {
 [[ -d "$REFS_DIR" ]] || fail "skills/implement/references/ missing: $REFS_DIR"
 
 # ---------------------------------------------------------------------------
-# Token-reporting structural pin: every token mark must have a matching
-# token-step-end for the same numbered step before the next token mark.
-# ---------------------------------------------------------------------------
-awk '
-  function marker_step(line, prefix,    rest) {
-    rest = line
-    sub(".*# " prefix " ", "", rest)
-    sub(" —.*", "", rest)
-    return rest
-  }
-  /# token-mark Step / {
-    if (current != "" && ended == 0) {
-      printf("FAIL: token mark for %s has no matching token-step-end before next mark\n", current) > "/dev/stderr"
-      exit 1
-    }
-    current = marker_step($0, "token-mark")
-    ended = 0
-    next
-  }
-  /# token-step-end Step / {
-    step = marker_step($0, "token-step-end")
-    if (current != "" && step == current) ended = 1
-  }
-  END {
-    if (current != "" && ended == 0) {
-      printf("FAIL: token mark for %s has no matching token-step-end before EOF\n", current) > "/dev/stderr"
-      exit 1
-    }
-  }
-' "$SKILL_MD"
-
-# ---------------------------------------------------------------------------
 # (1) Exactly one `^## Load-Bearing Invariants$` heading.
 # ---------------------------------------------------------------------------
 count=$(grep -c '^## Load-Bearing Invariants$' "$SKILL_MD" || true)

--- a/scripts/timing-report.md
+++ b/scripts/timing-report.md
@@ -6,6 +6,9 @@ Subcommands:
 
 - `--since-last-mark --terse` prints one line for the latest mark whose skill matches `${LARCH_TIMING_SKILL:-implement}`:
   `Step name: elapsed=<HH:MM:SS> vendor-tasks=<N> (codex=<n>, cursor=<m>, gemini=<k>)`.
+- `--summary` prints one grand-total line spanning all marks from the first to the present:
+  `Total: elapsed=<HH:MM:SS> vendor-tasks=<N> (codex=<n>, cursor=<m>, gemini=<k>)`.
+  Used as the default brief output in Step 17 when `LARCH_VERBOSE_TOKENS` is unset.
 - `--full --markdown [--output FILE]` renders the full markdown report.
 - `--append-timing-section FILE` renders the full report and idempotently replaces the block bracketed by `<!-- timing-report-begin -->` / `<!-- timing-report-end -->`.
 

--- a/scripts/timing-report.md
+++ b/scripts/timing-report.md
@@ -14,6 +14,8 @@ Subcommands:
 
 Full reports include the latest workflow path (`HARD`, `SIMPLE`, or `unknown`), per-step durations, and vendor task averages by `(vendor, task_kind)`. Failed rows (`status != complete` or `exit_code != 0`) are excluded from averages and summarized below the table.
 
+**Quick-mode review rows**: `/implement` quick-mode review rounds no longer emit per-round `LARCH_TIMING_SKILL=review` timing marks; quick-mode review cycles therefore no longer appear as nested `↳ review` rows under implement steps in the `--full` verbose table. The `--summary` and `--since-last-mark --terse` outputs are unaffected.
+
 Duration rules:
 
 - Implement marks are top-level rows when present.

--- a/scripts/timing-report.sh
+++ b/scripts/timing-report.sh
@@ -158,6 +158,21 @@ render_report() {
           printf "%s: elapsed=%s vendor-tasks=%d (codex=%d, cursor=%d, gemini=%d)\n", last_terse_step, hms(now - last_terse_ts), total, codex, cursor, gemini
           exit 0
         }
+        if (mode == "summary") {
+          if (mark_count == 0) {
+            print "Timing report unavailable: no step marks in ledger" > "/dev/stderr"
+            exit 0
+          }
+          total = codex = cursor = gemini = 0
+          for (i = 1; i <= vendor_count; i++) {
+            total++
+            if (vendor_name[i] == "codex") codex++
+            else if (vendor_name[i] == "cursor") cursor++
+            else if (vendor_name[i] == "gemini") gemini++
+          }
+          printf "Total: elapsed=%s vendor-tasks=%d (codex=%d, cursor=%d, gemini=%d)\n", hms(now - mark_ts[1]), total, codex, cursor, gemini
+          exit 0
+        }
         if (mark_count == 0) {
           print "Timing report unavailable: no step marks in ledger"
           exit 0
@@ -283,6 +298,7 @@ while [[ $# -gt 0 ]]; do
     case "$1" in
         --since-last-mark) MODE="terse"; shift ;;
         --terse) shift ;;
+        --summary) MODE="summary"; shift ;;
         --full) MODE="full"; shift ;;
         --markdown) shift ;;
         --output) OUTPUT="${2:?--output requires a value}"; shift 2 ;;

--- a/scripts/timing-report.sh
+++ b/scripts/timing-report.sh
@@ -165,10 +165,12 @@ render_report() {
           }
           total = codex = cursor = gemini = 0
           for (i = 1; i <= vendor_count; i++) {
-            total++
-            if (vendor_name[i] == "codex") codex++
-            else if (vendor_name[i] == "cursor") cursor++
-            else if (vendor_name[i] == "gemini") gemini++
+            if (vendor_end[i] >= mark_ts[1]) {
+              total++
+              if (vendor_name[i] == "codex") codex++
+              else if (vendor_name[i] == "cursor") cursor++
+              else if (vendor_name[i] == "gemini") gemini++
+            }
           }
           printf "Total: elapsed=%s vendor-tasks=%d (codex=%d, cursor=%d, gemini=%d)\n", hms(now - mark_ts[1]), total, codex, cursor, gemini
           exit 0

--- a/scripts/token-report.md
+++ b/scripts/token-report.md
@@ -10,6 +10,9 @@
 
 - `--since-last-mark --terse` prints one line for the most recent ledger mark:
   `Step N — <name>: claude=<total> tokens (input=A cache_read=B cache_create=C output=D); vendor=<sum> (codex=X, cursor=Y)`.
+- `--summary` prints one grand-total line spanning all marks from the first to the present:
+  `Total: claude=<total> tokens (input=A cache_read=B cache_create=C output=D); vendor=<sum>`.
+  Used as the default brief output in Step 17 when `LARCH_VERBOSE_TOKENS` is unset.
 - `--full --markdown [--output FILE]` renders a markdown table grouped by step with indented skill rows and vendor rows.
 - `--append-token-report FILE` renders the full table and idempotently replaces or appends a sentinel-bracketed block in `FILE`. Production `/implement` calls write this to `$IMPLEMENT_TMPDIR/anchor-sections/token-report.md`:
 

--- a/scripts/token-report.sh
+++ b/scripts/token-report.sh
@@ -339,6 +339,15 @@ render_jq() {
       | (map(select(.type == "assistant" and .message.usage? and .timestamp?) | usage_row(.; $marks)) | map(select(.ts != null))) as $claude
       | if ($marks | length) == 0 then error("no step marks in ledger")
         elif $mode == "terse" then terse_line($claude; $vendor; $marks[-1])
+        elif $mode == "summary" then
+          (step_slice($claude; $vendor; $marks[0].ts; null)) as $s
+          | (totals($s.claude)) as $ct
+          | (sumfield($s.vendor; "total")) as $vt
+          | (vendor_breakdown($s.vendor)) as $vb
+          | ("Total: claude=" + fmt($ct.total) + " tokens (input=" + fmt($ct.input)
+            + " cache_read=" + fmt($ct.cache_read) + " cache_create=" + fmt($ct.cache_create)
+            + " output=" + fmt($ct.output) + "); vendor=" + fmt($vt)
+            + (if $vt > 0 then " (" + ($vb | map(.vendor + "=" + (.total|tostring)) | join(", ")) + ")" else "" end))
         else markdown($marks; $claude; $vendor)
         end
     ' "${TRANSCRIPT_FILES[@]}" 2>"$jq_stderr_dest" || {
@@ -456,6 +465,7 @@ while [[ $# -gt 0 ]]; do
     case "$1" in
         --since-last-mark) MODE="terse"; shift ;;
         --terse) shift ;;
+        --summary) MODE="summary"; shift ;;
         --full) MODE="full"; shift ;;
         --markdown) shift ;;
         --output) OUTPUT="${2:?--output requires a value}"; shift 2 ;;

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -239,17 +239,6 @@ LARCH_CLAUDE_SOURCE_FILE=$("${CLAUDE_PLUGIN_ROOT}/scripts/read-session-env-key.s
 export LARCH_TOKEN_SESSION_ID LARCH_CLAUDE_SOURCE_FILE
 ```
 
-The immediate Step 0 report block uses this same pattern:
-
-```bash
-LARCH_TOKEN_SESSION_ID=$("${CLAUDE_PLUGIN_ROOT}/scripts/read-session-env-key.sh" --file "$IMPLEMENT_TMPDIR/session-env.sh" --key LARCH_TOKEN_SESSION_ID --default "")
-LARCH_CLAUDE_SOURCE_FILE=$("${CLAUDE_PLUGIN_ROOT}/scripts/read-session-env-key.sh" --file "$IMPLEMENT_TMPDIR/session-env.sh" --key LARCH_CLAUDE_SOURCE_FILE --default "")
-export LARCH_TOKEN_SESSION_ID LARCH_CLAUDE_SOURCE_FILE
-"${CLAUDE_PLUGIN_ROOT}/scripts/token-report.sh" --since-last-mark --terse || true
-"${CLAUDE_PLUGIN_ROOT}/scripts/timing-report.sh" --since-last-mark --terse || true
-# token-step-end Step 0
-```
-
 ### Cross-Skill Health Propagation
 
 ## Phantom Untracked Probe
@@ -666,15 +655,6 @@ Use `snapshot-untracked.sh`, not a raw pipeline, so a `git ls-files` failure
 removes the output file instead of leaving an empty readable baseline that
 would misclassify pre-existing untracked files as phantoms on later probes.
 
-```bash
-LARCH_TOKEN_SESSION_ID=$("${CLAUDE_PLUGIN_ROOT}/scripts/read-session-env-key.sh" --file "$IMPLEMENT_TMPDIR/session-env.sh" --key LARCH_TOKEN_SESSION_ID --default "")
-LARCH_CLAUDE_SOURCE_FILE=$("${CLAUDE_PLUGIN_ROOT}/scripts/read-session-env-key.sh" --file "$IMPLEMENT_TMPDIR/session-env.sh" --key LARCH_CLAUDE_SOURCE_FILE --default "")
-export LARCH_TOKEN_SESSION_ID LARCH_CLAUDE_SOURCE_FILE
-"${CLAUDE_PLUGIN_ROOT}/scripts/token-report.sh" --since-last-mark --terse || true
-"${CLAUDE_PLUGIN_ROOT}/scripts/timing-report.sh" --since-last-mark --terse || true
-# token-step-end Step 0.5
-```
-
 ## Step 1 — Ensure Design Plan Exists
 
 ```bash
@@ -890,15 +870,6 @@ Runs unconditionally in both modes UNLESS `design_only=true` (per the design-onl
 
 Apply the Rebase Checkpoint Macro with `<step-prefix>=1.r` and `<short-name>=design plan`.
 
-```bash
-LARCH_TOKEN_SESSION_ID=$("${CLAUDE_PLUGIN_ROOT}/scripts/read-session-env-key.sh" --file "$IMPLEMENT_TMPDIR/session-env.sh" --key LARCH_TOKEN_SESSION_ID --default "")
-LARCH_CLAUDE_SOURCE_FILE=$("${CLAUDE_PLUGIN_ROOT}/scripts/read-session-env-key.sh" --file "$IMPLEMENT_TMPDIR/session-env.sh" --key LARCH_CLAUDE_SOURCE_FILE --default "")
-export LARCH_TOKEN_SESSION_ID LARCH_CLAUDE_SOURCE_FILE
-"${CLAUDE_PLUGIN_ROOT}/scripts/token-report.sh" --since-last-mark --terse || true
-"${CLAUDE_PLUGIN_ROOT}/scripts/timing-report.sh" --since-last-mark --terse || true
-# token-step-end Step 1
-```
-
 ## Step 2 — Implement the Feature
 
 ```bash
@@ -1037,15 +1008,6 @@ If `deferred=true` or `repo_unavailable=true`: local-only append; Step 11's post
 
 Material answers that change scope or approach also log here (same `Q/A` category).
 
-```bash
-LARCH_TOKEN_SESSION_ID=$("${CLAUDE_PLUGIN_ROOT}/scripts/read-session-env-key.sh" --file "$IMPLEMENT_TMPDIR/session-env.sh" --key LARCH_TOKEN_SESSION_ID --default "")
-LARCH_CLAUDE_SOURCE_FILE=$("${CLAUDE_PLUGIN_ROOT}/scripts/read-session-env-key.sh" --file "$IMPLEMENT_TMPDIR/session-env.sh" --key LARCH_CLAUDE_SOURCE_FILE --default "")
-export LARCH_TOKEN_SESSION_ID LARCH_CLAUDE_SOURCE_FILE
-"${CLAUDE_PLUGIN_ROOT}/scripts/token-report.sh" --since-last-mark --terse || true
-"${CLAUDE_PLUGIN_ROOT}/scripts/timing-report.sh" --since-last-mark --terse || true
-# token-step-end Step 2
-```
-
 > **Continue to Step 3 IMMEDIATELY.** Implementation is not the end of the run — checks, commit, review, bump, PR, CI, and merge still must run.
 
 ## Step 3 — Relevant Checks (first pass)
@@ -1067,15 +1029,6 @@ export LARCH_TOKEN_SESSION_ID LARCH_CLAUDE_SOURCE_FILE
 ```
 
 After the helper returns clean (or after failure triage has made it clean), close Step 3 telemetry:
-
-```bash
-LARCH_TOKEN_SESSION_ID=$("${CLAUDE_PLUGIN_ROOT}/scripts/read-session-env-key.sh" --file "$IMPLEMENT_TMPDIR/session-env.sh" --key LARCH_TOKEN_SESSION_ID --default "")
-LARCH_CLAUDE_SOURCE_FILE=$("${CLAUDE_PLUGIN_ROOT}/scripts/read-session-env-key.sh" --file "$IMPLEMENT_TMPDIR/session-env.sh" --key LARCH_CLAUDE_SOURCE_FILE --default "")
-export LARCH_TOKEN_SESSION_ID LARCH_CLAUDE_SOURCE_FILE
-"${CLAUDE_PLUGIN_ROOT}/scripts/token-report.sh" --since-last-mark --terse || true
-"${CLAUDE_PLUGIN_ROOT}/scripts/timing-report.sh" --since-last-mark --terse || true
-# token-step-end Step 3
-```
 
 ## Step 4 — First Commit (implementation)
 
@@ -1105,15 +1058,6 @@ Apply the Rebase Checkpoint Macro with `<step-prefix>=4.r` and `<short-name>=com
 
 After the macro returns successfully or silently skips, run the Phantom
 Untracked Probe with `--step 4.r-post-rebase`.
-
-```bash
-LARCH_TOKEN_SESSION_ID=$("${CLAUDE_PLUGIN_ROOT}/scripts/read-session-env-key.sh" --file "$IMPLEMENT_TMPDIR/session-env.sh" --key LARCH_TOKEN_SESSION_ID --default "")
-LARCH_CLAUDE_SOURCE_FILE=$("${CLAUDE_PLUGIN_ROOT}/scripts/read-session-env-key.sh" --file "$IMPLEMENT_TMPDIR/session-env.sh" --key LARCH_CLAUDE_SOURCE_FILE --default "")
-export LARCH_TOKEN_SESSION_ID LARCH_CLAUDE_SOURCE_FILE
-"${CLAUDE_PLUGIN_ROOT}/scripts/token-report.sh" --since-last-mark --terse || true
-"${CLAUDE_PLUGIN_ROOT}/scripts/timing-report.sh" --since-last-mark --terse || true
-# token-step-end Step 4
-```
 
 > **Continue to Step 5 IMMEDIATELY.** The implementation commit is not the end of the run — code review, checks (2), commit, code flow diagram, bump, and PR still must run.
 
@@ -1149,11 +1093,7 @@ Skip `/review`. Review loop up to **7 rounds** of review + fix, with an early-ex
 
 Track `round_num` from 1. Also track `pre_fix_sha=""` (HEAD SHA captured in Step 5.7 before each round's fix edits; empty before round 1) and `prev_had_security_correctness=false` (set in Step 5.5 when any accepted finding has focus area `security` or `correctness`; reset to `false` at the start of each round's iteration so the override reflects only the immediately preceding round's findings). For each round:
 
-At the top of each round iteration, reset `prev_had_security_correctness=false`, then record a review-skill timing mark:
-
-```bash
-LARCH_TIMING_SKILL=review "${CLAUDE_PLUGIN_ROOT}/scripts/timing-ledger.sh" mark "review Step 5 quick round ${round_num} — review cycle" || true
-```
+At the top of each round iteration, reset `prev_had_security_correctness=false`.
 
 **5.1 — Gather context**:
 
@@ -1323,15 +1263,6 @@ If `ISSUE_NUMBER` is set, refresh the anchor immediately after compose (same mec
 
 Known limitation: accepted code-review findings are not currently captured in this fragment. The `/review` skill and the quick-mode 5.5 loop both accept findings without writing a byte-preserved `accepted-code-review-findings.md` artifact. The helper silently emits no records for the `accepted code-review` phase / outcome pair. See `scripts/compose-review-findings.md` "Known limitations" for follow-up wiring.
 
-```bash
-LARCH_TOKEN_SESSION_ID=$("${CLAUDE_PLUGIN_ROOT}/scripts/read-session-env-key.sh" --file "$IMPLEMENT_TMPDIR/session-env.sh" --key LARCH_TOKEN_SESSION_ID --default "")
-LARCH_CLAUDE_SOURCE_FILE=$("${CLAUDE_PLUGIN_ROOT}/scripts/read-session-env-key.sh" --file "$IMPLEMENT_TMPDIR/session-env.sh" --key LARCH_CLAUDE_SOURCE_FILE --default "")
-export LARCH_TOKEN_SESSION_ID LARCH_CLAUDE_SOURCE_FILE
-"${CLAUDE_PLUGIN_ROOT}/scripts/token-report.sh" --since-last-mark --terse || true
-"${CLAUDE_PLUGIN_ROOT}/scripts/timing-report.sh" --since-last-mark --terse || true
-# token-step-end Step 5
-```
-
 ## Step 6 — Relevant Checks (second pass)
 
 ```bash
@@ -1364,15 +1295,6 @@ Else (`FILES_CHANGED=true`):
 
 After the helper returns clean (or after failure triage has made it clean), close Step 6 telemetry:
 
-```bash
-LARCH_TOKEN_SESSION_ID=$("${CLAUDE_PLUGIN_ROOT}/scripts/read-session-env-key.sh" --file "$IMPLEMENT_TMPDIR/session-env.sh" --key LARCH_TOKEN_SESSION_ID --default "")
-LARCH_CLAUDE_SOURCE_FILE=$("${CLAUDE_PLUGIN_ROOT}/scripts/read-session-env-key.sh" --file "$IMPLEMENT_TMPDIR/session-env.sh" --key LARCH_CLAUDE_SOURCE_FILE --default "")
-export LARCH_TOKEN_SESSION_ID LARCH_CLAUDE_SOURCE_FILE
-"${CLAUDE_PLUGIN_ROOT}/scripts/token-report.sh" --since-last-mark --terse || true
-"${CLAUDE_PLUGIN_ROOT}/scripts/timing-report.sh" --since-last-mark --terse || true
-# token-step-end Step 6
-```
-
 ## Step 7 — Second Commit (review fixes)
 
 ```bash
@@ -1403,15 +1325,6 @@ After the macro returns successfully or silently skips, run the Phantom
 Untracked Probe with `--step 7.r-post-rebase`. This probe is inside the
 `FILES_CHANGED=true` guard with the Step 7.r rebase; if Steps 6-7 were skipped,
 do not run it.
-
-```bash
-LARCH_TOKEN_SESSION_ID=$("${CLAUDE_PLUGIN_ROOT}/scripts/read-session-env-key.sh" --file "$IMPLEMENT_TMPDIR/session-env.sh" --key LARCH_TOKEN_SESSION_ID --default "")
-LARCH_CLAUDE_SOURCE_FILE=$("${CLAUDE_PLUGIN_ROOT}/scripts/read-session-env-key.sh" --file "$IMPLEMENT_TMPDIR/session-env.sh" --key LARCH_CLAUDE_SOURCE_FILE --default "")
-export LARCH_TOKEN_SESSION_ID LARCH_CLAUDE_SOURCE_FILE
-"${CLAUDE_PLUGIN_ROOT}/scripts/token-report.sh" --since-last-mark --terse || true
-"${CLAUDE_PLUGIN_ROOT}/scripts/timing-report.sh" --since-last-mark --terse || true
-# token-step-end Step 7
-```
 
 ## Step 7a — Code Flow Diagram
 
@@ -1470,15 +1383,6 @@ Apply the Rebase Checkpoint Macro with `<step-prefix>=7a.r` and `<short-name>=co
 
 After the macro returns successfully or silently skips, run the Phantom
 Untracked Probe with `--step 7a.r-post-rebase`.
-
-```bash
-LARCH_TOKEN_SESSION_ID=$("${CLAUDE_PLUGIN_ROOT}/scripts/read-session-env-key.sh" --file "$IMPLEMENT_TMPDIR/session-env.sh" --key LARCH_TOKEN_SESSION_ID --default "")
-LARCH_CLAUDE_SOURCE_FILE=$("${CLAUDE_PLUGIN_ROOT}/scripts/read-session-env-key.sh" --file "$IMPLEMENT_TMPDIR/session-env.sh" --key LARCH_CLAUDE_SOURCE_FILE --default "")
-export LARCH_TOKEN_SESSION_ID LARCH_CLAUDE_SOURCE_FILE
-"${CLAUDE_PLUGIN_ROOT}/scripts/token-report.sh" --since-last-mark --terse || true
-"${CLAUDE_PLUGIN_ROOT}/scripts/timing-report.sh" --since-last-mark --terse || true
-# token-step-end Step 7a
-```
 
 > **Continue to Step 8 IMMEDIATELY.** The code flow diagram is not the end of the run — version bump, PR creation, CI monitoring, and merge still must run.
 
@@ -1564,15 +1468,6 @@ Parse the tail records and use the last `STATUS=` line. Branch:
 - `STATUS=rebase-failed`, `STATUS=push-failed`, `STATUS=remote-check-failed`, `STATUS=changelog-failed`, `STATUS=branch-mismatch`, or `STATUS=postbump-state-corrupt`: set `STALL_TRACKING=true`, set `STALL_STEP=8b`, and skip to Step 18.
 
 `postbump` emits Step 8a and Step 8b token/timing marks and reports internally. The prompt-side Step 8 mark above remains prompt-side because it predates `/bump-version`.
-
-```bash
-LARCH_TOKEN_SESSION_ID=$("${CLAUDE_PLUGIN_ROOT}/scripts/read-session-env-key.sh" --file "$IMPLEMENT_TMPDIR/session-env.sh" --key LARCH_TOKEN_SESSION_ID --default "")
-LARCH_CLAUDE_SOURCE_FILE=$("${CLAUDE_PLUGIN_ROOT}/scripts/read-session-env-key.sh" --file "$IMPLEMENT_TMPDIR/session-env.sh" --key LARCH_CLAUDE_SOURCE_FILE --default "")
-export LARCH_TOKEN_SESSION_ID LARCH_CLAUDE_SOURCE_FILE
-"${CLAUDE_PLUGIN_ROOT}/scripts/token-report.sh" --since-last-mark --terse || true
-"${CLAUDE_PLUGIN_ROOT}/scripts/timing-report.sh" --since-last-mark --terse || true
-# token-step-end Step 8
-```
 
 ## Step 8a — CHANGELOG Update
 
@@ -1668,15 +1563,6 @@ Print the PR URL. Save `PR_NUMBER`, `PR_URL`, `PR_TITLE` for Steps 10–15.
 
 > **Continue to Step 10.** PR creation is NOT the end of the run — IMMEDIATELY proceed to Step 10 (CI monitor). Do NOT end the turn, summarize, or write a handoff message after printing the PR URL.
 
-```bash
-LARCH_TOKEN_SESSION_ID=$("${CLAUDE_PLUGIN_ROOT}/scripts/read-session-env-key.sh" --file "$IMPLEMENT_TMPDIR/session-env.sh" --key LARCH_TOKEN_SESSION_ID --default "")
-LARCH_CLAUDE_SOURCE_FILE=$("${CLAUDE_PLUGIN_ROOT}/scripts/read-session-env-key.sh" --file "$IMPLEMENT_TMPDIR/session-env.sh" --key LARCH_CLAUDE_SOURCE_FILE --default "")
-export LARCH_TOKEN_SESSION_ID LARCH_CLAUDE_SOURCE_FILE
-"${CLAUDE_PLUGIN_ROOT}/scripts/token-report.sh" --since-last-mark --terse || true
-"${CLAUDE_PLUGIN_ROOT}/scripts/timing-report.sh" --since-last-mark --terse || true
-# token-step-end Step 9
-```
-
 ## Step 10 — CI Monitor (initial wait for green)
 
 ```bash
@@ -1731,15 +1617,6 @@ Log CI failures, transient retries, bail events to `CI Issues`. After any non-te
 
 > **Continue to Step 11.** Do NOT end the turn after CI monitoring completes.
 
-```bash
-LARCH_TOKEN_SESSION_ID=$("${CLAUDE_PLUGIN_ROOT}/scripts/read-session-env-key.sh" --file "$IMPLEMENT_TMPDIR/session-env.sh" --key LARCH_TOKEN_SESSION_ID --default "")
-LARCH_CLAUDE_SOURCE_FILE=$("${CLAUDE_PLUGIN_ROOT}/scripts/read-session-env-key.sh" --file "$IMPLEMENT_TMPDIR/session-env.sh" --key LARCH_CLAUDE_SOURCE_FILE --default "")
-export LARCH_TOKEN_SESSION_ID LARCH_CLAUDE_SOURCE_FILE
-"${CLAUDE_PLUGIN_ROOT}/scripts/token-report.sh" --since-last-mark --terse || true
-"${CLAUDE_PLUGIN_ROOT}/scripts/timing-report.sh" --since-last-mark --terse || true
-# token-step-end Step 10
-```
-
 ## Step 11 — Post-execution Anchor `execution-issues` Refresh
 
 ```bash
@@ -1787,15 +1664,6 @@ If `design_only=true` AND `no_issues=true`: print `⏭️ 11: execution-issues s
 Print: `✅ 11: execution-issues status=complete outcome=anchor-refreshed elapsed=<elapsed>` on success.
 
 > **Continue to Step 12.** Do NOT end the turn after anchor refresh.
-
-```bash
-LARCH_TOKEN_SESSION_ID=$("${CLAUDE_PLUGIN_ROOT}/scripts/read-session-env-key.sh" --file "$IMPLEMENT_TMPDIR/session-env.sh" --key LARCH_TOKEN_SESSION_ID --default "")
-LARCH_CLAUDE_SOURCE_FILE=$("${CLAUDE_PLUGIN_ROOT}/scripts/read-session-env-key.sh" --file "$IMPLEMENT_TMPDIR/session-env.sh" --key LARCH_CLAUDE_SOURCE_FILE --default "")
-export LARCH_TOKEN_SESSION_ID LARCH_CLAUDE_SOURCE_FILE
-"${CLAUDE_PLUGIN_ROOT}/scripts/token-report.sh" --since-last-mark --terse || true
-"${CLAUDE_PLUGIN_ROOT}/scripts/timing-report.sh" --since-last-mark --terse || true
-# token-step-end Step 11
-```
 
 ## Step 12 — CI + Rebase + Merge Loop
 
@@ -1906,15 +1774,6 @@ Use `FAILED_RUN_ID` from `ci-status.sh`. If empty, identify manually via `${CLAU
 - Set `FINAL_BAIL_REASON` = the `BAIL_REASON` value from the `ci-wait.sh` output that triggered the bail (or the caller-synthesized reason if the bail came from the Rebase + Re-bump Sub-procedure, a conflict, or fix-attempt exhaustion, or a mechanical `merge-pr.sh` bail result — in which case `FINAL_BAIL_REASON` is the literal `ERROR` string from the script, including `"branch protection denied merge; --no-admin-fallback set"` and `"origin/main HEAD already bumped to <X.Y.Z>; rebase and re-bump"`). Leave `BAIL_NEEDS_USER_INPUT` alone if it was already set by the Conflict Resolution Procedure Phase 2 under `auto_mode=true`; otherwise it stays `false`.
 - Set `STALL_TRACKING=true` — signals Step 18 to rename the tracking issue's title from `[IN PROGRESS]` to `[STALLED]` (see Step 18 "Title-prefix lifecycle terminal transition").
 
-```bash
-LARCH_TOKEN_SESSION_ID=$("${CLAUDE_PLUGIN_ROOT}/scripts/read-session-env-key.sh" --file "$IMPLEMENT_TMPDIR/session-env.sh" --key LARCH_TOKEN_SESSION_ID --default "")
-LARCH_CLAUDE_SOURCE_FILE=$("${CLAUDE_PLUGIN_ROOT}/scripts/read-session-env-key.sh" --file "$IMPLEMENT_TMPDIR/session-env.sh" --key LARCH_CLAUDE_SOURCE_FILE --default "")
-export LARCH_TOKEN_SESSION_ID LARCH_CLAUDE_SOURCE_FILE
-"${CLAUDE_PLUGIN_ROOT}/scripts/token-report.sh" --since-last-mark --terse || true
-"${CLAUDE_PLUGIN_ROOT}/scripts/timing-report.sh" --since-last-mark --terse || true
-# token-step-end Step 12
-```
-
 > **Continue to Step 14 IMMEDIATELY.** Step 12d bail is not terminal — after writing Step 13.5 finalizer state, run local cleanup, rejected findings, final report, and cleanup.
 
 ## Step 13.5 — Finalizer State
@@ -2024,15 +1883,6 @@ Relay the script's Step 14 / Step 15 breadcrumbs verbatim. Tail records document
 
 > **Continue to Step 15.** Do NOT end the turn after local cleanup.
 
-```bash
-LARCH_TOKEN_SESSION_ID=$("${CLAUDE_PLUGIN_ROOT}/scripts/read-session-env-key.sh" --file "$IMPLEMENT_TMPDIR/session-env.sh" --key LARCH_TOKEN_SESSION_ID --default "")
-LARCH_CLAUDE_SOURCE_FILE=$("${CLAUDE_PLUGIN_ROOT}/scripts/read-session-env-key.sh" --file "$IMPLEMENT_TMPDIR/session-env.sh" --key LARCH_CLAUDE_SOURCE_FILE --default "")
-export LARCH_TOKEN_SESSION_ID LARCH_CLAUDE_SOURCE_FILE
-"${CLAUDE_PLUGIN_ROOT}/scripts/token-report.sh" --since-last-mark --terse || true
-"${CLAUDE_PLUGIN_ROOT}/scripts/timing-report.sh" --since-last-mark --terse || true
-# token-step-end Step 14
-```
-
 ## Step 15 — Verify Main
 
 ```bash
@@ -2049,15 +1899,6 @@ Handled by Step 14's `implement-finalize.sh postmerge` invocation. Step 15 runs 
 
 > **Continue to Step 16.** Do NOT end the turn after verifying main.
 
-```bash
-LARCH_TOKEN_SESSION_ID=$("${CLAUDE_PLUGIN_ROOT}/scripts/read-session-env-key.sh" --file "$IMPLEMENT_TMPDIR/session-env.sh" --key LARCH_TOKEN_SESSION_ID --default "")
-LARCH_CLAUDE_SOURCE_FILE=$("${CLAUDE_PLUGIN_ROOT}/scripts/read-session-env-key.sh" --file "$IMPLEMENT_TMPDIR/session-env.sh" --key LARCH_CLAUDE_SOURCE_FILE --default "")
-export LARCH_TOKEN_SESSION_ID LARCH_CLAUDE_SOURCE_FILE
-"${CLAUDE_PLUGIN_ROOT}/scripts/token-report.sh" --since-last-mark --terse || true
-"${CLAUDE_PLUGIN_ROOT}/scripts/timing-report.sh" --since-last-mark --terse || true
-# token-step-end Step 15
-```
-
 ## Step 16 — Rejected Code Review Findings Report
 
 ```bash
@@ -2073,15 +1914,6 @@ export LARCH_TOKEN_SESSION_ID LARCH_CLAUDE_SOURCE_FILE
 Report unimplemented code review suggestions without reprinting the full findings inline. Check `$IMPLEMENT_TMPDIR/rejected-findings.md`. If non-empty, print `✅ 16: rejected findings status=complete outcome=saved-to-anchor elapsed=<elapsed>`; the full content was already posted via the `code-review-tally` anchor fragment. Otherwise print `✅ 16: rejected findings status=complete outcome=all-implemented elapsed=<elapsed>`.
 
 > **Continue to Step 17.** Do NOT end the turn after printing rejected findings.
-
-```bash
-LARCH_TOKEN_SESSION_ID=$("${CLAUDE_PLUGIN_ROOT}/scripts/read-session-env-key.sh" --file "$IMPLEMENT_TMPDIR/session-env.sh" --key LARCH_TOKEN_SESSION_ID --default "")
-LARCH_CLAUDE_SOURCE_FILE=$("${CLAUDE_PLUGIN_ROOT}/scripts/read-session-env-key.sh" --file "$IMPLEMENT_TMPDIR/session-env.sh" --key LARCH_CLAUDE_SOURCE_FILE --default "")
-export LARCH_TOKEN_SESSION_ID LARCH_CLAUDE_SOURCE_FILE
-"${CLAUDE_PLUGIN_ROOT}/scripts/token-report.sh" --since-last-mark --terse || true
-"${CLAUDE_PLUGIN_ROOT}/scripts/timing-report.sh" --since-last-mark --terse || true
-# token-step-end Step 16
-```
 
 ## Step 17 — Final Report
 
@@ -2109,26 +1941,22 @@ If `quick_mode=true` and `DESIGN_ONLY_DONE` is not true: print `✅ 17: final re
 
 If `quick_mode=false` and `DESIGN_ONLY_DONE` is not true: print a summary noting plan review findings were reported by `/design` (via the tracking issue anchor) and code review findings by `/review` (visible above). If both phases reported all suggestions implemented, print `✅ 17: final report status=complete outcome=all-suggestions-implemented elapsed=<elapsed>`.
 
-Print the full token table for immediate visibility:
+Print a token summary to chat. When `LARCH_VERBOSE_TOKENS=true`, print the full per-step table; otherwise print a single grand-total line. The full breakdown is always written to the artifact via `--append-token-report` in Step 18.
 
 ```bash
 LARCH_TOKEN_SESSION_ID=$("${CLAUDE_PLUGIN_ROOT}/scripts/read-session-env-key.sh" --file "$IMPLEMENT_TMPDIR/session-env.sh" --key LARCH_TOKEN_SESSION_ID --default "")
 LARCH_CLAUDE_SOURCE_FILE=$("${CLAUDE_PLUGIN_ROOT}/scripts/read-session-env-key.sh" --file "$IMPLEMENT_TMPDIR/session-env.sh" --key LARCH_CLAUDE_SOURCE_FILE --default "")
 export LARCH_TOKEN_SESSION_ID LARCH_CLAUDE_SOURCE_FILE
-"${CLAUDE_PLUGIN_ROOT}/scripts/token-report.sh" --full --markdown || true
-"${CLAUDE_PLUGIN_ROOT}/scripts/timing-report.sh" --full --markdown || true
+if [ "${LARCH_VERBOSE_TOKENS:-false}" = "true" ]; then
+  "${CLAUDE_PLUGIN_ROOT}/scripts/token-report.sh" --full --markdown || true
+  "${CLAUDE_PLUGIN_ROOT}/scripts/timing-report.sh" --full --markdown || true
+else
+  "${CLAUDE_PLUGIN_ROOT}/scripts/token-report.sh" --summary || true
+  "${CLAUDE_PLUGIN_ROOT}/scripts/timing-report.sh" --summary || true
+fi
 ```
 
 > **Continue to Step 18.** Do NOT end the turn after the final report.
-
-```bash
-LARCH_TOKEN_SESSION_ID=$("${CLAUDE_PLUGIN_ROOT}/scripts/read-session-env-key.sh" --file "$IMPLEMENT_TMPDIR/session-env.sh" --key LARCH_TOKEN_SESSION_ID --default "")
-LARCH_CLAUDE_SOURCE_FILE=$("${CLAUDE_PLUGIN_ROOT}/scripts/read-session-env-key.sh" --file "$IMPLEMENT_TMPDIR/session-env.sh" --key LARCH_CLAUDE_SOURCE_FILE --default "")
-export LARCH_TOKEN_SESSION_ID LARCH_CLAUDE_SOURCE_FILE
-"${CLAUDE_PLUGIN_ROOT}/scripts/token-report.sh" --since-last-mark --terse || true
-"${CLAUDE_PLUGIN_ROOT}/scripts/timing-report.sh" --since-last-mark --terse || true
-# token-step-end Step 17
-```
 
 ## Step 18 — Cleanup and Final Warnings
 

--- a/skills/shared/subskill-invocation.md
+++ b/skills/shared/subskill-invocation.md
@@ -146,7 +146,7 @@ Both presence and absence are enforced by `${CLAUDE_PLUGIN_ROOT}/scripts/test-an
 <a id="step-boundary"></a>
 ## Step-boundary anti-halt
 
-**Scope**: this rule covers numbered-step boundaries where the parent skill has just completed a step or sub-step and the next action is another numbered step, not a child `Skill` return. It is especially important after `# token-step-end Step N` boundaries, skip breadcrumbs, status footers, and terminal-sounding helper output where there is no immediately adjacent Skill-tool micro-reminder to re-anchor continuation.
+**Scope**: this rule covers numbered-step boundaries where the parent skill has just completed a step or sub-step and the next action is another numbered step, not a child `Skill` return. It is especially important after skip breadcrumbs, status footers, and terminal-sounding helper output where there is no immediately adjacent Skill-tool micro-reminder to re-anchor continuation.
 
 **Canonical form**: use a two-line blockquote at the specific boundary:
 


### PR DESCRIPTION
## Summary

- Remove all 18 per-step `--since-last-mark --terse` step-end blocks from `skills/implement/SKILL.md` (Steps 0–16); Step 18's already-silenced `/dev/null` calls are unchanged
- Add `--summary` flag to `scripts/token-report.sh` and `scripts/timing-report.sh` that prints a single grand-total line (`Total: claude=N tokens ...; vendor=N` / `Total: elapsed=HH:MM:SS ...`) spanning all marks
- Gate `/implement` Step 17's full token/timing table behind `LARCH_VERBOSE_TOKENS=true`; default chat output is now the new `--summary` one-liner
- Remove the per-round `LARCH_TIMING_SKILL=review` timing mark from the quick-mode review loop (sub-phase mark consolidation)
- Remove now-stale `# token-step-end` structural pin from `scripts/test-implement-structure.sh`

## Architecture Diagram

Architecture diagram not available.

## Code Flow Diagram

(Code Flow Diagram skipped — quick mode)

## Test plan

- `make lint` (pre-commit + agent-lint) passes
- `scripts/test-implement-structure.sh` passes with structural pin removed
- `scripts/token-report.sh --summary` emits `Total: claude=...` one-liner
- `scripts/timing-report.sh --summary` emits `Total: elapsed=...` one-liner
- `LARCH_VERBOSE_TOKENS=true` produces the same per-step table as before
- Step 18 `/dev/null` terse calls and `--append-token-report` artifact writes are unchanged

Closes #1840

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)
