### PR TITLE
Fixes #3381: root harness SCRATCH under ${TMPDIR:-/tmp} so token-ledger guard accepts paths

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "47.0.51",
+  "version": "47.0.52",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (default SIMPLE tier; opt-in `--hard` only) and `/implement` (positional `<issue-N>`, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified hard panel internally (public `--panel` argv removed). Post-plan steps use the conventional hard workflow path and `$IMPLEMENT_TMPDIR/plan.txt` for plan materialization — there is no `/implement --hard` flag.",
   "author": {
     "name": "Sergey Zhupanov",

--- a/skills/implement/scripts/test-codex-implementer.sh
+++ b/skills/implement/scripts/test-codex-implementer.sh
@@ -69,7 +69,7 @@ assert_subprocess_guard_present() {
     fi
 }
 
-SCRATCH=$(mktemp -d -t codex-implementer-test.XXXXXX)
+SCRATCH=$(mktemp -d "${TMPDIR:-/tmp}/codex-implementer-test.XXXXXX")
 trap 'rm -rf "$SCRATCH"' EXIT
 unset LARCH_EXECUTION_ISSUES_LOG SESSION_ENV_PATH IMPLEMENT_TMPDIR REVIEW_TMPDIR || true
 export LARCH_EXECUTION_ISSUES_LOG="$SCRATCH/execution-issues.md"

--- a/skills/implement/scripts/test-cursor-implementer.sh
+++ b/skills/implement/scripts/test-cursor-implementer.sh
@@ -20,7 +20,7 @@ if [[ "${1-}" == "--real-smoke" ]]; then
         echo "SKIP: real Cursor smoke requires CURSOR_PRESENT=true"
         exit 0
     fi
-    SCRATCH=$(mktemp -d -t cursor-implementer-smoke.XXXXXX)
+    SCRATCH=$(mktemp -d "${TMPDIR:-/tmp}/cursor-implementer-smoke.XXXXXX")
     trap 'rm -rf "$SCRATCH"' EXIT
     unset LARCH_EXECUTION_ISSUES_LOG SESSION_ENV_PATH IMPLEMENT_TMPDIR REVIEW_TMPDIR || true
     export LARCH_EXECUTION_ISSUES_LOG="$SCRATCH/execution-issues.md"
@@ -88,7 +88,7 @@ assert_subprocess_guard_absent() {
     fi
 }
 
-SCRATCH=$(mktemp -d -t cursor-implementer-test.XXXXXX)
+SCRATCH=$(mktemp -d "${TMPDIR:-/tmp}/cursor-implementer-test.XXXXXX")
 trap 'rm -rf "$SCRATCH"' EXIT
 trap 'printf "test-cursor-implementer.sh: unexpected exit at line %s (set -e)\n" "$LINENO" >&2' ERR
 unset LARCH_EXECUTION_ISSUES_LOG SESSION_ENV_PATH IMPLEMENT_TMPDIR REVIEW_TMPDIR || true


### PR DESCRIPTION
## Summary

- Replaces `mktemp -d -t <template>` with `mktemp -d "${TMPDIR:-/tmp}/<template>"` in two test harnesses
- On macOS, `mktemp -d -t` uses the Darwin per-user temp dir (`/var/folders/…`) and ignores `$TMPDIR`; `token-ledger.sh`'s `validate_under_tmp` guard rejects any ledger path not under `${TMPDIR:-/tmp}`, causing 4 spurious failures in `test-cursor-implementer.sh` when run under the Claude Code sandbox (`TMPDIR=/tmp/claude-501`)
- No runtime/public-surface change — PATCH

## Test plan

- [x] `TMPDIR=/tmp/claude-501 bash skills/implement/scripts/test-cursor-implementer.sh` → `PASS 43/43` (was `39/43`)
- [x] `TMPDIR=/tmp/claude-501 bash skills/implement/scripts/test-codex-implementer.sh` → `PASS 51/51`
- [x] `bash scripts/relevant-checks.sh` — all linters pass

Closes #3381

🤖 Generated with [Claude Code](https://claude.com/claude-code)
