### PR TITLE
Release v49.0.9

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "49.0.8",
+  "version": "49.0.9",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (default SIMPLE tier; opt-in `--hard` only) and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` has no workflow tier/path dimension and no `/implement --hard` flag. `/implement` Step 5 code review always uses the unified hard panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## v49.0.9

### Fixed

- `/release` no longer silently drops PRs whose merge-commit subject lacks a trailing `(#N)` suffix — the PR list is now complete regardless of commit-message format (#3900)
- `fix-pr` now enters a wait-and-retry loop (every 15 seconds, bounded at 1 hour) when GitHub reports that a CI run is still in progress, instead of bailing immediately to the main agent (#3902)
- `/combine-issues --oos` now checks whether the implementing issue is currently in-flight before discarding items whose referenced files are missing, preventing accidental discard of active work (#3895)

### Changed

- Added a shared sourceable-env reader and converted two unpinned result-env re-parse sites to use it, reducing fragile inline parsing in the `/design` pipeline (#3903)
- Reduced SKILL.md prose to reference links (I2 pass) and fixed a Bash 3.2 compatibility stall in `tally-code-votes.sh` (#3901)
- Applied 19 pipeline-script cleanups carried over from the design backlog (#3898)
