### PR TITLE
fix(design-log-publish): skip known revise/ session artifacts instead of hard-erroring

### DIFF
--- a/scripts/design-log-publish.sh
+++ b/scripts/design-log-publish.sh
@@ -574,6 +574,8 @@ if [[ -e "$DESIGN_TMPDIR/plan-review" || -L "$DESIGN_TMPDIR/plan-review" ]]; the
             _base=$(basename "$rel")
             if design_round_revise_artifact_included "$_base"; then
                 :
+            elif design_round_revise_artifact_excluded "$_base"; then
+                continue
             else
                 larch_err "design-log-publish: unexpected file under plan-review (see scripts/lib-design-round-artifacts.md): $rel"
                 emit_publish_result false

--- a/scripts/lib-design-round-artifacts.md
+++ b/scripts/lib-design-round-artifacts.md
@@ -32,9 +32,13 @@ Note: `ballot.txt` remains in the include list (copied into round-N/ during the 
 
 ## `round-N/revise/` allowlist
 
-The revise include set is empty. Step 3 no longer runs inter-round revise, so newly published design logs must not include revise prompts, outputs, or candidate patches.
+The revise include set is empty — no files from `revise/` appear in committed design logs.
 
-Anything under `revise/` is excluded.
+`design-log-publish.sh` uses a two-tier check for `revise/` files (mirroring the top-level round pattern):
+
+1. `design_round_revise_artifact_included` — always returns 1 (nothing published from `revise/`).
+2. `design_round_revise_artifact_excluded` — returns 0 for known session-only artifacts that are silently skipped: raw vendor outputs (`*-output.txt`), candidate patches (`*-output-candidate.patch`), revision outcome (`revise.env`), revision prompt (`prompt.txt`), and all sidecars (`*.done`, `*.dirty-tree`, `*.meta`, `*.prompt`, `*.sidecar`, `*.sidecar.history`, `*.events.jsonl`, `*.events.history`, `*.untracked-baseline`, `*.diag`, `*.failure-diag`, `*.json`).
+3. Anything matching neither function is an **unexpected file** and causes a hard publish failure — the loud-failure contract is preserved so genuinely new files added to `revise/` without a corresponding exclusion entry are immediately visible.
 
 ## Vendor failure-diagnostics carrier (#3713)
 

--- a/scripts/lib-design-round-artifacts.sh
+++ b/scripts/lib-design-round-artifacts.sh
@@ -49,3 +49,30 @@ design_round_revise_artifact_included() {
     local name="${1:-}"
     return 1
 }
+
+# Return 0 when basename is a known session-only artifact under round-N/revise/ that
+# must not appear in committed design logs (silently skipped by design-log-publish.sh).
+# Anything not matched by either function is an unexpected file and causes a hard error.
+design_round_revise_artifact_excluded() {
+    local name="${1:-}"
+    case "$name" in
+        # Raw vendor outputs and winning candidate patches
+        *-output.txt|*-output-candidate.patch)
+            return 0
+            ;;
+        # Revision outcome and prompt
+        revise.env|prompt.txt)
+            return 0
+            ;;
+        # Sidecars
+        *.done|*.dirty-tree|*.meta|*.prompt|*.sidecar|*.sidecar.history|*.events.jsonl|*.events.history)
+            return 0
+            ;;
+        *.untracked-baseline|*.diag|*.failure-diag|*.json)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}

--- a/scripts/test-lib-design-round-artifacts.sh
+++ b/scripts/test-lib-design-round-artifacts.sh
@@ -82,4 +82,32 @@ assert_revise_excluded cursor-output-candidate.patch
 assert_revise_excluded claude-output-candidate.patch
 assert_revise_excluded extra-revise.log
 
+# Explicit exclusion list: known session-only artifacts silently skipped at publish time.
+assert_revise_explicitly_excluded() {
+    design_round_revise_artifact_excluded "$1" || fail "expected revise explicitly excluded: $1"
+}
+assert_revise_not_explicitly_excluded() {
+    if design_round_revise_artifact_excluded "$1"; then
+        fail "expected revise NOT explicitly excluded (unknown file): $1"
+    fi
+}
+assert_revise_explicitly_excluded codex-output.txt
+assert_revise_explicitly_excluded cursor-output.txt
+assert_revise_explicitly_excluded codex-output-candidate.patch
+assert_revise_explicitly_excluded cursor-output-candidate.patch
+assert_revise_explicitly_excluded claude-output-candidate.patch
+assert_revise_explicitly_excluded revise.env
+assert_revise_explicitly_excluded prompt.txt
+assert_revise_explicitly_excluded codex-output.txt.done
+assert_revise_explicitly_excluded codex-output.txt.dirty-tree
+assert_revise_explicitly_excluded codex-output.txt.prompt
+assert_revise_explicitly_excluded codex-output.txt.meta
+assert_revise_explicitly_excluded codex-output.txt.sidecar
+assert_revise_explicitly_excluded codex-output.txt.events.jsonl
+assert_revise_explicitly_excluded codex-output.txt.untracked-baseline
+assert_revise_explicitly_excluded codex-output.txt.diag
+assert_revise_explicitly_excluded codex-output.txt.failure-diag
+assert_revise_explicitly_excluded codex-output.txt.json
+assert_revise_not_explicitly_excluded extra-revise.log
+
 printf '%s\n' 'test-lib-design-round-artifacts: ok'


### PR DESCRIPTION
Fixes #3875

## Summary

- Add `design_round_revise_artifact_excluded()` to `lib-design-round-artifacts.sh` covering all known session-only revise artifacts: raw vendor outputs, `*-output-candidate.patch`, `revise.env`, `prompt.txt`, and all sidecars.
- Update `design-log-publish.sh` to use a two-tier check for `revise/` files (include → stage; known-excluded → skip silently; unknown → hard-error), mirroring the existing top-level round file pattern.
- Update `lib-design-round-artifacts.md` prose and `test-lib-design-round-artifacts.sh` assertions.

## Test plan

- [ ] `bash scripts/test-lib-design-round-artifacts.sh` passes
- [ ] `bash scripts/relevant-checks.sh` passes
- [ ] Retry design-log publish on a session with revise/ candidate patches succeeds (`PUBLISH_OK=true`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
