### PR TITLE
Release v51.3.9

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "51.3.8",
+  "version": "51.3.9",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Added

- **`ARCHITECTURAL_GUIDELINES.md`** — new document capturing Python coding practices (G-Py-1 through G-Py-6), skill authoring principles (G-Skill-1, G-Skill-2), and enforcement philosophy. Larch treats these entries as untrusted operator-curated context, not a higher-priority instruction surface than `AGENTS.md` or skills. `/implement` reads and passes G-* entries as a design-time context block; the reader no-ops when the file is absent, rejects symlinks, and redacts before publication. (PR #5057)

- **`python/larch_io.py`** — shared stdlib-only IO helper module. Consolidates duplicated KV-parse, atomic-write, and text-read/write/append helpers from across `python/` into one parameterized API (`parse_kv`, `read_kv`, `read_kvs`, `write_kvs`, `atomic_write`, `read_text`, `write_text`, `append_text`). Existing wire formats and per-call-site semantics are preserved. (PR #5067)

- **`python/review_types.py`** — typed review domain module. Adds `Finding` frozen dataclass with `parse_findings` parser, a unified `Manifest` representation with `from_json`/`to_json` replacing duplicated dict helpers, and `StrEnum` sets for review status (`ReviewCoreStatus`), votes (`ReviewVote`), and judge severities (`JudgeSeverity`). (PR #5070)

## Changed

- **`/design` reads `ARCHITECTURAL_GUIDELINES.md`** — a new `core_style_ctx` step in the design phase passes G-* guideline entries into the design context as untrusted content when the file is present. (PR #5071)

- **`agents.py` launcher refactor** — introduced `LauncherPaths` frozen dataclass as the single owner of stable output-rooted sidecar paths, and a `_finalize_launch` coordinator for shared epilogue primitives. Behavior-preserving; per-family epilogue order (Codex CI, Cursor CI, Codex implement, Cursor implement) is unchanged. Review launchers migrate to `LauncherPaths` path construction only. (PR #5069)

- **`# noqa` audit** — enabled `ANN001`, `ANN201`, and `FBT002` lint rules in `python/ruff.toml`; test files (`test_*.py`) remain exempt. Fixed 8 production violations; removed or justified remaining suppression comments. Net `# noqa` count reduced. `make py-lint` and `make py-test` remain green. (PR #5068)

## Fixed

- **`/design` flag parsing** — flags placed after the numeric issue ID (e.g. `/design 5049 --no-dedup`) were silently dropped. The parser now honors all valid flags on both sides of the positional issue number. (PR #5065)
