### PR TITLE
Release v50.1.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "50.1.1",
+  "version": "50.1.2",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel) and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## What's Changed in v50.1.2

### Fixed

- **`--self-review` now shows review counts in final reports.** When `/implement --self-review` ran, the final report showed `Code review: N/A` even though inline review completed. The tally is now written at self-review completion so the report reflects the actual result (`self-review: 0 findings` when clean). ([#4424](https://github.com/character-ai/larch/issues/4424), [#4444](https://github.com/character-ai/larch/pull/4444))

- **`hook-bg-poll-guard.sh` unblocks reads after `design-step5c` and `design-step-final-summary` complete.** When the same-turn premature-notification race fired for either of those steps, `marker_step_completed` returned `1` (no matching case), so the guard stayed active indefinitely and blocked all Bash and Read calls on the session directory. The two missing sentinel cases are now handled. ([#4450](https://github.com/character-ai/larch/issues/4450), [#4457](https://github.com/character-ai/larch/pull/4457))

### Changed

- **`/design` apply-agent and `/review` round-2+ panels are now Cursor-first.** The unified-diff waterfall order changes from `codex → cursor → claude` to `cursor → codex → claude`. The round-2+ generic Codex reviewer is removed; Codex remains available as a fallback through normal waterfall when Cursor fails. ([#4396](https://github.com/character-ai/larch/issues/4396), [#4448](https://github.com/character-ai/larch/pull/4448))

- **CI matrix gating added for `test-harnesses` and `python-tests` jobs.** Both jobs now run as matrix gates. The ship driver skips pre-PR local checks. ([#4449](https://github.com/character-ai/larch/pull/4449))

- **CI test harness shards rebalanced.** The slowest harness targets are redistributed across shards to reduce wall-clock time for the `test-harnesses` CI job. ([#4453](https://github.com/character-ai/larch/pull/4453))

### Added

- **Python test suite now runs in parallel shards in CI.** A new `pytest_sharding.py` module and `conftest.py` hook shard collected tests by index via `PYTEST_SHARD_ID`/`PYTEST_SHARD_COUNT`. The `python-tests` CI job runs 4 shards in parallel. `make py-test` gains `--durations=0` to emit per-test timing for future rebalancing. ([#4407](https://github.com/character-ai/larch/issues/4407), [#4440](https://github.com/character-ai/larch/pull/4440))
