### PR TITLE
Release v49.0.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "49.0.0",
+  "version": "49.0.1",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (default SIMPLE tier; opt-in `--hard` only) and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` has no workflow tier/path dimension and no `/implement --hard` flag. `/implement` Step 5 code review always uses the unified hard panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## v49.0.1

### Added

- `/implement` and `/design` final reports now include a detailed review-phase summary: per-round stats (suggestions made, suggestions accepted, OOS items proposed, OOS items accepted, round duration, round cost, reviewer count), a totals row across all rounds, a top-7 reviewers breakdown by accepted-suggestion count (vendor/archetype), and a failure list by vendor/archetype. ([#3775](https://github.com/character-ai/larch/pull/3775))

### Fixed

- OOS security filter now correctly matches accepted-OOS blocks rendered as `- **Focus area**: security`. Previously only the bare `focus-area=security` token was matched, allowing security-tagged out-of-scope findings to slip through into the public combined file and be filed as public GitHub issues in violation of the SECURITY.md "held locally, never public" contract. ([#3786](https://github.com/character-ai/larch/pull/3786))
- `test-render-review-phase-detail.sh` vendor-cost block no longer aborts silently under `set -euo pipefail` when a subprocess fails transiently. Each subprocess is now guarded so any failure produces a labeled `FAIL:` diagnostic instead of an unexplained `make ... Error 1` that was indistinguishable from a real regression. ([#3787](https://github.com/character-ai/larch/pull/3787))
- `test-render-review-phase-detail.sh` per-round VENDOR cost test now uses hardcoded ISO timestamps, eliminating a source of transient flakiness. ([#3788](https://github.com/character-ai/larch/pull/3788))
