### PR TITLE
Release v50.1.4

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "50.1.3",
+  "version": "50.1.4",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel) and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## What's Changed

### Fixed

- **Ship `MAIN_ADVANCED` handling**: when the merge step returns `MAIN_ADVANCED`, the ship loop now routes through rebase (matching the monitor path) rather than retrying the merge without rebasing. Regression test added.
- **Research phase exit-code capture**: Bash snippets in the research phase now use a strict-mode-safe pattern (`rc=0; cmd || rc=$?`) so the real non-zero exit code is captured and surfaced in warnings instead of always showing `0`.
- **Conflict-fixer token sidecar fallback**: Codex and Cursor conflict-fixer launches now clear any stale sidecar before launch and pass `allow_output_fallback=True` during ingestion, matching the existing Claude behavior. Regression tests added.

### Changed

- **Live CI timing kinds recognized**: `codex-ci`, `cursor-ci`, and `claude-ci` task kinds are now accepted by the timing ledger (in addition to the existing `*-ci-fix` variants), preventing spurious "unknown task-kind" warnings during live CI phases.
- **CI rows filtered from live Gantt output**: inflight progress reports now suppress CI-task Gantt rows (`*-ci`, `*-ci-fix`, `*-ci-test`, and probe outputs such as `claude.out`/`codex.out`/`cursor.out`), matching the existing behavior of the post-phase review renderer.
