### PR TITLE
Fixes #2817: Gate accept-path launcher tests behind PATH stub + USER override

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "42.5.4",
+  "version": "42.5.5",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (tier flags `--trivial` / `--simple` / `--hard`) and `/implement` (positional `<issue-N>`, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified hard panel internally (public `--panel` argv removed). Post-plan steps use the conventional hard workflow path and `$IMPLEMENT_TMPDIR/plan.txt` for plan materialization — there is no `/implement --hard` flag.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/scripts/test-launch-review.sh
+++ b/scripts/test-launch-review.sh
@@ -691,8 +691,12 @@ done
 
 # --token-budget-cap accept path: flag recognized (not "unknown flag"), binary
 # absence or other required-flag errors cause non-0 exit from later checks.
+# PATH stub prevents the launcher from invoking the real codex CLI on dev Macs.
+# USER override gives this test a private serial-lock path so parallel clone
+# sessions running the same harness do not queue on /tmp/larch-codex-serial-${USER}.lock.
 set +e
-"$LAUNCHER" --output "$TMPDIR/budget-accept.txt" --timeout 5 --prompt "x" \
+PATH="$STUB_BIN:$PATH" USER="larch-test-budget-accept-codex-$$" \
+    "$LAUNCHER" --output "$TMPDIR/budget-accept.txt" --timeout 5 --prompt "x" \
     --token-budget-cap 9999999 >/dev/null 2>"$TMPDIR/budget-accept.stderr"
 set -e
 if grep -Fq "unknown flag: --token-budget-cap" "$TMPDIR/budget-accept.stderr" 2>/dev/null; then
@@ -734,8 +738,12 @@ else
 fi
 
 # --diff-file accept path: flag recognized (not "unknown flag").
+# PATH stub prevents the launcher from invoking the real codex CLI on dev Macs.
+# USER override gives this test a private serial-lock path so parallel clone
+# sessions running the same harness do not queue on /tmp/larch-codex-serial-${USER}.lock.
 set +e
-"$LAUNCHER" --output "$TMPDIR/diff-file-accept.txt" --timeout 5 --prompt "x" \
+PATH="$STUB_BIN:$PATH" USER="larch-test-diff-file-accept-codex-$$" \
+    "$LAUNCHER" --output "$TMPDIR/diff-file-accept.txt" --timeout 5 --prompt "x" \
     --diff-file "/nonexistent/branch.diff" >/dev/null 2>"$TMPDIR/diff-file-accept.stderr"
 set -e
 if grep -Fq "unknown flag: --diff-file" "$TMPDIR/diff-file-accept.stderr" 2>/dev/null; then
@@ -1886,8 +1894,12 @@ done
 
 # Accept path: flag recognized (not "unknown flag"), binary absence or other
 # required-flag errors cause non-0 exit from later checks.
+# PATH stub prevents the launcher from invoking the real cursor CLI on dev Macs.
+# USER override gives this test a private serial-lock path so parallel clone
+# sessions running the same harness do not queue on /tmp/larch-cursor-serial-${USER}.lock.
 set +e
-"$LAUNCHER" --output "$TMPDIR/budget-accept.txt" --timeout 5 --prompt "x" \
+PATH="$STUB_BIN:$PATH" USER="larch-test-budget-accept-cursor-$$" \
+    "$LAUNCHER" --output "$TMPDIR/budget-accept.txt" --timeout 5 --prompt "x" \
     --token-budget-cap 9999999 >/dev/null 2>"$TMPDIR/budget-accept.stderr"
 set -e
 if grep -Fq "unknown flag: --token-budget-cap" "$TMPDIR/budget-accept.stderr" 2>/dev/null; then
@@ -1897,8 +1909,12 @@ else
 fi
 
 # --diff-file accept path: flag recognized (not "unknown flag").
+# PATH stub prevents the launcher from invoking the real cursor CLI on dev Macs.
+# USER override gives this test a private serial-lock path so parallel clone
+# sessions running the same harness do not queue on /tmp/larch-cursor-serial-${USER}.lock.
 set +e
-"$LAUNCHER" --output "$TMPDIR/diff-file-accept.txt" --timeout 5 --prompt "x" \
+PATH="$STUB_BIN:$PATH" USER="larch-test-diff-file-accept-cursor-$$" \
+    "$LAUNCHER" --output "$TMPDIR/diff-file-accept.txt" --timeout 5 --prompt "x" \
     --diff-file "/nonexistent/branch.diff" >/dev/null 2>"$TMPDIR/diff-file-accept.stderr"
 set -e
 if grep -Fq "unknown flag: --diff-file" "$TMPDIR/diff-file-accept.stderr" 2>/dev/null; then


### PR DESCRIPTION
## Summary

- Four accept-path sections in `scripts/test-launch-review.sh` (codex/cursor × `--token-budget-cap` / `--diff-file`) invoked `$LAUNCHER` without a `PATH="$STUB_BIN:$PATH"` prefix and without a per-test `USER` override. On dev Macs with brew-installed `codex` / `cursor` this fell through to the real CLI (real LLM calls, billable) and contended on the global `/tmp/larch-${tool}-serial-${USER}.lock`.
- Each section now prepends `PATH="$STUB_BIN:$PATH" USER="larch-test-<section-key>-$$" \` before the existing `"$LAUNCHER"` invocation, matching the established shape used elsewhere in the file (e.g. lock-test block at the existing `CODEX_LOCK_USER` site, the cap-hit block, the cursor `--diff-file` specialist block).
- Patch-level version bump (no public skill/agent surface change).

## Acceptance

1. `bash scripts/test-launch-review.sh` passes on macOS (verified locally, 58.8 s, 280+ assertions).
2. Live probe during the run: `pgrep -f '/opt/homebrew/bin/codex|node /opt/homebrew/bin/codex'` returns 0 matches; `pgrep -f 'cursor-agent'` returns 0 matches throughout.
3. `/tmp/larch-codex-serial-${USER}.lock` and `/tmp/larch-cursor-serial-${USER}.lock` never appear; only per-test variants matching `/tmp/larch-(codex|cursor)-serial-larch-test-*-[0-9]*.lock` appear briefly.
4. `bash scripts/relevant-checks.sh` passes.

## Test plan

- [x] `bash scripts/test-launch-review.sh` passes on macOS
- [x] Live `pgrep` probe shows no real codex/cursor-agent spawned during the run
- [x] Global serial-lock paths never created; only per-test variants observed
- [x] `bash scripts/relevant-checks.sh` passes
- [ ] CI green (Linux runners — guard paths remain inert on Linux since `lib-external-launcher-common.sh` short-circuits to `return 0` on non-Darwin)

Closes #2817

🤖 Generated with [Claude Code](https://claude.com/claude-code)
