### PR TITLE
docs(rebalance): expose --n-runs via skill invocation

### DIFF
--- a/.claude/skills/rebalance-test-harnesses/SKILL.md
+++ b/.claude/skills/rebalance-test-harnesses/SKILL.md
@@ -52,7 +52,14 @@ Run from the repository root:
 python3 .claude/skills/rebalance-test-harnesses/scripts/rebalance.py [flags]
 ```
 
-Or invoke via this skill, which will call the script via Bash.
+Or invoke via this skill and pass flags directly to the script:
+
+```
+/rebalance-test-harnesses --n-runs 1
+/rebalance-test-harnesses --n-runs 3 --repo owner/name
+```
+
+Forward all args from the skill invocation to the script unchanged.
 
 ## Flags
 


### PR DESCRIPTION
## Summary

- Closes #4437
- Updates the **How to invoke** section of the `/rebalance-test-harnesses` SKILL.md
- Makes explicit that flags (e.g. `--n-runs 1`) are forwarded to the script unchanged
- No Makefile, script logic, or test changes

## Test plan

- [ ] Invoke `/rebalance-test-harnesses --n-runs 1` and confirm the script receives `--n-runs 1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)