### PR TITLE
Release v50.0.10

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "50.0.9",
+  "version": "50.0.10",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel) and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## v50.0.10

### Fixed

- `/design` Step 3 review loops now clean up orphan background processes from the session tmpdir after the loop exits. (#4324)
- Step 5 timing ledger idempotency: existing ledger rows are now detected correctly so duplicate rows are no longer inserted on re-entry. (#4293)
- Step 3 preserves operational status when result-env persistence fails and records Tool Failures evidence. Cursor reviewers now run with `/dev/null` stdin. (#4308)
- Design-log final republishes now rebuild on a freshly fetched default branch before push. Idempotency now only skips no-delta or manifest-timestamp-only reruns, so newer snapshots and deletions still publish. (#4307)

### Changed

- **Python CLI migrations:** review-and-fix Step 5 ownership, all machine envelopes, MAV apply, and pre-scout gating moved to the Python CLI, retiring the absorbed shell entrypoints and harnesses. (#4285)
- **Python CLI migrations:** `/research` helpers and research eval surfaces moved to Python CLI verbs, retiring shell harnesses and updating runtime call sites. (#4291)
- **Python CLI migrations:** `/design` plan-review entry points moved to the Python CLI, retiring shell paths and sweeping stale lint routing. (#4322)
- **Python CLI migrations:** reviewer dispatch, voting, scouting, and retry metadata ported to the `launch-review` Python agent CLI verb, retiring the shell launcher. (#4327)
- `/design` Step 2b: prelude checks are now folded into the drafter wrapper before external drafting; successful output is delegated to the postplan wrapper with machine-safe rows. (#4297)
- Clarify fetch and publish side effects moved behind launcher-owned wrappers; operator questions and clarify artifacts are now file-backed and separate from helper stdout. (#4298)
- Shared launcher-safe settle wrapper added for post-rewrite design paths; Gate B, Gate A, and discussion Round 2 prose route through the wrapper contract. (#4316)
- Reviewer timing charts now filter CI and launcher probe rows; axes are sized from displayed rows while preserving table timing windows. (#4300)
- Monitor ban for one-shot completion waits clarified in `/implement` and `/design` docs; the narrow premature-notification recovery path (one immediate-background completion waiter) is now formally defined. (#4296, #4320)
- Closed inherited blockers are now treated as satisfied dependencies rather than permanent close blockers. Fully stale OOS sources have an approval-gated close helper. Deferred combine output carries a stable source-to-combined mapping fragment. (#4321)
