### PR TITLE
Release v51.0.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "51.0.0",
+  "version": "51.0.1",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Fixed

- **`step_7a.py`**: Fixed `run_id` precedence bug where a session env containing `LARCH_RUN_ID` but no `session-id` file yielded an empty run ID instead of the env value.
- **`pr_body.py`**: Fixed execution-report issue counts: structured NDJSON rows now count per bullet rather than per record, matching the `body_text` fallback path.
- **`execution_issues.py`**: Fixed `append_execution_issue` inserting entries at the end of the file instead of at the end of the matching category section when another section follows it.
- **`bootstrap.py`**: `/implement` materialization now strips `review_status:` and `rounds_completed:` header lines from `plan.txt` so implementer agents and the plan-adequacy audit receive clean plan prose.
- **`agents.py`**: Fixed CI launcher workdir resolution: Codex review agents now resolve workdirs through `_resolve_review_codex_workdir` instead of using the raw argument, preventing directory-not-found failures when run from a non-root working directory.

## Changed

- **`checks.py`**: `skills/implement/SKILL.md` edits now trigger `test-implement-structure` and `test-render-cost-line-callsites` in focused CI, matching existing `skills/design/SKILL.md` coverage.
- **`checks.py`**: Added focused-target rows mapping all eleven `python/design_*.py` modules to their pytest targets.
- **Design step-validator autofix harness**: Added `AUTOFIX_STATUS=ok` harness case; documented `--stderr-sink` pairing for brainstorm waterfall fallback sinks in `references/brainstorm.md`.
- **`test-design-step1d5.sh`**: New committed harness for `design-step1d5.sh --mode collect` covering per-slot logging, idempotency sentinels, and dirty-tree merge.
- **Step 5 dynamic-archetypes cap**: Banner message and Python resolver now use the same cap, eliminating a parity gap between the displayed slot count and the actual resolved count.
- **OOS pipeline, run-logs, upgrade-larch, audit-runs, and `pr_body.py`**: Minor tooling and doc cleanups covering OOS-pipeline hygiene, run-log field alignment, upgrade-larch focused-test gaps, and audit-runs check wiring.
