### PR TITLE
Release v50.0.8

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "50.0.7",
+  "version": "50.0.8",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel) and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Changed

- **Review pipeline migrated to Python.** The review findings pipeline now runs through `python/cli.py review` verbs. Shell review entrypoints and their harnesses have been retired; all internal references now point to the Python surface. (#4226)
- **Rebalancer feasibility preflight added.** `/rebalance-test-harnesses` now runs a warning-only feasibility check before packing shards. The BEFORE table now shows the estimated spread for the new layout (derived from baseline medians) rather than the old layout. Repo-root resolution changed from `git rev-parse` to a path-relative lookup. (#4258)

## Fixed

- **`/combine-issues` temp-file collisions.** Body and state files are now written under a unique `mktemp -d` directory per run instead of hardcoded `/tmp/<name>` paths, preventing failures when a prior run left files at the same location. (#4218)
- **Progress report shows step 0 during ship-pr.** When `/implement` is running ship-pr, progress reports no longer display stale step-0 output. The progress renderer now selects the ship-pr display based on presence of the ship-pr state file rather than a hardcoded phase allow-list. (#4230)
- **Compact reviewer table fires for all background waits.** The compact reviewer status table is now scoped to Step 3 review and resume waits only. Steps 5c and Final Summary emit plain progress breadcrumbs instead of implying reviewers are active. (#4229)
- **`/design` Step 6 races in-flight Step 5c publish.** Step 6 now fails fast when a Step 5c publish is still in progress (background wait marker active but no status sidecar written), preventing race-condition state corruption. (#4219)
- **Stale scout cap-hit markers block fallback JSON writes.** Dynamic scout cap-hit markers are now cleared before each Cursor and Claude tier so subsequent fallback JSON writes are not rejected by a leftover marker from a prior tier attempt. (#4215)
- **Design publish retry overwrites success with failure.** A publish retry can no longer clobber a previously recorded success in the result-env file. Result-env writes are now serialized; an idempotent success path handles squash-merged design log branches whose remote branch is gone. (#4213)
- **`/design` Step 3b through Gate C not in scripted wrappers.** Step 3b classification, sanitizer cleanup, and Gate C tail handling are now wrapper-owned. The Gate C full-plan display routes through the allowlist-validated preview helper; obsolete split wrappers retired. (#4216)
- **Merge-time conflicts surface as review stalls.** GitHub merge failures that report conflicts or "not mergeable" are now classified as `MAIN_ADVANCED` so ship-pr rebases and retries automatically instead of halting on a review-required error. (#4234)
- **In-flight review Gantt charts not rendered.** Active-round Gantt charts now render for design Step 3 and implement Step 5, including first-round-only and mixed completed-plus-active states. Bash and Python fallback labels for aggregator, scout, and bare vendor rows are now consistent with manifest labels. (#4073)
- **Token sidecar ledger hygiene.** Active-ledger environments are now cleaned for Bash and Python sidecar ingestion. Codex drafter `TOKEN_RECORD` output is gated on a confirmed stable sidecar. Fresh Codex and Cursor CI-fix fallback ingestion added for validation-phase parity. (#4256)
- **Gantt reviewer labels and postplan timing.** Reviewer labels remain correct when manifests are absent, with manifest labels still taking precedence when available. Postplan failure timing is now anchored to the persisted round start time after resumes. Codex and Cursor plan revision attempts are tagged with explicit timing task kinds. (#4243)
