### PR TITLE
Release v51.1.5

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "51.1.4",
+  "version": "51.1.5",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Fixed

- **Plan-review panel always failed during `/design` Step 3** (PR #4748). The panel dispatcher passed `--mode plan-review` to `agent dispatch-waterfall`, which rejects any mode outside `{diff, description}` and exits before launching any reviewer. Every `/design` review round was silently degraded. Fixed by passing `description`. Also surfaces waterfall stderr via `PANEL_DISPATCH_EXIT_CODE` and `PANEL_FAILURE_DETAIL_LOG` so this class of failure can no longer be silent.

- **Coder apply stages changes but skips commit, leaving a dirty working tree that blocks subsequent rebases** (PR #4746). After a coder applied review fixes, the commit step was skipped on certain failure paths, leaving staged residue that broke the rebase. Fixed with a waterfall-plus-rollback approach: each coder attempt is treated as edit + submodule guard + commit; failed attempts roll back only coder-introduced changes before trying the next coder.

- **`/design` final summary showed empty Top reviewers and `unknown/collector-failure-N` labels** (PR #4749). Two independent rendering bugs in the review-phase-detail section: (1) "Top reviewers" was always empty because the renderer looked for `review-findings-full.jsonl`, which only `/implement` writes; `/design` writes per-round `findings-classification.tsv`. Fixed by reading from that TSV when the JSON-lines file is absent. (2) Slot failures were labeled `unknown/collector-failure-N` because round-meta only recorded a failure count with hardcoded placeholder records. Fixed by reading real slot info from `reviewer-status.tsv`.

- **Premature task-notifications during `/design` Step 3 caused turn/cost explosion** (PR #4750). When a notification fired early, the orchestrator launched a background sleep-loop waiter, which is itself a zero-output background task that fires another notification, forming a compounding re-engagement loop. Fixed: `hook-bg-poll-guard.sh` now denies background sleep-loop recovery waiters. Orchestrators must use a single foreground non-sleeping sentinel probe instead. Updated `AGENTS.md`, `skills/design/SKILL.md`, and `skills/shared/orchestrator-never.md` to document the sanctioned recovery path.

- **`plan-review step3-state` native Python port was incomplete** (PR #4738). The Python stub for `design-step3-state.sh` emitted state labels but did not replicate sentinel clearing, upstream restore, or pause-hygiene from the shell original. Direct-review re-entry and auto-continuation paths left stale downstream sentinels. Completed the port: clears downstream sentinels, restores step-2 sentinels, handles pause-hygiene, and settles round state. Deleted `design-step3-state.sh`. Added sentinel-mutation tests.

## Changed

- **Ported `/design` Step 5b OOS prepare and annotate to Python** (PR #4739). Added `step5b_prepare_main` and `step5b_annotate_main` in `python/design_lifecycle.py`. Includes a `_capture_stdout_stderr` failure boundary so crashes before sentinel writes are caught and converted to non-zero rc rather than escaping the step.

- **Split `python-lint` CI into `python-lint` and `python-pyright` jobs** (PR #4741). Pyright typecheck (`make py-typecheck`) moves to its own `python-pyright` CI job with a `setup-node` step. The `python-lint` job now runs `make py-lint-main` only. CI sets `PYLINT_JOBS: "0"` to force all pylint workers.

- **Ported rendering and round-meta script bodies to Python** (PR #4745). Ported `render-review-phase-detail.sh`, `render-run-summary.sh`, `write-design-round-meta.sh`, `write-implement-round-meta.sh`, and related renderer scripts into `python/rendering.py`, `python/progress_report.py`, and `python/pr_body.py` as part of the sh-to-py migration.

- **Duplicate-code lint runs through a custom parallel runner** (PR #4752). `make py-lint-duplicate-code` now invokes `python/cli.py lint duplicate-code` instead of `pylint -j 1`. Adds a `py-lint-duplicate-code-parity` gate. CI adds wall-time reporting for the duplicate-code step.

- **Ported external-agent launcher libraries to Python** (PR #4754). Ported `lib-external-launcher-common.sh`, `lib-failed-agent-stderr-tail.sh`, `lib-cursor-auth.sh`, `launch-claude-drafter.sh`, and `launch-codex-drafter.sh` into `python/agents.py`. Deleted `lib-cursor-launcher-common.sh` and `lib-codex-launcher-common.sh`.
