### PR TITLE
Release v49.0.6

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "49.0.5",
+  "version": "49.0.6",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (default SIMPLE tier; opt-in `--hard` only) and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` has no workflow tier/path dimension and no `/implement --hard` flag. `/implement` Step 5 code review always uses the unified hard panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## v49.0.6

### Fixed

- **CI test harness performance**: Added missing `session/read-key` and `session/write-env` stubs to `test-implement-bootstrap.sh` that were adding ~120 seconds to the CI test-harnesses-7 shard ([#3849](https://github.com/character-ai/larch/pull/3849))
- **Token source scan performance**: Eliminated O(n) stat loop in `token-claude-source.sh` that caused ~5.8s/call slowdown when `~/.claude/projects` is large ([#3850](https://github.com/character-ai/larch/pull/3850))
- **PR checks contract fidelity**: Resolved four contract-fidelity gaps in `python/pr.py` and `gh-pr-checks.sh` ([#3852](https://github.com/character-ai/larch/pull/3852))
- **Design OOS filing**: Corrected sentinel-success predicate, skip-already-filed-sentinel orchestration, annotate-skip surfacing, and harness gaps in the design OOS filing flow (`file-design-oos.sh` / Step 5b) ([#3853](https://github.com/character-ai/larch/pull/3853))
- **Implement skill documentation**: Completed call-site wiring and removed stale references for `execution-issues-tracking.md` ([#3854](https://github.com/character-ai/larch/pull/3854))
- **Design log publish — CI reliability**: Adopted `ship-pr` CI machinery in `design-log-publish.sh` for zero-flake behavior ([#3867](https://github.com/character-ai/larch/pull/3867))
- **Design log publish — artifact handling**: Skip known `revise/` session artifacts instead of hard-erroring during log publish ([#3876](https://github.com/character-ai/larch/pull/3876))
- **Fluff-analysis**: Corrected analysis lens and closed audit-flush gaps in review logs ([#3879](https://github.com/character-ai/larch/pull/3879))
- **Lint CI performance**: Excluded `larch-logs/` from linters and fixed O(n×m) scan in the retired-scripts check ([#3856](https://github.com/character-ai/larch/pull/3856))

### Changed

- **Timing ledger observability**: Added follow-up observability improvements to the timing ledger ([#3855](https://github.com/character-ai/larch/pull/3855))
