### PR TITLE
Release v50.0.4

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "50.0.3",
+  "version": "50.0.4",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel) and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Changed

- **`/design` session launcher**: Adds a per-Claude-PID launcher so post-setup Bash fences share one transport contract. Collapses `/design` fences to the launcher form while preserving explicit Step 0a setup. Fails closed when launcher creation is unsafe. (PR #4138)
- **Stall report cross-repo filing**: Files Tier B stall reports in the resolved upstream larch repository with exact-signature dedup. Keeps Tier A on the existing `/larch:issue` path with a normalized dedup pre-pass. Separates public dedup signatures from retry signatures and documents the public safety boundary. (PR #4147)
- **Progress renderer and Mermaid CI**: Splits the Time/Cost table from Gantt round windows. Skips live phase-detail render when all round directories are in-flight only. Installs Mermaid toolchain on CI shard 12 to validate generated fences from renderer fixtures. (PR #4144)

## Fixed

- **Plan review loop**: Rejects invalid `mechanical_churn` plan trailers with a `PLAN_SIZE_STATUS=invalid-mechanical-churn` diagnostic. Detects `ballot-items-lost` when in-scope ballot items remain but the round tally is header-only. Threads `REASON` and `INSCOPE_REMAINING` through Step 3 drivers so lost-ballot rounds continue correctly. (PR #4149)
