### PR TITLE
Release v50.1.6

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "50.1.5",
+  "version": "50.1.6",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel) and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Fixed

- `/design` Step 2b drafter default changed from Codex to Claude; default Claude drafter model changed from `claude-fable-5` to `claude-opus-4-8`. Set `LARCH_DESIGN_DRAFTER=codex` to opt back into Codex. Docs and security guidance updated.
- Implementer agents (Claude, Codex, Cursor) no longer block edits to `.claude-plugin/plugin.json`. The hard guard and all four enforcement points in the dispatcher were removed.
- `/design` postplan validator falsely flagged scripts present in the consumer repo as `missing-script` when the plugin cache was used as the path root. The validator now tries the consumer git root first, then falls back to the plugin root.
- `/implement` progress report showed a stale step when multiple old session pointer files existed. Live run candidates are now ranked by tmpdir mtime (last activity) instead of pointer file mtime.
- `/design` Step 3 stalled after a zero-reviewer (`ELIGIBLE=0`) round because `.completed/step-3` was not guaranteed on every terminal exit. An EXIT trap now writes the sentinel on all terminal paths of `design-step3-review.sh`. The recovery waiter matcher also now accepts a leading `DESIGN_TMPDIR=...;` prefix.
- `py-test` runs inside a live session polluted the session's `execution-issues.md` with simulated CI-fixer failures. `python/conftest.py` autouse isolation now scrubs `IMPLEMENT_TMPDIR`, `DESIGN_TMPDIR`, `REVIEW_TMPDIR`, `SESSION_ENV_PATH`, and `LARCH_EXECUTION_ISSUES_LOG`.
- Pylint duplicate-code `min-similarity-lines` was at an interim value of 20 after the CI job split. Lowered to 8 and all 17 R0801 violations at that threshold fixed.

## Changed

- `/rebalance-test-harnesses` now keys its pass/fail verdict on real per-shard CI job wall-clock from the GitHub jobs API. The `LARCH_HARNESS_TIMING` sum is retained as secondary context. Added `--max-shard-wall-clock` (default 60 s).
- Tightened 7 CI test harness Makefile `-k` filter partitions to close coverage gaps and overlaps between shards.

## CI

- Split pylint duplicate-code check into a dedicated CI job to fix incorrect results under `-j>1`.
- Enabled parallel workers (`-j 0`) in the main pylint CI job for faster runs.
- Timed 5 previously-untimed pytest groups; added fail-loud rebalance guard.
- Routine test harness shard rebalance.
