### PR TITLE
Disable duplicate-code CI job on push to main

### DIFF
--- a/.github/workflows/duplicate-code.yaml
+++ b/.github/workflows/duplicate-code.yaml
@@ -7,9 +7,9 @@ name: Duplicate code
 # in python/.pylintrc (min-similarity-lines); see issue #4480.
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
+  # push:
+  #   branches:
+  #     - main
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- Comments out the `push` trigger in `.github/workflows/duplicate-code.yaml` so the job no longer runs automatically on every merge to main.
- `workflow_dispatch` is preserved so the check can still be run manually when needed.
- Underlying pylint machinery and job definition are untouched.

## Test plan

- [ ] CI passes on this PR (the duplicate-code job itself will not run since the push trigger is removed)
- [ ] Verify `.github/workflows/duplicate-code.yaml` shows the trigger as commented out

🤖 Generated with [Claude Code](https://claude.com/claude-code)