### PR TITLE
Fixes #3869: add revise.status/tier to round-meta.json and multi-round regression tests

### DIFF
--- a/scripts/write-design-round-meta.md
+++ b/scripts/write-design-round-meta.md
@@ -19,8 +19,10 @@ later round or a retally cannot leak into round-N metadata.
 
 - `round-meta.json` with string tally keys `ACCEPTED_COUNT`, `REJECTED_COUNT`,
   `EXONERATED_COUNT`, `NEUTRAL_COUNT`, `OOS_ACCEPTED_COUNT`, and
-  `OOS_REJECTED_COUNT`, plus `summary.panel.total_slot_count` and a collector
-  failure string.
+  `OOS_REJECTED_COUNT`, plus `summary.panel.total_slot_count`, a collector
+  failure string, and a `revise` object (`status` / `tier`) read from
+  `round-N/revise/revise.env` when present (both fields are `null` when the
+  revise step has not yet run or is absent).
 - `panel-manifest.ndjson` with one compact JSON object per non-blank slot record,
   containing only `slot`, `tool`, and `output`.
 

--- a/scripts/write-design-round-meta.sh
+++ b/scripts/write-design-round-meta.sh
@@ -273,6 +273,20 @@ while [[ "$_i" -le "$_collect_failures" ]]; do
     _i=$((_i + 1))
 done
 
+# Read revise outcome from round-N/revise/revise.env when present (written by
+# revise-plan-with-waterfall.sh after the revise step runs for this round).
+_revise_status=""
+_revise_tier=""
+_revise_env="$ROUND_DIR/revise/revise.env"
+if [[ -f "$_revise_env" ]]; then
+    while IFS= read -r _rline || [[ -n "$_rline" ]]; do
+        case "$_rline" in
+            REVISE_STATUS=*) _revise_status="${_rline#REVISE_STATUS=}" ;;
+            REVISE_TIER=*)   _revise_tier="${_rline#REVISE_TIER=}" ;;
+        esac
+    done < "$_revise_env"
+fi
+
 if command -v jq >/dev/null 2>&1; then
     jq -n \
         --arg accepted "$ACCEPTED_COUNT" \
@@ -283,16 +297,18 @@ if command -v jq >/dev/null 2>&1; then
         --arg oos_rejected "$OOS_REJECTED_COUNT" \
         --arg panel_count "$_panel_count" \
         --arg collector "$_collector" \
-        '{tally:{ACCEPTED_COUNT:$accepted,REJECTED_COUNT:$rejected,EXONERATED_COUNT:$exonerated,NEUTRAL_COUNT:$neutral,OOS_ACCEPTED_COUNT:$oos_accepted,OOS_REJECTED_COUNT:$oos_rejected},summary:{panel:{total_slot_count:($panel_count|tonumber)}},collector:$collector}' \
+        --arg revise_status "$_revise_status" \
+        --arg revise_tier "$_revise_tier" \
+        '{tally:{ACCEPTED_COUNT:$accepted,REJECTED_COUNT:$rejected,EXONERATED_COUNT:$exonerated,NEUTRAL_COUNT:$neutral,OOS_ACCEPTED_COUNT:$oos_accepted,OOS_REJECTED_COUNT:$oos_rejected},summary:{panel:{total_slot_count:($panel_count|tonumber)}},collector:$collector,revise:{status:(if $revise_status=="" then null else $revise_status end),tier:(if $revise_tier=="" then null else $revise_tier end)}}' \
         >"$_meta_tmp" 2>/dev/null || : >"$_meta_tmp"
 fi
 
 if [[ ! -s "$_meta_tmp" ]]; then
     if command -v python3 >/dev/null 2>&1; then
-        python3 - "$ACCEPTED_COUNT" "$REJECTED_COUNT" "$EXONERATED_COUNT" "$NEUTRAL_COUNT" "$OOS_ACCEPTED_COUNT" "$OOS_REJECTED_COUNT" "$_panel_count" "$_collector" "$_meta_tmp" <<'PY' || : >"$_meta_tmp"
+        python3 - "$ACCEPTED_COUNT" "$REJECTED_COUNT" "$EXONERATED_COUNT" "$NEUTRAL_COUNT" "$OOS_ACCEPTED_COUNT" "$OOS_REJECTED_COUNT" "$_panel_count" "$_collector" "$_revise_status" "$_revise_tier" "$_meta_tmp" <<'PY' || : >"$_meta_tmp"
 import json
 import sys
-accepted, rejected, exonerated, neutral, oos_accepted, oos_rejected, panel_count, collector, out = sys.argv[1:10]
+accepted, rejected, exonerated, neutral, oos_accepted, oos_rejected, panel_count, collector, revise_status, revise_tier, out = sys.argv[1:12]
 obj = {
     "tally": {
         "ACCEPTED_COUNT": accepted,
@@ -304,6 +320,10 @@ obj = {
     },
     "summary": {"panel": {"total_slot_count": int(panel_count or 0)}},
     "collector": collector,
+    "revise": {
+        "status": revise_status or None,
+        "tier": revise_tier or None,
+    },
 }
 with open(out, "w", encoding="utf-8") as fh:
     json.dump(obj, fh, indent=2)

--- a/skills/design/scripts/review-design-step3-loop.md
+++ b/skills/design/scripts/review-design-step3-loop.md
@@ -37,6 +37,8 @@ run-step3-review.sh --design-tmpdir "$DESIGN_TMPDIR" --mode loop --starting-roun
 
 The happy path uses `revise-plan-with-waterfall.sh --patch-format file-replacement`, then `gate-b-dedup-plan.sh --snapshot-trailers` and `--dedup`, then `design-postplan-emit.sh --with-plan-size`. A loop-owned `plan-pre-apply-round-N.txt` snapshot is the restore source for dedup failure. The `.gate-b-postapply-ready-N` marker is written only after dedup succeeds.
 
+After a successful revise, the loop calls `write-design-round-meta.sh --round-dir round-N` to refresh `round-N/round-meta.json` with `revise.status` and `revise.tier` from `round-N/revise/revise.env`. The initial write (by `plan-review-loop.sh` at round end) contains `null` for both fields because revise has not yet run; this second call populates them so the Review Phase Detail table can show which tier was used each round.
+
 ## Harness
 
 `skills/design/scripts/test-review-design-step3-loop.sh` covers the offline envelope, bail-out, phase-resume, postplan-routing, and dedup-restore seams. `skills/design/scripts/test-run-step3-review.sh` covers launcher argv and `--starting-round` validation.

--- a/skills/design/scripts/review-design-step3-loop.sh
+++ b/skills/design/scripts/review-design-step3-loop.sh
@@ -384,6 +384,14 @@ step3_loop_run_apply() {
     fi
     step3_loop_write_phase "$round_num" awaiting-post-apply
 
+    # Refresh round-meta.json now that revise/revise.env is available. This
+    # adds revise.status and revise.tier to the per-round metadata so the
+    # Review Phase Detail table can show which tier applied each round.
+    local _rmd_sh="${WRITE_DESIGN_ROUND_META_SH:-$PLUGIN_ROOT/scripts/write-design-round-meta.sh}"
+    if [[ -x "$_rmd_sh" ]]; then
+        "$_rmd_sh" --round-dir "$DESIGN_TMPDIR/plan-review/round-${round_num}" 2>/dev/null || true
+    fi
+
     step3_loop_run_dedup "$round_num"
     return $?
 }

--- a/skills/design/scripts/test-plan-review-loop.md
+++ b/skills/design/scripts/test-plan-review-loop.md
@@ -33,3 +33,14 @@ global backstop when it needs specialized cursor/codex behavior.
 ## Scope anchor regressions
 
 The brainstorm case now asserts that `plan-review-scope-anchor.txt` is the binding feature file passed to panel dispatch, while `plan-review-feature-context.txt` retains brainstorm synthesis as non-binding context. Layout expectations include `findings-in-scope.pre-dedup.md` and the staged scope anchor.
+
+## Multi-round regressions (#3869)
+
+The multi-round test runs `plan-review-loop.sh` twice in the same design tmpdir — first with `--round-num 1` (one accepted finding), then with `--round-num 2` (zero findings, convergence). It asserts:
+
+- `round-1/round-meta.json` is written by round 1 with `ACCEPTED_COUNT == "1"`.
+- `round-2/round-meta.json` is written by round 2 with `ACCEPTED_COUNT == "0"`.
+- `round-1/round-meta.json` is NOT clobbered or deleted when round 2 runs.
+- Both rounds produce a timing ledger row at their respective round numbers.
+
+The `revise` field test calls `write-design-round-meta.sh` directly with and without `round-N/revise/revise.env` to verify `revise.{status,tier}` are populated from the env file when present, and `null` when absent.

--- a/skills/design/scripts/test-plan-review-loop.sh
+++ b/skills/design/scripts/test-plan-review-loop.sh
@@ -1907,4 +1907,70 @@ if problem_text(a) == problem_text(b):
     sys.exit(1)
 PY
 
+echo "=== multi-round: round-2 gets own round-meta.json without clobbering round-1 ==="
+# Regression for issue #3869: with 5 review passes, only round-1/round-meta.json
+# was appearing in the final summary because each successive pass overwrote the
+# same round directory. This test verifies that round-N gets its own round-meta.json
+# and that round-1's metadata is preserved when round-2 runs.
+DMR="$TMP/multi-round"
+mkdir -p "$DMR"
+printf 'plan\n\ndiff_lines: 1\n' >"$DMR/plan.txt"
+printf 'feat\n' >"$DMR/feature-description.txt"
+write_scout
+write_dispatch_one_slot
+write_collect_important  # one accepted finding so round-meta.json is non-trivial
+write_voters_three
+# Use the real tally (unset any stub tally left by a previous test).
+unset LARCH_PLAN_REVIEW_TALLY_SH
+
+# Run round 1 (single accepted finding so round-meta.json will be written).
+out_mr1=$(run_loop "$DMR" 1)
+printf '%s\n' "$out_mr1" | grep -q '^LOOP_STATUS=complete$' || fail "multi-round round-1 should complete"
+[[ -s "$DMR/plan-review/round-1/round-meta.json" ]] || fail "round-1/round-meta.json missing after round 1"
+jq -e '.tally.ACCEPTED_COUNT == "1"' "$DMR/plan-review/round-1/round-meta.json" >/dev/null \
+    || fail "round-1/round-meta.json should record accepted count"
+assert_plan_round_timing_row "$DMR" 1
+
+# Run round 2 (no findings → converges). Simulate run-step3-review.sh incrementing
+# the round counter between passes.
+write_collect_no_findings  # round 2 has no findings → ACCEPTED_COUNT=0
+
+# Remove the stale accepted-plan-findings.md from round 1 so round 2 tallies clean.
+: >"$DMR/accepted-plan-findings.md"
+out_mr2=$(run_loop "$DMR" 2)
+printf '%s\n' "$out_mr2" | grep -q '^LOOP_STATUS=complete$' || fail "multi-round round-2 should complete"
+
+# round-2 should write round-2/round-meta.json with 0 accepted.
+[[ -s "$DMR/plan-review/round-2/round-meta.json" ]] || fail "round-2/round-meta.json missing after round 2 (#3869 regression)"
+jq -e '.tally.ACCEPTED_COUNT == "0"' "$DMR/plan-review/round-2/round-meta.json" >/dev/null \
+    || fail "round-2/round-meta.json should record 0 accepted for convergence round"
+# CRITICAL: round-1/round-meta.json must NOT be deleted by round-2.
+[[ -s "$DMR/plan-review/round-1/round-meta.json" ]] || fail "round-1/round-meta.json was destroyed by round-2 (#3869 regression)"
+jq -e '.tally.ACCEPTED_COUNT == "1"' "$DMR/plan-review/round-1/round-meta.json" >/dev/null \
+    || fail "round-1/round-meta.json accepted count changed after round-2 ran"
+assert_plan_round_timing_row "$DMR" 2
+
+echo "=== round-meta.json includes revise field (null before revise, populated after) ==="
+# write-design-round-meta.sh should emit revise:{status,tier} from revise/revise.env
+# when present, and null for both fields when the revise dir is absent (round not yet
+# revised, or final convergence round with no accepted findings).
+DRREV="$TMP/round-meta-revise"
+mkdir -p "$DRREV/plan-review/round-1/revise"
+printf 'REVISE_STATUS=ok\nREVISE_TIER=codex\n' >"$DRREV/plan-review/round-1/revise/revise.env"
+printf 'FINDING_1\taccepted\t\n' >"$DRREV/plan-review/round-1/findings-classification.tsv"
+"$ROOT/scripts/write-design-round-meta.sh" --round-dir "$DRREV/plan-review/round-1" 2>/dev/null
+[[ -s "$DRREV/plan-review/round-1/round-meta.json" ]] || fail "revise: round-meta.json not written"
+jq -e '.revise.status == "ok" and .revise.tier == "codex"' \
+    "$DRREV/plan-review/round-1/round-meta.json" >/dev/null \
+    || fail "revise fields not populated from revise.env"
+
+DRREV2="$TMP/round-meta-no-revise"
+mkdir -p "$DRREV2/plan-review/round-1"
+printf 'FINDING_1\taccepted\t\n' >"$DRREV2/plan-review/round-1/findings-classification.tsv"
+"$ROOT/scripts/write-design-round-meta.sh" --round-dir "$DRREV2/plan-review/round-1" 2>/dev/null
+[[ -s "$DRREV2/plan-review/round-1/round-meta.json" ]] || fail "no-revise: round-meta.json not written"
+jq -e '.revise.status == null and .revise.tier == null' \
+    "$DRREV2/plan-review/round-1/round-meta.json" >/dev/null \
+    || fail "revise fields should be null when revise.env absent"
+
 printf '%s\n' "test-plan-review-loop: ok"


### PR DESCRIPTION
## Summary

- **`write-design-round-meta.sh`**: reads `round-N/revise/revise.env` when present and includes `revise.{status,tier}` in `round-meta.json` (both null when revise has not yet run or is absent). This lets the Review Phase Detail table show which tool tier revised the plan each round.
- **`review-design-step3-loop.sh`**: after a successful revise, calls `write-design-round-meta.sh` again to refresh `round-N/round-meta.json` with the revise outcome, closing the gap between the initial write (before revise runs) and the populated state operators need.
- **`test-plan-review-loop.sh`**: two new regression tests — (1) multi-round: verifies `round-2/round-meta.json` is created without clobbering `round-1/round-meta.json` and that both rounds emit correctly-numbered timing rows (issue #3869 root cause); (2) revise field: verifies `revise.{status,tier}` are populated from `revise.env` and null when absent.

## Test plan

- [ ] `make test-plan-review-loop` passes (includes new multi-round and revise-field tests)
- [ ] `bash scripts/test-render-review-phase-detail.sh` passes
- [ ] `bash skills/design/scripts/test-review-design-step3-loop.sh` passes
- [ ] `bash scripts/relevant-checks.sh` passes

Closes #3869

🤖 Generated with [Claude Code](https://claude.com/claude-code)
