### PR TITLE
Release v50.0.9

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "50.0.8",
+  "version": "50.0.9",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel) and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Changed

- **`/design` Step 3 MainAgent vote wrapper** — adjudication mechanics for the Step 3 MainAgent vote are now handled by a dedicated pre/post wrapper script (`design-step3-mav.sh`). The skill prose delegates to the wrapper contract; offline harness covers pause handling, safe result-env reads, re-tally routing, and loop phase persistence. (PR #4284)

- **`/design` launcher-owned resume state** — Step 3 re-entry flags, mid-loop resume state, postplan continue markers, and Step 2b completion-only markers are now owned by the launcher rather than inline skill prose. Updated `/design` contracts to use the new wrapper flags; regression coverage extended accordingly. (PR #4276)

- **`/design` Step 5 prelude folded into prepare wrapper** — the live empty Step 5 prelude turn is removed; its sentinel and timing setup move into `design-step5b-prepare`. `design-step5.sh` is retained as a compatibility delegator. Final summaries from Step 5c and cancellation wrappers now emit stable task-output markers with file fallback. (PR #4282)

- **`check-reviewers` and `run-negotiation-round` migrated to Python** — references to the retired `scripts/check-reviewers.sh` and `scripts/run-negotiation-round.sh` are updated to `python/cli.py agent check-reviewers` and `python/cli.py agent run-negotiation-round` across docs, SECURITY.md, configuration reference, agent-lint exclusions, and Makefile targets. (PR #4283)

- **`test-stall-recovery-report` convenience target** — a top-level `make test-stall-recovery-report` target that chains the three CI shard targets sequentially is now available for local development. The linting docs clarify the shard assignments for the individual split targets. (PR #4274)
