### PR TITLE
Release v50.1.9

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "50.1.8",
+  "version": "50.1.9",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel) and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## v50.1.9

### Fixed

- **`/design` spurious exit 1 on brainstorm-off runs** (PR #4520): `design-step1d5.sh --mode complete` exited 1 on every no-pause path because the final statement of the `complete)` case was a bare `[ -f .pause-requested ] && exec ...` test under `set -euo pipefail`. Converted to an explicit `if` block at both the `complete)` case and the `design_pause_check()` helper so the no-pause path returns 0.

- **`/design` false-positive dirty-tree WARN during plan-review** (PR #4521): `dirty-tree checkpoint` ran `git status` in the plugin-cache directory rather than the consumer repo, producing `STATUS=unknown REASON=git-status-failed` and triggering `plan-review-collection: dirty tree detected` on every run. Added `--cwd` to `checkpoint_main` and exposed `LARCH_CONSUMER_REPO` from `_run_legacy` so scripts invoked via the legacy runner target the correct repo.

- **`/design` run-summary showing "Plan review: N/A" and zero warnings** (PR #4522): `design_summary.py` hardcoded `--plan-review-line "N/A"` instead of reading `review_status`/`rounds_completed` from `.step3-review-result.env`. The `_issue_counts` helper matched only h2 headers, silently counting 0 for `### Warnings` and `### Tool Failures` (h3). Both are fixed: the plan-review line now renders e.g. "complete (5 rounds)" and warnings/exec-issues counts match the actual entries in `execution-issues.md`.

- **`/implement` lint-fix bail misclassified as transient/timeout** (PR #4523): Lint-fix stall tokens (`lint-fix-failed`, `lint-fix-attempt-cap`, `lint-fix-main-agent-required`) were not persisted into the durable bail channel, so a timeout-only detail log hid the real failure class. The stall-recovery classifier now checks for lint-fix bail tokens before the transient `timeout` scan, returning `FAILURE_CLASS=lint-failure` and `RESUME_HINT=step5-review`. The new tokens are added to the render-safe allowlist in both Python and Bash. Lint-fix coders are also instructed to use exact `# type: ignore[reportPrivateUsage]` comments for narrow Pyright failures rather than renaming private helpers.

- **`/design` success path not populating `final-summary.md`** (PR #4525): `design-step5c.sh` called `emit_final_summary_marked_from_disk` on the normal publish path without first calling `render-final-summary`, so `final-summary.md` was never written on success. The render call is now made before the marker emit, mirroring the existing failure-path tail.

- **`ingest_launcher_token_sidecar` permanently skipping records on first `None` tmpdir** (PR #4525): `seen.add(token_record)` ran before the `if effective_tmpdir:` guard, so a record encountered with `effective_tmpdir=None` was marked processed and silently skipped on all subsequent retries. Moved `seen.add()` inside the guard so records are only marked processed when `append-record` actually runs.

- **Single-target shard retry summing instead of deduping** (PR #4527): `harness_ci_timing._split_shard_attempts` summed all retry rows for single-target shards instead of using only the latest attempt. Consecutive retries of a single-target shard now deduplicate to the latest attempt, matching the multi-target retry behavior.

### Changed

- **Removed dev-only `rebalance-test-harnesses` skill** (PR #4526): `.claude/skills/rebalance-test-harnesses/` (SKILL.md, scripts/rebalance.md, scripts/rebalance.py) removed. The `/rebalance-tests` skill supersedes it.

### Added

- **Regression tests for CI shard timing retry-dedupe and multi-bash behavior** (PR #4519): Three new test functions in `python/test_harness_ci_timing.py` pin that retried shards use only the latest attempt, consecutive multi-bash rows are all summed (not treated as retries), and the combined retry+multi-bash case deduplicates correctly.
