### PR TITLE
ci: matrix gate jobs (test-harnesses, python-tests) + ship driver skips pre-PR local checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -299,6 +299,22 @@ jobs:
       - name: Run test harnesses (shard ${{ matrix.shard }} of 20)
         run: make test-harnesses-${{ matrix.shard }}
 
+  # Aggregate gate so branch protection can require the whole test-harnesses
+  # matrix via one stable check, regardless of shard count.
+  # needs.<job>.result is 'success' only when every matrix leg succeeded;
+  # `if: always()` ensures this job still runs (and reports failure) when a
+  # shard fails, instead of being skipped (a skipped required check passes).
+  test-harnesses-gate:
+    name: test-harnesses-gate
+    needs: [test-harnesses]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require all test-harnesses shards to pass
+        run: |
+          result="${{ needs.test-harnesses.result }}"
+          [ "$result" = success ] || { echo "::error::test-harnesses result=$result"; exit 1; }
+
   # agent-lint and agnix consolidated into one job so both run sequentially
   # on a single runner instead of competing for two.
   agent-lint:
@@ -597,6 +613,19 @@ jobs:
           PYTEST_SHARD_ID: ${{ matrix.shard }}
           PYTEST_SHARD_COUNT: "4"
         run: make py-test
+
+  # Aggregate gate for the python-tests matrix (see test-harnesses-gate for the
+  # rationale: one stable required check independent of shard count).
+  python-tests-gate:
+    name: python-tests-gate
+    needs: [python-tests]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require all python-tests shards to pass
+        run: |
+          result="${{ needs.python-tests.result }}"
+          [ "$result" = success ] || { echo "::error::python-tests result=$result"; exit 1; }
 
   # Bash 3.2 conformance check. macOS ships /bin/bash at 3.2.57 (Apple
   # keeps the GPLv2-era bash frozen). Runs bash -n (syntax-only, no

--- a/python/ci_monitor.py
+++ b/python/ci_monitor.py
@@ -650,6 +650,11 @@ def classify_failed_jobs(jobs: tuple[FailedJob, ...]) -> ClassifiedJobs:
         if not sanitized:
             continue
         name, shard, malformed = _parse_job_name_shard(sanitized)
+        # Aggregator gate jobs (e.g. test-harnesses-gate) mirror their matrix and
+        # have no local fix; skip them so a redundant gate failure does not force
+        # local-unfixable when the underlying matrix leg is fixable.
+        if name.endswith("-gate"):
+            continue
         if malformed or not _JOB_NAME_RE.match(name):
             row = JobClass(name=name, shard=shard, klass="no-local-equivalent")
         elif name in config.CI_FIXABLE_JOBS:

--- a/python/ship.py
+++ b/python/ship.py
@@ -48,7 +48,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, TextIO, cast
 
-import checks
 import ci_monitor
 import config
 import file_oos
@@ -1194,8 +1193,6 @@ def run_ship(
             return ShipResult(Outcome.STALLED, detail="invalid tmpdir")
         if not _state_file_under_tmpdir(ctx):
             return ShipResult(Outcome.STALLED, detail="invalid state_file")
-        codex_present = ctx.codex_present or bool(os.environ.get("CODEX") or os.environ.get("CODEX_HOME") or ctx.tool_label == "codex")
-        cursor_present = ctx.cursor_present or bool(os.environ.get("CURSOR") or os.environ.get("CURSOR_AUTH_ARGS") or ctx.tool_label == "cursor")
         base_ref = "main"
         resume = _resume_plan(ctx, runner, cwd=repo_root)
         if resume.start == "blocked-rebase-continuation":
@@ -1255,37 +1252,10 @@ def run_ship(
 
         if resume.start == "fresh":
             fresh_context = _hydrate_fresh_context(ctx, resume)
-            _write_ship_state(
-                fresh_context,
-                phase="checks",
-                iteration=resume.iteration,
-                rebase_count=resume.rebase_count,
-                fix_attempts=resume.fix_attempts,
-                transient_retries=resume.transient_retries,
-            )
-            _breadcrumb("checks", "Lint&Tests")
-            checks_result = checks.run_checks_phase(
-                runner,
-                tmpdir=fresh_context.tmpdir,
-                repo_root=repo_root,
-                codex_present=codex_present,
-                cursor_present=cursor_present,
-                site="step6",
-                checks_site="step6",
-                fix_site="ship-pr-ci-initial",
-            )
-            if checks_result.outcome is not Outcome.OK:
-                _write_terminal_state(
-                    fresh_context,
-                    checks_result.outcome,
-                    checks_result.detail or "checks",
-                    iteration=resume.iteration,
-                    rebase_count=resume.rebase_count,
-                    fix_attempts=resume.fix_attempts,
-                    transient_retries=resume.transient_retries,
-                )
-                return _step_result_to_ship(checks_result)
-
+            # Upfront local lint/tests phase removed by request: open the PR
+            # immediately and let CI surface failures (no pre-PR `make py-test`
+            # / relevant-checks run). The post-CI fix path is unaffected; only
+            # this fresh-run pre-PR checks gate is skipped.
             _write_ship_state(
                 fresh_context,
                 phase="pr-prep",

--- a/python/test_ci_monitor.py
+++ b/python/test_ci_monitor.py
@@ -922,6 +922,21 @@ def test_classify_failed_jobs_matrix_and_fixable() -> None:
     assert classified.unfixable[0].name == "gitleaks"
 
 
+def test_classify_failed_jobs_excludes_aggregator_gates() -> None:
+    # Gate jobs (e.g. test-harnesses-gate) mirror their matrix and have no local
+    # fix; they are excluded from the count and from both buckets so a redundant
+    # gate failure does not force local-unfixable.
+    jobs = (
+        FailedJob(name="test-harnesses-gate", conclusion="failure"),
+        FailedJob(name="lint", conclusion="failure"),
+        FailedJob(name="python-tests-gate", conclusion="failure"),
+    )
+    classified = ci_monitor.classify_failed_jobs(jobs)
+    assert classified.count == 1
+    assert [j.name for j in classified.fixable] == ["lint"]
+    assert not classified.unfixable
+
+
 def test_collect_failed_logs_redacts_tail() -> None:
     secret = "ghp_" + "A" * 40
     log_body = f"failed step\n{secret}\n"

--- a/python/test_ship.py
+++ b/python/test_ship.py
@@ -66,11 +66,6 @@ def test_happy_path_stage_order(
     flush_args: list[tuple[str | None, str | None]] = []
 
     monkeypatch.setattr(
-        ship.checks,
-        "run_checks_phase",
-        lambda *_a, **_k: order.append("checks") or StepResult(Outcome.OK),
-    )
-    monkeypatch.setattr(
         ship.finalize,
         "postbump",
         lambda *_a, **_k: order.append("postbump") or type("R", (), {"outcome": Outcome.OK})(),
@@ -131,7 +126,6 @@ def test_happy_path_stage_order(
     result = ship.run_ship(_ctx(tmp_path), runner=RecordingRunner(), cwd=str(tmp_path))
     assert result.outcome is Outcome.OK
     assert order == [
-        "checks",
         "flush-pre",
         "postbump",
         "pr-body",
@@ -147,7 +141,7 @@ def test_happy_path_stage_order(
     assert order.count("merge") == 1
     assert flush_args == [(None, str(tmp_path))]
     captured = capsys.readouterr()
-    assert "ship.py: checks:" in captured.err
+    assert "ship.py: pr-prep:" in captured.err
     assert "ship.py: pr-prep:" in captured.err
     assert "ship.py: pr-create:" in captured.err
     assert "ship.py: ci:" not in captured.err
@@ -169,7 +163,6 @@ def test_merge_review_required_exits_as_needs_user_input(
             {"result": config.MERGE_RESULT_REVIEW_REQUIRED, "error": "needs review"},
         )()
 
-    monkeypatch.setattr(ship.checks, "run_checks_phase", lambda *_a, **_k: StepResult(Outcome.OK))
     monkeypatch.setattr(ship.finalize, "postbump", lambda *_a, **_k: type("R", (), {"outcome": Outcome.OK})())
     monkeypatch.setattr(ship.pr_body, "compose_pr_body", lambda **_k: "body")
     monkeypatch.setattr(
@@ -209,7 +202,6 @@ def test_merge_loop_iteration_cap_stalls(
     tmp_path: Path,
 ) -> None:
     monkeypatch.setattr(config, "SHIP_MERGE_LOOP_MAX_ITERATIONS", 2)
-    monkeypatch.setattr(ship.checks, "run_checks_phase", lambda *_a, **_k: StepResult(Outcome.OK))
     monkeypatch.setattr(ship.finalize, "postbump", lambda *_a, **_k: type("R", (), {"outcome": Outcome.OK})())
     monkeypatch.setattr(ship.pr_body, "compose_pr_body", lambda **_k: "body")
     monkeypatch.setattr(
@@ -279,7 +271,6 @@ DRAFT=false
     def forbidden(*_args: object, **_kwargs: object) -> object:
         raise AssertionError("fresh-only phase must not run on open-pr resume")
 
-    monkeypatch.setattr(ship.checks, "run_checks_phase", forbidden)
     monkeypatch.setattr(ship.finalize, "postbump", forbidden)
     monkeypatch.setattr(ship.run_logs, "write_final_report_comment", forbidden)
     monkeypatch.setattr(ship.git, "current_branch", lambda *_a, **_k: "feat")
@@ -370,7 +361,6 @@ def test_resume_branch_mismatch_safe_refuses_without_fresh_work(
     def forbidden(*_args: object, **_kwargs: object) -> object:
         raise AssertionError("fresh work must not run after checkout mismatch")
 
-    monkeypatch.setattr(ship.checks, "run_checks_phase", forbidden)
     monkeypatch.setattr(ship.pr, "ensure_pr", forbidden)
 
     result = ship.run_ship(_ctx(tmp_path, state_file=str(state_file)), runner=RecordingRunner(), cwd=str(tmp_path))
@@ -555,7 +545,6 @@ def test_open_pr_resume_wrong_head_routes_through_fresh_checks(
         "pr_view",
         lambda *_a, **_k: type("PR", (), {"number": 7, "url": "https://example.test/pr/7", "state": "OPEN", "head_ref": "other"})(),
     )
-    monkeypatch.setattr(ship.checks, "run_checks_phase", lambda *_a, **_k: calls.append("checks") or StepResult(Outcome.OK))
     monkeypatch.setattr(
         ship.finalize,
         "postbump",
@@ -573,7 +562,7 @@ def test_open_pr_resume_wrong_head_routes_through_fresh_checks(
     result = ship.run_ship(_ctx(tmp_path, state_file=str(state_file)), runner=RecordingRunner(), cwd=str(tmp_path))
 
     assert result.outcome is Outcome.OK
-    assert calls == ["checks", "postbump"]
+    assert calls == ["postbump"]
 
 
 def test_non_forked_main_resume_refuses(
@@ -606,8 +595,7 @@ def test_closed_unmerged_pr_routes_through_fresh_checks(
         "pr_view",
         lambda *_a, **_k: type("PR", (), {"number": 7, "url": "https://example.test/pr/7", "state": "CLOSED", "head_ref": "feat"})(),
     )
-    monkeypatch.setattr(ship.checks, "run_checks_phase", lambda *_a, **_k: calls.append("checks") or StepResult(Outcome.OK))
-    monkeypatch.setattr(ship.finalize, "postbump", lambda *_a, **_k: type("R", (), {"outcome": Outcome.OK})())
+    monkeypatch.setattr(ship.finalize, "postbump", lambda *_a, **_k: calls.append("postbump") or type("R", (), {"outcome": Outcome.OK})())
     monkeypatch.setattr(ship.pr_body, "compose_pr_body", lambda **_k: "body")
     monkeypatch.setattr(ship.git, "log_subject", lambda *_a, **_k: "Implement driver")
     monkeypatch.setattr(
@@ -619,7 +607,7 @@ def test_closed_unmerged_pr_routes_through_fresh_checks(
     result = ship.run_ship(_ctx(tmp_path, state_file=str(state_file)), runner=RecordingRunner(), cwd=str(tmp_path))
 
     assert result.outcome is Outcome.OK
-    assert calls == ["checks"]
+    assert calls == ["postbump"]
 
 
 def test_invalid_pr_identity_routes_through_fresh_checks_without_github(
@@ -634,8 +622,7 @@ def test_invalid_pr_identity_routes_through_fresh_checks_without_github(
     calls: list[str] = []
     monkeypatch.setattr(ship.git, "current_branch", lambda *_a, **_k: "feat")
     monkeypatch.setattr(ship.gh, "pr_view", lambda *_a, **_k: (_ for _ in ()).throw(AssertionError("gh forbidden")))
-    monkeypatch.setattr(ship.checks, "run_checks_phase", lambda *_a, **_k: calls.append("checks") or StepResult(Outcome.OK))
-    monkeypatch.setattr(ship.finalize, "postbump", lambda *_a, **_k: type("R", (), {"outcome": Outcome.OK})())
+    monkeypatch.setattr(ship.finalize, "postbump", lambda *_a, **_k: calls.append("postbump") or type("R", (), {"outcome": Outcome.OK})())
     monkeypatch.setattr(ship.pr_body, "compose_pr_body", lambda **_k: "body")
     monkeypatch.setattr(ship.git, "log_subject", lambda *_a, **_k: "Implement driver")
     monkeypatch.setattr(
@@ -647,7 +634,7 @@ def test_invalid_pr_identity_routes_through_fresh_checks_without_github(
     result = ship.run_ship(_ctx(tmp_path, state_file=str(state_file)), runner=RecordingRunner(), cwd=str(tmp_path))
 
     assert result.outcome is Outcome.OK
-    assert calls == ["checks"]
+    assert calls == ["postbump"]
 
 
 def test_stale_merged_flags_with_open_pr_resume_open_path(
@@ -706,7 +693,6 @@ def test_repo_unavailable_blank_pr_open_resume_skips_fresh_work(
     state_file = tmp_path / "ship-pr-state.sh"
     _ = state_file.write_text("PHASE=ci-initial\nBRANCH_NAME=feat\nREPO=o/r\nREPO_UNAVAILABLE=true\nMERGE=false\n", encoding="utf-8")
     monkeypatch.setattr(ship.git, "current_branch", lambda *_a, **_k: "feat")
-    monkeypatch.setattr(ship.checks, "run_checks_phase", lambda *_a, **_k: (_ for _ in ()).throw(AssertionError("checks forbidden")))
     monkeypatch.setattr(ship.finalize, "postbump", lambda *_a, **_k: (_ for _ in ()).throw(AssertionError("postbump forbidden")))
     monkeypatch.setattr(ship.pr_body, "compose_pr_body", lambda **_k: "body")
     monkeypatch.setattr(ship.git, "log_subject", lambda *_a, **_k: "Implement driver")
@@ -727,7 +713,6 @@ def test_fresh_postmerge_stall_preserves_postmerge_phase(
     tmp_path: Path,
 ) -> None:
     state_file = tmp_path / "ship-pr-state.sh"
-    monkeypatch.setattr(ship.checks, "run_checks_phase", lambda *_a, **_k: StepResult(Outcome.OK))
     monkeypatch.setattr(ship.finalize, "postbump", lambda *_a, **_k: type("R", (), {"outcome": Outcome.OK})())
     monkeypatch.setattr(ship.pr_body, "compose_pr_body", lambda **_k: "body")
     monkeypatch.setattr(ship.git, "log_subject", lambda *_a, **_k: "Implement driver")
@@ -855,7 +840,7 @@ def test_terminal_state_uses_canonical_stalled_phase(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    monkeypatch.setattr(ship.checks, "run_checks_phase", lambda *_a, **_k: StepResult(Outcome.STALLED, "detail with spaces"))
+    monkeypatch.setattr(ship.finalize, "postbump_preflight", lambda *_a, **_k: (_ for _ in ()).throw(Stalled("detail with spaces")))
     state_file = tmp_path / "ship-pr-state.sh"
 
     result = ship.run_ship(_ctx(tmp_path, state_file=str(state_file)), runner=RecordingRunner(), cwd=str(tmp_path))
@@ -1079,7 +1064,7 @@ def test_run_ship_infrastructure_state_read_error_surfaces_internal_error(
     def raise_infra(*_args: object, **_kwargs: object) -> StepResult:
         raise ShipError("cannot read existing ship state: /tmp/state")
 
-    monkeypatch.setattr(ship.checks, "run_checks_phase", raise_infra)
+    monkeypatch.setattr(ship.finalize, "postbump_preflight", raise_infra)
 
     result = ship.run_ship(_ctx(tmp_path, state_file=str(state_file)), runner=RecordingRunner(), cwd=str(tmp_path))
 
@@ -1349,7 +1334,9 @@ def test_fresh_fallback_hydrates_modes_and_preserves_counters(
     )
     monkeypatch.setattr(ship.git, "current_branch", lambda *_a, **_k: "feat")
     monkeypatch.setattr(ship.gh, "pr_view", lambda *_a, **_k: (_ for _ in ()).throw(ShipError("gh down")))
-    monkeypatch.setattr(ship.checks, "run_checks_phase", lambda *_a, **_k: StepResult(Outcome.STALLED, "checks failed"))
+    monkeypatch.setattr(ship.finalize, "postbump_preflight", lambda *_a, **_k: ship.finalize.PostbumpPreflight(ok=True))
+    monkeypatch.setattr(ship.run_logs, "flush_logs_pre", lambda *_a, **_k: run_logs.RefreshSkip(skipped=False, reason=""))
+    monkeypatch.setattr(ship.finalize, "postbump", lambda *_a, **_k: type("R", (), {"outcome": Outcome.STALLED, "status": "stalled", "detail": "postbump failed"})())
 
     result = ship.run_ship(
         _ctx(tmp_path, merge=True, draft=False, pr_number=99, pr_url="stale-url", state_file=str(state_file)),
@@ -1683,12 +1670,12 @@ def test_run_ship_catches_ship_error_as_stalled(
     tmp_path: Path,
 ) -> None:
     def raise_ship_error(*_a: object, **_k: object) -> StepResult:
-        raise ShipError("checks failed operationally")
+        raise ShipError("postbump failed operationally")
 
-    monkeypatch.setattr(ship.checks, "run_checks_phase", raise_ship_error)
+    monkeypatch.setattr(ship.finalize, "postbump_preflight", raise_ship_error)
     result = ship.run_ship(_ctx(tmp_path), runner=RecordingRunner(), cwd=str(tmp_path))
     assert result.outcome is Outcome.STALLED
-    assert result.detail == "checks failed operationally"
+    assert result.detail == "postbump failed operationally"
 
 
 def test_main_emits_json_stdout_and_breadcrumb_stderr(
@@ -1779,7 +1766,6 @@ def test_ci_fix_rebase_pending_survives_head_mismatch(
         encoding="utf-8",
     )
     ctx = _ctx(tmp_path, state_file=str(state), ci_fix_rebase_pending=True)
-    monkeypatch.setattr(ship.checks, "run_checks_phase", lambda *_a, **_k: StepResult(Outcome.OK))
     monkeypatch.setattr(ship.finalize, "postbump_preflight", lambda *_a, **_k: ship.finalize.PostbumpPreflight(ok=True))
     monkeypatch.setattr(ship.finalize, "postbump", lambda *_a, **_k: type("R", (), {"outcome": Outcome.OK})())
     monkeypatch.setattr(ship.pr_body, "compose_pr_body", lambda **_k: "body")
@@ -1796,7 +1782,7 @@ def test_ci_fix_rebase_pending_survives_head_mismatch(
     written: list[str] = []
 
     def capture_state(ctx_arg: RunContext, **kwargs: object) -> None:
-        if kwargs.get("phase") == "checks":
+        if kwargs.get("phase") == "pr-prep":
             written.append("true" if ctx_arg.ci_fix_rebase_pending else "false")
 
     monkeypatch.setattr(ship, "_write_ship_state", capture_state)
@@ -2233,7 +2219,6 @@ def test_main_ensure_pr_stall_creates_finalize_state(
 ) -> None:
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(ship.logging_util, "quiet_init", lambda **_: None)
-    monkeypatch.setattr(ship.checks, "run_checks_phase", lambda *_a, **_k: StepResult(Outcome.OK))
     monkeypatch.setattr(ship.finalize, "postbump_preflight", lambda *_a, **_k: ship.finalize.PostbumpPreflight(ok=True))
     monkeypatch.setattr(ship.finalize, "postbump", lambda *_a, **_k: type("R", (), {"outcome": Outcome.OK})())
     monkeypatch.setattr(ship.pr_body, "compose_pr_body", lambda **_k: "body")
@@ -2401,7 +2386,6 @@ def test_postmerge_flush_skip_writes_stall_shape(monkeypatch: pytest.MonkeyPatch
 
 def test_postbump_stall_writes_terminal_finalize(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     state_file = tmp_path / "ship-pr-state.sh"
-    monkeypatch.setattr(ship.checks, "run_checks_phase", lambda *_a, **_k: StepResult(Outcome.OK))
     monkeypatch.setattr(ship.finalize, "postbump_preflight", lambda *_a, **_k: ship.finalize.PostbumpPreflight(ok=True))
     monkeypatch.setattr(
         ship.finalize,
@@ -2423,26 +2407,13 @@ def test_postbump_stall_writes_terminal_finalize(monkeypatch: pytest.MonkeyPatch
 
 
 
-def test_checks_stall_writes_terminal_finalize_state(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    state_file = tmp_path / "ship-pr-state.sh"
-    monkeypatch.setattr(ship.checks, "run_checks_phase", lambda *_a, **_k: StepResult(Outcome.STALLED, "checks"))
-
-    result = ship.run_ship(_ctx(tmp_path, state_file=str(state_file)), runner=RecordingRunner(), cwd=str(tmp_path))
-
-    assert result.outcome is Outcome.STALLED
-    finalize_state = ship.finalize.read_finalize_state(tmp_path / "finalize-state.sh")
-    assert finalize_state["STALL_TRACKING"] == "true"
-    assert finalize_state["EXIT_CODE"] == "4"
-    assert "STALL_TRACKING=true\n" in state_file.read_text(encoding="utf-8")
-
-
 def test_outer_stalled_exception_writes_terminal_state(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     state_file = tmp_path / "ship-pr-state.sh"
 
     def raise_stalled(*_a: object, **_k: object) -> StepResult:
         raise Stalled("outer stalled path")
 
-    monkeypatch.setattr(ship.checks, "run_checks_phase", raise_stalled)
+    monkeypatch.setattr(ship.finalize, "postbump_preflight", raise_stalled)
 
     result = ship.run_ship(_ctx(tmp_path, state_file=str(state_file)), runner=RecordingRunner(), cwd=str(tmp_path))
 
@@ -2458,7 +2429,6 @@ def test_outer_stalled_exception_writes_terminal_state(monkeypatch: pytest.Monke
 # ---------------------------------------------------------------------------
 
 def _patch_fresh_path_pre_pr_create(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(ship.checks, "run_checks_phase", lambda *_a, **_k: StepResult(Outcome.OK))
     monkeypatch.setattr(ship.finalize, "postbump_preflight", lambda *_a, **_k: ship.finalize.PostbumpPreflight(ok=True))
     monkeypatch.setattr(ship.run_logs, "flush_logs_pre", lambda *_a, **_k: run_logs.RefreshSkip(skipped=False, reason=""))
     monkeypatch.setattr(ship.finalize, "postbump", lambda *_a, **_k: type("R", (), {"outcome": Outcome.OK})())

--- a/scripts/ci-failed-jobs.md
+++ b/scripts/ci-failed-jobs.md
@@ -71,6 +71,12 @@ Fixable jobs are `lint`, `lint-mermaid`, `shellcheck`, `test-harnesses`,
 `agent-lint`, `agnix`, and `agent-sync`. `gitleaks` and
 `trufflehog` are `no-local-equivalent` because CI runs history scans.
 
+Aggregator gate jobs (names ending in `-gate`, e.g. `test-harnesses-gate`)
+are excluded from classification entirely: not counted, not emitted as
+fixable or unfixable, and no TSV row. They mirror their matrix and have no
+local fix, so the underlying matrix leg carries the real fix signal.
+`ci_monitor.py classify_failed_jobs` applies the same exclusion.
+
 Matrix names of the form `test-harnesses (7)` normalize to
 `JOB_NAME=test-harnesses` and `SLICE=7`. Non-digit slice text is ignored, so
 `test-harnesses (abc)` falls back to the unsharded local target. Job names must

--- a/scripts/ci-failed-jobs.sh
+++ b/scripts/ci-failed-jobs.sh
@@ -100,6 +100,12 @@ job_re='^[A-Za-z][A-Za-z0-9_-]*$'
 while IFS= read -r raw_name || [ -n "$raw_name" ]; do
     raw_name=$(printf '%s' "$raw_name" | sanitize_diagnostic_line)
     [ -n "$raw_name" ] || continue
+    # Aggregator gate jobs (e.g. test-harnesses-gate) mirror their matrix and
+    # have no local fix; the underlying leg carries the real fix signal. Skip
+    # them so they are neither counted nor classified as fixable/unfixable.
+    case "$raw_name" in
+        *-gate) continue ;;
+    esac
     count=$((count + 1))
 
     job_name=$raw_name

--- a/scripts/test-ci-failed-jobs.sh
+++ b/scripts/test-ci-failed-jobs.sh
@@ -211,6 +211,25 @@ else
     fail "all-control job name emitted $tsv_rows TSV rows"
 fi
 
+# Aggregator gate jobs (e.g. test-harnesses-gate) are excluded from
+# classification entirely: not counted, not fixable/unfixable, no TSV row.
+T_GATE="$TMPROOT/t_gate"
+mkdir -p "$T_GATE"
+write_subject "$T_GATE"
+write_gh_lines "$T_GATE"
+write_lines_file "$T_GATE/lines.txt" "test-harnesses-gate" "lint" "python-tests-gate"
+GH_MODE=lines
+GH_LINES_FILE="$T_GATE/lines.txt"
+rc=$(run_subject "$T_GATE" "$T_GATE/out" "$T_GATE/err" "$T_GATE/jobs.tsv")
+assert_rc "gate jobs excluded exits 0" "$rc" 0
+assert_file_contains "gate jobs excluded from count" "$T_GATE/out" "FAILED_JOBS_COUNT=1"
+assert_file_contains "gate jobs leave only lint fixable" "$T_GATE/out" "FAILED_JOBS_FIXABLE=lint"
+if grep -q -- '-gate' "$T_GATE/jobs.tsv"; then
+    fail "gate jobs must not appear in classification TSV"
+else
+    ok "gate jobs absent from classification TSV"
+fi
+
 workflow_jobs=$(awk '
     /^jobs:$/ { in_jobs=1; next }
     in_jobs && /^[a-zA-Z_][a-zA-Z0-9_-]*:/ { exit }
@@ -220,6 +239,9 @@ for job in $workflow_jobs; do
     case "$job" in
         lint|lint-local|lint-mermaid|shellcheck|test-harnesses|agent-lint|agent-sync|gitleaks|python-lint|python-tests|bash32-check)
             ok "workflow job mapped: $job"
+            ;;
+        *-gate)
+            ok "workflow job mapped (aggregator gate, excluded from classification): $job"
             ;;
         *)
             fail "workflow job missing from ci-failed-jobs mapping: $job"


### PR DESCRIPTION
## Summary

Two related changes (bundled per request):

**1. CI matrix gate jobs.** Adds `test-harnesses-gate` and `python-tests-gate` — aggregate jobs that `needs:` their matrix and pass only when every leg succeeds (`if: always()` so a failed or skipped leg is reported, not silently passed). This lets branch protection require each matrix via **one stable check**, independent of shard count, instead of pinning every expanded leg.

**2. Ship driver skips pre-PR local checks.** `python/ship.py` no longer runs the upfront local lint/tests phase on a fresh run. It creates the PR immediately and relies on CI to surface failures. The post-CI fix path is unchanged.

## Details

- Removes the now-unused `import checks` and the codex/cursor presence locals from `ship.py`.
- `test_ship.py`: re-points the former checks-phase stall/raise triggers to `postbump_preflight` (same outer handlers), deletes the checks-only test, and tracks the fresh path via `postbump`.

## Validation

- `make py-lint`: clean (ruff, pylint 10/10, pyright 0 errors)
- `make py-test`: 2818 passed, 20 skipped
- `actionlint .github/workflows/ci.yaml`: clean
- `test_ship.py`: 105 passed

## Follow-up (after merge, not in this PR)

The "CI and branch safety" ruleset can swap the 24 individual `test-harnesses (N)` / `python-tests (3.11, N)` pins for the 2 gate checks. Required checks can't reference the gates until they've run on `main` at least once, so this must happen after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
