### PR TITLE
Retry transient UNKNOWN mergeStateStatus after flush force-push (closes #2342)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "29.6.0",
+  "version": "29.6.1",
   "description": "Multi-agent workflow automation for Claude Code: design, code review, implementation, and PR automation. Code review runs a 7-reviewer specialist panel (6 Cursor specialists + 1 Codex generic) in SIMPLE mode or a 12-reviewer panel (6 Cursor + 6 Codex specialists) in HARD mode, both with a 3-judge voting panel every round (Claude opus + Codex + Cursor; Claude replacement when an external is unhealthy); plan review runs a 4-reviewer diagonal panel (2 Cursor: Arch, Edge + 2 Codex: Innovation, Pragmatic); design sketches run a 4-agent diverge-then-converge phase in regular mode (2 Cursor + 2 Codex) or 2 in quick mode.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Document the `review-and-fix.sh` applied-fixes contract change: accepted findings applied by the coder now complete with exit `0` plus `REVIEW_AND_FIX_STATUS=fix-applied`, and `review-and-fix-summary.json` now records `.status = "fix-applied"` instead of the old `fix-required`/exit-3 checkpoint shape. External wrappers, jq filters, and dashboards must key on the new status fields rather than exit `3`.
 
+## [29.6.1] - 2026-05-18
+
+### Fixed
+
+- `merge-pr.sh` no longer stalls Step 12d when `mergeStateStatus=UNKNOWN` immediately after the flush-commit force-push recovery. The post-force-push path now retries `gh pr view` up to 3 times (5s sleep) to absorb GitHub's transient post-push `UNKNOWN` propagation delay before failing closed (closes #2342).
+
 ## [29.6.0] - 2026-05-18
 
 ### Changed

--- a/scripts/merge-pr.md
+++ b/scripts/merge-pr.md
@@ -55,6 +55,8 @@ As part of OID mismatch handling for step 1, the script checks whether local HEA
 
 When the condition holds, the script calls `git-force-push.sh --expected-remote-oid <old-pr-head-oid>` so the force-push is leased against the PR head OID that was actually reviewed. This prevents the recovery path from overwriting a newer remote commit that landed after the initial `gh pr view`. After a successful push, the script re-reads PR metadata via `gh pr view` and re-runs `gh pr checks` for the updated head before any merge attempt. If the force-push fails or the OID still doesn't match after the push, `MERGE_RESULT=error` is emitted with a "force-push failed" or "after force-push recovery" suffix respectively.
 
+GitHub's API often returns `mergeStateStatus=UNKNOWN` immediately after a push due to propagation delay. When the post-force-push `gh pr view` returns `UNKNOWN` (or empty), the script sleeps 5 seconds and re-reads PR metadata, up to 3 times, before treating `UNKNOWN` as a hard error. If the state resolves to a non-UNKNOWN value (including `BEHIND` or a non-admin-eligible state), the existing post-recovery routing applies. If it remains `UNKNOWN` after all 3 retries, `MERGE_RESULT=error` is emitted with `ERROR=mergeStateStatus still UNKNOWN after 3 retries post-force-push (state="...")`.
+
 Non-recoverable divergence (any non-flush commit in the ahead range, any changed path outside `larch-logs/`, more than 5 ahead commits, or local HEAD behind the PR head OID) preserves the original `MERGE_RESULT=error` with "refusing to evaluate same-version gate".
 
 ## Batched discovery

--- a/scripts/merge-pr.sh
+++ b/scripts/merge-pr.sh
@@ -212,9 +212,21 @@ if [[ -z "$LOCAL_HEAD" ]] || [[ "$LOCAL_HEAD" != "$PR_HEAD_OID" ]]; then
             ERROR=""
             exit 0
         fi
+        # GitHub's API often returns UNKNOWN immediately after a push due to
+        # propagation delay (#2342). Retry briefly before treating as a hard
+        # error so transient post-push UNKNOWN states don't stall the merge.
+        if [[ -z "$MERGE_STATE" ]] || [[ "$MERGE_STATE" == "UNKNOWN" ]]; then
+            for _retry in 1 2 3; do
+                sleep 5
+                refresh_pr_info
+                if [[ -n "$MERGE_STATE" ]] && [[ "$MERGE_STATE" != "UNKNOWN" ]]; then
+                    break
+                fi
+            done
+        fi
         if [[ -z "$MERGE_STATE" ]] || [[ "$MERGE_STATE" == "UNKNOWN" ]]; then
             MERGE_RESULT="error"
-            ERROR="could not read mergeStateStatus from gh pr view --json mergeStateStatus,headRefOid after force-push recovery (state=\"$MERGE_STATE\")"
+            ERROR="mergeStateStatus still UNKNOWN after 3 retries post-force-push (state=\"$MERGE_STATE\")"
             exit 0
         fi
         refresh_ci_state

--- a/scripts/test-merge-pr.sh
+++ b/scripts/test-merge-pr.sh
@@ -49,6 +49,9 @@ case "$2" in
         # Compound call: returns JSON with both mergeStateStatus and headRefOid.
         # __EMPTY__ sentinel → null mergeStateStatus so jq // "" yields "".
         # GH_VIEW_SECOND_*: if set, return it on 2nd+ call (flush recovery).
+        # GH_VIEW_FLIP_AT_CALL / GH_VIEW_FLIP_MERGE_STATE: if set, override
+        # MERGE_STATE starting at the given call count (post-force-push UNKNOWN
+        # retry tests).
         HEAD_OID="${STUB_PR_HEAD_OID:-aaaa1111}"
         MERGE_STATE="${GH_MERGE_STATE:-CLEAN}"
         if [[ -n "${GH_VIEW_SECOND_HEAD_OID:-}" ]] && [[ -n "${GH_VIEW_COUNT_FILE:-}" ]]; then
@@ -57,6 +60,9 @@ case "$2" in
             if [[ "$_count" -ge 2 ]]; then
                 HEAD_OID="$GH_VIEW_SECOND_HEAD_OID"
                 MERGE_STATE="${GH_VIEW_SECOND_MERGE_STATE:-$MERGE_STATE}"
+            fi
+            if [[ -n "${GH_VIEW_FLIP_AT_CALL:-}" ]] && [[ "$_count" -ge "$GH_VIEW_FLIP_AT_CALL" ]]; then
+                MERGE_STATE="${GH_VIEW_FLIP_MERGE_STATE:-$MERGE_STATE}"
             fi
         fi
         if [[ "$MERGE_STATE" == "__EMPTY__" ]]; then
@@ -551,6 +557,42 @@ chore(larch-logs): flush implement run 6" \
 assert_stdout_contains "flush_recovery_cap" "MERGE_RESULT=error" "P1: >5 flush commits emit error"
 assert_stdout_contains "flush_recovery_cap" "ERROR=local HEAD (cccc3333) does not match PR head OID (aaaa1111); refusing to evaluate same-version gate" "P2: >5 flush commits preserve original OID error"
 assert_no_merge_commands "flush_recovery_cap" "P3: >5 flush commits skip merge commands"
+
+echo
+echo "Sub-test Q: post-force-push UNKNOWN retries before treating as error (#2342)"
+run_case "post_force_push_unknown_retry_success" \
+    env GH_MERGE_STATE=CLEAN \
+    STUB_HEAD_OID=cccc3333 \
+    STUB_PR_HEAD_OID=aaaa1111 \
+    GH_VIEW_SECOND_HEAD_OID=cccc3333 \
+    GH_VIEW_SECOND_MERGE_STATE=UNKNOWN \
+    GH_VIEW_FLIP_AT_CALL=5 \
+    GH_VIEW_FLIP_MERGE_STATE=CLEAN \
+    STUB_FLUSH_AHEAD_LOG="chore(larch-logs): flush implement run ABC" \
+    STUB_PUSH_EXIT=0 \
+    STUB_BRANCH_NAME=feature-branch \
+    STUB_REMOTE_OID=cccc3333 \
+    bash "$REPO_ROOT/scripts/merge-pr.sh" --pr 123 --repo owner/repo
+assert_stdout_contains "post_force_push_unknown_retry_success" "MERGE_RESULT=admin_merged" "Q1: UNKNOWN after force-push resolves on retry → admin_merged"
+assert_command_count "post_force_push_unknown_retry_success" "gh.log" "pr view 123 --repo owner/repo --json mergeStateStatus,headRefOid" "5" "Q2: pr view called 5x (initial + post-force-push + 3 retries)"
+
+echo
+echo "Sub-test R: post-force-push UNKNOWN persists, fails after 3 retries (#2342)"
+run_case "post_force_push_unknown_retry_failure" \
+    env GH_MERGE_STATE=CLEAN \
+    STUB_HEAD_OID=cccc3333 \
+    STUB_PR_HEAD_OID=aaaa1111 \
+    GH_VIEW_SECOND_HEAD_OID=cccc3333 \
+    GH_VIEW_SECOND_MERGE_STATE=UNKNOWN \
+    STUB_FLUSH_AHEAD_LOG="chore(larch-logs): flush implement run ABC" \
+    STUB_PUSH_EXIT=0 \
+    STUB_BRANCH_NAME=feature-branch \
+    STUB_REMOTE_OID=cccc3333 \
+    bash "$REPO_ROOT/scripts/merge-pr.sh" --pr 123 --repo owner/repo
+assert_stdout_contains "post_force_push_unknown_retry_failure" "MERGE_RESULT=error" "R1: UNKNOWN persists after 3 retries → error"
+assert_stdout_matches "post_force_push_unknown_retry_failure" "^ERROR=mergeStateStatus still UNKNOWN after 3 retries post-force-push" "R2: error message references retry count"
+assert_command_count "post_force_push_unknown_retry_failure" "gh.log" "pr view 123 --repo owner/repo --json mergeStateStatus,headRefOid" "5" "R3: pr view called 5x before bailing"
+assert_no_merge_commands "post_force_push_unknown_retry_failure" "R4: persistent UNKNOWN skips merge commands"
 
 echo
 if [[ "$FAIL_COUNT" -eq 0 ]]; then


### PR DESCRIPTION
## Summary

- Closes #2342. Retry transient `mergeStateStatus=UNKNOWN` (up to 3× 5s) after the flush-commit force-push recovery in `scripts/merge-pr.sh` so a transient post-push propagation delay no longer stalls `ship-pr.sh` Step 12d.
- Extends the test harness with a call-count-indexed state-transition mechanism and adds two sub-tests covering retry success and retry-exhaustion failure.
- PATCH bump 29.6.0 → 29.6.1.

## Behavior change

Only the flush-recovery branch after `git-force-push.sh` succeeds. The initial `gh pr view` UNKNOWN guard (line 133-137) is unchanged — that path is not in the issue scope.

| Scenario | Before | After |
|---|---|---|
| Post-force-push state is `CLEAN`/`UNSTABLE`/`HAS_HOOKS`/`BLOCKED` | proceeds | proceeds (no retry runs) |
| Post-force-push state is `BEHIND` | `main_advanced` (empty ERROR) | `main_advanced` (empty ERROR) — BEHIND check still short-circuits before retry |
| Post-force-push state is `UNKNOWN` or empty | `MERGE_RESULT=error` immediately | retries `gh pr view` 3× × 5s; if state resolves, falls through to existing routing; if it stays `UNKNOWN`, `MERGE_RESULT=error` with `"mergeStateStatus still UNKNOWN after 3 retries post-force-push"` |
| Retry resolves to `BEHIND`/`DIRTY`/`DRAFT`/etc. | n/a | catch-all at line 226 → `main_advanced` with `"...after force-push recovery"` suffix |

Worst-case latency added: ~15s in the failure mode. Trade-off accepted vs the alternative of operator-driven `--admin` merge.

## Files

- `scripts/merge-pr.sh` — insert retry loop between post-force-push BEHIND check and the UNKNOWN→error short-circuit; update terminal ERROR string.
- `scripts/merge-pr.md` — new paragraph in "Flush-commit OID recovery" documenting the retry contract.
- `scripts/test-merge-pr.sh` — extend fake `gh` view stub with `GH_VIEW_FLIP_AT_CALL` / `GH_VIEW_FLIP_MERGE_STATE`; add sub-tests Q (success after 3 retries) and R (failure after 3 retries).
- `CHANGELOG.md` — new `[29.6.1]` section with the `Fixed` entry.
- `.claude-plugin/plugin.json` — `29.6.0` → `29.6.1`.

## Test plan

- [x] `bash scripts/test-merge-pr.sh` — 87 assertions pass (4 new from Q + R)
- [x] `bash scripts/test-ship-pr.sh` — 121 assertions pass (no regression)
- [x] `make lint-bash32` — clean
- [x] `shellcheck -x scripts/merge-pr.sh scripts/test-merge-pr.sh` — clean
- [x] `pre-commit run --files <changed>` — all hooks pass
- [ ] CI on this branch — pending
