### PR TITLE
Release v51.0.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "50.1.10",
+  "version": "51.0.0",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel) and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## v51.0.0

### Changed

- **Skill catalog docs**: reconciled the public/private skill list and corrected discrepancies between README and skill entries. (PR #4531)
- **Agent-waterfall test harnesses**: migrated `test-dispatch-with-waterfall` and `test-no-grouped-reuse-guard` from shell scripts to Python (`test_agent_waterfall.py`); added `embedded_waterfall` filter to the design Step 3 loop test target. (PR #4532)
- **Implement-tmpdir resolver ported to Python**: `lib-resolve-implement-tmpdir.sh` replaced by `python/cli.py session resolve-implement-tmpdir`. The SessionStart hook (`scripts/sessionstart-health.sh`) now calls the Python resolver via a gated invocation; a Bash pre-check scans cache and `/tmp` session roots first so steady-state events do not spawn Python. CLONE_PATH matching, `LARCH_TOKEN_SESSION_ID` binding, sentinel precedence, and TTL behavior are preserved. (PR #4540)

