### PR TITLE
fix: restore design log-publish artifact filter (regressed in #4404)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -59,7 +59,15 @@ Claude prompts (`claude-plan-*.prompt`) and rendered plan-review prompts
 collector failure logs, dropped-slot diagnostics
 (`plan-review-slots.ndjson.output-files.dropped-slots`), and aggregate
 `plan-review-collector.stderr`; `findings.md` / `voting-tally.md` remain
-canonical.
+canonical. This exclusion is enforced by
+`design_log_publish_flow._publish_excluded`, matched by basename at every depth
+of the copied run tree (top level and `plan-review/round-N/`); it also drops the
+`plan-autofix/` draft subtree, `.completed/` step sentinels, the
+`step2b-codex-raw.*` drafter family, and per-launch `.token-record` /
+`.porcelain` carriers. The 2026-06 Python port of the publish flow
+(`design-log-publish.sh` to `design_log_publish_flow.py`) regressed this filter:
+it copied the whole `$DESIGN_TMPDIR` unfiltered and committed the raw streams,
+inflating committed design logs roughly 40x until the filter was restored.
 
 ## Stall recovery sanitization
 

--- a/docs/run-logs.md
+++ b/docs/run-logs.md
@@ -15,7 +15,7 @@ larch-logs/
   design/
     <RUN_ID>/
       manifest.json
-      (design session artifacts: depth-1 files from `$DESIGN_TMPDIR` plus `render-cache/` subtree, trimmed and redacted per `python/design_log_publish_flow.py`; `composed-plan.diff` is a unified diff of `composed-plan.md` vs final `plan.txt` — reconstruct with `patch plan.txt composed-plan.diff -o composed-plan.md`)
+      (design session artifacts: files from `$DESIGN_TMPDIR` plus `render-cache/` subtree, filtered to exclude raw per-lane transcripts and sidecars via `design_log_publish_flow._publish_excluded`, then trimmed and redacted per `python/design_log_publish_flow.py`; `composed-plan.diff` is a unified diff of `composed-plan.md` vs final `plan.txt` — reconstruct with `patch plan.txt composed-plan.diff -o composed-plan.md`)
       plan-review/
         round-<N>/
           findings-classification.tsv

--- a/python/design_log_publish_flow.py
+++ b/python/design_log_publish_flow.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import fnmatch
 import os
 import re
 import shutil
@@ -35,6 +36,97 @@ def _persist_metadata(design_tmpdir: Path, pr_number: str, pr_url: str, recovery
         )
 
 
+# Raw machine sidecars/transcripts the /design lanes drop into $DESIGN_TMPDIR.
+# They are launch carriers, not human-facing run content: a single Codex
+# `.events.jsonl` event stream is ~770 KB per lane, and the committed design log
+# ballooned ~40x (8.6 MB/run vs ~0.2 MB/run before) once that capture landed and
+# the publish copied them. The pre-port bash publisher (`design-log-publish.sh`,
+# `design_artifact_excluded`) excluded exactly this class; the Python port
+# (#3681 / #4404) dropped the filter and copied the whole tmpdir, regressing the
+# behavior SECURITY.md still documents. This restores that exclusion.
+#
+# The filter is applied by basename at every tree depth (top level and inside
+# `plan-review/round-N/`), so it intentionally lists ONLY universal-crud carriers
+# that never appear as curated content. The bash predicate also deduped
+# human-readable top-level copies (`findings.md`, `voting-tally.md`,
+# `*-vote-output.txt`, `round-meta.json`) that are canonical in the subtree;
+# those are NOT listed here because a basename rule cannot tell the top-level
+# duplicate from the curated subtree copy, and keeping the small duplicate is
+# harmless. Curated forensics (plan.txt, findings.md, voting-tally.md,
+# `*-vote-output.txt`, the plan-review/round-N/ subtree) are preserved.
+_PUBLISH_EXCLUDE_SUFFIXES = (
+    ".events.jsonl",
+    ".events.history",
+    ".prompt",
+    ".meta",
+    ".sidecar",
+    ".sidecar.history",
+    ".token-record",
+    ".dirty-tree",
+    ".untracked-baseline",
+    ".diag",
+    ".done",
+    ".cap-hit",
+    ".launch-stderr",
+    ".launcher-stderr",
+    ".stderr-tail",
+    ".porcelain",
+    ".txt.json",
+    ".txt.tsv",
+)
+
+# Glob-matched basenames. `*-plan-*-output*.txt` is the raw per-lane reviewer /
+# voter / drafter transcript (cursor-plan-*, codex-primary-plan-*, claude-plan-*,
+# their dyn-* and -phase/-retry variants); it deliberately spares
+# `aggregator-output.txt` (no `-plan-`) and the curated `*-vote-output.txt` (no
+# `-plan-`). `*-plan-*-output*.txt.*` sweeps any sidecar of those transcripts not
+# already caught by suffix. The rest are prompt carriers, the step2b drafter raw
+# family, slot-named collector failure logs, and raw scout stems.
+_PUBLISH_EXCLUDE_GLOBS = (
+    "*-plan-*-output*.txt",
+    "*-plan-*-output*.txt.*",
+    "*-prompt.txt",
+    "*-prompt.md",
+    "step2b-codex-raw.*",
+    "*-collector.failure.log",
+    "*.raw.cursor",
+    "*.raw.claude",
+)
+
+# Exact basenames: the aggregate plan-review collector stderr, the dropped-slot
+# diagnostic sidecar (both documented in SECURITY.md), and the pre-redaction
+# duplicate of composed-plan.md (the publish redacts on copy, so the `.redacted`
+# twin adds nothing).
+_PUBLISH_EXCLUDE_NAMES = frozenset({
+    "plan-review-collector.stderr",
+    "plan-review-slots.ndjson.output-files.dropped-slots",
+    "composed-plan.redacted.md",
+})
+
+# Whole subtrees of raw transcripts (plan-autofix drafts) or internal step
+# sentinels (.completed) that carry no committed-log value.
+_PUBLISH_EXCLUDE_DIRS = frozenset({
+    "plan-autofix",
+    ".completed",
+})
+
+
+def _publish_excluded(name: str, *, is_dir: bool) -> bool:
+    """Return True for raw machine sidecars/transcripts that must not be committed.
+
+    ``name`` is a single path component (basename). Directory names are matched
+    against ``_PUBLISH_EXCLUDE_DIRS``; files against the exact-name, suffix, and
+    glob sets.
+    """
+    if is_dir:
+        return name in _PUBLISH_EXCLUDE_DIRS
+    if name in _PUBLISH_EXCLUDE_NAMES:
+        return True
+    if name.endswith(_PUBLISH_EXCLUDE_SUFFIXES):
+        return True
+    return any(fnmatch.fnmatchcase(name, glob) for glob in _PUBLISH_EXCLUDE_GLOBS)
+
+
 def _copy_tree_redacted(plugin_root: Path, source: Path, dest: Path) -> bool:
     if source.is_symlink():
         return False
@@ -63,6 +155,8 @@ def _copy_tree_redacted(plugin_root: Path, source: Path, dest: Path) -> bool:
     if source.is_dir():
         for child in source.iterdir():
             if child.is_symlink():
+                continue
+            if _publish_excluded(child.name, is_dir=child.is_dir()):
                 continue
             if not _copy_tree_redacted(plugin_root, child, dest / child.name):
                 return False
@@ -156,6 +250,8 @@ def _publish_design_logs(
             return (False, "", "", "")
         for child in design_tmpdir.iterdir():
             if child.name == ".design-log-publish-metadata.env":
+                continue
+            if _publish_excluded(child.name, is_dir=child.is_dir()):
                 continue
             if not _copy_tree_redacted(plugin_root, child, run_dest / child.name):
                 return (False, "", "", "")

--- a/python/test_design_log_publish_flow.py
+++ b/python/test_design_log_publish_flow.py
@@ -195,6 +195,128 @@ def test_spawn_detached_admin_merge_omits_repo_when_empty(monkeypatch: pytest.Mo
     assert "--repo" not in captured_argv
 
 
+def test_publish_excluded_predicate() -> None:
+    # Raw machine sidecars/transcripts are dropped; curated forensics are kept.
+    # Guards the keep/drop boundary that restores the pre-Codex-capture committed
+    # design-log shape (the ~40x .events.jsonl bloat).
+    excluded = [
+        "codex-primary-plan-arch-output.txt.events.jsonl",
+        "codex-primary-plan-arch-output.txt.meta",
+        "render-plan-codex-arch.prompt",
+        "cursor-plan-requirements-output.txt",  # *-plan-*-output*.txt
+        "codex-plan-generic-output.txt",
+        "cursor-plan-arch-output-phase2.txt",  # -output*.txt phase variant
+        "codex-primary-plan-arch-output.txt.stderr-tail",  # *-plan-*-output*.txt.*
+        "claude-plan-voter-prompt.txt",  # *-prompt.txt
+        "aggregator-prompt.md",  # *-prompt.md
+        "step2b-codex-raw.40818.txt",
+        "cursor-plan-arch-output.txt.json",  # *.txt.json
+        "codex-primary-plan-arch-output.txt.tsv",  # *.txt.tsv
+        "claude-vote-output.txt.token-record",
+        "cursor-plan-arch-output.txt.dirty-tree",
+        "cursor-plan-requirements-collector.failure.log",  # *-collector.failure.log
+        "scout-plan-manifest.json.raw.cursor",  # *.raw.cursor
+        "plan-review-collector.stderr",  # exact name
+        "plan-review-slots.ndjson.output-files.dropped-slots",  # exact name
+        "composed-plan.redacted.md",  # redacted duplicate
+    ]
+    for name in excluded:
+        assert design_log_publish_flow._publish_excluded(name, is_dir=False), name
+    kept = [
+        "plan.txt",
+        "composed-plan.diff",
+        "findings.md",
+        "voting-tally.md",
+        "accepted-plan-findings.md",
+        "aggregator-output.txt",  # not -plan-, not -vote-
+        "codex-vote-output.txt",  # curated vote output, not *-plan-*-output*.txt
+        "aggregator-validate.stderr",  # bare .stderr kept; only -collector.stderr drops
+        "step2b-drafter-status.txt.failure-diag",  # composed carrier kept (#3713)
+        "architecture-diagram.md",
+        "manifest.json",  # not *.txt.json
+        "run-params.json",
+        "token-report.json",
+        "scout-plan-manifest.json",
+        "findings-classification.tsv",  # not *.txt.tsv
+        "plan-review-slots.ndjson",
+    ]
+    for name in kept:
+        assert not design_log_publish_flow._publish_excluded(name, is_dir=False), name
+    # Whole-subtree exclusions are directory-scoped.
+    assert design_log_publish_flow._publish_excluded("plan-autofix", is_dir=True)
+    assert design_log_publish_flow._publish_excluded(".completed", is_dir=True)
+    assert not design_log_publish_flow._publish_excluded("plan-review", is_dir=True)
+    assert not design_log_publish_flow._publish_excluded("breadcrumbs", is_dir=True)
+    assert not design_log_publish_flow._publish_excluded("plan-autofix", is_dir=False)
+
+
+def test_log_publish_excludes_sidecar_crud(tmp_path: Path) -> None:
+    # The publish copies a curated set: raw Codex event streams, prompt/meta
+    # sidecars, raw per-lane outputs, plan-autofix drafts, and .completed
+    # sentinels are dropped at every tree depth, while plan.txt, findings, and the
+    # curated plan-review/round-N/ subtree survive. Regression guard for the ~40x
+    # committed-log bloat that landed with Codex .events.jsonl capture.
+    repo = _operator_repo_with_remote(tmp_path)
+    design = tmp_path / "design"
+    design.mkdir()
+
+    keep = {
+        "plan.txt": "PLAN",
+        "aggregator-output.txt": "AGG",
+        "findings.md": "F",
+        "run-params.json": "{}",
+    }
+    drop = {
+        "codex-primary-plan-arch-output.txt.events.jsonl": "{}",
+        "codex-primary-plan-arch-output.txt.meta": "M",
+        "codex-primary-plan-arch-output.txt": "RAW",  # *-plan-*-output.txt
+        "render-plan-codex-arch.prompt": "P",
+        "claude-plan-voter-prompt.txt": "VP",
+        "step2b-codex-raw.40818.txt": "RAW2",
+        "cursor-plan-arch-output.txt.json": "{}",  # *.txt.json
+    }
+    for name, body in {**keep, **drop}.items():
+        _ = (design / name).write_text(body, encoding="utf-8")
+    # Nested: plan-review/round-1/ keeps curated files, drops sidecars.
+    pr_round = design / "plan-review" / "round-1"
+    pr_round.mkdir(parents=True)
+    _ = (pr_round / "findings.md").write_text("NF", encoding="utf-8")
+    _ = (pr_round / "codex-vote-output.txt").write_text("VOTE", encoding="utf-8")
+    _ = (pr_round / "codex-vote-output.txt.events.jsonl").write_text("{}", encoding="utf-8")
+    # Whole-subtree drops.
+    autofix = design / "plan-autofix"
+    autofix.mkdir()
+    _ = (autofix / "codex-output.txt").write_text("AF", encoding="utf-8")
+    completed = design / ".completed"
+    completed.mkdir()
+    _ = (completed / "step-3-terminal").write_text("", encoding="utf-8")
+
+    bin_dir = tmp_path / "bin"
+    _write_gh_stub(bin_dir / "gh", pr_create_rc=0)
+    result = _run_publish(repo, design, bin_dir)
+    assert result.returncode == 0, result.stderr
+    assert "PUBLISH_OK=true" in result.stdout, result.stderr
+
+    origin = tmp_path / "origin.git"
+    ls = subprocess.run(
+        ["git", "ls-tree", "-r", "--name-only", LOG_BRANCH],
+        cwd=origin, capture_output=True, text=True, check=False,
+    )
+    tree = ls.stdout
+    base = f"larch-logs/design/{RUN_ID}"
+    for name in keep:
+        assert f"{base}/{name}" in tree, f"expected kept: {name}\n{tree}"
+    assert f"{base}/plan-review/round-1/findings.md" in tree, tree
+    assert f"{base}/plan-review/round-1/codex-vote-output.txt" in tree, tree
+    assert f"{base}/manifest.json" in tree, tree
+    for name in drop:
+        assert f"{base}/{name}" not in tree, f"expected dropped: {name}\n{tree}"
+    assert "codex-vote-output.txt.events.jsonl" not in tree, tree
+    assert "plan-autofix" not in tree, tree
+    assert "/.completed/" not in tree, tree
+    assert "step2b-codex-raw" not in tree, tree
+
+
 def test_spawn_detached_admin_merge_swallows_launch_failure(monkeypatch: pytest.MonkeyPatch) -> None:
     # Best-effort: a launch failure must not raise (the log PR stays open for a
     # manual/CI merge and the working tree is already clean).


### PR DESCRIPTION
## Problem

`/design` committed run logs grew **~40x** starting 2026-06-15: ≈0.2 MB/run two weeks ago → ≈8.6 MB/run today. Sampling confirmed the jump is **new files**, not fatter existing ones:

| category | 14d ago | today |
|---|---|---|
| `*.events.jsonl` (Codex event streams) | 0 | **6.9 MB/run** |
| `*.prompt` sidecars | 0 | 0.40 MB |
| `*.meta` sidecars | ~0 | 0.24 MB |
| `plan-autofix/` subtree | 0 | 0.11 MB |

`/implement` was **not** affected (it actually shrank) — it filters its own round artifacts and never committed these streams.

## Root cause

The Python port of `design-log-publish.sh` (#3681, then #4395/#4404 "design log-publish not committing") replaced the bash `design_artifact_excluded` filter with a copy of **every** depth-1 child of `$DESIGN_TMPDIR`:

```python
for child in design_tmpdir.iterdir():
    if child.name == ".design-log-publish-metadata.env":
        continue
    if not _copy_tree_redacted(...):   # no allow/deny filter
```

Once Codex `--json` event-stream capture began writing `*.events.jsonl` (~770 KB per lane) into the tmpdir, the unfiltered publish committed them. **SECURITY.md still documents the exclusion the port dropped** — this PR restores it.

## Fix

Add `design_log_publish_flow._publish_excluded`, applied by basename at **every tree depth** (top level and `plan-review/round-N/`) in both copy paths. It lists only universal-crud carriers (`*.events.jsonl`, `*.prompt`, `*.meta`, `*.txt.json`/`.txt.tsv`, `.sidecar`/`.dirty-tree`/`.done`/`.token-record`/…, raw `*-plan-*-output*.txt` transcripts, `*-collector.failure.log`, the `plan-autofix/` and `.completed/` subtrees), so curated forensics survive: **`plan.txt`, `findings.md`, `voting-tally.md`, `*-vote-output.txt`, and the whole `plan-review/round-N/` subtree are kept.**

## Result

Replayed against the 15 real design runs from today:

- **8,590 KB/run → 465 KB/run (94.6% reduction)**, same order as the 212 KB/run from two weeks ago.
- Curated `plan-review/` subtree preserved (286 KB/run).

## Tests

- `test_publish_excluded_predicate` — pins the keep/drop boundary (e.g. `aggregator-output.txt` and `*-vote-output.txt` kept; `*-plan-*-output*.txt` dropped).
- `test_log_publish_excludes_sidecar_crud` — end-to-end: crud dropped at every depth, curated subtree + nested `*-vote-output.txt` survive.
- `make py-lint`, `pre-commit` (markdownlint + larch lints), and both design-publish test modules pass.

Docs: `SECURITY.md` and `docs/run-logs.md` updated to record the restored filter.

> Committed-log cleanup of the already-leaked files (~17.3k files, ~343 MB) ships as a separate log-only PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
