### PR TITLE
Release v50.0.7

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "50.0.6",
+  "version": "50.0.7",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel) and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## What's Changed

### Changed

- **Design plan validation migrated to Python.** `plan_quality.py` replaces the retired `validate-plan.sh` bash script. Makefile targets `test-invoke-plan-validator` and `test-trailer-helpers` now run through pytest rather than the shell harness. (#4193)

- **Design decompose phase migrated to Python.** Panel dispatch, aggregation, and file-issues scripts (`decompose-panel-dispatch.sh`, `decompose-aggregator.sh`, `decompose-file-issues.sh`) are replaced by `python/decompose.py` and `python/plan_scout.py`. Path-triggered rules updated to the new module paths. (#4203)

- **Reviewer timing charts switched from Mermaid to ASCII.** A new `python/gantt.py` module renders reviewer timelines as plain ASCII Gantt charts. Final-report and live progress detail both use the same absolute-time renderer. Mermaid output removed. (#4204)

### Added

- **`/design` failure reporting ported to the shared failure-report core.** Terminal failures and escalation-success runs now file bounded reports through the same path as `/implement`, using the `design-failure-*` artifact prefix. Adds terminal-state staging, teardown gating, Tier B cross-repo filing, operator-action audit trail, and fallback chat print. Docs updated across `SECURITY.md`, `docs/configuration-and-permissions.md`, `docs/linting.md`, `docs/run-logs.md`, and `docs/workflow-lifecycle.md`. (#4208)

- **Makefile harness definitions for new design test targets.** `.PHONY` declarations and target bodies for `test-design-stage-terminal-state`, `test-design-failure-report`, `test-design-step3-review`, `test-design-step5c`, and `test-design-step-validator-autofix` added; `test-design-step3-review` wired into shard 4. (#4209)

**Full Changelog**: https://github.com/character-ai/larch/compare/v50.0.6...v50.0.7
