### PR TITLE
Release v49.0.3

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "49.0.2",
+  "version": "49.0.3",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (default SIMPLE tier; opt-in `--hard` only) and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` has no workflow tier/path dimension and no `/implement --hard` flag. `/implement` Step 5 code review always uses the unified hard panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## What's Changed

### Changed

- **`/design` plan-size drift gate removed**: The relative drift threshold (rc=14) no longer pauses the design loop to prompt the operator with a Continue/Cancel question. Sub-maximum plan growth is now recorded as a logged advisory in the run's execution-issues file and the loop continues autonomously. The absolute hard-size limit (rc=12, plan > 800 lines or diff_added > 2000) is unchanged and still gates as before. ([#3800](https://github.com/character-ai/larch/pull/3800))
