### PR TITLE
Release v51.1.7

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "51.1.6",
+  "version": "51.1.7",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Fixed

- **Plan-review panel dropping all reviewer findings.** `plan_review_round.py` parsed collector output with a `\x1f` delimiter that the Python collector (`collect_results.py`) never emits; it emits `KEY=VALUE` blocks instead. Every collector record was silently skipped, yielding a false-clean `LOOP_STATUS=complete` with zero accepted findings. Fixed the parser to read `KEY=VALUE` blocks and hardened the empty-collector classification so a zero-OK round now reports `degraded-empty-collector` rather than passing. (PR #4793)

- **`/design` architecture diagram no longer posted at publish.** The `design_publish.py` `publish_main` tail lost the `diagrams upsert` call in the `#3681` sh-to-py port. The diagram was still generated (Step 3b) but never published to the `larch:diagrams` tracking-issue comment. Restored the upsert call with the original file-detection logic (`--architecture-file` / `--clear-architecture`) and failure logging. (PR #4791)

- **Submodule-path scrubber missing bold-label and bare-directory references.** `redact.py` `scrub_submodule_paths` anchored its label match to `^(Location|File):`, which never matches the production markdown-bold `- **Location**:` form, and required a trailing `/` after the submodule path, so bare-dir references (`vendor/libfoo`, `vendor/libfoo:120`) passed through to the `review-and-fix` coder. Fixed the label pattern and broadened the inline match to a complete path-token boundary (`/`, `:`, or end-of-token). (PR #4792)

- **`design_pause.py` dropped marker-binding and security guards from sh-to-py port.** The `#3681` port of `design-pause-save.sh` / `design-pause-load.sh` silently omitted guards that `SECURITY.md` still documented as live: immutable SHA pinning before extraction, `LOG_RECOVERY_BRANCH` format validation, repo/manifest binding cross-check, restored-path boundary enforcement, marker clear/delete lifecycle, pause-save tmpdir allowlist, and local state redaction. Restored all guards to match the documented contract. (PR #4795)

- **Port-parity gaps in `cli.py pr create`, breadcrumb confinement, and step9a1 verification.** Three latent parity gaps from the `#3672` run-log and ship-pr ports: `cli.py pr create` (`create_main`) passed the PR body to `gh pr_create` without redaction (parity with `create-pr.sh` now restored via shared `redact_pr_body`); breadcrumb `publish_breadcrumbs_main` lacked the source-directory confinement check (re-added as the documented no-op defense-in-depth); the `verify-completeness` step9a1 condition narrowing (intentional since `#4427`) documented with a comment. (PR #4794)
