### PR TITLE
Release v47.0.66

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "47.0.65",
+  "version": "47.0.66",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (default SIMPLE tier; opt-in `--hard` only) and `/implement` (positional `<issue-N>`, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified hard panel internally (public `--panel` argv removed). Post-plan steps use the conventional hard workflow path and `$IMPLEMENT_TMPDIR/plan.txt` for plan materialization — there is no `/implement --hard` flag.",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## v47.0.66

### Fixed

- Removed dormant version-tracking and changelog machinery that was no longer in use ([#3424](https://github.com/character-ai/larch/pull/3424))

### Changed

- Committed design run log for session 4AB6E15B-2E80-4B13-A0D4-A3B0A0A42CB1 ([#3363](https://github.com/character-ai/larch/pull/3363))
- Committed design run log for session 3D213C10-13E2-402A-AAA2-5283EB72FE62 ([#3370](https://github.com/character-ai/larch/pull/3370))
