### PR TITLE
Release v49.0.19

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "49.0.18",
+  "version": "49.0.19",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (default SIMPLE tier; opt-in `--hard` only) and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` has no workflow tier/path dimension and no `/implement --hard` flag. `/implement` Step 5 code review always uses the unified hard panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Fixed

- **Code review panel (`/review`) round-3+ Codex gating**: `dispatch-panel.sh` now suppresses Codex reviewer slots in round 3 and later when Cursor is available. Codex is still emitted in rounds 1–2 (unchanged) and in round 3+ when Cursor is unavailable. Previously Codex slots were emitted in every round regardless of round number, and round 3+ with Cursor absent produced an empty panel.
- **Code review `--no-fallback` scope**: `dispatch-panel.sh` now applies `--no-fallback` only in rounds 1–2 when both vendors are present. Round 3+ keeps normal fallback so a failed Cursor slot can be covered. Previously `--no-fallback` was applied whenever both vendors were available, regardless of round.
- **Plan review panel (`/design`) Codex round-3+ gating**: `dispatch-plan-review-panel.sh` now gates Codex slots on the same policy (rounds 1–2 always; round 3+ only when Cursor is absent). Previously the round number was parsed but never consulted for Codex gating, so Codex ran in every plan-review round.
- **Release notes direction-verification rule**: `/release` Step 3 now requires deriving behavioral direction from the merged diff rather than from issue or PR prose, to prevent before/after inversions from issues that describe desired end state.
