### PR TITLE
Release v49.0.4

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "49.0.3",
+  "version": "49.0.4",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (default SIMPLE tier; opt-in `--hard` only) and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` has no workflow tier/path dimension and no `/implement --hard` flag. `/implement` Step 5 code review always uses the unified hard panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## v49.0.4

### Fixed

- **Run-log timing ledger now records Claude subprocess roles.** Per-task wall-clock timing was missing for Claude invoked as a subprocess reviewer (code-review voter, plan-review voter, specialist reviewer, dynamic-archetype scout), leaving the Claude lane absent from `timing-report.json` vendor task averages and all per-round timing views. ([#3817](https://github.com/character-ai/larch/pull/3817))

- **`/design` summary OOS-filed count is now accurate when `/issue` runs inline.** When issues were created via a manual bash loop rather than the Skill-tool contract, `oos-issues-created.md` was never written, so `render-final-summary.sh` always reported `OOS filed: 0` despite successful issue creation. ([#3818](https://github.com/character-ai/larch/pull/3818))

### Changed

- **Python CLI modules consolidated from six thin companions to in-module `main()` dispatch.** Removes the six separate `*_cli.py` companion modules (`git_cli.py`, `push_cli.py`, `pr_cli.py`, `merge_cli.py`, `gh_cli.py`, `ci_cli.py`) in favour of dispatch directly from the domain module's own `main()`, aligning with the `docs/python-migration.md` house style. ([#3829](https://github.com/character-ai/larch/pull/3829))
