### PR TITLE
Release v51.1.5

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "51.1.4",
+  "version": "51.1.5",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
# Release v51.1.5

Patch release. 13 PRs since v51.1.4: continued sh-to-py ports, CI speedups, and workflow bug fixes.

## Changed

- Port /design Step 5b prepare and annotate from Bash to in-process Python (#4739).
- Port rendering, round-meta, and small skill bodies from Bash to in-process Python (#4745).
- Port the external-agent launcher libraries (Codex, Cursor, and Claude drafters, plus vendor failure diagnostics) from Bash to in-process Python (#4754).
- Speed up the python-lint CI job, previously the >3-minute CI bottleneck (#4741).
- Speed up the python-lint-duplicate-code CI job, previously a ~3-minute CI bottleneck (#4752).
- Rebalance the Python unit-test shards (#4760).
- Remove the duplicate-code legacy/new parity CI gate (#4761).

## Fixed

- Native plan-review Step 3 state now clears the direct-review and auto-continuation sentinel, restoring parity with the retired Bash path (#4738).
- Cursor review-fix application now commits staged fixes instead of leaving a dirty working tree that broke the subsequent rebase (#4746).
- plan-review panel dispatch no longer passes an unsupported `--mode` argument to the waterfall path, which previously made the panel always fail (#4748).
- /design final summary now populates Top reviewers and avoids unknown and collector-failure-N reviewer labels (#4749).
- Premature background task-notifications during design Step 3 review no longer re-engage the main agent (which caused a turn and cost explosion); adds a background-poll guard hook (#4750).
- Harden /implement escalation: commit review-loop fixes to avoid a ship-driver dirty-tree stall, and close the Codex allow-list and test-partition gaps that caused CI failures (#4759).
