### PR TITLE
Release v49.0.18

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "49.0.17",
+  "version": "49.0.18",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (default SIMPLE tier; opt-in `--hard` only) and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` has no workflow tier/path dimension and no `/implement --hard` flag. `/implement` Step 5 code review always uses the unified hard panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Changed

- **sh-to-py C4a**: Ported `/implement` entry machinery (bootstrap, bootstrap-invoke, routing envelope, admission, preflight, fork-env setup, dirty-tree checks, plan-scope checks) from shell scripts to Python. ([#4064](https://github.com/character-ai/larch/pull/4064))
- **Codex reviewer in rounds 3+**: `/design` and `/implement` now spawn Codex as a reviewer starting with round 3, restoring parity with rounds 1 and 2. Previously Codex was only spawned as a fallback when Cursor was unavailable. ([#4078](https://github.com/character-ai/larch/pull/4078))

## Fixed

- **Admission gate fail-closed**: `admission.py` `gate_main` previously treated any non-zero exit from the blocker helper subprocess (import errors, source failures, dispatcher errors) as an empty blocker list and returned `ADMISSION_RESULT=pass`. The gate now fails closed on subprocess errors. ([#4079](https://github.com/character-ai/larch/pull/4079))
- **`/design` Top Reviewers slot attribution**: `render-review-phase-detail.sh derive()` misattributed mixed-case dynamic slot names (e.g. `Cursor` vs `cursor`) in the post-session summary. Also fixes `--no-dedup` flag not forwarded during OOS issue recovery. ([#4065](https://github.com/character-ai/larch/pull/4065))
