### PR TITLE
Release v49.0.14

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "49.0.13",
+  "version": "49.0.14",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (default SIMPLE tier; opt-in `--hard` only) and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` has no workflow tier/path dimension and no `/implement --hard` flag. `/implement` Step 5 code review always uses the unified hard panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Fixed

- Resolved a failure in the design-log publish step that occurred when the `revise/` directory contained a `claude-output.txt.stderr` file (#3979)
- Applied fix for tracked issue #3974, resolving a reported defect (#3976)
- Applied fix for tracked issue #3924, resolving a reported defect (#3977)

## Changed

- Migrated small user skills from shell scripts to Python as part of the sh-to-py migration phase 3 (#3984)

## Maintenance

- Committed design run logs (#3967, #3970, #3972, #3983, #3989)
