### PR TITLE
Release v47.0.69

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "47.0.68",
+  "version": "47.0.69",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (default SIMPLE tier; opt-in `--hard` only) and `/implement` (positional `<issue-N>`, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified hard panel internally (public `--panel` argv removed). Post-plan steps use the conventional hard workflow path and `$IMPLEMENT_TMPDIR/plan.txt` for plan materialization — there is no `/implement --hard` flag.",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## v47.0.69

### Fixed

- Completed the Phase 7 driver implementation for the ship-pr Python port, closing out the Python rework of the ship-pr orchestration pipeline.

