### PR TITLE
Release v50.1.10

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "50.1.9",
+  "version": "50.1.10",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel) and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Fixed

- **`/design` log PRs now merge automatically.** Design-run log PRs were created with GitHub-native `--auto` merge enabled, but the repository's active "Code review" ruleset requires an approving review that automated PRs never receive. Auto-merge was permanently blocked, causing log PRs to pile up open and requiring manual admin intervention. The fix routes log PRs through the existing `ship design-log` admin-merge path (`run_design_log_ci_merge`), launched as a detached background process so the `/design` orchestrator is not stalled on CI. The waiter polls required checks to green, then merges with `--admin --squash --delete-branch`, bypassing only the review gate.
