### PR TITLE
chore(larch-logs): flush implement run 1CA227C8-7980-46A8-9844-0B70570B4915

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "27.5.37",
+  "version": "27.5.38",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 7-reviewer specialist panel (5 Cursor specialists + 1 Codex generic + 1 Claude generic) with 2-voter adjudication (Cursor + Codex primary; Claude conditional tie-breaker on 1Y/1N); plan review runs a 4-reviewer diagonal panel (2 Cursor: Arch, Edge + 2 Codex: Innovation, Pragmatic); design sketches run a 4-agent diverge-then-converge phase in regular mode (2 Cursor + 2 Codex) or 2 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/larch-logs/implement/1CA227C8-7980-46A8-9844-0B70570B4915/code-review-tally.ndjson
+++ b/larch-logs/implement/1CA227C8-7980-46A8-9844-0B70570B4915/code-review-tally.ndjson
@@ -1,0 +1,1 @@
+{"schema_version":1,"phase":"code-review","batch":"code-review-tally","mode":"simple","rounds":1,"accepted_count":0,"rejected_count":0,"body":"Quick mode — no voting panel. Round 1: 5 Cursor specialists + generic Codex.\nAccepted: 0. Rejected: 0. All findings were pre-existing in main, not introduced by this branch.\n"}

--- a/larch-logs/implement/1CA227C8-7980-46A8-9844-0B70570B4915/manifest.json
+++ b/larch-logs/implement/1CA227C8-7980-46A8-9844-0B70570B4915/manifest.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 2,
+  "skill": "implement",
+  "run_id": "1CA227C8-7980-46A8-9844-0B70570B4915",
+  "operator_cwd": "/Users/zhupanov/larch3",
+  "operator_repo_root": "/Users/zhupanov/larch3",
+  "parent_skill": null,
+  "issue_number": 2062,
+  "pr_number": null,
+  "status": "in-progress",
+  "larch_version": "27.5.25",
+  "model_roster": {},
+  "effort": "max",
+  "started_at": "2026-05-14T05:27:07Z",
+  "updated_at": "2026-05-14T05:27:07Z",
+  "attempt": 1,
+  "superseded_by": null,
+  "stalled_at_step": null,
+  "flags": {}
+}

--- a/larch-logs/implement/1CA227C8-7980-46A8-9844-0B70570B4915/plan-goals-test.md
+++ b/larch-logs/implement/1CA227C8-7980-46A8-9844-0B70570B4915/plan-goals-test.md
@@ -1,0 +1,47 @@
+## Goal
+Fix zero-duration Step 8a timing row and missing vendor task averages in timing-report.md
+
+## Implementation Plan
+## Implementation Plan
+
+Fix two timing-report quirks in larch-logs/implement/<RUN_ID>/timing-report.md.
+
+### Quirk A — zero-duration Step 8a changelog row
+
+File: scripts/implement-finalize.sh, function maybe_update_changelog()
+
+Problem: postbump_mark("Step 8a — changelog") is called unconditionally at function entry (line 708), before any skip checks. When the function exits early (no changelog present, forked, no bump, no bullets), postbump_report_since_mark() is called immediately after, producing a zero-duration row.
+
+Fix: Remove postbump_mark from the top. Move it to just before the actual write begins (after changelog_categories_to_markdown() confirms there are bullets to write). Remove postbump_report_since_mark() calls from all skip/early-exit paths that precede the mark. Keep postbump_report_since_mark() on all paths after the mark (success and failure writes).
+
+Paths that no longer call postbump_report_since_mark:
+- rc != 0 from check-changelog-present.sh (CHANGELOG absent)
+- forked_target=true
+- has_bump != true || bump_type = NONE (no bump commit)
+- collect_changelog_bullets failure
+- changelog_categories_to_markdown returns false (no bullets)
+
+Paths that keep postbump_report_since_mark (these have the mark):
+- write_changelog_entry rc=4 (multiple headings)
+- write_changelog_entry rc!=0 (no anchor)
+- mv failure
+- git-amend-add failure
+- git status dirty after amend
+- success path
+
+### Quirk B — missing Vendor Task Averages
+
+Root cause: timing-ledger.sh record-vendor-task in launch-review.sh cannot find the timing ledger because LARCH_TIMING_LEDGER, IMPLEMENT_TMPDIR, SESSION_ENV_PATH, and REVIEW_TMPDIR are not in the environment when launch-review.sh runs as a subprocess.
+
+Fix 1 — skills/review/SKILL.md Step 0 prose:
+Add LARCH_TIMING_LEDGER to the rehydration list alongside LARCH_TOKEN_SESSION_ID and LARCH_CLAUDE_SOURCE_FILE. The session-env.sh file already contains LARCH_TIMING_LEDGER (written by write-session-env.sh --timing-ledger). After reading, export it. This makes it available to all subsequent Bash calls within the review subagent session, including dispatch-panel.sh calls.
+
+Fix 2 — skills/review/scripts/dispatch-panel.sh:
+After SESSION_ENV_PATH is parsed from --session-env-path CLI arg (around line 41), add "export SESSION_ENV_PATH". This exports it so launch-review.sh child processes can inherit it, enabling timing-ledger.sh to resolve the ledger via the SESSION_ENV_PATH fallback (dirname(SESSION_ENV_PATH)/timing-ledger.tsv).
+
+### Verification
+- /relevant-checks clean
+- review timing-report.sh rendering for zero-row suppression
+
+## Test plan
+(no test plan section in plan-file)

--- a/larch-logs/implement/1CA227C8-7980-46A8-9844-0B70570B4915/plan-review-tally.ndjson
+++ b/larch-logs/implement/1CA227C8-7980-46A8-9844-0B70570B4915/plan-review-tally.ndjson
@@ -1,0 +1,1 @@
+{"schema_version":1,"phase":"plan-review","batch":"plan-review-tally","mode":"simple","rounds":0,"accepted_count":0,"rejected_count":0,"body":"Quick mode — no plan review voting.\n"}

--- a/larch-logs/implement/1CA227C8-7980-46A8-9844-0B70570B4915/timing-report.md
+++ b/larch-logs/implement/1CA227C8-7980-46A8-9844-0B70570B4915/timing-report.md
@@ -1,0 +1,21 @@
+**Workflow path**: SIMPLE
+
+## Per-Step Durations
+
+| Skill | Step | Duration |
+| --- | --- | ---: |
+| implement | Step 0 — preflight | 00:00:09 |
+| implement | Step 0.5 — tracking issue | 00:00:47 |
+| implement | Step 1 — design plan | 00:01:12 |
+| implement | Step 2 — implementation | 00:01:41 |
+| implement | Step 3 — checks first pass | 00:00:15 |
+| implement | Step 4 — commit implementation | 00:01:01 |
+| implement | Step 5 — code review | 00:04:28 |
+| implement | Step 6 — checks second pass | 00:00:08 |
+| implement | Step 7a — code flow diagram | 00:00:55 |
+| **Total** | | 00:09:41 |
+
+## Vendor Task Averages
+
+| Vendor | Task kind | Samples | Average | Range |
+| --- | --- | ---: | ---: | --- |

--- a/larch-logs/implement/1CA227C8-7980-46A8-9844-0B70570B4915/timing-report.md
+++ b/larch-logs/implement/1CA227C8-7980-46A8-9844-0B70570B4915/timing-report.md
@@ -12,7 +12,7 @@
 | implement | Step 4 — commit implementation | 00:01:01 |
 | implement | Step 5 — code review | 00:04:28 |
 | implement | Step 6 — checks second pass | 00:00:08 |
-| implement | Step 7a — code flow diagram | 00:00:55 |
+| implement | Step 7a — code flow diagram | 00:01:39 |
 | **Total** | | 00:09:41 |
 
 ## Vendor Task Averages

--- a/larch-logs/implement/1CA227C8-7980-46A8-9844-0B70570B4915/token-report.md
+++ b/larch-logs/implement/1CA227C8-7980-46A8-9844-0B70570B4915/token-report.md
@@ -18,6 +18,6 @@
 |  | larch:implement | 15 | 4216466 | 16687 | 10269 |
 | Step 6 — checks second pass | **step total** | 2 | 573974 | 3899 | 2376 |
 |  | larch:implement | 2 | 573974 | 3899 | 2376 |
-| Step 7a — code flow diagram | **step total** | 7 | 2032825 | 4808 | 4002 |
-|  | larch:implement | 7 | 2032825 | 4808 | 4002 |
-| **Grand total** |  | 76 | 20301466 | 79299 | 43460 |
+| Step 7a — code flow diagram | **step total** | 14 | 4086125 | 9270 | 8035 |
+|  | larch:implement | 14 | 4086125 | 9270 | 8035 |
+| **Grand total** |  | 83 | 22354766 | 83761 | 47493 |

--- a/larch-logs/implement/1CA227C8-7980-46A8-9844-0B70570B4915/token-report.md
+++ b/larch-logs/implement/1CA227C8-7980-46A8-9844-0B70570B4915/token-report.md
@@ -1,0 +1,23 @@
+### Claude
+
+| Step | Skill | Claude Input | Claude Cache Read | Claude Cache Create | Claude Output |
+| --- | --- | ---: | ---: | ---: | ---: |
+| Step 0 — preflight | **step total** | 1 | 246751 | 597 | 642 |
+|  | larch:implement | 1 | 246751 | 597 | 642 |
+| Step 0.5 — tracking issue | **step total** | 8 | 1985408 | 3987 | 2944 |
+|  | larch:implement | 8 | 1985408 | 3987 | 2944 |
+| Step 1 — design plan | **step total** | 8 | 2010534 | 5698 | 5698 |
+|  | larch:implement | 8 | 2010534 | 5698 | 5698 |
+| Step 2 — implementation | **step total** | 21 | 5456520 | 25651 | 11436 |
+|  | larch:implement | 21 | 5456520 | 25651 | 11436 |
+| Step 3 — checks first pass | **step total** | 3 | 799538 | 2137 | 1454 |
+|  | larch:implement | 3 | 799538 | 2137 | 1454 |
+| Step 4 — commit implementation | **step total** | 11 | 2979450 | 15835 | 4639 |
+|  | larch:implement | 11 | 2979450 | 15835 | 4639 |
+| Step 5 — code review | **step total** | 15 | 4216466 | 16687 | 10269 |
+|  | larch:implement | 15 | 4216466 | 16687 | 10269 |
+| Step 6 — checks second pass | **step total** | 2 | 573974 | 3899 | 2376 |
+|  | larch:implement | 2 | 573974 | 3899 | 2376 |
+| Step 7a — code flow diagram | **step total** | 7 | 2032825 | 4808 | 4002 |
+|  | larch:implement | 7 | 2032825 | 4808 | 4002 |
+| **Grand total** |  | 76 | 20301466 | 79299 | 43460 |

--- a/larch-logs/implement/1CA227C8-7980-46A8-9844-0B70570B4915/version-bump-reasoning.md
+++ b/larch-logs/implement/1CA227C8-7980-46A8-9844-0B70570B4915/version-bump-reasoning.md
@@ -1,0 +1,13 @@
+# Version Bump Reasoning
+
+- **Base commit**: `0c154a58` (chore(larch-logs): flush implement run 9B8E51CB-79C1-406F-AEC9-6ED35AD727E7)
+- **Current version**: `27.5.37`
+- **Classification scope**: `skills/**` and `agents/**` only (public plugin surface).
+
+## Result: PATCH
+
+- **New version**: `27.5.38`
+
+### PATCH rationale
+
+No MAJOR or MINOR evidence found in the public plugin surface. Defaulting to PATCH per policy ("every PR must bump at least PATCH").

--- a/scripts/implement-finalize.sh
+++ b/scripts/implement-finalize.sh
@@ -749,7 +749,6 @@ write_changelog_entry() {
 maybe_update_changelog() {
     local start out rc present forked_target has_bump bump_type new_version manifest_path tmpdir categories_md tmp_changelog status_out
     start=$(date +%s)
-    postbump_mark "Step 8a — changelog"
     CHANGELOG_STATUS="skipped-no-bump"
     set +e
     out=$("$SCRIPT_DIR/check-changelog-present.sh")
@@ -759,14 +758,12 @@ maybe_update_changelog() {
     if [ "$rc" -ne 0 ] || [ "$present" != "true" ]; then
         CHANGELOG_STATUS="skipped-absent"
         printf '⏩ 8a: changelog status=skip reason=changelog-absent elapsed=%s\n' "$(elapsed "$start")"
-        postbump_report_since_mark
         return 0
     fi
     forked_target=$(read_state FORKED_TARGET)
     if [ "$forked_target" = "true" ]; then
         CHANGELOG_STATUS="skipped-fork"
         printf '⏩ 8a: changelog status=skip reason=forked-dry-run elapsed=%s\n' "$(elapsed "$start")"
-        postbump_report_since_mark
         return 0
     fi
     has_bump=$(read_state HAS_BUMP)
@@ -774,7 +771,6 @@ maybe_update_changelog() {
     if [ "$has_bump" != "true" ] || [ "$bump_type" = "NONE" ]; then
         CHANGELOG_STATUS="skipped-no-bump"
         printf '⏩ 8a: changelog status=skip reason=no-bump-commit elapsed=%s\n' "$(elapsed "$start")"
-        postbump_report_since_mark
         return 0
     fi
 
@@ -787,7 +783,6 @@ maybe_update_changelog() {
         append_execution_issue "Step 8a changelog failed while reading changelog bullets."
         warn_line '**⚠ Step 8a: changelog update failed while reading bullets. Bailing to cleanup.**'
         rm -rf "$tmpdir"
-        postbump_report_since_mark
         return 1
     fi
     categories_md="$tmpdir/categories.md"
@@ -796,10 +791,11 @@ maybe_update_changelog() {
         append_execution_issue "Step 8a changelog skipped because no summary bullets were available."
         warn_line '**⚠ 8a: changelog — no summary bullets available; amend skipped. Continuing.**'
         rm -rf "$tmpdir"
-        postbump_report_since_mark
         return 0
     fi
 
+    # Only mark now that we have confirmed there are bullets to write
+    postbump_mark "Step 8a — changelog"
     tmp_changelog="$tmpdir/CHANGELOG.md"
     set +e
     write_changelog_entry "$new_version" "$categories_md" "$tmp_changelog"

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -48,7 +48,7 @@ SESSION_ENV_PATH="$SESSION_ENV_PATH" LARCH_TIMING_SKILL=review "${CLAUDE_PLUGIN_
 ${CLAUDE_PLUGIN_ROOT}/scripts/session-setup.sh --prefix claude-review --skip-preflight --skip-branch-check --skip-repo-check --check-reviewers [--caller-env "$SESSION_ENV_PATH"] [--skip-codex-probe] [--skip-cursor-probe] [--write-health "${SESSION_ENV_PATH}.health"]
 ```
 
-Parse `SESSION_TMPDIR`, reviewer health, token session fields, and set `REVIEW_TMPDIR=$SESSION_TMPDIR`. If `SESSION_ENV_PATH` is non-empty, rehydrate `LARCH_TOKEN_SESSION_ID` and `LARCH_CLAUDE_SOURCE_FILE` with `read-session-env-key.sh`.
+Parse `SESSION_TMPDIR`, reviewer health, token session fields, and set `REVIEW_TMPDIR=$SESSION_TMPDIR`. If `SESSION_ENV_PATH` is non-empty, rehydrate `LARCH_TOKEN_SESSION_ID`, `LARCH_CLAUDE_SOURCE_FILE`, and `LARCH_TIMING_LEDGER` with `read-session-env-key.sh`, then `export LARCH_TIMING_LEDGER` so subprocesses (`dispatch-panel.sh` → `launch-review.sh` → `timing-ledger.sh record-vendor-task`) can find the per-run timing ledger.
 
 If `subagent_mode=true` AND `diff_mode=true`, **MANDATORY — READ ENTIRE FILE** before dispatching: `${CLAUDE_PLUGIN_ROOT}/skills/review/references/heavy-worker.md`. If the worker returns `REVIEW_HEAVY=complete`, validate `$REVIEW_TMPDIR/review-summary.json` and proceed to Step 4. If it fails or omits the sentinel, fall back inline at Step 1.
 

--- a/skills/review/scripts/dispatch-panel.md
+++ b/skills/review/scripts/dispatch-panel.md
@@ -6,7 +6,7 @@ It launches Cursor and Codex specialists through `scripts/launch-review.sh` when
 
 Pass `--description-text` to thread the user's description through to both external and Claude reviewer prompts in description mode.
 
-Pass `--session-env-path` in nested `/implement` runs. Launch wrapper stdout/stderr is captured to `$REVIEW_TMPDIR/dispatch-<tool>-<slot>.log`; a non-zero launch exit appends that captured content verbatim via `scripts/append-tool-failure.sh` under `External Reviewer Issues`. The log path resolver uses `LARCH_EXECUTION_ISSUES_LOG` when set; otherwise it falls back through `$(dirname "$SESSION_ENV_PATH")/execution-issues.md`, `$IMPLEMENT_TMPDIR/execution-issues.md`, then `$REVIEW_TMPDIR/execution-issues.md`.
+Pass `--session-env-path` in nested `/implement` runs. `SESSION_ENV_PATH` is exported after argument parsing so `launch-review.sh` subprocesses inherit it; `timing-ledger.sh record-vendor-task` resolves the per-run timing ledger via the `SESSION_ENV_PATH` fallback, enabling Vendor Task Averages in timing reports. Launch wrapper stdout/stderr is captured to `$REVIEW_TMPDIR/dispatch-<tool>-<slot>.log`; a non-zero launch exit appends that captured content verbatim via `scripts/append-tool-failure.sh` under `External Reviewer Issues`. The log path resolver uses `LARCH_EXECUTION_ISSUES_LOG` when set; otherwise it falls back through `$(dirname "$SESSION_ENV_PATH")/execution-issues.md`, `$IMPLEMENT_TMPDIR/execution-issues.md`, then `$REVIEW_TMPDIR/execution-issues.md`.
 
 Stdout is `KEY=value` only: `EXTERNAL_OUTPUT_FILES`, `CLAUDE_OUTPUT_FILES`, `PANEL_MODE`, `SLOT_COUNT`, `PANEL_MANIFEST`, and `DISPATCH_OK`.
 

--- a/skills/review/scripts/dispatch-panel.sh
+++ b/skills/review/scripts/dispatch-panel.sh
@@ -44,6 +44,10 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+# Export so launch-review.sh subprocesses inherit it and timing-ledger.sh
+# can resolve the per-run ledger via the SESSION_ENV_PATH fallback.
+export SESSION_ENV_PATH
+
 [[ "$MODE" == "diff" || "$MODE" == "description" ]] || { echo "dispatch-panel.sh: --mode must be diff or description" >&2; exit 2; }
 [[ -n "$REVIEW_TMPDIR" ]] || { echo "dispatch-panel.sh: --review-tmpdir is required" >&2; exit 2; }
 [[ "$CODEX_AVAILABLE" == "true" || "$CODEX_AVAILABLE" == "false" ]] || { echo "dispatch-panel.sh: --codex-available must be true or false" >&2; exit 2; }


### PR DESCRIPTION
## Summary
- Fix zero-duration Step 8a timing row and missing vendor task averages in timing-report.md
- Cross-cutting changes across: .claude-plugin,larch-logs,scripts,skills.

<details><summary>Architecture Diagram</summary>

## Architecture Sketch

```mermaid
flowchart LR
  N1[".claude-plugin/"]
  N2["larch-logs/"]
  N3["scripts/"]
```

</details>

<details><summary>Code Flow Diagram</summary>

## Code Flow Diagram

```mermaid
sequenceDiagram
    participant FI as implement-finalize
    participant TL as timing-ledger
    participant DP as dispatch-panel
    participant LR as launch-review
    participant TLR as timing-ledger rec-vendor

    Note over FI: Quirk A fix
    FI->>FI: check-changelog-present
    alt no CHANGELOG or forked or no bump or no bullets
        FI->>FI: print skip breadcrumb and return
    else bullets confirmed
        FI->>TL: postbump_mark Step 8a
        FI->>FI: write_changelog_entry + git-amend
        FI->>TL: postbump_report_since_mark
    end

    Note over DP,TLR: Quirk B fix
    Note over DP: export SESSION_ENV_PATH
    DP->>LR: launch-review.sh subprocess
    Note over LR: inherits SESSION_ENV_PATH
    LR->>TLR: record-vendor-task
    TLR->>TLR: resolves ledger via SESSION_ENV_PATH
```

</details>

<details><summary>Test plan</summary>

- [x] Ran relevant checks.

</details>

Closes #2062

Generated with [Claude Code](https://claude.com/claude-code)
