### PR TITLE
Release v48.3.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "48.2.1",
+  "version": "48.3.0",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (default SIMPLE tier; opt-in `--hard` only) and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` has no workflow tier/path dimension and no `/implement --hard` flag. `/implement` Step 5 code review always uses the unified hard panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Added

- **`/gc-run-logs` skill** — new exported plugin skill implementing age-based retention for committed run logs. Caps long-term log corpus growth by slimming or removing run directories older than a configurable threshold; companion to the one-time retroactive cleanup phases. (#3736 / issue #3719)

## Changed

- **Run-log size reduction — Phase 2 (retroactive /implement cleanup)**: retroactively pruned committed `larch-logs/implement/` tree (~216 MB / 608 run dirs) to match the finalized publish-time rule set. (#3731 / issue #3709)
- **Run-log size reduction — Phase 3a (finding/plan deduplication)**: collapsed finding and plan prose that was previously stored in up to five places per round within `/implement` run logs, removing ~47 MB (36%) of redundant content. (#3730 / issue #3714)
- **Run-log size reduction — Phase 3c (sidecar consolidation)**: consolidated per-round sidecar files and repeated dynamic-archetype definitions into a unified `round-meta.json`; reduces thousands of small files per corpus, cutting checkout and indexing overhead. (#3734 / issue #3716)
- **Run-log size reduction — Phase 3c retroactive sweep**: applied the new sidecar consolidation to the ~851 already-committed round directories, producing a dedicated log-only PR with no code change. (#3738 / issue #3737)
- **Run-log size reduction — Phase 3d (/design log deduplication)**: dropped redundant cumulative accepted/rejected snapshots and GitHub-mirrored design log copies from `larch-logs/design/`, verified as zero-loss cuts. (#3729 / issue #3721)
- **Run-log size reduction — Phase 4 (prose-and-errors-only transcripts)**: changed session-transcript publishing to drop all `tool_call` events and non-error `tool_result` blocks, targeting the single largest residual item (~22.6 MB / 55 KB per run). (#3728 / issue #3718)

## Fixed

- **`python/ship.py` stall recovery misclassification**: fixed a bug where actionable outer-fix-attempt stalls were classified as `transient-infra` with `RESUME_HINT=none`, suppressing Step 18a dispatch and stranding the run without a recovery attempt. (#3733 / issue #3726)
