### PR TITLE
Release v51.1.3

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "51.1.2",
+  "version": "51.1.3",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Fixed

- `/implement` Step 5 falsely reported the review panel as failed even when all reviewers had completed, stalling the run (PR #4664, #4694)
- Silent plan-file drops in `/implement` Step 2 caused Step 5 panel-failed to recur after the initial fix (PR #4694)
- `code-review-tally.json` showed only round-1 results for multi-round `/implement` runs (PR #4666)
- `/implement --self-review` tally was hardcoded to `0/0`, under-reporting inline review counts (PR #4686)
- Progress hook selected the wrong session tmpdir when multiple live sessions shared a repo (PR #4690)

## Changed

- Code-review voter panel now uses 3 archetype-distinct Cursor voters instead of the previous Claude + Codex + Cursor mix for `/implement` and `/review` (PR #4662)
- In-flight progress Gantt now shows only current-round reviewers; prior-round reviewers no longer appear in the active display (PR #4667)
- Review pipeline collect/dispatch/gather bodies ported to Python in-process (PR #4684)
- Review pipeline aggregate/tally/compose/emit bodies ported to Python in-process (PR #4707)
- `/design` Step-0/1 bootstrap and routing bodies ported to Python in-process (PR #4691)
- `/design` Step-2 drafter and validator bodies ported to Python in-process (PR #4696)
- `/design` clarify phase ported to Python in-process (PR #4709)
- `/implement` finalize, preflight, and Step-18 closeout bodies ported to Python in-process (PR #4706)
- `/implement` stall-recovery report body ported to Python in-process (PR #4714)
- `/implement` Step-0/2/5/6 entry, OOS, and execution-issues bodies ported to Python in-process (PR #4711)
- Test-harness, dead-code, and lint-table cleanup (PR #4693)
- Aggregated rollup of 7 capped out-of-scope items (PR #4657)
