### PR TITLE
Fixes #3415: De-tokenize /design Step 0-pre CLAUDE_PLUGIN_ROOT guard sentinel

### DIFF
--- a/scripts/test-design-structure.sh
+++ b/scripts/test-design-structure.sh
@@ -272,6 +272,10 @@ printf '%s\n' "$step0pre_block" | grep -Fq 'unexpanded template literal' \
   || fail 'Step 0-pre must reject unexpanded CLAUDE_PLUGIN_ROOT template literal'
 printf '%s\n' "$step0pre_block" | grep -Fq 'parse-design-argv.sh not executable' \
   || fail 'Step 0-pre must verify parse-design-argv.sh is executable before invoke'
+# shellcheck disable=SC2016 # Markdown literal; ${CLAUDE_PLUGIN_ROOT} must stay unexpanded in the forbidden pattern.
+if printf '%s\n' "$step0pre_block" | grep -Fq "= '\${CLAUDE_PLUGIN_ROOT}'"; then
+  fail 'Step 0-pre must not compare CLAUDE_PLUGIN_ROOT against a bare ${CLAUDE_PLUGIN_ROOT} sentinel (loader expands it; use a de-tokenized literal)'
+fi
 contains "$PARSE_DESIGN_ARGV_SH" 'assert_safe_kv_value' 'parse-design-argv.sh missing newline guard on emitted values'
 
 DESIGN_DRIVER_SH="$REPO_ROOT/skills/design/scripts/design-driver.sh"

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -128,12 +128,13 @@ Run `parse-design-argv.sh` as the single authoritative Step 0-pre parser. Render
 
 ```bash
 export CLAUDE_PLUGIN_ROOT='${CLAUDE_PLUGIN_ROOT}'
+_cpr_literal='$''{CLAUDE_PLUGIN_ROOT}'
 if [ -z "${CLAUDE_PLUGIN_ROOT:-}" ]; then
-  printf '%s\n' '/design Step 0-pre: CLAUDE_PLUGIN_ROOT is empty after export — skill loader must expand ${CLAUDE_PLUGIN_ROOT} in the template line before Bash runs; abort' >&2
+  printf '%s\n' "/design Step 0-pre: CLAUDE_PLUGIN_ROOT is empty after export — skill loader must expand ${_cpr_literal} in the template line before Bash runs; abort" >&2
   exit 1
 fi
-if [ "${CLAUDE_PLUGIN_ROOT:-}" = '${CLAUDE_PLUGIN_ROOT}' ]; then
-  printf '%s\n' '/design Step 0-pre: CLAUDE_PLUGIN_ROOT is the unexpanded template literal — skill loader must expand ${CLAUDE_PLUGIN_ROOT} before Bash runs; abort' >&2
+if [ "${CLAUDE_PLUGIN_ROOT:-}" = "$_cpr_literal" ]; then
+  printf '%s\n' "/design Step 0-pre: CLAUDE_PLUGIN_ROOT is the unexpanded template literal ${_cpr_literal} — skill loader must expand it before Bash runs; abort" >&2
   exit 1
 fi
 if [ ! -x "${CLAUDE_PLUGIN_ROOT}/skills/design/scripts/parse-design-argv.sh" ]; then
@@ -245,8 +246,9 @@ On success, Step 0b consumes the bound mental booleans, optional `run_id`, `POSI
 
 ```bash
 export CLAUDE_PLUGIN_ROOT='${CLAUDE_PLUGIN_ROOT}'
+_cpr_literal='$''{CLAUDE_PLUGIN_ROOT}'
 if [ -z "${CLAUDE_PLUGIN_ROOT:-}" ]; then
-  printf '%s\n' '/design Step 0: CLAUDE_PLUGIN_ROOT is empty after export — skill loader must expand ${CLAUDE_PLUGIN_ROOT} in the template line before Bash runs; abort' >&2
+  printf '%s\n' "/design Step 0: CLAUDE_PLUGIN_ROOT is empty after export — skill loader must expand ${_cpr_literal} in the template line before Bash runs; abort" >&2
   exit 1
 fi
 LARCH_TIMING_SKILL=design "${CLAUDE_PLUGIN_ROOT}/scripts/timing-ledger.sh" mark "design Step 0 — session setup" || true


### PR DESCRIPTION
Fixes #3415.

## Problem

`/design` aborted on its **first** Bash block (Step 0-pre) with a false-positive `CLAUDE_PLUGIN_ROOT is the unexpanded template literal … abort`, even when `CLAUDE_PLUGIN_ROOT` was a real, existing path. The skill loader does a **uniform, exact-token** substitution of `${CLAUDE_PLUGIN_ROOT}` across the entire `SKILL.md` — including the guard's own single-quoted RHS sentinel:

```bash
if [ "${CLAUDE_PLUGIN_ROOT:-}" = '${CLAUDE_PLUGIN_ROOT}' ]; then   # both sides → /real/path → always equal
```

So on the success path both sides expanded to the real path, the equality held, and the guard fired. (The LHS `${CLAUDE_PLUGIN_ROOT:-}` is a *different* token thanks to the `:-}` suffix, so the loader leaves it alone.)

## Fix

De-tokenize the sentinel so the loader's exact-token match can't see it:

```bash
_cpr_literal='$''{CLAUDE_PLUGIN_ROOT}'   # two adjacent single-quoted strings → literal ${CLAUDE_PLUGIN_ROOT}
                                         # at bash parse time, but no contiguous token in source for the loader
if [ "${CLAUDE_PLUGIN_ROOT:-}" = "$_cpr_literal" ]; then
```

- Both Step 0-pre diagnostics and the Step 0a twin empty-guard message now reference `${_cpr_literal}` (no bare token survives in any message string).
- The `-x` parser-executable check and its path message are **unchanged** — they legitimately require the loader-expanded real path.
- `scripts/test-design-structure.sh` gains a negative regression assertion that the Step 0-pre block contains no `= '${CLAUDE_PLUGIN_ROOT}'` sentinel.

## Verification

- `bash scripts/test-design-structure.sh` — passes (existing `unexpanded template literal` and `parse-design-argv.sh not executable` pins still pass; new negative pin added).
- `bash scripts/relevant-checks.sh` — passes (bash32, renderer-substitution, flag-signature, bare-grep, agent-lint, `test-check-contains-pins` 44/44).
- `shellcheck` + `markdownlint` pre-commit hooks on the changed files — pass.
- **Empirical loader simulation** of the rendered fence under three behaviors:
  - uniform exact-token expander (the failing env): fence **passes**, no abort → bug fixed;
  - no expansion: unexpanded-literal guard **fires** correctly;
  - empty expansion: `-z` empty guard **fires** first.
- Confirmed the new assertion **fires** on a reintroduced bare-token sentinel and does **not** match the new code or the legitimate seed `export`/`-x` lines.

## Note (out of scope)

An independent review flagged a *pre-existing* gap: there is no negative assertion for the Step 0a fence. Step 0a never had an equality guard (only the `-z` empty check), and the approved plan scoped the test pin to Step 0-pre (the actual bug site), so this PR does not add one. Captured here for a potential follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
