### PR TITLE
Release v51.1.10

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "51.1.9",
+  "version": "51.1.10",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## What's Changed in v51.1.10

### Fixed

- **/design Step 3 dynamic reviewer scaffold** (PR #4853): Dynamic plan-review reviewer slots now receive the full render scaffold (plan path, output contract, scope anchor) instead of only the scout's raw prompt body. Previously, dynamic slots reviewed the wrong plan and emitted prose that was dropped as not substantive.
- **/design Step 3 plan-review warning key persistence** (PR #4855): Warning keys are now preserved across Step 3 continuations without carrying stale round state. Reviewer-prune and compose-review parsing are hardened for real-world plan-review artifacts, and run-log secret-scrub counts are reported accurately through design-publish and run-log commit paths.
- **/design Step 3 postplan validator wrong cwd** (PR #4863): The plan-review loop postplan validator now runs from the consumer-repo working directory instead of the plugin-cache directory. Previously, the validator falsely reported consumer-repo scripts as missing and forced a spurious operator override to continue (recurrence of #4490).
- **/design Step 3 reviewer-status table** (PR #4866): Added a `reviewer-status.tsv` producer so the compact per-slot reviewer status table renders correctly during live Step 3 runs. Previously, no code wrote the file that the SKILL.md cadence reads, so the table never appeared.
- **/design Step 4 unimplemented suggestions report** (PR #4860): Findings that were accepted and applied in an earlier review round are now excluded from the Step 4 "Unimplemented Plan Review Suggestions" report. Previously, such findings could re-surface after being re-raised and rejected in a later round, incorrectly telling the operator that already-applied improvements were not made.
- **Runtime checkpoint stale-state failure** (PR #4858): Stale or failed runtime checkpoints now fail closed instead of proceeding with stale state. Run-log and timing visibility are preserved across degraded review, Step 7a, and main-agent fallback paths.
- **Self-review volume recovery in audit consumers** (PR #4857): Audit and fluff-analysis consumers now recover self-review review volume when the findings JSONL is empty or absent. Clarify publish, stall recovery, and byte-escape regression paths are pinned with focused tests.
- **Duplicate Python code CI warnings** (PR #4839): Eliminated R0801 pylint duplicate-code CI warnings by restructuring two code pairs in the Python stdlib modules without introducing shared helpers across module boundaries.

### Changed

- **Reviewer attribution anonymization** (PR #4840): Reviewer attribution is now neutralized before plan-review and code-review voting while retaining proposer sidecars for scoring. Original reviewer lines are restored only in post-vote artifacts so audit trails remain attributed.
- **Health-check probe and launch-gate defaults** (PR #4852): Health-check probe and launch-gate fallback defaults are raised to reduce false degraded-tool gates. Per-knob override semantics, including the `0` opt-out for the launch health gate, are preserved. The 60-second defaults are now documented and covered by regression tests.
- **Step 5c publish orchestration ported to Python** (PR #4862): Step 5c orchestration now runs behind a Python entrypoint while preserving publish handoff contracts. The legacy publish verb remains callable as a publish tail with explicit result-env failure rc handling. Publish-tail rc coverage is shifted from the shell wrapper to Python lifecycle tests.
