### PR TITLE
Release v51.2.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "51.1.10",
+  "version": "51.2.0",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Added

- **`/deps` skill** for auditing open GitHub issues. Displays issues by in-flight state (DESIGNING, DESIGNED, IMPLEMENTING, REGULAR). For mutable REGULAR issues, proposes body refreshes and stale `not planned` closes. Runs an explicit-reference pass then a latent semantic pass to infer blocked-by dependencies, and writes edges via `/block-issue`. All mutations are gated behind one `AskUserQuestion` approval prompt; apply validates issue state again immediately before each write. `--pair-cap N` limits latent pairs for partial-audit mode. (#4871)

## Fixed

- **Findings aggregator OOS-attribution validation**: semantic-validation failures (OOS-attribution check rejecting a non-OOS block that cites an exclusively-OOS reviewer) now trigger a bounded re-dispatch with the validator error appended to the aggregator prompt, up to `LARCH_AGGREGATE_VALIDATION_RETRIES` additional attempts (default 2), before degrading to `REASON=validation-failed`. The session-local `findings.md` ballot is left unchanged on every failed attempt. Previously, a single non-deterministic LLM slip would cause the round to silently drop its dedup/merge. The orchestrator-aggregator agent prompt now also includes an explicit rule: a merged in-scope `### FINDING_N:` block must not cite a reviewer whose all input findings are `[OUT_OF_SCOPE]`. Machine validation rejects blocks that violate this. (#4870)

- **`/implement` ship driver hang**: resolved a hang that occurred when a CI-fix push triggered no fresh CI run, causing the ship driver to wait indefinitely. (#4872)

## Changed

- **G12 sh-to-py migration**: retired `git` and `phantom` plumbing helper scripts; all consumers now call `python3 python/cli.py` directly. (#4883)
