### PR TITLE
Release v50.0.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "49.0.19",
+  "version": "50.0.0",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel) and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",
@@ -31,7 +31,7 @@
     "codex_model": {
       "title": "Codex Model",
       "type": "string",
-      "description": "Model for Codex launches — review, implementation, sketches, voting (e.g., o3). Also accepted via LARCH_CODEX_MODEL env var. When unset, defaults to gpt-5.5.",
+      "description": "Model for Codex launches \u2014 review, implementation, sketches, voting (e.g., o3). Also accepted via LARCH_CODEX_MODEL env var. When unset, defaults to gpt-5.5.",
       "sensitive": false
     },
     "codex_effort": {


### PR DESCRIPTION
## Changed

- **`/design` single-flow:** The HARD design tier and `--hard` flag are removed. `/design` now runs one unified flow; SIMPLE tier labels are also removed from reports and documentation. Plan-size braking behavior is retained; size-trigger tokens are renamed (`SIZE_TRIGGER_FIRED`, etc.). (#4091)
- **Tracking issue lifecycle on Python CLI:** Read, write, rename, false-positive, and summary operations for tracking issues now go through `python3 .../python/cli.py tracking-issue ...`. Shell helpers for these operations are retired. (#4089)
- **Dev-only helper migration to Python CLI:** Release, audit-runs, combine-issues, and analyze-issues helpers are now Python CLI verbs. Absorbed shell, jq, and standalone helper files are retired. (#4090)
- **Token pricing consolidated in Python:** Vendor token pricing is corrected and Python is now the single pricing authority. Optional model metadata is preserved through token sidecars and active ledgers. Codex drafter, autofix, lint-fix, CI, and conflict sidecars are counted exactly once. (#4093)

## Fixed

- **Stall reporting:** Stall reports now emit at terminal and escalation-success moments with mandatory root-cause artifacts. Script-to-main-agent handoffs are recorded in a canonical ledger for recovered runs. Consumer-facing reports are constrained to allowlisted machine fields and validated bounded prose. Ledger-ready handoff data is emitted from lint, review, and ship-pr drivers. (#4056)
