### PR TITLE
Release v50.1.8

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "50.1.7",
+  "version": "50.1.8",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel) and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Fixed

- **Vendor health check routing overhaul.** Step 0 probe results (`CODEX_AVAILABLE`, `CURSOR_AVAILABLE`, `CODEX_PRESENT`, `CURSOR_PRESENT`) were propagated globally into later workflow stages and used to silently suppress Codex/Cursor slots even when the vendor binary was present. Step 0 is now used only as an operator gate: hard-fail when both vendors are down, warn-and-confirm when exactly one is down. All later call sites in `/design`, `/implement`, `/review`, `/research`, and related dispatch scripts now route via binary-presence keys (`CODEX_BINARY_FOUND`, `CURSOR_BINARY_FOUND`) or fresh executable checks. Stale probe-health false no longer shrinks review, voter, brainstorm, validation, or decompose manifests when binaries exist. Missing binaries fail fast without retry; present binaries that exit non-zero continue to use existing launcher retry behavior. The deprecated `_external_health_gate()` pre-launch guard is removed from `run_external_agent()`. Probe-health globals are absent from `source-env.sh` and `session-env.sh` after a normal run.
