### PR TITLE
Release v51.3.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "51.3.1",
+  "version": "51.3.2",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Fixed

- **Review threshold false-positive on `NOT_SUBSTANTIVE` prose** (#4938): `_output_file_success` in `review_pipeline.py` used a substring regex that matched reviewer findings prose mentioning `NOT_SUBSTANTIVE`, incorrectly downgrading collector-OK reviewer slots to `ERROR` and causing spurious `panel-failed` results. Narrowed the match to a structured `^STATUS=NOT_SUBSTANTIVE$` key-value line so prose references no longer trigger the check.

- **Merged runs committed as `bailed`/`partial` in run logs** (#4939): On `--merge` paths, the run-log `final-summary.md` and manifest were written before the PR was created, so squash-merged commits carried a stale pre-PR `bailed` snapshot. Added a post-`ensure_pr` flush-and-push on merge-eligible paths so PR-evidence state lands in the squash-merge tree, extended outcome classification to emit `pr-created` when PR evidence is present (with guards against terminal failures), reconciled manifest `status` to `in-progress` for non-terminal outcomes, and added audit tolerance so existing committed dirs with PR evidence are no longer misclassified as bail.

- **Flaky tests in `test_duplicate_code.py` and `test_launch_review.py`** (#4942): Stabilized intermittent failures in the duplicate-code worker and launch-review timeout harness tests that surfaced under parallel or randomized ordering.
