### PR TITLE
Release v48.0.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "47.0.72",
+  "version": "48.0.0",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (default SIMPLE tier; opt-in `--hard` only) and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` has no workflow tier/path dimension and no `/implement --hard` flag. `/implement` Step 5 code review always uses the unified hard panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Changed

- **`/design` scope-creep guard** — The SIMPLE-tier design loop no longer auto-applies review findings back into the plan between rounds (manual gate now required), and a drift guard prevents incremental reviewer suggestions from silently ratcheting the plan scope upward across rounds. (#3578)

## Fixed

- **`/implement` Step 2 dispatch failure (Codex)** — Resolved a stall where implementer dispatch exited with code 0 but left the run in a failed checks phase, blocking further progress. (#3581)
- **Python ship-pr driver: three hot-patch bugs** — Fixed silent success (no breadcrumb) on `rename_to_implementing` in `implement-bootstrap.sh`, plus two additional bugs surfaced during the first Python-path `/implement` run. (#3584)
