### PR TITLE
Release v50.1.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "50.0.15",
+  "version": "50.1.0",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel) and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Added

- **`/bug` skill**: new public exported skill that takes a bug description, investigates the repository inline (read-only), and files a detailed GitHub issue via `/issue`. The 10-heading body template covers summary, reproduction scenario, expected and observed behavior, root cause analysis, evidence, affected files, suggested fixes, and open questions. A security triage step aborts public issue filing when the report contains security-sensitive content. File writes are mechanically confined to `/tmp` via the `deny-edit-write.sh` hook. (PR #4418)

## Changed

- **Step 5 review entry consolidated**: the scripted review launcher, anti-halt banner, telemetry mark, and review loop are now emitted from a single entry point, keeping them coupled. The unconditional entry fence was retired and the retired-script manifest updated. (PR #4414)

- **Release Step 7 clarified**: the working-tree upgrade script applies both the just-released sparse allowlist and post-install dev/test cache cleanup using the canonical cache path rather than stable-verification gating. Dropped dev top-level directories from older caches (including `tests/`) are removed during cleanup. (PR #4415)

- **Implement fence-harness and pyright lambda rules**: two new path-triggered rules direct implementers to inspect `scripts/test-implement-fence-shape.sh` when editing implement fences and to use typed helpers or `# type: ignore[arg-type]` suppression for pyright strict-mode monkeypatching in Python tests. (PR #4412)

- **CI test harness shards rebalanced**: Makefile shard targets redistributed to equalize wall-clock time across shards. (PR #4411)

## Fixed

- **Plan-review panel always failing**: the embedded `plan-review-loop.sh` gzip+base64 blob in `python/plan_review.py` still referenced the deleted `scripts/collect-agent-results.sh`. Every `/design` Step 3 plan review was silently recording `COLLECT_OK_COUNT=0` and `LOOP_STATUS=panel-failed` even when all reviewer slots completed successfully. The blob now calls `python/cli.py agent collect-results` directly, and a regression test was added to `python/test_plan_review.py`. (PR #4421)

- **External-tool launch CWD gaps**: the Cursor review `--workspace` argument and the Codex implement `-C` flag in `python/agents.py` were using raw `Path.cwd()`. Under the `run_legacy_script` CWD override those paths resolved to the plugin cache root instead of the consumer repository. Both paths now use the proper workdir resolution. (PR #4420)
