### PR TITLE
Fix design failure report run ID: port source-env SESSION_ID fallback to python stall-recovery

### DIFF
--- a/python/stall_recovery.py
+++ b/python/stall_recovery.py
@@ -1306,10 +1306,44 @@ def _safe_simple_token(value: str, *, fallback: str = "redacted") -> str:
     return value if value and re.fullmatch(r"[A-Za-z0-9._:-]+", value) else fallback
 
 
+def _read_source_env_export(path: Path, key: str) -> str:
+    """Read an ``export KEY=value`` assignment from a shell source-env file.
+
+    Mirrors stall-recovery-report.sh ``source_env_export_get``: only honors a
+    line whose first token is ``export``, strips matching surrounding single or
+    double quotes, and refuses to follow symlinks.
+    """
+    if not path.is_file() or path.is_symlink():
+        return ""
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("export "):
+            continue
+        body = stripped[len("export "):].lstrip()
+        if not body.startswith(f"{key}="):
+            continue
+        value = body[len(key) + 1:]
+        quote = value[:1]
+        if quote in ("'", '"') and value[-1:] == quote:
+            value = value[1:-1]
+        return value
+    return ""
+
+
+def _read_source_env_session_id(tmpdir: Path) -> str:
+    return _read_source_env_export(tmpdir / "source-env.sh", "SESSION_ID")
+
+
 def _read_run_id(tmpdir: Path) -> str:
     value = read_kv(tmpdir / "parent-issue.md", "RUN_ID", "")
     if not value and (tmpdir / "session-id").is_file():
         value = (tmpdir / "session-id").read_text(encoding="utf-8", errors="replace").strip()
+    if not value:
+        value = _read_source_env_session_id(tmpdir)
     return _safe_simple_token(value, fallback="unknown")
 
 


### PR DESCRIPTION
## Summary

Fixes a regression on `main` introduced when PR #4337 (sh-to-py C4c migration of issue #3685) merged on top of #4325.

- #4325 (`d6e969ae5`) added a **source-env `SESSION_ID`** fallback to the bash `stall-recovery-report.sh` `read_run_id`, so design failure/recovery reports carry the `/design` run id.
- #4337's migration had already ported that reader to `python/stall_recovery.py` **before** #4325 existed, so the python `_read_run_id` lacked the fallback.
- The two PRs merged without a textual conflict, but the combined `main` dropped the SESSION_ID run id from `design-failure-report.sh` artifacts (which now call `python/cli.py stall-recovery`), failing `test-design-publish.sh` on `main`.

## Fix

- Add `_read_source_env_export` / `_read_source_env_session_id` to `python/stall_recovery.py`, mirroring the bash `source_env_export_get`: `export`-only lines, surrounding single/double-quote stripping, and symlink refusal.
- Wire it into `_read_run_id` as the final fallback before `unknown`. Both tier-a and tier-b compose surfaces use `_read_run_id`, so both report kinds recover the run id.

## Validation

- `make test-design-publish` passes (the previously-failing source-env SESSION_ID assertions now pass).
- `make test-design-failure-report` passes.
- `python/test_stall_recovery.py` passes (27 tests).
- `ruff check python/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
