### PR TITLE
Release v48.1.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "48.1.1",
+  "version": "48.1.2",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (default SIMPLE tier; opt-in `--hard` only) and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` has no workflow tier/path dimension and no `/implement --hard` flag. `/implement` Step 5 code review always uses the unified hard panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Fixed

- Improved test-harness shard scheduling: replaced the prior packing strategy with a greedy Longest Processing Time algorithm and split oversized slow shards so CI wall-clock time is more evenly distributed across shards. ([#3624](https://github.com/character-ai/larch/pull/3624))

## Internal

- Flushed committed design run logs for two completed runs. ([#3623](https://github.com/character-ai/larch/pull/3623), [#3625](https://github.com/character-ai/larch/pull/3625))
