### PR TITLE
feat(report-tokens): fix plot_dir bug, add --no-issue/--no-plot/--plot-from, auto-post report issue (v26.0.1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "26.0.0",
+  "version": "26.0.1",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 7-reviewer specialist panel (5 Cursor specialists + 1 Codex generic + 1 Claude generic) with 2-voter adjudication (Cursor + Codex primary; Claude conditional tie-breaker on 1Y/1N); plan review runs a 4-reviewer diagonal panel (2 Cursor: Arch, Edge + 2 Codex: Innovation, Pragmatic); design sketches run a 4-agent diverge-then-converge phase in regular mode (2 Cursor + 2 Codex) or 2 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [26.0.1] - 2026-05-11
+
+### Added
+
+- /report-tokens: auto-post [Analysis Report] GitHub issue after each analysis run
+- /report-tokens: --no-issue flag to skip analysis report issue creation
+- /report-tokens: --no-plot flag to skip plot generation
+- /report-tokens: --plot-from <N> flag to re-plot from a prior report issue
+
+### Fixed
+
+- Fix plot_dir NameError in /report-tokens matplotlib subprocess (sys.argv[2] passthrough)
+
 ## [26.0.0] - 2026-05-11
 
 ### Changed

--- a/skills/report-tokens/SKILL.md
+++ b/skills/report-tokens/SKILL.md
@@ -6,17 +6,29 @@ allowed-tools: Bash, Read
 
 # Report Tokens
 
-Analyze token-report data across closed GitHub issues in the current larch repository. The script finds issues whose comments contain the token-report sentinel, parses the latest structured report on each issue, estimates costs, writes a JSON cache, generates SIMPLE and HARD cost-over-time plots, opens the plots when supported, and prints the written analysis.
+Analyze token-report data across closed GitHub issues in the current larch repository. The script finds issues whose comments contain the token-report sentinel, parses the latest structured report on each issue, estimates costs, generates SIMPLE and HARD cost-over-time plots, prints the analysis, and posts a GitHub `[Analysis Report]` issue.
+
+## Flags
+
+Pass any of these after the skill name (e.g. `/report-tokens --no-issue`):
+
+- `--no-issue` — skip posting the `[Analysis Report]` GitHub issue.
+- `--no-plot` — skip plot generation; text analysis is still printed.
+- `--plot-from <N>` — re-plot from a prior `[Analysis Report]` issue number (skips the GitHub scan).
 
 ## Step 1 - Run analysis
 
+Parse any `--no-issue`, `--no-plot`, or `--plot-from <N>` flags from the skill invocation arguments. Then:
+
 ```bash
-"${CLAUDE_PLUGIN_ROOT}/skills/report-tokens/scripts/run-analysis.sh"
+"${CLAUDE_PLUGIN_ROOT}/skills/report-tokens/scripts/run-analysis.sh" [FLAGS]
 ```
+
+where `[FLAGS]` are the validated flags from the invocation (empty if none were provided).
 
 Script contract: `${CLAUDE_PLUGIN_ROOT}/skills/report-tokens/scripts/run-analysis.md`.
 
-Verify the script exited successfully and stdout includes `## Report Tokens Analysis` plus `Cache JSON:`. If it exits non-zero, stop and surface the error; do not invent partial cost results.
+Verify the script exited successfully. On a normal run, stdout includes `## Report Tokens Analysis` plus `Cache JSON:`. On a `--plot-from` run, stdout includes `Plots written to:` or `No plots generated.`. If it exits non-zero, stop and surface the error; do not invent partial cost results.
 
 ## NEVER
 

--- a/skills/report-tokens/scripts/run-analysis.md
+++ b/skills/report-tokens/scripts/run-analysis.md
@@ -4,7 +4,7 @@
 
 ## Purpose
 
-Fetch closed GitHub issues in the current larch repository whose comments contain `token-report-begin`, parse the latest structured token report on each issue, estimate per-issue dollar costs for Claude/Codex/Cursor, classify issues by `**Workflow path**`, generate SIMPLE and HARD cost-over-time PNG plots, and print a written analysis.
+Fetch closed GitHub issues in the current larch repository whose comments contain `token-report-begin`, parse the latest structured token report on each issue, estimate per-issue dollar costs for Claude/Codex/Cursor, classify issues by `**Workflow path**`, generate SIMPLE and HARD cost-over-time PNG plots, print a written analysis, and optionally post a GitHub `[Analysis Report]` issue with the results and raw per-issue data.
 
 ## Primary caller
 
@@ -12,7 +12,11 @@ Fetch closed GitHub issues in the current larch repository whose comments contai
 
 ## Inputs
 
-The script takes no positional arguments. It resolves the repository from `LARCH_REPORT_TOKENS_REPO` or `gh repo view --json nameWithOwner`.
+The script accepts optional flags:
+
+- `--no-issue`: skip posting the `[Analysis Report]` GitHub issue after analysis.
+- `--no-plot`: skip plot generation; textual analysis is still printed.
+- `--plot-from <N>`: re-plot from a prior `[Analysis Report]` issue (skips the GitHub scan and analysis; fetches the issue body, extracts the raw per-issue JSON block, and generates plots).
 
 Optional environment variables:
 
@@ -51,7 +55,9 @@ Stdout contains progress lines while fetching and then a markdown analysis with:
 - cache-read dominance
 - cost-reduction suggestions
 
-Generated plots are written to `tempfile.gettempdir()` as `larch-report-tokens-simple.png` and `larch-report-tokens-hard.png`. On macOS, the script attempts to open them with `open` unless `LARCH_REPORT_TOKENS_NO_OPEN=1` is set. Plotting runs in a child Python process so missing or crashing `matplotlib` skips plot generation without losing the textual analysis.
+After the textual analysis, the script posts a GitHub issue titled `[Analysis Report] Token costs as of <YYYY-MM-DD HH:MM UTC>` unless `--no-issue` is passed. The issue body contains the full analysis text plus a fenced JSON block with raw per-issue data (`number`, `workflow`, `closed_at`, `cost`) for re-plotting via `--plot-from`.
+
+Generated plots are written to a temporary directory as `larch-report-tokens-simple.png` and `larch-report-tokens-hard.png`. On macOS, the script attempts to open them with `open` unless `LARCH_REPORT_TOKENS_NO_OPEN=1` is set. Plotting runs in a child Python process so missing or crashing `matplotlib` skips plot generation without losing the textual analysis. Pass `--no-plot` to skip plot generation entirely.
 
 ## Cost model
 

--- a/skills/report-tokens/scripts/run-analysis.sh
+++ b/skills/report-tokens/scripts/run-analysis.sh
@@ -5,7 +5,12 @@ set -euo pipefail
 
 usage() {
     cat <<'EOF' >&2
-Usage: run-analysis.sh
+Usage: run-analysis.sh [--no-issue] [--no-plot] [--plot-from <issue-number>]
+
+Flags:
+  --no-issue               Skip posting the analysis report GitHub issue.
+  --no-plot                Skip plot generation (text analysis still printed).
+  --plot-from <N>          Re-plot from a prior [Analysis Report] issue body (skips scan).
 
 Environment overrides:
   LARCH_REPORT_TOKENS_REPO=<owner/repo>   GitHub repository to scan; defaults to gh repo view.
@@ -27,10 +32,21 @@ Rate env names:
 EOF
 }
 
-if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
-    usage
-    exit 0
-fi
+NO_ISSUE=
+NO_PLOT=
+PLOT_FROM=
+
+while [[ $# -gt 0 ]]; do
+    case "${1:-}" in
+        --help|-h) usage; exit 0 ;;
+        --no-issue) NO_ISSUE=1; shift ;;
+        --no-plot)  NO_PLOT=1;  shift ;;
+        --plot-from)
+            [[ -n "${2:-}" ]] || { echo "ERROR: --plot-from requires an issue number" >&2; exit 1; }
+            PLOT_FROM="$2"; shift 2 ;;
+        *) echo "ERROR: unknown argument: $1" >&2; usage; exit 1 ;;
+    esac
+done
 
 need_cmd() {
     command -v "$1" >/dev/null 2>&1 || {
@@ -57,6 +73,10 @@ if [[ -z "$REPO" || "$REPO" != */* ]]; then
     exit 1
 fi
 
+export LARCH_REPORT_TOKENS_REPO_FULL="$REPO"
+export LARCH_REPORT_TOKENS_NO_ISSUE="${NO_ISSUE:-}"
+export LARCH_REPORT_TOKENS_NO_PLOT="${NO_PLOT:-}"
+
 LIMIT="${LARCH_REPORT_TOKENS_LIMIT:-}"
 if [[ -n "$LIMIT" && ! "$LIMIT" =~ ^[0-9]+$ ]]; then
     echo "ERROR: LARCH_REPORT_TOKENS_LIMIT must be a non-negative integer" >&2
@@ -71,38 +91,42 @@ CACHE_TMP="$TMPROOT/issues-cache.json.tmp"
 CACHE_JSON="$TMPROOT/issues-cache.json"
 ANALYZER="$TMPROOT/analyze-token-reports.py"
 
-echo "Scanning $REPO for closed issues with token-report-begin comments..."
+if [[ -z "$PLOT_FROM" ]]; then
+    echo "Scanning $REPO for closed issues with token-report-begin comments..."
 
-SEARCH_QUERY="repo:${REPO} is:issue is:closed token-report-begin in:comments"
-gh api --paginate -X GET search/issues \
-    -f "q=$SEARCH_QUERY" \
-    -f per_page=100 \
-    --jq '.items[] | {number, closed_at, title, html_url}' > "$SEARCH_JSONL"
+    SEARCH_QUERY="repo:${REPO} is:issue is:closed token-report-begin in:comments"
+    gh api --paginate -X GET search/issues \
+        -f "q=$SEARCH_QUERY" \
+        -f per_page=100 \
+        --jq '.items[] | {number, closed_at, title, html_url}' > "$SEARCH_JSONL"
 
-if [[ -n "$LIMIT" && "$LIMIT" != "0" ]]; then
-    head -n "$LIMIT" "$SEARCH_JSONL" > "$SEARCH_JSONL.limited"
-    mv "$SEARCH_JSONL.limited" "$SEARCH_JSONL"
+    if [[ -n "$LIMIT" && "$LIMIT" != "0" ]]; then
+        head -n "$LIMIT" "$SEARCH_JSONL" > "$SEARCH_JSONL.limited"
+        mv "$SEARCH_JSONL.limited" "$SEARCH_JSONL"
+    fi
+
+    : > "$ISSUES_JSONL"
+    while IFS= read -r item; do
+        [[ -n "$item" ]] || continue
+        number="$(printf '%s\n' "$item" | jq -r '.number')"
+        [[ "$number" =~ ^[0-9]+$ ]] || continue
+        echo "Fetching issue #$number..."
+        gh issue view "$number" \
+            --repo "$REPO" \
+            --comments \
+            --json number,title,url,closedAt,body,comments \
+            | jq -c . >> "$ISSUES_JSONL"
+    done < "$SEARCH_JSONL"
+
+    jq -s . "$ISSUES_JSONL" > "$CACHE_TMP"
+    mv "$CACHE_TMP" "$CACHE_JSON"
 fi
-
-: > "$ISSUES_JSONL"
-while IFS= read -r item; do
-    [[ -n "$item" ]] || continue
-    number="$(printf '%s\n' "$item" | jq -r '.number')"
-    [[ "$number" =~ ^[0-9]+$ ]] || continue
-    echo "Fetching issue #$number..."
-    gh issue view "$number" \
-        --repo "$REPO" \
-        --comments \
-        --json number,title,url,closedAt,body,comments \
-        | jq -c . >> "$ISSUES_JSONL"
-done < "$SEARCH_JSONL"
-
-jq -s . "$ISSUES_JSONL" > "$CACHE_TMP"
-mv "$CACHE_TMP" "$CACHE_JSON"
 
 cat > "$ANALYZER" <<'PY'
 #!/usr/bin/env python3
+import contextlib
 import datetime as dt
+import io
 import json
 import os
 import re
@@ -382,6 +406,8 @@ def analyze(cache_path):
 
 def plot(records):
     out_paths = []
+    if os.environ.get("LARCH_REPORT_TOKENS_NO_PLOT") in {"1", "true", "TRUE", "yes", "YES"}:
+        return out_paths
     if os.environ.get("LARCH_REPORT_TOKENS_NO_OPEN") in {"1", "true", "TRUE", "yes", "YES"}:
         should_open = False
     else:
@@ -413,7 +439,6 @@ import datetime as dt
 import json
 import os
 import sys
-import tempfile
 
 import matplotlib
 matplotlib.use("Agg")
@@ -423,6 +448,7 @@ import matplotlib.pyplot as plt
 with open(sys.argv[1], "r", encoding="utf-8") as fh:
     rows = json.load(fh)
 
+plot_dir = sys.argv[2]
 paths = []
 for workflow in ("SIMPLE", "HARD"):
     selected = [r for r in rows if r["workflow"] == workflow]
@@ -456,7 +482,7 @@ print(json.dumps(paths))
     env.setdefault("MPLCONFIGDIR", os.path.join(plot_dir, "mpl"))
     os.makedirs(env["MPLCONFIGDIR"], exist_ok=True)
     result = subprocess.run(
-        [sys.executable, script_path, input_path],
+        [sys.executable, script_path, input_path, plot_dir],
         check=False,
         env=env,
         stdout=subprocess.PIPE,
@@ -593,13 +619,95 @@ def print_analysis(cache_path, records, skipped, plot_paths):
     print("- When cache-read volume dominates, prioritize trimming repeated static context and large unchanged markdown blocks before reducing output verbosity.")
 
 
+def load_raw_records(body_file):
+    with open(body_file, encoding="utf-8") as fh:
+        body = fh.read()
+    match = re.search(r"```(?:json)?\s*\n(\[.*?\])\s*\n```", body, re.DOTALL)
+    if not match:
+        print("ERROR: could not find raw per-issue data block in issue body", file=sys.stderr)
+        return None
+    try:
+        raw = json.loads(match.group(1))
+    except json.JSONDecodeError as exc:
+        print(f"ERROR: failed to parse raw data: {exc}", file=sys.stderr)
+        return None
+    records = []
+    for item in raw:
+        records.append({
+            "number": item.get("number"),
+            "workflow": item.get("workflow", "unknown"),
+            "closed_at": parse_date(item.get("closed_at")),
+            "cost": float(item.get("cost", 0)),
+            "title": "",
+            "url": "",
+            "totals": {},
+            "phase_rows": [],
+        })
+    return records
+
+
+def create_report_issue(records, analysis_text):
+    raw_rows = [
+        {
+            "number": r["number"],
+            "workflow": r["workflow"],
+            "closed_at": r["closed_at"].isoformat() if r["closed_at"] else None,
+            "cost": r["cost"],
+        }
+        for r in records
+    ]
+    now = dt.datetime.utcnow().strftime("%Y-%m-%d %H:%M UTC")
+    title = f"[Analysis Report] Token costs as of {now}"
+    body = (
+        analysis_text
+        + "\n\n## Raw per-issue data\n\n```json\n"
+        + json.dumps(raw_rows, indent=2)
+        + "\n```\n"
+    )
+    repo = os.environ.get("LARCH_REPORT_TOKENS_REPO_FULL", "")
+    args = ["gh", "issue", "create", "--title", title, "--body", body]
+    if repo:
+        args += ["--repo", repo]
+    result = subprocess.run(args, check=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    if result.returncode == 0:
+        print(f"\nAnalysis report issue created: {result.stdout.strip()}")
+    else:
+        print(f"\nWarning: failed to create analysis report issue: {result.stderr.strip()}", file=sys.stderr)
+
+
 def main():
+    if len(sys.argv) >= 2 and sys.argv[1] == "--plot-from":
+        if len(sys.argv) != 3:
+            print("usage: analyze-token-reports.py --plot-from <issue-body-file>", file=sys.stderr)
+            return 2
+        records = load_raw_records(sys.argv[2])
+        if records is None:
+            return 1
+        plot_paths = plot(records)
+        if plot_paths:
+            print("Plots written to:")
+            for p in plot_paths:
+                print(f"  {p}")
+        else:
+            print("No plots generated.")
+        return 0
+
     if len(sys.argv) != 2:
         print("usage: analyze-token-reports.py <cache-json>", file=sys.stderr)
         return 2
+
     records, skipped = analyze(sys.argv[1])
     plot_paths = plot(records)
-    print_analysis(sys.argv[1], records, skipped, plot_paths)
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        print_analysis(sys.argv[1], records, skipped, plot_paths)
+    analysis_text = buf.getvalue()
+    sys.stdout.write(analysis_text)
+
+    if not os.environ.get("LARCH_REPORT_TOKENS_NO_ISSUE") in {"1", "true", "TRUE", "yes", "YES"}:
+        create_report_issue(records, analysis_text)
+
     return 0
 
 
@@ -608,4 +716,13 @@ if __name__ == "__main__":
 PY
 
 chmod +x "$ANALYZER"
+
+if [[ -n "$PLOT_FROM" ]]; then
+    echo "Fetching analysis report issue #$PLOT_FROM..."
+    ISSUE_BODY_FILE="$TMPROOT/plot-from-body.txt"
+    gh issue view "$PLOT_FROM" --repo "$REPO" --json body --jq '.body' > "$ISSUE_BODY_FILE"
+    python3 "$ANALYZER" --plot-from "$ISSUE_BODY_FILE"
+    exit $?
+fi
+
 python3 "$ANALYZER" "$CACHE_JSON"

--- a/skills/report-tokens/scripts/run-analysis.sh
+++ b/skills/report-tokens/scripts/run-analysis.sh
@@ -622,12 +622,18 @@ def print_analysis(cache_path, records, skipped, plot_paths):
 def load_raw_records(body_file):
     with open(body_file, encoding="utf-8") as fh:
         body = fh.read()
-    match = re.search(r"```(?:json)?\s*\n(\[.*?\])\s*\n```", body, re.DOTALL)
-    if not match:
+    # Anchor on the "## Raw per-issue data" heading to avoid matching earlier code fences
+    section_match = re.search(r"## Raw per-issue data\s*\n", body)
+    if not section_match:
+        print("ERROR: could not find '## Raw per-issue data' section in issue body", file=sys.stderr)
+        return None
+    tail = body[section_match.end():]
+    fence_match = re.search(r"```(?:json)?\s*\n(.*?)\n```", tail, re.DOTALL)
+    if not fence_match:
         print("ERROR: could not find raw per-issue data block in issue body", file=sys.stderr)
         return None
     try:
-        raw = json.loads(match.group(1))
+        raw = json.loads(fence_match.group(1))
     except json.JSONDecodeError as exc:
         print(f"ERROR: failed to parse raw data: {exc}", file=sys.stderr)
         return None
@@ -637,7 +643,7 @@ def load_raw_records(body_file):
             "number": item.get("number"),
             "workflow": item.get("workflow", "unknown"),
             "closed_at": parse_date(item.get("closed_at")),
-            "cost": float(item.get("cost", 0)),
+            "cost": float(item.get("cost") or 0),
             "title": "",
             "url": "",
             "totals": {},


### PR DESCRIPTION
## Summary

- Fix `plot_dir` NameError in `/report-tokens` matplotlib subprocess (`sys.argv[2]` passthrough so the child process can write PNGs to the correct temp directory)
- Auto-post a `[Analysis Report]` GitHub issue after each analysis run (body: full textual analysis + raw per-issue JSON for re-plotting); skip with `--no-issue`
- Add `--no-plot` flag to skip plot generation entirely (text analysis still printed)
- Add `--plot-from <N>` flag to re-plot from a prior `[Analysis Report]` issue without re-scanning 170+ issues

## Architecture Diagram

Architecture diagram not available.

## Code Flow Diagram

```mermaid
flowchart TD
    A[run-analysis.sh start] --> B{parse flags}
    B -->|--no-issue / --no-plot / --plot-from| C[resolve REPO via gh]
    C --> D{PLOT_FROM set?}
    D -->|yes| E[gh issue view PLOT_FROM\nwrite body to tmpfile]
    D -->|no| F[scan GitHub issues\nfetch each issue JSON\njq -s to cache JSON]
    F --> G[write ANALYZER Python to tmpfile]
    E --> G
    G --> H{--plot-from mode?}
    H -->|yes| I[load_raw_records:\nfind section heading\nextract JSON fence\nparse records]
    H -->|no| J[analyze cache JSON:\nparse token reports\ncompute costs per issue]
    I --> K[plot records via subprocess]
    J --> K
    K --> O{--plot-from mode?}
    O -->|yes| P[print plot paths and exit]
    O -->|no| Q[redirect_stdout to StringIO\nprint_analysis\nwrite to stdout]
    Q --> R{NO_ISSUE set?}
    R -->|yes| S[exit 0]
    R -->|no| T[create_report_issue via gh issue create]
    T --> S
```

## Test plan

- `/relevant-checks` (pre-commit on changed files + agent-lint): passes
- Manual: `run-analysis.sh --no-issue --no-plot` skips both side effects
- Manual: `run-analysis.sh --plot-from <prior-report-issue-N>` re-plots without scanning

Closes #1864

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
