### PR TITLE
Release v50.0.15

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "50.0.14",
+  "version": "50.0.15",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel) and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Fixed

- **`/design` lingering shell after completion.** The plan-review loop Step 3 now gates routing on the terminal sentinel `.completed/step-3`. Stale per-round state (`.step3-review-result.env`) is cleared before automatic round continuation so no in-flight waiter can fire on round-1 state.
- **Non-unique `run-1` log directories.** Run-1 log directory names are now unique, preventing collisions when multiple runs share the same directory prefix.
- **`/design` log-publish not committing.** The log-publish flow now commits correctly after flushing the design run log.
- **`/design` Step 3 plan-review and log-publish drift.** Seven drift and correctness items in the Step 3 plan-review and log-publish flows are resolved.

## Changed

- **sh-to-py C1a5: relevant-checks and lint-fix loop migrated to Python.** `scripts/relevant-checks.sh`, `scripts/lint-fix-loop.sh`, `scripts/run-relevant-checks-captured.sh`, `scripts/check-contains-pins.sh`, `scripts/ship-pr.sh`, and their test suites are retired. Their responsibilities are now handled by `python/cli.py checks run-relevant`, `python/cli.py checks lint-fix`, and `python/cli.py ship pr`.
- **sh-to-py C1a4: results collector and retry contracts migrated to Python.** The external-reviewer results collector and retry contracts are now implemented in Python (`python/cli.py agent collect-results`), replacing the prior Bash implementation.
