### PR TITLE
Release v51.0.3

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "51.0.2",
+  "version": "51.0.3",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Changed

- Ported code-review voter dispatch from Bash to Python. The new module preserves shrink-not-backfill and parse-rate retry behavior, adds pytest coverage, and retires the legacy shell voter harness.

## Fixed

- Restored per-round review tables and Gantt charts in `/design` and `/implement` final reports. These sections were dropped when the summary renderers were migrated from shell to Python. A new shared Python helper re-invokes the existing renderer and splices the output into the final summary, with pre-redact and post-redact swallow contracts so missing inputs or renderer failures never block the report.
