### PR TITLE
Release v47.0.67

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "47.0.66",
+  "version": "47.0.67",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (default SIMPLE tier; opt-in `--hard` only) and `/implement` (positional `<issue-N>`, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified hard panel internally (public `--panel` argv removed). Post-plan steps use the conventional hard workflow path and `$IMPLEMENT_TMPDIR/plan.txt` for plan materialization — there is no `/implement --hard` flag.",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## What's Changed

### Fixed

- Ensure the `/implement` Step 18 shutdown phase records closing token and timing marks before teardown runs, preventing missing metrics on normal exits ([#3427](https://github.com/character-ai/larch/pull/3427))
- Remove inadvertent tokenization of the `CLAUDE_PLUGIN_ROOT` guard sentinel in the `/design` Step 0 pre-check, which was causing false-positive guard trips ([#3428](https://github.com/character-ai/larch/pull/3428))
- Recover Cursor plan-review slots that were silently dropped when a format-gate check failed mid-run, so plan reviews complete even after a format gate miss ([#3429](https://github.com/character-ai/larch/pull/3429))

**Full Changelog**: https://github.com/character-ai/larch/compare/v47.0.66...v47.0.67
