### PR TITLE
Release v50.1.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "50.1.0",
+  "version": "50.1.1",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel) and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Fixed

- Repaired the `/design` Step 3 review loop subprocess and same-turn recovery ([#4441](https://github.com/character-ai/larch/pull/4441))

## Changed

- Ported plan-review tally computation to in-process Python, replacing a shell subprocess ([#4432](https://github.com/character-ai/larch/pull/4432))
- Rebalanced CI test harness shards to equalize wall-clock time across the 20 shards ([#4428](https://github.com/character-ai/larch/pull/4428))
- Documented `--n-runs` exposure via the `rebalance-test-harnesses` skill invocation ([#4438](https://github.com/character-ai/larch/pull/4438))
