### PR TITLE
Release v49.0.8

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "49.0.7",
+  "version": "49.0.8",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (default SIMPLE tier; opt-in `--hard` only) and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` has no workflow tier/path dimension and no `/implement --hard` flag. `/implement` Step 5 code review always uses the unified hard panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## What's Changed

### Added
- `/design` plan drafting is now delegated to a configurable strong model (default `claude-fable-5`, via `LARCH_DESIGN_PLAN_MODEL`), improving plan quality without requiring the entire orchestrator to run on an expensive model
- The always-on Claude voter in `/design` is now configurable (default `claude-fable-5`, via `LARCH_VOTER_MODEL`)

### Fixed
- `/design` final-summary Review Phase Detail table now correctly shows one row per review pass instead of collapsing all passes into a single row with the total wall-clock duration
- `round-meta.json` now includes `revise.status` and `revise.tier` fields (populated after a revise run, null when revise has not run), giving the summary table accurate per-round tool-tier data
- Model pins for the fallback reviewers and voter in the design workflow have been corrected
