### PR TITLE
Fixes #2872: decompose-file-issues parses multi-blocker dependency lists

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "42.5.17",
+  "version": "42.5.18",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (tier flags `--trivial` / `--simple` / `--hard`) and `/implement` (positional `<issue-N>`, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified hard panel internally (public `--panel` argv removed). Post-plan steps use the conventional hard workflow path and `$IMPLEMENT_TMPDIR/plan.txt` for plan materialization — there is no `/implement --hard` flag.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/skills/design/scripts/decompose-aggregator.sh
+++ b/skills/design/scripts/decompose-aggregator.sh
@@ -92,7 +92,7 @@ split | no-split
 
 ### Piece 1: <short title>
 - Scope: <files / behaviors covered>
-- Dependencies: none | blocked-by Piece N
+- Dependencies: none | blocked-by Piece N[, Piece M ...]
 - Diff_lines estimate: <integer>
 - Why independently mergeable: <prose>
 

--- a/skills/design/scripts/decompose-file-issues.md
+++ b/skills/design/scripts/decompose-file-issues.md
@@ -2,6 +2,8 @@
 
 **Purpose**: `prepare` (validate partition Markdown, emit `/larch:issue` batch input + intra-batch deps TSV, run cycle detection; drops prior batch artifacts at start and on non-`ok` status; cycle witness line in `prepare-python.log`), `annotate` (parse `/larch:issue` stdout into `partition-filed.md`; writes `.decompose-issues-filed` only when `ISSUES_FAILED=0`), and `close-original` (compose close comment, `redact-secrets.sh`, `gh issue comment --body-file`, `gh issue close`, `.decompose-original-closed` sentinel; uses `$DESIGN_TMPDIR/decompose/.decompose-close-comment-posted` so a retry after a successful comment but failed close does not duplicate the GitHub comment).
 
+**Edge-extraction rules**: `prepare` parses each piece's `- Dependencies:` line. When the line contains `blocked-by`, the remainder is split on commas or `and`; each non-empty segment must fullmatch `Piece <N>` (case-insensitive). One edge is emitted per unique blocker number (duplicate entries on the same line are deduped). Any non-`Piece <N>` segment (including the deferred plural shape `Pieces 1, 2, 3`), any unknown blocker number, or an empty segment list after parsing aborts with `DECOMPOSE_PARTITION_STATUS=bad-dependency-ref` exit 2 and emits no batch artifacts.
+
 **Primary caller**: `/design` Split-path filing sequence in `skills/design/references/decompose-panel.md`.
 
 **Security**: `close-original` always pipes the composed body through `scripts/redact-secrets.sh` before GitHub publication.

--- a/skills/design/scripts/decompose-file-issues.sh
+++ b/skills/design/scripts/decompose-file-issues.sh
@@ -94,14 +94,29 @@ for i, (pnum, title, body) in enumerate(pieces):
             dep = s.split(":", 1)[1].strip()
             break
     dep_lines.append(dep)
-    m = re.search(r"blocked-by\s+Piece\s+(\d+)", dep, re.I)
-    if m:
-        blocker = int(m.group(1))
-        if blocker not in index_by_num:
+    m_anchor = re.search(r"blocked-by\b(.*)$", dep, re.I)
+    if m_anchor:
+        remainder = m_anchor.group(1)
+        segments = [seg.strip() for seg in re.split(r",|\s+and\b", remainder, flags=re.I)]
+        segments = [seg for seg in segments if seg]
+        if not segments:
             print("DECOMPOSE_PARTITION_STATUS=bad-dependency-ref", flush=True)
             sys.exit(2)
-        bi = index_by_num[blocker]
-        edges.append((bi, i))
+        seen = set()
+        for seg in segments:
+            sm = re.fullmatch(r"Piece\s+(\d+)", seg, re.I)
+            if not sm:
+                print("DECOMPOSE_PARTITION_STATUS=bad-dependency-ref", flush=True)
+                sys.exit(2)
+            blocker = int(sm.group(1))
+            if blocker in seen:
+                continue
+            seen.add(blocker)
+            if blocker not in index_by_num:
+                print("DECOMPOSE_PARTITION_STATUS=bad-dependency-ref", flush=True)
+                sys.exit(2)
+            bi = index_by_num[blocker]
+            edges.append((bi, i))
 
 adj = defaultdict(list)
 indeg = [0] * n

--- a/skills/design/scripts/decompose-prompts/_common-tail.txt
+++ b/skills/design/scripts/decompose-prompts/_common-tail.txt
@@ -24,7 +24,7 @@ split | no-split
 
 ### Piece 1: <short title>
 - Scope: <files / behaviors covered>
-- Dependencies: none | blocked-by Piece N
+- Dependencies: none | blocked-by Piece N[, Piece M ...]
 - Diff_lines estimate: <integer>
 - Why independently mergeable: <one paragraph>
 

--- a/skills/design/scripts/test-decompose-file-issues.sh
+++ b/skills/design/scripts/test-decompose-file-issues.sh
@@ -89,6 +89,152 @@ printf '%s\n' "$_out2" | grep -Fq 'DECOMPOSE_PARTITION_STATUS=cycle-detected' ||
 grep -Fq 'DECOMPOSE_PARTITION_CYCLE_WITNESS=' "$D2/decompose/prepare-python.log" || fail "expected cycle witness in prepare log"
 [[ ! -f "$D2/decompose/partition-input.txt" ]] || fail "partition-input should not exist on cycle"
 
+echo "=== prepare multi-blocker comma list ==="
+D2c="$TMP/p2c"
+mkdir -p "$D2c"
+printf 'feat' >"$D2c/feature-description.txt"
+cat >"$D2c/part.md" <<'MD'
+## Recommendation
+split
+
+## Pieces
+
+### Piece 1: Alpha
+- Scope: a
+- Dependencies: none
+- Diff_lines estimate: 1
+- Why: x
+
+### Piece 2: Beta
+- Scope: b
+- Dependencies: none
+- Diff_lines estimate: 1
+- Why: x
+
+### Piece 3: Gamma
+- Scope: c
+- Dependencies: none
+- Diff_lines estimate: 1
+- Why: x
+
+### Piece 4: Delta
+- Scope: d
+- Dependencies: none
+- Diff_lines estimate: 1
+- Why: x
+
+### Piece 5: Epsilon
+- Scope: e
+- Dependencies: blocked-by Piece 1, Piece 2, Piece 3, Piece 4
+- Diff_lines estimate: 5
+- Why: y
+MD
+_out2c=$("$DFI" prepare --design-tmpdir "$D2c" --partition-file "$D2c/part.md" --issue-number 99 2>/dev/null || true)
+printf '%s\n' "$_out2c" | grep -Fq 'DECOMPOSE_PARTITION_STATUS=ok' || fail "multi-blocker ok status missing"
+[[ -f "$D2c/decompose/partition-deps.tsv" ]] || fail "multi-blocker deps tsv missing"
+grep -Fq $'1\t5' "$D2c/decompose/partition-deps.tsv" || fail "expected edge 1->5 in multi-blocker"
+grep -Fq $'2\t5' "$D2c/decompose/partition-deps.tsv" || fail "expected edge 2->5 in multi-blocker"
+grep -Fq $'3\t5' "$D2c/decompose/partition-deps.tsv" || fail "expected edge 3->5 in multi-blocker"
+grep -Fq $'4\t5' "$D2c/decompose/partition-deps.tsv" || fail "expected edge 4->5 in multi-blocker"
+_edges2c=$(wc -l <"$D2c/decompose/partition-deps.tsv" | tr -d ' ')
+[[ "$_edges2c" == "4" ]] || fail "expected 4 edges in multi-blocker tsv got $_edges2c"
+
+echo "=== prepare bad-ref inside multi list ==="
+D2d="$TMP/p2d"
+mkdir -p "$D2d"
+printf 'f' >"$D2d/feature-description.txt"
+cat >"$D2d/part.md" <<'MD'
+## Recommendation
+split
+
+## Pieces
+
+### Piece 1: A
+- Scope: a
+- Dependencies: none
+- Diff_lines estimate: 1
+- Why: x
+
+### Piece 2: B
+- Scope: b
+- Dependencies: blocked-by Piece 1, Piece 99
+- Diff_lines estimate: 1
+- Why: y
+MD
+set +e
+_out2d=$("$DFI" prepare --design-tmpdir "$D2d" --partition-file "$D2d/part.md" 2>/dev/null)
+_rc2d=$?
+set -e
+[[ "$_rc2d" -eq 2 ]] || fail "expected exit 2 on bad-ref in multi list got $_rc2d"
+printf '%s\n' "$_out2d" | grep -Fq 'DECOMPOSE_PARTITION_STATUS=bad-dependency-ref' || fail "expected bad-dependency-ref status"
+[[ ! -f "$D2d/decompose/partition-input.txt" ]] || fail "partition-input must not exist on bad-ref"
+[[ ! -f "$D2d/decompose/partition-deps.tsv" ]] || fail "partition-deps must not exist on bad-ref"
+
+echo "=== prepare and-separator multi-blocker ==="
+D2e="$TMP/p2e"
+mkdir -p "$D2e"
+printf 'feat' >"$D2e/feature-description.txt"
+cat >"$D2e/part.md" <<'MD'
+## Recommendation
+split
+
+## Pieces
+
+### Piece 1: Alpha
+- Scope: a
+- Dependencies: none
+- Diff_lines estimate: 1
+- Why: x
+
+### Piece 2: Beta
+- Scope: b
+- Dependencies: none
+- Diff_lines estimate: 1
+- Why: x
+
+### Piece 3: Gamma
+- Scope: c
+- Dependencies: blocked-by Piece 1 and Piece 2
+- Diff_lines estimate: 2
+- Why: y
+MD
+_out2e=$("$DFI" prepare --design-tmpdir "$D2e" --partition-file "$D2e/part.md" --issue-number 99 2>/dev/null || true)
+printf '%s\n' "$_out2e" | grep -Fq 'DECOMPOSE_PARTITION_STATUS=ok' || fail "and-separator ok status missing"
+[[ -f "$D2e/decompose/partition-deps.tsv" ]] || fail "and-separator deps tsv missing"
+grep -Fq $'1\t3' "$D2e/decompose/partition-deps.tsv" || fail "expected edge 1->3 in and-separator"
+grep -Fq $'2\t3' "$D2e/decompose/partition-deps.tsv" || fail "expected edge 2->3 in and-separator"
+_edges2e=$(wc -l <"$D2e/decompose/partition-deps.tsv" | tr -d ' ')
+[[ "$_edges2e" == "2" ]] || fail "expected 2 edges in and-separator tsv got $_edges2e"
+
+echo "=== prepare duplicate-blocker idempotency ==="
+D2f="$TMP/p2f"
+mkdir -p "$D2f"
+printf 'feat' >"$D2f/feature-description.txt"
+cat >"$D2f/part.md" <<'MD'
+## Recommendation
+split
+
+## Pieces
+
+### Piece 1: Alpha
+- Scope: a
+- Dependencies: none
+- Diff_lines estimate: 1
+- Why: x
+
+### Piece 2: Beta
+- Scope: b
+- Dependencies: blocked-by Piece 1, Piece 1
+- Diff_lines estimate: 1
+- Why: y
+MD
+_out2f=$("$DFI" prepare --design-tmpdir "$D2f" --partition-file "$D2f/part.md" --issue-number 99 2>/dev/null || true)
+printf '%s\n' "$_out2f" | grep -Fq 'DECOMPOSE_PARTITION_STATUS=ok' || fail "dup-blocker ok status missing"
+[[ -f "$D2f/decompose/partition-deps.tsv" ]] || fail "dup-blocker deps tsv missing"
+grep -Fq $'1\t2' "$D2f/decompose/partition-deps.tsv" || fail "expected edge 1->2 in dup-blocker"
+_edges2f=$(wc -l <"$D2f/decompose/partition-deps.tsv" | tr -d ' ')
+[[ "$_edges2f" == "1" ]] || fail "expected 1 deduped edge in dup-blocker tsv got $_edges2f"
+
 echo "=== prepare neutralizes embedded ^### in feature excerpt ==="
 D2b="$TMP/p2b"
 mkdir -p "$D2b"


### PR DESCRIPTION
## Summary

- Fixes #2872: `decompose-file-issues.sh prepare` no longer silently truncates multi-blocker dependency lists to the first blocker.
- New parse anchors on `blocked-by`, splits the remainder on commas or `and`, requires each segment to fullmatch `Piece <N>`, and dedupes blocker numbers. Strict `bad-dependency-ref` exit 2 now applies across **all** blockers — unknown numbers, non-`Piece N` segments (incidental prose, the deferred plural shape `Pieces 1, 2, 3`), and empty segment lists all fail closed with no batch artifacts.
- Producer prompt grammar in `decompose-prompts/_common-tail.txt` and `decompose-aggregator.sh` advertises the multi-blocker shape so the end-to-end contract is consistent.

## Changes

- `skills/design/scripts/decompose-file-issues.sh` — segment-based blocker parse (anchor + split + fullmatch + dedupe).
- `skills/design/scripts/decompose-prompts/_common-tail.txt`, `skills/design/scripts/decompose-aggregator.sh` — grammar update to `none | blocked-by Piece N[, Piece M ...]`.
- `skills/design/scripts/decompose-file-issues.md` — new **Edge-extraction rules** paragraph documenting the contract.
- `skills/design/scripts/test-decompose-file-issues.sh` — four new fixtures: multi-blocker comma list (`p2c`), bad-ref inside multi list (`p2d`), `and`-separator (`p2e`), duplicate-blocker idempotency (`p2f`).
- `.claude-plugin/plugin.json` — version bump 42.5.17 → 42.5.18 (PATCH; scripts/prompt/test/doc only).

## Test plan

- [x] `bash skills/design/scripts/test-decompose-file-issues.sh` — all 12 sections pass.
- [x] `bash scripts/relevant-checks.sh` — shellcheck, markdownlint, agent-lint, gitleaks, mermaid, skill-invocation, literal-counts, foreground-markers all pass.
- [ ] CI green on the PR.

Issue plan reference: <https://github.com/character-ai/larch/issues/2872>
