### PR TITLE
Release v50.1.3

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "50.1.2",
+  "version": "50.1.3",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel) and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Fixed

- **`/implement --emergency` now skips plan validation entirely.** Preflight item 4 is bypassed when `--emergency` is set; previously the validation ran but its findings were silently ignored, leaving misleading audit artifacts. (PR #4466, fixes #4442)
- **`implement-preflight.sh` self-locates on initial runs.** The script now derives `CLAUDE_PLUGIN_ROOT` from its own path (`$0`) when the env var is absent. Previously any fresh `/implement` invocation where `CLAUDE_PLUGIN_ROOT` was not already in the environment would exit 2 before doing any real work. (PR #4468, fixes #4458)
- **Cursor plan review no longer reports dirty-tree false positives.** (PR #4469, fixes #4452)

## Changed

- CI test harness shards rebalanced. (PR #4463)
