### PR TITLE
Release v50.0.6

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "50.0.5",
+  "version": "50.0.6",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel) and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Fixed

- `/design` background polling probes are now blocked while an immediate-background wait is active. A shipped `PreToolUse` hook (`hook-bg-poll-guard.sh`) denies `Read`/`Bash` progress observations of the design tmpdir, task outputs, reviewer outputs, and plan-review directories whenever the background wait marker is live, then signals the orchestrator to yield for `<task-notification>`. Telemetry from the guard appears in the `/design` final summary. Operators can disable with `LARCH_BG_POLL_GUARD_DISABLE=1`. (PR #4183)

- Orphaned Step 3 review loops in `/design` are now prevented. The review loop runs in a job-control process group; the wrapper traps on exit and terminates the group before teardown. When monitor mode cannot be verified before launch, the script fails closed with a fresh `panel-failed` envelope. (PR #4191)

- The `/design` degraded-tools gate is now run from `design-step0-session.sh` after the session env is written, rather than a standalone `design-step0-degraded` wrapper. The retired wrapper is removed; Step 0 is now a three-fence path. (PR #4194)

- The `test_finalize.py` regression for session local-cleanup now asserts the Python finalizer walks the live process ancestor chain before consulting the transient shell probe, so the signal-safety path is directly covered. (PR #4195)

## Internal

- Committed design run logs from 8 planning sessions. (PRs #4177, #4179, #4181, #4184, #4186, #4187, #4189, #4190)
