### PR TITLE
Release v47.0.72

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "47.0.71",
+  "version": "47.0.72",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (default SIMPLE tier; opt-in `--hard` only) and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` has no workflow tier/path dimension and no `/implement --hard` flag. `/implement` Step 5 code review always uses the unified hard panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## v47.0.72

### Fixed

- Wire shared Codex env-key authentication into previously uncovered `codex exec` call sites (`run-external-agent.sh`, lint-fix helpers, negotiation scripts) so that `OPENAI_API_KEY` preference applies uniformly across all Codex invocation surfaces (#3571)
- Fix OOS disposition gate silently dropping accepted out-of-scope review findings when findings carry the legacy `### FINDING_N: [OUT_OF_SCOPE]` header format; counters and the gate now recognise both header shapes, preventing silent filing failures (#3572)
