### PR TITLE
Fix SIGPIPE crash in dispatch-plan-review-panel.sh both-absent generic panel loop

### DIFF
--- a/skills/design/scripts/dispatch-plan-review-panel.sh
+++ b/skills/design/scripts/dispatch-plan-review-panel.sh
@@ -102,9 +102,9 @@ if [[ "$CODEX_PRESENT" == "false" && "$CURSOR_PRESENT" == "false" ]]; then
         printf '%s\n' "You are a combined plan-review panel applying all five standard archetype lenses in a single pass. Address each lens below, then follow the shared output contract."
         printf '\n'
         for _archetype in arch edge innovation pragmatic requirements; do
-            _role_line=$(bash "${PLUGIN_ROOT}/skills/design/scripts/render-plan-review-prompt.sh" \
-                --archetype "$_archetype" --vendor cursor --plan-file "$PLAN_FILE" --design-tmpdir "$DESIGN_TMPDIR" \
-                | head -n 1)
+            _role_render=$(bash "${PLUGIN_ROOT}/skills/design/scripts/render-plan-review-prompt.sh" \
+                --archetype "$_archetype" --vendor cursor --plan-file "$PLAN_FILE" --design-tmpdir "$DESIGN_TMPDIR")
+            _role_line="${_role_render%%$'\n'*}"
             printf '%s\n\n' "$_role_line"
         done
         append_shared_prompt_tail "$PLAN_FILE"


### PR DESCRIPTION
## Summary

- Fixes SIGPIPE crash in `dispatch-plan-review-panel.sh` when both Cursor and Codex are absent (the generic Claude reviewer path).
- In the both-absent branch, `render-plan-review-prompt.sh` was piped into `head -n 1` to extract the first line (the role description). On Linux, when `head` exits after reading one line, the pipe closes and `render-plan-review-prompt.sh`'s final `printf` gets EPIPE. Because that script has `set -euo pipefail`, it exits with error, which propagates through the pipeline and fails the test harness.
- Fix: capture the full render output into `_role_render`, then extract the first line with `${_role_render%%$'\n'*}`. No pipe = no SIGPIPE.

Note: this failure was pre-existing on `main` at `12677a01e` (the same error in the same file on the same line), but pre-existing does not mean acceptable.

## Test plan

- [x] `bash skills/design/scripts/test-dispatch-plan-review-panel.sh` — passes cleanly, no Broken pipe warnings
- [x] `bash scripts/relevant-checks.sh` — all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
