### PR TITLE
fix: set RUN_EXTERNAL_AGENT_POLL_INTERVAL=0.05 in test-launch-codex-exec

### DIFF
--- a/scripts/test-launch-codex-exec.sh
+++ b/scripts/test-launch-codex-exec.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 
 export LARCH_QUIET_DISABLE=1
 export LARCH_EXTERNAL_HEALTH_CHECK_TIMEOUT=0
+export RUN_EXTERNAL_AGENT_POLL_INTERVAL=0.05
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TMPDIR_BASE="$(mktemp -d -t launch-codex-exec-test.XXXXXX)"


### PR DESCRIPTION
## Summary

`test-launch-codex-exec.sh` takes ~101s in CI because it invokes `launch-codex-exec.sh` about 12 times with a stub codex, but `run-external-agent.sh` polls the child every **10 seconds** by default (`RUN_EXTERNAL_AGENT_POLL_INTERVAL`). Even though the stub exits immediately, each invocation waits a full poll cycle before detecting completion.

Fix: add `export RUN_EXTERNAL_AGENT_POLL_INTERVAL=0.05` (the conventional test value, matching `test-run-external-agent.sh`, `test-dispatch-with-waterfall.sh`, etc.).

**Before**: ~101s | **After**: ~6s (verified locally)

The header comment in `run-external-agent.sh` even says *"default 10s; tests override to a fraction of a second"* — this harness simply forgot to set it.