### PR TITLE
Release v47.0.62

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "47.0.61",
+  "version": "47.0.62",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (default SIMPLE tier; opt-in `--hard` only) and `/implement` (positional `<issue-N>`, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified hard panel internally (public `--panel` argv removed). Post-plan steps use the conventional hard workflow path and `$IMPLEMENT_TMPDIR/plan.txt` for plan materialization — there is no `/implement --hard` flag.",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## What's changed in v47.0.62

### Added
- Operator-run `/release` skill for aggregate version cuts (#3400)
- Detection of Codex usage-limit / quota signals on the `--json` events stream (#3395)
- Per-slot plan-review drop diagnostics (#3396)

### Changed
- `/design` log-publish now runs CI, then admin-merges once checks pass (#3394)
- `lint-fix-loop` prompts scoped to checks-log failures (#3397)

### Fixed
- Empty exit-0 Cursor `.result` handled with retry, diagnostics, and launch jitter (#3399)

_Also includes the mechanical version bump to 47.0.61 (#3398)._
