### PR TITLE
Fixes #3275: Drop --convergence-threshold forward to plan-review-loop.sh

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "47.0.19",
+  "version": "47.0.20",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (default SIMPLE tier; opt-in `--hard` only) and `/implement` (positional `<issue-N>`, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified hard panel internally (public `--panel` argv removed). Post-plan steps use the conventional hard workflow path and `$IMPLEMENT_TMPDIR/plan.txt` for plan materialization — there is no `/implement --hard` flag.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/scripts/test-design-structure.sh
+++ b/scripts/test-design-structure.sh
@@ -60,7 +60,7 @@ contains "$RUN_STEP3_SH" 'review-round-count.txt' 'run-step3-review.sh missing r
 # shellcheck disable=SC2016 # Script literal intentionally checks unexpanded parameter syntax.
 contains "$RUN_STEP3_SH" '--round-cap "$ROUND_CAP"' 'run-step3-review.sh must pass round-cap to plan-review-loop'
 # shellcheck disable=SC2016 # Script literal intentionally checks unexpanded parameter syntax.
-contains "$RUN_STEP3_SH" '--convergence-threshold "$CONVERGENCE_THRESHOLD"' 'run-step3-review.sh must pass convergence-threshold to plan-review-loop'
+absent "$RUN_STEP3_SH" '--convergence-threshold "$CONVERGENCE_THRESHOLD"' 'run-step3-review.sh must NOT forward convergence-threshold to plan-review-loop'
 # shellcheck disable=SC2016 # Markdown literal intentionally checks unexpanded parameter syntax.
 contains "$SKILL_MD" '--round-cap "${LARCH_DESIGN_ROUND_CAP:-5}"' 'SKILL must pass explicit round-cap to run-step3-review.sh'
 # shellcheck disable=SC2016 # Markdown literal intentionally checks unexpanded parameter syntax.

--- a/skills/design/scripts/run-step3-review.sh
+++ b/skills/design/scripts/run-step3-review.sh
@@ -206,8 +206,7 @@ else
             --codex-present "${CODEX_PRESENT:-false}" \
             --cursor-present "${CURSOR_PRESENT:-false}" \
             --round-num "$ROUND_NUM" \
-            --round-cap "$ROUND_CAP" \
-            --convergence-threshold "$CONVERGENCE_THRESHOLD")
+            --round-cap "$ROUND_CAP")
         _plan_review_rc=$?
         set -e
 

--- a/skills/design/scripts/test-run-step3-review.sh
+++ b/skills/design/scripts/test-run-step3-review.sh
@@ -379,13 +379,25 @@ out="$("${launcher_env[@]}" "$LAUNCHER" \
 assert_contains "$out" 'LOOP_STATUS=panel-failed' 'invalid round-cap panel-failed'
 grep -Fq 'LOOP_STATUS=panel-failed' "$D11/.step3-review-result.env" || fail 'invalid round-cap result env panel-failed'
 
-echo "=== invalid convergence-threshold normalizes to panel-failed ==="
-D11C="$TMP/invalid-convergence"
+echo "=== loop is not forwarded --convergence-threshold ==="
+D11C="$TMP/no-ct-forward"
 write_common_inputs "$D11C" SIMPLE
-out="$("${launcher_env[@]}" "$LAUNCHER" \
-    --design-tmpdir "$D11C" --round-cap 5 --convergence-threshold abc 2>&1)"
-assert_contains "$out" 'LOOP_STATUS=panel-failed' 'invalid convergence-threshold panel-failed'
-grep -Fq 'LOOP_STATUS=panel-failed' "$D11C/.step3-review-result.env" || fail 'invalid convergence-threshold result env panel-failed'
+ct_stub="$D11C/ct-stub.sh"
+cat >"$ct_stub" <<'STUBEOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$@" >"${CT_ARGV_FILE:-/dev/null}"
+printf 'LOOP_STATUS=complete\nACCEPTED_COUNT=0\nIMPORTANT_ACCEPTED_COUNT=0\nDEGRADED_PANEL=0\nROUNDS_COMPLETED=1\nTALLY_PLAN_REVIEW_STATUS=ok\nAGGREGATOR_STATUS=ok\nVOTING_TALLY_FILE=\n'
+STUBEOF
+chmod +x "$ct_stub"
+CT_ARGV_FILE="$D11C/loop-argv.txt"
+"${launcher_env[@]}" CT_ARGV_FILE="$CT_ARGV_FILE" RUN_STEP3_PLAN_REVIEW_LOOP_SH="$ct_stub" "$LAUNCHER" \
+    --design-tmpdir "$D11C" --round-cap 5 --convergence-threshold 3 >/dev/null
+if grep -Fq -- '--convergence-threshold' "$CT_ARGV_FILE" 2>/dev/null; then
+    fail 'loop should not receive --convergence-threshold'
+else
+    pass 'loop is not forwarded --convergence-threshold'
+fi
 
 echo "=== terminal stdout breadcrumbs include round identifiers ==="
 D11B="$TMP/breadcrumb-rounds"


### PR DESCRIPTION
## Summary

- Removes `--convergence-threshold "$CONVERGENCE_THRESHOLD"` from the `plan-review-loop.sh` invocation in `run-step3-review.sh`. The loop does not accept this flag (removed/never-added in #3243), so every `/design` Step 3 was aborting with `unknown option: --convergence-threshold` and silently degrading to `panel-failed`.
- The driver still accepts `--convergence-threshold` on its own argv (SKILL.md passes it) and treats it as accepted-and-unused — convergence is fully owned inside `plan-review-loop.sh` per #3243.
- Updates `test-run-step3-review.sh`: replaces the "invalid convergence-threshold normalizes to panel-failed" case with a stub-based argv-recorder that asserts `--convergence-threshold` is NOT in the args forwarded to the loop.
- Updates `test-design-structure.sh`: flips the structural pin from `contains` to `absent` for this forwarded flag.

## Test plan

- [x] `bash skills/design/scripts/test-run-step3-review.sh` — 53/53 assertions pass
- [x] `bash scripts/relevant-checks.sh` — all lint checks pass
- [x] `bash scripts/test-design-structure.sh` — structural invariants hold

Closes #3275

🤖 Generated with [Claude Code](https://claude.com/claude-code)
