### PR TITLE
Release v49.0.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "49.0.1",
+  "version": "49.0.2",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (default SIMPLE tier; opt-in `--hard` only) and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` has no workflow tier/path dimension and no `/implement --hard` flag. `/implement` Step 5 code review always uses the unified hard panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/scripts/test-degraded-tools-gate.sh
+++ b/scripts/test-degraded-tools-gate.sh
@@ -10,18 +10,20 @@ FAIL=0
 
 assert_contains() {
     local haystack=$1 needle=$2 label=$3
-    if printf '%s\n' "$haystack" | grep -Fq -- "$needle"; then
+    if grep -Fq -- "$needle" <<< "$haystack"; then
         PASS=$((PASS + 1))
     else
         FAIL=$((FAIL + 1))
         printf 'FAIL: %s — expected to contain: %s\n' "$label" "$needle" >&2
-        printf '----- output -----\n%s\n------------------\n' "$haystack" >&2
+        printf '%s\n' "--- output ---" >&2
+        printf '%s\n' "$haystack" >&2
+        printf '%s\n' "---" >&2
     fi
 }
 
 assert_not_contains() {
     local haystack=$1 needle=$2 label=$3
-    if printf '%s\n' "$haystack" | grep -Fq -- "$needle"; then
+    if grep -Fq -- "$needle" <<< "$haystack"; then
         FAIL=$((FAIL + 1))
         printf 'FAIL: %s — expected NOT to contain: %s\n' "$label" "$needle" >&2
     else


### PR DESCRIPTION
## v49.0.2

### Fixed

- `/implement` report no longer shows a blank Review Phase Detail table; corrected the `--rounds-root` argument passed to the report formatter (#3795)

### Changed

- Shell-to-Python migration: linter suite ported to Python (`py-lint` target, `make lint` path unchanged) (#3790)
- Shell-to-Python migration: session/state lifecycle verbs consolidated into `session_env.py`; `python/cli.py session` is now the canonical interface for session reads and writes (#3791)
- Shell-to-Python migration: git/gh/CI primitive helpers consolidated under the Python driver, reducing standalone shell script surface (#3792)
- `/design` Step 3 plan review refactored into a script-internal multi-round loop, removing the prior per-round shell re-entry pattern (#3793)
