### PR TITLE
Release v50.0.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "50.0.1",
+  "version": "50.0.2",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel) and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Changed

- **Codex reviewer schedule adjusted.** Specialized Codex reviewers now launch only on round 1. Rounds 2 through 5 use a single generic Codex reviewer subject to the prune policy. Round 5 uses exactly one generic Codex reviewer alongside all Cursor specialists. Affects `/design`, `/implement`, and `/review --diff`.

- **Cursor replaces Codex as the default suggestion applicator in `/implement`.** The review-suggestion applier and finding aggregator/deduplicator in Step 5 now use Cursor instead of Codex.

## Fixed

- **`/design` Step 3 anti-polling guidance strengthened.** Both the initial and resume Step 3 fences now explicitly ban polling `.step3-review-result.env` with a sleep loop before the task-completion notification. A shared NEVER rule for `run_in_background` result-file sleep loops was added and the anti-polling harness extended to cover both sites.

- **Protected-path Codex bails classified as a durable recovery class.** Protected-path-edit-required-out-of-scope bails are now a named recovery class with documented retry policy and stale-evidence classifier precedence, rather than transient infrastructure failures. Operators are warned when Main Claude will handle the protected plugin manifest path inline.
