### PR TITLE
Release v51.2.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "51.2.0",
+  "version": "51.2.1",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Fixed

- **design publish**: `named-block write` subprocess no longer inherits Step 5c's captured stdout (`stdout=subprocess.DEVNULL` added). (#4894)
- **design publish**: Omitting `--session-id` now fails closed with rc 5, distinct from `--session-id ""` (present-empty), which skips log-publish and continues. (#4894)
- **design Step 5c**: Pre-render unlink in `_step5c_render_final_summary` is gated to success outcomes only; failed-plan-write paths preserve the existing stdout-fallback summary contract. (#4894)
- **plan review panel**: `_dynamic_slot_rows` now returns per-slot failures explicitly; `dispatch_panel` emits a compact warning KV when dynamic slot renders fail. (#4894)
- **secret scrub**: Scrub and redact failures now abort publish with fatal rc 5, distinct from recoverable `PUBLISH_OK=false` push/create misses. Rotation warnings are preserved when a secret was found and successfully scrubbed. (#4896)

## Changed

- **sh-to-py G6.5**: `/design` Step 6 cleanup ported to Python. Added `python/cli.py design step6`, `design step6-prelude`, and `design step6-cleanup` entrypoints. Retired the shell harness `test-design-step6.sh`; `make test-design-step6` now runs pytest. (#4897)
- **self-review tally**: Extracted shared tally-count expansion into `python/self_review_tally.py`. (#4896)
- **`/implement` NEVER #8**: Added a clause stating the `/design` foreground terminal-sentinel probe is an intentional carve-out, not a contradiction of the notification-driven `/implement` recovery path. (#4896)
