### PR TITLE
Fixes #3949: add resume@* test coverage, extract shared sentinel parser, add trusted-instructions-file tests, fix stale rubric reference

### DIFF
--- a/scripts/launch-claude-drafter.md
+++ b/scripts/launch-claude-drafter.md
@@ -64,7 +64,7 @@ Any JSON envelope or extracted `.result` is scratch-only and removed before exit
 
 Claude is run with `--output-format json`. A successful subprocess must produce valid JSON with `is_error` absent/false and a non-empty string `.result`; invalid JSON, `is_error:true`, missing/non-string/empty `.result`, or 0-byte promoted result fails closed with `CLAUDE_JSON_RESULT_INVALID`, exit `99`, and no token-ledger row.
 
-The `.result` text is parsed from scratch with exact whole-line sentinels:
+The `.result` text is parsed from scratch by `scripts/parse-drafter-output.py` with exact whole-line sentinels:
 
 - `LARCH_PLAN_BEGIN` / `LARCH_PLAN_END` — required exactly once.
 - `LARCH_SUMMARY_BEGIN` / `LARCH_SUMMARY_END` — optional, but when present must be exactly one balanced non-empty pair.
@@ -87,3 +87,10 @@ Step 2b treats only `STATUS=dirty MODE=baseline-delta` as confirmed new drafter 
 After JSON promotion and delimiter extraction succeed, the launcher records `token-ledger.sh record-vendor claude_sub ... raw=<role>`, with `raw` derived locally from `--timing-task-kind` (`claude_draft`, `claude_scout`, `claude_vote`, or `claude_review`). Timing is recorded with vendor `claude` and the supplied task kind. JSON/delimiter failures skip token recording.
 
 Regression harness: `scripts/test-launch-claude-drafter.sh`.
+
+## Edit-in-sync
+
+- `scripts/parse-drafter-output.py` — shared sentinel parser; sentinel contract
+  changes must be made there and will affect both launchers.
+- `scripts/launch-codex-drafter.sh` — codex-side equivalent; keep status KV
+  contract identical so SKILL.md Step 2b can use either launcher.

--- a/scripts/launch-claude-drafter.sh
+++ b/scripts/launch-claude-drafter.sh
@@ -263,58 +263,8 @@ if [[ "$exit_code" -eq 0 ]]; then
 fi
 
 if [[ "$exit_code" -eq 0 ]]; then
-    if ! python3 - "$result_tmp" "$plan_tmp" "$summary_tmp" > "${OUTPUT_CANON}.parse" 2> "${OUTPUT_CANON}.failure-diag" <<'PY'
-import re
-import sys
-from pathlib import Path
-
-src = Path(sys.argv[1])
-plan_tmp = Path(sys.argv[2])
-summary_tmp = Path(sys.argv[3])
-text = src.read_text(encoding='utf-8')
-lines = text.splitlines()
-
-def positions(marker):
-    return [i for i, line in enumerate(lines) if line == marker]
-
-pb = positions('LARCH_PLAN_BEGIN')
-pe = positions('LARCH_PLAN_END')
-sb = positions('LARCH_SUMMARY_BEGIN')
-se = positions('LARCH_SUMMARY_END')
-if len(pb) != 1 or len(pe) != 1:
-    raise SystemExit('invalid plan sentinels: require exactly one LARCH_PLAN_BEGIN and LARCH_PLAN_END')
-if pb[0] >= pe[0]:
-    raise SystemExit('invalid plan sentinels: reversed or empty plan envelope')
-if (len(sb) == 0) != (len(se) == 0) or len(sb) > 1 or len(se) > 1:
-    raise SystemExit('invalid summary sentinels: require zero or one balanced pair')
-if sb and sb[0] >= se[0]:
-    raise SystemExit('invalid summary sentinels: reversed or empty summary envelope')
-if sb and (pb[0] < sb[0] < pe[0] or pb[0] < se[0] < pe[0]):
-    raise SystemExit('invalid sentinels: nested summary inside plan envelope')
-if sb and sb[0] < pb[0] < pe[0] < se[0]:
-    raise SystemExit('invalid sentinels: nested plan inside summary envelope')
-plan_lines = lines[pb[0] + 1:pe[0]]
-if not plan_lines or not ''.join(plan_lines).strip():
-    raise SystemExit('empty extracted plan body')
-while plan_lines and plan_lines[-1] == '':
-    plan_lines.pop()
-if not plan_lines or not re.match(r'^diff_lines: [0-9][0-9]*$', plan_lines[-1]):
-    raise SystemExit('missing final diff_lines trailer')
-plan_body = '\n'.join(plan_lines) + '\n'
-plan_tmp.write_text(plan_body, encoding='utf-8')
-summary_written = False
-if sb:
-    summary_lines = lines[sb[0] + 1:se[0]]
-    if ''.join(summary_lines).strip():
-        summary_tmp.write_text('\n'.join(summary_lines).rstrip('\n') + '\n', encoding='utf-8')
-        summary_written = True
-    else:
-        raise SystemExit('empty extracted summary body')
-print(f'PLAN_LINES={len(plan_lines)}')
-print(f'DIFF_LINES={plan_lines[-1].split(": ", 1)[1]}')
-print(f'SUMMARY_WRITTEN={str(summary_written).lower()}')
-PY
-    then
+    if ! python3 "$SCRIPT_DIR/parse-drafter-output.py" "$result_tmp" "$plan_tmp" "$summary_tmp" \
+            > "${OUTPUT_CANON}.parse" 2> "${OUTPUT_CANON}.failure-diag"; then
         parse_reason=$(cat "${OUTPUT_CANON}.failure-diag" 2>/dev/null || printf '%s' delimiter-extraction-failed)
         printf 'DELIMITER_EXTRACTION_INVALID\n%s\n' "$parse_reason" > "${OUTPUT_CANON}.failure-diag"
         write_status_file "ERROR" "false" 0 0 "false" "true" "DELIMITER_EXTRACTION_INVALID"

--- a/scripts/launch-codex-drafter.md
+++ b/scripts/launch-codex-drafter.md
@@ -57,13 +57,14 @@ Under `DESIGN_TMPDIR`:
 
 Calls `launch-codex-exec.sh --sandbox read-only --add-dir REPO_ROOT`, captures
 `LAUNCHER_EXIT` from its stdout, then parses the `--output-last-message` file
-for plan sentinels using the same Python parser as `launch-claude-drafter.sh`.
+for plan sentinels using the shared `scripts/parse-drafter-output.py` helper.
 Token and timing recording are handled inside `launch-codex-exec.sh`.
 
 ## Edit-in-sync
 
 - `scripts/launch-claude-drafter.sh` — claude-side equivalent; keep status KV
   contract identical so SKILL.md Step 2b can use either launcher
+- `scripts/parse-drafter-output.py` — shared sentinel parser called by both launchers
 - `scripts/launch-codex-exec.sh` — inner launcher; argv changes affect this wrapper
 - `skills/design/SKILL.md` — Step 2b drafter dispatch block
 - `docs/configuration-and-permissions.md` — `LARCH_DESIGN_DRAFTER` env var docs

--- a/scripts/launch-codex-drafter.sh
+++ b/scripts/launch-codex-drafter.sh
@@ -227,58 +227,8 @@ if [[ ! -s "$_codex_raw" ]]; then
     exit 1
 fi
 
-if ! python3 - "$_codex_raw" "$_plan_tmp" "$_summary_tmp" \
-        > "${OUTPUT_CANON}.parse" 2> "${OUTPUT_CANON}.failure-diag" <<'PY'
-import re
-import sys
-from pathlib import Path
-
-src = Path(sys.argv[1])
-plan_tmp = Path(sys.argv[2])
-summary_tmp = Path(sys.argv[3])
-text = src.read_text(encoding='utf-8')
-lines = text.splitlines()
-
-def positions(marker):
-    return [i for i, line in enumerate(lines) if line == marker]
-
-pb = positions('LARCH_PLAN_BEGIN')
-pe = positions('LARCH_PLAN_END')
-sb = positions('LARCH_SUMMARY_BEGIN')
-se = positions('LARCH_SUMMARY_END')
-if len(pb) != 1 or len(pe) != 1:
-    raise SystemExit('invalid plan sentinels: require exactly one LARCH_PLAN_BEGIN and LARCH_PLAN_END')
-if pb[0] >= pe[0]:
-    raise SystemExit('invalid plan sentinels: reversed or empty plan envelope')
-if (len(sb) == 0) != (len(se) == 0) or len(sb) > 1 or len(se) > 1:
-    raise SystemExit('invalid summary sentinels: require zero or one balanced pair')
-if sb and sb[0] >= se[0]:
-    raise SystemExit('invalid summary sentinels: reversed or empty summary envelope')
-if sb and (pb[0] < sb[0] < pe[0] or pb[0] < se[0] < pe[0]):
-    raise SystemExit('invalid sentinels: nested summary inside plan envelope')
-if sb and sb[0] < pb[0] < pe[0] < se[0]:
-    raise SystemExit('invalid sentinels: nested plan inside summary envelope')
-plan_lines = lines[pb[0] + 1:pe[0]]
-if not plan_lines or not ''.join(plan_lines).strip():
-    raise SystemExit('empty extracted plan body')
-while plan_lines and plan_lines[-1] == '':
-    plan_lines.pop()
-if not plan_lines or not re.match(r'^diff_lines: [0-9][0-9]*$', plan_lines[-1]):
-    raise SystemExit('missing final diff_lines trailer')
-plan_body = '\n'.join(plan_lines) + '\n'
-plan_tmp.write_text(plan_body, encoding='utf-8')
-summary_written = False
-if sb:
-    summary_lines = lines[sb[0] + 1:se[0]]
-    if ''.join(summary_lines).strip():
-        summary_tmp.write_text('\n'.join(summary_lines).rstrip('\n') + '\n', encoding='utf-8')
-        summary_written = True
-    else:
-        raise SystemExit('empty extracted summary body')
-print(f'PLAN_LINES={len(plan_lines)}')
-print(f'DIFF_LINES={plan_lines[-1].split(": ", 1)[1]}')
-print(f'SUMMARY_WRITTEN={str(summary_written).lower()}')
-PY
+if ! python3 "$SCRIPT_DIR/parse-drafter-output.py" "$_codex_raw" "$_plan_tmp" "$_summary_tmp" \
+        > "${OUTPUT_CANON}.parse" 2> "${OUTPUT_CANON}.failure-diag"
 then
     _parse_reason=$(cat "${OUTPUT_CANON}.failure-diag" 2>/dev/null || printf '%s' delimiter-extraction-failed)
     printf 'DELIMITER_EXTRACTION_INVALID\n%s\n' "$_parse_reason" > "${OUTPUT_CANON}.failure-diag"

--- a/scripts/parse-drafter-output.md
+++ b/scripts/parse-drafter-output.md
@@ -1,0 +1,44 @@
+# parse-drafter-output.py
+
+## Purpose
+
+Shared sentinel parser for `/design` Step 2b plan drafter output. Extracts
+`LARCH_PLAN_BEGIN/END` and `LARCH_SUMMARY_BEGIN/END` blocks from a raw drafter
+output file and writes `plan.txt` and (when present) `plan-summary.md`.
+
+Extracted from the inline heredoc that was duplicated in `launch-codex-drafter.sh`
+and `launch-claude-drafter.sh`.
+
+## Usage
+
+```
+python3 scripts/parse-drafter-output.py <raw-file> <plan-out> <summary-out>
+```
+
+- `<raw-file>` — raw drafter output (full text including sentinel markers).
+- `<plan-out>` — path where the extracted plan body is written.
+- `<summary-out>` — path where the extracted summary body is written (when present).
+
+Prints `PLAN_LINES=N`, `DIFF_LINES=N`, `SUMMARY_WRITTEN=true|false` to stdout.
+Exits non-zero with a single-line message on stderr on any validation failure.
+
+## Sentinel contract
+
+- `LARCH_PLAN_BEGIN` / `LARCH_PLAN_END` — required, exactly one balanced pair.
+- `LARCH_SUMMARY_BEGIN` / `LARCH_SUMMARY_END` — optional; when present, exactly
+  one balanced non-empty pair; must not be nested inside the plan envelope nor
+  contain the plan envelope.
+- The extracted plan body must be non-empty and its final non-blank line must
+  match `diff_lines: <N>`.
+
+## Primary callers
+
+- `scripts/launch-codex-drafter.sh` — Codex plan drafter launcher.
+- `scripts/launch-claude-drafter.sh` — Claude plan drafter launcher.
+
+## Edit-in-sync
+
+- `scripts/launch-codex-drafter.sh` and `scripts/launch-claude-drafter.sh` —
+  both call this script; sentinel contract changes affect both launchers.
+- `scripts/test-launch-codex-drafter.sh` and `scripts/test-launch-claude-drafter.sh`
+  — regression harnesses that exercise this parser indirectly via the launchers.

--- a/scripts/parse-drafter-output.py
+++ b/scripts/parse-drafter-output.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Parse LARCH_PLAN_BEGIN/END and LARCH_SUMMARY_BEGIN/END sentinel blocks.
+
+Usage: parse-drafter-output.py <raw-file> <plan-out> <summary-out>
+
+Writes plan body to <plan-out> and (when present) summary body to <summary-out>.
+Prints PLAN_LINES=N, DIFF_LINES=N, SUMMARY_WRITTEN=true|false to stdout.
+Exits non-zero with a message on stderr on any validation failure.
+"""
+import re
+import sys
+from pathlib import Path
+
+src = Path(sys.argv[1])
+plan_tmp = Path(sys.argv[2])
+summary_tmp = Path(sys.argv[3])
+text = src.read_text(encoding='utf-8')
+lines = text.splitlines()
+
+
+def positions(marker):
+    return [i for i, line in enumerate(lines) if line == marker]
+
+
+pb = positions('LARCH_PLAN_BEGIN')
+pe = positions('LARCH_PLAN_END')
+sb = positions('LARCH_SUMMARY_BEGIN')
+se = positions('LARCH_SUMMARY_END')
+if len(pb) != 1 or len(pe) != 1:
+    raise SystemExit('invalid plan sentinels: require exactly one LARCH_PLAN_BEGIN and LARCH_PLAN_END')
+if pb[0] >= pe[0]:
+    raise SystemExit('invalid plan sentinels: reversed or empty plan envelope')
+if (len(sb) == 0) != (len(se) == 0) or len(sb) > 1 or len(se) > 1:
+    raise SystemExit('invalid summary sentinels: require zero or one balanced pair')
+if sb and sb[0] >= se[0]:
+    raise SystemExit('invalid summary sentinels: reversed or empty summary envelope')
+if sb and (pb[0] < sb[0] < pe[0] or pb[0] < se[0] < pe[0]):
+    raise SystemExit('invalid sentinels: nested summary inside plan envelope')
+if sb and sb[0] < pb[0] < pe[0] < se[0]:
+    raise SystemExit('invalid sentinels: nested plan inside summary envelope')
+plan_lines = lines[pb[0] + 1:pe[0]]
+if not plan_lines or not ''.join(plan_lines).strip():
+    raise SystemExit('empty extracted plan body')
+while plan_lines and plan_lines[-1] == '':
+    plan_lines.pop()
+if not plan_lines or not re.match(r'^diff_lines: [0-9][0-9]*$', plan_lines[-1]):
+    raise SystemExit('missing final diff_lines trailer')
+plan_body = '\n'.join(plan_lines) + '\n'
+plan_tmp.write_text(plan_body, encoding='utf-8')
+summary_written = False
+if sb:
+    summary_lines = lines[sb[0] + 1:se[0]]
+    if ''.join(summary_lines).strip():
+        summary_tmp.write_text('\n'.join(summary_lines).rstrip('\n') + '\n', encoding='utf-8')
+        summary_written = True
+    else:
+        raise SystemExit('empty extracted summary body')
+print(f'PLAN_LINES={len(plan_lines)}')
+print(f'DIFF_LINES={plan_lines[-1].split(": ", 1)[1]}')
+print(f'SUMMARY_WRITTEN={str(summary_written).lower()}')

--- a/scripts/test-launch-codex-exec.sh
+++ b/scripts/test-launch-codex-exec.sh
@@ -386,5 +386,53 @@ else
     fail "model-args failure writes preflight bundle"
 fi
 
+# --trusted-instructions-file: rejection cases
+assert_fails "trusted-instructions-file: rejects missing file" \
+    --output "$OUT" --timeout 60 --prompt hi \
+    --trusted-instructions-file "$TMPDIR_BASE/nonexistent-trusted.txt"
+SYMLINK_TARGET="$TMPDIR_BASE/symlink-target.txt"
+SYMLINK_PATH="$TMPDIR_BASE/symlink-trusted.txt"
+printf 'instructions content\n' >"$SYMLINK_TARGET"
+ln -sf "$SYMLINK_TARGET" "$SYMLINK_PATH"
+assert_fails "trusted-instructions-file: rejects symlink" \
+    --output "$OUT" --timeout 60 --prompt hi \
+    --trusted-instructions-file "$SYMLINK_PATH"
+TRIPLE_QUOTE_FILE="$TMPDIR_BASE/triple-quote.txt"
+printf "instructions '''\n" >"$TRIPLE_QUOTE_FILE"
+assert_fails "trusted-instructions-file: rejects triple-single-quote content" \
+    --output "$OUT" --timeout 60 --prompt hi \
+    --trusted-instructions-file "$TRIPLE_QUOTE_FILE"
+
+# --trusted-instructions-file: happy path prepends instructions and strips stale block
+HOME_TIF="$TMPDIR_BASE/home-tif"
+CONFIG_TIF="$TMPDIR_BASE/tif.config.toml"
+OUT_TIF="$TMPDIR_BASE/exec-tif-out.txt"
+mkdir -p "$HOME_TIF/.codex"
+printf '%s\n' \
+    "instructions = '''" \
+    'stale instructions' \
+    "'''" \
+    '[model_providers.keep]' \
+    'name = "keep section"' >"$HOME_TIF/.codex/config.toml"
+TRUSTED_FILE="$TMPDIR_BASE/trusted.txt"
+printf 'Always be brief\n' >"$TRUSTED_FILE"
+set +e
+(cd "$REPO_ROOT" && PATH="$stub_bin:$PATH" CLAUDE_PLUGIN_ROOT="$REPO_ROOT" HOME="$HOME_TIF" \
+    CODEX_STUB_CONFIG_FILE="$CONFIG_TIF" \
+    env -u OPENAI_API_KEY bash "$REPO_ROOT/scripts/launch-codex-exec.sh" \
+    --output "$OUT_TIF" --timeout 60 --workdir "$REPO_ROOT" --prompt "hello" \
+    --trusted-instructions-file "$TRUSTED_FILE") \
+    >"$TMPDIR_BASE/launcher-tif.stdout" 2>"$TMPDIR_BASE/launcher-tif.stderr"
+rc=$?
+set -e
+if [[ "$rc" -eq 0 ]] && grep -Fq "instructions = '''" "$CONFIG_TIF" \
+    && grep -Fq 'Always be brief' "$CONFIG_TIF" \
+    && grep -Fq 'name = "keep section"' "$CONFIG_TIF" \
+    && ! grep -Fq 'stale instructions' "$CONFIG_TIF"; then
+    ok "trusted-instructions-file: prepends instructions and strips stale block"
+else
+    fail "trusted-instructions-file: prepends instructions and strips stale block (rc=$rc config=$(cat "$CONFIG_TIF" 2>/dev/null || echo MISSING))"
+fi
+
 echo "Results: $PASS passed, $FAIL failed"
 [[ "$FAIL" -eq 0 ]]

--- a/scripts/test-step0b-router-flag-recovery.sh
+++ b/scripts/test-step0b-router-flag-recovery.sh
@@ -332,4 +332,92 @@ grep -Fq 'merge_router_flags()' "$DESIGN_ROUTE" \
 grep -Fq -- '--approve-requested "$approve_requested"' "$REPO_ROOT/skills/design/SKILL.md" \
   || fail "case12: SKILL.md route fence must pass current --per-round-approval"
 
+# --- Resume route integration (Cases 13 and 13b) ---
+# Set up a fresh fake plugin with stubs needed for resume@* route.
+FAKE_RESUME_PLUGIN="$TMPROOT/fake-resume-plugin"
+STUB_RESUME_SCRIPTS="$FAKE_RESUME_PLUGIN/scripts"
+STUB_RESUME_DESIGN="$FAKE_RESUME_PLUGIN/skills/design/scripts"
+mkdir -p "$STUB_RESUME_SCRIPTS" "$FAKE_RESUME_PLUGIN/python" "$STUB_RESUME_DESIGN"
+for _lib in lib-quiet.sh lib-larch-log.sh append-tool-failure.sh append-execution-issue.sh; do
+  ln -sf "$REPO_ROOT/scripts/$_lib" "$STUB_RESUME_SCRIPTS/$_lib"
+done
+cat >"$FAKE_RESUME_PLUGIN/python/cli.py" <<STUB
+#!/usr/bin/env python3
+import os, subprocess, sys
+if sys.argv[1:3] == ["session", "write-design-env"]:
+    raise SystemExit(0)
+raise SystemExit(subprocess.call(["$PYTHON_BIN", "$REPO_ROOT/python/cli.py", *sys.argv[1:]]))
+STUB
+chmod +x "$FAKE_RESUME_PLUGIN/python/cli.py"
+# Minimal step-name-registry.tsv covering steps used by Cases 13 and 13b.
+printf 'step\tname\n3\tplan review\n2b\tplan draft\n' >"$STUB_RESUME_DESIGN/step-name-registry.tsv"
+# Parametric design-pause-load.sh stub: LARCH_TEST_PAUSE_STEP controls the STEP output.
+cat >"$STUB_RESUME_SCRIPTS/design-pause-load.sh" <<'STUB'
+#!/usr/bin/env bash
+printf 'LOAD_OK=true\n'
+printf 'STEP=%s\n' "${LARCH_TEST_PAUSE_STEP:-3}"
+printf 'SESSION_ID=test-resume\n'
+printf 'MARKER_CLEARED=true\n'
+exit 0
+STUB
+chmod +x "$STUB_RESUME_SCRIPTS/design-pause-load.sh"
+
+# Case 13: resume@3 route; --approve-requested true OR-merges into run-params.json.
+D13="$TMPROOT/route13"
+mkdir -p "$D13"
+BODY13="$D13/body.txt"
+printf '<!-- larch:design-pause:start -->\n' >"$BODY13"
+"${WRITER[@]}" --classification SIMPLE --partition-requested false --brainstorm-requested false \
+  --approve-requested false --skip-approve-requested false --output "$D13/run-params.json" >/dev/null
+set +e
+route13_out=$(CLAUDE_PLUGIN_ROOT="$FAKE_RESUME_PLUGIN" LARCH_TEST_PAUSE_STEP=3 \
+  "$DESIGN_ROUTE" \
+  --design-tmpdir "$D13" \
+  --issue 42 \
+  --issue-title "Feature fixture" \
+  --issue-body-file "$BODY13" \
+  --has-clarify-label false \
+  --claude-pid "$$" \
+  --session-id "route13" \
+  --partition-requested false \
+  --brainstorm-requested false \
+  --approve-requested true \
+  --skip-approve-requested false 2>&1)
+route13_rc=$?
+set -e
+[[ "$route13_rc" -eq 0 ]] || fail "case13: design-route.sh rc=$route13_rc out=$route13_out"
+printf '%s\n' "$route13_out" | grep -Fq 'ROUTE=resume@3' \
+  || fail "case13: design-route.sh did not emit resume@3 route: $route13_out"
+jq -e '.approve_requested == true' "$D13/run-params.json" >/dev/null \
+  || fail "case13: design-route.sh resume@* did not OR-merge approve_requested; got $(cat "$D13/run-params.json")"
+
+# Case 13b: resume@2b route; --partition-requested true OR-merges into run-params.json.
+D13B="$TMPROOT/route13b"
+mkdir -p "$D13B"
+BODY13B="$D13B/body.txt"
+printf '<!-- larch:design-pause:start -->\n' >"$BODY13B"
+"${WRITER[@]}" --classification SIMPLE --partition-requested false --brainstorm-requested false \
+  --approve-requested false --skip-approve-requested false --output "$D13B/run-params.json" >/dev/null
+set +e
+route13b_out=$(CLAUDE_PLUGIN_ROOT="$FAKE_RESUME_PLUGIN" LARCH_TEST_PAUSE_STEP=2b \
+  "$DESIGN_ROUTE" \
+  --design-tmpdir "$D13B" \
+  --issue 42 \
+  --issue-title "Feature fixture" \
+  --issue-body-file "$BODY13B" \
+  --has-clarify-label false \
+  --claude-pid "$$" \
+  --session-id "route13b" \
+  --partition-requested true \
+  --brainstorm-requested false \
+  --approve-requested false \
+  --skip-approve-requested false 2>&1)
+route13b_rc=$?
+set -e
+[[ "$route13b_rc" -eq 0 ]] || fail "case13b: design-route.sh rc=$route13b_rc out=$route13b_out"
+printf '%s\n' "$route13b_out" | grep -Fq 'ROUTE=resume@2b' \
+  || fail "case13b: design-route.sh did not emit resume@2b route: $route13b_out"
+jq -e '.partition_requested == true' "$D13B/run-params.json" >/dev/null \
+  || fail "case13b: design-route.sh resume@* did not OR-merge partition_requested; got $(cat "$D13B/run-params.json")"
+
 echo "PASS: test-step0b-router-flag-recovery.sh"

--- a/skills/shared/review-acceptance-rubric.md
+++ b/skills/shared/review-acceptance-rubric.md
@@ -51,7 +51,7 @@ the spec is the originating issue scope (the staged scope anchor / feature descr
 
 ## Update triggers
 
-The following surfaces embed this rubric's necessity-gate language. When the rubric changes, update all of them and run `make test-render-voter-prompt`:
+The following surfaces embed this rubric's necessity-gate language. When the rubric changes, update all of them and run `make test-prompt-template-invariants`:
 
 - `python/cli.py render voter` — embeds rubric body verbatim for external voters
 - `skills/shared/reviewer-templates.md` — Necessity gate subsection for reviewer self-filter


### PR DESCRIPTION
- Implement requested changes.

## Test plan

- [ ] `make py-lint`
- [ ] `make py-test`

Closes #3949
