### PR TITLE
Release v49.0.15

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "49.0.14",
+  "version": "49.0.15",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (default SIMPLE tier; opt-in `--hard` only) and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` has no workflow tier/path dimension and no `/implement --hard` flag. `/implement` Step 5 code review always uses the unified hard panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## v49.0.15

### Changed

- **Python runtime now owns voting and scoring.** Voting, tally, parse-rate, scoreboard, and judge-vote logic migrated from shell into the Python CLI. Review, design, research, and implement callers now call Python CLI verbs directly. Shell-harness test coverage replaced with pytest. ([#3985](https://github.com/character-ai/larch/pull/3985))
- **`/design` step bodies moved behind wrapper scripts.** Bash skill surface is now wrapper-only; structure harness enforces direct wrapper calls, executable siblings, and key handoffs. Step 3 adjudication, postplan, OOS, and Step 5c recovery contracts are documented under the new wrappers. ([#3987](https://github.com/character-ai/larch/pull/3987))
- **`/design` Step 3 progress now shown in real time.** Reviewer progress is surfaced with implement-style detail. Progress is guarded against stale manifests and reused reviewer outputs; freshness anchors, retry sidecars, and label matching are covered. ([#3993](https://github.com/character-ai/larch/pull/3993))
- **Codex now handles all fixer roles.** CI failure fixer, rebase conflict fixer, lint error fixer, and local test failure fixer all route through Codex. ([#4000](https://github.com/character-ai/larch/pull/4000))

### Fixed

- **Stale Makefile and lint references cleaned up.** References to the removed step-telemetry scripts were left in `Makefile` and `agent-lint.toml`; these are now corrected. Linting docs updated to remove the retired `false-positive-keywords` target and stale voting-script names. ([#3995](https://github.com/character-ai/larch/pull/3995))
