### PR TITLE
Release v49.0.13

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "49.0.12",
+  "version": "49.0.13",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (default SIMPLE tier; opt-in `--hard` only) and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` has no workflow tier/path dimension and no `/implement --hard` flag. `/implement` Step 5 code review always uses the unified hard panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## v49.0.13

### Fixed

- **Codex executor retries on transient infra failures** — `launch-codex-exec.sh` now retries when the subprocess exits with codes 5 or 7 (transient infra) instead of failing immediately.
- **Merge loop detects `REVIEW_REQUIRED` / `BLOCKED`** — the Python ship driver no longer spins to the iteration cap when a repo ruleset requires an approving review; it now surfaces a clear failure with the correct class label instead of misclassifying as `transient-infra`.
- **Cursor auth preflight no longer permanently excludes Cursor on transient keychain lock** — single-shot keychain read failure is now treated as transient rather than permanent, so Cursor is retried on subsequent runs.

### Changed

- **Plan-size R2 check removed from `/design`** — the remote size check is eliminated to reduce latency and token overhead on each design run.
- **OOS wire format migrated to Python** — `oos-serialize` and `normalize-oos-block-header` are now handled by `python/` (sh-to-py migration step F3a).
- **Test coverage and shared utilities for resume and trusted-instructions flows** — added `resume@*` test coverage, extracted a shared sentinel parser, added trusted-instructions-file tests, and corrected a stale rubric reference.
