### PR TITLE
Release v48.1.3

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "48.1.2",
+  "version": "48.1.3",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (default SIMPLE tier; opt-in `--hard` only) and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` has no workflow tier/path dimension and no `/implement --hard` flag. `/implement` Step 5 code review always uses the unified hard panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## v48.1.3

### Fixed

- Align Python version floor to 3.11 across all configuration files and documentation — `python/pyproject.toml`, `python/pyrightconfig.json`, `python/.pylintrc`, `.github/workflows/ci.yaml`, `scripts/implement-bootstrap.sh`, `docs/installation-and-setup.md`, and `docs/linting.md` previously required Python 3.12 despite the actual runtime floor being 3.11, causing `make py-lint` and `make py-test` to fail for users on Python 3.11.
