### PR TITLE
Release v50.0.3

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "50.0.2",
+  "version": "50.0.3",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel) and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## What's Changed

### Fixed

- **Restored Codex-first as the default `/implement` Step 2 coder.** A prior PR had accidentally flipped the implicit implementer order to Cursor-first. The order is now back to Codex, then Cursor, then Claude. (#4141)
- **Fixed `/design` step3 loop silently dropping the result envelope when `PLAN_REVIEW_CONTINUE_REASON` contained CR or LF characters.** The loop now strips CR/LF before emitting or persisting the value, omits `SCOPE_ANCHOR_FILE` when it contains newlines, and surfaces envelope write failures with an explicit `WARN=` signal instead of swallowing them with `|| true`. (#4137)
- **Corrected `SECURITY.md` to reflect that `--emergency` and `--merge` are compatible.** The previous wording incorrectly stated they were mutually exclusive. Also wired the implement-preflight harness into `relevant-checks.sh` and pinned exact admission refusal assertions in the offline test harness. (#4140)

### Changed

- **`/combine-issues --oos` now resolves the target repository before any OOS sub-commands and passes `--repo` to all of them.** The OOS apply step uses `--defer-close` and tracks source closure eligibility across a new dependency pipeline: fetch-deps, plan-inherited, inherited-exception gate, refresh, close-eligible, close-sources, and a post-closure prose and semantic audit (steps oos-6 through oos-9). (#4132)

### Internal

- Flushed design run logs. (#4127, #4128, #4129, #4131, #4136)
