### PR TITLE
ci: run main pylint pass with -j 0 to speed up the python-lint job

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,10 @@ lint: test-harnesses lint-bash32 lint-readability-preamble lint-renderer-substit
 py-lint:
 	@$(PYTHON) -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 11) else 1)' \
 		|| (printf '%s\n' "ERROR: make py-lint requires Python 3.11 or newer (PYTHON=$(PYTHON))" >&2; exit 1)
-	cd python && ruff check . && pylint . && pyright
+	# pylint runs -j 0 (all cores) for the per-file checks. duplicate-code is
+	# disabled here (.pylintrc) and runs single-process in py-lint-duplicate-code,
+	# so parallelism is safe (the similarities checker is incorrect under -j>1).
+	cd python && ruff check . && pylint -j 0 . && pyright
 
 py-lint-duplicate-code:
 	@$(PYTHON) -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 11) else 1)' \

--- a/python/README.md
+++ b/python/README.md
@@ -46,7 +46,7 @@ From the repository root (after `pip install -r python/requirements-dev.txt` and
 `python/requirements-test.txt`):
 
 ```bash
-make py-lint   # cd python && ruff check . && pylint . && pyright
+make py-lint   # cd python && ruff check . && pylint -j 0 . && pyright
 make py-test   # cd python && pytest
 ```
 


### PR DESCRIPTION
## What

Run the main `python-lint` job's pylint pass with `-j 0` (all cores).

## Why

The `python-lint` job ran `pylint .` single-threaded (~2 min, the CI bottleneck). Now that duplicate-code is isolated in its own `-j 1` job (#4481), the main per-file pylint pass can parallelize safely. Measured locally on pylint 4.0.5: ~37s -> ~12s (about 3x on an 11-core machine; CI runners have fewer cores, so a smaller but real gain).

## Safety

`-j 0` only affects the main `py-lint` target. duplicate-code stays disabled there (`.pylintrc`) and runs single-process in the `python-lint-duplicate-code` job via an explicit `-j 1`, so the similarities checker (incorrect under `-j>1`) is unaffected.

## Validation

- `make py-lint` -> passes (0 errors) with `-j 0`.
- The recipe comment in `python/README.md` is updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
