### PR TITLE
Release v50.0.5

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "50.0.4",
+  "version": "50.0.5",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel) and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Fixed

- **Codex drafter token copy failures now surface warnings** (PR #4171): `scripts/launch-codex-drafter.sh` previously swallowed sidecar copy failures with `|| true`, silently losing billable token records. The copy now emits an operator-visible warning when it fails.
- **Missing `LAUNCHER_EXIT` on non-zero CI exit treated as failure** (PR #4172): `python/agents.py` previously parsed `LAUNCHER_EXIT` only when the launcher exited zero. A missing value on non-zero exit was silently treated as success. Now it is treated as a failure, preventing misclassified failed tiers from being passed in the CI waterfall.
- **CI stall detection and bail-token normalization** (PR #4172): Stall handling in `scripts/ci-wait.sh`, `scripts/lib-net.sh`, and `python/ci_monitor.py` is more reliable; isolated rebase state and retry logic in `python/rebase.py` and `python/retry.py`.
- **Step 2 scout sidecar normalization unified with design phase** (PR #4174): `/implement` Step 2 delegates external coder scout sidecar normalization to the design scout wrapper so reserved static plan-review slugs are filtered consistently across design and implement.
- **Step 5 lint-fix stall timing recorded in-loop** (PR #4162): Terminal lint-fix main-agent stalls are now recorded in the timing ledger within the loop instead of leaving deferred round-start state for a prompt-side resume.
- **`classify-bump.md` references to deleted scripts removed** (PR #4163): The document no longer references the retired `release-prepare.sh` and `classify-bump.sh` shell scripts; entry points now correctly point to `python/cli.py release prepare` and `python/cli.py release classify-bump`.
- **Python lint-fix and research Codex sidecars ingested into correct ledgers** (PR #4171): Codex lint-fix sidecars are now appended to NDJSON and ingested into the active ledger with isolated implementation-tmpdir routing, even when the launcher fails; research sidecar ingestion against the research ledger is documented.
