### PR TITLE
[BUG] design-log-publish fails when revise/ contains claude-output.txt.stderr

### DIFF
--- a/scripts/lib-design-round-artifacts.md
+++ b/scripts/lib-design-round-artifacts.md
@@ -37,7 +37,7 @@ The revise include set is empty — no files from `revise/` appear in committed 
 `design-log-publish.sh` uses a two-tier check for `revise/` files (mirroring the top-level round pattern):
 
 1. `design_round_revise_artifact_included` — always returns 1 (nothing published from `revise/`).
-2. `design_round_revise_artifact_excluded` — returns 0 for known session-only artifacts that are silently skipped: raw vendor outputs (`*-output.txt`), candidate patches (`*-output-candidate.patch`), revision outcome (`revise.env`), revision prompt (`prompt.txt`), and all sidecars (`*.done`, `*.dirty-tree`, `*.meta`, `*.prompt`, `*.sidecar`, `*.sidecar.history`, `*.events.jsonl`, `*.events.history`, `*.untracked-baseline`, `*.diag`, `*.failure-diag`, `*.json`).
+2. `design_round_revise_artifact_excluded` — returns 0 for known session-only artifacts that are silently skipped: raw vendor outputs (`*-output.txt`), candidate patches (`*-output-candidate.patch`), revision outcome (`revise.env`), revision prompt (`prompt.txt`), and all sidecars (`*.done`, `*.dirty-tree`, `*.meta`, `*.prompt`, `*.sidecar`, `*.sidecar.history`, `*.events.jsonl`, `*.events.history`, `*.untracked-baseline`, `*.diag`, `*.failure-diag`, `*.json`, `*.stderr`).
 3. Anything matching neither function is an **unexpected file** and causes a hard publish failure — the loud-failure contract is preserved so genuinely new files added to `revise/` without a corresponding exclusion entry are immediately visible.
 
 ## Vendor failure-diagnostics carrier (#3713)

--- a/scripts/lib-design-round-artifacts.sh
+++ b/scripts/lib-design-round-artifacts.sh
@@ -39,7 +39,7 @@ design_round_revise_artifact_excluded() {
         *.done|*.dirty-tree|*.meta|*.prompt|*.sidecar|*.sidecar.history|*.events.jsonl|*.events.history)
             return 0
             ;;
-        *.untracked-baseline|*.diag|*.failure-diag|*.json)
+        *.untracked-baseline|*.diag|*.failure-diag|*.json|*.stderr)
             return 0
             ;;
         *)

--- a/scripts/test-lib-design-round-artifacts.sh
+++ b/scripts/test-lib-design-round-artifacts.sh
@@ -93,6 +93,7 @@ assert_revise_explicitly_excluded codex-output.txt.untracked-baseline
 assert_revise_explicitly_excluded codex-output.txt.diag
 assert_revise_explicitly_excluded codex-output.txt.failure-diag
 assert_revise_explicitly_excluded codex-output.txt.json
+assert_revise_explicitly_excluded claude-output.txt.stderr
 assert_revise_not_explicitly_excluded extra-revise.log
 
 printf '%s\n' 'test-lib-design-round-artifacts: ok'


### PR DESCRIPTION
Fixes #3986

## Summary

- `design_round_revise_artifact_excluded` did not cover `*.stderr`, so `claude-output.txt.stderr` written by a Gate-B revise Claude subprocess caused `design-log-publish.sh` to abort with "unexpected file under plan-review".
- Add `*.stderr` to the sidecar exclusion arm in `lib-design-round-artifacts.sh`, update the sibling prose doc, and pin a harness assertion.

## Test plan

- [x] `bash scripts/test-lib-design-round-artifacts.sh` passes (added `assert_revise_explicitly_excluded claude-output.txt.stderr`)
- [x] `bash scripts/relevant-checks.sh` clean (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)