### PR TITLE
Release v51.1.9

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "51.1.8",
+  "version": "51.1.9",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Changed

- **Design terminal-state, failure-report, and step-final-summary scripts ported to Python** ([#4830](https://github.com/character-ai/larch/pull/4830)): migrated `design-stage-terminal-state.sh`, `design-failure-report.sh`, and `design-step-final-summary.sh` to in-process Python with a pure-core / CLI-entrypoint split and fd isolation; test harnesses converted to pytest; `test-design-step-final-summary` added to `test-harnesses-6`.

## Fixed

- **Review Phase Detail Total row labeled as per-round sum** ([#4832](https://github.com/character-ai/larch/pull/4832)): the Total row and "Top reviewers" heading in the run-summary Review Phase Detail table now indicate they count each occurrence per review round, not distinct findings. A clarifying caption is added so the table no longer implies deduplication when the plan-review loop re-accepts recurring findings across rounds.
