### PR TITLE
Fixes #4452: dirty-tree false positives in Cursor plan review

### DIFF
--- a/python/agents.py
+++ b/python/agents.py
@@ -3303,12 +3303,14 @@ def _review_capture_cursor_dirty_baseline(output: Path) -> Path:
     ):
         with contextlib.suppress(FileNotFoundError):
             stale.unlink()
-    git.snapshot_untracked(proc, str(baseline), nul=True)
+    workdir = _resolve_review_codex_workdir(str(Path.cwd()))
+    git.snapshot_untracked(proc, str(baseline), nul=True, cwd=workdir)
     return baseline
 
 
 def _review_write_cursor_dirty_tree_from_baseline(output: Path, baseline: Path) -> None:
-    lines = dirty_tree.baseline(baseline_path=str(baseline), sidecar=str(output.with_suffix(output.suffix + ".dirty-tree")))
+    workdir = _resolve_review_codex_workdir(str(Path.cwd()))
+    lines = dirty_tree.baseline(baseline_path=str(baseline), sidecar=str(output.with_suffix(output.suffix + ".dirty-tree")), cwd=workdir)
     _write(output.with_suffix(output.suffix + ".dirty-tree"), "\n".join(lines) + "\n")
 
 

--- a/python/dirty_tree.py
+++ b/python/dirty_tree.py
@@ -22,9 +22,9 @@ def _valid_meta_path(value: str) -> bool:
     return bool(value) and _META_PATH_RE.fullmatch(value) is not None
 
 
-def _run_bytes(argv: list[str]) -> tuple[int, bytes]:
+def _run_bytes(argv: list[str], cwd: str | None = None) -> tuple[int, bytes]:
     try:
-        completed = subprocess.run(argv, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, check=False)
+        completed = subprocess.run(argv, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, check=False, cwd=cwd)
     except OSError:
         return 127, b""
     return completed.returncode, completed.stdout
@@ -74,9 +74,9 @@ def _publish(lines: list[str], sidecar: str = "") -> None:
         _ = _write_atomic(Path(sidecar), text.encode())
 
 
-def checkpoint(*, sidecar: str = "") -> list[str]:
+def checkpoint(*, sidecar: str = "", cwd: str | None = None) -> list[str]:
     _ = sidecar
-    rc, status = _run_bytes(["git", "status", "--porcelain"])
+    rc, status = _run_bytes(["git", "status", "--porcelain"], cwd=cwd)
     if rc != 0:
         return _result_lines(status="unknown", mode="checkpoint", reason="git-status-failed")
     if status:
@@ -84,7 +84,7 @@ def checkpoint(*, sidecar: str = "") -> list[str]:
     return _result_lines(status="clean", mode="checkpoint")
 
 
-def baseline(*, baseline_path: str, sidecar: str = "") -> list[str]:
+def baseline(*, baseline_path: str, sidecar: str = "", cwd: str | None = None) -> list[str]:
     if sidecar and not _valid_meta_path(sidecar):
         return _result_lines(
             status="unknown",
@@ -100,16 +100,16 @@ def baseline(*, baseline_path: str, sidecar: str = "") -> list[str]:
             baseline_state="missing",
         )
 
-    rc, _status = _run_bytes(["git", "status", "--porcelain"])
+    rc, _status = _run_bytes(["git", "status", "--porcelain"], cwd=cwd)
     if rc != 0:
         return _result_lines(status="unknown", mode="baseline", reason="git-status-failed", baseline_state="missing")
-    rc, unstaged = _run_bytes(["git", "diff", "--name-only", "-z"])
+    rc, unstaged = _run_bytes(["git", "diff", "--name-only", "-z"], cwd=cwd)
     if rc != 0:
         return _result_lines(status="unknown", mode="baseline", reason="git-diff-failed", baseline_state="missing")
-    rc, staged = _run_bytes(["git", "diff", "--name-only", "--cached", "-z"])
+    rc, staged = _run_bytes(["git", "diff", "--name-only", "--cached", "-z"], cwd=cwd)
     if rc != 0:
         return _result_lines(status="unknown", mode="baseline", reason="git-diff-cached-failed", baseline_state="missing")
-    rc, current_untracked = _run_bytes(["git", "ls-files", "--others", "--exclude-standard", "-z"])
+    rc, current_untracked = _run_bytes(["git", "ls-files", "--others", "--exclude-standard", "-z"], cwd=cwd)
     if rc != 0:
         return _result_lines(status="unknown", mode="baseline", reason="git-ls-files-failed", baseline_state="missing")
 

--- a/python/test_dirty_tree.py
+++ b/python/test_dirty_tree.py
@@ -82,7 +82,7 @@ def test_bad_baseline_path_status_unknown() -> None:
 def test_baseline_rejects_bad_sidecar_path_without_writing(monkeypatch, tmp_path) -> None:
     calls: list[list[str]] = []
 
-    def fake_run_bytes(argv: list[str]) -> tuple[int, bytes]:
+    def fake_run_bytes(argv: list[str], **_kwargs: object) -> tuple[int, bytes]:
         calls.append(argv)
         return 0, b""
 
@@ -95,7 +95,7 @@ def test_baseline_rejects_bad_sidecar_path_without_writing(monkeypatch, tmp_path
 
 
 def test_baseline_main_bad_sidecar_emits_reason_and_does_not_write(monkeypatch, tmp_path, capsys) -> None:
-    def fake_run_bytes(_argv: list[str]) -> tuple[int, bytes]:
+    def fake_run_bytes(_argv: list[str], **_kwargs: object) -> tuple[int, bytes]:
         return 0, b""
 
     monkeypatch.setattr(dirty_tree, "_run_bytes", fake_run_bytes)  # pyright: ignore[reportPrivateUsage]
@@ -107,7 +107,7 @@ def test_baseline_main_bad_sidecar_emits_reason_and_does_not_write(monkeypatch, 
 
 
 def test_checkpoint_dirty(monkeypatch) -> None:
-    def fake_run_bytes(_argv: list[str]) -> tuple[int, bytes]:
+    def fake_run_bytes(_argv: list[str], **_kwargs: object) -> tuple[int, bytes]:
         return 0, b" M python/dirty_tree.py\n"
 
     monkeypatch.setattr(dirty_tree, "_run_bytes", fake_run_bytes)  # pyright: ignore[reportPrivateUsage]
@@ -117,7 +117,7 @@ def test_checkpoint_dirty(monkeypatch) -> None:
 
 
 def test_checkpoint_git_failure(monkeypatch) -> None:
-    def fake_run_bytes(_argv: list[str]) -> tuple[int, bytes]:
+    def fake_run_bytes(_argv: list[str], **_kwargs: object) -> tuple[int, bytes]:
         return 128, b""
 
     monkeypatch.setattr(dirty_tree, "_run_bytes", fake_run_bytes)  # pyright: ignore[reportPrivateUsage]
@@ -127,7 +127,7 @@ def test_checkpoint_git_failure(monkeypatch) -> None:
 
 
 def test_baseline_clean_missing_baseline_without_untracked(monkeypatch, tmp_path) -> None:
-    def fake_run_bytes(argv: list[str]) -> tuple[int, bytes]:
+    def fake_run_bytes(argv: list[str], **_kwargs: object) -> tuple[int, bytes]:
         _ = argv
         return 0, b""
 
@@ -138,7 +138,7 @@ def test_baseline_clean_missing_baseline_without_untracked(monkeypatch, tmp_path
 
 
 def test_baseline_missing_with_untracked_is_ambiguous(monkeypatch, tmp_path) -> None:
-    def fake_run_bytes(argv: list[str]) -> tuple[int, bytes]:
+    def fake_run_bytes(argv: list[str], **_kwargs: object) -> tuple[int, bytes]:
         if argv[:2] == ["git", "ls-files"]:
             return 0, b"new.txt\0"
         return 0, b""
@@ -150,7 +150,7 @@ def test_baseline_missing_with_untracked_is_ambiguous(monkeypatch, tmp_path) -> 
 
 
 def test_baseline_missing_with_untracked_still_writes_tracked_sidecar(monkeypatch, tmp_path) -> None:
-    def fake_run_bytes(argv: list[str]) -> tuple[int, bytes]:
+    def fake_run_bytes(argv: list[str], **_kwargs: object) -> tuple[int, bytes]:
         if argv[:4] == ["git", "diff", "--name-only", "--cached"]:
             return 0, b"python/test_dirty_tree.py\0"
         if argv[:3] == ["git", "diff", "--name-only"]:
@@ -173,7 +173,7 @@ def test_baseline_dirty_writes_sidecar_paths(monkeypatch, tmp_path) -> None:
     baseline = tmp_path / "baseline.z"
     baseline.write_bytes(b"old.txt\0")
 
-    def fake_run_bytes(argv: list[str]) -> tuple[int, bytes]:
+    def fake_run_bytes(argv: list[str], **_kwargs: object) -> tuple[int, bytes]:
         if argv[:4] == ["git", "diff", "--name-only", "--cached"]:
             return 0, b"python/test_dirty_tree.py\0"
         if argv[:3] == ["git", "diff", "--name-only"]:
@@ -193,7 +193,7 @@ def test_baseline_dirty_writes_sidecar_paths(monkeypatch, tmp_path) -> None:
 
 
 def test_baseline_git_failure(monkeypatch, tmp_path) -> None:
-    def fake_run_bytes(argv: list[str]) -> tuple[int, bytes]:
+    def fake_run_bytes(argv: list[str], **_kwargs: object) -> tuple[int, bytes]:
         if argv[:3] == ["git", "diff", "--name-only"]:
             return 128, b""
         return 0, b""
@@ -222,3 +222,51 @@ def test_checkpoint_main_disables_inherited_quiet(monkeypatch, capsys) -> None:
     assert dirty_tree.checkpoint_main([]) == 0
     assert os.environ["LARCH_QUIET_DISABLE"] == "1"
     assert "STATUS=clean" in capsys.readouterr().out
+
+
+def test_baseline_forwards_cwd_to_every_git_call(monkeypatch, tmp_path) -> None:
+    seen_cwds: list[str | None] = []
+
+    def fake_run_bytes(argv: list[str], cwd: str | None = None) -> tuple[int, bytes]:
+        _ = argv
+        seen_cwds.append(cwd)
+        return 0, b""
+
+    monkeypatch.setattr(dirty_tree, "_run_bytes", fake_run_bytes)  # pyright: ignore[reportPrivateUsage]
+    lines = dirty_tree.baseline(baseline_path=str(tmp_path / "missing.z"), cwd="/consumer/repo")
+    assert "STATUS=clean" in lines
+    # status + diff + diff --cached + ls-files all run in the consumer repo, not the process CWD.
+    assert seen_cwds == ["/consumer/repo", "/consumer/repo", "/consumer/repo", "/consumer/repo"]
+
+
+def test_checkpoint_forwards_cwd_to_run_bytes(monkeypatch) -> None:
+    seen_cwds: list[str | None] = []
+
+    def fake_run_bytes(argv: list[str], cwd: str | None = None) -> tuple[int, bytes]:
+        _ = argv
+        seen_cwds.append(cwd)
+        return 0, b""
+
+    monkeypatch.setattr(dirty_tree, "_run_bytes", fake_run_bytes)  # pyright: ignore[reportPrivateUsage]
+    lines = dirty_tree.checkpoint(cwd="/consumer/repo")
+    assert "STATUS=clean" in lines
+    assert seen_cwds == ["/consumer/repo"]
+
+
+def test_run_bytes_forwards_cwd_to_subprocess(monkeypatch, tmp_path) -> None:
+    captured: dict[str, object] = {}
+
+    class _Completed:
+        returncode = 0
+        stdout = b"out"
+
+    def fake_run(argv: list[str], **kwargs: object) -> _Completed:
+        captured["argv"] = argv
+        captured["cwd"] = kwargs.get("cwd")
+        return _Completed()
+
+    monkeypatch.setattr(dirty_tree.subprocess, "run", fake_run)
+    rc, out = dirty_tree._run_bytes(["git", "status", "--porcelain"], cwd=str(tmp_path))  # pyright: ignore[reportPrivateUsage]
+    assert rc == 0
+    assert out == b"out"
+    assert captured["cwd"] == str(tmp_path)

--- a/python/test_launch_review.py
+++ b/python/test_launch_review.py
@@ -1088,6 +1088,7 @@ def test_cursor_preexisting_untracked_baseline_stays_clean(tmp_path: Path, monke
         return agents.RunExternalAgentResult(0, out)
 
     monkeypatch.chdir(repo)
+    monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
     monkeypatch.setattr(agents, "cursor_auth_preflight", cursor_auth_ok)
     monkeypatch.setattr(agents, "cursor_preread_service_token", lambda: None)
     monkeypatch.setattr(agents, "cursor_auth_export_env", lambda: None)
@@ -1116,6 +1117,7 @@ def test_cursor_reviewer_untracked_yields_dirty_sidecar(tmp_path: Path, monkeypa
     (repo / "preexisting.txt").write_text("baseline\n", encoding="utf-8")
     out = tmp_path / "out.txt"
     monkeypatch.chdir(repo)
+    monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
     baseline = agents._review_capture_cursor_dirty_baseline(out)
     (repo / "reviewer-new.txt").write_text("reviewer\n", encoding="utf-8")
     agents._review_write_cursor_dirty_tree_from_baseline(out, baseline)
@@ -1124,6 +1126,25 @@ def test_cursor_reviewer_untracked_yields_dirty_sidecar(tmp_path: Path, monkeypa
     new_untracked = out.with_suffix(out.suffix + ".dirty-tree.new-untracked-paths")
     assert new_untracked.is_file()
     assert b"reviewer-new.txt" in new_untracked.read_bytes()
+
+
+def test_cursor_dirty_tree_resolves_consumer_repo_from_non_git_cwd(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Regression for #4452: when the review subprocess CWD is the plugin cache dir
+    # (not a git repo), the cursor dirty-tree path must resolve the consumer repo via
+    # CLAUDE_PROJECT_DIR instead of reporting STATUS=unknown / git-status-failed.
+    consumer = tmp_path / "consumer"
+    consumer.mkdir()
+    _init_git_repo(consumer)
+    plugin_cache = tmp_path / "plugin-cache"
+    plugin_cache.mkdir()
+    out = tmp_path / "out.txt"
+    monkeypatch.chdir(plugin_cache)
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(consumer))
+    baseline = agents._review_capture_cursor_dirty_baseline(out)
+    agents._review_write_cursor_dirty_tree_from_baseline(out, baseline)
+    dirty = out.with_suffix(out.suffix + ".dirty-tree").read_text(encoding="utf-8")
+    assert "STATUS=clean" in dirty
+    assert "git-status-failed" not in dirty
 
 
 def test_cursor_empty_result_retries_with_lock_when_enabled(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

Fixes #4452. The Cursor plan-review aggregator computed its dirty-tree sidecar by running `git status` / `git diff` / `git ls-files` from the Python process CWD, which during plan review is the plugin cache dir (not a git repo). `git status --porcelain` exited 128, so every round logged a false `dirty tree detected` (`STATUS=unknown, REASON=git-status-failed`).

## Changes

- **`python/agents.py`**: both Cursor dirty-tree helpers (`_review_capture_cursor_dirty_baseline`, `_review_write_cursor_dirty_tree_from_baseline`) now resolve the consumer repo via `_resolve_review_codex_workdir` (the same resolver `--workspace` already uses) and pass it as `cwd` to both git-invoking paths — the untracked-baseline snapshot **and** the comparison.
- **`python/dirty_tree.py`**: added an optional `cwd` parameter to `_run_bytes`, `baseline`, and `checkpoint` (keyword-only, `None` default → no behavior change for existing callers).

## Approach

Implements the issue's recommended **Option A** (CWD-aware dirty-tree), which preserves real mutation detection rather than disabling it (Options B/C). The workdir is resolved inside the helpers (rather than threading a new param down from `_review_launch_cursor`) to keep helper signatures stable, so the existing monkeypatch fakes need no churn. Fixes **both** git paths, not just the comparison the issue sketched — otherwise a missing baseline would surface a different false positive (`baseline-missing-untracked-ambiguous`).

## Tests

- **`python/test_dirty_tree.py`**: 3 new tests asserting `cwd` flows `baseline`/`checkpoint` → `_run_bytes` → `subprocess`.
- **`python/test_launch_review.py`**: a regression test reproducing #4452 (non-git CWD + `CLAUDE_PROJECT_DIR` → `STATUS=clean`; fails pre-fix), plus two existing real-helper tests made env-deterministic.

`ruff` / `pylint` / `pyright` / `pytest` pass locally.

Closes #4452.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
