### PR TITLE
Bump python-tests CI matrix from 4 to 10 shards

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -604,7 +604,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.11"]
-        shard: [1, 2, 3, 4]
+        shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -617,10 +617,10 @@ jobs:
           PIP_RETRIES: "5"
           PIP_DEFAULT_TIMEOUT: "30"
         run: pip install -r python/requirements-test.txt
-      - name: Run Python tests (shard ${{ matrix.shard }} of 4)
+      - name: Run Python tests (shard ${{ matrix.shard }} of 10)
         env:
           PYTEST_SHARD_ID: ${{ matrix.shard }}
-          PYTEST_SHARD_COUNT: "4"
+          PYTEST_SHARD_COUNT: "10"
         run: make py-test
 
   # Aggregate gate for the python-tests matrix (see test-harnesses-gate for the

--- a/docs/linting.md
+++ b/docs/linting.md
@@ -74,7 +74,7 @@ leg in memory. Harness work rejects untimed targets, then runs
 `_select_packed_workload`, `pack`, and warning-only `_check_feasibility` before
 `write_shards`. Python work rejects empty timing rows, dedupes retried shard
 attempts before medians, and validates `--n-python-shards` against the observed
-`python-tests` matrix shard count. The current matrix count is 4, and the parser
+`python-tests` matrix shard count. The current matrix count is 10, and the parser
 prefers the `shard X of N` total from CI logs over the maximum shard id seen in
 rows. Under `--kind all`, every selected gate must pass before the first write.
 


### PR DESCRIPTION
## What

Bump the `python-tests` CI matrix from **4** to **10** shards to parallelize the Python unit suite across more runners.

## Changes

- **`.github/workflows/ci.yaml`**
  - `matrix.shard`: `[1, 2, 3, 4]` → `[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]`
  - `PYTEST_SHARD_COUNT`: `"4"` → `"10"`
  - Step label `Run Python tests (shard N of 4)` → `of 10`
- **`docs/linting.md`** — update the stated current matrix count to 10.

## Why the step label matters

The `shard X of N` label is **load-bearing**, not cosmetic. `python/pytest_ci_timing.py` (`_STEP_SHARD_RE` → `observed_shard_count`) reads `of N` from CI logs to validate `--n-python-shards` during `/rebalance-tests`. It must match the matrix or rebalance verification mis-detects the shard count.

## Coverage safety

The checked-in `python/shard-assignments.json` still maxes at shard 4. `pytest_sharding.select_shard_nodeids` ignores any assignment map whose max shard id ≠ the runtime `PYTEST_SHARD_COUNT`, falling back to round-robin across all 10 shards. No test coverage is lost in the interim.

## Follow-up

A separate `/rebalance-tests --kind all --n-python-shards 10` run regenerates `python/shard-assignments.json` (and rebalances the harness shards) for the new count.

## Test plan

- `actionlint` + `markdownlint` pass locally on the changed files.
- CI runs the full `python-tests` matrix (now 10 legs); `python-tests-gate` aggregates them into one required check (stable across shard count).
- Merge with `--admin` once CI is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
