### PR TITLE
Release v51.3.8

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "51.3.7",
+  "version": "51.3.8",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Fixed

- **Plan-review zero-findings round misclassified as panel-failed** — when all reviewers in a `/design` plan-review round found no issues, the empty ballot triggered a voter panel that degraded and was mapped to `panel-failed` instead of the benign zero-findings outcome. The round now classifies correctly so a fully-converged review no longer surfaces as a review failure. (`python/plan_review_round.py`) #5042

- **Waterfall straggler-drop skips dropped-slots file without `--no-fallback`** — when a static reviewer (e.g. `correctness`) was straggler-dropped in a waterfall dispatch running without `--no-fallback`, `_write_drops` was skipped and the coverage gate received no dropped-slots file, producing a spurious `panel-failed` stall. The dropped-slots file is now written regardless of `--no-fallback` state. (`python/agent_waterfall.py`) #5056

- **OOS filer capped aggregate retry retains only first source stable ID** — when `issue_cap` rewrote accepted blocks into one aggregate, retry evidence could only match the first original block and risked re-filing rolled-up remainders. (`python/oos_filer.py`) #5050

## Changed

- **Python complexity ratchet added to `make py-lint`** — re-enables ruff rules `C901`, `PLR0911`, `PLR0912`, `PLR0913`, and `PLR0915` as hard errors for `python/` production code. Existing violations are grandfathered via `ruff.toml` per-file ignores; new violations in new or refactored code fail CI. A baseline-comparison audit (`python/cli.py lint complexity-baseline`) catches new complexity growth inside already-grandfathered modules keyed by stable qualified function identity rather than line numbers. Documented in `docs/linting.md`. #5051

- **Complexity baseline regeneration entrypoint added** — `make regen-complexity-baseline` (backed by `python/cli.py lint complexity-baseline --write`) mechanically regenerates `python/complexity-baseline.json` from live ruff output so the ratchet baseline is generated rather than hand-edited. #5059

- **Symlink containment guards added to implement-log cleanup** — `python/cleanup_implement_logs.py` now guards `rglob`/`unlink`/`rmtree` calls against symlinks that escape the run-log directory boundary. #5053

- **OOS awk text-processors inlined into Python** — replaced the `awk -f` subprocess in `python/design_oos.py` with a direct call to the existing `file_oos._count_non_security_markdown` counter. Deleted three OOS `.awk` files (`oos-non-security-block-count.awk`, `oos-accumulated-seq-seed.awk`, `oos-has-legacy-finding-block-opener.awk`). #5054

- **Pylint duplicate-code CI warnings resolved** — de-duplicated repeated code patterns flagged by pylint to clear CI warnings. #5055
