### PR TITLE
Release v49.0.7

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "49.0.6",
+  "version": "49.0.7",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (default SIMPLE tier; opt-in `--hard` only) and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` has no workflow tier/path dimension and no `/implement --hard` flag. `/implement` Step 5 code review always uses the unified hard panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Changed

- `/combine-issues`: add `--oos` flag to combine open out-of-scope (`[OOS]`-prefixed) issues — checks each item for actuality, discards stale items, and aggressively recombines the rest to minimize issue count ([#3881](https://github.com/character-ai/larch/pull/3881))
- Review pipelines (`/design`, `/implement`): reduce OOS review fluff — enforce a 1-issue-per-run cap across design and implement, apply a stricter materiality gate before routing findings to the OOS ballot, and align the latent-issue standard to reduce low-value OOS filings ([#3882](https://github.com/character-ai/larch/pull/3882))
