### PR TITLE
Release v49.0.11

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "49.0.10",
+  "version": "49.0.11",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (default SIMPLE tier; opt-in `--hard` only) and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` has no workflow tier/path dimension and no `/implement --hard` flag. `/implement` Step 5 code review always uses the unified hard panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## v49.0.11

### Changed

- Reduced reviewer archetype count by 1 in `/implement`, `/review`, and `/design`: combined the security and edge-cases archetypes into one, migrated the design Edge-cases archetype into Architecture/Standards and Failure-modes into Pragmatism/Safety. All places that spawn reviewers now do so on a per-existing-archetype basis so future changes do not require code edits. Documentation updated throughout. ([#3920](https://github.com/character-ai/larch/pull/3920))

### Fixed

- **Progress `p` key unreliable on resumed and large runs.** Two gaps fixed: (1) `resume_existing_tmpdir` no longer skips writing the `current-implement-env-$LARCH_CLAUDE_PID.sh` pointer, so resumed runs in a new Claude process are discoverable again. (2) The `UserPromptSubmit` progress hook timeout has been extended so large runs no longer have their progress reports silenced. ([#3918](https://github.com/character-ai/larch/pull/3918))
- **ship.py silently dropped accepted OOS review items.** `_context_with_state_overlay()` did not include `OOS_PENDING` in its state-key loop, and no OOS detection existed in `ship.py`, so `/implement --merge` runs with accepted OOS findings never filed the corresponding GitHub issues. Both gaps are now corrected. ([#3919](https://github.com/character-ai/larch/pull/3919))
