### PR TITLE
Commit review fixes per round; emit CODER_STATUS=no-changes (#2236)

### DIFF
--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -1476,7 +1476,7 @@ if [ -z "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -n "${IMPLEMENT_TMPDIR:-}" ] && [ -f "$
   CLAUDE_PLUGIN_ROOT=$(awk 'BEGIN{p="LARCH_CLAUDE_PLUGIN_ROOT="} index($0,p)==1{print substr($0,length(p)+1); exit}' "$IMPLEMENT_TMPDIR/session-env.sh" 2>/dev/null || true)
 fi
 export CLAUDE_PLUGIN_ROOT
-${CLAUDE_PLUGIN_ROOT}/skills/implement/scripts/check-review-changes.sh --baseline "$IMPLEMENT_TMPDIR/pre-review-untracked.txt"
+${CLAUDE_PLUGIN_ROOT}/skills/implement/scripts/check-review-changes.sh --baseline "$IMPLEMENT_TMPDIR/pre-review-untracked.txt" --head-baseline "$IMPLEMENT_TMPDIR/pre-review-head.txt"
 ```
 
 Parse all three stdout keys with key-based extraction (e.g., `awk -F= '$1=="FILES_CHANGED"{print $2}'`) — all keys are always emitted on every invocation in stable order: `FILES_CHANGED` first, `UNTRACKED_BASELINE` second, `GIT_PROBE_FAILED` third. Do NOT `eval`/`source` the script's stdout. If `UNTRACKED_BASELINE=missing` (snapshot was never written or got cleaned up after a Step 5 failure), log to `Warnings` (`Step 6 — pre-/review untracked baseline missing; untracked delta not computed for this run`) and continue — `FILES_CHANGED` is still authoritative for staged + unstaged. If `GIT_PROBE_FAILED=true` (one or more git probes returned non-zero — transient git outage, missing `.git` directory, etc.), log to `Warnings` (`Step 6 — git probe failed during review-change detection; FILES_CHANGED may have missed review-induced edits`) and continue. Step 6 does NOT pass `--strict` by default: today's contract is to preserve the historical graceful-degradation behavior on the `/implement` Step 6 path. The `--strict` flag exists for callers that want to fail-closed (treat a probe failure as `FILES_CHANGED=true`); adopting it project-wide is a separate decision tracked outside this PR. Issue #1485 added the `GIT_PROBE_FAILED` key and `--strict` flag.
@@ -1529,7 +1529,7 @@ export CLAUDE_PLUGIN_ROOT
 ${CLAUDE_PLUGIN_ROOT}/scripts/git-commit.sh -m "Address code review feedback" <specific-files>
 ```
 
-If no files changed, skip.
+If no files changed, skip. Note: `review-and-fix.sh` commits each round's accepted-fixes inline (commit message `Address code review feedback (round N)`) for both `--panel simple` (quick mode) and `--panel hard` (normal mode), so on the common path the working tree is already clean here and Step 7's commit is a no-op. Step 7's commit still fires when the main agent landed manual edits — typically after the `main-agent-vote-required` adjudication branch of `review-and-fix.sh`, where the coder dispatch did not run.
 
 ### Rebase onto latest main (after review fixes commit)
 

--- a/skills/implement/scripts/check-review-changes.md
+++ b/skills/implement/scripts/check-review-changes.md
@@ -33,14 +33,19 @@ In **default mode** (no `--strict`), `FILES_CHANGED=true` if and only if any of:
 - `git diff --name-only` (unstaged) is non-empty
 - `git diff --name-only --cached` (staged) is non-empty
 - `UNTRACKED_BASELINE=present` AND the untracked delta is non-empty
+- `--head-baseline <path>` is passed, the file is readable, and `git rev-parse HEAD` differs from the baseline SHA
 
 The untracked delta is `comm -23 <(current-sorted) <(baseline-sorted)` — paths in the current untracked set that were NOT in the pre-/review snapshot. The baseline sort uses `sort -- "$BASELINE"` so a dash-prefixed baseline path is treated as an operand, not as a `sort` flag.
+
+The HEAD-baseline source is the load-bearing signal for the per-round-commit flow added by `skills/review-and-fix/scripts/review-and-fix.sh`. When that script commits each round's accepted fixes, the working tree is clean at Step 6 entry, so the staged/unstaged/untracked sources all report empty. Comparing `git rev-parse HEAD` against the round-1 snapshot at `$IMPLEMENT_TMPDIR/pre-review-head.txt` lets Step 6 still detect that the repository moved forward and run the second lint pass. A missing or unreadable head-baseline file silently disables this dimension (consistent with the untracked baseline degradation policy). A failure to run `git rev-parse HEAD` sets `GIT_PROBE_FAILED=true` so `--strict` can fail closed.
 
 **`--strict` mode adds a fail-closed override**: when `--strict` is set AND `GIT_PROBE_FAILED=true`, `FILES_CHANGED` is forced to `true` regardless of whether any of the three signals above is non-empty. The fail-closed override lets the caller treat unknown working-tree state as may-have-changed instead of silently skipping the post-/review checks pass on a transient git outage.
 
 ## Required pre-snapshot
 
 The `--baseline <path>` flag points to a sorted list of untracked paths captured BEFORE `/review` ran. `/implement` Step 5 owns this snapshot. The snapshot is an artifact of the `/implement` orchestration contract, not of this script.
+
+The `--head-baseline <path>` flag points to a single-line file containing the HEAD SHA captured BEFORE `/review` ran. `skills/review-and-fix/scripts/review-and-fix.sh` writes this file at the start of round 1 (alongside the untracked baseline). Like the untracked baseline, missing/unreadable is a silent degradation.
 
 ## Baseline-state classification
 

--- a/skills/implement/scripts/check-review-changes.sh
+++ b/skills/implement/scripts/check-review-changes.sh
@@ -1,10 +1,17 @@
 #!/usr/bin/env bash
 # check-review-changes.sh — Check if the code review step modified the working tree.
 #
-# Detects review-induced changes via three sources:
+# Detects review-induced changes via four sources:
 #   - staged modifications (git diff --cached)
 #   - unstaged modifications (git diff)
 #   - new untracked files (current untracked set minus a pre-/review baseline)
+#   - HEAD movement (current HEAD differs from a pre-/review HEAD baseline)
+#
+# The HEAD-movement source covers the case where review-and-fix.sh commits
+# each round's fixes (per-round commits in skills/review-and-fix/scripts/
+# review-and-fix.sh). Without this dimension, a clean working tree after
+# per-round commits would report FILES_CHANGED=false even though the
+# repository moved forward — silently skipping Step 6's lint pass.
 #
 # The untracked dimension requires a pre-/review baseline file (sorted list of
 # untracked paths captured before /review ran). Without a readable baseline,
@@ -24,7 +31,7 @@
 #   GIT_PROBE_FAILED=true|false
 #
 # Usage:
-#   check-review-changes.sh [--baseline <path>] [--strict]
+#   check-review-changes.sh [--baseline <path>] [--head-baseline <path>] [--strict]
 #
 # Exit codes:
 #   0 — always (including bad CLI input — see Parse-error policy below).
@@ -57,6 +64,7 @@ source "$PLUGIN_ROOT/scripts/lib-quiet.sh"
 larch_quiet_init
 
 BASELINE=""
+HEAD_BASELINE=""
 STRICT="false"
 PARSE_ERROR=""
 while [[ $# -gt 0 ]]; do
@@ -67,6 +75,14 @@ while [[ $# -gt 0 ]]; do
                 break
             fi
             BASELINE="$2"
+            shift 2
+            ;;
+        --head-baseline)
+            if [[ $# -lt 2 ]]; then
+                PARSE_ERROR="--head-baseline requires a path argument"
+                break
+            fi
+            HEAD_BASELINE="$2"
             shift 2
             ;;
         --strict)
@@ -125,8 +141,20 @@ if [[ -n "$BASELINE" ]] && [[ -r "$BASELINE" ]]; then
     UNTRACKED_DELTA=$(comm -23 <(printf '%s\n' "$CURRENT") <(LC_ALL=C sort -- "$BASELINE") | sed '/^$/d' || echo "")
 fi
 
+HEAD_MOVED="false"
+if [[ -n "$HEAD_BASELINE" ]] && [[ -r "$HEAD_BASELINE" ]]; then
+    baseline_head=$(tr -d '[:space:]' < "$HEAD_BASELINE" 2>/dev/null || true)
+    if current_head=$(git rev-parse HEAD 2>/dev/null); then
+        if [[ -n "$baseline_head" && "$baseline_head" != "$current_head" ]]; then
+            HEAD_MOVED="true"
+        fi
+    else
+        GIT_PROBE_FAILED="true"
+    fi
+fi
+
 FILES_CHANGED="false"
-if [[ -n "$UNSTAGED" ]] || [[ -n "$STAGED" ]] || [[ -n "$UNTRACKED_DELTA" ]]; then
+if [[ -n "$UNSTAGED" ]] || [[ -n "$STAGED" ]] || [[ -n "$UNTRACKED_DELTA" ]] || [[ "$HEAD_MOVED" == "true" ]]; then
     FILES_CHANGED="true"
 fi
 

--- a/skills/implement/scripts/test-check-review-changes.md
+++ b/skills/implement/scripts/test-check-review-changes.md
@@ -24,6 +24,8 @@ Each case sets up an isolated `git init` sandbox via `mktemp -d` (or a non-git `
 | (l) | clean tree + `--strict` | `FILES_CHANGED=false UNTRACKED_BASELINE=missing GIT_PROBE_FAILED=false` | `--strict` is a no-op when all probes succeed; it does NOT artificially flip `FILES_CHANGED` outside the probe-failure path |
 | (m) | clean repo + `--bogus` | `FILES_CHANGED=false UNTRACKED_BASELINE=missing GIT_PROBE_FAILED=false` (stderr `ERROR=…`) | parse error short-circuits BEFORE any git probe runs; the three stdout keys still emit with their conservative degraded values |
 | (n) | non-git sandbox + `--strict --bogus` | `FILES_CHANGED=false UNTRACKED_BASELINE=missing GIT_PROBE_FAILED=false` (stderr `ERROR=…`) | **issue #1485 round-1 review fix** — parse error must short-circuit BEFORE probes run, so `--strict` cannot promote a CLI typo to `FILES_CHANGED=true` via a probe failure (pre-fix: `FILES_CHANGED=true GIT_PROBE_FAILED=true`) |
+| (o) | clean tree + `--head-baseline` matching current HEAD | `FILES_CHANGED=false` | HEAD-baseline dimension is a no-op when HEAD has not moved |
+| (p) | `--head-baseline` points at prior commit, current HEAD has advanced via per-round commit | `FILES_CHANGED=true` | **issue #2236 per-round commit flow** — review-and-fix.sh commits each round's accepted fixes, leaving a clean working tree but an advanced HEAD; without the HEAD-baseline dimension, Step 6's lint pass would silently skip |
 
 ## Case (f) is a deliberate behavior change — do NOT "fix" it
 

--- a/skills/implement/scripts/test-check-review-changes.sh
+++ b/skills/implement/scripts/test-check-review-changes.sh
@@ -44,6 +44,12 @@
 #       (issue #1485 round-1 review fix: parse error must short-circuit
 #       BEFORE probes run, so --strict cannot promote a typo to
 #       FILES_CHANGED=true via probe failure)
+#   (o) HEAD-baseline equals current HEAD → FILES_CHANGED=false
+#       (no movement; the head-baseline dimension is a no-op)
+#   (p) HEAD-baseline points at a prior commit, current HEAD has advanced →
+#       FILES_CHANGED=true (issue #2236: review-and-fix.sh per-round commits
+#       leave a clean working tree, so the head-baseline dimension is the
+#       only signal that Step 5 modified the repo)
 #
 # Usage:
 #   bash skills/implement/scripts/test-check-review-changes.sh
@@ -299,8 +305,50 @@ else
 fi
 rm -f "$STDERR_N"
 
+# Cases (o)-(p): HEAD-baseline dimension. Covers the issue #2236 per-round
+# commit flow — review-and-fix.sh commits each round's accepted-fixes, so by
+# Step 6 entry the working tree is clean but HEAD has advanced. Without the
+# HEAD-baseline source, FILES_CHANGED would be false and the second lint
+# pass would silently skip. With --head-baseline, the SUT detects HEAD
+# movement and reports FILES_CHANGED=true.
+
+# Case (o): HEAD-baseline matches current HEAD (no movement) → no signal.
+SBX_O=$(mkrepo)
+HEAD_BL_O="$SBX_O/pre-review-head.txt"
+( cd "$SBX_O" && git rev-parse HEAD > "$HEAD_BL_O" )
+out_o=$(cd "$SBX_O" && "$SUT" --head-baseline "$HEAD_BL_O")
+fc_o=$(echo "$out_o" | awk -F= '$1=="FILES_CHANGED"{print $2}')
+if [[ "$fc_o" == "false" ]]; then
+    echo "PASS: (o) head-baseline matches current HEAD → FILES_CHANGED=$fc_o"
+    PASS=$((PASS + 1))
+else
+    echo "FAIL: (o) head-baseline matches current HEAD" >&2
+    echo "  expected: FILES_CHANGED=false" >&2
+    echo "  actual:   FILES_CHANGED=$fc_o" >&2
+    FAIL=$((FAIL + 1))
+fi
+
+# Case (p): HEAD-baseline points at a prior commit; current HEAD has
+# advanced → FILES_CHANGED=true even though the working tree is clean.
+# This is the load-bearing case for issue #2236.
+SBX_P=$(mkrepo)
+HEAD_BL_P="$SBX_P/pre-review-head.txt"
+( cd "$SBX_P" && git rev-parse HEAD > "$HEAD_BL_P" )
+( cd "$SBX_P" && echo "review-fix" >> tracked.txt && git add tracked.txt && git commit --quiet -m "Address code review feedback (round 1)" )
+out_p=$(cd "$SBX_P" && "$SUT" --head-baseline "$HEAD_BL_P")
+fc_p=$(echo "$out_p" | awk -F= '$1=="FILES_CHANGED"{print $2}')
+if [[ "$fc_p" == "true" ]]; then
+    echo "PASS: (p) head-baseline differs from current HEAD (per-round commit) → FILES_CHANGED=$fc_p"
+    PASS=$((PASS + 1))
+else
+    echo "FAIL: (p) head-baseline differs from current HEAD (per-round commit)" >&2
+    echo "  expected: FILES_CHANGED=true" >&2
+    echo "  actual:   FILES_CHANGED=$fc_p" >&2
+    FAIL=$((FAIL + 1))
+fi
+
 # Cleanup sandboxes.
-rm -rf "$SBX_A" "$SBX_B" "$SBX_C" "$SBX_D" "$SBX_E" "$SBX_F" "$SBX_G" "$SBX_H" "$SBX_I" "$SBX_J" "$SBX_K" "$SBX_L" "$SBX_M" "$SBX_N"
+rm -rf "$SBX_A" "$SBX_B" "$SBX_C" "$SBX_D" "$SBX_E" "$SBX_F" "$SBX_G" "$SBX_H" "$SBX_I" "$SBX_J" "$SBX_K" "$SBX_L" "$SBX_M" "$SBX_N" "$SBX_O" "$SBX_P"
 
 echo ""
 echo "RESULTS: $PASS passed, $FAIL failed"

--- a/skills/review-and-fix/scripts/review-and-fix.md
+++ b/skills/review-and-fix/scripts/review-and-fix.md
@@ -13,13 +13,16 @@ Flags:
 
 Output is `KEY=value` only through `scripts/lib-quiet.sh`:
 
-- `REVIEW_AND_FIX_STATUS=complete|no-findings|coder-failed|main-agent-vote-required`
+- `REVIEW_AND_FIX_STATUS=complete|no-findings|coder-failed|main-agent-vote-required|no-changes`
 - `FIX_COUNT=N`
 - `CODER_TOOL=none|codex|cursor`
-- `CODER_STATUS=skipped|applied|failed|submodule-violation`
+- `CODER_STATUS=skipped|applied|no-changes|failed|submodule-violation`
 - `CODER_LOG_FILE=<path>` when a coder ran
+- `CODER_COMMIT_SHA=<sha>` when the script committed the round's accepted-fixes
 - `SUBMODULE_SCRUB_COUNT=N`
 - `SUBMODULE_REVERT_COUNT=N`
+
+`CODER_STATUS=applied` means the coder dispatch exited 0 AND `git status --porcelain` reports a non-empty working tree after submodule revert — i.e., real edits landed in the repo. `CODER_STATUS=no-changes` covers the case where the dispatcher exited 0 but the working tree is clean (sandbox blocked writes, coder declined every finding, etc.). The orchestrator must treat `no-changes` as terminal: a re-run of the same review would produce the same fixed point.
 
 The script applies edits by dispatching Codex, then Cursor. The main agent does not apply review fixes with Edit/Write.
 
@@ -40,15 +43,17 @@ Flags:
 - `--codex-available true|false`
 - `--cursor-available true|false`
 
-Orchestrator mode invokes `skills/review/scripts/review-core.sh` once with `--output-dir "$IMPLEMENT_TMPDIR/round-N"`. On round 1 it captures `$IMPLEMENT_TMPDIR/pre-review-untracked.txt` via `scripts/snapshot-untracked.sh` so Step 6 can detect review-created untracked files.
+Orchestrator mode invokes `skills/review/scripts/review-core.sh` once with `--output-dir "$IMPLEMENT_TMPDIR/round-N"`. On round 1 it captures `$IMPLEMENT_TMPDIR/pre-review-untracked.txt` via `scripts/snapshot-untracked.sh` so Step 6 can detect review-created untracked files, and writes `$IMPLEMENT_TMPDIR/pre-review-head.txt` (current HEAD SHA) so `check-review-changes.sh --head-baseline` can detect the per-round commits this script makes during Step 5.
+
+After each round's `apply_findings_with_coder` dispatch finishes successfully and any submodule violations have been reverted, the script checks `git status --porcelain`. If the working tree is dirty, it stages all non-submodule changes via `git add -A` (submodule paths were already reverted, so `-A` cannot resurrect them) and calls `scripts/git-commit.sh -m "Address code review feedback (round N)"`. The commit SHA is emitted as `CODER_COMMIT_SHA`. If the working tree is clean, the script emits `CODER_STATUS=no-changes` with no commit. The coder prompt invariant ("Do NOT commit; the parent handles commits") is preserved: the bash script — not the coder — owns the commit.
 
 On round 1, orchestrator mode also marks `Step 5 — code review` through `scripts/timing-ledger.sh` with `IMPLEMENT_TMPDIR` in the subprocess environment. The mark is best-effort and runs after argument/tool validation, before review-core dispatch.
 
 Exit codes:
 
-- `0`: no accepted findings remain for this round, or `main-agent-vote-required` when no voting judges were available and the parent must adjudicate the ballot.
+- `0`: no accepted findings remain for this round, OR `main-agent-vote-required` when no voting judges were available and the parent must adjudicate the ballot, OR `no-changes` when the coder dispatch exited 0 but did not modify the working tree (the parent halts the loop — re-running the same review would produce the same fixed point).
 - `2`: panel failure, coder failure, or submodule violation; parent `/implement` treats this as blocking.
-- `3`: a coder applied accepted findings. The parent runs relevant checks and decides whether to call the script for the next round.
+- `3`: a coder applied accepted findings AND the script committed them as `Address code review feedback (round N)`. The parent runs relevant checks and decides whether to call the script for the next round.
 
 Additional output keys:
 
@@ -66,6 +71,7 @@ Additional output keys:
 - `CODER_TOOL`
 - `CODER_STATUS`
 - `CODER_LOG_FILE`
+- `CODER_COMMIT_SHA` (only when the round committed a per-round fix commit)
 - `SUBMODULE_SCRUB_COUNT`
 - `SUBMODULE_REVERT_COUNT`
 - `SKIPPED_FINDING_COUNT` — count of unique `FINDING_N` ids that the coder logged as
@@ -78,7 +84,7 @@ Additional output keys:
 pre-scrub accepted in-scope count. This keeps the `/implement` bulk-skip-ratio denominator
 aligned with the findings file the coder actually saw.
 
-The script writes `$IMPLEMENT_TMPDIR/review-and-fix-summary.json` atomically with `schema_version=2`, aggregate accepted/rejected counts, `rounds_completed`, latest approved-fixes path, latest round directory, accumulated OOS artifact paths, and coder/submodule status fields. Accepted OOS markdown is accumulated at `$IMPLEMENT_TMPDIR/accumulated-oos.md` and mirrored to `$IMPLEMENT_TMPDIR/oos-accepted-review.md` for existing Step 9a.1 consumers; a JSONL audit copy is appended at `$IMPLEMENT_TMPDIR/accumulated-oos.jsonl`. That mirror copy is load-bearing: if the copy fails, the round fails instead of silently leaving the legacy mirror stale.
+The script writes `$IMPLEMENT_TMPDIR/review-and-fix-summary.json` atomically with `schema_version=2`, aggregate accepted/rejected counts, `rounds_completed`, latest approved-fixes path, latest round directory, accumulated OOS artifact paths, coder/submodule status fields, and `coder_commit_sha` (latest round's per-round commit, empty string when the round produced no commit). Accepted OOS markdown is accumulated at `$IMPLEMENT_TMPDIR/accumulated-oos.md` and mirrored to `$IMPLEMENT_TMPDIR/oos-accepted-review.md` for existing Step 9a.1 consumers; a JSONL audit copy is appended at `$IMPLEMENT_TMPDIR/accumulated-oos.jsonl`. That mirror copy is load-bearing: if the copy fails, the round fails instead of silently leaving the legacy mirror stale.
 
 When an orchestrator round exits `0` (cap-reached or clean) or `3` (fix-required) and `--run-id` is non-empty, the script best-effort flushes the Step 5 implement run-log batches:
 

--- a/skills/review-and-fix/scripts/review-and-fix.sh
+++ b/skills/review-and-fix/scripts/review-and-fix.sh
@@ -154,7 +154,7 @@ run_coder_dispatch() {
     local round_dir="$1" prompt_body="$2" tool_log="$3" tool_stdout="$4"
 
     if "$RUN_EXTERNAL_AGENT_SH" --tool codex --output "$round_dir/coder-codex.log" --timeout 1800 --capture-stdout -- \
-        codex exec --full-auto -C "$PWD" --add-dir "$round_dir" "$prompt_body" > "$round_dir/coder-codex.wrapper.log" 2>&1; then
+        codex exec --full-auto -C "$PWD" --add-dir "$round_dir" --add-dir "$PWD" "$prompt_body" > "$round_dir/coder-codex.wrapper.log" 2>&1; then
         cp "$round_dir/coder-codex.log" "$tool_log" 2>/dev/null || : > "$tool_log"
         printf 'codex\n' > "$tool_stdout"
         return 0
@@ -214,8 +214,8 @@ post_dispatch_submodule_revert() {
 }
 
 apply_findings_with_coder() {
-    local input_file="$1" round_dir="$2" result_file="$3"
-    local in_scope_count scrub_out scrub_rc scrub_ok scrub_count scrubbed_file scrubbed_count submodules_list prompt_file prompt_body tool_file tool_log revert_count
+    local input_file="$1" round_dir="$2" result_file="$3" round_num="${4:-}"
+    local in_scope_count scrub_out scrub_rc scrub_ok scrub_count scrubbed_file scrubbed_count submodules_list prompt_file prompt_body tool_file tool_log revert_count commit_sha=""
 
     mkdir -p "$round_dir"
     : > "$result_file"
@@ -298,6 +298,51 @@ apply_findings_with_coder() {
         return 3
     fi
 
+    # Detect actual file changes after dispatch (post submodule revert). If the
+    # working tree is clean, the dispatcher exit code lies — the coder ran but
+    # did not actually modify any file. Emit CODER_STATUS=no-changes so callers
+    # can distinguish "dispatcher ok, no edits landed" from "edits applied".
+    if [[ -z "$(git status --porcelain 2>/dev/null)" ]]; then
+        {
+            printf 'CODER_TOOL=%s\n' "$(cat "$tool_file")"
+            printf 'CODER_STATUS=no-changes\n'
+            printf 'CODER_LOG_FILE=%s\n' "$tool_log"
+            printf 'CODER_INPUT_COUNT=%s\n' "$scrubbed_count"
+            printf 'SUBMODULE_SCRUB_COUNT=%s\n' "$scrub_count"
+            printf 'SUBMODULE_REVERT_COUNT=0\n'
+        } > "$result_file"
+        return 0
+    fi
+
+    # Working tree dirty — commit per round when round_num is provided so the
+    # next review round can evaluate the fixes as committed code. When called
+    # from findings mode (no round_num), the parent caller owns the commit.
+    if [[ "$round_num" =~ ^[0-9]+$ ]] && (( round_num > 0 )); then
+        if ! git add -A 2>>"$round_dir/coder-commit.log"; then
+            {
+                printf 'CODER_TOOL=%s\n' "$(cat "$tool_file")"
+                printf 'CODER_STATUS=failed\n'
+                printf 'CODER_LOG_FILE=%s\n' "$tool_log"
+                printf 'CODER_INPUT_COUNT=%s\n' "$scrubbed_count"
+                printf 'SUBMODULE_SCRUB_COUNT=%s\n' "$scrub_count"
+                printf 'SUBMODULE_REVERT_COUNT=0\n'
+            } > "$result_file"
+            return 2
+        fi
+        if ! "$PLUGIN_ROOT/scripts/git-commit.sh" -m "Address code review feedback (round $round_num)" >>"$round_dir/coder-commit.log" 2>&1; then
+            {
+                printf 'CODER_TOOL=%s\n' "$(cat "$tool_file")"
+                printf 'CODER_STATUS=failed\n'
+                printf 'CODER_LOG_FILE=%s\n' "$tool_log"
+                printf 'CODER_INPUT_COUNT=%s\n' "$scrubbed_count"
+                printf 'SUBMODULE_SCRUB_COUNT=%s\n' "$scrub_count"
+                printf 'SUBMODULE_REVERT_COUNT=0\n'
+            } > "$result_file"
+            return 2
+        fi
+        commit_sha=$(git rev-parse HEAD 2>/dev/null || true)
+    fi
+
     {
         printf 'CODER_TOOL=%s\n' "$(cat "$tool_file")"
         printf 'CODER_STATUS=applied\n'
@@ -305,13 +350,14 @@ apply_findings_with_coder() {
         printf 'CODER_INPUT_COUNT=%s\n' "$scrubbed_count"
         printf 'SUBMODULE_SCRUB_COUNT=%s\n' "$scrub_count"
         printf 'SUBMODULE_REVERT_COUNT=0\n'
+        [[ -n "$commit_sha" ]] && printf 'CODER_COMMIT_SHA=%s\n' "$commit_sha"
     } > "$result_file"
     return 0
 }
 
 write_summary_json() {
     local output="$1" tmp="$1.tmp.$$"
-    local status="$2" core_status="$3" round="$4" accepted="$5" rejected="$6" rounds_completed="$7" approved="$8" round_dir="$9" oos_jsonl="${10}" oos_markdown="${11}" cap="${12:-0}" coder_tool="${13:-none}" coder_status="${14:-skipped}" scrub_count="${15:-0}" revert_count="${16:-0}"
+    local status="$2" core_status="$3" round="$4" accepted="$5" rejected="$6" rounds_completed="$7" approved="$8" round_dir="$9" oos_jsonl="${10}" oos_markdown="${11}" cap="${12:-0}" coder_tool="${13:-none}" coder_status="${14:-skipped}" scrub_count="${15:-0}" revert_count="${16:-0}" commit_sha="${17:-}"
     jq -n \
         --arg status "$status" \
         --arg core_status "$core_status" \
@@ -328,6 +374,7 @@ write_summary_json() {
         --arg coder_status "$coder_status" \
         --argjson submodule_scrub_count "$scrub_count" \
         --argjson submodule_revert_count "$revert_count" \
+        --arg coder_commit_sha "$commit_sha" \
         '{
             schema_version: 2,
             status: $status,
@@ -344,7 +391,8 @@ write_summary_json() {
             coder_tool: $coder_tool,
             coder_status: $coder_status,
             submodule_scrub_count: $submodule_scrub_count,
-            submodule_revert_count: $submodule_revert_count
+            submodule_revert_count: $submodule_revert_count,
+            coder_commit_sha: $coder_commit_sha
         }' > "$tmp"
     mv -f "$tmp" "$output"
 }
@@ -491,6 +539,7 @@ run_findings_mode() {
     coder_input_count=$(kv_get "$coder_env" CODER_INPUT_COUNT)
     scrub_count=$(kv_get "$coder_env" SUBMODULE_SCRUB_COUNT)
     revert_count=$(kv_get "$coder_env" SUBMODULE_REVERT_COUNT)
+    coder_commit_sha=$(kv_get "$coder_env" CODER_COMMIT_SHA)
 
     case "$coder_rc" in
         0) review_status="complete"; exit_code=0 ;;
@@ -504,6 +553,7 @@ run_findings_mode() {
     emit_kv CODER_TOOL "${coder_tool:-none}"
     emit_kv CODER_STATUS "${coder_status:-unknown}"
     [[ -n "${coder_log:-}" ]] && emit_kv CODER_LOG_FILE "$coder_log"
+    [[ -n "${coder_commit_sha:-}" ]] && emit_kv CODER_COMMIT_SHA "$coder_commit_sha"
     emit_kv SUBMODULE_SCRUB_COUNT "${scrub_count:-0}"
     emit_kv SUBMODULE_REVERT_COUNT "${revert_count:-0}"
     exit "$exit_code"
@@ -538,6 +588,7 @@ run_implement_round() {
     mkdir -p "$round_dir"
     if (( round_num_dec == 1 )) && [[ -x "$PLUGIN_ROOT/scripts/snapshot-untracked.sh" ]]; then
         "$PLUGIN_ROOT/scripts/snapshot-untracked.sh" --output "$IMPLEMENT_TMPDIR/pre-review-untracked.txt"
+        git rev-parse HEAD > "$IMPLEMENT_TMPDIR/pre-review-head.txt" 2>/dev/null || rm -f "$IMPLEMENT_TMPDIR/pre-review-head.txt"
     fi
     core_out="$round_dir/review-core.env"
     core_args=(
@@ -590,6 +641,7 @@ run_implement_round() {
     coder_tool="none"
     coder_status="skipped"
     coder_log=""
+    coder_commit_sha=""
     scrub_count=0
     revert_count=0
     in_scope_count=0
@@ -603,7 +655,7 @@ run_implement_round() {
         if (( in_scope_count > 0 )); then
             coder_env="$round_dir/coder.env"
             set +e
-            apply_findings_with_coder "$in_scope_file" "$round_dir" "$coder_env"
+            apply_findings_with_coder "$in_scope_file" "$round_dir" "$coder_env" "$round_num_dec"
             coder_rc=$?
             set -e
             coder_tool=$(kv_get "$coder_env" CODER_TOOL)
@@ -612,6 +664,7 @@ run_implement_round() {
             coder_input_count=$(kv_get "$coder_env" CODER_INPUT_COUNT)
             scrub_count=$(kv_get "$coder_env" SUBMODULE_SCRUB_COUNT)
             revert_count=$(kv_get "$coder_env" SUBMODULE_REVERT_COUNT)
+            coder_commit_sha=$(kv_get "$coder_env" CODER_COMMIT_SHA)
             coder_tool="${coder_tool:-none}"
             coder_status="${coder_status:-unknown}"
             coder_input_count="${coder_input_count:-0}"
@@ -702,6 +755,9 @@ run_implement_round() {
             elif [[ "$coder_status" == "applied" ]]; then
                 status="fix-required"
                 exit_code=3
+            elif [[ "$coder_status" == "no-changes" ]]; then
+                status="no-changes"
+                emit_breadcrumb "⚠ review-and-fix: round $round_num_dec — coder dispatch exited 0 but did not modify the working tree; halting loop"
             else
                 status="in-scope-filtered-out"
                 emit_breadcrumb "⚠ review-and-fix: round $round_num_dec — all accepted findings scrubbed; nothing to apply"
@@ -716,7 +772,7 @@ run_implement_round() {
     esac
 
     local round_cap_val="${ROUND_CAP:-0}"
-    write_summary_json "$prior_summary" "$status" "$core_status" "$round_num_dec" "$total_accepted" "$total_rejected" "$round_num_dec" "$accepted_file" "$round_dir" "$oos_jsonl" "$oos_markdown" "$round_cap_val" "$coder_tool" "$coder_status" "$scrub_count" "$revert_count"
+    write_summary_json "$prior_summary" "$status" "$core_status" "$round_num_dec" "$total_accepted" "$total_rejected" "$round_num_dec" "$accepted_file" "$round_dir" "$oos_jsonl" "$oos_markdown" "$round_cap_val" "$coder_tool" "$coder_status" "$scrub_count" "$revert_count" "$coder_commit_sha"
 
     emit_kv REVIEW_AND_FIX_STATUS "$status"
     emit_kv REVIEW_CORE_STATUS "$core_status"
@@ -733,6 +789,7 @@ run_implement_round() {
     emit_kv CODER_TOOL "$coder_tool"
     emit_kv CODER_STATUS "$coder_status"
     [[ -n "$coder_log" ]] && emit_kv CODER_LOG_FILE "$coder_log"
+    [[ -n "$coder_commit_sha" ]] && emit_kv CODER_COMMIT_SHA "$coder_commit_sha"
     emit_kv SUBMODULE_SCRUB_COUNT "$scrub_count"
     emit_kv SUBMODULE_REVERT_COUNT "$revert_count"
     emit_kv SKIPPED_FINDING_COUNT "${skipped_finding_count:-0}"

--- a/skills/review-and-fix/scripts/test-review-and-fix.sh
+++ b/skills/review-and-fix/scripts/test-review-and-fix.sh
@@ -42,10 +42,16 @@ if [[ "$tool" == "cursor" ]]; then
 fi
 case "${TEST_AGENT_BEHAVIOR:-codex-success}:$tool" in
   codex-success:codex)
+    printf 'modified by codex stub\n' >> src/main.py
     printf 'APPLIED: FINDING_1\n' > "$output"
     exit 0
     ;;
   cursor-success:cursor)
+    printf 'modified by cursor stub\n' >> src/main.py
+    printf 'APPLIED: FINDING_1\n' > "$output"
+    exit 0
+    ;;
+  codex-no-changes:codex)
     printf 'APPLIED: FINDING_1\n' > "$output"
     exit 0
     ;;
@@ -136,9 +142,16 @@ make_work_repo() {
     local dir="$1"
     mkdir -p "$dir/src"
     git -C "$dir" init -q
+    git -C "$dir" config user.email "test@example.com"
+    git -C "$dir" config user.name "Test User"
+    git -C "$dir" config commit.gpgsign false
     printf 'original\n' > "$dir/src/main.py"
-    git -C "$dir" add src/main.py
-    git -C "$dir" -c user.email=test@example.com -c user.name='Test User' commit -qm init
+    # Production-equivalent: IMPLEMENT_TMPDIR lives outside the repo. In the
+    # harness we keep it under the work tree for convenience, so .gitignore
+    # prevents `git add -A` (from the per-round commit step) from staging it.
+    printf 'implement*/\nreview*/\n' > "$dir/.gitignore"
+    git -C "$dir" add src/main.py .gitignore
+    git -C "$dir" commit -qm init
 }
 
 run_review_and_fix() {
@@ -175,11 +188,12 @@ grep -Fq 'CODER_STATUS=applied' <<< "$out" || fail "findings coder applied"
 
 run_orchestrator_case() {
     local label="$1" behavior="$2" expected_tool="$3"
-    local work="$TMP/$label" implement_tmp out rc
+    local work="$TMP/$label" implement_tmp out rc initial_head current_head
     make_work_repo "$work"
     implement_tmp="$work/implement"
     mkdir -p "$implement_tmp"
     printf 'CODEX_PRESENT=true\nCURSOR_PRESENT=true\n' > "$implement_tmp/session-env.sh"
+    initial_head=$(git -C "$work" rev-parse HEAD)
     set +e
     out=$(TEST_AGENT_BEHAVIOR="$behavior" run_review_and_fix "$work" \
         --implement-tmpdir "$implement_tmp" --mode diff --panel simple --round-num 1 --session-env-path "$implement_tmp/session-env.sh" --run-id "$label-run")
@@ -189,8 +203,14 @@ run_orchestrator_case() {
     grep -Fq 'REVIEW_AND_FIX_STATUS=fix-required' <<< "$out" || fail "$label status"
     grep -Fq "CODER_TOOL=$expected_tool" <<< "$out" || fail "$label tool"
     grep -Fq 'CODER_STATUS=applied' <<< "$out" || fail "$label applied"
+    grep -Eq '^CODER_COMMIT_SHA=[0-9a-f]+' <<< "$out" || fail "$label commit sha"
     [[ -f "$implement_tmp/round-1/coder-output.log" ]] || fail "$label coder output"
-    jq -e '.schema_version == 2 and .status == "fix-required" and .accepted_count == 1 and .coder_tool == "'"$expected_tool"'" and .coder_status == "applied" and .submodule_scrub_count == 0 and .submodule_revert_count == 0' "$implement_tmp/review-and-fix-summary.json" >/dev/null \
+    [[ -s "$implement_tmp/pre-review-head.txt" ]] || fail "$label pre-review-head snapshot"
+    [[ "$(cat "$implement_tmp/pre-review-head.txt")" == "$initial_head" ]] || fail "$label pre-review-head matches initial"
+    current_head=$(git -C "$work" rev-parse HEAD)
+    [[ "$current_head" != "$initial_head" ]] || fail "$label HEAD did not advance"
+    git -C "$work" log -1 --format='%s' | grep -Fq "Address code review feedback (round 1)" || fail "$label commit message"
+    jq -e '.schema_version == 2 and .status == "fix-required" and .accepted_count == 1 and .coder_tool == "'"$expected_tool"'" and .coder_status == "applied" and .submodule_scrub_count == 0 and .submodule_revert_count == 0 and (.coder_commit_sha | length > 0)' "$implement_tmp/review-and-fix-summary.json" >/dev/null \
         || fail "$label summary schema"
     jq -e '.batch == "code-review-tally" and .rounds == 1 and .accepted_count == 1 and .rejected_count == 0 and (.body | contains("# Review Round 1"))' \
         "$implement_tmp/larch-logs/implement/$label-run/code-review-tally.json" >/dev/null \
@@ -202,6 +222,27 @@ run_orchestrator_case() {
 
 run_orchestrator_case codex-case codex-success codex
 run_orchestrator_case cursor-case cursor-success cursor
+
+work_no_changes="$TMP/no-changes"
+make_work_repo "$work_no_changes"
+implement_tmp="$work_no_changes/implement"
+mkdir -p "$implement_tmp"
+printf 'CODEX_PRESENT=true\nCURSOR_PRESENT=true\n' > "$implement_tmp/session-env.sh"
+initial_head=$(git -C "$work_no_changes" rev-parse HEAD)
+set +e
+out=$(TEST_AGENT_BEHAVIOR=codex-no-changes run_review_and_fix "$work_no_changes" \
+    --implement-tmpdir "$implement_tmp" --mode diff --panel simple --round-num 1 --session-env-path "$implement_tmp/session-env.sh" --run-id no-changes-run)
+rc=$?
+set -e
+[[ "$rc" -eq 0 ]] || { echo "$out" >&2; fail "no-changes expected exit 0 got $rc"; }
+grep -Fq 'REVIEW_AND_FIX_STATUS=no-changes' <<< "$out" || fail "no-changes status"
+grep -Fq 'CODER_STATUS=no-changes' <<< "$out" || fail "no-changes coder status"
+if grep -q '^CODER_COMMIT_SHA=' <<< "$out"; then
+    fail "no-changes must not emit CODER_COMMIT_SHA"
+fi
+[[ "$(git -C "$work_no_changes" rev-parse HEAD)" == "$initial_head" ]] || fail "no-changes must not advance HEAD"
+jq -e '.schema_version == 2 and .status == "no-changes" and .coder_status == "no-changes" and .coder_commit_sha == ""' "$implement_tmp/review-and-fix-summary.json" >/dev/null \
+    || fail "no-changes summary schema"
 
 work_main_agent="$TMP/main-agent-required"
 make_work_repo "$work_main_agent"
@@ -509,6 +550,10 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 mkdir -p "$(dirname "$output")"
+# Mimic a real coder run that applied at least one finding (so CODER_STATUS
+# becomes "applied" under the new dirty-tree contract) while also logging
+# SKIPPED lines that the SKIPPED-routing logic must classify.
+printf 'modified by skipped stub\n' >> src/main.py
 cat "$PWD/implement/round-1-coder.log.seed" > "$output"
 exit 0
 EOF_AGENT_SKIPPED


### PR DESCRIPTION
## Summary

- `review-and-fix.sh` now commits each round's accepted fixes inline as `Address code review feedback (round N)` and emits `CODER_COMMIT_SHA=<sha>`; the next round's `review-core` therefore sees the prior fixes as committed code instead of writes that were silently dropped by Codex's `--full-auto` sandbox.
- When the coder dispatch exits 0 but `git status --porcelain` is empty (sandbox blocked writes, coder declined every finding), the script emits the new `CODER_STATUS=no-changes` instead of the misleading `applied`; the orchestrator treats this as terminal so it stops looping on a fixed point.
- Adds `--add-dir "$PWD"` to the Codex invocation in `run_coder_dispatch` for parity with `scripts/launch-codex-implement.sh` — without it, codex's `--full-auto` sandbox can write to `--add-dir "$round_dir"` only, which is what produced the silent-failure mode the issue describes.
- `check-review-changes.sh` learns a `--head-baseline` flag, and `review-and-fix.sh` writes `$IMPLEMENT_TMPDIR/pre-review-head.txt` at the start of round 1 (alongside `pre-review-untracked.txt`). After per-round commits leave the working tree clean, Step 6 still detects HEAD movement and runs the second lint pass instead of silently skipping.
- `/implement` Step 7's "Address code review feedback" commit prose now notes that it is a no-op on the common path because per-round commits already exist; it still fires when the main agent landed manual edits (e.g., the `main-agent-vote-required` adjudication branch).

Closes #2236.

## Test plan

- [x] `bash skills/review-and-fix/scripts/test-review-and-fix.sh` — passes; new orchestrator assertions verify `CODER_COMMIT_SHA` emission, HEAD advance, `Address code review feedback (round 1)` commit message, `pre-review-head.txt` snapshot, and a dedicated `codex-no-changes` scenario that asserts `CODER_STATUS=no-changes`, no commit_sha, and HEAD does not advance.
- [x] `bash skills/implement/scripts/test-check-review-changes.sh` — 16/16 pass; new cases (o) and (p) pin the `--head-baseline` no-op-vs-detect semantics for the per-round commit flow.
- [x] `$PWD/.claude/skills/relevant-checks/scripts/run-checks.sh` — clean on both changed-file and full-repo phases.
- [ ] CI green on the PR (gh checks).
