### PR TITLE
Release v48.2.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "48.2.0",
+  "version": "48.2.1",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (default SIMPLE tier; opt-in `--hard` only) and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` has no workflow tier/path dimension and no `/implement --hard` flag. `/implement` Step 5 code review always uses the unified hard panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## v48.2.1

### Changed

- **Review-round cap unified to 5** across both `/design` tiers and `/implement`; removed legacy per-knob overrides that could produce inconsistent behavior (#3662, PR #3699)
- **`/design` review loop improvements**: heuristic multi-round continuation, corrected "0 findings" summary display, and clarified per-tier cap documentation (#3700, PR #3724)
- **Run-log size reduction — `/design`**: stopped committing derived and duplicate log artifacts at publish time (Phase 1, #3705, PR #3711); retroactively cleaned up previously committed design run logs (Phase 2, #3706, PR #3723); collapsed remaining log duplication (Phase 3b, #3715, PR #3725)
- **Run-log size reduction — `/implement`**: stopped committing redundant implement log artifacts at publish time (Phase 1, #3708, PR #3722)

### Fixed

- **`/block-issue`**: eliminated false "may already exist" warning caused by a stale summary read in `add-blocked-by.sh` (#3701, PR #3707)
- **`/implement` review dispatch**: voters now run in parallel and Cursor is used as the default fix-coder (#3704, PR #3712)
- **Run-log root resolution**: fixed a bug where run-log trees were incorrectly committed under `python/larch-logs` instead of the intended root (#3710, PR #3720)

### Infrastructure

- Rebalanced CI test harness shards to equalize wall-clock time (PR #3661)
- Split lint and shellcheck CI jobs into parallel halves; bumped shellcheck to v0.11.0.1 (PR #3663)
