### PR TITLE
Release v51.3.7

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "51.3.6",
+  "version": "51.3.7",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Fixed

- **File-conflict dependency detection parity restored** (`python/file_oos.py`): Removed a pre-cleaning guard that incorrectly dropped regex matches with a leading `/` before the cleaning pipeline ran. OOS parallel workers now correctly serialize items that cite the same leading-slash path or extensionless subdirectory path, restoring parity with the retired Bash helper. Regression tests added for leading-slash normalization and extensionless subdirectory paths.

- **`cleanup_implement_logs --run-dir` now guarded against paths outside the implement tree**: When `--run-dir` resolves outside `larch-logs/implement/`, the command exits 1 with no file modifications (fail-closed).

- **Duplicate Python code CI job errors resolved**: Extracted a shared `env_file.py` parser (consumed by `cleanup_skill` and `progress_report`) and routed file-scanning linters (`lint_literal_counts`, `lint_no_raw_stderr_after_quiet_init`, `lint_skill_invocations`) through shared `git_ls_files_z` and `run_file_lint` helpers in `lint_common`. Removes the duplicate-code blocks the `python-lint-duplicate-code` CI job flagged.

- **Bulk cleanup mode symlink escape fixed** (`cleanup_implement_logs`): Bulk `impl_root.iterdir()` now skips any entry whose resolved path is outside `larch-logs/implement/`, preventing destructive cleanup from following escape symlinks.

## Changed

- **OOS issue-cap helper migrated from Bash to Python**: `oos-issue-cap.sh` and `oos-issue-cap-excerpt.py` retired; OOS issue capping is now handled by `python/cli.py oos issue-cap` via `python/file_oos.py`. Test coverage migrated to pytest. Docs and agent-lint excludes updated.

- **OOS manifest materialization shell helper retired**: `materialize-manifest-oos.sh` retired; `/implement` Step 2 now calls `file_oos.materialize_manifest_oos()` in-process. Fail-closed bail semantics preserved. Retired helper and harness recorded in `migrated-scripts.tsv`.
