### PR TITLE
Release v51.1.8

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "51.1.7",
+  "version": "51.1.8",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Fixed

- **`/design` plan-review loop convergence** (PR #4822): The plan-review loop no longer re-accepts the same findings on every round. Previously, accepted findings were re-raised each round until the round cap; the loop now deduplicates and converges correctly.
- **Terminal 0-accepted round in Review Phase Detail table** (PR #4820): The final plan-review round that accepts zero findings now appears in the Review Phase Detail table. Previously it was omitted because no `round-meta.json` was written for the zero-accepted stop round, causing a header vs. table round-count mismatch.
- **Design log-publish: restore two omissions from the Python port** (PR #4800): Restores GitHub-redundant snapshot file exclusions (`issue-body.txt`, `issue.json`, `architecture-diagram.md`, `panel-manifest.ndjson`) dropped during the #3681 port, and re-surfaces the secret-rotation operator warning when `SECRET_SCRUB_VIOLATIONS` are detected on the publish path.

## Changed

- **Precision-aware conditional reviewer pruning** (PR #4824): Conditional reviewer pruning now keys on precision (net score ≤ 0 or acceptance rate below 1/3) rather than zero accepted findings. The existing `−1` reject penalty now has a live in-loop consequence; a reviewer that produces one accepted finding alongside heavy rejected noise can now be pruned.
- **Plan-review panel degrades gracefully on invalid slot rows** (PR #4827): The `/design` plan-review panel now skips invalid or unrenderable slot rows and continues launching remaining valid slots, recording a degraded-panel warning. Previously a single bad row aborted the entire panel.
- **Reviewer straggler timeout cap** (PR #4816): A time cap is applied to reviewer slots to prevent slow stragglers from holding up the overall review process. Previously a single slow reviewer could block the panel for the full window.
- **External-tool health probes, voting diagnostics, and auth improvements** (PR #4825): Addresses 10 items: probe timeout exits gain retry handling; voter failure diagnostics switch to bounded reads; Cursor keychain preflight/preread runs inside the unified external-startup mutex; failure diagnostic source selection and panel/voter redaction improvements.
- **review-and-fix stage path collection, lint-fix loop, and test improvements** (PR #4814): Stops `_collect_round_stage_paths` from using whole-tree fallback paths when no valid baseline exists; restricts `_lint_fix_delta_paths` to paths that still differ from the pre-lint baseline; adds a partial-cleanup regression test in full snapshot mode.

## Internal

- **sh-to-py G13: ci/pr/merge/push cutover** (PR #4818): All live consumers of 16 bash helpers (`merge-pr.sh`, `create-pr.sh`, `rebase-push.sh`, `ci-wait.sh`, `ci-status.sh`, and others) are repointed to `python/cli.py`; helpers and their siblings deleted; `migrated-scripts.tsv` updated.
- **Python-tests CI matrix expanded to 10 shards** (PR #4797): Increased from 4 to 10 parallel shards to reduce CI wall-clock time.
- **Test shard rebalance** (PR #4798): Harness and Python test shards rebalanced after the shard count increase.
