### PR TITLE
fix(harness): time and de-duplicate the 5 untimed pytest groups; fail-loud rebalance guard

### DIFF
--- a/.claude/skills/rebalance-test-harnesses/SKILL.md
+++ b/.claude/skills/rebalance-test-harnesses/SKILL.md
@@ -25,22 +25,27 @@ All flags are optional; defaults are sensible for normal use in this repository.
 
 1. Fetch `LARCH_HARNESS_TIMING` rows from the last 5 successful CI runs on `main`.
 2. Compute the per-target median wall time.
-3. Sort all shard targets slowest-to-fastest and distribute across 20 shards in
+3. **Refuse to rebalance** (exit 1, loud error listing each offender) if any
+   shard target has no timing data. An untimed target is invisible to the
+   packer (zero weight), so it piles onto whichever shard looks lightest and
+   creates an unbalanced "monster" shard. Instrument it with `timing
+   harness-mark` (or, for a genuinely new test, let CI run it once), then retry.
+4. Sort all shard targets slowest-to-fastest and distribute across 20 shards in
    round-robin order (LPT heuristic — guarantees the slowest tests never cluster).
    Packing runs before the warning-only feasibility check. The check evaluates
    packed shard totals against the configured threshold. Orphan timing rows
    remain ignored because totals come from packed shard targets.
-4. Write the new `test-harnesses-N:` lines to `Makefile`.
-5. Validate the partition with `bash scripts/test-harness-shards-coverage.sh`.
-6. Commit, push a new branch, and create a PR.
-7. Wait for the first CI run (triggered automatically by the push), then trigger
+5. Write the new `test-harnesses-N:` lines to `Makefile`.
+6. Validate the partition with `bash scripts/test-harness-shards-coverage.sh`.
+7. Commit, push a new branch, and create a PR.
+8. Wait for the first CI run (triggered automatically by the push), then trigger
    two more via `gh workflow run ci.yaml --ref <branch>`.
-8. Collect timing from all three runs, compute median per-shard wall times.
-9. Verify: `max_shard_total − min_shard_total ≤ 15 s`.
-10. Print a before / after comparison table. BEFORE shows the estimated spread
+9. Collect timing from all three runs, compute median per-shard wall times.
+10. Verify: `max_shard_total − min_shard_total ≤ 15 s`.
+11. Print a before / after comparison table. BEFORE shows the estimated spread
     of the new layout from baseline medians. AFTER shows the measured spread of
     that same new layout from verification CI runs.
-11. **Merge is intentionally commented out.** Inspect the PR and merge manually
+12. **Merge is intentionally commented out.** Inspect the PR and merge manually
     (or uncomment the `_merge_pr` call in `scripts/rebalance.py` when you are
     satisfied).
 

--- a/.claude/skills/rebalance-test-harnesses/scripts/rebalance.md
+++ b/.claude/skills/rebalance-test-harnesses/scripts/rebalance.md
@@ -15,13 +15,14 @@ It samples recent baseline CI timings, repacks Makefile shard targets, opens a P
 1. Read the current `test-harnesses-N` targets from `Makefile`.
 2. Fetch `LARCH_HARNESS_TIMING` rows from recent successful baseline CI runs.
 3. Compute per-target median seconds.
-4. Select the measured workload that is also present in the shard target set.
-5. Pass the selected workload to `pack()` for round-robin LPT packing.
-6. Run the warning-only feasibility check on the packed shard totals.
-7. Write the new shard lines and validate coverage.
-8. Create a branch and PR for the new Makefile layout.
-9. Trigger verification CI runs and collect median per-shard totals.
-10. Print BEFORE and AFTER tables for the new shard layout.
+4. **Hard gate:** refuse to rebalance (exit 1, loud error) if any shard target has no timing data.
+5. Select the measured workload that is also present in the shard target set.
+6. Pass the selected workload to `pack()` for round-robin LPT packing.
+7. Run the warning-only feasibility check on the packed shard totals.
+8. Write the new shard lines and validate coverage.
+9. Create a branch and PR for the new Makefile layout.
+10. Trigger verification CI runs and collect median per-shard totals.
+11. Print BEFORE and AFTER tables for the new shard layout.
 
 BEFORE is estimated from baseline per-target medians for the new layout.
 AFTER is measured from verification CI runs for that same new layout.
@@ -38,17 +39,25 @@ AFTER is measured from verification CI runs for that same new layout.
 | `--workflow` | `ci.yaml` | Workflow file used for baseline and verification runs. |
 | `--baseline-branch` | `main` | Branch used for baseline timing data. |
 
+## Timing-completeness hard gate
+
+Before packing, `untimed_targets(all_shard_targets, medians)` (from `harness_ci_timing`) lists every shard target with no timing data.
+If that list is non-empty the run prints each offending target and exits 1 — it never emits a layout.
+An untimed target is invisible to `pack()` (zero weight), so it silently piles onto whichever shard the packer thinks is lightest and creates an unbalanced "monster" shard the balancer never measures.
+Every `test-harnesses` target must therefore emit a `LARCH_HARNESS_TIMING` row via `timing harness-mark`.
+A genuinely new test blocks a rebalance until it has run in CI at least once; instrument it (or wait for one CI run), then retry.
+
 ## Feasibility preflight
 
 The preflight checks whether the estimated packed shard spread exceeds the configured threshold.
 It is warning-only.
 It never aborts the rebalance.
 
-The check runs after packing:
+The check runs after the hard gate and packing:
 
 ```python
 measured = _select_packed_workload(medians, all_shard_targets)
-new_shards = pack(measured, n_shards, guard=_GUARD, extras=extras)
+new_shards = pack(measured, n_shards, guard=_GUARD)
 _check_feasibility(new_shards, medians, args.balance_threshold)
 ```
 

--- a/.claude/skills/rebalance-test-harnesses/scripts/rebalance.py
+++ b/.claude/skills/rebalance-test-harnesses/scripts/rebalance.py
@@ -35,6 +35,7 @@ from harness_ci_timing import (  # noqa: E402
     compute_medians,
     median_shard_totals,
     parse_log,
+    untimed_targets,
 )
 from harness_makefile import read_shards, write_shards  # noqa: E402
 from harness_shard_packer import pack  # noqa: E402
@@ -368,20 +369,40 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901
     medians = compute_medians(all_timing_rows)
     print(f"  Medians computed for {len(medians)} targets")
 
-    # Targets present in the Makefile shards but absent from timing data
-    extras = [
-        t for t in all_shard_targets
-        if t not in medians and t != _GUARD
-    ]
-    if extras:
-        print(f"  {len(extras)} targets have no timing data (new tests?) → placed at tail")
+    # ------------------------------------------------------------------
+    # Hard gate: refuse to rebalance on partial timing data.
+    # An untimed target is invisible to the LPT packer (zero weight), so it
+    # silently piles onto whichever shard looks lightest and creates an
+    # unbalanced "monster" shard the balancer never measures. Fail loud and
+    # abort rather than emit a layout we know is wrong.
+    # ------------------------------------------------------------------
+    untimed = untimed_targets(all_shard_targets, medians)
+    if untimed:
+        print(
+            f"\nERROR: refusing to rebalance — {len(untimed)} shard target(s) "
+            "have NO timing data:",
+            file=sys.stderr,
+        )
+        for target in sorted(untimed):
+            print(f"  - {target}", file=sys.stderr)
+        print(
+            "\nEvery test-harnesses target must emit a LARCH_HARNESS_TIMING row. "
+            "Wrap each recipe with\n"
+            "  python3 python/cli.py timing harness-mark --label $@ -- <command>\n"
+            "Untimed targets are invisible to the balancer and create an "
+            "unbalanced 'monster' shard.\n"
+            "Instrument them (or let CI run them once, for genuinely new tests), "
+            "then retry.",
+            file=sys.stderr,
+        )
+        return 1
 
     # ------------------------------------------------------------------
     # Step 3: Pack shards with round-robin LPT
     # ------------------------------------------------------------------
     print(f"\n[3/9] Packing {n_shards} shards with round-robin LPT …")
     measured = _select_packed_workload(medians, all_shard_targets)
-    new_shards = pack(measured, n_shards, guard=_GUARD, extras=extras)
+    new_shards = pack(measured, n_shards, guard=_GUARD)
     _check_feasibility(new_shards, medians, args.balance_threshold)
 
     # ------------------------------------------------------------------
@@ -449,7 +470,7 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901
         f"- Baseline: {args.n_runs} successful runs on `{args.baseline_branch}`\n"
         f"- Algorithm: round-robin LPT (slowest-first, {n_shards} shards)\n"
         f"- Before spread (estimated): {baseline_spread:.1f}s\n"
-        f"- {len(extras)} target(s) with no timing data placed at tail\n\n"
+        "- All shard targets have timing data (rebalance refuses otherwise)\n\n"
         "After merging, the new shard layout will take effect on the next CI run.\n"
     )
     pr, created = gh.pr_create(

--- a/Makefile
+++ b/Makefile
@@ -232,10 +232,10 @@ test-lib-scope-anchor-handoff:
 	python3 python/cli.py timing harness-mark --label $@ -- python3 -m pytest python/test_rendering.py -q
 
 test-clarify-comment:
-	cd python && $(PYTHON) -m pytest test_clarify.py
+	python3 python/cli.py timing harness-mark --label $@ -- python3 -m pytest python/test_clarify.py -q -k comment
 
 test-clarify-state:
-	cd python && $(PYTHON) -m pytest test_clarify.py
+	python3 python/cli.py timing harness-mark --label $@ -- python3 -m pytest python/test_clarify.py -q -k 'not comment'
 
 test-check-stale-plugin:
 	python3 python/cli.py timing harness-mark --label $@ -- bash scripts/test-check-stale-plugin.sh
@@ -265,22 +265,22 @@ test-deny-edit-write:
 
 
 test-token-tally:
-	cd python && $(PYTHON) -m pytest test_tokens.py -q
+	python3 python/cli.py timing harness-mark --label $@ -- python3 -m pytest python/test_tokens.py -q -k tally
 
 test-token-ledger:
-	cd python && $(PYTHON) -m pytest test_tokens.py -q
+	python3 python/cli.py timing harness-mark --label $@ -- python3 -m pytest python/test_tokens.py -q -k ledger
 
 test-token-report:
-	cd python && $(PYTHON) -m pytest test_tokens.py -q
+	python3 python/cli.py timing harness-mark --label $@ -- python3 -m pytest python/test_tokens.py -q -k token_report
 
 test-token-report-dedup:
-	cd python && $(PYTHON) -m pytest test_tokens.py -q
+	python3 python/cli.py timing harness-mark --label $@ -- python3 -m pytest python/test_tokens.py -q -k dedupe
 
 test-token-cost-per-bucket:
-	cd python && $(PYTHON) -m pytest test_report_tokens_cost.py -q
+	python3 python/cli.py timing harness-mark --label $@ -- python3 -m pytest python/test_report_tokens_cost.py -q -k bucket
 
 test-render-cost-line-realism:
-	cd python && $(PYTHON) -m pytest test_report_tokens_cost.py -q
+	python3 python/cli.py timing harness-mark --label $@ -- python3 -m pytest python/test_report_tokens_cost.py -q -k 'not (render_cost_line or token_cost or bucket)'
 
 test-render-cost-line-callsites:
 	python3 python/cli.py timing harness-mark --label $@ -- bash scripts/test-render-cost-line-callsites.sh
@@ -292,10 +292,10 @@ test-render-run-summary-format:
 	python3 python/cli.py timing harness-mark --label $@ -- bash scripts/test-render-run-summary-format.sh
 
 test-token-report-summary-format:
-	cd python && $(PYTHON) -m pytest test_tokens.py -q
+	python3 python/cli.py timing harness-mark --label $@ -- python3 -m pytest python/test_tokens.py -q -k 'not (compute_pr_line_counts or claude_source or ledger or tally or dedupe or token_report)'
 
 test-timing-ledger:
-	cd python && $(PYTHON) -m pytest test_timing.py -q
+	python3 python/cli.py timing harness-mark --label $@ -- python3 -m pytest python/test_timing.py -q -k 'not harness_mark and not telemetry_mark and not report'
 
 test-review-and-fix-record-timing:
 	python3 python/cli.py timing harness-mark --label $@ -- python3 -m pytest python/test_review_and_fix.py -q -k record_timing
@@ -307,19 +307,19 @@ test-record-plan-review-round-timing:
 	python3 python/cli.py timing harness-mark --label $@ -- python3 -m pytest python/test_plan_review.py -q -k record_round_timing
 
 test-step-telemetry-mark:
-	cd python && $(PYTHON) -m pytest test_timing.py -q
+	python3 python/cli.py timing harness-mark --label $@ -- python3 -m pytest python/test_timing.py -q -k telemetry_mark
 
 test-timing-report:
-	cd python && $(PYTHON) -m pytest test_timing.py -q
+	python3 python/cli.py timing harness-mark --label $@ -- python3 -m pytest python/test_timing.py -q -k report
 
 test-token-vendor-scrapers:
 	python3 python/cli.py timing harness-mark --label $@ -- bash scripts/test-token-vendor-scrapers.sh
 
 test-parse-codex-usage:
-	cd python && $(PYTHON) -m pytest test_agents.py -q
+	python3 python/cli.py timing harness-mark --label $@ -- python3 -m pytest python/test_agents.py -q -k parse_codex_usage
 
 test-token-claude-source:
-	cd python && $(PYTHON) -m pytest test_tokens.py -q
+	python3 python/cli.py timing harness-mark --label $@ -- python3 -m pytest python/test_tokens.py -q -k claude_source
 
 test-verify-skill-called:
 	python3 python/cli.py timing harness-mark --label $@ -- python3 -m pytest -q python/test_verify_skill.py
@@ -526,16 +526,16 @@ test-brainstorm-prompts:
 	python3 python/cli.py timing harness-mark --label $@ -- bash skills/design/scripts/test-brainstorm-prompts.sh
 
 test-lint-readability-preamble:
-	cd python && $(PYTHON) -m pytest test_lint_readability_preamble.py
+	python3 python/cli.py timing harness-mark --label $@ -- python3 -m pytest python/test_lint_readability_preamble.py -q
 
 test-lint-skill-md-flag-signature:
-	cd python && $(PYTHON) -m pytest test_lint_skill_md_flag_signature.py
+	python3 python/cli.py timing harness-mark --label $@ -- python3 -m pytest python/test_lint_skill_md_flag_signature.py -q
 
 test-lint-codex-exec-auth:
-	cd python && $(PYTHON) -m pytest test_lint_codex_exec_auth.py
+	python3 python/cli.py timing harness-mark --label $@ -- python3 -m pytest python/test_lint_codex_exec_auth.py -q
 
 test-lint-skill-invocations:
-	cd python && $(PYTHON) -m pytest test_lint_skill_invocations.py
+	python3 python/cli.py timing harness-mark --label $@ -- python3 -m pytest python/test_lint_skill_invocations.py -q
 
 test-lint-renderer-substitution-safety:
 	python3 python/cli.py timing harness-mark --label $@ -- bash scripts/test-lint-renderer-substitution-safety.sh
@@ -546,7 +546,7 @@ test-lint-bare-grep-probe:
 
 
 test-launch-codex-exec:
-	cd python && $(PYTHON) -m pytest test_agents.py -q
+	python3 python/cli.py timing harness-mark --label $@ -- python3 -m pytest python/test_agents.py -q -k launch_codex_exec
 
 test-lint-awk-multibyte-regex:
 	python3 python/cli.py timing harness-mark --label $@ -- bash scripts/test-lint-awk-multibyte-regex.sh
@@ -567,10 +567,10 @@ test-implement-rebase-macro:
 	python3 python/cli.py timing harness-mark --label $@ -- bash scripts/test-implement-rebase-macro.sh
 
 test-rebase-checkpoint-probe:
-	bash scripts/test-rebase-checkpoint-probe.sh
+	python3 python/cli.py timing harness-mark --label $@ -- bash scripts/test-rebase-checkpoint-probe.sh
 
 test-phantom-probe-with-warn:
-	bash scripts/test-phantom-probe-with-warn.sh
+	python3 python/cli.py timing harness-mark --label $@ -- bash scripts/test-phantom-probe-with-warn.sh
 
 test-implement-step2-routing:
 	python3 python/cli.py timing harness-mark --label $@ -- bash scripts/test-implement-step2-routing.sh
@@ -685,19 +685,19 @@ test-ci-wait:
 	python3 python/cli.py timing harness-mark --label $@ -- bash scripts/test-ci-wait.sh
 
 test-launch-cursor-ci:
-	cd python && $(PYTHON) -m pytest test_agents.py -q
+	python3 python/cli.py timing harness-mark --label $@ -- python3 -m pytest python/test_agents.py -q -k launch_cursor_ci
 
 test-launch-claude-ci:
-	cd python && $(PYTHON) -m pytest test_agents.py -q
+	python3 python/cli.py timing harness-mark --label $@ -- python3 -m pytest python/test_agents.py -q -k launch_claude_ci
 
 test-launch-codex-ci:
-	cd python && $(PYTHON) -m pytest test_agents.py -q
+	python3 python/cli.py timing harness-mark --label $@ -- python3 -m pytest python/test_agents.py -q -k launch_codex_ci
 
 test-run-negotiation-round:
 	python3 python/cli.py timing harness-mark --label $@ -- python3 -m pytest python/test_agents.py -q -k negotiation_round
 
 test-run-external-agent-args:
-	cd python && $(PYTHON) -m pytest test_agents.py -q
+	python3 python/cli.py timing harness-mark --label $@ -- python3 -m pytest python/test_agents.py -q -k run_external_agent_args
 
 test-quick-mode-docs-sync:
 	python3 python/cli.py timing harness-mark --label $@ -- bash scripts/test-quick-mode-docs-sync.sh
@@ -755,7 +755,7 @@ test-render-review-phase-detail:
 	python3 python/cli.py timing harness-mark --label $@ -- bash scripts/test-render-review-phase-detail.sh
 
 test-token-cost:
-	cd python && $(PYTHON) -m pytest test_report_tokens_cost.py -q
+	python3 python/cli.py timing harness-mark --label $@ -- python3 -m pytest python/test_report_tokens_cost.py -q -k token_cost
 
 lint-retired-scripts:
 	@$(PYTHON) -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 11) else 1)' \
@@ -763,7 +763,7 @@ lint-retired-scripts:
 	$(PYTHON) python/cli.py lint retired-scripts
 
 test-render-cost-line:
-	cd python && $(PYTHON) -m pytest test_report_tokens_cost.py -q
+	python3 python/cli.py timing harness-mark --label $@ -- python3 -m pytest python/test_report_tokens_cost.py -q -k render_cost_line
 
 test-implement-cleanup-script:
 	python3 python/cli.py timing harness-mark --label $@ -- python3 -m pytest python/test_finalize.py -q -k cleanup
@@ -773,7 +773,7 @@ test-harness-shards-coverage:
 	python3 python/cli.py timing harness-mark --label $@ -- bash scripts/test-harness-shards-coverage.sh --self-test
 
 test-harness-timer:
-	cd python && $(PYTHON) -m pytest test_timing.py -q
+	python3 python/cli.py timing harness-mark --label $@ -- python3 -m pytest python/test_timing.py -q -k harness_mark
 
 test-references-headers:
 	python3 python/cli.py timing harness-mark --label $@ -- bash scripts/test-references-headers.sh
@@ -929,7 +929,7 @@ test-compose-pr-summary:
 	python3 python/cli.py timing harness-mark --label $@ -- python3 -m pytest python/test_pr_body.py -q -k 'compose_summary'
 
 test-compute-pr-line-counts:
-	cd python && $(PYTHON) -m pytest test_tokens.py -q
+	python3 python/cli.py timing harness-mark --label $@ -- python3 -m pytest python/test_tokens.py -q -k compute_pr_line_counts
 
 test-compose-review-findings:
 	python3 python/cli.py timing harness-mark --label $@ -- python3 -m pytest -q python/test_compose_review.py
@@ -953,7 +953,7 @@ test-check-reviewers:
 	python3 python/cli.py timing harness-mark --label $@ -- python3 -m pytest python/test_agents.py -q -k 'check_reviewers or health_gate'
 
 test-degraded-tools-gate:
-	cd python && $(PYTHON) -m pytest test_agents.py -q
+	python3 python/cli.py timing harness-mark --label $@ -- python3 -m pytest python/test_agents.py -q -k degraded_tools
 
 test-no-grouped-reuse-guard:
 	python3 python/cli.py timing harness-mark --label $@ -- bash scripts/test-no-grouped-reuse-guard.sh
@@ -971,10 +971,10 @@ test-lib-external-launcher-common:
 	python3 python/cli.py timing harness-mark --label $@ -- bash scripts/test-lib-external-launcher-common.sh
 
 test-launch-claude-subprocess:
-	cd python && $(PYTHON) -m pytest test_agents.py -q
+	python3 python/cli.py timing harness-mark --label $@ -- python3 -m pytest python/test_agents.py -q -k launch_claude_subprocess
 
 test-launch-claude-review:
-	cd python && $(PYTHON) -m pytest test_agents.py -q
+	python3 python/cli.py timing harness-mark --label $@ -- python3 -m pytest python/test_agents.py -q -k launch_claude_review
 
 test-launch-claude-drafter:
 	python3 python/cli.py timing harness-mark --label $@ -- bash scripts/test-launch-claude-drafter.sh
@@ -992,7 +992,7 @@ test-revise-plan-with-waterfall:
 	python3 python/cli.py timing harness-mark --label $@ -- python3 -m pytest -q python/test_plan_quality.py -k revise_waterfall
 
 test-agent-model-args:
-	cd python && $(PYTHON) -m pytest test_agents.py -q
+	python3 python/cli.py timing harness-mark --label $@ -- python3 -m pytest python/test_agents.py -q -k 'model_args and not launch_codex_exec'
 
 test-effort-prose:
 	python3 python/cli.py timing harness-mark --label $@ -- bash scripts/test-effort-prose.sh
@@ -1031,7 +1031,7 @@ test-gather-branch-context:
 	python3 python/cli.py timing harness-mark --label $@ -- python3 -m pytest -q python/test_review_dispatch.py -k gather_branch_context
 
 test-run-external-agent:
-	cd python && $(PYTHON) -m pytest test_agents.py -q
+	python3 python/cli.py timing harness-mark --label $@ -- python3 -m pytest python/test_agents.py -q -k 'not (negotiation_round or check_reviewers or health_gate or launch_claude_ci or launch_claude_review or launch_claude_subprocess or launch_codex_ci or launch_codex_exec or launch_cursor_ci or parse_codex_usage or run_external_agent_args or model_args or degraded_tools)'
 
 
 

--- a/python/harness_ci_timing.py
+++ b/python/harness_ci_timing.py
@@ -153,3 +153,27 @@ def median_shard_totals(rows: Sequence[TimingRow]) -> dict[int, float]:
         for shard, total in run_data.items():
             by_shard.setdefault(shard, []).append(total)
     return {shard: statistics.median(totals) for shard, totals in by_shard.items()}
+
+
+def untimed_targets(
+    all_shard_targets: Sequence[str],
+    medians: dict[str, float],
+) -> list[str]:
+    """Return shard targets with no timing data, de-duplicated, order-preserving.
+
+    A target is *untimed* when no ``LARCH_HARNESS_TIMING`` row yielded a median
+    for it across the sampled runs — either its Makefile recipe is missing the
+    ``timing harness-mark`` wrapper, or it has never run in the sampled CI.
+
+    The rebalancer refuses to proceed when this list is non-empty: an untimed
+    target is invisible to the LPT packer, which assigns it zero weight and
+    piles it onto whichever shard it believes is lightest, producing an
+    unbalanced "monster" shard whose real wall-clock the balancer never sees.
+    """
+    seen: set[str] = set()
+    out: list[str] = []
+    for target in all_shard_targets:
+        if target not in medians and target not in seen:
+            seen.add(target)
+            out.append(target)
+    return out

--- a/python/harness_shard_packer.py
+++ b/python/harness_shard_packer.py
@@ -61,14 +61,19 @@ def pack(
     all_targets = sorted_targets + (extras or [])
 
     shards: dict[int, list[str]] = {i: [] for i in range(1, n_shards + 1)}
-    # heap entries: (cumulative_seconds, shard_id) — shard_id breaks ties
-    heap: list[tuple[float, int]] = [(0.0, i) for i in range(1, n_shards + 1)]
+    # heap entries: (cumulative_seconds, item_count, shard_id). The item_count
+    # secondary key makes zero-weight targets (extras with no timing data) fan
+    # out round-robin instead of avalanching onto one shard: a 0.0-weight target
+    # leaves the popped shard's total unchanged, so without the count tiebreak
+    # that shard stays lightest and every subsequent 0-weight target piles onto
+    # it. shard_id remains the final tiebreak for determinism.
+    heap: list[tuple[float, int, int]] = [(0.0, 0, i) for i in range(1, n_shards + 1)]
     heapq.heapify(heap)
 
     for target in all_targets:
-        total, shard_id = heapq.heappop(heap)
+        total, count, shard_id = heapq.heappop(heap)
         shards[shard_id].append(target)
-        heapq.heappush(heap, (total + medians.get(target, 0.0), shard_id))
+        heapq.heappush(heap, (total + medians.get(target, 0.0), count + 1, shard_id))
 
     # Ensure guard is first in its assigned shard (structural invariant)
     if guard:

--- a/python/test_harness_ci_timing.py
+++ b/python/test_harness_ci_timing.py
@@ -9,6 +9,7 @@ from harness_ci_timing import (
     median_shard_totals,
     parse_log,
     shard_totals_per_run,
+    untimed_targets,
 )
 from proc import CommandResult
 from test_support import RecordingRunner
@@ -202,3 +203,21 @@ def test_fetch_timing_rows_skips_failed_log_fetch() -> None:
     )
     rows = fetch_timing_rows(runner, repo="owner/repo", n_runs=1)
     assert not rows
+
+
+def test_untimed_targets_flags_targets_absent_from_medians() -> None:
+    all_targets = ["test-a", "test-b", "test-c", "test-d"]
+    medians = {"test-a": 1.0, "test-c": 2.0}
+    assert untimed_targets(all_targets, medians) == ["test-b", "test-d"]
+
+
+def test_untimed_targets_empty_when_all_present() -> None:
+    all_targets = ["test-a", "test-b"]
+    medians = {"test-a": 1.0, "test-b": 2.0}
+    assert not untimed_targets(all_targets, medians)
+
+
+def test_untimed_targets_dedupes_preserving_first_seen_order() -> None:
+    # A target repeated across shard lists must appear once, in first-seen order.
+    all_targets = ["test-z", "test-a", "test-z", "test-a"]
+    assert untimed_targets(all_targets, {}) == ["test-z", "test-a"]

--- a/python/test_harness_shard_packer.py
+++ b/python/test_harness_shard_packer.py
@@ -63,6 +63,18 @@ def test_pack_extras_all_distributed() -> None:
         assert e in all_targets
 
 
+def test_pack_zero_weight_extras_fan_out_not_avalanche() -> None:
+    # Regression: zero-weight extras (no timing data) must spread across shards,
+    # not avalanche onto whichever shard is lightest. With a pure (total, id)
+    # heap a 0.0-weight item left the popped shard still lightest, so all extras
+    # piled onto one shard — the bug behind the 2-minute "monster" shard.
+    medians: dict[str, float] = {}
+    extras = [f"test-x{i}" for i in range(20)]
+    shards = pack(medians, 5, extras=extras, guard="")
+    counts = sorted(len(ts) for ts in shards.values())
+    assert counts == [4, 4, 4, 4, 4], f"extras avalanched instead of spreading: {counts}"
+
+
 def test_pack_all_targets_covered() -> None:
     medians = {f"test-{i}": float(i) for i in range(40)}
     shards = pack(medians, 20, guard="")

--- a/scripts/lint-harness-pytest-partition.md
+++ b/scripts/lint-harness-pytest-partition.md
@@ -27,13 +27,19 @@ requires every script under `scripts/` to carry a neighboring
   (`test-render-findings-batch`) after the four redundant research targets
   were retired (Trick A3). A single full-file target is a valid partition;
   the guard fails if a duplicate full-file target is reintroduced.
+- `python/test_agents.py`, `python/test_tokens.py`,
+  `python/test_report_tokens_cost.py`, `python/test_timing.py`,
+  `python/test_clarify.py` — the five previously-**untimed** full-file
+  groups, now sliced into per-target `-k` selections (each target also
+  wrapped with `timing harness-mark`). One target per file carries a
+  `not (...)` catch-all so new tests stay covered.
 
-The guard does **not** enforce the invariant globally. ~25 other
-multi-target files (e.g. `test_agents.py`, `test_run_logs.py`,
-`test_tokens.py`) currently run their full file under several target names;
-de-duplicating those is a separate, larger effort. To bring a file under
-the guard, slice its targets into disjoint `-k`/node-id selections first,
-then add the file to `ENFORCED`.
+The guard does **not** yet enforce the invariant globally. The remaining
+timed-but-duplicated multi-target files (e.g. `test_run_logs.py`,
+`test_implement_dispatch.py`, `test_release.py`) still run their full file
+under several target names; de-duplicating those is a tracked follow-up. To
+bring a file under the guard, slice its targets into disjoint `-k`/node-id
+selections first, then add the file to `ENFORCED`.
 
 ## Invariants
 

--- a/scripts/lint-harness-pytest-partition.py
+++ b/scripts/lint-harness-pytest-partition.py
@@ -6,12 +6,15 @@ For an explicit allow-list of pytest source files that several
 targets' selections form a *strict partition*: every test in the file is
 covered by exactly one target (no test uncovered, no test covered twice).
 
-This locks in the per-target `-k` slicing landed for #4439 (Tricks A1/A2)
-and the research-target de-duplication (Trick A3) against regression. It
-does **not** attempt to enforce the same invariant on the ~25 other
-multi-target files that currently run their full file under several target
-names; that broader de-duplication is a separate, larger effort. To bring
-another file under the guard, slice its targets and add it to ENFORCED.
+This locks in the per-target `-k` slicing landed for #4439 (Tricks A1/A2),
+the research-target de-duplication (Trick A3), and the timing-blind-spot
+de-duplication of the five previously-untimed full-file pytest groups
+(test_agents/test_tokens/test_report_tokens_cost/test_timing/test_clarify)
+against regression. It does **not** yet enforce the invariant on the
+remaining ~9 timed-but-duplicated multi-target files (e.g. test_run_logs.py,
+test_implement_dispatch.py, test_release.py) that still run their full file
+under several target names; that de-duplication is a tracked follow-up. To
+bring another file under the guard, slice its targets and add it to ENFORCED.
 
 Invoked from scripts/test-harness-shards-coverage.sh (rides the
 `test-harness-shards-coverage` harness target, already in `make lint`).
@@ -36,6 +39,11 @@ ENFORCED = (
     "python/test_review_tally.py",
     "python/test_review_pipeline.py",
     "python/test_research.py",
+    "python/test_agents.py",
+    "python/test_tokens.py",
+    "python/test_report_tokens_cost.py",
+    "python/test_timing.py",
+    "python/test_clarify.py",
 )
 
 # Mirrors CARVE_OUTS in scripts/test-harness-shards-coverage.sh: targets that


### PR DESCRIPTION
## Problem

`/rebalance-test-harnesses` optimized a metric blind to real cost. **34 shard targets emitted no `LARCH_HARNESS_TIMING` row**, so the LPT packer gave them zero weight and avalanched them onto one shard — a ~2-minute "monster" shard no rebalance could fix (it just hopped shards each repack).

Root cause: refactor #4087 consolidated launcher test scripts into `test_agents.py` (and similar for tokens/timing/cost/clarify), repointed each old target at the **whole merged file**, and dropped the `harness-mark` wrapper — making those targets both **untimed** and **duplicative** (`test_agents.py` ran 11× per CI pass).

## Changes

**1. Instrument every shard target (0 untimed, was 34).**
- 5 multi-target untimed files sliced into strict per-target `-k` partitions, each wrapped with `timing harness-mark`, so every test runs exactly once and emits timing: `test_agents.py` (13 targets), `test_tokens.py` (7), `test_report_tokens_cost.py` (4), `test_timing.py` (4), `test_clarify.py` (2). One target per file carries a `not (...)` catch-all so new tests stay covered.
- 6 single-target untimed targets wrapped with `harness-mark`.

**2. Fail-loud rebalance guard.** `rebalance.py` now refuses (exit 1, lists offenders) if any shard target lacks timing data, instead of silently placing it "at tail."

**3. Harden the packer.** `pack()` fans zero-weight extras out round-robin (item-count tiebreak) instead of avalanching them onto the lightest shard.

**4. Lock it in.** The 5 newly-sliced files join `lint-harness-pytest-partition.py` `ENFORCED`, so the strict no-duplicate / no-gap partition is enforced under `make lint`.

## No duplicate execution

Each of the 5 files now runs **exactly once** across its targets (verified by the partition lint). `test_agents.py` drops from 11 full-file runs to 1 partitioned run.

## Verification

- `make py-test`, `make py-lint`, `make lint` green.
- `bash scripts/test-harness-shards-coverage.sh` (partition + `.PHONY` + membership + partition lint) green.
- Sampled targets executed via `make` (including both large catch-all slices) pass.
- New unit tests: packer zero-weight fan-out regression; `untimed_targets` helper.

## Follow-up

9 timed-but-duplicated multi-target files (`test_run_logs.py`, `test_implement_dispatch.py`, `test_release.py`, ...) still run full-file under multiple names — CPU waste, not the monster. Tracked in a separate issue; identical `-k` slice + `ENFORCED` pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
