### PR TITLE
Release v50.0.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "50.0.0",
+  "version": "50.0.1",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel) and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Changed

- **Review phase detail: Mermaid Gantt timing charts.** Completed review round summaries now include a per-round Mermaid Gantt chart showing reviewer timing from the timing ledger. A new `--no-gantt` flag on `render-review-phase-detail.sh` suppresses chart output for terminal progress callers. Final summaries from `/design` and `/implement` render the shared no-completed-round section when no review rounds finished.

- **`/implement` Preflight: consolidated admission helper.** Mechanical Preflight gates (admission check, issue fetch, plan-block extraction, and emergency fallback composition) are now handled by `scripts/implement-preflight.sh`. The main-agent audit boundary starts after the helper succeeds; `audit.txt` is written only on refusal. An offline regression harness (`test-implement-preflight`) is wired into `make lint`.

- **`/design` plan-voter runner migration.** The plan-voter lane now invokes `python/cli.py agent run-external-agent` instead of `scripts/run-external-agent.sh` directly. Rule path references and CI configuration updated to match.
