### PR TITLE
Release v51.1.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "51.1.1",
+  "version": "51.1.2",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Changed

- **New larch scripts default to Python.** Added convention to `AGENTS.md`, clarification to `docs/python-migration.md`, and new `.claude/rules/python-first-scripts.md` path-triggered rule. Bash is allowed only for thin `cli.py` delegation wrappers, Claude Code hooks, and pre-commit/CI glue. ([#4621](https://github.com/character-ai/larch/pull/4621))

- **Degraded-tools gate docs updated.** `docs/skills.md` and `docs/external-reviewers.md` now reflect actual gate behavior: one vendor down requires explicit Continue/Abort; both vendors down hard-fails in every mode. ([#4646](https://github.com/character-ai/larch/pull/4646))

- **/implement Step 18 refactored.** Combined into a single wrapper with an early-exit stall gate and marker-based body emission; reduces the no-stall path from three retired wrappers to two Bash calls. Adds `make test-step-18` harness. ([#4648](https://github.com/character-ai/larch/pull/4648))

## Fixed

- **Reviewer result-quality retry (ns-retry) removed.** `NOT_SUBSTANTIVE` validation failures are now terminal: warn, tally, drop, continue. No ns-retry, no voter parse-rate relaunch, no alt-tool waterfall for content-shape failures. Affects `python/collect_results.py`, `python/voting.py`, and embedded plan-review blobs in `python/plan_review.py`. ([#4603](https://github.com/character-ai/larch/pull/4603))

- **Embedded plan-review scripts defer quiet-log init.** `_LEGACY_ASSETS` plan-review bash bodies in `python/plan_review.py` now call `larch_quiet_init` only after `session validate-design-tmpdir` succeeds, preventing quiet logs from writing to an unvalidated design tmpdir. ([#4622](https://github.com/character-ai/larch/pull/4622))

- **External-tool health probe transient retry budget added.** New `LARCH_PROBE_RETRIES` env var (default `2`) controls additional retries after transient `rc==1` probe failures, independent of auth retries (`LARCH_EXTERNAL_AUTH_RETRIES`). Health-gate fast-fail probes (`LARCH_EXTERNAL_AUTH_RETRIES=1`) suppress transient retries unless `LARCH_PROBE_RETRIES` is explicitly set. ([#4644](https://github.com/character-ai/larch/pull/4644))
