### PR TITLE
Release v50.0.14

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "50.0.13",
+  "version": "50.0.14",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel) and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Fixed

- **`/design` plan-review provenance** — new plan writes now record `review_status` and `rounds_completed` trailer fields in the `larch:plan` block. A `panel-init-failed` result is a hard stop before Gate C. The `/implement` preflight now refuses plans that carry `panel-init-failed`, `panel-skipped`, or `rounds_completed: 0`. (#4391)
- **`/design` scope anchor** — scope anchor is created and validated before the Step 3 review-panel background launch, preventing review runs against a missing or stale anchor. (#4391)
- **`/design` stale-worktree recovery** — `design-log-publish.sh` retries after cleaning up a stale worktree sharing the same run ID, instead of failing the publish step. (#4391)
- **`/design` failure reporter** — the failure reporter now files an issue on panel failure regardless of `COMPOSE_STATUS`, closing a gap where panel failures were silently swallowed. (#4391)
- **`/design` `mechanical_churn` normalization** — `mechanical_churn:` now accepts numeric values as boolean input, preventing a parse failure on numeric plan output. (#4391)
- **`/design` `feature-description.txt` on replace path** — the feature-description file is now written on the already-planned→replace code path, matching the new-plan path. (#4391)

## Changed

- **New design harness targets** — `test-design-step3-entry` and `test-design-step0-init` added to `test-harnesses-7` and registered as `.PHONY` targets in the Makefile. (#4391)
