### PR TITLE
Release v49.0.5

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "49.0.4",
+  "version": "49.0.5",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (default SIMPLE tier; opt-in `--hard` only) and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` has no workflow tier/path dimension and no `/implement --hard` flag. `/implement` Step 5 code review always uses the unified hard panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## v49.0.5

### Added

- `/design` final report now includes a per-review-round detail section, matching the analogous section already present in `/implement` reports ([#3841](https://github.com/character-ai/larch/pull/3841))

### Changed

- `/implement` `SKILL.md`: moved the "Execution Issues Tracking" block to an on-demand reference to reduce per-turn context size ([#3840](https://github.com/character-ai/larch/pull/3840))

### Fixed

- `timing-ledger`: filled allow-list gaps for `claude-phase3-dyn-*` task kinds in the waterfall fallback lane; improved error visibility for timing-related failures (follow-up to #3797) ([#3843](https://github.com/character-ai/larch/pull/3843))
- `file-design-oos.sh`: fixed sentinel-idempotency gap where `cmd_prepare` could duplicate OOS issues on resume; added harness coverage for the new `annotate-skipped-empty-stdout` path ([#3839](https://github.com/character-ai/larch/pull/3839))
- `python/pr.py`: fixed two contract-fidelity gaps carried forward during the companion-module migration — `pr_checks_main` validation skip and a related latent bug in the same module ([#3838](https://github.com/character-ai/larch/pull/3838))
