### PR TITLE
test: add --summary flag coverage to token-report and timing-report harnesses (v24.1.7)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "24.2.0",
+  "version": "24.2.1",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 7-reviewer specialist panel (5 Cursor specialists + 1 Codex generic + 1 Claude generic) with 2-voter adjudication (Cursor + Codex primary; Claude conditional tie-breaker on 1Y/1N); plan review runs a 4-reviewer diagonal panel (2 Cursor: Arch, Edge + 2 Codex: Innovation, Pragmatic); design sketches run a 4-agent diverge-then-converge phase in regular mode (2 Cursor + 2 Codex) or 2 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Reviewer dirty-tree changes are now automatically logged and discarded instead of prompting the operator with a restore/stash/bail `AskUserQuestion`. When a Cursor, Codex, or Claude reviewer leaves uncommitted changes in the working tree, the orchestrator logs which reviewer caused it (to `execution-issues.md` under `Warnings` in `/implement` runs, or to the transcript in standalone `/review` runs) and immediately discards the changes via scoped `git restore` / `git clean` — no stash is created and `git stash list` remains clean. This replaces the three-option recovery prompt introduced by #1437. Updated: `skills/implement/SKILL.md` (Step 5.3.b quick mode, Step 5 normal mode, `--auto` flag description), `skills/review/SKILL.md` (Step 3a, line 22), `skills/review/references/heavy-worker.md`, `docs/external-reviewers.md`, `SECURITY.md`
 
+## [24.2.1] - 2026-05-11
+
+### Added
+
+- Add `--summary` flag test coverage to `test-token-report.sh` and `test-timing-report.sh` harnesses (three cases each: normal output, zero-vendor run, no-marks unavailable warning)
+
 ## [24.2.0] - 2026-05-11
 
 ### Added

--- a/scripts/test-timing-report.sh
+++ b/scripts/test-timing-report.sh
@@ -99,4 +99,43 @@ cp "$LEDGER" "$NONTMP_LEDGER"
 IMPLEMENT_TMPDIR="$NONTMP_DIR" LARCH_TEST_TIMING_NOW=310 "$REPO_ROOT/scripts/timing-report.sh" --ledger "$NONTMP_LEDGER" --full --markdown > "$TMP_BASE/nontmp.out"
 grep -Fq '**Workflow path**: HARD' "$TMP_BASE/nontmp.out"
 
+# --- --summary mode ---
+
+# Case 1: normal summary — Total: prefix + correct elapsed + vendor-tasks parenthetical.
+# Fixture: LEDGER (2 codex + 1 cursor tasks, all end_s >= mark_ts[1]=0), now=310.
+# elapsed = 310 - 0 = 310 s = 00:05:10; codex=2, cursor=1 → vendor-tasks=3.
+SUMMARY_OUT=$(LARCH_TEST_TIMING_NOW=310 "$REPO_ROOT/scripts/timing-report.sh" --ledger "$LEDGER" --summary)
+expected_summary="Total: elapsed=00:05:10 vendor-tasks=3 (codex=2, cursor=1, gemini=0)"
+if [[ "$SUMMARY_OUT" == "$expected_summary" ]]; then
+    echo "PASS: summary normal"
+else
+    echo "FAIL: summary normal: expected '$expected_summary' got '$SUMMARY_OUT'" >&2
+    exit 1
+fi
+
+# Case 2: zero-vendor summary — parenthetical shows all zeros.
+# Build a mark-only ledger (no vendor rows); now=150 gives elapsed=00:02:30.
+SUMMARY_NO_VENDOR_LEDGER="$TMP_BASE/summary-no-vendor.tsv"
+cat > "$SUMMARY_NO_VENDOR_LEDGER" <<'EOF'
+v1	mark	0	implement	Step 1 — design plan	-	-	-	-	-	-	-	-
+v1	mark	100	implement	Step 2 — implementation	-	-	-	-	-	-	-	-
+EOF
+SUMMARY_NO_VENDOR_OUT=$(LARCH_TEST_TIMING_NOW=150 "$REPO_ROOT/scripts/timing-report.sh" --ledger "$SUMMARY_NO_VENDOR_LEDGER" --summary)
+expected_summary_no_vendor="Total: elapsed=00:02:30 vendor-tasks=0 (codex=0, cursor=0, gemini=0)"
+if [[ "$SUMMARY_NO_VENDOR_OUT" == "$expected_summary_no_vendor" ]]; then
+    echo "PASS: summary zero-vendor"
+else
+    echo "FAIL: summary zero-vendor: expected '$expected_summary_no_vendor' got '$SUMMARY_NO_VENDOR_OUT'" >&2
+    exit 1
+fi
+
+# Case 3: no-marks ledger — prints unavailable warning to stderr and exits 0.
+NO_MARKS_SUMMARY_ERR=$("$REPO_ROOT/scripts/timing-report.sh" --ledger "$EMPTY" --summary 2>&1)
+if [[ "$NO_MARKS_SUMMARY_ERR" == "Timing report unavailable: no step marks in ledger" ]]; then
+    echo "PASS: summary no-marks unavailable"
+else
+    echo "FAIL: summary no-marks unavailable: got '$NO_MARKS_SUMMARY_ERR'" >&2
+    exit 1
+fi
+
 echo "PASS: test-timing-report.sh"

--- a/scripts/test-token-report.sh
+++ b/scripts/test-token-report.sh
@@ -490,6 +490,35 @@ else
     pass
 fi
 
+# --- --summary mode ---
+
+# Case 1: normal summary — Total: prefix + correct claude grand total + vendor parenthetical.
+# Fixture: LEDGER (codex=100, cursor=10) + TRANSCRIPT (claude input/cache_read/cache_create/output = 11/22/33/44 grand totals).
+summary=$("$SCRIPT" --ledger "$LEDGER" --transcript "$TRANSCRIPT" --summary)
+contains "summary Total prefix"          "Total:"                            "$summary"
+contains "summary claude grand total"    "claude=110 tokens"                 "$summary"
+contains "summary vendor parenthetical"  "(codex=100, cursor=10)"            "$summary"
+
+# Case 2: zero-vendor run — vendor=0 with no parenthetical.
+# Build a mark-only ledger so the vendor total is 0; the existing TRANSCRIPT
+# still contributes Claude usage, confirming the claude portion renders normally.
+SUMMARY_NO_VENDOR_LEDGER="$TMP/summary-no-vendor-ledger.jsonl"
+cat > "$SUMMARY_NO_VENDOR_LEDGER" <<'JSONL'
+{"type":"mark","step":"Step 1 - design","ts":"2026-05-06T00:00:00Z"}
+JSONL
+summary_no_vendor=$("$SCRIPT" --ledger "$SUMMARY_NO_VENDOR_LEDGER" --transcript "$TRANSCRIPT" --summary)
+contains "summary zero-vendor Total prefix" "Total:"    "$summary_no_vendor"
+contains "summary zero-vendor vendor=0"     "vendor=0"  "$summary_no_vendor"
+case "$summary_no_vendor" in
+    *"vendor=0 ("*) fail "zero-vendor summary must not include parenthetical: $summary_no_vendor" ;;
+    *) pass ;;
+esac
+
+# Case 3: no-marks ledger — prints unavailable warning and exits 0.
+# Reuse LEDGER_NO_MARKS (vendor-only rows, no marks).
+no_marks_summary=$("$SCRIPT" --ledger "$LEDGER_NO_MARKS" --transcript "$TRANSCRIPT" --summary 2>&1)
+contains "summary no-marks unavailable" "Token report unavailable:" "$no_marks_summary"
+
 total=$((PASS + FAIL))
 if (( FAIL == 0 )); then
     echo "PASS: test-token-report.sh — $PASS/$total assertions"


### PR DESCRIPTION
## Summary

- Add 3 `--summary` flag test cases to `scripts/test-token-report.sh`: normal output (checks `Total:` prefix, claude grand total, vendor parenthetical), zero-vendor run (verifies no parenthetical when `vendor=0`), and no-marks ledger (verifies unavailable warning)
- Add 3 `--summary` flag test cases to `scripts/test-timing-report.sh`: normal output (checks elapsed + vendor-tasks parenthetical), zero-vendor run (verifies `vendor-tasks=0` with zero counts), and no-marks ledger (verifies unavailable warning to stderr)

## Architecture Diagram

Architecture diagram not available.

## Code Flow Diagram

(Code Flow Diagram skipped — quick mode)

## Test plan

- `bash scripts/test-token-report.sh` → 127/127 assertions pass
- `bash scripts/test-timing-report.sh` → all pass

Closes #1851

---
🤖 Generated with [Claude Code](https://claude.ai/code)
