### PR TITLE
Fixes #2491: stop false-positive validator reject for shared-OOS reviewers

### DIFF
--- a/skills/review/scripts/aggregate-findings.md
+++ b/skills/review/scripts/aggregate-findings.md
@@ -24,7 +24,7 @@
 - Fewer than two `### FINDING_` blocks → pass-through, `REASON=insufficient-input`.
 - Otherwise builds a prompt from `agents/orchestrator-aggregator.md` (YAML frontmatter stripped) plus the raw `findings.md` body, writes a one-row NDJSON slot (`slot=aggregator`, `tool=cursor`, `output=$REVIEW_TMPDIR/aggregator-output.txt`, `prompt_file=…`), and invokes `${CLAUDE_PLUGIN_ROOT}/scripts/dispatch-with-waterfall.sh` (override for tests: `AGGREGATE_DISPATCH_SH`).
 - On `DISPATCH_OK=false`, dispatch non-zero, empty output, or Python validation failure → keep original `findings.md`, append execution issue, `REASON=dispatch-failed` or `validation-failed`.
-- Validation (Python): every output block has a reviewer attribution line (`**Reviewer(s)**` / `**Reviewer**` / `**Reviewers**` / unbolded `Reviewer(s):` / `Reviewer:` / `Reviewers:`); every comma-separated slot must appear in the input reviewer set; every input reviewer label must appear in at least one output block; unknown slots in merged output fail validation.
+- Validation (Python): every output block has a reviewer attribution line (`**Reviewer(s)**` / `**Reviewer**` / `**Reviewers**` / unbolded `Reviewer(s):` / `Reviewer:` / `Reviewers:`); every comma-separated slot must appear in the input reviewer set; every input reviewer label must appear in at least one output block; unknown slots in merged output fail validation. A reviewer label that appears exclusively on OOS-tagged input findings (never on a non-OOS input finding) must not appear in a non-OOS output block; reviewers with both OOS and in-scope input findings may appear in either kind of output block (issue #2491).
 
 ## Stdout
 

--- a/skills/review/scripts/aggregate-findings.sh
+++ b/skills/review/scripts/aggregate-findings.sh
@@ -283,10 +283,18 @@ def main():
     outtext = open(output_path, encoding="utf-8").read()
     oos_slots = oos_attributed_slots(intext)
     input_slot_set = set()
+    non_oos_input_slots = set()
     for block in input_blocks(intext):
         _line, slots = reviewer_line_slots(block)
+        is_oos = "[OUT_OF_SCOPE]" in heading_line(block)
         for sl in slots:
             input_slot_set.add(sl)
+            if not is_oos:
+                non_oos_input_slots.add(sl)
+    # Only flag reviewers who are EXCLUSIVELY OOS in the input. A reviewer that
+    # contributed both OOS and in-scope input findings is legitimately attributed
+    # to non-OOS merged output blocks (see issue #2491).
+    oos_only_slots = oos_slots - non_oos_input_slots
     if not input_slot_set:
         print("no input reviewer labels", file=sys.stderr)
         return 1
@@ -314,10 +322,10 @@ def main():
             return 1
         if not is_oos_out:
             for sl in slots:
-                if sl in oos_slots:
+                if sl in oos_only_slots:
                     print(
                         "merged output lacks [OUT_OF_SCOPE] while listing reviewer %r "
-                        "that appears on an OOS-tagged input finding" % (sl,),
+                        "that appears only on OOS-tagged input findings" % (sl,),
                         file=sys.stderr,
                     )
                     return 1

--- a/skills/review/scripts/test-aggregate-findings.sh
+++ b/skills/review/scripts/test-aggregate-findings.sh
@@ -77,10 +77,15 @@ EOF
                 ;;
             oos_shared_slot_merge)
                 cat > "$out" <<'EOF'
-### FINDING_1: merged in scope
+### FINDING_1: in-scope A
 - **Reviewer(s)**: cursor-a-output.txt
-- **Concern**: merged
+- **Concern**: x
 - **Suggested revision**: fix
+
+### FINDING_2: [OUT_OF_SCOPE] **code-quality** [`x`]
+- **Reviewer(s)**: cursor-a-output.txt
+- **Concern**: oos
+- **Suggested revision**: n/a
 
 EOF
                 ;;
@@ -254,7 +259,7 @@ grep -Fq 'AGGREGATED=false' "$TMP/out-oos.env" || fail "oos-drop AGGREGATED"
 grep -Fq 'REASON=validation-failed' "$TMP/out-oos.env" || fail "oos-drop REASON"
 cmp -s "$TMP/in-oos.md" "$TMP/in-oos-work.md" || fail "findings unchanged on OOS tag drop"
 
-echo "=== validation rejects merge when OOS-tagged input shares a reviewer with in-scope merge ==="
+echo "=== validation accepts merge when reviewer has both OOS and in-scope input findings (#2491) ==="
 cat > "$TMP/in-oos-shared.md" <<'EOF'
 ### FINDING_1: in-scope A
 - **Reviewer**: cursor-a-output.txt
@@ -278,9 +283,11 @@ AGGREGATE_STUB_MERGE_KIND=oos_shared_slot_merge \
     --codex-present true \
     --cursor-present true \
     --mode diff >"$TMP/out-oos-shared.env"
-grep -Fq 'AGGREGATED=false' "$TMP/out-oos-shared.env" || fail "oos-shared AGGREGATED"
-grep -Fq 'REASON=validation-failed' "$TMP/out-oos-shared.env" || fail "oos-shared REASON"
-cmp -s "$TMP/in-oos-shared.md" "$TMP/in-oos-shared-work.md" || fail "findings unchanged on OOS shared-slot merge"
+grep -Fq 'AGGREGATED=true' "$TMP/out-oos-shared.env" || fail "oos-shared AGGREGATED"
+grep -Fq 'REASON=ok' "$TMP/out-oos-shared.env" || fail "oos-shared REASON"
+grep -Fq 'MERGED_COUNT=2' "$TMP/out-oos-shared.env" || fail "oos-shared MERGED_COUNT"
+[[ "$(grep -c '^### FINDING_' "$TMP/in-oos-shared-work.md" | tr -d '[:space:]')" == "2" ]] || fail "expected two FINDING blocks after OOS shared-slot merge"
+grep -Fq '[OUT_OF_SCOPE]' "$TMP/in-oos-shared-work.md" || fail "expected [OUT_OF_SCOPE] preserved in OOS shared-slot merge"
 
 issues_parent="$TMP/agg-exec-issues"
 mkdir -p "$issues_parent"


### PR DESCRIPTION
## Summary

Fixes #2491. `aggregate-findings.sh`'s `validate_py` rejected legitimate merges when a reviewer contributed both OOS and in-scope input findings: it built `oos_slots` from any OOS-tagged input finding, then forbade those reviewers from non-OOS output blocks — turning a shared reviewer into a false positive that left `findings.md` with all unmerged duplicate findings.

The fix replaces that check with `oos_only_slots = oos_slots - non_oos_input_slots`, so only reviewers **exclusively** attributed to OOS input findings are forbidden from non-OOS output blocks. Reviewers with both OOS and in-scope input findings can legitimately appear in either kind of output block.

## Changes

- `skills/review/scripts/aggregate-findings.sh`: compute `non_oos_input_slots` in the existing input loop; derive `oos_only_slots = oos_slots - non_oos_input_slots`; use it in the non-OOS output block check; update the diagnostic message.
- `skills/review/scripts/test-aggregate-findings.sh`: kept the only-OOS reviewer rejection case (still rejects, now via `oos_only_slots`); flipped the shared-reviewer case from reject-on-1-block-merge to accept-on-proper-2-block-merge (in-scope + OOS preserved with shared reviewer attribution).
- `skills/review/scripts/aggregate-findings.md`: documented the OOS validation rule and reference to #2491.

## Test plan

- [x] `bash skills/review/scripts/test-aggregate-findings.sh` — all 8 harness assertions pass, including the new acceptance test for the previously-false-positive shared-reviewer case.
- [x] `.claude/skills/relevant-checks/scripts/run-checks.sh` — pre-commit (shellcheck, markdownlint, agent-lint, gitleaks, etc.) and full-repo agent-lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
