### PR TITLE
fix(rebalance): AFTER table shows all zeros due to wrong dict type

### DIFF
--- a/.claude/skills/rebalance-test-harnesses/scripts/rebalance.py
+++ b/.claude/skills/rebalance-test-harnesses/scripts/rebalance.py
@@ -470,8 +470,16 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901
         else:
             print(f"⚠ Shard balance FAILED (spread {spread:.1f}s > {threshold}s threshold)")
 
+        # BEFORE: per-shard totals estimated from per-target baseline medians
         _print_shard_table("BEFORE (estimated from baseline medians):", current_shards, medians)
-        _print_shard_table("AFTER (median of verification runs):", new_shards, medians_verify)
+        # AFTER: per-shard totals measured directly from verification runs.
+        # medians_verify is {shard_int: total_float} — print it directly instead
+        # of routing through _print_shard_table (which expects {target: seconds}).
+        print(f"\nAFTER (measured median of {args.n_verify_runs} verification runs):")
+        print(f"  {'Shard':>6}  {'Total (s)':>10}")
+        for shard_n in sorted(medians_verify):
+            print(f"  {shard_n:>6}  {medians_verify[shard_n]:>10.1f}")
+        print(f"  Spread (max-min): {spread:.1f}s")
 
     # ------------------------------------------------------------------
     # Merge (COMMENTED OUT — operator must merge manually)


### PR DESCRIPTION
## Summary

Bug 8 found during first end-to-end run of `/rebalance-test-harnesses`.

`_print_shard_table("AFTER…", new_shards, medians_verify)` was called with
`medians_verify = {shard_int: total_float}` but the function iterates the
shard layout targets and looks up `medians.get(target_name, 0.0)`.
Since the dict keys are integers (shard numbers) and the lookups use string
target names, every lookup returned 0.0.

The verification spread computation (max-min) was already correct — only
the display table was broken.

Fix: print the AFTER column directly from `medians_verify` without routing
through `_print_shard_table`.

## Test plan
- [x] Manually verified `parse_log` returns 326 rows on a real verification run log
- [ ] CI green on this PR
