### PR TITLE
Release v51.1.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "51.1.0",
+  "version": "51.1.1",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
### Changed

- **Ship-pr CI fixing** now runs as a single write-capable Claude/Opus 4.8 agentic loop that edits, verifies locally, pushes behind guard checks, and blocks on CI, replacing the Codex-then-Cursor-then-Claude fixer waterfall.
- **Local lint-fix and conflict-resolution fixers** now try Claude/Opus 4.8 first, then Codex, then Cursor, reversing the prior Codex-first order.
- **Version-bump conflict special-casing was removed.** Version-adjacent files (`plugin.json`, `version.go`, `go.sum`) and the `LARCH_VERSION_FILES` / `LARCH_BUMP_FILES` env vars no longer receive distinct conflict handling.
- **`/implement` Steps 16-17** now run through one wrapper that delivers the run summary via inline begin/end markers in captured output, instead of the orchestrator reading the summary file separately.
- **`/release`** now excludes larch run-log housekeeping PRs (`chore(larch-logs): …`) from the PR count and release notes, reporting the ignored count separately.
- **`/design` tmpdir validation** now runs through the Python `session validate-design-tmpdir` CLI instead of a sourced Bash library, deferring quiet logging until after the path passes validation.
- **CI pytest shards** were de-duplicated across nine multi-target harness files so each shard target runs a disjoint test slice instead of re-running the whole file, with a partition guard enforcing no coverage gaps or overlaps.
- **Documentation and config drift corrected.** Aligned the `/implement --emergency` description, the run-statistics ownership note, and the degraded-vendor status copy with actual behavior, and added two missing strict-permission allowlist entries.

### Fixed

- **Reviewer-timing Gantt charts** now include the fix-applying coder (shown as `codex/apply` or `cursor/apply`) and span the full round window, instead of dropping those agents and clipping to only the displayed tasks.

### Added

- **Regression test coverage** for clearing a stale session token before the SessionStart health resolver runs, and for logging non-zero collector-result failures.
