### PR TITLE
Release v51.3.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "51.2.1",
+  "version": "51.3.0",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Added

- **`/voter-calibration` skill** — new diagnostic skill that measures voter agreement and flags chronic outlier voters from committed `larch-logs/design/*/`, `larch-logs/implement/*/`, and `larch-logs/review/*/` classification TSVs. Arguments: `[--log-root DIR] [--min-votes N] [--outlier-threshold R] [--out FILE]`. Diagnostic only; does not affect spawning, thresholds, tokens, or reviewer points. Adds `test-voter-calibration` Makefile target to `test-harnesses-15` shard. ([#4775](https://github.com/character-ai/larch/pull/4915))

- **`### MAY_UPDATE:` optional plan heading** — `/design` plans may now declare conditionally-scoped files with `### MAY_UPDATE:` headings. These paths are included in scope extraction and dirty-tree scope checks, but `WARN_PLAN_FILES_UNTOUCHED` compares only firm headings (`### NEW:`, `### UPDATED:`, `### REWRITTEN:`). Fixes a false positive where optional paths triggered untouched-file warnings. ([#4898](https://github.com/character-ai/larch/pull/4921))

## Changed

- **Severity-weighted reviewer scoring** — accepted in-scope findings where at least one YES voter assigns panel severity `blocker` or `major` now earn +2 points instead of +1. All other accepted in-scope findings remain +1. OOS accepted findings keep flat +1 scoring regardless of voter severity. `body_severity` is forensic metadata only and does not affect points. Conditional spawning (rounds 3-4 prune gate) continues using unweighted accepted-minus-rejected counts. ([#4773](https://github.com/character-ai/larch/pull/4904))

- **Classification TSV schema expanded** — design plan-review TSVs now use a 23-column schema (was 21), adding `body_severity` and `scope` trailing columns. Code-review TSVs now use a 22-column schema (was 21), adding a `scope` trailing column. `scope` is `in_scope` or `oos`; producers write `scope=oos` for `OOS_*` ids, legacy `[OUT_OF_SCOPE]`/`[OOS]` rows, and scope-drift rows. Legacy TSVs without `scope` remain readable with flat accepted +1 scoring and `OOS_` prefix fallback. ([#4773](https://github.com/character-ai/larch/pull/4904))

- **Voter agreement scoreboard in `voting-tally.md`** — `voting-tally.md` now includes a Voter Agreement Scoreboard section after the reviewer scoreboard. It counts only `accepted`/`rejected` rows with at least two parseable `YES`/`NO` voter cells. A voter agrees when `accepted` pairs with `YES`, or `rejected` pairs with `NO`. Chronic outliers are flagged when `eligible >= 20` and `agreement_rate < 0.50`. Neutral outcomes, single-voter, and zero-voter panels are excluded. ([#4775](https://github.com/character-ai/larch/pull/4915))

## Fixed

- **Ship driver no longer hangs ~30 min when no CI run starts** — the ship merge loop now applies a bounded 300-second poll-based startup window on the initial CI wait. When no checks appear within the window, the monitor returns `NO_CHECKS`/`bail` instead of waiting indefinitely. The startup deadline resets if any checks appear before expiry, and it is consumed as a one-shot flag per merge-loop entry. Post-fix blocking grace (120 s) for head-changing re-entries is unchanged. ([#4877](https://github.com/character-ai/larch/pull/4918))

- **Duplicate code in reviewer pipeline resolved** — deduplicated `_consumer_repo_root()` helper shared between `design_postplan.py` and `plan_review.py`; extracted shared basename-normalizer from `plan_review_round.py` and `review_tally.py`; consolidated test-fixture construction in `test_ci_agentic_fix.py` and `test_ci_monitor.py` to use the existing `test_support.make_run_context()` factory. Eliminates CI `duplicate-code` job failures from these clusters. ([#4893](https://github.com/character-ai/larch/pull/4901))
