### PR TITLE
Release v51.3.3

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "51.3.2",
+  "version": "51.3.3",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## What's Changed in v51.3.3

### Fixed

- **CI monitor checks race** — `ci_monitor.py` no longer issues a second `gh pr checks` query for the startup-deadline check. A new `_resolve_checks_observation` helper fetches checks once per `gather_status` call and derives both status and rollup-empty inline, eliminating the race where a second empty query discarded the first query's results. (PR #4948)
- **`duplicate_code.py` pool teardown discards results on `OSError`** — A `collected` flag now guards the serial fallback so an `OSError` raised during pool teardown does not discard already-collected results and trigger a wasteful re-run. (PR #4951)
- **`duplicate_code.py` non-`PermissionError` pool-creation failures** — Both `_find_commonalities_fork` and `_find_commonalities_spawn` now catch `OSError` instead of the narrower `PermissionError` for pool-setup failures, covering more platform failure modes in the serial fallback path. (PR #4948)
- **Reviewer no-issues salvage with prose preamble** — `research_eval.py` now recovers `no_issues_found` responses when narration precedes the sentinel, preventing `NOT_SUBSTANTIVE` failures for reviewers that have no findings but prepend prose. (PR #4952)
- **Launch-failure site labels** — `agent launch-review` gains a `--site` argument; `/design` plan-review passes `design Step 3` and `/implement` review passes `implement Step 2` so failure diagnostics identify the calling site. `_append_implement_launch_failure` site label is normalized from `"2"` to `"implement Step 2"`. (PR #4952, #4957)
- **`review_pipeline.py` no-issues sentinel parity** — `_file_has_no_findings_sentinel` now recognizes a standalone JSON sentinel line after prose, matching the behavior added to `research_eval.py` in PR #4952. (PR #4957)
- **`/implement` code-review degraded-panel warnings** — Per-voter JUDGE_ERROR warnings now reach the operator-visible run-summary Warnings count instead of only the diagnostic log; tally denominators in the run summary are reconciled; the aggregator validation-retry is scoped to OOS-attribution failures only. (PR #4953)
- **CI empty-checks timeout** — `ci wait` and `ci status` default `--empty-checks-grace` raised from 0 to 120s, preventing a runless PR head from polling until the full poll budget is exhausted. (PR #4958)
- **`/design` plan-review concern-level overlap** — A rejected-concern ledger suppresses already-addressed voter concerns from reappearing in the Step 4 rejected-findings report across rounds. (PR #4958)
- **Run discovery liveness for long Step 5 reviews** — `progress_report.py` uses `_latest_timing_ledger_activity_ts` (scanning mark, vendor, and round rows) as the liveness signal for concurrent-run discovery; a long-running Step 5 review no longer loses discovery to a stale run whose pointer was created later. (PR #4960)

### Changed

- **Reviewer neutral-finding scoring** — Neutral in-scope findings (≥1 YES vote, not accepted) now cost -0.25 points instead of 0. Scoring tables, scoreboard examples, and reviewer prompts updated throughout. (PR #4950)
- **OOS accepted scoring labeled provisional** — OOS accepted points are now labeled "+1 provisional" in docs and reviewer prompts; `/analyze-issues` fate-adjusted scoring can retroactively dock combined-away or closed-unfixed OOS to 0 in a diagnostic report without changing live vote tallies. (PR #4963)
- **Pre-commit shellcheck scope** — `.pre-commit-config.yaml` now runs shellcheck only against the residual-bash allowlist (via `python/cli.py residual-bash paths --null-delimited`) instead of all shell files, matching the python-first script policy. (PR #4956)
- **Run-log and diagram docs** — `docs/run-logs.md` clarifies that diagram body artifacts and code-flow diagram failures are excluded from committed run logs; `docs/linting.md` and `docs/review-agents.md` reflect current behavior. (PR #4955)

### Added

- **`/analyze-issues` fate-adjusted OOS scoring** — A new `## Fate-adjusted OOS Scoring` section joins filed OOS issues against their GitHub fate (open, PR-closed, combined-away, closed-unfixed) and reports provisional vs fate-adjusted points per reviewer. Open or PR-closed OOS stays provisional +1; combined-away or closed-unfixed becomes 0 in the diagnostic; no retroactive -1. (PR #4963)
- **`/analyze-issues` offline reanalysis** — New `--log-root PATH` and `--repo OWNER/REPO` flags; new `python/cli.py analyze-issues analyze --json` subcommand with optional `--filed-issue-details-json` for offline reanalysis without live `gh` calls. (PR #4963)
- **`combine-issues` combined-away marker** — `combine-issues close-sources` now writes a `<!-- larch:combined-away source=#N target=#M -->` HTML comment on each closed source issue for detection by `/analyze-issues` fate scoring. (PR #4963)
- **`net-score-per-finding` precision-value signal** — `docs/point-competition.md` and `skills/shared/voting-protocol.md` now name `net-score-per-finding` (`(accepted_weight - Rejected) ÷ Proposed`, in-scope only) as the signal for future reviewer token budget allocation. (PR #4949)
