### PR TITLE
fix(implement/report-tokens): 9a.1 duplicate breadcrumb + matplotlib stderr masking (v26.0.3)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "26.0.2",
+  "version": "26.0.3",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 7-reviewer specialist panel (5 Cursor specialists + 1 Codex generic + 1 Claude generic) with 2-voter adjudication (Cursor + Codex primary; Claude conditional tie-breaker on 1Y/1N); plan review runs a 4-reviewer diagonal panel (2 Cursor: Arch, Edge + 2 Codex: Innovation, Pragmatic); design sketches run a 4-agent diverge-then-converge phase in regular mode (2 Cursor + 2 Codex) or 2 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [26.0.3] - 2026-05-11
+
+### Fixed
+
+- fix duplicate step 9a.1 breadcrumb in /implement output (add explicit refresh-anchor.sh fence)
+- /report-tokens now surfaces full matplotlib subprocess errors via stderr tail instead of masking them behind the font-cache banner
+
 ## [26.0.2] - 2026-05-11
 
 ### Fixed

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -1505,7 +1505,13 @@ export LARCH_TOKEN_SESSION_ID LARCH_CLAUDE_SOURCE_FILE
 "${CLAUDE_PLUGIN_ROOT}/scripts/timing-report.sh" --append-timing-section "$IMPLEMENT_TMPDIR/anchor-sections/timing-report.md" || true
 ```
 
-After fragments are written, assemble the anchor body and upsert (see Step 0.5 "Anchor-section accumulation"). Assembly order follows the sourced `SECTION_MARKERS` array; see `scripts/anchor-section-markers.sh` for the definitive sequence.
+Assemble the anchor body and upsert (see Step 0.5 "Anchor-section accumulation" and `scripts/refresh-anchor.md`):
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/scripts/refresh-anchor.sh --sections-dir "$IMPLEMENT_TMPDIR/anchor-sections" --issue "$ISSUE_NUMBER" --anchor-id "$ANCHOR_COMMENT_ID" --output "$IMPLEMENT_TMPDIR/anchor-assembled.md"
+```
+
+On `FAILED=true`, log to `Warnings` (`Step 9a.1 — anchor refresh failed: $ERROR`) and proceed.
 
 Print: `✅ 9a.1: OOS issues status=complete created=<ISSUES_CREATED> deduplicated=<ISSUES_DEDUPLICATED> elapsed=<elapsed>` (or the appropriate early-exit breadcrumb).
 

--- a/skills/report-tokens/scripts/run-analysis.sh
+++ b/skills/report-tokens/scripts/run-analysis.sh
@@ -490,9 +490,13 @@ print(json.dumps(paths))
         text=True,
     )
     if result.returncode != 0:
-        first_line = (result.stderr or "").strip().splitlines()
-        detail = f": {first_line[0]}" if first_line else ""
-        print(f"Plot generation skipped: matplotlib subprocess exited {result.returncode}{detail}")
+        stderr_text = (result.stderr or "").strip()
+        if stderr_text:
+            tail = stderr_text[-2000:]
+            print(f"Plot generation skipped: matplotlib subprocess exited {result.returncode}:")
+            print(tail)
+        else:
+            print(f"Plot generation skipped: matplotlib subprocess exited {result.returncode} with no stderr")
         return out_paths
     try:
         out_paths = json.loads(result.stdout)


### PR DESCRIPTION
## Summary
- Added explicit `refresh-anchor.sh` Bash code fence to `/implement` SKILL.md step 9a.1 anchor assembly section, preventing the orchestrator from grouping the anchor call and breadcrumb echo into one Bash call and producing duplicate output
- Fixed `/report-tokens` matplotlib subprocess error handler to surface the tail of stderr (capped at 2KB) instead of only the first line, which was masked by the font-cache banner on cold starts

<details><summary>Architecture Diagram</summary>

Architecture diagram not available.

</details>

<details><summary>Code Flow Diagram</summary>

Code flow diagram not available.

</details>

<details><summary>Test plan</summary>

- Run `/relevant-checks` — pre-commit (markdownlint, shellcheck, etc.) + agent-lint
- Verify SKILL.md step 9a.1 now has an explicit `refresh-anchor.sh` code fence matching step 11's structure
- Verify run-analysis.sh error handler uses stderr tail; no regression in the JSON parse / open paths below

</details>

Closes #1870

Generated with [Claude Code](https://claude.com/claude-code)
