### PR TITLE
Release v47.0.70

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "47.0.69",
+  "version": "47.0.70",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (default SIMPLE tier; opt-in `--hard` only) and `/implement` (positional `<issue-N>`, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified hard panel internally (public `--panel` argv removed). Post-plan steps use the conventional hard workflow path and `$IMPLEMENT_TMPDIR/plan.txt` for plan materialization — there is no `/implement --hard` flag.",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## What's Changed

### Fixed

- Re-enabled the design-log publish merge gate that had been inadvertently disabled ([#3454](https://github.com/character-ai/larch/pull/3454))
- Added `python/` to the plugin sparse-checkout allowlist so the directory is included in plugin installs ([#3455](https://github.com/character-ai/larch/pull/3455))

**Full Changelog**: https://github.com/character-ai/larch/compare/v47.0.69...v47.0.70
