### PR TITLE
Fixes #2865: Add --require-result-pattern gate to dispatch-with-waterfall

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "42.5.20",
+  "version": "42.5.21",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (tier flags `--trivial` / `--simple` / `--hard`) and `/implement` (positional `<issue-N>`, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified hard panel internally (public `--panel` argv removed). Post-plan steps use the conventional hard workflow path and `$IMPLEMENT_TMPDIR/plan.txt` for plan materialization — there is no `/implement --hard` flag.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `scripts/dispatch-with-waterfall.sh` accepts `--require-result-pattern <regex>` so callers can require a `STATUS=OK` result file to match a structural ERE; misses route through the existing phase-1 → phase-2 → phase-3 fallback. The decomposition aggregator (`skills/design/scripts/decompose-aggregator.sh`) and 8-slot panel (`skills/design/scripts/decompose-panel-dispatch.sh`) opt in with `^[[:space:]]*## Recommendation`, the aggregator's single-slot primary tool switches from Cursor to Codex, and `panel-outputs.ndjson` rows now reflect the dispatcher's resolved final paths (`ALL_OUTPUT_FILES_PATH`) so phase-2/phase-3 fallback content reaches operator presentation. `STATUS=cap_hit` bypasses the gate (token-budget skip stays terminal); invalid ERE patterns exit **2** before any slot launches. Closes #2865.
 - Codex per-bucket token accounting now stays visible across launcher, `token-report`, and `/design` final-summary paths; per-bucket Codex cost rendering no longer emits misleading blended-rate warnings when `BUCKETS_codex` is populated.
 - test-aggregate-findings, test-launch-review, test-append-tool-failure: unset `LARCH_EXECUTION_ISSUES_LOG` and related vars at harness entry so synthetic aggregator warnings do not append to a parent `/implement` execution-issues log.
 - /implement — Create the feature branch at the start of Step 0 plan materialization (regression from #2588 / #2598; pre-existing dispatcher main-branch-prohibited guard exposed the gap).

--- a/scripts/dispatch-with-waterfall.md
+++ b/scripts/dispatch-with-waterfall.md
@@ -32,6 +32,9 @@ Stdout keys:
 Flags:
 
 - `--paths-file <path>` — write the final paths list to this path instead of the default `<slots-file>.output-files`. The file is replaced atomically each run (temp file in the same directory + `mv`).
+- `--require-result-pattern <regex>` — caller-supplied ERE (`grep -E`) that a `STATUS=OK` result file must match for the slot to settle on the assigned phase tool. Pre-validated once after argv parse against empty stdin; if the pattern is not a valid ERE (`grep` rc > 1) the dispatcher exits **2** with `larch_err` before any slot launches. Applied only to `STATUS=OK`; `STATUS=cap_hit` bypasses the gate so the launcher-side token-budget skip remains terminal. On a `STATUS=OK` pattern miss, the slot is routed through the existing `failed[]` path (phase-1 → phase-2 → phase-3 fallback) with no new exit codes or sidecar files. When the flag is unset (default), behavior is unchanged.
+
+Non-adopters: the sketch phase has no waterfall caller (sketches tolerate narration-only outputs as "no contested position" in synthesis) and the plan-review collector flow (`plan-review-loop.sh` / `dispatch-plan-review-panel.sh`) performs its own structured checks via `collect-agent-results.sh --structured-reviewer-validation`. Current opt-in callers are `skills/design/scripts/decompose-aggregator.sh` and `skills/design/scripts/decompose-panel-dispatch.sh`, both passing `^[[:space:]]*## Recommendation`.
 
 Guards:
 

--- a/scripts/dispatch-with-waterfall.sh
+++ b/scripts/dispatch-with-waterfall.sh
@@ -28,6 +28,7 @@ FALLBACK_COUNTER_FILE=""
 COMPETITION_NOTICE=false
 COMPETITION_NOTICE_FILE=""
 WATERFALL_PATHS_FILE=""
+REQUIRE_RESULT_PATTERN=""
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -46,6 +47,7 @@ while [[ $# -gt 0 ]]; do
         --competition-notice) COMPETITION_NOTICE=true; shift ;;
         --competition-notice-file) COMPETITION_NOTICE_FILE="${2:?--competition-notice-file requires a value}"; shift 2 ;;
         --paths-file) WATERFALL_PATHS_FILE="${2:?--paths-file requires a value}"; shift 2 ;;
+        --require-result-pattern) REQUIRE_RESULT_PATTERN="${2:?--require-result-pattern requires a value}"; shift 2 ;;
         --help) usage; exit 0 ;;
         *) larch_err "dispatch-with-waterfall.sh: unknown option: $1"; usage; exit 2 ;;
     esac
@@ -57,6 +59,20 @@ done
 [[ "$MODE" == "diff" || "$MODE" == "description" ]] || { larch_err "dispatch-with-waterfall.sh: --mode must be diff or description"; exit 2; }
 case "$TIMEOUT" in ''|*[!0-9]*|0) larch_err "dispatch-with-waterfall.sh: --timeout must be a positive integer"; exit 2 ;; esac
 command -v jq >/dev/null 2>&1 || { larch_err "dispatch-with-waterfall.sh: jq is required"; exit 2; }
+
+# Prevalidate --require-result-pattern as ERE once before any slot launches.
+# grep -E on empty stdin returns 1 (no match) for valid patterns and 2 for
+# invalid ERE syntax; only the latter is a caller bug we should refuse upfront.
+if [[ -n "$REQUIRE_RESULT_PATTERN" ]]; then
+    set +e
+    printf '' | grep -E -- "$REQUIRE_RESULT_PATTERN" >/dev/null 2>&1
+    _rrp_rc=$?
+    set -e
+    if (( _rrp_rc > 1 )); then
+        larch_err "dispatch-with-waterfall.sh: --require-result-pattern is not a valid ERE: $REQUIRE_RESULT_PATTERN"
+        exit 2
+    fi
+fi
 
 slot_names=()
 slot_tools=()
@@ -210,7 +226,7 @@ launch_slot() {
 
 collect_phase() {
     local failed_var="$1"
-    local idx output tool block key value status rf
+    local idx output tool block key value status rf check_file
     local -a failed=()
     [[ ${#phase_outputs[@]} -gt 0 ]] || {
         eval "$failed_var=()"
@@ -257,6 +273,20 @@ collect_phase() {
             [[ "$key" == "REVIEWER_FILE" ]] && rf="$value"
         done <<< "$block"
         if [[ "$status" == "OK" || "$status" == "cap_hit" ]]; then
+            # STATUS=cap_hit is a launcher-side budget skip and remains terminal
+            # under the pattern gate (token-budget skip contract preserved).
+            if [[ "$status" == "OK" && -n "$REQUIRE_RESULT_PATTERN" ]]; then
+                check_file="${rf:-$output}"
+                if [[ ! -r "$check_file" ]]; then
+                    larch_err "dispatch-with-waterfall.sh: result file not readable for --require-result-pattern check: $check_file"
+                    failed+=("$idx")
+                    continue
+                fi
+                if ! grep -Eq -- "$REQUIRE_RESULT_PATTERN" "$check_file"; then
+                    failed+=("$idx")
+                    continue
+                fi
+            fi
             # shellcheck disable=SC2004
             final_outputs[$idx]="${rf:-$output}"
             # shellcheck disable=SC2004

--- a/scripts/test-dispatch-with-waterfall.sh
+++ b/scripts/test-dispatch-with-waterfall.sh
@@ -29,7 +29,9 @@ done
 if [[ "${CODEX_STUB_FAIL:-false}" == "true" ]]; then
     exit 7
 fi
-printf 'codex ok\n' > "$out"
+# Default preserves prior `codex ok\n` byte-identically; callers can pass
+# CODEX_STUB_RESULT_CONTENT (no trailing newline) to inject other content.
+printf '%s\n' "${CODEX_STUB_RESULT_CONTENT:-codex ok}" > "$out"
 STUB
 cat > "$STUB_BIN/cursor" <<'STUB'
 #!/usr/bin/env bash
@@ -38,7 +40,11 @@ log="${CURSOR_STUB_LOG:-}"
 if [[ "${CURSOR_STUB_FAIL:-false}" == "true" ]]; then
     exit 8
 fi
-printf '{"result":"cursor ok","usage":{"inputTokens":1,"outputTokens":1,"cacheReadTokens":0,"cacheWriteTokens":0}}\n'
+# Build the JSON envelope with jq so metacharacters in caller-supplied
+# CURSOR_STUB_RESULT_CONTENT are safely escaped. Default preserves the
+# prior `cursor ok` .result value byte-identically.
+jq -nc --arg r "${CURSOR_STUB_RESULT_CONTENT:-cursor ok}" \
+    '{result:$r,usage:{inputTokens:1,outputTokens:1,cacheReadTokens:0,cacheWriteTokens:0}}'
 STUB
 cat > "$STUB_BIN/claude" <<'STUB'
 #!/usr/bin/env bash
@@ -290,5 +296,81 @@ rc_cr=$?
 set -e
 [[ "$rc_cr" -eq 2 ]] || { echo "FAIL: CR in output path exit=$rc_cr" >&2; exit 1; }
 grep -Fq 'newline or carriage return' "$TMPROOT/cr.stderr" || { echo "FAIL: CR-in-path stderr" >&2; exit 1; }
+
+# --- --require-result-pattern tests ---
+
+# Case A: pattern-mismatch on the primary tool falls through to phase 2.
+# Cursor's `STATUS=OK` returns narration only; codex (phase 2) returns a
+# valid `## Recommendation` heading. Final tool must be codex, no phase-3
+# Claude fallback fires, and the dispatcher reports DISPATCH_OK=true.
+manifest="$TMPROOT/slots-pattern-fallback.ndjson"
+printf '{"slot":"s1","tool":"cursor","output":"%s","prompt_file":"%s"}\n' \
+    "$TMPROOT/pattern-fallback-slot.txt" "$prompt" > "$manifest"
+out=$(PATH="$STUB_BIN:$PATH" \
+    CURSOR_STUB_RESULT_CONTENT='narration only, no heading' \
+    CODEX_STUB_RESULT_CONTENT=$'## Recommendation\nsplit' \
+    "$REPO_ROOT/scripts/dispatch-with-waterfall.sh" \
+    --slots-file "$manifest" \
+    --codex-present true \
+    --cursor-present true \
+    --mode description \
+    --require-result-pattern '^[[:space:]]*## Recommendation' \
+    --timeout 5)
+assert_line "FALLBACK_COUNT=0" "$out"
+assert_line "ALL_OUTPUT_TOOLS=codex" "$out"
+assert_line "DISPATCH_OK=true" "$out"
+grep -Fq '## Recommendation' "$TMPROOT/pattern-fallback-slot-phase2.txt" \
+    || { echo "FAIL: phase2 codex did not produce Recommendation heading" >&2; exit 1; }
+
+# Case B: STATUS=cap_hit bypasses the pattern gate (token-budget skip is
+# terminal). Cursor returns `STATUS=cap_hit\n...` as its `.result`, which
+# collect-agent-results.sh promotes to STATUS=cap_hit. Slot settles on the
+# assigned primary tool; no phase-2 launch occurs.
+manifest="$TMPROOT/slots-pattern-caphit.ndjson"
+printf '{"slot":"s1","tool":"cursor","output":"%s","prompt_file":"%s"}\n' \
+    "$TMPROOT/pattern-caphit-slot.txt" "$prompt" > "$manifest"
+codex_caphit_log="$TMPROOT/codex-caphit.log"
+: >"$codex_caphit_log"
+out=$(PATH="$STUB_BIN:$PATH" \
+    CURSOR_STUB_RESULT_CONTENT=$'STATUS=cap_hit\nbudget exceeded' \
+    CODEX_STUB_LOG="$codex_caphit_log" \
+    "$REPO_ROOT/scripts/dispatch-with-waterfall.sh" \
+    --slots-file "$manifest" \
+    --codex-present true \
+    --cursor-present true \
+    --mode description \
+    --require-result-pattern '^[[:space:]]*## Recommendation' \
+    --timeout 5)
+assert_line "FALLBACK_COUNT=0" "$out"
+assert_line "ALL_OUTPUT_TOOLS=cursor" "$out"
+assert_line "DISPATCH_OK=true" "$out"
+[[ ! -s "$codex_caphit_log" ]] || { echo "FAIL: cap_hit must not advance to phase 2 (codex stub ran)" >&2; cat "$codex_caphit_log" >&2; exit 1; }
+
+# Case C: invalid ERE exits 2 before any slot launches.
+manifest="$TMPROOT/slots-pattern-invalid.ndjson"
+printf '{"slot":"s1","tool":"codex","output":"%s","prompt_file":"%s"}\n' \
+    "$TMPROOT/pattern-invalid-slot.txt" "$prompt" > "$manifest"
+codex_invalid_log="$TMPROOT/codex-invalid.log"
+cursor_invalid_log="$TMPROOT/cursor-invalid.log"
+: >"$codex_invalid_log"
+: >"$cursor_invalid_log"
+set +e
+PATH="$STUB_BIN:$PATH" \
+    CODEX_STUB_LOG="$codex_invalid_log" \
+    CURSOR_STUB_LOG="$cursor_invalid_log" \
+    "$REPO_ROOT/scripts/dispatch-with-waterfall.sh" \
+    --slots-file "$manifest" \
+    --codex-present true \
+    --cursor-present true \
+    --mode description \
+    --require-result-pattern '[' \
+    --timeout 5 >/dev/null 2>"$TMPROOT/pattern-invalid.stderr"
+rc_pat=$?
+set -e
+[[ "$rc_pat" -eq 2 ]] || { echo "FAIL: invalid ERE pattern exit=$rc_pat" >&2; exit 1; }
+grep -Fq 'is not a valid ERE' "$TMPROOT/pattern-invalid.stderr" \
+    || { echo "FAIL: invalid ERE stderr message" >&2; cat "$TMPROOT/pattern-invalid.stderr" >&2; exit 1; }
+[[ ! -s "$codex_invalid_log" ]] || { echo "FAIL: invalid ERE must not launch codex" >&2; exit 1; }
+[[ ! -s "$cursor_invalid_log" ]] || { echo "FAIL: invalid ERE must not launch cursor" >&2; exit 1; }
 
 echo "PASS: test-dispatch-with-waterfall.sh"

--- a/skills/design/references/decompose-panel.md
+++ b/skills/design/references/decompose-panel.md
@@ -104,7 +104,9 @@ Concatenate the eight panel outputs and merge into one canonical partition propo
   --timeout 1800
 ```
 
-`aggregate-findings.sh` remains **finding-shaped** (### `FINDING_N` blocks with voting metadata). Partition merges therefore use this dedicated **single-slot Cursor → Codex → Claude waterfall** merger prompt — **not** the findings aggregator.
+`aggregate-findings.sh` remains **finding-shaped** (### `FINDING_N` blocks with voting metadata). Partition merges therefore use this dedicated **single-slot Codex → Cursor → Claude waterfall** merger prompt — **not** the findings aggregator.
+
+Both the aggregator and the 8-slot panel thread `--require-result-pattern '^[[:space:]]*## Recommendation'` into `dispatch-with-waterfall.sh`, so narration-only `STATUS=OK` outputs (Cursor `--mode plan` abstention, etc.) fall through to the next waterfall phase at the dispatcher boundary instead of settling silently. The panel rows written to `panel-outputs.ndjson` reflect the dispatcher's resolved final paths (`ALL_OUTPUT_FILES_PATH`), so phase-2/phase-3 fallback content reaches operator presentation when the primary tool returns narration-only.
 
 Parse stdout for `AGGREGATOR_STATUS=ok|failed` and consume `AGGREGATOR_OUTPUT` when `ok`.
 

--- a/skills/design/scripts/decompose-aggregator.md
+++ b/skills/design/scripts/decompose-aggregator.md
@@ -8,6 +8,10 @@
 
 **Stdout**: `AGGREGATOR_STATUS=ok|failed` and `AGGREGATOR_OUTPUT=<path>` via `emit_kv`.
 
+**Primary tool**: the single-slot row is assigned to `codex` (more reliable than Cursor at returning structured output on the single safety-net slot); the shared dispatcher's `cursor → claude` fallback covers the remaining waterfall positions.
+
+**Recommendation-heading gate**: the aggregator threads `--require-result-pattern '^[[:space:]]*## Recommendation'` into `dispatch-with-waterfall.sh` so narration-only "OK" outputs at the dispatcher boundary fall through to the next phase instead of settling silently. The post-call `grep -Eq '^[[:space:]]*## Recommendation'` on `AGGREGATOR_STATUS` is retained as defense-in-depth.
+
 **Note**: `skills/review/scripts/aggregate-findings.sh` expects ### `FINDING_N` voting-shaped blocks; partition merges intentionally **do not** route through that script.
 
 **Harness override**: `DECOMPOSE_AGGREGATE_WATERFALL_SH` — stub waterfall for offline tests (`skills/design/scripts/test-decompose-aggregator.sh`).

--- a/skills/design/scripts/decompose-aggregator.sh
+++ b/skills/design/scripts/decompose-aggregator.sh
@@ -105,7 +105,7 @@ AGG_OUT="$DECOMP_DIR/aggregator-raw-output.txt"
 _slots="$DECOMP_DIR/aggregator-slots.ndjson"
 jq -nc \
     --arg slot decompose-aggregator \
-    --arg tool cursor \
+    --arg tool codex \
     --arg output "$AGG_OUT" \
     --arg prompt_file "$MERGE_PROMPT" \
     '{slot:$slot,tool:$tool,output:$output,prompt_file:$prompt_file}' >"$_slots"
@@ -119,6 +119,7 @@ _agg_out=$("$WATERFALL_SH" \
     --cursor-present "$CURSOR_PRESENT" \
     --mode description \
     --feature-file "$FEATURE_FILE" \
+    --require-result-pattern '^[[:space:]]*## Recommendation' \
     --timeout "$TIMEOUT")
 _agg_rc=$?
 set -e

--- a/skills/design/scripts/decompose-panel-dispatch.sh
+++ b/skills/design/scripts/decompose-panel-dispatch.sh
@@ -155,6 +155,7 @@ _dispatch_out=$("$WATERFALL_SH" \
     --codex-present "$CODEX_PRESENT" \
     --cursor-present "$CURSOR_PRESENT" \
     --mode description \
+    --require-result-pattern '^[[:space:]]*## Recommendation' \
     "${_wf_extra[@]}")
 _wf_rc=$?
 set -e
@@ -211,6 +212,18 @@ usable=0
 _panel_rows="$DECOMP_DIR/panel-outputs.ndjson"
 : >"$_panel_rows"
 
+# Read the dispatcher's resolved paths (one per slot, manifest order) so panel
+# rows reflect phase-2/phase-3 fallback files instead of the original manifest
+# phase-1 path. Bash 3.2-compatible: no mapfile/readarray.
+_resolved_paths=()
+if [[ -n "$ALL_OUTPUT_FILES_PATH" && -f "$ALL_OUTPUT_FILES_PATH" ]]; then
+    while IFS= read -r _rp_line || [[ -n "$_rp_line" ]]; do
+        _resolved_paths+=("$_rp_line")
+    done <"$ALL_OUTPUT_FILES_PATH"
+fi
+
+_i=0
+_warned_missing_paths=false
 while IFS= read -r row || [[ -n "$row" ]]; do
     [[ -n "$row" ]] || continue
     _slot=$(printf '%s' "$row" | jq -r '.slot // empty')
@@ -218,19 +231,29 @@ while IFS= read -r row || [[ -n "$row" ]]; do
     _outp=$(printf '%s' "$row" | jq -r '.output // empty')
     _arch="${_slot#decomp-cursor-}"
     _arch="${_arch#decomp-codex-}"
+    if (( ${#_resolved_paths[@]} > 0 )); then
+        _outp_resolved="${_resolved_paths[$_i]:-$_outp}"
+    else
+        if [[ "$_warned_missing_paths" != true ]]; then
+            larch_err "decompose-panel-dispatch.sh: ALL_OUTPUT_FILES_PATH empty or missing; falling back to manifest paths for panel-outputs rows"
+            _warned_missing_paths=true
+        fi
+        _outp_resolved="$_outp"
+    fi
     _status="missing"
-    if [[ -f "$_outp" ]] && grep -Eq '^[[:space:]]*## Recommendation' "$_outp"; then
+    if [[ -f "$_outp_resolved" ]] && grep -Eq '^[[:space:]]*## Recommendation' "$_outp_resolved"; then
         _status="ok"
         usable=$((usable + 1))
-    elif [[ -f "$_outp" ]]; then
+    elif [[ -f "$_outp_resolved" ]]; then
         _status="unparsed"
     fi
     jq -nc \
         --arg archetype "$_arch" \
         --arg vendor "$_tool" \
-        --arg output "$_outp" \
+        --arg output "$_outp_resolved" \
         --arg status "$_status" \
         '{archetype:$archetype,vendor:$vendor,output:$output,status:$status}' >>"$_panel_rows"
+    _i=$((_i + 1))
 done <"$_manifest"
 
 PANEL_STATUS="ok"

--- a/skills/design/scripts/test-decompose-aggregator.md
+++ b/skills/design/scripts/test-decompose-aggregator.md
@@ -1,5 +1,5 @@
 # test-decompose-aggregator.sh
 
-Offline regression for `decompose-aggregator.sh`: concatenation, merge prompt presence, `AGGREGATOR_STATUS` against a stub waterfall.
+Offline regression for `decompose-aggregator.sh`: concatenation, merge prompt presence, `AGGREGATOR_STATUS` against a stub waterfall. Also verifies the aggregator builds its single-slot row with `tool=codex` and threads `--require-result-pattern '^[[:space:]]*## Recommendation'` to `dispatch-with-waterfall.sh`.
 
 Run via `make test-decompose-aggregator` or `bash skills/design/scripts/test-decompose-aggregator.sh`.

--- a/skills/design/scripts/test-decompose-aggregator.sh
+++ b/skills/design/scripts/test-decompose-aggregator.sh
@@ -74,6 +74,20 @@ grep -Fq '## Recommendation' "$D/merged.md" || fail "merged output missing headi
 grep -Fq '## Panel output' "$D/decompose/aggregator-partition-merge.prompt" \
     || fail "merge prompt missing concatenated panel headers"
 
+# Aggregator's single-slot row is built with tool=codex (Fix 1) so the more
+# reliable vendor runs first on the safety-net slot.
+agg_tool=$(jq -r '.tool' "$D/decompose/aggregator-slots.ndjson")
+[[ "$agg_tool" == "codex" ]] || fail "expected aggregator slot tool=codex got '$agg_tool'"
+
+# Aggregator threads the recommendation-heading gate through the waterfall
+# (Fix 2 caller adoption). The stub logs `"$0 $*"` per invocation; both the
+# flag and its argument must appear so a future regression that drops either
+# half of the pair is caught.
+grep -Fq -- '--require-result-pattern' "$D/wf.log" \
+    || fail "expected --require-result-pattern threaded to waterfall"
+grep -Fq -- '^[[:space:]]*## Recommendation' "$D/wf.log" \
+    || fail "expected recommendation-heading regex threaded to waterfall"
+
 echo "=== AGGREGATOR_STATUS=failed when DISPATCH_OK path broken ==="
 D2="$TMP/b"
 mkdir -p "$D2"

--- a/skills/design/scripts/test-decompose-panel-dispatch.md
+++ b/skills/design/scripts/test-decompose-panel-dispatch.md
@@ -1,5 +1,5 @@
 # test-decompose-panel-dispatch.sh
 
-Offline regression for `decompose-panel-dispatch.sh`: eight NDJSON slots, prompt substitution, `DEGRADED_PANEL` / `PANEL_STATUS` wiring against a stub waterfall.
+Offline regression for `decompose-panel-dispatch.sh`: eight NDJSON slots, prompt substitution, `DEGRADED_PANEL` / `PANEL_STATUS` wiring against a stub waterfall. Also verifies the panel threads `--require-result-pattern '^[[:space:]]*## Recommendation'` to the waterfall and that `panel-outputs.ndjson` rows record the dispatcher's resolved final paths from `ALL_OUTPUT_FILES_PATH` (so phase-2/phase-3 fallback content reaches operator presentation).
 
 Run via `make test-decompose-panel-dispatch` or `bash skills/design/scripts/test-decompose-panel-dispatch.sh`.

--- a/skills/design/scripts/test-decompose-panel-dispatch.sh
+++ b/skills/design/scripts/test-decompose-panel-dispatch.sh
@@ -90,6 +90,12 @@ rows=$(grep -c . "$D1/decompose/panel-outputs.ndjson" || true)
 grep -Fq 'Plan body.' "$D1/decompose/render-decomp-cursor-decomposition-specialist.prompt" \
     || fail "plan body missing from rendered prompt"
 
+# Recommendation-heading gate threaded to the waterfall (Fix 2 caller adoption).
+grep -Fq -- '--require-result-pattern' "$D1/wf.log" \
+    || fail "expected --require-result-pattern threaded to waterfall"
+grep -Fq -- '^[[:space:]]*## Recommendation' "$D1/wf.log" \
+    || fail "expected recommendation-heading regex threaded to waterfall"
+
 echo "=== degraded when STATIC_DISPATCH_OK=false ==="
 D2="$TMP/m2"
 prep_common "$D2"
@@ -157,5 +163,78 @@ DECOMPOSE_PANEL_WATERFALL_SH="$STUB4" \
     --timeout 30 >"$D4/out.kv"
 grep -Fq 'PANEL_STATUS=degraded' "$D4/out.kv" || fail "expected degraded when waterfall fails with usable outputs"
 grep -Fq 'DEGRADED_PANEL=true' "$D4/out.kv" || fail "expected DEGRADED_PANEL true"
+
+echo "=== plan mode: resolved-paths panel rows ==="
+# When the dispatcher resolves a slot through phase-2/phase-3 fallback, the
+# `ALL_OUTPUT_FILES_PATH` line for that slot points at the fallback file. The
+# panel must record THAT path in `panel-outputs.ndjson`, not the manifest's
+# original phase-1 path, so operator presentation sees the recovered content.
+D5="$TMP/m5"
+prep_common "$D5"
+STUB5="$TMP/stub5.sh"
+cat >"$STUB5" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+log="${WATERFALL_STUB_LOG:?}"
+paths_out="${WATERFALL_STUB_PATHS_OUT:?}"
+printf '%s\n' "$0 $*" >>"$log"
+slots=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --slots-file) slots="${2:?}"; shift 2 ;;
+        --paths-file) paths_out="${2:?}"; shift 2 ;;
+        --codex-present|--cursor-present|--mode|--timeout|--plan-file|--feature-file) shift 2 ;;
+        *) shift 1 ;;
+    esac
+done
+[[ -n "$slots" ]] || exit 2
+: >"$paths_out"
+first=true
+while IFS= read -r row || [[ -n "$row" ]]; do
+    [[ -n "$row" ]] || continue
+    out=$(printf '%s' "$row" | jq -r '.output // empty')
+    mkdir -p "$(dirname "$out")"
+    if [[ "$first" == true ]]; then
+        printf 'narration only, no heading\n' >"$out"
+        phase2_out="${out%.txt}-phase2.txt"
+        printf '## Recommendation\nsplit\n' >"$phase2_out"
+        printf '%s\n' "$phase2_out" >>"$paths_out"
+        first=false
+    else
+        printf '## Recommendation\nsplit\n' >"$out"
+        printf '%s\n' "$out" >>"$paths_out"
+    fi
+done <"$slots"
+printf 'DISPATCH_OK=true\n'
+printf 'FALLBACK_COUNT=1\n'
+printf 'STATIC_DISPATCH_OK=true\n'
+printf 'DYNAMIC_DISPATCH_OK=true\n'
+printf 'ALL_OUTPUT_FILES_PATH=%s\n' "$paths_out"
+exit 0
+STUB
+chmod +x "$STUB5"
+: >"$D5/wf.log"
+DECOMPOSE_PANEL_WATERFALL_SH="$STUB5" \
+    WATERFALL_STUB_LOG="$D5/wf.log" \
+    WATERFALL_STUB_PATHS_OUT="$D5/paths.out" \
+    CLAUDE_PLUGIN_ROOT="$REPO_ROOT" \
+    "$PANEL" \
+    --design-tmpdir "$D5" \
+    --codex-present true \
+    --cursor-present true \
+    --mode plan \
+    --plan-file "$D5/plan.txt" \
+    --timeout 30 >"$D5/out.kv"
+first_row=$(sed -n '1p' "$D5/decompose/panel-outputs.ndjson")
+first_status=$(printf '%s' "$first_row" | jq -r '.status')
+first_output=$(printf '%s' "$first_row" | jq -r '.output')
+[[ "$first_status" == "ok" ]] || fail "expected resolved-paths first row status=ok got '$first_status'"
+case "$first_output" in
+    *-phase2.txt) ;;
+    *) fail "expected first row output to point at phase-2 fallback path, got '$first_output'" ;;
+esac
+[[ -f "$first_output" ]] || fail "resolved phase-2 path does not exist: $first_output"
+grep -Fq '## Recommendation' "$first_output" \
+    || fail "resolved phase-2 file missing Recommendation heading"
 
 echo "PASS: test-decompose-panel-dispatch.sh"


### PR DESCRIPTION
## Summary

- Add an optional `--require-result-pattern <ERE>` flag to `scripts/dispatch-with-waterfall.sh` so callers can require a `STATUS=OK` result file to match a structural regex. Pattern misses route through the existing phase-1 → phase-2 → phase-3 fallback at the dispatcher boundary. `STATUS=cap_hit` bypasses the gate (token-budget skip stays terminal); invalid ERE patterns exit **2** before any slot launches.
- Opt in the two decomposition callers with `^[[:space:]]*## Recommendation`: `skills/design/scripts/decompose-aggregator.sh` (also swaps its single-slot primary tool from Cursor to Codex) and `skills/design/scripts/decompose-panel-dispatch.sh` (also rewrites its panel-row generation loop to consume the dispatcher's resolved paths via `ALL_OUTPUT_FILES_PATH`, so phase-2/phase-3 fallback content reaches `panel-outputs.ndjson`).
- Extend three harnesses (no new harness files): three new positive cases in `scripts/test-dispatch-with-waterfall.sh` (pattern-mismatch cursor→codex fallback, `STATUS=cap_hit` terminal under pattern gate, invalid ERE exit 2 before launches); three new assertions in `skills/design/scripts/test-decompose-aggregator.sh` (slot `tool=codex`, flag and regex threaded); two argv-grep assertions plus a new resolved-paths sub-case in `skills/design/scripts/test-decompose-panel-dispatch.sh`.

Closes #2865.

## Test plan

- [x] `make test-dispatch-with-waterfall test-decompose-aggregator test-decompose-panel-dispatch test-design-structure`
- [x] `make lint` (pre-existing flaky `lint-mermaid-fences` on an unrelated `larch-logs/design/D9213D45-…/architecture-diagram.md` run-log file from #2857; CI runs the mermaid hook with `--changed-only` so it does not affect this PR)
- [x] Targeted shellcheck on the modified scripts (no new findings)
- [x] Bash 3.2 compatibility verified (no `mapfile` / `readarray` / associative arrays in the new loops)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
