### PR TITLE
Release v51.1.6

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "51.1.5",
+  "version": "51.1.6",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
# Release v51.1.6

Patch release. 3 PRs since v51.1.5: a lint-CI restructure and two /design workflow fixes.

## Changed

- De-matrix the lint CI jobs and move duplicate-code detection to a post-merge job (#4763).

## Fixed

- Restore the design log-publish artifact filter that regressed in #4404 (#4766).
- The /design Step 3 plan-review panel now launches its reviewers; it previously emitted slot rows the dispatcher ignored, so zero reviewers ran and every /design run shipped an unreviewed plan (#4769).
