### PR TITLE
Release v51.1.4

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "51.1.3",
+  "version": "51.1.4",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Changed

- **Orchestrator recovery guidance expanded for premature `<task-notification>` events** (#4719). `AGENTS.md` now documents a two-path recovery strategy: a re-launched background `until` waiter as the primary path, and a single foreground `[ -f … ]` / `test -f …` probe (targeting `.completed/step-3-terminal`, `.completed/step-5c-terminal`, or `.completed/step-final-summary`) as the fallback when the waiter is killed or unavailable. Includes `DESIGN_TMPDIR` prefix guidance for Bash calls that do not persist the variable.

- **`/design` Step 3 plan-review loop ported to Python** (#4729). `python/plan_review.py`, `python/plan_review_panel.py`, and `python/plan_review_round.py` now own the loop logic (sh-to-py G3 migration). Bash wrappers (`review-design-step3-loop.sh`, `plan-review-continuation.sh`) delegate to `python/cli.py`. `python/migrated-scripts.tsv` and `skills/design/SKILL.md` updated to reflect the new authority.

## Fixed

- **`/design` Step 3 reviewer aggregation silent failure** (#4728). When all reviewer slots produced TSV output but `findings.md` remained empty and `.completed/step-3` was never written, the root cause was two separate defects in `design-step3-review.sh`: (1) a trap window between `trap - EXIT` and the guarantee trap reinstall that could leave the process with no EXIT trap active, and (2) a TSV parser that failed on Codex output files lacking a trailing newline. Both are fixed; `test-design-step3-review.sh` covers the regression.
