### PR TITLE
Release v47.0.71

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "47.0.70",
+  "version": "47.0.71",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (default SIMPLE tier; opt-in `--hard` only) and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` has no workflow tier/path dimension and no `/implement --hard` flag. `/implement` Step 5 code review always uses the unified hard panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
# Release v47.0.71

Patch release covering 70 merged PRs since v47.0.70. Highlights: continued `/design` step-script thinning and reorganization, further Python runtime migration, and Codex/OpenAI key and log-retention refinements.

## Added
- `--with-plan-size` mode for `design-postplan-emit.sh`, collapsing the Step 2b fences (#3503)
- Python pre-push conflict handoff signal (#3515)

## Changed
- Migrated `/report-tokens` to Python (#3460)
- Completed the Python Step 8 cutover contract (#3535)
- Prefer `OPENAI_API_KEY` for covered Codex paths (#3477)
- Made dynamic Codex log retention explicit (#3557)
- Collapsed the code-review panel to four both-vendor archetypes (#3505)
- Hardened `/design` Step 3.6 thin-fence coverage (#3469)
- Folded design publish validation into the Step 5c driver (#3491)
- Moved Step 3 preview ownership into `run-step3-review.sh --preview-only` (#3494)
- Thinned `/design` Step 0b route/init fences (#3517)
- Folded design setup into existing step boundaries (#3518)
- Anchored design plan review to the staged issue scope (#3548)
- Moved the design title rename ahead of log publish (#3501)
- Documented `CI_FIX_REBASE_PENDING` non-port and pinned push-failed STALLED handling (#3507)
- Implemented a batch of tracked issues (#3464, #3473, #3474, #3489, #3492, #3500, #3519, #3532, #3541, #3542, #3546, #3549, #3555, #3556, #3558, #3566, #3567)

## Fixed
- Restored Step 9a.1 OOS pipeline materialization (#3497)
- Fixed a design publish failure and repo handling (#3498)
- Handle empty degraded-tool presence inputs (#3540)

## Maintenance
- 35 committed `/design` run-log flushes
