### PR TITLE
docs: fix stale Step 18 references left uncommitted from PR #2427

### DIFF
--- a/scripts/larch-log-batches.md
+++ b/scripts/larch-log-batches.md
@@ -14,8 +14,9 @@ The table intentionally covers the legacy tracking sections as durable files:
 `review-scout-manifest`, `review-tally`), `version-bump-reasoning`,
 `oos-issues`, `run-statistics`, `token-report`, `timing-report`,
 `execution-issues`, and `session-transcript`
-(the redacted Claude Code session transcript captured at Step 18 for full
-post-hoc auditability).
+(the redacted Claude Code session transcript captured at Step 7a tail
+pre-bump flush for full post-hoc auditability; refreshed on each CI-retry
+push via `scripts/refresh-run-logs.sh`).
 
 `plan-goals-test` uses the `plan-goals` sanitizer. The sanitizer requires a
 sectioned payload with a non-empty `## Implementation Plan` body and rejects

--- a/scripts/ship-pr.sh
+++ b/scripts/ship-pr.sh
@@ -1606,7 +1606,8 @@ run_postmerge_phase() {
     [ "$rc" -eq 0 ] || record_failure postmerge "implement-finalize.sh postmerge" "$rc" "$fail_file"
     # Finalize manifest to status=done here so the update survives if the
     # LLM session ends before prompt-side Step 18 teardown runs. The manifest
-    # fields are committed by the session-transcript capture in Step 18.
+    # status=done update is local-only; the last committed snapshot remains
+    # in-progress (by design — the transcript was flushed at Step 7a before merge).
     local flush_run_id pr_num manifest_path_pm flush_issue_num recovery_ok
     flush_run_id=$(read_state RUN_ID)
     pr_num=$(read_state PR_NUMBER)


### PR DESCRIPTION
## Summary

- `scripts/larch-log-batches.md`: updates the `session-transcript` description from "captured at Step 18" to "captured at Step 7a tail pre-bump flush … refreshed on each CI-retry push via `scripts/refresh-run-logs.sh`"
- `scripts/ship-pr.sh`: replaces a stale comment ("fields are committed by the session-transcript capture in Step 18") with an accurate description of the post-merge manifest update behavior

## Context

These are OOS doc-drift fixes (FINDING_18) from the #2420 fix run (PR #2427). They were applied to the working tree during review-round processing but were not staged and committed before the `implement` pipeline ran its final log-flush commits and merged. The teardown script does not commit or stash uncommitted working-tree changes, so they survived on the feature branch as dirty state after merge. This PR lands them on main as a follow-on patch.

Closes #2436 (tracking issue).

## Test plan

- [ ] CI passes (docs-only change, no shell logic modified)
- [ ] `grep -n "Step 18" scripts/larch-log-batches.md` returns no match after merge
- [ ] `grep -n "Step 18" scripts/ship-pr.sh | grep session-transcript` returns no match after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)