### PR TITLE
Release v51.1.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "51.0.3",
+  "version": "51.1.0",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Added

- **`/bug --urgent` flag** — `/bug` now accepts a leading `--urgent` token. Urgent reports use a `[BUG] (URGENT)` title prefix instead of `[BUG]`; the flag is stripped before description validation.
- **`/bug` structure harness** — Added `test-bug-structure` CI target (shard 13) covering `--urgent` parsing and title-prefix delegation.

## Fixed

- **Bounded memory reads in voter context copy** — `_make_bounded_context_copy` in `agent_voters.py` now opens files with `handle.read(max_bytes)` instead of `read_bytes()[:max_bytes]`, preventing full-file allocation for large inputs.
- **OOS URL extraction via NDJSON** — `_derive_oos_fields` in `pr_body.py` parses OOS records from NDJSON and extracts URLs from structured `body` fields instead of regex-scanning free text, fixing truncated URLs in the run summary.
- **Enriched diagram failure diagnostics** — `generate_code_flow_diagram` writes a `code-flow-diagram.failure.log` to the run tmpdir and returns an enriched reason including return code and a capped, redacted stderr/stdout tail; bare `generation-failed` is no longer the only signal.
- **Gitleaks false positives on larch run-log patterns** — Added stopwords and regex allowlist entries for `IMPLEMENT_BAIL_REASON=`, `MERGE_RESULT=merged`, `LARCH_TOKEN_SESSION_ID=`, and test-fixture placeholder strings.
