### PR TITLE
ci: de-matrix lint jobs; move duplicate-code to post-merge

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -197,24 +197,15 @@ jobs:
       - name: Pipe SIGPIPE safety lint
         run: bash scripts/test-pipe-sigpipe-safety.sh
 
-  # Dedicated shellcheck jobs — split into `scripts` and `skills/.claude`
-  # scopes running in parallel to halve wall-clock time. Each scope installs
-  # the pinned shellcheck-py==0.11.0.1 binary directly (no pre-commit
-  # overhead) and runs shellcheck -x in parallel via xargs. The pre-commit
+  # Dedicated shellcheck job — installs the pinned shellcheck-py==0.11.0.1
+  # binary directly (no pre-commit overhead) and runs shellcheck -x in
+  # parallel via xargs over scripts, skills, and .claude. The pre-commit
   # `shellcheck` hook remains active for local `pre-commit run` and the dev
   # git-hook; CI skips it in `lint` and `lint-local` via the SKIP env var.
   # shellcheck-py pinned to 0.11.0.1 — keep in sync with .pre-commit-config.yaml on bump.
   shellcheck:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - scope: scripts
-            paths: scripts
-          - scope: skills
-            paths: "skills .claude"
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -229,11 +220,11 @@ jobs:
           PIP_RETRIES: "5"
           PIP_DEFAULT_TIMEOUT: "30"
         run: pip install shellcheck-py==0.11.0.1
-      - name: Run shellcheck (${{ matrix.scope }})
+      - name: Run shellcheck
         run: |
           set -euo pipefail
           max_parallel="$(nproc 2>/dev/null || echo 1)"
-          find ${{ matrix.paths }} -name "*.sh" -not -path "*/larch-logs/*" -print0 \
+          find scripts skills .claude -name "*.sh" -not -path "*/larch-logs/*" -print0 \
             | xargs -0 -r -n 1 -P "$max_parallel" shellcheck -x --exclude=SC2329 --
 
   # Regression harness shards (the `test-*` bash scripts in Makefile). Runs
@@ -567,14 +558,11 @@ jobs:
     # CI forces all pylint workers; the Makefile sysconf fallback stays local.
     env:
       PYLINT_JOBS: "0"
-    strategy:
-      matrix:
-        python-version: ["3.11"]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.11"
           cache: pip
           cache-dependency-path: python/requirements-dev.txt
       - name: Install Python lint dependencies
@@ -588,14 +576,11 @@ jobs:
   python-pyright:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    strategy:
-      matrix:
-        python-version: ["3.11"]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.11"
           cache: pip
           cache-dependency-path: python/requirements-dev.txt
       - uses: actions/setup-node@v5
@@ -606,34 +591,6 @@ jobs:
         run: pip install -r python/requirements-dev.txt
       - name: Run Python typecheck
         run: make py-typecheck
-
-  # Duplicate-code (R0801) is split into its own job: pylint's similarities
-  # checker is incorrect under -j>1 (workers each see only a slice of files), so
-  # it must run single-process. Splitting it keeps the main python-lint job fast.
-  # Threshold lives in python/.pylintrc (min-similarity-lines); see issue #4480.
-  python-lint-duplicate-code:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    strategy:
-      matrix:
-        python-version: ["3.11"]
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: pip
-          cache-dependency-path: python/requirements-dev.txt
-      - name: Install Python lint dependencies
-        env:
-          PIP_RETRIES: "5"
-          PIP_DEFAULT_TIMEOUT: "30"
-        run: pip install -r python/requirements-dev.txt
-      - name: Run pylint duplicate-code check
-        run: |
-          SECONDS=0
-          make py-lint-duplicate-code
-          echo "duplicate-code wall time: ${SECONDS}s"
 
   # Python unit tests, sharded across a matrix to speed up CI. conftest.py
   # round-robins the collected tests by index using PYTEST_SHARD_ID /

--- a/.github/workflows/duplicate-code.yaml
+++ b/.github/workflows/duplicate-code.yaml
@@ -1,0 +1,42 @@
+name: Duplicate code
+
+# Pylint's duplicate-code (R0801) similarities checker is incorrect under -j>1
+# (workers each see only a slice of files), so it must run single-process and
+# is slow. It is too slow to gate every PR, so it runs only on merge to main
+# instead of in the PR CI workflow (.github/workflows/ci.yaml). Threshold lives
+# in python/.pylintrc (min-similarity-lines); see issue #4480.
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+env:
+  # Force JavaScript-based actions (e.g. actions/setup-python) onto Node.js 24
+  # to suppress the Node 20 deprecation warning. Mirrors .github/workflows/ci.yaml.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  python-lint-duplicate-code:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: python/requirements-dev.txt
+      - name: Install Python lint dependencies
+        env:
+          PIP_RETRIES: "5"
+          PIP_DEFAULT_TIMEOUT: "30"
+        run: pip install -r python/requirements-dev.txt
+      - name: Run pylint duplicate-code check
+        run: |
+          SECONDS=0
+          make py-lint-duplicate-code
+          echo "duplicate-code wall time: ${SECONDS}s"


### PR DESCRIPTION
## What

- **De-matrix** `python-lint`, `python-pyright`, and `shellcheck`: convert from `strategy.matrix` to regular jobs. `python-lint`/`python-pyright` dropped a single-element `python-version` matrix; `shellcheck` collapsed its two-leg scope matrix into one `find scripts skills .claude` run.
- **Move** `python-lint-duplicate-code` out of PR CI into a new workflow (`.github/workflows/duplicate-code.yaml`) triggered on `push: main`.

## Why

- The single-element matrices only added noise (parenthesized check names like `python-lint (3.11)`) with no benefit.
- Duplicate-code (R0801) must run single-process and is slow. Running it only on merge to main keeps PR CI fast.

## Required-checks sequencing

- **Before this PR**: dropped the stale matrix-named checks (`python-lint (3.11)`, `shellcheck (scripts, scripts)`, `shellcheck (skills, skills .claude)`, `python-lint-duplicate-code (3.11)`) from the "CI and branch safety" ruleset, so this PR is not blocked by checks that never report under the new job names.
- **After merge**: the required set will be updated to the new names: `python-lint`, `python-pyright` (newly required, per "all CI jobs must be required"), and `shellcheck`. `python-lint-duplicate-code` stays out of the required set since it no longer runs on PRs.

## Notes

- `ci-failed-jobs.sh` and `config.py` keep the `python-lint-duplicate-code` classifier mapping, since the job still runs on `main`.
- `make test-ci-failed-jobs` passes; `actionlint` passes on both workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
