### PR TITLE
Release v50.0.13

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "50.0.12",
+  "version": "50.0.13",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel) and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## What's Changed

### Changed

- **`/design` lifecycle ported from Bash to Python (sh-to-py C3b)**: routing, argv parsing, run-params init, phase drivers, publish/postplan emission, log publishing, final summary, OOS filing, and pause/resume are now handled by Python modules. References to retired shell scripts updated across rules, `SECURITY.md`, `Makefile`, and `agent-lint.toml`. (#4382)
- **OOS filing pipeline redesigned for the Python ship path**: accepted OOS items are now filed by `python/cli.py oos file` before the Python ship driver runs, so OOS evidence is committed into the PR branch before merge. The ship driver retains only the security-sidecar stall; non-security accepted-OOS filing is removed from ship. Terminal reports without OOS evidence now record an explicit `step9a1=false` in the run manifest. The Python/Bash OOS path split is documented and covered with offline tests. (#4383)
- **`/implement` Step 2 post-dispatch work consolidated into one wrapper**: `step-2-post-dispatch.sh` bundles the phantom untracked probe, branch assertion, and optional commit SHA into a single foreground call. Phantom telemetry is always parsed from stdout before branch-failure routing, preserving advisory data on detached-HEAD failures. The new wrapper contract is pinned with structure coverage and a `.md` sibling doc. (#4384)

### Fixed

- **Rebase checkpoint auto-resolves larch-log conflicts**: `rebase-checkpoint-probe.sh` now auto-resolves generated larch-log rebase conflicts inside the checkpoint wrapper and surfaces only remaining non-trivial conflicts. Existing success and failure routing is preserved. Offline harness coverage expanded for larch-log-only, consecutive, mixed, continue-failure, resolve-failure, and empty-conflict paths. (#4380)

**Full Changelog**: https://github.com/character-ai/larch/compare/v50.0.12...v50.0.13
