### PR TITLE
fix(implement): capture Codex stdout+stderr in review sidecar; export IMPLEMENT_TMPDIR (v26.0.5)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "26.0.4",
+  "version": "26.0.5",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 7-reviewer specialist panel (5 Cursor specialists + 1 Codex generic + 1 Claude generic) with 2-voter adjudication (Cursor + Codex primary; Claude conditional tie-breaker on 1Y/1N); plan review runs a 4-reviewer diagonal panel (2 Cursor: Arch, Edge + 2 Codex: Innovation, Pragmatic); design sketches run a 4-agent diverge-then-converge phase in regular mode (2 Cursor + 2 Codex) or 2 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [26.0.5] - 2026-05-11
+
+### Fixed
+
+- fix(implement): capture Codex stdout+stderr in review sidecar so "tokens used" lines land in the token ledger; export IMPLEMENT_TMPDIR for reliable session-id propagation to reviewer subprocesses
+
 ## [26.0.4] - 2026-05-11
 
 ### Added

--- a/scripts/launch-review.md
+++ b/scripts/launch-review.md
@@ -34,6 +34,9 @@ Gemini remains generic-only and rejects specialist flags.
   `STATUS=clean MODE=baseline REASON=codex-sandbox-read-only` sidecar without
   running the scan — `--sandbox read-only` blocks writes at the syscall level,
   making the after-the-fact scan redundant. Cursor still runs the full scan.
+- Codex captures both stdout AND stderr to `${OUTPUT}.sidecar` (`>>"$SIDECAR" 2>&1`)
+  so that token-usage lines printed to either stream are available for the
+  `token-ledger.sh record-vendor` scraper. Mirrors `launch-codex-implement.sh`.
 - `--commit-count <n>` (optional): passed through to `render-specialist-prompt.sh`
   on `--agent-file` paths; when `1 ≤ n ≤ 5`, the rendered specialist prompt omits
   the `git log` instruction from its diff preamble. Stored in the specialist prompt

--- a/scripts/launch-review.sh
+++ b/scripts/launch-review.sh
@@ -458,7 +458,7 @@ if : > "$SIDECAR" 2>/dev/null; then
         --output-last-message "$OUTPUT" \
         -- \
         "$PROMPT" \
-        2>>"$SIDECAR" || EXIT_CODE=$?
+        >>"$SIDECAR" 2>&1 || EXIT_CODE=$?
 else
     SIDECAR=/dev/null
     CODEX_HOME="$CODEX_HOME_DIR" \
@@ -475,7 +475,7 @@ else
         --output-last-message "$OUTPUT" \
         -- \
         "$PROMPT" \
-        2>/dev/null || EXIT_CODE=$?
+        >/dev/null 2>&1 || EXIT_CODE=$?
 fi
 
 codex_launcher_append_outer_meta "${OUTPUT}.meta" "$SCRIPT_DIR/launch-review.sh" "$PROMPT_FILE_SIDECAR" "$PWD"

--- a/scripts/test-launch-review.sh
+++ b/scripts/test-launch-review.sh
@@ -533,6 +533,74 @@ STUB_EOF
         fi
         rm -f "$LCR_LEDGER"
     fi
+
+    # Issue #1874 regression: verify ### Codex section appears in token-report.sh output.
+    # Stub writes "tokens used\n42\n" to STDOUT (not stderr) to exercise the
+    # stdout-capture fix (>>"$SIDECAR" 2>&1) in launch-review.sh Codex section.
+    LCR_STDOUT_BIN="$TMPDIR/lcr-stdout-bin"
+    mkdir -p "$LCR_STDOUT_BIN"
+    cat > "$LCR_STDOUT_BIN/codex" <<'STUB_EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+output_path=""
+last=""
+for arg in "$@"; do
+    if [[ "$last" == "--output-last-message" ]]; then output_path="$arg"; fi
+    last="$arg"
+done
+[[ -n "$output_path" ]] || exit 9
+printf 'stub codex review payload\n' > "$output_path"
+printf 'tokens used\n42\n'
+STUB_EOF
+    chmod +x "$LCR_STDOUT_BIN/codex"
+
+    LCR_REPORT_SESSION="lcr-codex-report-$$"
+    LCR_REPORT_OUT="$TMPDIR/lcr-codex-report-output.txt"
+    LCR_REPORT_STDERR="$TMPDIR/lcr-report.stderr"
+
+    LARCH_TOKEN_SESSION_ID="$LCR_REPORT_SESSION" \
+        "$REPO_ROOT/scripts/token-ledger.sh" mark "Step 5 — code review" >/dev/null 2>&1 || true
+
+    set +e
+    LARCH_TOKEN_SESSION_ID="$LCR_REPORT_SESSION" \
+    IMPLEMENT_TMPDIR='' \
+    PATH="$LCR_STDOUT_BIN:$PATH" \
+    LARCH_CODEX_MODEL="stub-model" \
+    CLAUDE_PLUGIN_ROOT="$REPO_ROOT" \
+        "$LAUNCHER" \
+            --output "$LCR_REPORT_OUT" \
+            --timeout 30 \
+            --prompt "review" \
+            >/dev/null 2>"$LCR_REPORT_STDERR"
+    LCR_REPORT_RC=$?
+    set -e
+
+    if [[ "$LCR_REPORT_RC" -ne 0 ]]; then
+        fail "issue#1874 codex-stdout-sidecar: launcher exited rc=$LCR_REPORT_RC; stderr=$(cat "$LCR_REPORT_STDERR" 2>/dev/null)"
+    else
+        LCR_REPORT_LEDGER=$(LARCH_TOKEN_SESSION_ID="$LCR_REPORT_SESSION" \
+            "$REPO_ROOT/scripts/token-ledger.sh" dump | sed -n '1p')
+        if [[ -s "$LCR_REPORT_LEDGER" ]] \
+           && jq -e 'select(.type=="vendor" and .vendor=="codex" and .raw=="codex_review" and .total==42)' \
+               "$LCR_REPORT_LEDGER" >/dev/null 2>&1; then
+            pass
+        else
+            fail "issue#1874 codex-stdout-sidecar: vendor record missing; ledger=$(cat "$LCR_REPORT_LEDGER" 2>/dev/null); stderr=$(cat "$LCR_REPORT_STDERR" 2>/dev/null)"
+        fi
+        LCR_EMPTY_TRANSCRIPT=$(mktemp "$TMPDIR/lcr-empty-XXXXXX")
+        : > "$LCR_EMPTY_TRANSCRIPT"
+        CODEX_REPORT_MD=$(LARCH_TOKEN_SESSION_ID="$LCR_REPORT_SESSION" \
+            "$REPO_ROOT/scripts/token-report.sh" \
+            --ledger "$LCR_REPORT_LEDGER" \
+            --transcript "$LCR_EMPTY_TRANSCRIPT" \
+            --full --markdown 2>/dev/null || true)
+        if printf '%s\n' "$CODEX_REPORT_MD" | grep -Fq '### Codex'; then
+            pass
+        else
+            fail "issue#1874 codex-stdout-sidecar: ### Codex missing from token-report.sh output; got=$(printf '%s' "$CODEX_REPORT_MD")"
+        fi
+        rm -f "$LCR_REPORT_LEDGER" "$LCR_EMPTY_TRANSCRIPT"
+    fi
 else
     pass
 fi

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -194,6 +194,7 @@ Then:
 - Ensure a per-run session id exists for design-manifest freshness checks. `session-setup.sh` already wrote the value; this call is preserved as an idempotent no-op for older harnesses and fallback paths (see `scripts/write-session-id.md` for the contract):
   ```bash
   ${CLAUDE_PLUGIN_ROOT}/scripts/write-session-id.sh --output "$IMPLEMENT_TMPDIR/session-id"
+  export IMPLEMENT_TMPDIR
   export LARCH_TOKEN_SESSION_ID="$(tr -d '\r\n' < "$IMPLEMENT_TMPDIR/session-id" 2>/dev/null || true)"
   export LARCH_TIMING_LEDGER="$IMPLEMENT_TMPDIR/timing-ledger.tsv"
   # Snapshot the live Claude transcript path BEFORE later concurrent


### PR DESCRIPTION
## Summary

- Codex sidecar now captures both stdout AND stderr (`>>"$SIDECAR" 2>&1`) so "tokens used\n<count>" output lands in the ledger regardless of stream
- `export IMPLEMENT_TMPDIR` added in `/implement` Step 0 so reviewer subprocesses can resolve the session-id for token-ledger path without relying on inherited env state
- Regression test: stdout-only codex stub + mark + `token-report.sh` assertion for `### Codex` section

## Architecture Diagram

Architecture diagram not available.

## Code Flow Diagram

(Code Flow Diagram skipped — quick mode)

## Test plan

- `/relevant-checks`: shellcheck, markdownlint, agent-lint all pass
- `test-launch-review.sh` (codex suite): 85 assertions pass including new `issue#1874 codex-stdout-sidecar` regression test
- Regression test verifies that when codex writes "tokens used\n42\n" to stdout only (not stderr), the `### Codex` section still appears in `token-report.sh --full --markdown` output

Closes #1874

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
