### PR TITLE
Release v50.0.12

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "50.0.11",
+  "version": "50.0.12",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel) and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Fixed

- **Codex plan-review slots now receive the correct working directory.** A tiered resolver (`_resolve_review_codex_workdir`) replaces the naive `Path.cwd()` lookup. When `run_legacy_script` forces CWD to the managed plugin-cache directory (not a git root), the resolver recovers the consumer repo path via `git rev-parse --show-toplevel` or session keepalive metadata. This stops every Codex reviewer slot from failing immediately with "Not inside a trusted directory". ([#4373](https://github.com/character-ai/larch/pull/4373))
