### PR TITLE
Release v49.0.16

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "49.0.15",
+  "version": "49.0.16",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (default SIMPLE tier; opt-in `--hard` only) and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` has no workflow tier/path dimension and no `/implement --hard` flag. `/implement` Step 5 code review always uses the unified hard panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Changed

- **Voter 1 default model** switched from `claude-fable-5` to `claude-sonnet-4-6`, reducing per-round voting cost across `/design` plan ballots and `/review`+`/implement` code ballots. ([#4003](https://github.com/character-ai/larch/pull/4003))

## Fixed

- **`CLAUDE_PLUGIN_ROOT`** is now pinned to the repository root in the `launch-claude-subprocess` harness, preventing it from leaking or being inherited incorrectly across sessions. ([#4007](https://github.com/character-ai/larch/pull/4007))
- **SECURITY.md** reference to `lib-timing-kinds.sh` corrected after a rebase shifted the path. ([#4005](https://github.com/character-ai/larch/pull/4005))
