### PR TITLE
Release v50.0.11

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "50.0.10",
+  "version": "50.0.11",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel) and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Added

- **`/larch-size` skill** (dev-only): new skill that prints a repository line-count table and a run-logs size breakdown with percentages.

## Changed

- **sh-to-py C4b**: `/implement` Step 2 dispatch (implementer selection, Codex/Cursor launchers, recovery paths, commit-on-behalf) migrated from Bash to Python.
- **sh-to-py C4c**: `/implement` back half (OOS pipeline, stall-recovery, execution-issue ledger, finalize, reports, tracking-issue posting) migrated from Bash to Python.
- **Orphaned-script cleanup**: removed 7 orphaned migration-leftover `scripts/*.sh` files, their companion `.md` docs, agent-lint allowlist entries, and migrated-scripts ledger entries.

## Fixed

- **`/design` Step 5c**: missing or empty `composed-plan.md` is now treated as a recoverable validator defect; `design-publish.sh` no longer exits 5. Prevents `--skip-validate` from bypassing the plan-file precondition.
- **`/design` publish terminal failure**: unrecoverable publish-path failures at `design-publish.sh` are now classified and surfaced correctly instead of being silently dropped.
- **`/design` failure-report run ID**: Python stall-recovery reader now carries the `SESSION_ID` fallback; design failure/recovery reports include the `/design` run ID again (regression introduced by the C4c migration).
- **`/design` and `/implement` final-summary display**: Gantt charts and review-phase detail are emitted as orchestrator chat text rather than via a Bash tool call; structure pins guard against regression.
- **`design-log-publish.sh` sidecar crash**: publish no longer fails when `.token-record` or `.stderr-tail` sidecar files appear under `plan-review/round-*/revise/`.
- **`auto-fix-commands` empty-plan guard**: empty `composed-plan.md` files no longer trigger vendor dispatch; the auto-fix path returns `AUTOFIX_STATUS=unavailable` and `FINAL_VALIDATE_STATUS=empty-target`.
- **`--skip-validate` scope documentation**: `flags.md` now correctly describes that `--skip-validate` skips ordinary Step 5c validator defects but not the plan-file precondition.
- **Step 5c recovery guidance**: clarifies that Override is not offered for missing-composed-plan failures.
- **`launch_review` test coverage**: pytest suite extended; blocking-severity handling and orchestrator-never contract gaps addressed.
