### PR TITLE
Harden MANIFEST_PATH handling end-to-end (closes #2233)

### DIFF
--- a/scripts/implement-finalize.sh
+++ b/scripts/implement-finalize.sh
@@ -517,7 +517,10 @@ collect_changelog_bullets() {
                 jq -r --arg c "$category" '(.summary_bullets_categorized // {})[$c] // [] | if type == "array" then .[] else empty end' "$manifest_path" 2>/dev/null >> "$dir/$category" || return 1
             done
         else
-            jq -r '(.summary_bullets // []) | if type == "array" then .[] else empty end' "$manifest_path" 2>/dev/null >> "$dir/Changed" || return 1
+            # Mirror the categorized fallback above: a non-JSON manifest (e.g.
+            # design-side manifest.env mistakenly routed here) must yield "no
+            # bullets" silently rather than fail the whole phase. See issue #2233.
+            jq -r '(.summary_bullets // []) | if type == "array" then .[] else empty end' "$manifest_path" 2>/dev/null >> "$dir/Changed" || true
         fi
     else
         # No manifest and no bullets file → empty categories, not an error (skipped-no-bullets path)

--- a/scripts/ship-pr.sh
+++ b/scripts/ship-pr.sh
@@ -255,6 +255,18 @@ for key in REPO_UNAVAILABLE FORKED_TARGET HAS_BUMP MERGE DRAFT DEFERRED PR_CLOSE
     is_bool "$(read_state "$key")" || die_usage "state-file key $key must be true or false"
 done
 
+# Fail fast at the entry boundary if MANIFEST_PATH points at a non-JSON file
+# (e.g. the /design Step 5 manifest.env shell KV file mistakenly routed here).
+# See issue #2233: without this guard, a bad MANIFEST_PATH surfaces four phases
+# downstream inside collect_changelog_bullets with no actionable diagnostic.
+manifest_path_check=$(read_state MANIFEST_PATH)
+if [ -n "$manifest_path_check" ]; then
+    if [ ! -r "$manifest_path_check" ] || ! jq empty "$manifest_path_check" >/dev/null 2>&1; then
+        die_usage "MANIFEST_PATH must be empty or a readable JSON file (got: $manifest_path_check)"
+    fi
+fi
+unset manifest_path_check
+
 kv_value() {
     local key=$1 input=$2
     printf '%s\n' "$input" | awk -F= -v k="$key" '$1 == k {print substr($0, index($0, "=") + 1); found=1} END {if (!found) print ""}' | tail -n 1

--- a/scripts/test-implement-finalize.sh
+++ b/scripts/test-implement-finalize.sh
@@ -1007,6 +1007,21 @@ assert_file_contains "### Fixed" "$SANDBOX/repo/CHANGELOG.md" "postbump: fallbac
 assert_file_contains "### Added" "$SANDBOX/repo/CHANGELOG.md" "postbump: fallback categorized Added"
 assert_file_contains "### Changed" "$SANDBOX/repo/CHANGELOG.md" "postbump: fallback bare bullet defaults Changed"
 
+# Issue #2233: non-JSON MANIFEST_PATH (e.g. /design Step 5 manifest.env shell KV file
+# mistakenly routed here) must yield "no bullets" silently rather than fail the bump
+# phase. Combined with ship-pr.sh entry validation, the worst-case behavior stays safe
+# even if entry validation is bypassed.
+cp "$SANDBOX/original-CHANGELOG.md" "$SANDBOX/repo/CHANGELOG.md"
+cat > "$SANDBOX/tmp/manifest-non-json.env" <<'KV'
+PLAN_FILE=/tmp/x
+TIMESTAMP=2026-05-17
+SESSION_ID=abc
+KV
+write_postbump_state "$POSTBUMP_STATE" MANIFEST_PATH="$SANDBOX/tmp/manifest-non-json.env"
+OUT=$(run_subject postbump --state-file "$POSTBUMP_STATE" --implement-tmpdir "$SANDBOX/tmp")
+assert_contains "STATUS=ok" "$OUT" "postbump: non-JSON manifest does not fail the phase"
+assert_not_contains "STATUS=changelog-failed" "$OUT" "postbump: non-JSON manifest does not route to changelog-failed"
+
 # Regression: when target version header already exists (replacement path), no double blank before next header.
 cat > "$SANDBOX/repo/CHANGELOG.md" <<'CHANGELOG_REPLACE'
 # Changelog

--- a/scripts/test-ship-pr.sh
+++ b/scripts/test-ship-pr.sh
@@ -942,6 +942,57 @@ else
     sed 's/^/    /' "$tmp/execution-issues.md" 2>/dev/null || true
 fi
 
+# Issue #2233: MANIFEST_PATH entry validation contract tests.
+# Confirms ship-pr.sh fails fast when MANIFEST_PATH points at a non-JSON file
+# (e.g. the /design Step 5 manifest.env shell KV file mistakenly routed here),
+# and accepts a valid JSON manifest.
+root=$(make_repo manifest_path_non_json)
+tmp=$(make_tmpdir)
+write_state "$tmp/ship-pr-state.sh" checks
+# Simulate the failure mode: a shell KEY=VALUE file (design-side manifest.env)
+# written into MANIFEST_PATH instead of the implement-side JSON manifest.
+cat > "$tmp/fake-design-manifest.env" <<'KV'
+PLAN_FILE=/tmp/x
+TIMESTAMP=2026-05-17
+SESSION_ID=abc
+KV
+sed -i.bak "s|^MANIFEST_PATH=.*|MANIFEST_PATH=$tmp/fake-design-manifest.env|" "$tmp/ship-pr-state.sh"
+rm -f "$tmp/ship-pr-state.sh.bak"
+run_subject "$root" "$tmp" "$tmp/rc"
+assert_rc "$tmp/rc" 2 "non-JSON MANIFEST_PATH: ship-pr.sh exits 2 (die_usage) at entry"
+if grep -q "MANIFEST_PATH must be empty or a readable JSON file" "$tmp/stderr"; then
+    ok "non-JSON MANIFEST_PATH: diagnostic names the offending key"
+else
+    fail "non-JSON MANIFEST_PATH: diagnostic names the offending key"
+    sed 's/^/    stderr: /' "$tmp/stderr"
+fi
+
+root=$(make_repo manifest_path_valid_json)
+tmp=$(make_tmpdir)
+write_state "$tmp/ship-pr-state.sh" checks
+printf '{"summary_bullets":["x"],"files_modified":[]}\n' > "$tmp/fake-implement-manifest.json"
+sed -i.bak "s|^MANIFEST_PATH=.*|MANIFEST_PATH=$tmp/fake-implement-manifest.json|" "$tmp/ship-pr-state.sh"
+rm -f "$tmp/ship-pr-state.sh.bak"
+run_subject "$root" "$tmp" "$tmp/rc"
+if grep -q "MANIFEST_PATH must be empty or a readable JSON file" "$tmp/stderr"; then
+    fail "valid JSON MANIFEST_PATH: entry validation must not fire"
+    sed 's/^/    stderr: /' "$tmp/stderr"
+else
+    ok "valid JSON MANIFEST_PATH: entry validation does not fire"
+fi
+
+root=$(make_repo manifest_path_empty)
+tmp=$(make_tmpdir)
+write_state "$tmp/ship-pr-state.sh" checks
+# write_state already sets MANIFEST_PATH= empty; just confirm the empty path passes.
+run_subject "$root" "$tmp" "$tmp/rc"
+if grep -q "MANIFEST_PATH must be empty or a readable JSON file" "$tmp/stderr"; then
+    fail "empty MANIFEST_PATH: entry validation must not fire"
+    sed 's/^/    stderr: /' "$tmp/stderr"
+else
+    ok "empty MANIFEST_PATH: entry validation does not fire"
+fi
+
 if [[ "$FAIL_COUNT" -ne 0 ]]; then
     echo "test-ship-pr: $FAIL_COUNT failure(s), $PASS_COUNT pass(es)" >&2
     exit 1

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -1697,6 +1697,8 @@ Before invoking the script, write `$IMPLEMENT_TMPDIR/ship-pr-state.sh` with uppe
 - `MANIFEST_PATH`, `TOOL_LABEL`, `DESIGN_ONLY_DONE=false`, `EXPECTED_SESSION_ID`, `EXPECTED_TMPDIR_BASENAME_PREFIX`
 - `NO_LOGS_COMMIT=$no_logs_commit`, `IMPLEMENT_TMPDIR=$IMPLEMENT_TMPDIR`
 
+> **`MANIFEST_PATH` MUST be empty unless `/implement` Step 2 returned `STATUS=complete` with a JSON manifest path.** On manifest-reuse fast paths (Step 1 resumed sessions where Step 2 does not dispatch), claude-fallback paths (Step 2.4), bailed-Step-2 paths, and any other path where Step 2 did not produce a JSON manifest at `$MANIFEST`, leave `MANIFEST_PATH` empty. **The `/design` Step 5 manifest (`design-export/manifest.env`, a shell KV file) is NEVER a valid value for `MANIFEST_PATH` — these are two different artifacts despite the shared noun.** `ship-pr.sh` hard-fails at entry if `MANIFEST_PATH` is non-empty and not readable JSON; see issue #2233.
+
 Invoke:
 
 ```bash


### PR DESCRIPTION
## Summary

Closes #2233. Layered defense-in-depth against the failure class where the `/design` Step 5 `manifest.env` (shell KV file) is mistakenly written into `ship-pr-state.sh` `MANIFEST_PATH` (which expects the `/implement` Step 2 dispatcher JSON manifest). Previously the bug surfaced four phases downstream inside `collect_changelog_bullets` with no actionable diagnostic; recovery required hand-editing two state files.

- **Fix 1 (inner layer)** — `scripts/implement-finalize.sh`: `collect_changelog_bullets` now tolerates non-JSON manifests on the `summary_bullets` branch by replacing `|| return 1` with `|| true`, mirroring the existing categorized-branch fallback. A non-JSON manifest now yields "no bullets" silently rather than failing the whole bump phase.

- **Fix 2 (outer layer)** — `scripts/ship-pr.sh`: hard-fails at entry with a clear diagnostic (`MANIFEST_PATH must be empty or a readable JSON file (got: ...)`) if `MANIFEST_PATH` is non-empty and not readable JSON. The check runs after `validate_state_syntax` and the bool/required-key sweeps, so the bug class surfaces at the closest blame boundary instead of four phases downstream.

- **Fix 3 (root cause documentation)** — `skills/implement/SKILL.md`: adds a note to the Step 8+ ship-pr-state.sh write block clarifying that `MANIFEST_PATH` MUST be empty unless `/implement` Step 2 returned `STATUS=complete` with a JSON manifest path, and that the `/design` Step 5 `manifest.env` is never a valid value despite the shared noun.

## Test plan

- [x] `bash scripts/test-ship-pr.sh` — 62 passes (4 new contract tests: non-JSON exits 2 with diagnostic; valid JSON passes; empty passes)
- [x] `bash scripts/test-implement-finalize.sh` — 171 passes (2 new regression tests: non-JSON manifest does not fail the phase; does not route to `STATUS=changelog-failed`)
- [x] `/relevant-checks` — green (pre-commit + agent-lint, 91 suppressed by `agent-lint`)
- [x] Manual reproduction of the bug confirmed (`jq` exit 5 on shell KV file)

## Why one PR

The three fixes are layered defenses against the same failure class and share the same diagnostic narrative. Shipping them together avoids two follow-on PRs that would re-derive the same context, and lets reviewers see the full defense-in-depth picture in one place.

## Trade-offs

Issue #2233 recommended Option 1 + Option 3 (rename + contract test). This PR ships Option 2 + Option 3 (docs note + contract test) instead — the rename is mostly stylistic given the entry-validation hard-fail in Fix 2, and renaming `MANIFEST_PATH` across 19 files including the state files written to disk by in-flight sessions would create backward-compatibility friction in the current release window. Fix 2 alone makes the bug class hard-fail at the entry boundary with a clear diagnostic; the rename is a future cleanup if drift recurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
