### PR TITLE
Release v51.3.6

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "51.3.5",
+  "version": "51.3.6",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Fixed

- **Stall-recovery escalation recording** no longer fires for pure infrastructure reships. The `record-escalation` call for `step8-shippr` now triggers only when Step 18a performs Main Claude code edits (e.g. a `protected-path` bail or a `ledger_ready=true` ship-pr failure). A `transient-infra` reship that re-invokes `step-8-ship.sh` directly skips `record-escalation` as expected. ([#5024](https://github.com/character-ai/larch/pull/5024))

- **Review aggregator slot normalization** now reconciles reviewer attribution that carries artifact file suffixes (`-output`, `-output-ns-retry`, `-output.txt`) with the bare slot names used in merged output. Previously, mismatched slot spellings caused the validator to return a failure code and discard the round's dedup/merge results. ([#5030](https://github.com/character-ai/larch/pull/5030))

## Changed

- **`implement step-16-16a`** combined command added. Runs Step 16 (final report) immediately followed by the Step 16a Slack issue-announce in a single invocation. The Slack notify logic is now shared between `step-16-16a` and the existing `step-16-17` command via an extracted `_step_16a_slack()` helper. ([#5026](https://github.com/character-ai/larch/pull/5026))

- **Immutable dataclasses marked `frozen=True`** across Python modules (`agent_waterfall`, `bootstrap`, `forked_repo`, `implement_dispatch`, `issue_create`, `logging_util`, `plan_scout`, `rendering`, `review_dispatch`, `timing`, `tokens`, and others). Mutable dataclasses retain unfrozen form with added comments documenting why mutation is required. ([#5027](https://github.com/character-ai/larch/pull/5027))