### PR TITLE
Release v47.0.64

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "47.0.63",
+  "version": "47.0.64",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (default SIMPLE tier; opt-in `--hard` only) and `/implement` (positional `<issue-N>`, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified hard panel internally (public `--panel` argv removed). Post-plan steps use the conventional hard workflow path and `$IMPLEMENT_TMPDIR/plan.txt` for plan materialization — there is no `/implement --hard` flag.",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## What's Changed

### Fixed

- External-launch health gate now defaults to enabled via resolver fallback, ensuring the gate is active even when not explicitly configured (#3403)
- Merging while behind the base branch is now permitted when CI passes and the branch is free of conflicts (#3407)
- Corrected a misleading Codex probe in the `/design` review panel and suppressed spurious empty-rows warnings (#3408)

### Changed

- Per-merge release tagging has been removed (Phase 4 of the release-workflow overhaul) (#3406)
- `/design` Step 3.6 has been extracted into a dedicated `design-plan-quality-assessor` phase driver, improving modularity of the design review pipeline (#3409)
