### PR TITLE
Release v51.3.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "51.3.0",
+  "version": "51.3.1",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Fixed

- **Stale `.git/index.lock` handling in Step 5 review commits** — Added stale-lock probe and retry helpers in `python/git.py`. Routes `add()`, `add_pathspec_file()`, `commit()`, and `commit_with_trailer()` through a one-shot retry policy; added a preemptive lock sweep in `commit_main()` before staging; removed duplicate raw pre-add calls in `review_and_fix.py`. When lock cleanup is refused, the review coder path now surfaces `CODER_STATUS=stale-index-lock` while preserving the existing `STALL_REASON=coder-failed` envelope for stall-recovery continuity. (PR [#4927](https://github.com/character-ai/larch/pull/4927))

- **`p`/`progress` report no longer working** — Removed an erroneous `logging_util.quiet_init()` call from `report_main` in `python/progress_report.py` that redirected stdout into the quiet log, causing the hook to capture an empty string and fall through to a normal model turn. Added a subprocess regression test that verifies the report reaches stdout under a quiet-enabled parent environment. (PR [#4929](https://github.com/character-ai/larch/pull/4929))

- **`/design` review-phase output hygiene** — Added `--report-framing` mode to `plan-review emit-rejected` so rejected plan-review suggestions are labeled as "considered but not adopted" rather than implying unimplemented gaps. Removed a stale pre-launch all-pending reviewer status table from the `/design` skill; unified post-notification ordering across the compact reviewer status table and both Step 3 wait rules. (PR [#4931](https://github.com/character-ai/larch/pull/4931))

- **Step 5c publish-tail validator false `missing-script` positive** — Extracted a shared `consumer_repo_root()` helper in `python/repo_roots.py` and adopted it in `design_publish.py`, `design_postplan.py`, `plan_review.py`, `design_lifecycle.py`, and `plan_quality.py`, replacing copy-pasted inline `git rev-parse --show-toplevel` calls. Fixed `design_publish.py` to pass the consumer repo as `--repo-root` (not the plugin root) when running `plan validate` during Step 5c. Adds `VALIDATE_MISSING_SCRIPT_COUNT` to the result-env for improved operator guidance on `missing-script` defects. (PR [#4932](https://github.com/character-ai/larch/pull/4932))
