### PR TITLE
Release v49.0.17

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "49.0.16",
+  "version": "49.0.17",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (default SIMPLE tier; opt-in `--hard` only) and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` has no workflow tier/path dimension and no `/implement --hard` flag. `/implement` Step 5 code review always uses the unified hard panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## What's Changed in v49.0.17

### Fixed

- **(URGENT) `/design` Step 3:** Removed `--mode` arg from orchestrator surface to prevent single-round regression (#4023, PR #4027)
- **(URGENT) `/design`:** Free-form recap no longer emitted after publish; run-log PR merge state correctly reported (#4025, PR #4028)
- **(URGENT) `/implement` Step 4:** Removed stale `git-commit.sh` prose and corrected wrapper usage hint (#4021, PR #4033)
- **(URGENT) `/implement`:** Progress report step marks no longer lost when entry fences are skipped (#4024, PR #4036)
- **(URGENT) `/implement` Step 18:** Guarded `plugin-root.env` source; no longer crashes with "No such file" when tmpdir is pre-cleaned (#4037, PR #4042)
- **(URGENT) `rebase.py`:** `PrePushConflictHandoff` now triggered when fixer waterfall reports partial success, allowing main agent to intervene (#4045, PR #4046)
- **`/implement`:** Resolved root cause of PR creation failure due to Makefile rebase conflict (#3982, PR #4032)
- **`/implement` final report:** Fixed missing "Review Phase Detail" table; `render-review-phase-detail.sh` no longer requires `round-meta.json` that the code review pipeline never writes (#4038, PR #4044)
- **`/design` rich header:** Header now tracks plan-voter-slots in addition to plan-review-slots (#3981, PR #4026)
- **`/design` Step 3 rich header:** Multiple correctness gaps in voter progress display resolved (#4022, PR #4043)

### Changed

- **Long-running scripts:** All long-running scripts now spawned in immediate-background mode rather than deferred mode (#3997, PR #4029)
- **`/implement`:** Dropped vestigial runtime reference loads and removed dead `SKILL.md` text (#4010, PR #4041)

### Added

- **sh-to-py F3d:** Migrated issue wire core (plan-block, named-block, scope, untrusted, title, P3119) to Python (#3926, PR #4031)
- **sh-to-py F3c:** Migrated issue query and blockers (blocker-helpers, parse-prose-blockers, get-issue-state/info/context) to Python (#3925, PR #4035)

### Chores

- Rebalanced CI test harness shards for improved wall-clock distribution (PR #4009)
