### PR TITLE
Release v49.0.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "48.3.0",
+  "version": "49.0.0",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (default SIMPLE tier; opt-in `--hard` only) and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` has no workflow tier/path dimension and no `/implement --hard` flag. `/implement` Step 5 code review always uses the unified hard panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## What's Changed in v49.0.0

### Added
- New `/fluff-analysis` skill for analyzing committed review-fluff logs and surfacing patterns (#3753)
- New `/status` skill that reports the installed larch version and checks external vendor (Codex, Cursor) health (#3760)

### Changed
- `/design` gains optional `--skip-approve`/`-s` flag to bypass the two plan-approval prompts without suppressing Q&A questions (#3764)
- Review agents are now conditionally spawned based on accepted-finding rate over the last two rounds, cutting wasted review tokens (#3757)
- Extended the review necessity rubric and introduced a judge severity floor to reduce low-signal review suggestions (#3755)
- Nit-severity review findings are now automatically routed to OOS before the voting round, replacing manual triage (#3770)
- `reviewer-prune.sh` now reads `review-round-count.txt` directly instead of threading the counter through argv (#3768)
- CI third-party binary installs (gitleaks, ripgrep) are hardened with caching and retry to survive transient download failures (#3765)
- All CI third-party tool downloads are hardened against upstream 504 outages (#3772)
- Vendor failure-diag publish surface is hardened, extended, and documented (`*.failure-diag` / vendor-failure-diagnostics) (#3767)

### Fixed
- Vendor-agent error diagnostics are now preserved in committed run logs across all affected call sites — previously silently dropped (#3759)
- `commit-review-fixes.sh`: unguarded `${FILES[@]}` caused no-arg commits to fail under Bash 3.2 — urgent fix (#3762)
- `RUN_ID` absent from `session-env.sh` caused an empty run-id to silently skip the run-log commit — urgent fix (#3766)
