### PR TITLE
Release v51.3.4

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "51.3.3",
+  "version": "51.3.4",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Added

- **`LARCH_UNIQUE_FINDER_BONUS` experimental reviewer bonus.** Set to a positive float (e.g. `0.25`) to award an additive bonus to the sole finder of an accepted in-scope finding. The bonus is off by default; co-proposed, OOS, rejected, and scope-drifted findings are unaffected. When active and at least one finding is rewarded, a note appears below the reviewer scoreboard showing the bonus value and rewarded finding count. Pruning math remains unweighted accepted-minus-rejected and does not use this bonus. Documented in `docs/point-competition.md`, `skills/shared/voting-protocol.md`, and `skills/design/references/plan-review.md`.
