### PR TITLE
fix(implement): reduce transient retry threshold to 1 so second evaluate_failure escalates to CI fix agent

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "27.0.16",
+  "version": "27.0.17",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 7-reviewer specialist panel (5 Cursor specialists + 1 Codex generic + 1 Claude generic) with 2-voter adjudication (Cursor + Codex primary; Claude conditional tie-breaker on 1Y/1N); plan review runs a 4-reviewer diagonal panel (2 Cursor: Arch, Edge + 2 Codex: Innovation, Pragmatic); design sketches run a 4-agent diverge-then-converge phase in regular mode (2 Cursor + 2 Codex) or 2 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/scripts/ship-pr.sh
+++ b/scripts/ship-pr.sh
@@ -533,7 +533,7 @@ run_evaluate_failure() {
     failed_run=$(read_state FAILED_RUN_ID)
     [ -n "$failed_run" ] || exit_stall "$([ "$phase" = "ci-initial" ] && echo 10 || echo 12c)"
     retries=$(read_state TRANSIENT_RETRIES)
-    if [ "$retries" -lt 2 ]; then
+    if [ "$retries" -lt 1 ]; then
         rerun_out=$("$SCRIPT_DIR/ci-rerun-failed.sh" --run-id "$failed_run" --repo "$(read_state REPO)" 2>&1)
         printf '%s\n' "$rerun_out"
         if [ "$(kv_value RERUN_SUBMITTED "$rerun_out")" = "true" ]; then

--- a/scripts/test-ship-pr.sh
+++ b/scripts/test-ship-pr.sh
@@ -361,6 +361,51 @@ else
 fi
 rm -rf "$sentinel_dir"
 
+# Regression: second evaluate_failure (TRANSIENT_RETRIES=1) escalates to fix agent,
+# not another rerun. Guards the threshold change in run_evaluate_failure (issue #1987).
+root=$(make_repo ci_fix_escalation)
+tmp=$(make_tmpdir)
+call_dir=$(mktemp -d /tmp/ship-pr-escalation.XXXXXX)
+
+# ci-wait.sh: return evaluate_failure on first call, merge on subsequent calls.
+cat > "$root/scripts/ci-wait.sh" <<STUB
+#!/usr/bin/env bash
+set -euo pipefail
+count_file="$call_dir/ci-wait-count"
+count=\$(cat "\$count_file" 2>/dev/null || echo 0)
+printf '%s\n' "\$((count + 1))" > "\$count_file"
+if [ "\$count" -eq 0 ]; then
+    printf 'ACTION=evaluate_failure\nCI_STATUS=fail\nBEHIND_COUNT=0\nFAILED_RUN_ID=run123\nBAIL_REASON=\nITERATION=0\nELAPSED=1\n'
+else
+    printf 'ACTION=merge\nCI_STATUS=pass\nBEHIND_COUNT=0\nFAILED_RUN_ID=\nBAIL_REASON=\nITERATION=1\nELAPSED=1\n'
+fi
+STUB
+chmod +x "$root/scripts/ci-wait.sh"
+
+# ci-rerun-failed.sh: write sentinel if called — must NOT be called when TRANSIENT_RETRIES=1.
+cat > "$root/scripts/ci-rerun-failed.sh" <<'STUB'
+#!/usr/bin/env bash
+printf 'RERUN_SUBMITTED=true\nALREADY_RUNNING=false\nERROR=\n'
+touch "${RERUN_SENTINEL_FILE:-/tmp/rerun-called}"
+STUB
+chmod +x "$root/scripts/ci-rerun-failed.sh"
+
+write_state "$tmp/ship-pr-state.sh" ci-initial
+awk '/^TRANSIENT_RETRIES=/ {print "TRANSIENT_RETRIES=1"; next}
+     /^FAILED_RUN_ID=/ {print "FAILED_RUN_ID=run123"; next}
+     {print}' "$tmp/ship-pr-state.sh" > "$tmp/ship-pr-state.sh.new" \
+    && mv "$tmp/ship-pr-state.sh.new" "$tmp/ship-pr-state.sh"
+
+rerun_sentinel="$call_dir/rerun-called"
+RERUN_SENTINEL_FILE="$rerun_sentinel" run_subject "$root" "$tmp" "$tmp/rc"
+assert_rc "$tmp/rc" 0 "second evaluate_failure (TRANSIENT_RETRIES=1) exits 0 via fix-agent path"
+if [ -f "$rerun_sentinel" ]; then
+    fail "second evaluate_failure must NOT submit another rerun when TRANSIENT_RETRIES=1"
+else
+    ok "second evaluate_failure skips rerun and escalates to fix agent (TRANSIENT_RETRIES=1)"
+fi
+rm -rf "$call_dir"
+
 if [[ "$FAIL_COUNT" -ne 0 ]]; then
     echo "test-ship-pr: $FAIL_COUNT failure(s), $PASS_COUNT pass(es)" >&2
     exit 1


### PR DESCRIPTION
## Summary

- Reduces `TRANSIENT_RETRIES` threshold in `run_evaluate_failure` from `< 2` to `< 1` so the **second** `evaluate_failure` cycle invokes the CI fix agent instead of submitting another transient rerun
- Adds regression test in `test-ship-pr.sh` verifying `ci-rerun-failed.sh` is NOT called when `TRANSIENT_RETRIES=1` on entry
- Root cause: when `FAILED_RUN_ID` was unchanged on cycle 2 (GitHub API TOCTOU window or fast-failing rerun), both retry slots were consumed without the fix agent ever running, causing `ship-pr.sh` to bail to exit 4

Closes #1987
See also: #1988 (process failure during `/fix-issue` execution of this issue)

## Test plan

- [x] `bash scripts/test-ship-pr.sh` — all 19 tests pass including new regression
- [x] `relevant-checks` — shellcheck, agent-lint, pre-commit all pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)