### PR TITLE
Release v48.2.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "48.1.3",
+  "version": "48.2.0",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (default SIMPLE tier; opt-in `--hard` only) and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` has no workflow tier/path dimension and no `/implement --hard` flag. `/implement` Step 5 code review always uses the unified hard panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## What's Changed in v48.2.0

### Changed

- **Review voting simplified to YES/NO** — removed the EXONERATE outcome; all reviewer votes are now binary, reducing ambiguity in the review panel ([#3655](https://github.com/character-ai/larch/pull/3655))
- **Plan-quality assessor removed from `/design`** — Step 3.6 (plan-quality assessment) is eliminated entirely, streamlining the design flow ([#3656](https://github.com/character-ai/larch/pull/3656))
- **Necessity-gated code review** — added a rubric, YES/NO judge bar, and reviewer self-filter so review agents only engage when warranted ([#3658](https://github.com/character-ai/larch/pull/3658))
- **`/design` auto-apply of accepted findings restored** — the default behavior (assessor-gated) is reinstated after a prior regression ([#3641](https://github.com/character-ai/larch/pull/3641))
- **Judge panel shrinks on vendor unavailability** — when a vendor is unavailable during `/implement` code review, the panel contracts rather than back-filling with duplicates ([#3643](https://github.com/character-ai/larch/pull/3643))
- **Max dynamic review archetypes capped at 3** — applies uniformly across `/implement`, `/design`, and `/review` to reduce token spend ([#3634](https://github.com/character-ai/larch/pull/3634))
- **OOS filing decoupled from `ship-pr`** — out-of-scope items are now filed post-ship via `file_oos.py`; `ship-pr.sh` no longer handles OOS ([#3654](https://github.com/character-ai/larch/pull/3654))

### Fixed

- **Spawned-process Claude tokens now tracked** — tokens from sub-process Claude invocations were missing from `/design` and `/implement` cost reports; all lanes now report correctly ([#3646](https://github.com/character-ai/larch/pull/3646))
- **Token-lane follow-up hardening** — launcher audit, additional test coverage, and correctness fixes for the `claude_sub` token tracking introduced in the prior fix ([#3652](https://github.com/character-ai/larch/pull/3652))
- **`auto-fix-plan-commands.sh` live-path gaps closed** — coverage gaps in the live execution path are resolved ([#3653](https://github.com/character-ai/larch/pull/3653))
- **Stall-recovery hardening** — enum, docs, lint updates, and timing pin improvements for the stall-recovery mechanism ([#3657](https://github.com/character-ai/larch/pull/3657))
- **`/design` voter and external-agent reliability** — ballot-pointer grammar regression test added; Codex health-probe, Claude read-tools, and lenient vendor retry logic improve resilience ([#3659](https://github.com/character-ai/larch/pull/3659))
