### PR TITLE
Release v49.0.12

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "49.0.11",
+  "version": "49.0.12",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (default SIMPLE tier; opt-in `--hard` only) and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` has no workflow tier/path dimension and no `/implement --hard` flag. `/implement` Step 5 code review always uses the unified hard panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## What's Changed in v49.0.12

### Added

- Scoped human-facing output style guide, including Strunk & White guidance, in `AGENTS.md`. (#3934)

### Changed

- `/release` now fetches and fast-forwards local `main` to the latest before cutting a release. (#3928)
- `/design` Step 2b drafter now defaults to `codex` instead of `claude-fable-5`. (#3931)
- `/design` re-parses the three CI-pinned result-env sites through the shared reader (D2). (#3822)
- `/implement` SKILL.md restructured: prose moved to references, inline Bash removed, consecutive fences merged (I3). (#3826)
- sh-to-py migration B6: prompt rendering and generators ported to Python. (#3675)

### Fixed

- `design-log-publish.sh` no longer hard-fails on `panel-manifest.ndjson` / `round-meta.json` artifacts written by `write-design-round-meta.sh`. (#3929)
- Plan-review tally no longer crashes on macOS bash 3.2 after the first finding, where `command grep` in an `if` condition tripped `set -e`. (#3935)
- Cleaned up poorly formatted progress reporting in Claude. (#3936)

**Full Changelog**: https://github.com/character-ai/larch/compare/v49.0.11...v49.0.12
