### PR TITLE
Release v51.0.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "51.0.1",
+  "version": "51.0.2",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Fixed

- **Stop hook clears stale session ID on empty payload.** The `/implement` Stop hook now unsets any inherited `LARCH_TOKEN_SESSION_ID` when the Stop payload carries an empty, missing, or null `session_id`. Previously a stale inherited value could cause `session resolve-implement-tmpdir` to select the wrong active tmpdir by bypassing the TTL backstop. ([#4567](https://github.com/character-ai/larch/pull/4567))

## Added

- **Shared clone-tag derivation library for Step 8.** A new `lib-implement-clone-tag.sh` helper exports `CLONE_TAG_FULL` and `EXPECTED_TMPDIR_BASENAME_PREFIX` so the ship driver and the seeder agree on the tmpdir prefix without duplicating derivation logic. ([#4568](https://github.com/character-ai/larch/pull/4568))

- **Step 8 Python-version guard wrapper.** A new `step-8-python-guard.sh` checks the Python version requirement (3.11+) in a single one-liner fence, emitting a STALLED JSON and exiting 4 on older interpreters. It is sourced by both the pre-driver orchestrator and the ship driver. ([#4568](https://github.com/character-ai/larch/pull/4568))

- **Step 8 initial ship-pr-state seeder.** A new `step-8-seed-initial.sh` wrapper assembles all `python/cli.py ship seed-initial-state` argv internally, assembling keys from `bootstrap-routing.env`, `ship-seed-input.env`, and `session-env.sh` in a defined priority order. It enforces a create-if-absent contract so it never overwrites a seeder state already written. ([#4568](https://github.com/character-ai/larch/pull/4568))

## Changed

- **Unified Codex/Cursor startup lock.** Per-tool serial locks (`/tmp/larch-{tool}-serial-$USER.lock`) are merged into one shared path `/tmp/larch-external-startup-$USER.lock` because Codex and Cursor contend for the same per-user macOS Keychain resource. Lock helpers are renamed to `external_startup_lock_acquire` and `external_startup_lock_release_after`; operator env vars are renamed from `LARCH_EXTERNAL_SERIAL_LOCK_*` to `LARCH_EXTERNAL_STARTUP_LOCK_*`. Python and Bash paths use identical lock paths; unset or empty `USER` resolves to `larch` in both lanes. ([#4569](https://github.com/character-ai/larch/pull/4569))
