### PR TITLE
Fixes #3756: Add /status skill: larch version and vendor health check (#3756)

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,12 @@ Larch is a Claude Code workflow automation framework that orchestrates multi-age
     <tr><td colspan="2">Configure the current checkout for upstream/fork OSS contribution: verify the fork, optionally sync it from upstream, rewire remotes, disable upstream pushes, and set <code>main</code> tracking.</td></tr>
     <tr><td colspan="2"><hr></td></tr>
     <tr>
+      <td><a href="docs/skills.md#status"><code>/status</code></a></td>
+      <td><em>(none)</em></td>
+    </tr>
+    <tr><td colspan="2">Print the current larch version and health status of external vendor tools (Codex and Cursor), using the same probe machinery as <code>/implement</code>.</td></tr>
+    <tr><td colspan="2"><hr></td></tr>
+    <tr>
       <td><a href="docs/skills.md#upgrade-larch"><code>/upgrade-larch</code></a></td>
       <td><em>(none)</em></td>
     </tr>

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -15,6 +15,7 @@ Reference for every slash command shipped by the larch plugin. Each section belo
 - [`/review`](#review)
 - [`/review-and-fix`](#review-and-fix)
 - [`/set-up-forked-open-source-repo`](#set-up-forked-open-source-repo)
+- [`/status`](#status)
 - [`/upgrade-larch`](#upgrade-larch)
 
 ## `/alias`
@@ -160,6 +161,14 @@ Apply accepted review findings as code fixes. Internal sub-skill invoked by `/re
 Configure the current checkout for upstream/fork OSS contribution. The skill verifies that the fork exists on GitHub and that its immediate parent is the declared upstream, probes both repositories' `refs/heads/main`, optionally performs a destructive fork sync of branches and tags after explicit confirmation, then rewires local remotes so `origin` points at the fork and `upstream` points at upstream. It disables upstream pushes with an invalid-scheme push URL, fetches `origin`, sets `main` to track `origin/main`, and fast-forwards only from a clean `main` checkout.
 
 The workflow is intentionally single-clone (per-clone single-flight lock; multiple clones may run concurrently) and supports any GitHub-compatible host, with github.com as the default. It refuses dirty linked worktrees, in-progress git operations in any linked worktree, missing local `main`, non-`main` checkouts, local `main` ahead of `origin/main`, diverged local/remote `main`, ambiguous remote layouts, non-parseable / mixed-host URLs, duplicate fork remotes, multi-fetch URL remotes, and multi-push URL remotes. If the fork is missing, it prints fork-creation instructions and exits without local mutation. `--init-submodules` is opt-in; default runs ignore submodules.
+
+## `/status`
+
+**Arguments**: *(none)*
+
+**Source**: [`skills/status/SKILL.md`](../skills/status/SKILL.md)
+
+Print the current larch version and health status of external vendor tools (Codex and Cursor). Uses the same probe machinery as `/implement` Step 0: `check-reviewers.sh` for binary/runtime probes, then `degraded-tools-gate.sh` to classify each vendor. Reports whether the session would run degraded (reduced panel or Claude-only fallback).
 
 ## `/upgrade-larch`
 

--- a/skills/status/SKILL.md
+++ b/skills/status/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: status
+description: "Use when checking larch plugin health: reports the current larch version and checks availability of external vendor tools (Codex and Cursor) using the same probe machinery as /implement."
+allowed-tools: Bash
+---
+
+# status
+
+Print the current larch version and health status of external vendor tools (Codex and Cursor). Uses the same probe machinery as `/implement` Step 0: `check-reviewers.sh` for binary/runtime probes, then `degraded-tools-gate.sh` to classify each vendor as `ok`, `binary-missing`, or `probe-failed`.
+
+<!-- step:1 — Run status check -->
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/skills/status/scripts/status.sh"
+```
+
+Parse all KV pairs from stdout without `eval`/`source`. Extract at minimum:
+`LARCH_PLUGIN_VERSION`, `CODEX_STATE`, `CURSOR_STATE`, `CODEX_BINARY_FOUND`,
+`CURSOR_BINARY_FOUND`, `CODEX_PRESENT`, `CURSOR_PRESENT`, and `DEGRADED`.
+
+<!-- step:2 — Render and report -->
+
+Render a human-readable status report using the parsed values:
+
+- **Version**: `LARCH_PLUGIN_VERSION`
+- **Codex**: translate `CODEX_STATE` — `ok` → `ok`; `binary-missing` → `binary not found on PATH`; `probe-failed` → `binary found but runtime probe failed`; `unknown` → `probe did not run`
+- **Cursor**: same translation using `CURSOR_STATE`
+
+When `DEGRADED=true`, append a brief note that one or more vendors are unavailable and that `/implement` will fall back to a reduced panel or Claude-only mode.
+
+If the script exits non-zero, surface the error message and do not invent status values.

--- a/skills/status/scripts/status.sh
+++ b/skills/status/scripts/status.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# status.sh — larch version and vendor health status check.
+#
+# Outputs (KEY=value on stdout via emit_kv):
+#   LARCH_PLUGIN_VERSION=<value>   Current larch plugin version.
+#   CODEX_BINARY_FOUND=true|false  Whether the codex binary is on PATH.
+#   CURSOR_BINARY_FOUND=true|false Whether the cursor binary is on PATH.
+#   CODEX_PRESENT=true|false       Codex binary found AND runtime probe passed.
+#   CURSOR_PRESENT=true|false      Cursor binary found AND runtime probe passed.
+#   CODEX_STATE=ok|binary-missing|probe-failed
+#   CURSOR_STATE=ok|binary-missing|probe-failed
+#   DEGRADED=true|false            Whether any vendor is unavailable.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd -P)}"
+# shellcheck source=scripts/lib-quiet.sh
+source "$PLUGIN_ROOT/scripts/lib-quiet.sh"
+larch_quiet_init
+
+# Read plugin version (best-effort; always emits a value)
+LARCH_PLUGIN_VERSION="unknown"
+_ver_out=$("$PLUGIN_ROOT/scripts/read-plugin-version.sh" 2>/dev/null || true)
+if [ -n "$_ver_out" ]; then
+    _v=$(printf '%s\n' "$_ver_out" | awk -F= '/^LARCH_PLUGIN_VERSION=/{print substr($0, index($0,"=")+1); exit}')
+    [ -n "$_v" ] && LARCH_PLUGIN_VERSION="$_v"
+fi
+
+# Run reviewer health probes (same machinery as /implement Step 0)
+CODEX_BINARY_FOUND=false
+CURSOR_BINARY_FOUND=false
+CODEX_PRESENT=false
+CURSOR_PRESENT=false
+_check_out=$("$PLUGIN_ROOT/scripts/check-reviewers.sh" 2>/dev/null || true)
+if [ -n "$_check_out" ]; then
+    _v=$(printf '%s\n' "$_check_out" | awk -F= '/^CODEX_BINARY_FOUND=/{print substr($0, index($0,"=")+1); exit}')
+    [ -n "$_v" ] && CODEX_BINARY_FOUND="$_v"
+    _v=$(printf '%s\n' "$_check_out" | awk -F= '/^CURSOR_BINARY_FOUND=/{print substr($0, index($0,"=")+1); exit}')
+    [ -n "$_v" ] && CURSOR_BINARY_FOUND="$_v"
+    _v=$(printf '%s\n' "$_check_out" | awk -F= '/^CODEX_PRESENT=/{print substr($0, index($0,"=")+1); exit}')
+    [ -n "$_v" ] && CODEX_PRESENT="$_v"
+    _v=$(printf '%s\n' "$_check_out" | awk -F= '/^CURSOR_PRESENT=/{print substr($0, index($0,"=")+1); exit}')
+    [ -n "$_v" ] && CURSOR_PRESENT="$_v"
+fi
+
+# Interpret results using degraded-tools-gate.sh (same gate as /implement Step 0)
+CODEX_STATE=unknown
+CURSOR_STATE=unknown
+DEGRADED=false
+_gate_out=$("$PLUGIN_ROOT/scripts/degraded-tools-gate.sh" \
+    --codex-binary-found "$CODEX_BINARY_FOUND" \
+    --codex-present "$CODEX_PRESENT" \
+    --cursor-binary-found "$CURSOR_BINARY_FOUND" \
+    --cursor-present "$CURSOR_PRESENT" \
+    --skill status 2>/dev/null || true)
+if [ -n "$_gate_out" ]; then
+    _v=$(printf '%s\n' "$_gate_out" | awk -F= '/^CODEX_STATE=/{print substr($0, index($0,"=")+1); exit}')
+    [ -n "$_v" ] && CODEX_STATE="$_v"
+    _v=$(printf '%s\n' "$_gate_out" | awk -F= '/^CURSOR_STATE=/{print substr($0, index($0,"=")+1); exit}')
+    [ -n "$_v" ] && CURSOR_STATE="$_v"
+    _v=$(printf '%s\n' "$_gate_out" | awk -F= '/^DEGRADED=/{print substr($0, index($0,"=")+1); exit}')
+    [ -n "$_v" ] && DEGRADED="$_v"
+fi
+
+emit_kv LARCH_PLUGIN_VERSION "$LARCH_PLUGIN_VERSION"
+emit_kv CODEX_BINARY_FOUND   "$CODEX_BINARY_FOUND"
+emit_kv CURSOR_BINARY_FOUND  "$CURSOR_BINARY_FOUND"
+emit_kv CODEX_PRESENT        "$CODEX_PRESENT"
+emit_kv CURSOR_PRESENT       "$CURSOR_PRESENT"
+emit_kv CODEX_STATE          "$CODEX_STATE"
+emit_kv CURSOR_STATE         "$CURSOR_STATE"
+emit_kv DEGRADED             "$DEGRADED"


### PR DESCRIPTION
- Implement requested changes.

## Test plan

- [ ] `make py-lint`
- [ ] `make py-test`

Closes #3756
