### PR TITLE
Release v51.3.5

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "51.3.4",
+  "version": "51.3.5",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## v51.3.5

### Fixed

- **Live-run liveness discovery**: Design-run live-run ranking now uses timing-ledger activity. The ledger scanner handles legacy design-round row shapes (`start_s\tend_s\tdesign\tround\...`), not only v1 rows. Stale design pointers whose resolved tmpdir is missing are reaped. Design env targets are parsed with the `export`-prefixed grammar used by `progress_report._read_env_file`. (#4989)
- **Aggregator failure forensics no longer overwritten each round in `/design`**: When the findings aggregator fails validation in an early plan-review round, its forensics (`aggregator-output.txt`, `aggregator-validate.stderr`, `aggregator-dispatch.env`, `aggregator-dispatch.stderr`) are now snapshotted into `plan-review/round-N/`. Later successful rounds no longer clobber the evidence. The `execution-issues.md` "See ..." pointer resolves to a durable round-stamped artifact. (#4996)
- **Cursor plan-review reviewers no longer dropped NOT_SUBSTANTIVE on valid findings**: The structured-record validator now accepts a pure-integer `schema_version` column (normalizes to `"1"`) and maps `focus_area` value `completeness` to `code-quality`. Cursor reviewers that used these non-conforming values were previously dropped entirely, wasting reviewer spend and degrading the panel. Per-row reject-reason diagnostics are now emitted to stderr. (#4994)
- **Round-stamped forensics set corrected**: A phantom `aggregator-strip.stderr` entry (which no producer writes) has been removed from `_ROUND_STAMPED_FORENSICS`. The snapshot list is now sourced from the same set as the committed pointers, preventing cross-module drift between `review_aggregate.py` and `plan_review_round.py`. Extends the #4996 fix to the `aggregator-empty-merge.stderr` / `aggregator-scope-parity.stderr` / `aggregator-mv.stderr` failure classes. (#5004)
- **Classification replay applies the unique-finder bonus**: The `voting scoreboard` and progress-report Top reviewers surfaces now apply `LARCH_UNIQUE_FINDER_BONUS` during classification replay, matching live tally scoring. Sole-finder eligibility uses corpus-aware raw attribution with a comma-part guard and label-aware tokenization. (#4965)

### Changed

- **Implementer scout manifest is now always written**: All three implementer agents (base, Codex, Cursor) now write the scout sidecar unconditionally as a best-effort step; `{"archetypes":[]}` is written when no dynamic reviewers are useful. Sidecar failure is reported rather than silently swallowed. Slug names now prefer `dyn-<topic>`; the `REVIEW_RESERVED` set in `python/plan_scout.py` is cited as authoritative for reserved names. (#4962)
- **Slack issue announce: removed `__LARCH_FAKE_CURL` subprocess path**: `python/pr_body.py` now always uses `urllib.request.urlopen` directly. Transport exception text is normalized before truncation so `ERROR=` remains single-line KV. The `--implement-tmpdir` argument is validated explicitly before calling the announce function. The orphaned shell harness and its docs are deleted; stale `agent-lint.toml` pins removed. (#4972)
- **OOS file-conflict dependency detection migrated to Python**: `python/cli.py oos file-conflict-deps` now runs a faithful Python port of the former Bash union-find algorithm, including Bash-parity `clean_match` normalization, 1-based ordinal indexing from `parse_issue_input()`, and env-cap validation before output binding. The Bash helper, its docs, and the Bash harness are retired; `python/migrated-scripts.tsv` updated. (#4967)
- **Sourced Bash libraries `plan-optional-trailers` and `clone-tag` removed**: Clone-tag derivation is now a direct Python CLI verb (`python/cli.py implement clone-tag`) with byte-for-byte parity to the retired Bash (`basename "$PWD"`, per-byte `tr -c 'A-Za-z0-9_-' '_'`, 32-byte truncation). `step-8-seed-initial.sh` and `step-8-ship.sh` repointed with fail-closed capture before `eval`. (#4971)
- **Three lint scripts migrated to Python CLI**: `scripts/check-topology-rule-paths.py`, `scripts/lint-literal-counts.py`, and `scripts/lint-no-raw-stderr-after-quiet-init.py` are now routed through `python/cli.py lint <verb>`. Pre-commit hooks, CI workflow, `agent-lint.toml`, and `docs/linting.md` updated. PyYAML dependency removed from `requirements-lint.txt`. (#4974)
- **`/design` Step 3 state normalization extended**: `test-design-step3-state` now also covers `step3_normalize` and `step3_read_result_env` test cases. `agent-lint.toml` adds `scripts/read-result-env.sh` as an explicit false-positive exclusion for G004/dead-script reachability. (#4973)
