### PR TITLE
chore(larch-logs): retroactively reprice pre-v50 vendor costs in final summaries

### DIFF
--- a/larch-logs/design/00B13B87-B6BB-4310-A8D7-A3DECC016777/final-summary.md
+++ b/larch-logs/design/00B13B87-B6BB-4310-A8D7-A3DECC016777/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: HARD
 - **Path**: HARD
 - **Duration**: 00:40:03
-- **Cost**: 💰 TOTAL ~$28.82 — Claude $24.71, Codex $1.01, Cursor $3.10  |  Tokens: 38810k
+- **Cost**: 💰 TOTAL ~$37.54 — Claude $24.71, Codex $11.01, Cursor $1.82, Claude (subprocess) $0.00  |  Tokens: 38810k
 - **Issue**: #2871
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/05CD2101-F3A9-4A05-8268-1219AD89769D/final-summary.md
+++ b/larch-logs/design/05CD2101-F3A9-4A05-8268-1219AD89769D/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: unknown
 - **Duration**: 01:22:36
-- **Cost**: 💰 TOTAL ~$12.36 — Claude $10.44, Codex $0.48, Cursor $1.44  |  Tokens: 15317k
+- **Cost**: 💰 TOTAL ~$16.51 — Claude $10.44, Codex $5.25, Cursor $0.82, Claude (subprocess) $0.00  |  Tokens: 15317k
 - **Issue**: #3092 — https://github.com/character-ai/larch/issues/3092
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/06E11B19-03E6-438A-97A8-2549018B6ED8/final-summary.md
+++ b/larch-logs/design/06E11B19-03E6-438A-97A8-2549018B6ED8/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 02:45:37
-- **Cost**: 💰 TOTAL ~$26.45 — Claude $23.18, Codex $0.77, Cursor $2.50  |  Tokens: 36265k
+- **Cost**: 💰 TOTAL ~$33.04 — Claude $23.18, Codex $8.42, Cursor $1.44, Claude (subprocess) $0.00  |  Tokens: 36265k
 - **Issue**: #2974 — https://github.com/character-ai/larch/issues/2974
 - **Plan review**: 0 findings
 - **OOS filed**: 1 — https://github.com/character-ai/larch/issues/2989

--- a/larch-logs/design/072C28F7-468B-43C4-9F71-28C635D34463/final-summary.md
+++ b/larch-logs/design/072C28F7-468B-43C4-9F71-28C635D34463/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 00:38:16
-- **Cost**: 💰 TOTAL ~$17.17 — Claude $15.43, Codex $0.36, Cursor $1.38  |  Tokens: 25043k
+- **Cost**: 💰 TOTAL ~$20.05 — Claude $15.43, Codex $3.87, Cursor $0.75, Claude (subprocess) $0.00  |  Tokens: 25043k
 - **Issue**: #2823 — https://github.com/character-ai/larch/issues/2823
 - **Plan review**: 0 findings
 - **OOS filed**: 4 — https://github.com/character-ai/larch/issues/2904,https://github.com/character-ai/larch/issues/2905,https://github.com/character-ai/larch/issues/2906,https://github.com/character-ai/larch/issues/2907

--- a/larch-logs/design/09B2C160-DEB4-4A41-879B-BE828247C80D/final-summary.md
+++ b/larch-logs/design/09B2C160-DEB4-4A41-879B-BE828247C80D/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: unknown
 - **Duration**: 02:13:28
-- **Cost**: 💰 TOTAL ~$18.98 — Claude $16.10, Codex $0.60, Cursor $2.28  |  Tokens: 29097k
+- **Cost**: 💰 TOTAL ~$24.02 — Claude $16.10, Codex $6.52, Cursor $1.40, Claude (subprocess) $0.00  |  Tokens: 29097k
 - **Issue**: #2870 — https://github.com/character-ai/larch/issues/2870
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/0C0B0C05-4B3F-41C8-AFAB-402B4ED6F5D5/final-summary.md
+++ b/larch-logs/design/0C0B0C05-4B3F-41C8-AFAB-402B4ED6F5D5/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: N/A
 - **Path**: SIMPLE
 - **Duration**: N/A
-- **Cost**: 💰 TOTAL ~$37.19 — Claude $32.00, Codex $2.19, Cursor $3.00  |  Tokens: 55939k
+- **Cost**: 💰 TOTAL ~$35.09 — Claude $32.00, Codex $1.22, Cursor $1.87, Claude (subprocess) $0.00  |  Tokens: 55939k
 - **Issue**: #2742 — https://github.com/character-ai/larch/issues/2742
 - **Plan review**: 0 findings
 - **OOS filed**: 2 — https://github.com/character-ai/larch/issues/2752,https://github.com/character-ai/larch/issues/2753

--- a/larch-logs/design/0CC577B6-96D4-4507-A892-A8F7EA98D2AF/final-summary.md
+++ b/larch-logs/design/0CC577B6-96D4-4507-A892-A8F7EA98D2AF/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 01:29:45
-- **Cost**: 💰 TOTAL ~$21.85 — Claude $17.63, Codex $0.00, Cursor $4.22  |  Tokens: 25334k
+- **Cost**: 💰 TOTAL ~$20.15 — Claude $17.63, Codex $0.00, Cursor $2.52, Claude (subprocess) $0.00  |  Tokens: 25334k
 - **Issue**: #3210 — https://github.com/character-ai/larch/issues/3210
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/0CCC4140-F308-4574-93AC-E3EAF4151F83/final-summary.md
+++ b/larch-logs/design/0CCC4140-F308-4574-93AC-E3EAF4151F83/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 00:02:42
-- **Cost**: 💰 TOTAL ~$22.00 — Claude $18.10, Codex $0.78, Cursor $3.12  |  Tokens: 30883k
+- **Cost**: 💰 TOTAL ~$28.54 — Claude $18.10, Codex $8.45, Cursor $1.99, Claude (subprocess) $0.00  |  Tokens: 30883k
 - **Issue**: #3117
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/0D7D52CF-244E-48F1-906E-0B061E1FD3BB/final-summary.md
+++ b/larch-logs/design/0D7D52CF-244E-48F1-906E-0B061E1FD3BB/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: TRIVIAL_DOC_ONLY
 - **Path**: SIMPLE
 - **Duration**: 00:25:37
-- **Cost**: 💰 TOTAL ~$4.40 — Claude $4.40, Codex $0.00, Cursor $0.00  |  Tokens: 5395k
+- **Cost**: 💰 TOTAL ~$4.40 — Claude $4.40, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.00  |  Tokens: 5395k
 - **Issue**: #2692 — https://github.com/character-ai/larch/issues/2692
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/1104CA3E-5F1A-4436-A697-9C7270689F27/final-summary.md
+++ b/larch-logs/design/1104CA3E-5F1A-4436-A697-9C7270689F27/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: unknown
 - **Duration**: 00:00:00
-- **Cost**: 💰 TOTAL ~$13.30 — Claude $11.05, Codex $0.51, Cursor $1.74  |  Tokens: 18056k
+- **Cost**: 💰 TOTAL ~$17.54 — Claude $11.05, Codex $5.50, Cursor $0.99, Claude (subprocess) $0.00  |  Tokens: 18056k
 - **Issue**: #3035 — https://github.com/character-ai/larch/issues/3035
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/15376AA2-F987-4D9B-98FD-AA99E361A3E5/final-summary.md
+++ b/larch-logs/design/15376AA2-F987-4D9B-98FD-AA99E361A3E5/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 02:56:16
-- **Cost**: 💰 TOTAL ~$27.02 — Claude $16.57, Codex $0.00, Cursor $10.45  |  Tokens: 38609k
+- **Cost**: 💰 TOTAL ~$23.12 — Claude $16.57, Codex $0.00, Cursor $6.55, Claude (subprocess) $0.00  |  Tokens: 38609k
 - **Issue**: #3218 — https://github.com/character-ai/larch/issues/3218
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/193746D3-3C8D-42C9-8F37-F9F94CCDCF78/final-summary.md
+++ b/larch-logs/design/193746D3-3C8D-42C9-8F37-F9F94CCDCF78/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: N/A
 - **Path**: SIMPLE
 - **Duration**: 01:11:19
-- **Cost**: 💰 TOTAL ~$24.58 — Claude $19.96, Codex $4.59, Cursor $0.03  |  Tokens: 22158k
+- **Cost**: 💰 TOTAL ~$22.53 — Claude $19.96, Codex $2.55, Cursor $0.02, Claude (subprocess) $0.00  |  Tokens: 22158k
 - **Issue**: #2754 — https://github.com/character-ai/larch/issues/2754
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/1A2BC1F1-45CA-4B30-BD89-0AD3C7E944C2/final-summary.md
+++ b/larch-logs/design/1A2BC1F1-45CA-4B30-BD89-0AD3C7E944C2/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 03:29:02
-- **Cost**: 💰 TOTAL ~$21.57 — Claude $17.67, Codex $0.00, Cursor $3.90  |  Tokens: 21183k
+- **Cost**: 💰 TOTAL ~$19.95 — Claude $17.67, Codex $0.00, Cursor $2.28, Claude (subprocess) $0.00  |  Tokens: 21183k
 - **Issue**: #3250 — https://github.com/character-ai/larch/issues/3250
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/1B23BC45-FCA9-4467-BD75-713E4868B608/final-summary.md
+++ b/larch-logs/design/1B23BC45-FCA9-4467-BD75-713E4868B608/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 01:25:47
-- **Cost**: 💰 TOTAL ~$23.78 — Claude $14.10, Codex $0.00, Cursor $9.68  |  Tokens: 35230k
+- **Cost**: 💰 TOTAL ~$20.05 — Claude $14.10, Codex $0.00, Cursor $5.95, Claude (subprocess) $0.00  |  Tokens: 35230k
 - **Issue**: #3288 — https://github.com/character-ai/larch/issues/3288
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/1C19ADE4-D97A-460B-8BAC-5A5484E2DFA4/final-summary.md
+++ b/larch-logs/design/1C19ADE4-D97A-460B-8BAC-5A5484E2DFA4/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 01:37:41
-- **Cost**: 💰 TOTAL ~$18.93 — Claude $14.69, Codex $0.99, Cursor $3.25  |  Tokens: 32490k
+- **Cost**: 💰 TOTAL ~$27.68 — Claude $14.69, Codex $10.97, Cursor $2.02, Claude (subprocess) $0.00  |  Tokens: 32490k
 - **Issue**: #3296 — https://github.com/character-ai/larch/issues/3296
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/208E92E5-DE7D-4959-B040-FDD80E4D9A95/final-summary.md
+++ b/larch-logs/design/208E92E5-DE7D-4959-B040-FDD80E4D9A95/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 01:22:31
-- **Cost**: 💰 TOTAL ~$18.40 — Claude $15.85, Codex $0.54, Cursor $2.01  |  Tokens: 24299k
+- **Cost**: 💰 TOTAL ~$22.79 — Claude $15.85, Codex $5.79, Cursor $1.15, Claude (subprocess) $0.00  |  Tokens: 24299k
 - **Issue**: #2897 — https://github.com/character-ai/larch/issues/2897
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/20B78C02-0777-48FF-902D-FE250DB1558F/final-summary.md
+++ b/larch-logs/design/20B78C02-0777-48FF-902D-FE250DB1558F/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 01:51:07
-- **Cost**: 💰 TOTAL ~$26.89 — Claude $15.93, Codex $0.00, Cursor $10.96  |  Tokens: 38103k
+- **Cost**: 💰 TOTAL ~$22.38 — Claude $15.93, Codex $0.00, Cursor $6.45, Claude (subprocess) $0.00  |  Tokens: 38103k
 - **Issue**: #3292 — https://github.com/character-ai/larch/issues/3292
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/2314E6DF-550B-4853-9FB8-15BFE72C320C/final-summary.md
+++ b/larch-logs/design/2314E6DF-550B-4853-9FB8-15BFE72C320C/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 01:17:03
-- **Cost**: 💰 TOTAL ~$24.51 — Claude $14.20, Codex $0.00, Cursor $10.31  |  Tokens: 40342k
+- **Cost**: 💰 TOTAL ~$20.57 — Claude $14.20, Codex $0.00, Cursor $6.37, Claude (subprocess) $0.00  |  Tokens: 40342k
 - **Issue**: #3236 — https://github.com/character-ai/larch/issues/3236
 - **Plan review**: 0 findings
 - **OOS filed**: 3 — https://github.com/character-ai/larch/issues/3309,https://github.com/character-ai/larch/issues/3310,https://github.com/character-ai/larch/issues/3311

--- a/larch-logs/design/237837DD-843D-4178-B98F-DB37ADF30363/final-summary.md
+++ b/larch-logs/design/237837DD-843D-4178-B98F-DB37ADF30363/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 00:00:00
-- **Cost**: 💰 TOTAL ~$22.68 — Claude $19.13, Codex $0.63, Cursor $2.92  |  Tokens: 31725k
+- **Cost**: 💰 TOTAL ~$27.75 — Claude $19.13, Codex $6.85, Cursor $1.77, Claude (subprocess) $0.00  |  Tokens: 31725k
 - **Issue**: #2881 — https://github.com/character-ai/larch/issues/2881
 - **Plan review**: 0 findings
 - **OOS filed**: 1 — https://github.com/character-ai/larch/issues/2927

--- a/larch-logs/design/241EE6B6-671B-40C3-A96F-199AF99865E1/final-summary.md
+++ b/larch-logs/design/241EE6B6-671B-40C3-A96F-199AF99865E1/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 00:59:55
-- **Cost**: 💰 TOTAL ~$17.15 — Claude $12.64, Codex $0.76, Cursor $3.75  |  Tokens: 30581k
+- **Cost**: 💰 TOTAL ~$23.48 — Claude $12.64, Codex $8.48, Cursor $2.36, Claude (subprocess) $0.00  |  Tokens: 30581k
 - **Issue**: #2995 — https://github.com/character-ai/larch/issues/2995
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/243BABAF-CC11-4C47-BBB0-1F57BEBB8FB5/final-summary.md
+++ b/larch-logs/design/243BABAF-CC11-4C47-BBB0-1F57BEBB8FB5/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: N/A
-- **Cost**: 💰 TOTAL ~$29.20 — Claude $24.61, Codex $2.56, Cursor $2.03  |  Tokens: 31014k
+- **Cost**: 💰 TOTAL ~$27.16 — Claude $24.61, Codex $1.42, Cursor $1.13, Claude (subprocess) $0.00  |  Tokens: 31014k
 - **Issue**: #2736 — https://github.com/character-ai/larch/issues/2736
 - **Plan review**: 0 findings
 - **OOS filed**: 3 — https://github.com/character-ai/larch/issues/2736,https://github.com/character-ai/larch/issues/2772,https://github.com/character-ai/larch/issues/2773

--- a/larch-logs/design/246CFA52-CF67-4373-BC24-DEEABF64164C/final-summary.md
+++ b/larch-logs/design/246CFA52-CF67-4373-BC24-DEEABF64164C/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 00:51:27
-- **Cost**: 💰 TOTAL ~$21.45 — Claude $19.41, Codex $0.01, Cursor $2.03  |  Tokens: 27545k
+- **Cost**: 💰 TOTAL ~$20.79 — Claude $19.41, Codex $0.15, Cursor $1.23, Claude (subprocess) $0.00  |  Tokens: 27545k
 - **Issue**: #3235 — https://github.com/character-ai/larch/issues/3235
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/27365D51-EA1F-4C64-987B-80FE069D697A/final-summary.md
+++ b/larch-logs/design/27365D51-EA1F-4C64-987B-80FE069D697A/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 00:16:54
-- **Cost**: 💰 TOTAL ~$18.71 — Claude $15.78, Codex $0.87, Cursor $2.06  |  Tokens: 32328k
+- **Cost**: 💰 TOTAL ~$26.63 — Claude $15.78, Codex $9.61, Cursor $1.24, Claude (subprocess) $0.00  |  Tokens: 32328k
 - **Issue**: #3126 — https://github.com/character-ai/larch/issues/3126
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/2962125A-CCD6-4AC2-97E7-C5BD25DC6499/final-summary.md
+++ b/larch-logs/design/2962125A-CCD6-4AC2-97E7-C5BD25DC6499/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 00:00:00
-- **Cost**: 💰 TOTAL ~$14.82 — Claude $12.70, Codex $0.56, Cursor $1.56  |  Tokens: 20571k
+- **Cost**: 💰 TOTAL ~$19.71 — Claude $12.70, Codex $6.10, Cursor $0.91, Claude (subprocess) $0.00  |  Tokens: 20571k
 - **Issue**: #3097 — https://github.com/character-ai/larch/issues/3097
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/2A9E142B-9A0C-4718-8981-962D9FACA1CB/final-summary.md
+++ b/larch-logs/design/2A9E142B-9A0C-4718-8981-962D9FACA1CB/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 01:22:54
-- **Cost**: 💰 TOTAL ~$26.71 — Claude $17.17, Codex $4.63, Cursor $4.91  |  Tokens: 33546k
+- **Cost**: 💰 TOTAL ~$22.81 — Claude $17.17, Codex $2.57, Cursor $3.07, Claude (subprocess) $0.00  |  Tokens: 33546k
 - **Issue**: #2672 — https://github.com/character-ai/larch/issues/2672
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/2B03457A-AC27-4F3C-B088-FBD6D49BCEA7/final-summary.md
+++ b/larch-logs/design/2B03457A-AC27-4F3C-B088-FBD6D49BCEA7/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: N/A
-- **Cost**: 💰 TOTAL ~$16.49 — Claude $13.51, Codex $0.64, Cursor $2.34  |  Tokens: 26487k
+- **Cost**: 💰 TOTAL ~$21.83 — Claude $13.51, Codex $6.94, Cursor $1.38, Claude (subprocess) $0.00  |  Tokens: 26487k
 - **Issue**: #2865 — https://github.com/character-ai/larch/issues/2865
 - **Plan review**: 0 findings
 - **OOS filed**: 1 — https://github.com/character-ai/larch/issues/2885

--- a/larch-logs/design/2BF6F288-8F76-4CBD-A5A5-EE5458AAB9B3/final-summary.md
+++ b/larch-logs/design/2BF6F288-8F76-4CBD-A5A5-EE5458AAB9B3/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 10:15:51
-- **Cost**: 💰 TOTAL ~$22.40 — Claude $12.93, Codex $1.15, Cursor $8.32  |  Tokens: 40821k
+- **Cost**: 💰 TOTAL ~$30.96 — Claude $12.93, Codex $12.92, Cursor $5.11, Claude (subprocess) $0.00  |  Tokens: 40821k
 - **Issue**: #3300 — https://github.com/character-ai/larch/issues/3300
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/2C149C32-47B0-44A2-AAD7-B2A589E5FD51/final-summary.md
+++ b/larch-logs/design/2C149C32-47B0-44A2-AAD7-B2A589E5FD51/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: unknown
 - **Duration**: 00:39:12
-- **Cost**: 💰 TOTAL ~$15.06 — Claude $12.62, Codex $0.58, Cursor $1.86  |  Tokens: 21255k
+- **Cost**: 💰 TOTAL ~$20.13 — Claude $12.62, Codex $6.38, Cursor $1.13, Claude (subprocess) $0.00  |  Tokens: 21255k
 - **Issue**: #2921 — https://github.com/character-ai/larch/issues/2921
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/2F814722-73C1-4E88-A2A5-98E73F6186F9/final-summary.md
+++ b/larch-logs/design/2F814722-73C1-4E88-A2A5-98E73F6186F9/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 00:38:25
-- **Cost**: 💰 TOTAL ~$16.82 — Claude $13.96, Codex $0.79, Cursor $2.07  |  Tokens: 23626k
+- **Cost**: 💰 TOTAL ~$23.75 — Claude $13.96, Codex $8.59, Cursor $1.20, Claude (subprocess) $0.00  |  Tokens: 23626k
 - **Issue**: #2958 — https://github.com/character-ai/larch/issues/2958
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/30670272-89B6-4E91-B333-7C2233FC398F/final-summary.md
+++ b/larch-logs/design/30670272-89B6-4E91-B333-7C2233FC398F/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 09:47:47
-- **Cost**: 💰 TOTAL ~$18.05 — Claude $13.74, Codex $0.18, Cursor $4.13  |  Tokens: 25560k
+- **Cost**: 💰 TOTAL ~$18.54 — Claude $13.74, Codex $2.01, Cursor $2.79, Claude (subprocess) $0.00  |  Tokens: 25560k
 - **Issue**: #3338 — https://github.com/character-ai/larch/issues/3338
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/306D947E-674E-42D9-B943-345E79571FDD/final-summary.md
+++ b/larch-logs/design/306D947E-674E-42D9-B943-345E79571FDD/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: unknown
 - **Duration**: 00:00:00
-- **Cost**: 💰 TOTAL ~$12.18 — Claude $10.38, Codex $0.41, Cursor $1.39  |  Tokens: 16604k
+- **Cost**: 💰 TOTAL ~$15.58 — Claude $10.38, Codex $4.38, Cursor $0.82, Claude (subprocess) $0.00  |  Tokens: 16604k
 - **Issue**: #3050 — https://github.com/character-ai/larch/issues/3050
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/31573426-65DB-4645-A91D-A3953DE05E94/final-summary.md
+++ b/larch-logs/design/31573426-65DB-4645-A91D-A3953DE05E94/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 04:06:08
-- **Cost**: 💰 TOTAL ~$25.42 — Claude $23.27, Codex $0.00, Cursor $2.15  |  Tokens: 20883k
+- **Cost**: 💰 TOTAL ~$24.53 — Claude $23.27, Codex $0.00, Cursor $1.26, Claude (subprocess) $0.00  |  Tokens: 20883k
 - **Issue**: #3237 — https://github.com/character-ai/larch/issues/3237
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/319DE006-9164-4E48-91E4-E49473E363D6/final-summary.md
+++ b/larch-logs/design/319DE006-9164-4E48-91E4-E49473E363D6/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 03:54:24
-- **Cost**: 💰 TOTAL ~$34.68 — Claude $25.61, Codex $0.70, Cursor $8.37  |  Tokens: 49217k
+- **Cost**: 💰 TOTAL ~$38.61 — Claude $25.61, Codex $7.75, Cursor $5.25, Claude (subprocess) $0.00  |  Tokens: 49217k
 - **Issue**: #3243 — https://github.com/character-ai/larch/issues/3243
 - **Plan review**: 0 findings
 - **OOS filed**: 1 — https://github.com/character-ai/larch/issues/3255

--- a/larch-logs/design/3885D389-B9B8-48B4-8CC3-C64E3ACD5CB6/final-summary.md
+++ b/larch-logs/design/3885D389-B9B8-48B4-8CC3-C64E3ACD5CB6/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 10:16:59
-- **Cost**: 💰 TOTAL ~$34.20 — Claude $16.76, Codex $0.01, Cursor $17.43  |  Tokens: 53456k
+- **Cost**: 💰 TOTAL ~$27.72 — Claude $16.76, Codex $0.12, Cursor $10.84, Claude (subprocess) $0.00  |  Tokens: 53456k
 - **Issue**: #3298 — https://github.com/character-ai/larch/issues/3298
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/39A98F73-2E67-42AF-B620-08A2B289C869/final-summary.md
+++ b/larch-logs/design/39A98F73-2E67-42AF-B620-08A2B289C869/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 05:59:21
-- **Cost**: 💰 TOTAL ~$65.41 — Claude $48.33, Codex $0.00, Cursor $17.08  |  Tokens: 66710k
+- **Cost**: 💰 TOTAL ~$58.63 — Claude $48.33, Codex $0.00, Cursor $10.30, Claude (subprocess) $0.00  |  Tokens: 66710k
 - **Issue**: #3195 — https://github.com/character-ai/larch/issues/3195
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/3AEF9065-070F-4296-BBA8-344F6A3625F1/final-summary.md
+++ b/larch-logs/design/3AEF9065-070F-4296-BBA8-344F6A3625F1/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 00:18:22
-- **Cost**: 💰 TOTAL ~$12.14 — Claude $9.67, Codex $0.58, Cursor $1.89  |  Tokens: 17057k
+- **Cost**: 💰 TOTAL ~$16.95 — Claude $9.67, Codex $6.18, Cursor $1.10, Claude (subprocess) $0.00  |  Tokens: 17057k
 - **Issue**: #3091 — https://github.com/character-ai/larch/issues/3091
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/3BFB97C9-7986-4FDC-9E27-50930B3584AE/final-summary.md
+++ b/larch-logs/design/3BFB97C9-7986-4FDC-9E27-50930B3584AE/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 02:14:40
-- **Cost**: 💰 TOTAL ~$17.58 — Claude $15.82, Codex $0.37, Cursor $1.39  |  Tokens: 21181k
+- **Cost**: 💰 TOTAL ~$20.49 — Claude $15.82, Codex $3.94, Cursor $0.73, Claude (subprocess) $0.00  |  Tokens: 21181k
 - **Issue**: #3153 — https://github.com/character-ai/larch/issues/3153
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/3C06897B-F401-4287-AECD-DFBAFA9F7973/final-summary.md
+++ b/larch-logs/design/3C06897B-F401-4287-AECD-DFBAFA9F7973/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 00:25:39
-- **Cost**: 💰 TOTAL ~$18.98 — Claude $14.02, Codex $0.85, Cursor $4.11  |  Tokens: 35834k
+- **Cost**: 💰 TOTAL ~$25.88 — Claude $14.02, Codex $9.29, Cursor $2.57, Claude (subprocess) $0.00  |  Tokens: 35834k
 - **Issue**: #2737 — https://github.com/character-ai/larch/issues/2737
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/3D213C10-13E2-402A-AAA2-5283EB72FE62/final-summary.md
+++ b/larch-logs/design/3D213C10-13E2-402A-AAA2-5283EB72FE62/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 02:05:33
-- **Cost**: 💰 TOTAL ~$21.87 — Claude $17.90, Codex $0.00, Cursor $3.97  |  Tokens: 29884k
+- **Cost**: 💰 TOTAL ~$20.37 — Claude $17.90, Codex $0.00, Cursor $2.47, Claude (subprocess) $0.00  |  Tokens: 29884k
 - **Issue**: #3348 — https://github.com/character-ai/larch/issues/3348
 - **Plan review**: 0 findings
 - **OOS filed**: 1 — https://github.com/character-ai/larch/issues/3369

--- a/larch-logs/design/3F2C1E03-C44D-409B-AB18-64DD74A56C6F/final-summary.md
+++ b/larch-logs/design/3F2C1E03-C44D-409B-AB18-64DD74A56C6F/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 02:26:35
-- **Cost**: 💰 TOTAL ~$19.52 — Claude $16.90, Codex $0.60, Cursor $2.02  |  Tokens: 25474k
+- **Cost**: 💰 TOTAL ~$24.46 — Claude $16.90, Codex $6.39, Cursor $1.17, Claude (subprocess) $0.00  |  Tokens: 25474k
 - **Issue**: #2970 — https://github.com/character-ai/larch/issues/2970
 - **Plan review**: 0 findings
 - **OOS filed**: 2 — https://github.com/character-ai/larch/issues/2982,https://github.com/character-ai/larch/issues/2985

--- a/larch-logs/design/40808BE7-F7B1-4C8F-820E-01BE7CE86E6E/final-summary.md
+++ b/larch-logs/design/40808BE7-F7B1-4C8F-820E-01BE7CE86E6E/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 00:41:09
-- **Cost**: 💰 TOTAL ~$14.95 — Claude $11.90, Codex $0.77, Cursor $2.28  |  Tokens: 20101k
+- **Cost**: 💰 TOTAL ~$13.68 — Claude $11.90, Codex $0.43, Cursor $1.35, Claude (subprocess) $0.00  |  Tokens: 20101k
 - **Issue**: #2822 — https://github.com/character-ai/larch/issues/2822
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/408B7882-31EA-4DC8-8A82-9D5F6731C2D2/final-summary.md
+++ b/larch-logs/design/408B7882-31EA-4DC8-8A82-9D5F6731C2D2/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 00:45:55
-- **Cost**: 💰 TOTAL ~$15.77 — Claude $13.86, Codex $0.31, Cursor $1.60  |  Tokens: 21520k
+- **Cost**: 💰 TOTAL ~$18.14 — Claude $13.86, Codex $3.35, Cursor $0.93, Claude (subprocess) $0.00  |  Tokens: 21520k
 - **Issue**: #2909 — https://github.com/character-ai/larch/issues/2909
 - **Plan review**: 0 findings
 - **OOS filed**: 2 — https://github.com/character-ai/larch/issues/2925,https://github.com/character-ai/larch/issues/2926

--- a/larch-logs/design/4168AEA5-8A4B-4901-863C-9E68617C11E6/final-summary.md
+++ b/larch-logs/design/4168AEA5-8A4B-4901-863C-9E68617C11E6/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 01:49:06
-- **Cost**: 💰 TOTAL ~$19.46 — Claude $16.58, Codex $0.14, Cursor $2.74  |  Tokens: 22336k
+- **Cost**: 💰 TOTAL ~$19.94 — Claude $16.58, Codex $1.57, Cursor $1.79, Claude (subprocess) $0.00  |  Tokens: 22336k
 - **Issue**: #3238 — https://github.com/character-ai/larch/issues/3238
 - **Plan review**: 0 findings
 - **OOS filed**: 1 — https://github.com/character-ai/larch/issues/3326

--- a/larch-logs/design/437EAA7E-D691-46B5-9C21-4BD53A24E6B2/final-summary.md
+++ b/larch-logs/design/437EAA7E-D691-46B5-9C21-4BD53A24E6B2/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 01:19:37
-- **Cost**: 💰 TOTAL ~$27.10 — Claude $20.96, Codex $0.41, Cursor $5.73  |  Tokens: 32801k
+- **Cost**: 💰 TOTAL ~$28.60 — Claude $20.96, Codex $4.39, Cursor $3.25, Claude (subprocess) $0.00  |  Tokens: 32801k
 - **Issue**: #3272 — https://github.com/character-ai/larch/issues/3272
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/485FD753-CBCD-456D-B80A-563B04B2642A/final-summary.md
+++ b/larch-logs/design/485FD753-CBCD-456D-B80A-563B04B2642A/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 00:02:40
-- **Cost**: 💰 TOTAL ~$27.75 — Claude $25.55, Codex $0.60, Cursor $1.60  |  Tokens: 43706k
+- **Cost**: 💰 TOTAL ~$32.97 — Claude $25.55, Codex $6.49, Cursor $0.93, Claude (subprocess) $0.00  |  Tokens: 43706k
 - **Issue**: #2939 — https://github.com/character-ai/larch/issues/2939
 - **Plan review**: 0 findings
 - **OOS filed**: 1 — https://github.com/character-ai/larch/issues/2981

--- a/larch-logs/design/4A419573-9DC8-432F-AA4B-070A32547A77/final-summary.md
+++ b/larch-logs/design/4A419573-9DC8-432F-AA4B-070A32547A77/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 01:27:54
-- **Cost**: 💰 TOTAL ~$14.65 — Claude $10.74, Codex $0.75, Cursor $3.16  |  Tokens: 25330k
+- **Cost**: 💰 TOTAL ~$20.99 — Claude $10.74, Codex $8.36, Cursor $1.89, Claude (subprocess) $0.00  |  Tokens: 25330k
 - **Issue**: #3317 — https://github.com/character-ai/larch/issues/3317
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/4A4F7B69-9EF5-4B05-B3B7-404248BAF6C7/final-summary.md
+++ b/larch-logs/design/4A4F7B69-9EF5-4B05-B3B7-404248BAF6C7/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 01:37:15
-- **Cost**: 💰 TOTAL ~$21.07 — Claude $13.72, Codex $1.03, Cursor $6.32  |  Tokens: 37693k
+- **Cost**: 💰 TOTAL ~$28.85 — Claude $13.72, Codex $11.35, Cursor $3.78, Claude (subprocess) $0.00  |  Tokens: 37693k
 - **Issue**: #3246 — https://github.com/character-ai/larch/issues/3246
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/4A83C0D5-013E-4228-ACF2-6D4247110CE5/final-summary.md
+++ b/larch-logs/design/4A83C0D5-013E-4228-ACF2-6D4247110CE5/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 04:08:20
-- **Cost**: 💰 TOTAL ~$35.16 — Claude $21.44, Codex $0.33, Cursor $13.39  |  Tokens: 47212k
+- **Cost**: 💰 TOTAL ~$32.93 — Claude $21.44, Codex $3.61, Cursor $7.88, Claude (subprocess) $0.00  |  Tokens: 47212k
 - **Issue**: #3245 — https://github.com/character-ai/larch/issues/3245
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/4AB6E15B-2E80-4B13-A0D4-A3B0A0A42CB1/final-summary.md
+++ b/larch-logs/design/4AB6E15B-2E80-4B13-A0D4-A3B0A0A42CB1/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 02:01:41
-- **Cost**: 💰 TOTAL ~$16.47 — Claude $15.57, Codex $0.00, Cursor $0.90  |  Tokens: 13937k
+- **Cost**: 💰 TOTAL ~$16.09 — Claude $15.57, Codex $0.00, Cursor $0.52, Claude (subprocess) $0.00  |  Tokens: 13937k
 - **Issue**: #3326 — https://github.com/character-ai/larch/issues/3326
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/4AF68F34-3916-4BA9-A63F-200094CAA757/final-summary.md
+++ b/larch-logs/design/4AF68F34-3916-4BA9-A63F-200094CAA757/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 00:48:39
-- **Cost**: 💰 TOTAL ~$20.03 — Claude $14.58, Codex $0.78, Cursor $4.67  |  Tokens: 30703k
+- **Cost**: 💰 TOTAL ~$26.09 — Claude $14.58, Codex $8.63, Cursor $2.88, Claude (subprocess) $0.00  |  Tokens: 30703k
 - **Issue**: #3274 — https://github.com/character-ai/larch/issues/3274
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/508DE0DB-C40E-4C61-9B9E-EC9F9D487BB8/final-summary.md
+++ b/larch-logs/design/508DE0DB-C40E-4C61-9B9E-EC9F9D487BB8/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 01:25:48
-- **Cost**: 💰 TOTAL ~$12.50 — Claude $9.87, Codex $0.47, Cursor $2.16  |  Tokens: 15720k
+- **Cost**: 💰 TOTAL ~$16.03 — Claude $9.87, Codex $5.01, Cursor $1.15, Claude (subprocess) $0.00  |  Tokens: 15720k
 - **Issue**: #3320 — https://github.com/character-ai/larch/issues/3320
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/512E9E35-57B0-4487-81A6-AD1FF4D72A66/final-summary.md
+++ b/larch-logs/design/512E9E35-57B0-4487-81A6-AD1FF4D72A66/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 03:38:58
-- **Cost**: 💰 TOTAL ~$26.72 — Claude $20.39, Codex $0.91, Cursor $5.42  |  Tokens: 41791k
+- **Cost**: 💰 TOTAL ~$33.99 — Claude $20.39, Codex $10.02, Cursor $3.58, Claude (subprocess) $0.00  |  Tokens: 41791k
 - **Issue**: N/A
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/51D173ED-0398-4A52-A5C5-E8515DB6693F/final-summary.md
+++ b/larch-logs/design/51D173ED-0398-4A52-A5C5-E8515DB6693F/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: unknown
 - **Duration**: N/A
-- **Cost**: 💰 TOTAL ~$25.61 — Claude $21.00, Codex $1.03, Cursor $3.58  |  Tokens: 45612k
+- **Cost**: 💰 TOTAL ~$34.77 — Claude $21.00, Codex $11.44, Cursor $2.33, Claude (subprocess) $0.00  |  Tokens: 45612k
 - **Issue**: #3063 — https://github.com/character-ai/larch/issues/3063
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/57463F99-6ACE-4482-852B-403E1042BB4C/final-summary.md
+++ b/larch-logs/design/57463F99-6ACE-4482-852B-403E1042BB4C/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 00:31:17
-- **Cost**: 💰 TOTAL ~$13.48 — Claude $10.92, Codex $0.48, Cursor $2.08  |  Tokens: 21277k
+- **Cost**: 💰 TOTAL ~$17.25 — Claude $10.92, Codex $5.12, Cursor $1.21, Claude (subprocess) $0.00  |  Tokens: 21277k
 - **Issue**: #2830 — https://github.com/character-ai/larch/issues/2830
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/584E7DA0-52BF-4A29-99E9-D9ACB92E78C2/final-summary.md
+++ b/larch-logs/design/584E7DA0-52BF-4A29-99E9-D9ACB92E78C2/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 10:15:12
-- **Cost**: 💰 TOTAL ~$23.42 — Claude $16.02, Codex $0.00, Cursor $7.40  |  Tokens: 31375k
+- **Cost**: 💰 TOTAL ~$20.67 — Claude $16.02, Codex $0.00, Cursor $4.65, Claude (subprocess) $0.00  |  Tokens: 31375k
 - **Issue**: #3299 — https://github.com/character-ai/larch/issues/3299
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/5BB5A50A-8E04-453C-840B-09B45EF8BE04/final-summary.md
+++ b/larch-logs/design/5BB5A50A-8E04-453C-840B-09B45EF8BE04/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 08:26:51
-- **Cost**: 💰 TOTAL ~$15.11 — Claude $10.91, Codex $1.18, Cursor $3.02  |  Tokens: 25766k
+- **Cost**: 💰 TOTAL ~$25.82 — Claude $10.91, Codex $13.15, Cursor $1.76, Claude (subprocess) $0.00  |  Tokens: 25766k
 - **Issue**: #3181 — https://github.com/character-ai/larch/issues/3181
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/5D373FCB-41CD-40B8-88D3-750D58BB4608/final-summary.md
+++ b/larch-logs/design/5D373FCB-41CD-40B8-88D3-750D58BB4608/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: N/A
 - **Path**: SIMPLE
 - **Duration**: 00:31:39
-- **Cost**: 💰 TOTAL ~$6.69 — Claude $6.69, Codex $0.00, Cursor $0.00  |  Tokens: 7570k
+- **Cost**: 💰 TOTAL ~$6.69 — Claude $6.69, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.00  |  Tokens: 7570k
 - **Issue**: #2720 — https://github.com/character-ai/larch/issues/2720
 - **Plan review**: 1 accepted (0 critical / 1 high / 0 medium / 0 low)
 - **OOS filed**: 0

--- a/larch-logs/design/5D645773-020F-4678-9179-A56F3E50DBD9/final-summary.md
+++ b/larch-logs/design/5D645773-020F-4678-9179-A56F3E50DBD9/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: TRIVIAL_DOC_ONLY
 - **Path**: SIMPLE
 - **Duration**: N/A
-- **Cost**: 💰 TOTAL ~$2.40 — Claude $2.40, Codex $0.00, Cursor $0.00  |  Tokens: 3008k
+- **Cost**: 💰 TOTAL ~$2.40 — Claude $2.40, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.00  |  Tokens: 3008k
 - **Issue**: #2817 — https://github.com/character-ai/larch/issues/2817
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/5EA2AE60-BB8E-46D9-8743-7D236D69E9ED/final-summary.md
+++ b/larch-logs/design/5EA2AE60-BB8E-46D9-8743-7D236D69E9ED/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 00:52:27
-- **Cost**: 💰 TOTAL ~$19.67 — Claude $17.10, Codex $0.59, Cursor $1.98  |  Tokens: 28512k
+- **Cost**: 💰 TOTAL ~$24.58 — Claude $17.10, Codex $6.33, Cursor $1.15, Claude (subprocess) $0.00  |  Tokens: 28512k
 - **Issue**: #2963 — https://github.com/character-ai/larch/issues/2963
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/60142F2E-F00C-404E-A0A9-9E1E7523F693/final-summary.md
+++ b/larch-logs/design/60142F2E-F00C-404E-A0A9-9E1E7523F693/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 03:28:33
-- **Cost**: 💰 TOTAL ~$28.60 — Claude $15.63, Codex $2.77, Cursor $10.20  |  Tokens: 61871k
+- **Cost**: 💰 TOTAL ~$52.81 — Claude $15.63, Codex $30.68, Cursor $6.50, Claude (subprocess) $0.00  |  Tokens: 61871k
 - **Issue**: #3166 — https://github.com/character-ai/larch/issues/3166
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/625CC38C-1547-4522-8F3D-B9E3C9BC1CB0/final-summary.md
+++ b/larch-logs/design/625CC38C-1547-4522-8F3D-B9E3C9BC1CB0/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: unknown
 - **Duration**: 00:37:43
-- **Cost**: 💰 TOTAL ~$15.40 — Claude $11.68, Codex $0.86, Cursor $2.86  |  Tokens: 24878k
+- **Cost**: 💰 TOTAL ~$22.92 — Claude $11.68, Codex $9.44, Cursor $1.80, Claude (subprocess) $0.00  |  Tokens: 24878k
 - **Issue**: #3077 — https://github.com/character-ai/larch/issues/3077
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/629DC672-21B7-4C28-92C3-26BBD455D7D8/final-summary.md
+++ b/larch-logs/design/629DC672-21B7-4C28-92C3-26BBD455D7D8/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: N/A
-- **Cost**: 💰 TOTAL ~$21.24 — Claude $16.84, Codex $1.62, Cursor $2.78  |  Tokens: 28753k
+- **Cost**: 💰 TOTAL ~$19.51 — Claude $16.84, Codex $0.90, Cursor $1.77, Claude (subprocess) $0.00  |  Tokens: 28753k
 - **Issue**: #2790 — https://github.com/character-ai/larch/issues/2790
 - **Plan review**: 0 findings
 - **OOS filed**: 1 — https://github.com/character-ai/larch/issues/2833

--- a/larch-logs/design/62CB09DA-4657-45BE-B085-2D2E1BED1054/final-summary.md
+++ b/larch-logs/design/62CB09DA-4657-45BE-B085-2D2E1BED1054/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 00:00:00
-- **Cost**: 💰 TOTAL ~$16.52 — Claude $11.75, Codex $1.93, Cursor $2.84  |  Tokens: 22278k
+- **Cost**: 💰 TOTAL ~$14.53 — Claude $11.75, Codex $1.07, Cursor $1.71, Claude (subprocess) $0.00  |  Tokens: 22278k
 - **Issue**: N/A
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/639438B1-E99D-4897-AAB8-77D92BD52982/final-summary.md
+++ b/larch-logs/design/639438B1-E99D-4897-AAB8-77D92BD52982/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 11:02:48
-- **Cost**: 💰 TOTAL ~$22.90 — Claude $19.99, Codex $0.51, Cursor $2.40  |  Tokens: 29730k
+- **Cost**: 💰 TOTAL ~$26.84 — Claude $19.99, Codex $5.50, Cursor $1.35, Claude (subprocess) $0.00  |  Tokens: 29730k
 - **Issue**: N/A
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/657071F3-B85A-4B8C-8705-BBA2232EC915/final-summary.md
+++ b/larch-logs/design/657071F3-B85A-4B8C-8705-BBA2232EC915/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 07:26:33
-- **Cost**: 💰 TOTAL ~$35.01 — Claude $19.95, Codex $0.00, Cursor $15.06  |  Tokens: 52115k
+- **Cost**: 💰 TOTAL ~$29.12 — Claude $19.95, Codex $0.00, Cursor $9.17, Claude (subprocess) $0.00  |  Tokens: 52115k
 - **Issue**: #3227 — https://github.com/character-ai/larch/issues/3227
 - **Plan review**: 0 findings
 - **OOS filed**: 1 — https://github.com/character-ai/larch/issues/3257

--- a/larch-logs/design/65CD4FCD-C9E8-4ED4-8781-4DF2EC40FC17/final-summary.md
+++ b/larch-logs/design/65CD4FCD-C9E8-4ED4-8781-4DF2EC40FC17/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 00:42:36
-- **Cost**: 💰 TOTAL ~$26.88 — Claude $22.90, Codex $0.83, Cursor $3.15  |  Tokens: 42687k
+- **Cost**: 💰 TOTAL ~$34.00 — Claude $22.90, Codex $9.16, Cursor $1.94, Claude (subprocess) $0.00  |  Tokens: 42687k
 - **Issue**: #2837 — https://github.com/character-ai/larch/issues/2837
 - **Plan review**: 0 findings
 - **OOS filed**: 1 — https://github.com/character-ai/larch/issues/2915

--- a/larch-logs/design/660F22A3-B997-4F51-AC2C-2B31EF3508B4/final-summary.md
+++ b/larch-logs/design/660F22A3-B997-4F51-AC2C-2B31EF3508B4/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 00:27:09
-- **Cost**: 💰 TOTAL ~$15.70 — Claude $12.51, Codex $0.69, Cursor $2.50  |  Tokens: 24630k
+- **Cost**: 💰 TOTAL ~$21.71 — Claude $12.51, Codex $7.64, Cursor $1.56, Claude (subprocess) $0.00  |  Tokens: 24630k
 - **Issue**: #3074 — https://github.com/character-ai/larch/issues/3074
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/66C302BB-F8F7-49E7-918E-3CBB9AD0C4F0/final-summary.md
+++ b/larch-logs/design/66C302BB-F8F7-49E7-918E-3CBB9AD0C4F0/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 07:33:20
-- **Cost**: 💰 TOTAL ~$33.03 — Claude $25.18, Codex $0.00, Cursor $7.85  |  Tokens: 32542k
+- **Cost**: 💰 TOTAL ~$29.65 — Claude $25.18, Codex $0.00, Cursor $4.47, Claude (subprocess) $0.00  |  Tokens: 32542k
 - **Issue**: #3229 — https://github.com/character-ai/larch/issues/3229
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/68AD124C-2357-43C1-A249-4B1A6ACAAE32/final-summary.md
+++ b/larch-logs/design/68AD124C-2357-43C1-A249-4B1A6ACAAE32/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: HARD
 - **Path**: HARD
 - **Duration**: 01:25:30
-- **Cost**: 💰 TOTAL ~$33.31 — Claude $28.71, Codex $1.18, Cursor $3.42  |  Tokens: 49867k
+- **Cost**: 💰 TOTAL ~$43.72 — Claude $28.71, Codex $13.02, Cursor $1.99, Claude (subprocess) $0.00  |  Tokens: 49867k
 - **Issue**: #2953 — https://github.com/character-ai/larch/issues/2953
 - **Plan review**: 0 findings
 - **OOS filed**: 3 — https://github.com/character-ai/larch/issues/2999,https://github.com/character-ai/larch/issues/3000,https://github.com/character-ai/larch/issues/3001

--- a/larch-logs/design/6955327F-B918-4B07-B5D3-E946FDC2A0EC/final-summary.md
+++ b/larch-logs/design/6955327F-B918-4B07-B5D3-E946FDC2A0EC/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 02:20:06
-- **Cost**: 💰 TOTAL ~$42.45 — Claude $17.90, Codex $1.10, Cursor $23.45  |  Tokens: 85050k
+- **Cost**: 💰 TOTAL ~$45.07 — Claude $17.90, Codex $12.44, Cursor $14.73, Claude (subprocess) $0.00  |  Tokens: 85050k
 - **Issue**: #3187 — https://github.com/character-ai/larch/issues/3187
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/6A4AC6E7-2A0F-4A45-BEB3-2B76C2FE38E0/final-summary.md
+++ b/larch-logs/design/6A4AC6E7-2A0F-4A45-BEB3-2B76C2FE38E0/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: HARD
 - **Path**: HARD
 - **Duration**: 01:14:18
-- **Cost**: 💰 TOTAL ~$54.45 — Claude $48.27, Codex $1.19, Cursor $4.99  |  Tokens: 87132k
+- **Cost**: 💰 TOTAL ~$64.43 — Claude $48.27, Codex $13.18, Cursor $2.98, Claude (subprocess) $0.00  |  Tokens: 87132k
 - **Issue**: #2973 — https://github.com/character-ai/larch/issues/2973
 - **Plan review**: 0 findings
 - **OOS filed**: 1 — https://github.com/character-ai/larch/issues/3005

--- a/larch-logs/design/6BED5CC3-25C9-455A-889D-D619BE35FE8F/final-summary.md
+++ b/larch-logs/design/6BED5CC3-25C9-455A-889D-D619BE35FE8F/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 05:01:01
-- **Cost**: 💰 TOTAL ~$38.81 — Claude $20.83, Codex $0.00, Cursor $17.98  |  Tokens: 58414k
+- **Cost**: 💰 TOTAL ~$32.04 — Claude $20.83, Codex $0.00, Cursor $11.21, Claude (subprocess) $0.00  |  Tokens: 58414k
 - **Issue**: #3204 — https://github.com/character-ai/larch/issues/3204
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/6BF64582-DB4A-4410-9D3C-C4C7D22F4AF1/final-summary.md
+++ b/larch-logs/design/6BF64582-DB4A-4410-9D3C-C4C7D22F4AF1/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 00:27:21
-- **Cost**: 💰 TOTAL ~$10.33 — Claude $7.64, Codex $0.59, Cursor $2.10  |  Tokens: 17634k
+- **Cost**: 💰 TOTAL ~$15.40 — Claude $7.64, Codex $6.53, Cursor $1.23, Claude (subprocess) $0.00  |  Tokens: 17634k
 - **Issue**: #2807 — https://github.com/character-ai/larch/issues/2807
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/6CDFD52D-0341-4BEB-8A43-AC28405FF117/final-summary.md
+++ b/larch-logs/design/6CDFD52D-0341-4BEB-8A43-AC28405FF117/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 04:31:17
-- **Cost**: 💰 TOTAL ~$34.41 — Claude $18.75, Codex $0.00, Cursor $15.66  |  Tokens: 52569k
+- **Cost**: 💰 TOTAL ~$28.27 — Claude $18.75, Codex $0.00, Cursor $9.52, Claude (subprocess) $0.00  |  Tokens: 52569k
 - **Issue**: #3120 — https://github.com/character-ai/larch/issues/3120
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/707E97A2-2BE7-499C-AA13-1FE59892BDD6/final-summary.md
+++ b/larch-logs/design/707E97A2-2BE7-499C-AA13-1FE59892BDD6/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 03:45:12
-- **Cost**: 💰 TOTAL ~$28.46 — Claude $24.08, Codex $0.95, Cursor $3.43  |  Tokens: 40442k
+- **Cost**: 💰 TOTAL ~$36.55 — Claude $24.08, Codex $10.33, Cursor $2.14, Claude (subprocess) $0.00  |  Tokens: 40442k
 - **Issue**: #2959 — https://github.com/character-ai/larch/issues/2959
 - **Plan review**: 0 findings
 - **OOS filed**: 4 — https://github.com/character-ai/larch/issues/2983,https://github.com/character-ai/larch/issues/2984

--- a/larch-logs/design/7276F2CF-2285-491B-BC32-984CF760DA6F/final-summary.md
+++ b/larch-logs/design/7276F2CF-2285-491B-BC32-984CF760DA6F/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 01:40:01
-- **Cost**: 💰 TOTAL ~$27.56 — Claude $22.26, Codex $1.11, Cursor $4.19  |  Tokens: 38989k
+- **Cost**: 💰 TOTAL ~$36.87 — Claude $22.26, Codex $12.29, Cursor $2.32, Claude (subprocess) $0.00  |  Tokens: 38989k
 - **Issue**: N/A
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/72FDFA9C-88B2-4CE0-97B4-BF768B7E38AF/final-summary.md
+++ b/larch-logs/design/72FDFA9C-88B2-4CE0-97B4-BF768B7E38AF/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 01:02:19
-- **Cost**: 💰 TOTAL ~$13.88 — Claude $11.54, Codex $0.45, Cursor $1.89  |  Tokens: 19505k
+- **Cost**: 💰 TOTAL ~$17.68 — Claude $11.54, Codex $4.96, Cursor $1.18, Claude (subprocess) $0.00  |  Tokens: 19505k
 - **Issue**: #3121 — https://github.com/character-ai/larch/issues/3121
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/75457DB5-F540-4E5B-B1A4-845CA93B3971/final-summary.md
+++ b/larch-logs/design/75457DB5-F540-4E5B-B1A4-845CA93B3971/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: TRIVIAL_DOC_ONLY
 - **Path**: SIMPLE
 - **Duration**: N/A
-- **Cost**: 💰 TOTAL ~$6.71 — Claude $6.71, Codex $0.00, Cursor $0.00  |  Tokens: 9610k
+- **Cost**: 💰 TOTAL ~$6.71 — Claude $6.71, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.00  |  Tokens: 9610k
 - **Issue**: #2805 — https://github.com/character-ai/larch/issues/2805
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/75B6F5BD-2D39-4CCB-9E34-5751B24DC6D0/final-summary.md
+++ b/larch-logs/design/75B6F5BD-2D39-4CCB-9E34-5751B24DC6D0/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: unknown
 - **Duration**: N/A
-- **Cost**: 💰 TOTAL ~$24.21 — Claude $21.44, Codex $0.59, Cursor $2.18  |  Tokens: 38645k
+- **Cost**: 💰 TOTAL ~$29.26 — Claude $21.44, Codex $6.49, Cursor $1.33, Claude (subprocess) $0.00  |  Tokens: 38645k
 - **Issue**: #3053 — https://github.com/character-ai/larch/issues/3053
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/77E51DBB-E6C4-4944-AA34-10092352662B/final-summary.md
+++ b/larch-logs/design/77E51DBB-E6C4-4944-AA34-10092352662B/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 10:22:27
-- **Cost**: 💰 TOTAL ~$32.53 — Claude $18.96, Codex $3.50, Cursor $10.07  |  Tokens: 59067k
+- **Cost**: 💰 TOTAL ~$63.21 — Claude $18.96, Codex $38.36, Cursor $5.89, Claude (subprocess) $0.00  |  Tokens: 59067k
 - **Issue**: #3175 — https://github.com/character-ai/larch/issues/3175
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/7A6A495A-C1D9-4296-8BF0-6A006555E8B7/final-summary.md
+++ b/larch-logs/design/7A6A495A-C1D9-4296-8BF0-6A006555E8B7/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 00:29:09
-- **Cost**: 💰 TOTAL ~$9.99 — Claude $8.11, Codex $0.33, Cursor $1.55  |  Tokens: 14040k
+- **Cost**: 💰 TOTAL ~$12.55 — Claude $8.11, Codex $3.55, Cursor $0.89, Claude (subprocess) $0.00  |  Tokens: 14040k
 - **Issue**: N/A
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/7B29B3A0-3392-4DA9-92BF-AD7FC479FAF2/final-summary.md
+++ b/larch-logs/design/7B29B3A0-3392-4DA9-92BF-AD7FC479FAF2/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: unknown
 - **Duration**: 00:28:00
-- **Cost**: 💰 TOTAL ~$13.18 — Claude $10.35, Codex $0.88, Cursor $1.95  |  Tokens: 26054k
+- **Cost**: 💰 TOTAL ~$21.38 — Claude $10.35, Codex $9.85, Cursor $1.18, Claude (subprocess) $0.00  |  Tokens: 26054k
 - **Issue**: #3039 — https://github.com/character-ai/larch/issues/3039
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/7C31FA9E-D00E-41E9-B338-D8E4D44A6FEE/final-summary.md
+++ b/larch-logs/design/7C31FA9E-D00E-41E9-B338-D8E4D44A6FEE/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 01:48:40
-- **Cost**: 💰 TOTAL ~$35.71 — Claude $23.42, Codex $0.12, Cursor $12.17  |  Tokens: 48959k
+- **Cost**: 💰 TOTAL ~$32.64 — Claude $23.42, Codex $1.38, Cursor $7.84, Claude (subprocess) $0.00  |  Tokens: 48959k
 - **Issue**: #3119 — https://github.com/character-ai/larch/issues/3119
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/7D6BC283-6D45-4357-920A-08EC0DA5DAAB/final-summary.md
+++ b/larch-logs/design/7D6BC283-6D45-4357-920A-08EC0DA5DAAB/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: unknown
 - **Duration**: N/A
-- **Cost**: 💰 TOTAL ~$20.88 — Claude $20.50, Codex $0.38, Cursor $0.00  |  Tokens: 27520k
+- **Cost**: 💰 TOTAL ~$24.75 — Claude $20.50, Codex $4.25, Cursor $0.00, Claude (subprocess) $0.00  |  Tokens: 27520k
 - **Issue**: #2977 — https://github.com/character-ai/larch/issues/2977
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/82003CE1-EF46-47F1-BF7B-6295FE1FB22C/final-summary.md
+++ b/larch-logs/design/82003CE1-EF46-47F1-BF7B-6295FE1FB22C/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 01:53:50
-- **Cost**: 💰 TOTAL ~$18.38 — Claude $15.51, Codex $0.66, Cursor $2.21  |  Tokens: 23747k
+- **Cost**: 💰 TOTAL ~$23.84 — Claude $15.51, Codex $7.04, Cursor $1.29, Claude (subprocess) $0.00  |  Tokens: 23747k
 - **Issue**: #3150 — https://github.com/character-ai/larch/issues/3150
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/831D57DF-765E-4F6D-A01D-6227BC7C985E/final-summary.md
+++ b/larch-logs/design/831D57DF-765E-4F6D-A01D-6227BC7C985E/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 01:00:16
-- **Cost**: 💰 TOTAL ~$30.62 — Claude $27.78, Codex $0.45, Cursor $2.39  |  Tokens: 48459k
+- **Cost**: 💰 TOTAL ~$34.00 — Claude $27.78, Codex $4.82, Cursor $1.40, Claude (subprocess) $0.00  |  Tokens: 48459k
 - **Issue**: #2882 — https://github.com/character-ai/larch/issues/2882
 - **Plan review**: 0 findings
 - **OOS filed**: 3 — https://github.com/character-ai/larch/issues/2911,https://github.com/character-ai/larch/issues/2912,https://github.com/character-ai/larch/issues/2913

--- a/larch-logs/design/83378491-6051-4957-BEC9-944AE4D13C57/final-summary.md
+++ b/larch-logs/design/83378491-6051-4957-BEC9-944AE4D13C57/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: N/A
-- **Cost**: 💰 TOTAL ~$24.99 — Claude $21.76, Codex $1.57, Cursor $1.66  |  Tokens: 24147k
+- **Cost**: 💰 TOTAL ~$23.62 — Claude $21.76, Codex $0.87, Cursor $0.99, Claude (subprocess) $0.00  |  Tokens: 24147k
 - **Issue**: N/A
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/83BB588F-41BA-489D-8691-BFCBBBC1DE78/final-summary.md
+++ b/larch-logs/design/83BB588F-41BA-489D-8691-BFCBBBC1DE78/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 00:40:05
-- **Cost**: 💰 TOTAL ~$23.69 — Claude $17.00, Codex $2.37, Cursor $4.32  |  Tokens: 29751k
+- **Cost**: 💰 TOTAL ~$20.97 — Claude $17.00, Codex $1.31, Cursor $2.66, Claude (subprocess) $0.00  |  Tokens: 29751k
 - **Issue**: N/A
 - **Plan review**: 0 findings
 - **OOS filed**: 4 — https://github.com/character-ai/larch/issues/2806,https://github.com/character-ai/larch/issues/2807,https://github.com/character-ai/larch/issues/2808,https://github.com/character-ai/larch/issues/2809

--- a/larch-logs/design/85D65C76-9683-4199-8746-AF323F6EDD12/final-summary.md
+++ b/larch-logs/design/85D65C76-9683-4199-8746-AF323F6EDD12/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 03:51:49
-- **Cost**: 💰 TOTAL ~$22.46 — Claude $17.16, Codex $0.00, Cursor $5.30  |  Tokens: 25590k
+- **Cost**: 💰 TOTAL ~$20.38 — Claude $17.16, Codex $0.00, Cursor $3.22, Claude (subprocess) $0.00  |  Tokens: 25590k
 - **Issue**: #3241 — https://github.com/character-ai/larch/issues/3241
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/85DD61C6-F1AA-419C-A663-8B2B9514BBC6/final-summary.md
+++ b/larch-logs/design/85DD61C6-F1AA-419C-A663-8B2B9514BBC6/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 01:41:36
-- **Cost**: 💰 TOTAL ~$49.04 — Claude $43.88, Codex $2.13, Cursor $3.03  |  Tokens: 78926k
+- **Cost**: 💰 TOTAL ~$46.91 — Claude $43.88, Codex $1.18, Cursor $1.85, Claude (subprocess) $0.00  |  Tokens: 78926k
 - **Issue**: N/A
 - **Plan review**: 0 findings
 - **OOS filed**: 1 — https://github.com/character-ai/larch/issues/2839

--- a/larch-logs/design/8666E494-99BB-467B-8B5D-6815954A282C/final-summary.md
+++ b/larch-logs/design/8666E494-99BB-467B-8B5D-6815954A282C/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: TRIVIAL_DOC_ONLY
 - **Path**: SIMPLE
 - **Duration**: 00:16:01
-- **Cost**: 💰 TOTAL ~$13.23 — Claude $13.23, Codex $0.00, Cursor $0.00  |  Tokens: 15823k
+- **Cost**: 💰 TOTAL ~$13.23 — Claude $13.23, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.00  |  Tokens: 15823k
 - **Issue**: #2782 — https://github.com/character-ai/larch/issues/2782
 - **Plan review**: 0 findings
 - **OOS filed**: 1 — https://github.com/character-ai/larch/issues/2787

--- a/larch-logs/design/87244B4A-5715-4CF7-A203-433242603035/final-summary.md
+++ b/larch-logs/design/87244B4A-5715-4CF7-A203-433242603035/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: TRIVIAL_DOC_ONLY
 - **Path**: SIMPLE
 - **Duration**: 00:40:30
-- **Cost**: 💰 TOTAL ~$14.85 — Claude $14.85, Codex $0.00, Cursor $0.00  |  Tokens: 15392k
+- **Cost**: 💰 TOTAL ~$14.85 — Claude $14.85, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.00  |  Tokens: 15392k
 - **Issue**: N/A
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/8B334AEA-6461-4983-B926-91D87804FFAB/final-summary.md
+++ b/larch-logs/design/8B334AEA-6461-4983-B926-91D87804FFAB/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: N/A
-- **Cost**: 💰 TOTAL ~$29.61 — Claude $22.55, Codex $1.24, Cursor $5.82  |  Tokens: 58706k
+- **Cost**: 💰 TOTAL ~$39.83 — Claude $22.55, Codex $13.56, Cursor $3.72, Claude (subprocess) $0.00  |  Tokens: 58706k
 - **Issue**: #3134 — https://github.com/character-ai/larch/issues/3134
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/8CED3392-A0EE-4B3D-BB9E-5FDEE5650706/final-summary.md
+++ b/larch-logs/design/8CED3392-A0EE-4B3D-BB9E-5FDEE5650706/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 00:00:00
-- **Cost**: 💰 TOTAL ~$21.48 — Claude $14.59, Codex $1.29, Cursor $5.60  |  Tokens: 39260k
+- **Cost**: 💰 TOTAL ~$32.27 — Claude $14.59, Codex $14.19, Cursor $3.49, Claude (subprocess) $0.00  |  Tokens: 39260k
 - **Issue**: #3008 — https://github.com/character-ai/larch/issues/3008
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/8D8EA977-D688-4066-81D4-450DFBECDD48/final-summary.md
+++ b/larch-logs/design/8D8EA977-D688-4066-81D4-450DFBECDD48/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 03:45:14
-- **Cost**: 💰 TOTAL ~$20.80 — Claude $17.51, Codex $0.82, Cursor $2.47  |  Tokens: 25066k
+- **Cost**: 💰 TOTAL ~$28.09 — Claude $17.51, Codex $9.11, Cursor $1.47, Claude (subprocess) $0.00  |  Tokens: 25066k
 - **Issue**: #3234 — https://github.com/character-ai/larch/issues/3234
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/8F35C771-51C9-4A28-A9EA-17A5C2F36CD7/final-summary.md
+++ b/larch-logs/design/8F35C771-51C9-4A28-A9EA-17A5C2F36CD7/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: N/A
-- **Cost**: 💰 TOTAL ~$28.21 — Claude $21.26, Codex $2.06, Cursor $4.89  |  Tokens: 34086k
+- **Cost**: 💰 TOTAL ~$25.39 — Claude $21.26, Codex $1.14, Cursor $2.99, Claude (subprocess) $0.00  |  Tokens: 34086k
 - **Issue**: #2848 — https://github.com/character-ai/larch/issues/2848
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/90628862-9A18-4A56-8420-63DE723F9D81/final-summary.md
+++ b/larch-logs/design/90628862-9A18-4A56-8420-63DE723F9D81/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: unknown
 - **Duration**: 01:17:09
-- **Cost**: 💰 TOTAL ~$21.95 — Claude $17.83, Codex $0.99, Cursor $3.13  |  Tokens: 36344k
+- **Cost**: 💰 TOTAL ~$30.89 — Claude $17.83, Codex $11.09, Cursor $1.97, Claude (subprocess) $0.00  |  Tokens: 36344k
 - **Issue**: #3068 — https://github.com/character-ai/larch/issues/3068
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/93D16165-A841-4B6B-8AA8-1566E45CE6C3/final-summary.md
+++ b/larch-logs/design/93D16165-A841-4B6B-8AA8-1566E45CE6C3/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 02:47:45
-- **Cost**: 💰 TOTAL ~$28.46 — Claude $24.11, Codex $0.97, Cursor $3.38  |  Tokens: 45185k
+- **Cost**: 💰 TOTAL ~$37.05 — Claude $24.11, Codex $10.78, Cursor $2.16, Claude (subprocess) $0.00  |  Tokens: 45185k
 - **Issue**: N/A
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/942CE074-226E-409A-8E70-C745E60956B8/final-summary.md
+++ b/larch-logs/design/942CE074-226E-409A-8E70-C745E60956B8/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 00:39:28
-- **Cost**: 💰 TOTAL ~$14.00 — Claude $12.36, Codex $0.32, Cursor $1.32  |  Tokens: 15567k
+- **Cost**: 💰 TOTAL ~$16.64 — Claude $12.36, Codex $3.52, Cursor $0.76, Claude (subprocess) $0.00  |  Tokens: 15567k
 - **Issue**: #3160 — https://github.com/character-ai/larch/issues/3160
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/96586560-1A44-481A-9613-A912A1D8F495/final-summary.md
+++ b/larch-logs/design/96586560-1A44-481A-9613-A912A1D8F495/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 00:48:47
-- **Cost**: 💰 TOTAL ~$20.22 — Claude $15.29, Codex $2.03, Cursor $2.90  |  Tokens: 23448k
+- **Cost**: 💰 TOTAL ~$18.14 — Claude $15.29, Codex $1.13, Cursor $1.72, Claude (subprocess) $0.00  |  Tokens: 23448k
 - **Issue**: #2847 — https://github.com/character-ai/larch/issues/2847
 - **Plan review**: 0 findings
 - **OOS filed**: 1 — https://github.com/character-ai/larch/issues/2861

--- a/larch-logs/design/96806BD1-ED37-45B2-947C-8BCD073A947E/final-summary.md
+++ b/larch-logs/design/96806BD1-ED37-45B2-947C-8BCD073A947E/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: N/A
 - **Path**: SIMPLE
 - **Duration**: 01:17:14
-- **Cost**: 💰 TOTAL ~$24.37 — Claude $20.19, Codex $1.85, Cursor $2.33  |  Tokens: 25001k
+- **Cost**: 💰 TOTAL ~$22.59 — Claude $20.19, Codex $1.03, Cursor $1.37, Claude (subprocess) $0.00  |  Tokens: 25001k
 - **Issue**: N/A
 - **Plan review**: 0 findings
 - **OOS filed**: 1 — https://github.com/character-ai/larch/issues/2770

--- a/larch-logs/design/9727E99F-67D4-4E42-8D9F-350231BDD4AE/final-summary.md
+++ b/larch-logs/design/9727E99F-67D4-4E42-8D9F-350231BDD4AE/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: HARD
 - **Path**: unknown
 - **Duration**: 00:45:32
-- **Cost**: 💰 TOTAL ~$37.26 — Claude $31.50, Codex $1.27, Cursor $4.49  |  Tokens: 56603k
+- **Cost**: 💰 TOTAL ~$48.48 — Claude $31.50, Codex $14.17, Cursor $2.81, Claude (subprocess) $0.00  |  Tokens: 56603k
 - **Issue**: #2738 — https://github.com/character-ai/larch/issues/2738
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/993D3FDA-9ADD-4654-961F-78BA03B488EE/final-summary.md
+++ b/larch-logs/design/993D3FDA-9ADD-4654-961F-78BA03B488EE/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 09:41:56
-- **Cost**: 💰 TOTAL ~$15.76 — Claude $15.13, Codex $0.63, Cursor $0.00  |  Tokens: 18467k
+- **Cost**: 💰 TOTAL ~$21.96 — Claude $15.13, Codex $6.83, Cursor $0.00, Claude (subprocess) $0.00  |  Tokens: 18467k
 - **Issue**: #2991 — https://github.com/character-ai/larch/issues/2991
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/9C6B52A0-3003-4A0A-AD87-F57DF44ABC06/final-summary.md
+++ b/larch-logs/design/9C6B52A0-3003-4A0A-AD87-F57DF44ABC06/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 02:35:32
-- **Cost**: 💰 TOTAL ~$29.80 — Claude $18.58, Codex $2.83, Cursor $8.39  |  Tokens: 53134k
+- **Cost**: 💰 TOTAL ~$54.41 — Claude $18.58, Codex $30.86, Cursor $4.97, Claude (subprocess) $0.00  |  Tokens: 53134k
 - **Issue**: #3172 — https://github.com/character-ai/larch/issues/3172
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/9D106746-5032-49D8-B32E-CB08A9C75282/final-summary.md
+++ b/larch-logs/design/9D106746-5032-49D8-B32E-CB08A9C75282/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 02:09:13
-- **Cost**: 💰 TOTAL ~$42.65 — Claude $19.52, Codex $0.00, Cursor $23.13  |  Tokens: 78627k
+- **Cost**: 💰 TOTAL ~$34.44 — Claude $19.52, Codex $0.00, Cursor $14.92, Claude (subprocess) $0.00  |  Tokens: 78627k
 - **Issue**: #3192 — https://github.com/character-ai/larch/issues/3192
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/9D599588-7727-44DF-A72A-8EA2DE8134C5/final-summary.md
+++ b/larch-logs/design/9D599588-7727-44DF-A72A-8EA2DE8134C5/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: TRIVIAL_DOC_ONLY
 - **Path**: SIMPLE
 - **Duration**: 00:20:00
-- **Cost**: 💰 TOTAL ~$7.12 — Claude $7.12, Codex $0.00, Cursor $0.00  |  Tokens: 9707k
+- **Cost**: 💰 TOTAL ~$7.12 — Claude $7.12, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.00  |  Tokens: 9707k
 - **Issue**: #2764 — https://github.com/character-ai/larch/issues/2764
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/9F937A0D-29F6-4DBC-B85F-2419956076AE/final-summary.md
+++ b/larch-logs/design/9F937A0D-29F6-4DBC-B85F-2419956076AE/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 10:17:20
-- **Cost**: 💰 TOTAL ~$19.07 — Claude $12.59, Codex $0.72, Cursor $5.76  |  Tokens: 26625k
+- **Cost**: 💰 TOTAL ~$23.67 — Claude $12.59, Codex $7.76, Cursor $3.32, Claude (subprocess) $0.00  |  Tokens: 26625k
 - **Issue**: #3297 — https://github.com/character-ai/larch/issues/3297
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/9FDD11DD-2018-4E2D-985F-AB6F24CA76A1/final-summary.md
+++ b/larch-logs/design/9FDD11DD-2018-4E2D-985F-AB6F24CA76A1/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: N/A
 - **Path**: SIMPLE
 - **Duration**: 00:05:33
-- **Cost**: 💰 TOTAL ~$4.43 — Claude $4.43, Codex $0.00, Cursor $0.00  |  Tokens: 6025k
+- **Cost**: 💰 TOTAL ~$4.43 — Claude $4.43, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.00  |  Tokens: 6025k
 - **Issue**: #2756 — https://github.com/character-ai/larch/issues/2756
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/A11257C8-1AD3-49A6-9F01-262C5603263D/final-summary.md
+++ b/larch-logs/design/A11257C8-1AD3-49A6-9F01-262C5603263D/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 01:13:29
-- **Cost**: 💰 TOTAL ~$22.76 — Claude $20.18, Codex $0.59, Cursor $1.99  |  Tokens: 33324k
+- **Cost**: 💰 TOTAL ~$27.80 — Claude $20.18, Codex $6.46, Cursor $1.16, Claude (subprocess) $0.00  |  Tokens: 33324k
 - **Issue**: #3143 — https://github.com/character-ai/larch/issues/3143
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/A28EED38-7B62-4409-BD58-3E6B9336EA7A/final-summary.md
+++ b/larch-logs/design/A28EED38-7B62-4409-BD58-3E6B9336EA7A/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: N/A
 - **Path**: SIMPLE
 - **Duration**: 00:33:11
-- **Cost**: 💰 TOTAL ~$7.48 — Claude $7.48, Codex $0.00, Cursor $0.00  |  Tokens: 7946k
+- **Cost**: 💰 TOTAL ~$7.48 — Claude $7.48, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.00  |  Tokens: 7946k
 - **Issue**: #2752 — https://github.com/character-ai/larch/issues/2752
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/A37EA08D-B002-4309-88AB-1A87C8CE1B75/final-summary.md
+++ b/larch-logs/design/A37EA08D-B002-4309-88AB-1A87C8CE1B75/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 01:26:32
-- **Cost**: 💰 TOTAL ~$23.59 — Claude $20.35, Codex $0.74, Cursor $2.50  |  Tokens: 31741k
+- **Cost**: 💰 TOTAL ~$29.91 — Claude $20.35, Codex $8.11, Cursor $1.45, Claude (subprocess) $0.00  |  Tokens: 31741k
 - **Issue**: #2930 — https://github.com/character-ai/larch/issues/2930
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/A42F8656-7587-4E6B-B49D-F890403E120B/final-summary.md
+++ b/larch-logs/design/A42F8656-7587-4E6B-B49D-F890403E120B/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 01:15:27
-- **Cost**: 💰 TOTAL ~$17.33 — Claude $13.57, Codex $0.82, Cursor $2.94  |  Tokens: 26596k
+- **Cost**: 💰 TOTAL ~$24.58 — Claude $13.57, Codex $9.13, Cursor $1.88, Claude (subprocess) $0.00  |  Tokens: 26596k
 - **Issue**: #3116 — https://github.com/character-ai/larch/issues/3116
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/A7B7E6B8-2B52-49F0-A0A6-E04D1C815CFF/final-summary.md
+++ b/larch-logs/design/A7B7E6B8-2B52-49F0-A0A6-E04D1C815CFF/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: N/A
-- **Cost**: 💰 TOTAL ~$18.18 — Claude $12.73, Codex $1.58, Cursor $3.87  |  Tokens: 21293k
+- **Cost**: 💰 TOTAL ~$16.00 — Claude $12.73, Codex $0.88, Cursor $2.39, Claude (subprocess) $0.00  |  Tokens: 21293k
 - **Issue**: #2671 — https://github.com/character-ai/larch/issues/2671
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/A8283567-3B1E-4B80-9A7C-456FAFFD3FF7/final-summary.md
+++ b/larch-logs/design/A8283567-3B1E-4B80-9A7C-456FAFFD3FF7/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: N/A
 - **Path**: SIMPLE
 - **Duration**: N/A
-- **Cost**: 💰 TOTAL ~$43.07 — Claude $38.95, Codex $1.77, Cursor $2.35  |  Tokens: 51770k
+- **Cost**: 💰 TOTAL ~$41.30 — Claude $38.95, Codex $0.98, Cursor $1.37, Claude (subprocess) $0.00  |  Tokens: 51770k
 - **Issue**: #2757 — https://github.com/character-ai/larch/issues/2757
 - **Plan review**: 0 findings
 - **OOS filed**: 1 — https://github.com/character-ai/larch/issues/2798

--- a/larch-logs/design/A9846A4A-0AC3-4F90-996C-AC0BE3A569E4/final-summary.md
+++ b/larch-logs/design/A9846A4A-0AC3-4F90-996C-AC0BE3A569E4/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 01:02:00
-- **Cost**: 💰 TOTAL ~$18.11 — Claude $15.25, Codex $0.43, Cursor $2.43  |  Tokens: 20404k
+- **Cost**: 💰 TOTAL ~$21.14 — Claude $15.25, Codex $4.49, Cursor $1.40, Claude (subprocess) $0.00  |  Tokens: 20404k
 - **Issue**: #2867 — https://github.com/character-ai/larch/issues/2867
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/AC4789A8-6E34-4710-9C8B-20411EBAB330/final-summary.md
+++ b/larch-logs/design/AC4789A8-6E34-4710-9C8B-20411EBAB330/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: N/A
 - **Path**: SIMPLE
 - **Duration**: 00:21:05
-- **Cost**: 💰 TOTAL ~$5.10 — Claude $5.10, Codex $0.00, Cursor $0.00  |  Tokens: 5210k
+- **Cost**: 💰 TOTAL ~$5.10 — Claude $5.10, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.00  |  Tokens: 5210k
 - **Issue**: #2721 — https://github.com/character-ai/larch/issues/2721
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/AD771CDC-6A78-48EF-9D21-4A53933932E9/final-summary.md
+++ b/larch-logs/design/AD771CDC-6A78-48EF-9D21-4A53933932E9/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 02:27:34
-- **Cost**: 💰 TOTAL ~$30.55 — Claude $21.84, Codex $0.00, Cursor $8.71  |  Tokens: 42890k
+- **Cost**: 💰 TOTAL ~$27.09 — Claude $21.84, Codex $0.00, Cursor $5.25, Claude (subprocess) $0.00  |  Tokens: 42890k
 - **Issue**: #3202 — https://github.com/character-ai/larch/issues/3202
 - **Plan review**: 0 findings
 - **OOS filed**: 1 — https://github.com/character-ai/larch/issues/3218

--- a/larch-logs/design/AD904A6F-1C78-48F2-8F5B-5650ED5D386C/final-summary.md
+++ b/larch-logs/design/AD904A6F-1C78-48F2-8F5B-5650ED5D386C/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 00:56:29
-- **Cost**: 💰 TOTAL ~$18.66 — Claude $14.22, Codex $0.74, Cursor $3.70  |  Tokens: 29033k
+- **Cost**: 💰 TOTAL ~$24.55 — Claude $14.22, Codex $8.05, Cursor $2.28, Claude (subprocess) $0.00  |  Tokens: 29033k
 - **Issue**: #2840 — https://github.com/character-ai/larch/issues/2840
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/B32336A4-A41B-4AF6-80ED-6A3C6AC2639D/final-summary.md
+++ b/larch-logs/design/B32336A4-A41B-4AF6-80ED-6A3C6AC2639D/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 00:54:28
-- **Cost**: 💰 TOTAL ~$13.17 — Claude $10.16, Codex $0.00, Cursor $3.01  |  Tokens: 19146k
+- **Cost**: 💰 TOTAL ~$11.84 — Claude $10.16, Codex $0.00, Cursor $1.68, Claude (subprocess) $0.00  |  Tokens: 19146k
 - **Issue**: #3291 — https://github.com/character-ai/larch/issues/3291
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/B62A431A-E5EF-49A2-B881-DB086A9D999F/final-summary.md
+++ b/larch-logs/design/B62A431A-E5EF-49A2-B881-DB086A9D999F/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 00:46:54
-- **Cost**: 💰 TOTAL ~$16.41 — Claude $14.86, Codex $0.37, Cursor $1.18  |  Tokens: 17606k
+- **Cost**: 💰 TOTAL ~$19.40 — Claude $14.86, Codex $3.89, Cursor $0.65, Claude (subprocess) $0.00  |  Tokens: 17606k
 - **Issue**: #3161 — https://github.com/character-ai/larch/issues/3161
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/B6810B23-6BDF-4531-8995-1DE063CE7B99/final-summary.md
+++ b/larch-logs/design/B6810B23-6BDF-4531-8995-1DE063CE7B99/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: unknown
 - **Duration**: 00:47:35
-- **Cost**: 💰 TOTAL ~$16.48 — Claude $14.96, Codex $0.35, Cursor $1.17  |  Tokens: 22277k
+- **Cost**: 💰 TOTAL ~$19.40 — Claude $14.96, Codex $3.78, Cursor $0.66, Claude (subprocess) $0.00  |  Tokens: 22277k
 - **Issue**: #3059 — https://github.com/character-ai/larch/issues/3059
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/B9BD216C-60DD-4248-B404-B3D5F25F909E/final-summary.md
+++ b/larch-logs/design/B9BD216C-60DD-4248-B404-B3D5F25F909E/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 10:47:19
-- **Cost**: 💰 TOTAL ~$41.38 — Claude $23.66, Codex $4.09, Cursor $13.63  |  Tokens: 83674k
+- **Cost**: 💰 TOTAL ~$77.08 — Claude $23.66, Codex $44.95, Cursor $8.47, Claude (subprocess) $0.00  |  Tokens: 83674k
 - **Issue**: #3174 — https://github.com/character-ai/larch/issues/3174
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/BA402E7A-89E4-4D39-ACB6-0048D940BC35/final-summary.md
+++ b/larch-logs/design/BA402E7A-89E4-4D39-ACB6-0048D940BC35/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 00:21:54
-- **Cost**: 💰 TOTAL ~$19.54 — Claude $17.95, Codex $0.42, Cursor $1.17  |  Tokens: 29724k
+- **Cost**: 💰 TOTAL ~$23.20 — Claude $17.95, Codex $4.57, Cursor $0.68, Claude (subprocess) $0.00  |  Tokens: 29724k
 - **Issue**: #3003 — https://github.com/character-ai/larch/issues/3003
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/BB9F416C-D72F-4E71-A4F9-98DE2C87AD17/final-summary.md
+++ b/larch-logs/design/BB9F416C-D72F-4E71-A4F9-98DE2C87AD17/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: unknown
 - **Duration**: 00:23:04
-- **Cost**: 💰 TOTAL ~$17.61 — Claude $15.80, Codex $0.54, Cursor $1.27  |  Tokens: 22517k
+- **Cost**: 💰 TOTAL ~$22.29 — Claude $15.80, Codex $5.79, Cursor $0.70, Claude (subprocess) $0.00  |  Tokens: 22517k
 - **Issue**: #3065 — https://github.com/character-ai/larch/issues/3065
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/BBD58F10-FA77-4906-BD43-3EDB779326DB/final-summary.md
+++ b/larch-logs/design/BBD58F10-FA77-4906-BD43-3EDB779326DB/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: unknown
 - **Duration**: 02:25:48
-- **Cost**: 💰 TOTAL ~$13.90 — Claude $10.73, Codex $0.69, Cursor $2.48  |  Tokens: 24514k
+- **Cost**: 💰 TOTAL ~$19.92 — Claude $10.73, Codex $7.63, Cursor $1.56, Claude (subprocess) $0.00  |  Tokens: 24514k
 - **Issue**: #3064 — https://github.com/character-ai/larch/issues/3064
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/BD5796CA-ABAA-46EA-AB43-566D4086BDDF/final-summary.md
+++ b/larch-logs/design/BD5796CA-ABAA-46EA-AB43-566D4086BDDF/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 01:38:16
-- **Cost**: 💰 TOTAL ~$33.65 — Claude $29.75, Codex $0.78, Cursor $3.12  |  Tokens: 52778k
+- **Cost**: 💰 TOTAL ~$40.20 — Claude $29.75, Codex $8.57, Cursor $1.88, Claude (subprocess) $0.00  |  Tokens: 52778k
 - **Issue**: #2935 — https://github.com/character-ai/larch/issues/2935
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/BEBB7037-AA88-4887-A2E9-4DD7EDFD52A2/final-summary.md
+++ b/larch-logs/design/BEBB7037-AA88-4887-A2E9-4DD7EDFD52A2/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 05:48:23
-- **Cost**: 💰 TOTAL ~$64.63 — Claude $12.55, Codex $6.42, Cursor $30.15, Claude (subprocess) $15.51  |  Tokens: 189843k
+- **Cost**: 💰 TOTAL ~$120.38 — Claude $12.55, Codex $72.14, Cursor $20.18, Claude (subprocess) $15.51  |  Tokens: 189843k
 - **Issue**: #3672 — https://github.com/character-ai/larch/issues/3672
 - **Plan review**: 55 accepted (0 critical / 6 high / 4 medium / 45 low)
 - **OOS filed**: 1 — https://github.com/character-ai/larch/issues/3969

--- a/larch-logs/design/C13866EF-95A8-46D0-AB43-5095D5E83906/final-summary.md
+++ b/larch-logs/design/C13866EF-95A8-46D0-AB43-5095D5E83906/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 03:02:43
-- **Cost**: 💰 TOTAL ~$27.97 — Claude $24.02, Codex $0.90, Cursor $3.05  |  Tokens: 31119k
+- **Cost**: 💰 TOTAL ~$35.82 — Claude $24.02, Codex $9.88, Cursor $1.92, Claude (subprocess) $0.00  |  Tokens: 31119k
 - **Issue**: #3118 — https://github.com/character-ai/larch/issues/3118
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/C215FE91-6FF3-4526-BF19-B83686B8BDCC/final-summary.md
+++ b/larch-logs/design/C215FE91-6FF3-4526-BF19-B83686B8BDCC/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 00:44:16
-- **Cost**: 💰 TOTAL ~$13.74 — Claude $10.87, Codex $0.55, Cursor $2.32  |  Tokens: 20245k
+- **Cost**: 💰 TOTAL ~$18.14 — Claude $10.87, Codex $5.90, Cursor $1.37, Claude (subprocess) $0.00  |  Tokens: 20245k
 - **Issue**: #3085 — https://github.com/character-ai/larch/issues/3085
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/C291D66A-F157-49D2-9DAA-B3768DCFC5C2/final-summary.md
+++ b/larch-logs/design/C291D66A-F157-49D2-9DAA-B3768DCFC5C2/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 03:55:06
-- **Cost**: 💰 TOTAL ~$19.30 — Claude $14.75, Codex $0.00, Cursor $4.55  |  Tokens: 18356k
+- **Cost**: 💰 TOTAL ~$17.43 — Claude $14.75, Codex $0.00, Cursor $2.68, Claude (subprocess) $0.00  |  Tokens: 18356k
 - **Issue**: #3212 — https://github.com/character-ai/larch/issues/3212
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/C3D286E5-1506-498B-8883-22D05AB6F930/final-summary.md
+++ b/larch-logs/design/C3D286E5-1506-498B-8883-22D05AB6F930/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 00:54:00
-- **Cost**: 💰 TOTAL ~$23.59 — Claude $16.84, Codex $0.90, Cursor $5.85  |  Tokens: 41390k
+- **Cost**: 💰 TOTAL ~$30.52 — Claude $16.84, Codex $10.01, Cursor $3.67, Claude (subprocess) $0.00  |  Tokens: 41390k
 - **Issue**: #3273 — https://github.com/character-ai/larch/issues/3273
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/C3F210EC-3D6B-4F27-956E-07611E72BBC1/final-summary.md
+++ b/larch-logs/design/C3F210EC-3D6B-4F27-956E-07611E72BBC1/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: N/A
 - **Path**: SIMPLE
 - **Duration**: 01:15:40
-- **Cost**: 💰 TOTAL ~$25.84 — Claude $20.73, Codex $5.07, Cursor $0.04  |  Tokens: 24611k
+- **Cost**: 💰 TOTAL ~$23.56 — Claude $20.73, Codex $2.81, Cursor $0.02, Claude (subprocess) $0.00  |  Tokens: 24611k
 - **Issue**: #2749 — https://github.com/character-ai/larch/issues/2749
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/C4FD8126-2834-4B1D-BEE6-CD1C7EFB072D/final-summary.md
+++ b/larch-logs/design/C4FD8126-2834-4B1D-BEE6-CD1C7EFB072D/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 10:35:00
-- **Cost**: 💰 TOTAL ~$27.62 — Claude $11.38, Codex $0.00, Cursor $16.24  |  Tokens: 58110k
+- **Cost**: 💰 TOTAL ~$21.84 — Claude $11.38, Codex $0.00, Cursor $10.46, Claude (subprocess) $0.00  |  Tokens: 58110k
 - **Issue**: #3314 — https://github.com/character-ai/larch/issues/3314
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/C8FC6714-1F7B-4BEC-B731-1AF66EA11BB5/final-summary.md
+++ b/larch-logs/design/C8FC6714-1F7B-4BEC-B731-1AF66EA11BB5/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 01:24:06
-- **Cost**: 💰 TOTAL ~$26.82 — Claude $21.69, Codex $1.03, Cursor $4.10  |  Tokens: 41374k
+- **Cost**: 💰 TOTAL ~$35.65 — Claude $21.69, Codex $11.37, Cursor $2.59, Claude (subprocess) $0.00  |  Tokens: 41374k
 - **Issue**: #2996 — https://github.com/character-ai/larch/issues/2996
 - **Plan review**: 0 findings
 - **OOS filed**: 1 — https://github.com/character-ai/larch/issues/3017

--- a/larch-logs/design/CA608422-E2F1-4934-A06A-5960F9CCB2F2/final-summary.md
+++ b/larch-logs/design/CA608422-E2F1-4934-A06A-5960F9CCB2F2/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 00:53:42
-- **Cost**: 💰 TOTAL ~$20.97 — Claude $12.39, Codex $0.00, Cursor $8.58  |  Tokens: 36946k
+- **Cost**: 💰 TOTAL ~$17.90 — Claude $12.39, Codex $0.00, Cursor $5.51, Claude (subprocess) $0.00  |  Tokens: 36946k
 - **Issue**: #3337 — https://github.com/character-ai/larch/issues/3337
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/CCA26A49-5E7F-44B0-AE5C-19787126BDD1/final-summary.md
+++ b/larch-logs/design/CCA26A49-5E7F-44B0-AE5C-19787126BDD1/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: N/A
-- **Cost**: 💰 TOTAL ~$14.73 — Claude $11.81, Codex $0.38, Cursor $2.54  |  Tokens: 19391k
+- **Cost**: 💰 TOTAL ~$17.38 — Claude $11.81, Codex $4.04, Cursor $1.53, Claude (subprocess) $0.00  |  Tokens: 19391k
 - **Issue**: #2899 — https://github.com/character-ai/larch/issues/2899
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/CCC6D057-03EC-4E37-9D92-AAE8818A3CD2/final-summary.md
+++ b/larch-logs/design/CCC6D057-03EC-4E37-9D92-AAE8818A3CD2/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 00:50:57
-- **Cost**: 💰 TOTAL ~$20.92 — Claude $17.27, Codex $0.65, Cursor $3.00  |  Tokens: 29890k
+- **Cost**: 💰 TOTAL ~$25.97 — Claude $17.27, Codex $7.07, Cursor $1.63, Claude (subprocess) $0.00  |  Tokens: 29890k
 - **Issue**: #2898 — https://github.com/character-ai/larch/issues/2898
 - **Plan review**: 0 findings
 - **OOS filed**: 2 — https://github.com/character-ai/larch/issues/2928,https://github.com/character-ai/larch/issues/2929

--- a/larch-logs/design/CD9C798A-6471-493F-9574-B93619203B18/final-summary.md
+++ b/larch-logs/design/CD9C798A-6471-493F-9574-B93619203B18/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 01:30:26
-- **Cost**: 💰 TOTAL ~$21.86 — Claude $11.15, Codex $0.65, Cursor $10.06  |  Tokens: 36599k
+- **Cost**: 💰 TOTAL ~$24.11 — Claude $11.15, Codex $7.02, Cursor $5.94, Claude (subprocess) $0.00  |  Tokens: 36599k
 - **Issue**: #3305 — https://github.com/character-ai/larch/issues/3305
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/CE052C8E-6861-4558-931F-F944E2D6BE6E/final-summary.md
+++ b/larch-logs/design/CE052C8E-6861-4558-931F-F944E2D6BE6E/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: unknown
 - **Duration**: N/A
-- **Cost**: 💰 TOTAL ~$24.99 — Claude $21.54, Codex $0.69, Cursor $2.76  |  Tokens: 40629k
+- **Cost**: 💰 TOTAL ~$30.81 — Claude $21.54, Codex $7.51, Cursor $1.76, Claude (subprocess) $0.00  |  Tokens: 40629k
 - **Issue**: #3041 — https://github.com/character-ai/larch/issues/3041
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/CE1B9903-59D2-4671-A052-60580425752C/final-summary.md
+++ b/larch-logs/design/CE1B9903-59D2-4671-A052-60580425752C/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: TRIVIAL_DOC_ONLY
 - **Path**: SIMPLE
 - **Duration**: 00:07:17
-- **Cost**: 💰 TOTAL ~$7.37 — Claude $7.37, Codex $0.00, Cursor $0.00  |  Tokens: 11500k
+- **Cost**: 💰 TOTAL ~$7.37 — Claude $7.37, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.00  |  Tokens: 11500k
 - **Issue**: #2743 — https://github.com/character-ai/larch/issues/2743
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/D449F20C-4089-42C1-8070-5EEE93042861/final-summary.md
+++ b/larch-logs/design/D449F20C-4089-42C1-8070-5EEE93042861/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 03:25:40
-- **Cost**: 💰 TOTAL ~$34.78 — Claude $21.14, Codex $3.13, Cursor $10.51  |  Tokens: 59947k
+- **Cost**: 💰 TOTAL ~$61.59 — Claude $21.14, Codex $34.24, Cursor $6.21, Claude (subprocess) $0.00  |  Tokens: 59947k
 - **Issue**: #3155 — https://github.com/character-ai/larch/issues/3155
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/D7A709D2-140D-439D-96DC-00F707B5CAF1/final-summary.md
+++ b/larch-logs/design/D7A709D2-140D-439D-96DC-00F707B5CAF1/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 00:55:04
-- **Cost**: 💰 TOTAL ~$15.49 — Claude $12.63, Codex $0.87, Cursor $1.99  |  Tokens: 16066k
+- **Cost**: 💰 TOTAL ~$14.22 — Claude $12.63, Codex $0.48, Cursor $1.11, Claude (subprocess) $0.00  |  Tokens: 16066k
 - **Issue**: #2843 — https://github.com/character-ai/larch/issues/2843
 - **Plan review**: 0 findings
 - **OOS filed**: 3 — https://github.com/character-ai/larch/issues/2862

--- a/larch-logs/design/D8312EC8-9BDC-4086-8C9C-1639362A934F/final-summary.md
+++ b/larch-logs/design/D8312EC8-9BDC-4086-8C9C-1639362A934F/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: TRIVIAL_DOC_ONLY
 - **Path**: SIMPLE
 - **Duration**: 00:22:15
-- **Cost**: 💰 TOTAL ~$3.92 — Claude $3.92, Codex $0.00, Cursor $0.00  |  Tokens: 4275k
+- **Cost**: 💰 TOTAL ~$3.92 — Claude $3.92, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.00  |  Tokens: 4275k
 - **Issue**: #2962 — https://github.com/character-ai/larch/issues/2962
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/D9213D45-D5E2-4EEC-A787-0911CAF926D8/final-summary.md
+++ b/larch-logs/design/D9213D45-D5E2-4EEC-A787-0911CAF926D8/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: N/A
-- **Cost**: 💰 TOTAL ~$22.73 — Claude $13.91, Codex $2.15, Cursor $6.67  |  Tokens: 27837k
+- **Cost**: 💰 TOTAL ~$18.94 — Claude $13.91, Codex $1.19, Cursor $3.84, Claude (subprocess) $0.00  |  Tokens: 27837k
 - **Issue**: #2853 — https://github.com/character-ai/larch/issues/2853
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/DD4D3283-21F1-455D-B7F0-10884E349CA7/final-summary.md
+++ b/larch-logs/design/DD4D3283-21F1-455D-B7F0-10884E349CA7/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: N/A
 - **Path**: SIMPLE
 - **Duration**: 09:07:20
-- **Cost**: 💰 TOTAL ~$24.02 — Claude $19.10, Codex $1.92, Cursor $3.00  |  Tokens: 27502k
+- **Cost**: 💰 TOTAL ~$22.03 — Claude $19.10, Codex $1.07, Cursor $1.86, Claude (subprocess) $0.00  |  Tokens: 27502k
 - **Issue**: #2741 — https://github.com/character-ai/larch/issues/2741
 - **Plan review**: 0 findings
 - **OOS filed**: 1 — https://github.com/character-ai/larch/issues/2794

--- a/larch-logs/design/DFFD6845-CB01-4BA4-AF2A-B6ED536580AC/final-summary.md
+++ b/larch-logs/design/DFFD6845-CB01-4BA4-AF2A-B6ED536580AC/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 02:08:38
-- **Cost**: 💰 TOTAL ~$50.71 — Claude $16.52, Codex $5.39, Cursor $23.51, Claude (subprocess) $5.29  |  Tokens: 132696k
+- **Cost**: 💰 TOTAL ~$95.48 — Claude $16.52, Codex $59.05, Cursor $14.62, Claude (subprocess) $5.29  |  Tokens: 132696k
 - **Issue**: #3820 — https://github.com/character-ai/larch/issues/3820
 - **Plan review**: 58 accepted (3 critical / 12 high / 12 medium / 31 low)
 - **OOS filed**: 4 — https://github.com/character-ai/larch/issues/3870,https://github.com/character-ai/larch/issues/3871,https://github.com/character-ai/larch/issues/3872,https://github.com/character-ai/larch/issues/3873

--- a/larch-logs/design/E06F4ABF-C441-4CD8-BB88-E185DC6C306F/final-summary.md
+++ b/larch-logs/design/E06F4ABF-C441-4CD8-BB88-E185DC6C306F/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: unknown
 - **Duration**: N/A
-- **Cost**: 💰 TOTAL ~$16.58 — Claude $14.71, Codex $0.41, Cursor $1.46  |  Tokens: 21300k
+- **Cost**: 💰 TOTAL ~$19.95 — Claude $14.71, Codex $4.41, Cursor $0.83, Claude (subprocess) $0.00  |  Tokens: 21300k
 - **Issue**: #3025 — https://github.com/character-ai/larch/issues/3025
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/E5C57D2F-C902-441B-8EEC-58E7B04EE1FB/final-summary.md
+++ b/larch-logs/design/E5C57D2F-C902-441B-8EEC-58E7B04EE1FB/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 01:04:04
-- **Cost**: 💰 TOTAL ~$23.52 — Claude $19.83, Codex $0.00, Cursor $3.69  |  Tokens: 27974k
+- **Cost**: 💰 TOTAL ~$22.03 — Claude $19.83, Codex $0.00, Cursor $2.20, Claude (subprocess) $0.00  |  Tokens: 27974k
 - **Issue**: #3267 — https://github.com/character-ai/larch/issues/3267
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/E64A80FF-9D73-461F-8871-F314B343601F/final-summary.md
+++ b/larch-logs/design/E64A80FF-9D73-461F-8871-F314B343601F/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 24:29:58
-- **Cost**: 💰 TOTAL ~$51.78 — Claude $35.48, Codex $0.77, Cursor $15.53  |  Tokens: 74267k
+- **Cost**: 💰 TOTAL ~$53.62 — Claude $35.48, Codex $8.53, Cursor $9.61, Claude (subprocess) $0.00  |  Tokens: 74267k
 - **Issue**: #3247 — https://github.com/character-ai/larch/issues/3247
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/E9150098-40B4-4D6D-81BB-AD5589831C7A/final-summary.md
+++ b/larch-logs/design/E9150098-40B4-4D6D-81BB-AD5589831C7A/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 00:00:00
-- **Cost**: 💰 TOTAL ~$22.80 — Claude $19.43, Codex $0.92, Cursor $2.45  |  Tokens: 30960k
+- **Cost**: 💰 TOTAL ~$31.14 — Claude $19.43, Codex $10.24, Cursor $1.47, Claude (subprocess) $0.00  |  Tokens: 30960k
 - **Issue**: #2667 — https://github.com/character-ai/larch/issues/2667
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/E9600CCA-5F10-4E44-AA45-D92668792735/final-summary.md
+++ b/larch-logs/design/E9600CCA-5F10-4E44-AA45-D92668792735/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 10:17:08
-- **Cost**: 💰 TOTAL ~$36.21 — Claude $14.43, Codex $2.50, Cursor $19.28  |  Tokens: 84451k
+- **Cost**: 💰 TOTAL ~$54.78 — Claude $14.43, Codex $28.08, Cursor $12.27, Claude (subprocess) $0.00  |  Tokens: 84451k
 - **Issue**: #3334 — https://github.com/character-ai/larch/issues/3334
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/ED1E0D05-E4DC-4D49-9256-F2999AFBF4E3/final-summary.md
+++ b/larch-logs/design/ED1E0D05-E4DC-4D49-9256-F2999AFBF4E3/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 03:20:34
-- **Cost**: 💰 TOTAL ~$19.23 — Claude $16.46, Codex $0.00, Cursor $2.77  |  Tokens: 19752k
+- **Cost**: 💰 TOTAL ~$18.11 — Claude $16.46, Codex $0.00, Cursor $1.65, Claude (subprocess) $0.00  |  Tokens: 19752k
 - **Issue**: #3244 — https://github.com/character-ai/larch/issues/3244
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/EE0C588A-F596-48E0-A1A1-8F71C7BA3517/final-summary.md
+++ b/larch-logs/design/EE0C588A-F596-48E0-A1A1-8F71C7BA3517/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 01:20:51
-- **Cost**: 💰 TOTAL ~$17.89 — Claude $15.52, Codex $0.00, Cursor $2.37  |  Tokens: 19395k
+- **Cost**: 💰 TOTAL ~$16.95 — Claude $15.52, Codex $0.00, Cursor $1.43, Claude (subprocess) $0.00  |  Tokens: 19395k
 - **Issue**: #3209 — https://github.com/character-ai/larch/issues/3209
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/F20E3AEA-1241-4C0A-A9F2-BA86BAD793E8/final-summary.md
+++ b/larch-logs/design/F20E3AEA-1241-4C0A-A9F2-BA86BAD793E8/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: N/A
 - **Path**: SIMPLE
 - **Duration**: 00:14:54
-- **Cost**: 💰 TOTAL ~$4.57 — Claude $4.57, Codex $0.00, Cursor $0.00  |  Tokens: 5124k
+- **Cost**: 💰 TOTAL ~$4.57 — Claude $4.57, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.00  |  Tokens: 5124k
 - **Issue**: #2753 — https://github.com/character-ai/larch/issues/2753
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/F44D5848-1741-4B19-A0AE-22C664A50F50/final-summary.md
+++ b/larch-logs/design/F44D5848-1741-4B19-A0AE-22C664A50F50/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 01:10:53
-- **Cost**: 💰 TOTAL ~$14.32 — Claude $12.88, Codex $0.27, Cursor $1.17  |  Tokens: 15468k
+- **Cost**: 💰 TOTAL ~$16.54 — Claude $12.88, Codex $2.97, Cursor $0.69, Claude (subprocess) $0.00  |  Tokens: 15468k
 - **Issue**: #3190 — https://github.com/character-ai/larch/issues/3190
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/FA4B6502-E46F-4FE5-B747-4C216A453119/final-summary.md
+++ b/larch-logs/design/FA4B6502-E46F-4FE5-B747-4C216A453119/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 00:54:42
-- **Cost**: 💰 TOTAL ~$18.46 — Claude $14.39, Codex $1.34, Cursor $2.73  |  Tokens: 22330k
+- **Cost**: 💰 TOTAL ~$16.76 — Claude $14.39, Codex $0.74, Cursor $1.63, Claude (subprocess) $0.00  |  Tokens: 22330k
 - **Issue**: #2844 — https://github.com/character-ai/larch/issues/2844
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/FBCDD597-AE05-4E2A-A257-6F676D497124/final-summary.md
+++ b/larch-logs/design/FBCDD597-AE05-4E2A-A257-6F676D497124/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: N/A
-- **Cost**: 💰 TOTAL ~$19.74 — Claude $17.05, Codex $0.49, Cursor $2.20  |  Tokens: 24231k
+- **Cost**: 💰 TOTAL ~$23.49 — Claude $17.05, Codex $5.28, Cursor $1.16, Claude (subprocess) $0.00  |  Tokens: 24231k
 - **Issue**: #2854 — https://github.com/character-ai/larch/issues/2854
 - **Plan review**: 0 findings
 - **OOS filed**: 3 — https://github.com/character-ai/larch/issues/2874,https://github.com/character-ai/larch/issues/2875,https://github.com/character-ai/larch/issues/2876

--- a/larch-logs/design/FC008426-ECFD-438B-A81B-269C773A1754/final-summary.md
+++ b/larch-logs/design/FC008426-ECFD-438B-A81B-269C773A1754/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 01:44:00
-- **Cost**: 💰 TOTAL ~$27.64 — Claude $19.43, Codex $0.00, Cursor $8.21  |  Tokens: 34691k
+- **Cost**: 💰 TOTAL ~$24.31 — Claude $19.43, Codex $0.00, Cursor $4.88, Claude (subprocess) $0.00  |  Tokens: 34691k
 - **Issue**: #3239 — https://github.com/character-ai/larch/issues/3239
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/FCD3F671-E7F6-4D10-8BAD-06897564C1AD/final-summary.md
+++ b/larch-logs/design/FCD3F671-E7F6-4D10-8BAD-06897564C1AD/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 00:58:21
-- **Cost**: 💰 TOTAL ~$21.67 — Claude $18.47, Codex $0.66, Cursor $2.54  |  Tokens: 29701k
+- **Cost**: 💰 TOTAL ~$27.12 — Claude $18.47, Codex $7.15, Cursor $1.50, Claude (subprocess) $0.00  |  Tokens: 29701k
 - **Issue**: #3146 — https://github.com/character-ai/larch/issues/3146
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/FD56F206-89F3-48F3-8017-DE182E3837D6/final-summary.md
+++ b/larch-logs/design/FD56F206-89F3-48F3-8017-DE182E3837D6/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: SIMPLE
 - **Path**: SIMPLE
 - **Duration**: 00:37:20
-- **Cost**: 💰 TOTAL ~$13.71 — Claude $9.38, Codex $1.80, Cursor $2.53  |  Tokens: 13955k
+- **Cost**: 💰 TOTAL ~$11.85 — Claude $9.38, Codex $1.00, Cursor $1.47, Claude (subprocess) $0.00  |  Tokens: 13955k
 - **Issue**: #2803 — https://github.com/character-ai/larch/issues/2803
 - **Plan review**: 0 findings
 - **OOS filed**: 0

--- a/larch-logs/design/FE9A32C2-2BCC-42EE-93B5-89153667045E/final-summary.md
+++ b/larch-logs/design/FE9A32C2-2BCC-42EE-93B5-89153667045E/final-summary.md
@@ -3,7 +3,7 @@
 - **Mode**: TRIVIAL_DOC_ONLY
 - **Path**: SIMPLE
 - **Duration**: 00:27:07
-- **Cost**: 💰 TOTAL ~$10.88 — Claude $10.88, Codex $0.00, Cursor $0.00  |  Tokens: 13902k
+- **Cost**: 💰 TOTAL ~$10.88 — Claude $10.88, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.00  |  Tokens: 13902k
 - **Issue**: #2787 — https://github.com/character-ai/larch/issues/2787
 - **Plan review**: 0 findings
 - **OOS filed**: 1 — https://github.com/character-ai/larch/issues/2801

--- a/larch-logs/implement/0038852C-4060-4B09-822E-D2E1E97EE856/final-summary.md
+++ b/larch-logs/implement/0038852C-4060-4B09-822E-D2E1E97EE856/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - Emergency: true
 - **Duration**: 00:10:10
-- **Cost**: 💰 TOTAL ~$2.64 — Claude $2.30, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.34  |  Tokens: 3477k
+- **Cost**: 💰 TOTAL ~$2.86 — Claude $2.52, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.34  |  Tokens: 3842k
 - **Issue**: #4045 — https://github.com/character-ai/larch/issues/4045
 - **Plan review**: N/A
 - **Code review**: N/A

--- a/larch-logs/implement/00EF27EE-D305-4A60-8B89-BD9DC48B84E1/final-summary.md
+++ b/larch-logs/implement/00EF27EE-D305-4A60-8B89-BD9DC48B84E1/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 02:21:11
-- **Cost**: 💰 TOTAL ~$32.12 — Claude $12.88, Codex $1.03, Cursor $18.21  |  Tokens: 67929k
+- **Cost**: 💰 TOTAL ~$27.64 — Claude $15.06, Codex $0.57, Cursor $12.01, Claude (subprocess) $0.00  |  Tokens: 71867k
 - **Issue**: #2674 — https://github.com/character-ai/larch/issues/2674
 - **PR**: #2706 — https://github.com/character-ai/larch/pull/2706
 - **Plan review**: N/A

--- a/larch-logs/implement/0199F1E2-2238-403D-9F89-F37CA698998C/final-summary.md
+++ b/larch-logs/implement/0199F1E2-2238-403D-9F89-F37CA698998C/final-summary.md
@@ -3,7 +3,7 @@
 - **Outcome**: bailed
 - **Mode**: N/A
 - **Duration**: 03:50:18
-- **Cost**: 💰 TOTAL ~$52.72 — Claude $11.82, Codex $6.70, Cursor $23.13, Claude (subprocess) $11.07  |  Tokens: 158112k
+- **Cost**: 💰 TOTAL ~$116.15 — Claude $14.79, Codex $75.55, Cursor $14.74, Claude (subprocess) $11.07  |  Tokens: 161556k
 - **Issue**: #3771 — https://github.com/character-ai/larch/issues/3771
 - **PR**: #3793 — https://github.com/character-ai/larch/pull/3793
 - **Plan review**: N/A

--- a/larch-logs/implement/03DFC44F-6FAD-48E6-9483-667F61F16691/final-summary.md
+++ b/larch-logs/implement/03DFC44F-6FAD-48E6-9483-667F61F16691/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - Emergency: true
 - **Duration**: 00:11:05
-- **Cost**: 💰 TOTAL ~$3.14 — Claude $2.81, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.33  |  Tokens: 4065k
+- **Cost**: 💰 TOTAL ~$3.45 — Claude $3.12, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.33  |  Tokens: 4600k
 - **Issue**: #4022 — https://github.com/character-ai/larch/issues/4022
 - **Plan review**: N/A
 - **Code review**: N/A

--- a/larch-logs/implement/0705E997-073E-44AA-8ECD-7C97EB957568/final-summary.md
+++ b/larch-logs/implement/0705E997-073E-44AA-8ECD-7C97EB957568/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 01:23:33
-- **Cost**: 💰 TOTAL ~$9.69 — Claude $7.09, Codex $1.03, Cursor $1.57  |  Tokens: 29685k
+- **Cost**: 💰 TOTAL ~$20.14 — Claude $7.09, Codex $12.13, Cursor $0.92, Claude (subprocess) $0.00  |  Tokens: 29685k
 - **Issue**: #2921 — https://github.com/character-ai/larch/issues/2921
 - **Plan review**: N/A
 - **Code review**: 7/10 accepted

--- a/larch-logs/implement/07939FD8-A2C6-40C2-A7B0-28F42C48FECD/final-summary.md
+++ b/larch-logs/implement/07939FD8-A2C6-40C2-A7B0-28F42C48FECD/final-summary.md
@@ -3,7 +3,7 @@
 - **Outcome**: bailed
 - **Mode**: N/A
 - **Duration**: 00:48:04
-- **Cost**: 💰 TOTAL ~$9.53 — Claude $3.38, Codex $1.50, Cursor $4.65  |  Tokens: 36863k
+- **Cost**: 💰 TOTAL ~$26.16 — Claude $5.90, Codex $17.13, Cursor $3.13, Claude (subprocess) $0.00  |  Tokens: 40536k
 - **Issue**: #3552 — https://github.com/character-ai/larch/issues/3552
 - **Plan review**: N/A
 - **Code review**: 3/19 accepted

--- a/larch-logs/implement/08C9F258-49D8-42C3-80E1-A93B2B97095C/final-summary.md
+++ b/larch-logs/implement/08C9F258-49D8-42C3-80E1-A93B2B97095C/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 10:13:27
-- **Cost**: 💰 TOTAL ~$45.51 — Claude $33.96, Codex $0.00, Cursor $11.55  |  Tokens: 60512k
+- **Cost**: 💰 TOTAL ~$41.06 — Claude $33.96, Codex $0.00, Cursor $7.10, Claude (subprocess) $0.00  |  Tokens: 60512k
 - **Issue**: #3334 — https://github.com/character-ai/larch/issues/3334
 - **Plan review**: N/A
 - **Code review**: 29/52 accepted

--- a/larch-logs/implement/09C05974-A1EF-4E1E-9B6B-E5C484EB759A/final-summary.md
+++ b/larch-logs/implement/09C05974-A1EF-4E1E-9B6B-E5C484EB759A/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:59:08
-- **Cost**: 💰 TOTAL ~$7.21 — Claude $6.09, Codex $1.12, Cursor $0.00  |  Tokens: 7290k
+- **Cost**: 💰 TOTAL ~$6.71 — Claude $6.09, Codex $0.62, Cursor $0.00, Claude (subprocess) $0.00  |  Tokens: 7290k
 - **Issue**: #2730 — https://github.com/character-ai/larch/issues/2730
 - **Plan review**: N/A
 - **Code review**: 7/20 accepted

--- a/larch-logs/implement/09D875CA-C30C-4B62-8B4F-97ADB6E3A7F2/final-summary.md
+++ b/larch-logs/implement/09D875CA-C30C-4B62-8B4F-97ADB6E3A7F2/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 01:10:59
-- **Cost**: 💰 TOTAL ~$16.92 — Claude $13.88, Codex $0.91, Cursor $2.13  |  Tokens: 41260k
+- **Cost**: 💰 TOTAL ~$25.86 — Claude $13.88, Codex $10.71, Cursor $1.27, Claude (subprocess) $0.00  |  Tokens: 41260k
 - **Issue**: #2898 — https://github.com/character-ai/larch/issues/2898
 - **Plan review**: N/A
 - **Code review**: N/A

--- a/larch-logs/implement/0B6CCD67-F8AC-4EA2-9375-7134D5D8AE4C/final-summary.md
+++ b/larch-logs/implement/0B6CCD67-F8AC-4EA2-9375-7134D5D8AE4C/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 01:49:53
-- **Cost**: 💰 TOTAL ~$12.00 — Claude $3.95, Codex $0.00, Cursor $8.05  |  Tokens: 27791k
+- **Cost**: 💰 TOTAL ~$16.70 — Claude $11.26, Codex $0.00, Cursor $5.44, Claude (subprocess) $0.00  |  Tokens: 38233k
 - **Issue**: #3243 — https://github.com/character-ai/larch/issues/3243
 - **PR**: #3265 — https://github.com/character-ai/larch/pull/3265
 - **Plan review**: N/A

--- a/larch-logs/implement/0BAF384A-6FEA-48BE-86F9-21FA8B4FBD99/final-summary.md
+++ b/larch-logs/implement/0BAF384A-6FEA-48BE-86F9-21FA8B4FBD99/final-summary.md
@@ -3,7 +3,7 @@
 - **Outcome**: stalled
 - **Mode**: N/A
 - **Duration**: 02:50:34
-- **Cost**: 💰 TOTAL ~$57.72 — Claude $3.97, Codex $8.52, Cursor $28.28, Claude (subprocess) $16.95  |  Tokens: 235637k
+- **Cost**: 💰 TOTAL ~$139.24 — Claude $3.97, Codex $98.73, Cursor $19.59, Claude (subprocess) $16.95  |  Tokens: 235637k
 - **Issue**: #3688 — https://github.com/character-ai/larch/issues/3688
 - **Plan review**: N/A
 - **Code review**: 43/48 accepted

--- a/larch-logs/implement/0BC107A3-3884-49C4-8725-E6A1C5E8F803/final-summary.md
+++ b/larch-logs/implement/0BC107A3-3884-49C4-8725-E6A1C5E8F803/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:16:02
-- **Cost**: 💰 TOTAL ~$5.24 — Claude $3.51, Codex $0.23, Cursor $1.50  |  Tokens: 8134k
+- **Cost**: 💰 TOTAL ~$4.54 — Claude $3.51, Codex $0.13, Cursor $0.90, Claude (subprocess) $0.00  |  Tokens: 8134k
 - **Issue**: #2743 — https://github.com/character-ai/larch/issues/2743
 - **PR**: #2748 — https://github.com/character-ai/larch/pull/2748
 - **Plan review**: N/A

--- a/larch-logs/implement/0CAA5D1D-02EA-4EA6-8C05-8104010926CA/final-summary.md
+++ b/larch-logs/implement/0CAA5D1D-02EA-4EA6-8C05-8104010926CA/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 02:37:09
-- **Cost**: 💰 TOTAL ~$34.00 — Claude $7.62, Codex $2.61, Cursor $23.77  |  Tokens: 117894k
+- **Cost**: 💰 TOTAL ~$56.08 — Claude $9.70, Codex $30.29, Cursor $16.09, Claude (subprocess) $0.00  |  Tokens: 121481k
 - **Issue**: #3368 — https://github.com/character-ai/larch/issues/3368
 - **PR**: #3424 — https://github.com/character-ai/larch/pull/3424
 - **Plan review**: N/A

--- a/larch-logs/implement/0CF88C8D-727A-4F0D-A26C-F57DF6A9076C/final-summary.md
+++ b/larch-logs/implement/0CF88C8D-727A-4F0D-A26C-F57DF6A9076C/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 03:54:04
-- **Cost**: 💰 TOTAL ~$54.00 — Claude $23.95, Codex $2.21, Cursor $27.84  |  Tokens: 124756k
+- **Cost**: 💰 TOTAL ~$69.09 — Claude $26.49, Codex $25.11, Cursor $17.49, Claude (subprocess) $0.00  |  Tokens: 128976k
 - **Issue**: #3550 — https://github.com/character-ai/larch/issues/3550
 - **PR**: #3572 — https://github.com/character-ai/larch/pull/3572
 - **Plan review**: N/A

--- a/larch-logs/implement/0DD0DB4D-B705-4B1E-8181-C7CC62A868DA/final-summary.md
+++ b/larch-logs/implement/0DD0DB4D-B705-4B1E-8181-C7CC62A868DA/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:30:50
-- **Cost**: 💰 TOTAL ~$7.12 — Claude $3.30, Codex $0.00, Cursor $3.82  |  Tokens: 14187k
+- **Cost**: 💰 TOTAL ~$5.73 — Claude $3.30, Codex $0.00, Cursor $2.43, Claude (subprocess) $0.00  |  Tokens: 14187k
 - **Issue**: #3314 — https://github.com/character-ai/larch/issues/3314
 - **Plan review**: N/A
 - **Code review**: 2/5 accepted

--- a/larch-logs/implement/0DEC50EA-9022-4D20-8F4F-BED4D53E6590/final-summary.md
+++ b/larch-logs/implement/0DEC50EA-9022-4D20-8F4F-BED4D53E6590/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:16:44
-- **Cost**: 💰 TOTAL ~$6.07 — Claude $4.60, Codex $0.12, Cursor $1.35  |  Tokens: 11560k
+- **Cost**: 💰 TOTAL ~$6.75 — Claude $4.60, Codex $1.33, Cursor $0.82, Claude (subprocess) $0.00  |  Tokens: 11560k
 - **Issue**: #3031 — https://github.com/character-ai/larch/issues/3031
 - **PR**: #3055 — https://github.com/character-ai/larch/pull/3055
 - **Plan review**: N/A

--- a/larch-logs/implement/0E07020A-24D5-47A8-B8BD-5E3812D22B23/final-summary.md
+++ b/larch-logs/implement/0E07020A-24D5-47A8-B8BD-5E3812D22B23/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:16:54
-- **Cost**: 💰 TOTAL ~$10.44 — Claude $7.77, Codex $0.17, Cursor $2.50  |  Tokens: 17633k
+- **Cost**: 💰 TOTAL ~$9.43 — Claude $7.77, Codex $0.10, Cursor $1.56, Claude (subprocess) $0.00  |  Tokens: 17633k
 - **Issue**: #2643 — https://github.com/character-ai/larch/issues/2643
 - **Plan review**: N/A
 - **Code review**: N/A

--- a/larch-logs/implement/0ED92B41-1C0E-42CF-8316-A42AAD4DDC21/final-summary.md
+++ b/larch-logs/implement/0ED92B41-1C0E-42CF-8316-A42AAD4DDC21/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 03:00:37
-- **Cost**: 💰 TOTAL ~$29.46 — Claude $12.98, Codex $0.60, Cursor $15.88  |  Tokens: 62419k
+- **Cost**: 💰 TOTAL ~$29.85 — Claude $12.98, Codex $6.92, Cursor $9.95, Claude (subprocess) $0.00  |  Tokens: 62419k
 - **Issue**: #3237 — https://github.com/character-ai/larch/issues/3237
 - **PR**: #3315 — https://github.com/character-ai/larch/pull/3315
 - **Plan review**: N/A

--- a/larch-logs/implement/0F823E6B-3BC9-4CF3-8668-F6B7B5BAAA06/final-summary.md
+++ b/larch-logs/implement/0F823E6B-3BC9-4CF3-8668-F6B7B5BAAA06/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:28:01
-- **Cost**: 💰 TOTAL ~$9.44 — Claude $5.56, Codex $0.15, Cursor $3.73  |  Tokens: 17468k
+- **Cost**: 💰 TOTAL ~$8.14 — Claude $5.56, Codex $0.08, Cursor $2.50, Claude (subprocess) $0.00  |  Tokens: 17468k
 - **Issue**: #2661 — https://github.com/character-ai/larch/issues/2661
 - **Plan review**: N/A
 - **Code review**: N/A

--- a/larch-logs/implement/0FC394D3-7A16-4F62-8C80-0B3A6CB04BE0/final-summary.md
+++ b/larch-logs/implement/0FC394D3-7A16-4F62-8C80-0B3A6CB04BE0/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 01:40:55
-- **Cost**: 💰 TOTAL ~$12.35 — Claude $2.46, Codex $0.86, Cursor $9.03  |  Tokens: 35652k
+- **Cost**: 💰 TOTAL ~$17.82 — Claude $2.46, Codex $9.63, Cursor $5.73, Claude (subprocess) $0.00  |  Tokens: 35652k
 - **Issue**: #3404 — https://github.com/character-ai/larch/issues/3404
 - **Plan review**: N/A
 - **Code review**: 8/16 accepted

--- a/larch-logs/implement/0FC51114-39DC-4535-9F9A-836ADD88602B/final-summary.md
+++ b/larch-logs/implement/0FC51114-39DC-4535-9F9A-836ADD88602B/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:22:22
-- **Cost**: 💰 TOTAL ~$5.89 — Claude $1.77, Codex $0.08, Cursor $4.04  |  Tokens: 13414k
+- **Cost**: 💰 TOTAL ~$5.20 — Claude $1.77, Codex $0.79, Cursor $2.64, Claude (subprocess) $0.00  |  Tokens: 13414k
 - **Issue**: #3338 — https://github.com/character-ai/larch/issues/3338
 - **Plan review**: N/A
 - **Code review**: 0/1 accepted

--- a/larch-logs/implement/1155499A-6F9F-48EE-9D1B-E423B3D294DB/final-summary.md
+++ b/larch-logs/implement/1155499A-6F9F-48EE-9D1B-E423B3D294DB/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 01:04:08
-- **Cost**: 💰 TOTAL ~$12.55 — Claude $5.77, Codex $0.47, Cursor $6.31  |  Tokens: 21128k
+- **Cost**: 💰 TOTAL ~$11.99 — Claude $8.01, Codex $0.26, Cursor $3.72, Claude (subprocess) $0.00  |  Tokens: 23072k
 - **Issue**: #2683 — https://github.com/character-ai/larch/issues/2683
 - **PR**: #2705 — https://github.com/character-ai/larch/pull/2705
 - **Plan review**: N/A

--- a/larch-logs/implement/1420E622-F606-4C34-8385-ABDA542F979C/final-summary.md
+++ b/larch-logs/implement/1420E622-F606-4C34-8385-ABDA542F979C/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - Emergency: true
 - **Duration**: 01:12:39
-- **Cost**: 💰 TOTAL ~$26.82 — Claude $26.46, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.36  |  Tokens: 42667k
+- **Cost**: 💰 TOTAL ~$30.61 — Claude $28.31, Codex $0.00, Cursor $0.00, Claude (subprocess) $2.30  |  Tokens: 45079k
 - **Issue**: #3708 — https://github.com/character-ai/larch/issues/3708
 - **PR**: #3722 — https://github.com/character-ai/larch/pull/3722
 - **Plan review**: N/A

--- a/larch-logs/implement/1446FF4C-B070-45B2-901C-4EAD31252CB9/final-summary.md
+++ b/larch-logs/implement/1446FF4C-B070-45B2-901C-4EAD31252CB9/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:50:53
-- **Cost**: 💰 TOTAL ~$38.52 — Claude $25.17, Codex $0.00, Cursor $13.35  |  Tokens: 61447k
+- **Cost**: 💰 TOTAL ~$33.62 — Claude $25.17, Codex $0.00, Cursor $8.45, Claude (subprocess) $0.00  |  Tokens: 61447k
 - **Issue**: #3187 — https://github.com/character-ai/larch/issues/3187
 - **PR**: #3208 — https://github.com/character-ai/larch/pull/3208
 - **Plan review**: N/A

--- a/larch-logs/implement/14511FDC-4A4A-474D-848E-5BC25BDFF267/final-summary.md
+++ b/larch-logs/implement/14511FDC-4A4A-474D-848E-5BC25BDFF267/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - Emergency: true
 - **Duration**: 00:20:21
-- **Cost**: 💰 TOTAL ~$8.47 — Claude $7.89, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.58  |  Tokens: 13013k
+- **Cost**: 💰 TOTAL ~$12.63 — Claude $12.05, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.58  |  Tokens: 18586k
 - **Issue**: #3851 — https://github.com/character-ai/larch/issues/3851
 - **PR**: #3855 — https://github.com/character-ai/larch/pull/3855
 - **Plan review**: N/A

--- a/larch-logs/implement/14EE54F7-CAA0-4C03-8BA4-A59AD3304AEA/final-summary.md
+++ b/larch-logs/implement/14EE54F7-CAA0-4C03-8BA4-A59AD3304AEA/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 07:06:58
-- **Cost**: 💰 TOTAL ~$83.79 — Claude $70.81, Codex $0.00, Cursor $12.98  |  Tokens: 126115k
+- **Cost**: 💰 TOTAL ~$92.81 — Claude $84.63, Codex $0.00, Cursor $8.18, Claude (subprocess) $0.00  |  Tokens: 141649k
 - **Issue**: #3210 — https://github.com/character-ai/larch/issues/3210
 - **PR**: #3226 — https://github.com/character-ai/larch/pull/3226
 - **Plan review**: N/A

--- a/larch-logs/implement/15160643-DAFF-4C57-8B98-56C6566F5C74/final-summary.md
+++ b/larch-logs/implement/15160643-DAFF-4C57-8B98-56C6566F5C74/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:54:56
-- **Cost**: 💰 TOTAL ~$11.05 — Claude $5.61, Codex $0.24, Cursor $5.20  |  Tokens: 24025k
+- **Cost**: 💰 TOTAL ~$18.18 — Claude $12.07, Codex $2.66, Cursor $3.45, Claude (subprocess) $0.00  |  Tokens: 35433k
 - **Issue**: #3241 — https://github.com/character-ai/larch/issues/3241
 - **PR**: #3264 — https://github.com/character-ai/larch/pull/3264
 - **Plan review**: N/A

--- a/larch-logs/implement/1567F11D-6FA0-4863-A1C5-C6D57EEFD249/final-summary.md
+++ b/larch-logs/implement/1567F11D-6FA0-4863-A1C5-C6D57EEFD249/final-summary.md
@@ -3,7 +3,7 @@
 - **Outcome**: bailed
 - **Mode**: N/A
 - **Duration**: 03:34:12
-- **Cost**: 💰 TOTAL ~$79.63 — Claude $20.24, Codex $8.02, Cursor $26.24, Claude (subprocess) $25.13  |  Tokens: 211286k
+- **Cost**: 💰 TOTAL ~$163.94 — Claude $27.59, Codex $91.61, Cursor $17.41, Claude (subprocess) $27.33  |  Tokens: 221779k
 - **Issue**: #3823 — https://github.com/character-ai/larch/issues/3823
 - **PR**: #3987 — https://github.com/character-ai/larch/pull/3987
 - **Plan review**: N/A

--- a/larch-logs/implement/19427C91-002B-4C68-8235-802D44DA5ED6/final-summary.md
+++ b/larch-logs/implement/19427C91-002B-4C68-8235-802D44DA5ED6/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 01:59:01
-- **Cost**: 💰 TOTAL ~$38.46 — Claude $21.50, Codex $0.59, Cursor $16.37  |  Tokens: 68528k
+- **Cost**: 💰 TOTAL ~$38.55 — Claude $21.50, Codex $6.69, Cursor $10.36, Claude (subprocess) $0.00  |  Tokens: 68528k
 - **Issue**: #3174 — https://github.com/character-ai/larch/issues/3174
 - **Plan review**: N/A
 - **Code review**: 32/87 accepted

--- a/larch-logs/implement/1961B860-E305-466E-B917-03F3990EC849/final-summary.md
+++ b/larch-logs/implement/1961B860-E305-466E-B917-03F3990EC849/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 03:47:08
-- **Cost**: 💰 TOTAL ~$32.21 — Claude $19.94, Codex $0.00, Cursor $12.27  |  Tokens: 44604k
+- **Cost**: 💰 TOTAL ~$27.15 — Claude $19.94, Codex $0.00, Cursor $7.21, Claude (subprocess) $0.00  |  Tokens: 44604k
 - **Issue**: #3209 — https://github.com/character-ai/larch/issues/3209
 - **Plan review**: N/A
 - **Code review**: 43/83 accepted

--- a/larch-logs/implement/1A415FB7-D75C-4B78-90E1-D29AC59D32F7/final-summary.md
+++ b/larch-logs/implement/1A415FB7-D75C-4B78-90E1-D29AC59D32F7/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:41:36
-- **Cost**: 💰 TOTAL ~$9.01 — Claude $6.20, Codex $0.49, Cursor $2.32  |  Tokens: 19064k
+- **Cost**: 💰 TOTAL ~$13.11 — Claude $6.20, Codex $5.47, Cursor $1.44, Claude (subprocess) $0.00  |  Tokens: 19064k
 - **Issue**: #2870 — https://github.com/character-ai/larch/issues/2870
 - **Plan review**: N/A
 - **Code review**: 4/8 accepted

--- a/larch-logs/implement/1B259A67-8F33-4A6F-8A14-FC0C43E11DF8/final-summary.md
+++ b/larch-logs/implement/1B259A67-8F33-4A6F-8A14-FC0C43E11DF8/final-summary.md
@@ -3,7 +3,7 @@
 - **Outcome**: bailed
 - **Mode**: N/A
 - **Duration**: 05:00:04
-- **Cost**: 💰 TOTAL ~$67.97 — Claude $18.55, Codex $8.15, Cursor $29.65, Claude (subprocess) $11.62  |  Tokens: 255755k
+- **Cost**: 💰 TOTAL ~$149.57 — Claude $22.24, Codex $95.38, Cursor $20.33, Claude (subprocess) $11.62  |  Tokens: 259890k
 - **Issue**: #4053 — https://github.com/character-ai/larch/issues/4053
 - **PR**: #4093 — https://github.com/character-ai/larch/pull/4093
 - **Plan review**: N/A

--- a/larch-logs/implement/1BE3968F-C562-46CF-8337-C2248006DBFC/final-summary.md
+++ b/larch-logs/implement/1BE3968F-C562-46CF-8337-C2248006DBFC/final-summary.md
@@ -3,7 +3,7 @@
 - **Outcome**: bailed
 - **Mode**: N/A
 - **Duration**: 00:35:48
-- **Cost**: 💰 TOTAL ~$13.18 — Claude $3.35, Codex $2.74, Cursor $5.64, Claude (subprocess) $1.45  |  Tokens: 63276k
+- **Cost**: 💰 TOTAL ~$40.76 — Claude $3.55, Codex $32.01, Cursor $3.75, Claude (subprocess) $1.45  |  Tokens: 63532k
 - **Issue**: #3662 — https://github.com/character-ai/larch/issues/3662
 - **Plan review**: N/A
 - **Code review**: 0/5 accepted

--- a/larch-logs/implement/1D8914D7-AEAA-461D-839A-FED904799FBB/final-summary.md
+++ b/larch-logs/implement/1D8914D7-AEAA-461D-839A-FED904799FBB/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 02:43:48
-- **Cost**: 💰 TOTAL ~$37.09 — Claude $17.45, Codex $1.45, Cursor $18.19  |  Tokens: 66403k
+- **Cost**: 💰 TOTAL ~$29.53 — Claude $17.45, Codex $0.80, Cursor $11.28, Claude (subprocess) $0.00  |  Tokens: 66403k
 - **Issue**: #2741 — https://github.com/character-ai/larch/issues/2741
 - **PR**: #2845 — https://github.com/character-ai/larch/pull/2845
 - **Plan review**: N/A

--- a/larch-logs/implement/1DD1BB63-A606-403B-8D33-FF5EA33CD053/final-summary.md
+++ b/larch-logs/implement/1DD1BB63-A606-403B-8D33-FF5EA33CD053/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:21:52
-- **Cost**: 💰 TOTAL ~$6.27 — Claude $2.01, Codex $0.02, Cursor $4.24  |  Tokens: 12830k
+- **Cost**: 💰 TOTAL ~$4.78 — Claude $2.01, Codex $0.21, Cursor $2.56, Claude (subprocess) $0.00  |  Tokens: 12830k
 - **Issue**: #3296 — https://github.com/character-ai/larch/issues/3296
 - **Plan review**: N/A
 - **Code review**: 1/21 accepted

--- a/larch-logs/implement/1E7D400B-3601-4934-B2E2-A57F25D9BF3E/final-summary.md
+++ b/larch-logs/implement/1E7D400B-3601-4934-B2E2-A57F25D9BF3E/final-summary.md
@@ -3,7 +3,7 @@
 - **Outcome**: stalled
 - **Mode**: N/A
 - **Duration**: 02:08:36
-- **Cost**: 💰 TOTAL ~$22.83 — Claude $8.29, Codex $4.03, Cursor $10.51  |  Tokens: 82796k
+- **Cost**: 💰 TOTAL ~$64.23 — Claude $12.69, Codex $45.04, Cursor $6.50, Claude (subprocess) $0.00  |  Tokens: 88666k
 - **Issue**: #3568 — https://github.com/character-ai/larch/issues/3568
 - **Plan review**: N/A
 - **Code review**: 17/22 accepted

--- a/larch-logs/implement/1ECFD288-7D59-4C54-957A-0F5FF6266C75/final-summary.md
+++ b/larch-logs/implement/1ECFD288-7D59-4C54-957A-0F5FF6266C75/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:28:16
-- **Cost**: 💰 TOTAL ~$6.40 — Claude $4.74, Codex $0.25, Cursor $1.41  |  Tokens: 11070k
+- **Cost**: 💰 TOTAL ~$8.24 — Claude $4.74, Codex $2.71, Cursor $0.79, Claude (subprocess) $0.00  |  Tokens: 11070k
 - **Issue**: #2971 — https://github.com/character-ai/larch/issues/2971
 - **PR**: #3061 — https://github.com/character-ai/larch/pull/3061
 - **Plan review**: N/A

--- a/larch-logs/implement/1F6EABF8-88FF-496C-BE10-7ED4AFF43432/final-summary.md
+++ b/larch-logs/implement/1F6EABF8-88FF-496C-BE10-7ED4AFF43432/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:56:34
-- **Cost**: 💰 TOTAL ~$13.76 — Claude $11.91, Codex $0.07, Cursor $1.78  |  Tokens: 23206k
+- **Cost**: 💰 TOTAL ~$13.76 — Claude $11.91, Codex $0.77, Cursor $1.08, Claude (subprocess) $0.00  |  Tokens: 23206k
 - **Issue**: #3121 — https://github.com/character-ai/larch/issues/3121
 - **Plan review**: N/A
 - **Code review**: N/A

--- a/larch-logs/implement/1FE6CE06-7EEA-4988-8C9A-9BE06DC53208/final-summary.md
+++ b/larch-logs/implement/1FE6CE06-7EEA-4988-8C9A-9BE06DC53208/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 04:45:56
-- **Cost**: 💰 TOTAL ~$39.51 — Claude $4.61, Codex $4.12, Cursor $30.78  |  Tokens: 156465k
+- **Cost**: 💰 TOTAL ~$72.49 — Claude $4.61, Codex $48.06, Cursor $19.82, Claude (subprocess) $0.00  |  Tokens: 156465k
 - **Issue**: #3413 — https://github.com/character-ai/larch/issues/3413
 - **Plan review**: N/A
 - **Code review**: 46/90 accepted

--- a/larch-logs/implement/2087144D-0446-4BC9-8DEE-E28336E41EDB/final-summary.md
+++ b/larch-logs/implement/2087144D-0446-4BC9-8DEE-E28336E41EDB/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 04:05:32
-- **Cost**: 💰 TOTAL ~$27.94 — Claude $3.30, Codex $2.40, Cursor $22.24  |  Tokens: 86155k
+- **Cost**: 💰 TOTAL ~$44.06 — Claude $3.63, Codex $26.95, Cursor $13.48, Claude (subprocess) $0.00  |  Tokens: 86690k
 - **Issue**: #3461 — https://github.com/character-ai/larch/issues/3461
 - **Plan review**: N/A
 - **Code review**: 64/95 accepted

--- a/larch-logs/implement/20BCA88F-0CE0-454E-AA96-8CEAE3C7C202/final-summary.md
+++ b/larch-logs/implement/20BCA88F-0CE0-454E-AA96-8CEAE3C7C202/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 02:39:57
-- **Cost**: 💰 TOTAL ~$48.62 — Claude $30.81, Codex $1.83, Cursor $15.98  |  Tokens: 96505k
+- **Cost**: 💰 TOTAL ~$61.88 — Claude $30.81, Codex $20.67, Cursor $10.40, Claude (subprocess) $0.00  |  Tokens: 96505k
 - **Issue**: #3150 — https://github.com/character-ai/larch/issues/3150
 - **PR**: #3173 — https://github.com/character-ai/larch/pull/3173
 - **Plan review**: N/A

--- a/larch-logs/implement/2152D93F-0882-4EE0-AD3B-C7DEC5EAAFBC/final-summary.md
+++ b/larch-logs/implement/2152D93F-0882-4EE0-AD3B-C7DEC5EAAFBC/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - Emergency: true
 - **Duration**: 00:49:10
-- **Cost**: 💰 TOTAL ~$21.14 — Claude $20.64, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.50  |  Tokens: 35032k
+- **Cost**: 💰 TOTAL ~$26.71 — Claude $26.21, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.50  |  Tokens: 42348k
 - **Issue**: #3716 — https://github.com/character-ai/larch/issues/3716
 - **PR**: #3734 — https://github.com/character-ai/larch/pull/3734
 - **Plan review**: N/A

--- a/larch-logs/implement/242C658E-7737-4872-B28C-B78C7A473889/final-summary.md
+++ b/larch-logs/implement/242C658E-7737-4872-B28C-B78C7A473889/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 01:17:58
-- **Cost**: 💰 TOTAL ~$19.58 — Claude $5.97, Codex $0.59, Cursor $13.02  |  Tokens: 46312k
+- **Cost**: 💰 TOTAL ~$20.73 — Claude $5.97, Codex $6.52, Cursor $8.24, Claude (subprocess) $0.00  |  Tokens: 46312k
 - **Issue**: #2853 — https://github.com/character-ai/larch/issues/2853
 - **Plan review**: N/A
 - **Code review**: 31/68 accepted

--- a/larch-logs/implement/24B9AFDB-C527-40FE-A195-71C0D2828E09/final-summary.md
+++ b/larch-logs/implement/24B9AFDB-C527-40FE-A195-71C0D2828E09/final-summary.md
@@ -3,7 +3,7 @@
 - **Outcome**: bailed
 - **Mode**: N/A
 - **Duration**: 02:12:37
-- **Cost**: 💰 TOTAL ~$22.07 — Claude $4.01, Codex $3.83, Cursor $9.73, Claude (subprocess) $4.50  |  Tokens: 92556k
+- **Cost**: 💰 TOTAL ~$60.28 — Claude $5.07, Codex $44.21, Cursor $6.50, Claude (subprocess) $4.50  |  Tokens: 93301k
 - **Issue**: #3925 — https://github.com/character-ai/larch/issues/3925
 - **Plan review**: N/A
 - **Code review**: 5/6 accepted

--- a/larch-logs/implement/25869E15-DE04-464F-9871-2A9678FAC5F3/final-summary.md
+++ b/larch-logs/implement/25869E15-DE04-464F-9871-2A9678FAC5F3/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:20:26
-- **Cost**: 💰 TOTAL ~$4.82 — Claude $1.88, Codex $0.00, Cursor $2.94  |  Tokens: 8087k
+- **Cost**: 💰 TOTAL ~$3.49 — Claude $1.88, Codex $0.00, Cursor $1.61, Claude (subprocess) $0.00  |  Tokens: 8087k
 - **Issue**: #3320 — https://github.com/character-ai/larch/issues/3320
 - **Plan review**: N/A
 - **Code review**: 2/14 accepted

--- a/larch-logs/implement/26798078-F70E-47AF-AC37-ED7E5A4A5E34/final-summary.md
+++ b/larch-logs/implement/26798078-F70E-47AF-AC37-ED7E5A4A5E34/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 01:46:25
-- **Cost**: 💰 TOTAL ~$24.22 — Claude $12.72, Codex $1.06, Cursor $10.44  |  Tokens: 70104k
+- **Cost**: 💰 TOTAL ~$32.11 — Claude $12.72, Codex $12.34, Cursor $7.05, Claude (subprocess) $0.00  |  Tokens: 70104k
 - **Issue**: #3418 — https://github.com/character-ai/larch/issues/3418
 - **PR**: #3491 — https://github.com/character-ai/larch/pull/3491
 - **Plan review**: N/A

--- a/larch-logs/implement/2772C40E-335A-4386-80E8-B8207504E075/final-summary.md
+++ b/larch-logs/implement/2772C40E-335A-4386-80E8-B8207504E075/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:46:59
-- **Cost**: 💰 TOTAL ~$7.25 — Claude $4.12, Codex $0.00, Cursor $3.13  |  Tokens: 10751k
+- **Cost**: 💰 TOTAL ~$6.01 — Claude $4.12, Codex $0.00, Cursor $1.89, Claude (subprocess) $0.00  |  Tokens: 10751k
 - **Issue**: #3272 — https://github.com/character-ai/larch/issues/3272
 - **Plan review**: N/A
 - **Code review**: 4/14 accepted

--- a/larch-logs/implement/27EFA801-0F80-4598-B87E-6E6052E37946/final-summary.md
+++ b/larch-logs/implement/27EFA801-0F80-4598-B87E-6E6052E37946/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:34:57
-- **Cost**: 💰 TOTAL ~$5.47 — Claude $2.91, Codex $0.00, Cursor $2.56  |  Tokens: 8431k
+- **Cost**: 💰 TOTAL ~$4.42 — Claude $2.91, Codex $0.00, Cursor $1.51, Claude (subprocess) $0.00  |  Tokens: 8431k
 - **Issue**: #3274 — https://github.com/character-ai/larch/issues/3274
 - **Plan review**: N/A
 - **Code review**: 5/18 accepted

--- a/larch-logs/implement/28058602-8DDF-445B-8BFD-A53BD3A617FA/final-summary.md
+++ b/larch-logs/implement/28058602-8DDF-445B-8BFD-A53BD3A617FA/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 04:23:21
-- **Cost**: 💰 TOTAL ~$71.17 — Claude $11.73, Codex $4.74, Cursor $54.70  |  Tokens: 256221k
+- **Cost**: 💰 TOTAL ~$109.93 — Claude $17.01, Codex $55.67, Cursor $37.25, Claude (subprocess) $0.00  |  Tokens: 263653k
 - **Issue**: #3512 — https://github.com/character-ai/larch/issues/3512
 - **Plan review**: N/A
 - **Code review**: 82/110 accepted

--- a/larch-logs/implement/297B702A-897F-4413-9FAF-564685386089/final-summary.md
+++ b/larch-logs/implement/297B702A-897F-4413-9FAF-564685386089/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:49:21
-- **Cost**: 💰 TOTAL ~$7.53 — Claude $5.84, Codex $0.00, Cursor $1.69  |  Tokens: 9792k
+- **Cost**: 💰 TOTAL ~$6.85 — Claude $5.84, Codex $0.00, Cursor $1.01, Claude (subprocess) $0.00  |  Tokens: 9792k
 - **Issue**: #3267 — https://github.com/character-ai/larch/issues/3267
 - **Plan review**: N/A
 - **Code review**: 7/13 accepted

--- a/larch-logs/implement/297EB5CD-27BF-4012-977C-6A7C203D325B/final-summary.md
+++ b/larch-logs/implement/297EB5CD-27BF-4012-977C-6A7C203D325B/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - Emergency: true
 - **Duration**: 00:10:34
-- **Cost**: 💰 TOTAL ~$2.02 — Claude $2.02, Codex $0.00, Cursor $0.00  |  Tokens: 3070k
+- **Cost**: 💰 TOTAL ~$2.71 — Claude $2.71, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.00  |  Tokens: 4178k
 - **Issue**: #3629 — https://github.com/character-ai/larch/issues/3629
 - **Plan review**: N/A
 - **Code review**: N/A

--- a/larch-logs/implement/2A3D3378-FC29-489A-95E6-20BB409D5BB3/final-summary.md
+++ b/larch-logs/implement/2A3D3378-FC29-489A-95E6-20BB409D5BB3/final-summary.md
@@ -3,7 +3,7 @@
 - **Outcome**: bailed
 - **Mode**: N/A
 - **Duration**: 08:00:15
-- **Cost**: 💰 TOTAL ~$224.14 — Claude $203.65, Codex $4.54, Cursor $6.69, Claude (subprocess) $9.26  |  Tokens: 411426k
+- **Cost**: 💰 TOTAL ~$274.95 — Claude $203.65, Codex $52.22, Cursor $4.62, Claude (subprocess) $14.46  |  Tokens: 418596k
 - **Issue**: #3672 — https://github.com/character-ai/larch/issues/3672
 - **PR**: #4007 — https://github.com/character-ai/larch/pull/4007
 - **Plan review**: N/A

--- a/larch-logs/implement/2AF5A4C7-7446-4865-A23E-DA2164D1C836/final-summary.md
+++ b/larch-logs/implement/2AF5A4C7-7446-4865-A23E-DA2164D1C836/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 02:54:41
-- **Cost**: 💰 TOTAL ~$33.97 — Claude $3.69, Codex $0.00, Cursor $30.28  |  Tokens: 90401k
+- **Cost**: 💰 TOTAL ~$23.77 — Claude $3.69, Codex $0.00, Cursor $20.08, Claude (subprocess) $0.00  |  Tokens: 90401k
 - **Issue**: #3364 — https://github.com/character-ai/larch/issues/3364
 - **PR**: #3398 — https://github.com/character-ai/larch/pull/3398
 - **Plan review**: N/A

--- a/larch-logs/implement/2B49008C-5F47-44B8-9BF9-A69D13CAF931/final-summary.md
+++ b/larch-logs/implement/2B49008C-5F47-44B8-9BF9-A69D13CAF931/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:30:10
-- **Cost**: 💰 TOTAL ~$5.91 — Claude $4.17, Codex $0.33, Cursor $1.41  |  Tokens: 13107k
+- **Cost**: 💰 TOTAL ~$8.68 — Claude $4.17, Codex $3.66, Cursor $0.85, Claude (subprocess) $0.00  |  Tokens: 13107k
 - **Issue**: #3053 — https://github.com/character-ai/larch/issues/3053
 - **PR**: #3078 — https://github.com/character-ai/larch/pull/3078
 - **Plan review**: N/A

--- a/larch-logs/implement/2BD6528B-6FA3-4862-AA74-D95EA61F0FB5/final-summary.md
+++ b/larch-logs/implement/2BD6528B-6FA3-4862-AA74-D95EA61F0FB5/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 01:42:19
-- **Cost**: 💰 TOTAL ~$17.59 — Claude $7.08, Codex $1.51, Cursor $9.00  |  Tokens: 29658k
+- **Cost**: 💰 TOTAL ~$13.35 — Claude $7.08, Codex $0.84, Cursor $5.43, Claude (subprocess) $0.00  |  Tokens: 29658k
 - **Issue**: #2757 — https://github.com/character-ai/larch/issues/2757
 - **Plan review**: N/A
 - **Code review**: 10/19 accepted

--- a/larch-logs/implement/2E0B125E-0C89-42C0-9BD5-95E5C3500220/final-summary.md
+++ b/larch-logs/implement/2E0B125E-0C89-42C0-9BD5-95E5C3500220/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:38:26
-- **Cost**: 💰 TOTAL ~$19.56 — Claude $15.15, Codex $0.31, Cursor $4.10  |  Tokens: 35590k
+- **Cost**: 💰 TOTAL ~$19.19 — Claude $16.15, Codex $0.47, Cursor $2.57, Claude (subprocess) $0.00  |  Tokens: 38210k
 - **Issue**: #2787 — https://github.com/character-ai/larch/issues/2787
 - **PR**: #2820 — https://github.com/character-ai/larch/pull/2820
 - **Plan review**: N/A

--- a/larch-logs/implement/2EC2BB54-80E6-498D-A002-5304A6F25990/final-summary.md
+++ b/larch-logs/implement/2EC2BB54-80E6-498D-A002-5304A6F25990/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - Emergency: true
 - **Duration**: 00:12:32
-- **Cost**: 💰 TOTAL ~$3.14 — Claude $2.89, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.25  |  Tokens: 3809k
+- **Cost**: 💰 TOTAL ~$3.56 — Claude $3.31, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.25  |  Tokens: 4531k
 - **Issue**: #4059 — https://github.com/character-ai/larch/issues/4059
 - **Plan review**: N/A
 - **Code review**: N/A

--- a/larch-logs/implement/2ECDF57C-56CA-4CCC-87E0-CEACE9CB53D3/final-summary.md
+++ b/larch-logs/implement/2ECDF57C-56CA-4CCC-87E0-CEACE9CB53D3/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 01:14:20
-- **Cost**: 💰 TOTAL ~$20.66 — Claude $14.69, Codex $0.64, Cursor $5.33  |  Tokens: 29620k
+- **Cost**: 💰 TOTAL ~$18.22 — Claude $14.69, Codex $0.35, Cursor $3.18, Claude (subprocess) $0.00  |  Tokens: 29620k
 - **Issue**: #2655 — https://github.com/character-ai/larch/issues/2655
 - **Plan review**: N/A
 - **Code review**: 6/31 accepted

--- a/larch-logs/implement/2EF6999C-7EA9-40FB-BEB2-E9B848C995B9/final-summary.md
+++ b/larch-logs/implement/2EF6999C-7EA9-40FB-BEB2-E9B848C995B9/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:57:24
-- **Cost**: 💰 TOTAL ~$14.14 — Claude $7.88, Codex $0.15, Cursor $6.11  |  Tokens: 20129k
+- **Cost**: 💰 TOTAL ~$11.44 — Claude $7.88, Codex $0.08, Cursor $3.48, Claude (subprocess) $0.00  |  Tokens: 20129k
 - **Issue**: #2636 — https://github.com/character-ai/larch/issues/2636
 - **Plan review**: N/A
 - **Code review**: 10/12 accepted

--- a/larch-logs/implement/30F658A4-E9C3-487A-AD1E-AB1B40778B4F/final-summary.md
+++ b/larch-logs/implement/30F658A4-E9C3-487A-AD1E-AB1B40778B4F/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:46:31
-- **Cost**: 💰 TOTAL ~$9.73 — Claude $7.10, Codex $0.48, Cursor $2.15  |  Tokens: 20428k
+- **Cost**: 💰 TOTAL ~$13.95 — Claude $7.10, Codex $5.56, Cursor $1.29, Claude (subprocess) $0.00  |  Tokens: 20428k
 - **Issue**: #2844 — https://github.com/character-ai/larch/issues/2844
 - **PR**: #2880 — https://github.com/character-ai/larch/pull/2880
 - **Plan review**: N/A

--- a/larch-logs/implement/3112952D-9808-4345-A430-A5CDD1A64B57/final-summary.md
+++ b/larch-logs/implement/3112952D-9808-4345-A430-A5CDD1A64B57/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 01:35:50
-- **Cost**: 💰 TOTAL ~$6.73 — Claude $2.23, Codex $0.00, Cursor $4.50  |  Tokens: 14039k
+- **Cost**: 💰 TOTAL ~$4.99 — Claude $2.23, Codex $0.00, Cursor $2.76, Claude (subprocess) $0.00  |  Tokens: 14039k
 - **Issue**: #3292 — https://github.com/character-ai/larch/issues/3292
 - **Plan review**: N/A
 - **Code review**: 7/13 accepted

--- a/larch-logs/implement/3138C377-A704-43EB-8C24-EAA94E2CD562/final-summary.md
+++ b/larch-logs/implement/3138C377-A704-43EB-8C24-EAA94E2CD562/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:27:35
-- **Cost**: 💰 TOTAL ~$8.22 — Claude $2.26, Codex $0.00, Cursor $5.96  |  Tokens: 17908k
+- **Cost**: 💰 TOTAL ~$5.97 — Claude $2.26, Codex $0.00, Cursor $3.71, Claude (subprocess) $0.00  |  Tokens: 17908k
 - **Issue**: #3305 — https://github.com/character-ai/larch/issues/3305
 - **PR**: #3332 — https://github.com/character-ai/larch/pull/3332
 - **Plan review**: N/A

--- a/larch-logs/implement/31B08CAB-9F43-4519-AA5D-7A9FE92A6AC3/final-summary.md
+++ b/larch-logs/implement/31B08CAB-9F43-4519-AA5D-7A9FE92A6AC3/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 02:24:18
-- **Cost**: 💰 TOTAL ~$34.26 — Claude $21.07, Codex $0.20, Cursor $12.99  |  Tokens: 58845k
+- **Cost**: 💰 TOTAL ~$30.52 — Claude $22.13, Codex $0.11, Cursor $8.28, Claude (subprocess) $0.00  |  Tokens: 60688k
 - **Issue**: #2641 — https://github.com/character-ai/larch/issues/2641
 - **PR**: #2653 — https://github.com/character-ai/larch/pull/2653
 - **Plan review**: N/A

--- a/larch-logs/implement/324C785E-1E6E-4C32-95C5-63227B09B442/final-summary.md
+++ b/larch-logs/implement/324C785E-1E6E-4C32-95C5-63227B09B442/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 03:44:27
-- **Cost**: 💰 TOTAL ~$51.50 — Claude $12.80, Codex $2.12, Cursor $36.58  |  Tokens: 157256k
+- **Cost**: 💰 TOTAL ~$62.59 — Claude $13.19, Codex $24.91, Cursor $24.49, Claude (subprocess) $0.00  |  Tokens: 157915k
 - **Issue**: #3475 — https://github.com/character-ai/larch/issues/3475
 - **PR**: #3571 — https://github.com/character-ai/larch/pull/3571
 - **Plan review**: N/A

--- a/larch-logs/implement/338E1541-8089-4BCE-A8FA-8C3CE0FF46AF/final-summary.md
+++ b/larch-logs/implement/338E1541-8089-4BCE-A8FA-8C3CE0FF46AF/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 01:02:50
-- **Cost**: 💰 TOTAL ~$29.66 — Claude $22.59, Codex $0.42, Cursor $6.65  |  Tokens: 42349k
+- **Cost**: 💰 TOTAL ~$27.40 — Claude $22.90, Codex $0.23, Cursor $4.27, Claude (subprocess) $0.00  |  Tokens: 42943k
 - **Issue**: #2735 — https://github.com/character-ai/larch/issues/2735
 - **PR**: #2750 — https://github.com/character-ai/larch/pull/2750
 - **Plan review**: N/A

--- a/larch-logs/implement/3573CBE7-45A6-4F04-9840-F38542654FFB/final-summary.md
+++ b/larch-logs/implement/3573CBE7-45A6-4F04-9840-F38542654FFB/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 02:31:10
-- **Cost**: 💰 TOTAL ~$22.66 — Claude $2.91, Codex $2.58, Cursor $17.17  |  Tokens: 81174k
+- **Cost**: 💰 TOTAL ~$43.46 — Claude $2.91, Codex $29.45, Cursor $11.10, Claude (subprocess) $0.00  |  Tokens: 81174k
 - **Issue**: #3068 — https://github.com/character-ai/larch/issues/3068
 - **Plan review**: N/A
 - **Code review**: 55/75 accepted

--- a/larch-logs/implement/35E1D8DE-597E-42D4-8A11-3F0A9A72F0CD/final-summary.md
+++ b/larch-logs/implement/35E1D8DE-597E-42D4-8A11-3F0A9A72F0CD/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 01:54:56
-- **Cost**: 💰 TOTAL ~$22.94 — Claude $16.22, Codex $0.00, Cursor $6.72  |  Tokens: 41930k
+- **Cost**: 💰 TOTAL ~$20.60 — Claude $16.22, Codex $0.00, Cursor $4.38, Claude (subprocess) $0.00  |  Tokens: 41930k
 - **Issue**: #3239 — https://github.com/character-ai/larch/issues/3239
 - **Plan review**: N/A
 - **Code review**: 21/24 accepted

--- a/larch-logs/implement/37915FB8-54D8-4A85-AB8C-85E802915D4D/final-summary.md
+++ b/larch-logs/implement/37915FB8-54D8-4A85-AB8C-85E802915D4D/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 04:17:13
-- **Cost**: 💰 TOTAL ~$47.85 — Claude $11.00, Codex $3.59, Cursor $33.26  |  Tokens: 153849k
+- **Cost**: 💰 TOTAL ~$73.72 — Claude $11.24, Codex $40.89, Cursor $21.59, Claude (subprocess) $0.00  |  Tokens: 154315k
 - **Issue**: #3434 — https://github.com/character-ai/larch/issues/3434
 - **PR**: #3460 — https://github.com/character-ai/larch/pull/3460
 - **Plan review**: N/A

--- a/larch-logs/implement/37BD5132-0D63-4410-B48C-54DC0B2B094E/final-summary.md
+++ b/larch-logs/implement/37BD5132-0D63-4410-B48C-54DC0B2B094E/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:33:04
-- **Cost**: 💰 TOTAL ~$22.25 — Claude $17.14, Codex $0.43, Cursor $4.68  |  Tokens: 43851k
+- **Cost**: 💰 TOTAL ~$24.78 — Claude $17.14, Codex $4.84, Cursor $2.80, Claude (subprocess) $0.00  |  Tokens: 43851k
 - **Issue**: #2830 — https://github.com/character-ai/larch/issues/2830
 - **PR**: #2923 — https://github.com/character-ai/larch/pull/2923
 - **Plan review**: N/A

--- a/larch-logs/implement/3876DC27-D694-4C99-B942-61A52A2554D7/final-summary.md
+++ b/larch-logs/implement/3876DC27-D694-4C99-B942-61A52A2554D7/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: N/A
-- **Cost**: 💰 TOTAL ~$52.39 — Claude $21.50, Codex $1.52, Cursor $29.37  |  Tokens: 133640k
+- **Cost**: 💰 TOTAL ~$61.80 — Claude $24.89, Codex $17.46, Cursor $19.45, Claude (subprocess) $0.00  |  Tokens: 138990k
 - **Issue**: #3547 — https://github.com/character-ai/larch/issues/3547
 - **Plan review**: N/A
 - **Code review**: 67/86 accepted

--- a/larch-logs/implement/388888EA-0F11-4102-A943-EA7CCB3738BC/final-summary.md
+++ b/larch-logs/implement/388888EA-0F11-4102-A943-EA7CCB3738BC/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:30:22
-- **Cost**: 💰 TOTAL ~$9.34 — Claude $3.25, Codex $0.10, Cursor $5.99  |  Tokens: 21833k
+- **Cost**: 💰 TOTAL ~$7.69 — Claude $3.48, Codex $0.06, Cursor $4.15, Claude (subprocess) $0.00  |  Tokens: 22198k
 - **Issue**: #2682 — https://github.com/character-ai/larch/issues/2682
 - **Plan review**: N/A
 - **Code review**: N/A

--- a/larch-logs/implement/3892A442-19CA-40FF-BFE8-BAF587EEF83D/final-summary.md
+++ b/larch-logs/implement/3892A442-19CA-40FF-BFE8-BAF587EEF83D/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:26:48
-- **Cost**: 💰 TOTAL ~$8.02 — Claude $4.24, Codex $0.00, Cursor $3.78  |  Tokens: 14744k
+- **Cost**: 💰 TOTAL ~$6.56 — Claude $4.24, Codex $0.00, Cursor $2.32, Claude (subprocess) $0.00  |  Tokens: 14744k
 - **Issue**: #3192 — https://github.com/character-ai/larch/issues/3192
 - **Plan review**: N/A
 - **Code review**: 4/7 accepted

--- a/larch-logs/implement/38BEDCD5-1BE7-40BD-9AA3-A9C0643CA3EB/final-summary.md
+++ b/larch-logs/implement/38BEDCD5-1BE7-40BD-9AA3-A9C0643CA3EB/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 04:56:13
-- **Cost**: 💰 TOTAL ~$73.08 — Claude $15.59, Codex $4.30, Cursor $53.19  |  Tokens: 243020k
+- **Cost**: 💰 TOTAL ~$101.52 — Claude $15.59, Codex $49.84, Cursor $36.09, Claude (subprocess) $0.00  |  Tokens: 243020k
 - **Issue**: #3511 — https://github.com/character-ai/larch/issues/3511
 - **PR**: #3548 — https://github.com/character-ai/larch/pull/3548
 - **Plan review**: N/A

--- a/larch-logs/implement/38FC5125-4CC7-48EF-9C55-7B0ED7BD0E4A/final-summary.md
+++ b/larch-logs/implement/38FC5125-4CC7-48EF-9C55-7B0ED7BD0E4A/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - Emergency: true
 - **Duration**: 00:16:19
-- **Cost**: 💰 TOTAL ~$10.32 — Claude $9.69, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.63  |  Tokens: 16301k
+- **Cost**: 💰 TOTAL ~$13.67 — Claude $13.04, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.63  |  Tokens: 22347k
 - **Issue**: #3857 — https://github.com/character-ai/larch/issues/3857
 - **PR**: #3882 — https://github.com/character-ai/larch/pull/3882
 - **Plan review**: N/A

--- a/larch-logs/implement/3A560EF7-514C-430E-B64A-6AF96A29F922/final-summary.md
+++ b/larch-logs/implement/3A560EF7-514C-430E-B64A-6AF96A29F922/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 01:24:13
-- **Cost**: 💰 TOTAL ~$12.79 — Claude $4.53, Codex $1.05, Cursor $7.21  |  Tokens: 34643k
+- **Cost**: 💰 TOTAL ~$20.62 — Claude $4.53, Codex $11.77, Cursor $4.32, Claude (subprocess) $0.00  |  Tokens: 34643k
 - **Issue**: #3025 — https://github.com/character-ai/larch/issues/3025
 - **Plan review**: N/A
 - **Code review**: 21/45 accepted

--- a/larch-logs/implement/3D982BC8-84F1-41E2-9DEF-E3A9B1489007/final-summary.md
+++ b/larch-logs/implement/3D982BC8-84F1-41E2-9DEF-E3A9B1489007/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:17:31
-- **Cost**: 💰 TOTAL ~$4.66 — Claude $3.28, Codex $0.07, Cursor $1.31  |  Tokens: 6432k
+- **Cost**: 💰 TOTAL ~$4.02 — Claude $3.28, Codex $0.04, Cursor $0.70, Claude (subprocess) $0.00  |  Tokens: 6432k
 - **Issue**: #2715 — https://github.com/character-ai/larch/issues/2715
 - **Plan review**: N/A
 - **Code review**: N/A

--- a/larch-logs/implement/3E5FAAE1-734A-4DDC-A646-49E09041A2CA/final-summary.md
+++ b/larch-logs/implement/3E5FAAE1-734A-4DDC-A646-49E09041A2CA/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - Emergency: true
 - **Duration**: 01:39:48
-- **Cost**: 💰 TOTAL ~$25.51 — Claude $24.59, Codex $0.02, Cursor $0.90  |  Tokens: 36779k
+- **Cost**: 💰 TOTAL ~$26.39 — Claude $25.56, Codex $0.21, Cursor $0.62, Claude (subprocess) $0.00  |  Tokens: 38238k
 - **Issue**: #3638 — https://github.com/character-ai/larch/issues/3638
 - **Plan review**: N/A
 - **Code review**: N/A

--- a/larch-logs/implement/3E9F38B8-CED7-4AB8-8DE2-89525DA60863/final-summary.md
+++ b/larch-logs/implement/3E9F38B8-CED7-4AB8-8DE2-89525DA60863/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:26:20
-- **Cost**: 💰 TOTAL ~$4.90 — Claude $1.38, Codex $0.34, Cursor $3.18  |  Tokens: 13872k
+- **Cost**: 💰 TOTAL ~$7.49 — Claude $1.61, Codex $3.86, Cursor $2.02, Claude (subprocess) $0.00  |  Tokens: 14211k
 - **Issue**: #3458 — https://github.com/character-ai/larch/issues/3458
 - **Plan review**: N/A
 - **Code review**: 1/2 accepted

--- a/larch-logs/implement/3F2B5CF2-D011-44B9-A7AE-98B65C770494/final-summary.md
+++ b/larch-logs/implement/3F2B5CF2-D011-44B9-A7AE-98B65C770494/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 03:48:52
-- **Cost**: 💰 TOTAL ~$24.15 — Claude $6.50, Codex $2.86, Cursor $14.79  |  Tokens: 86267k
+- **Cost**: 💰 TOTAL ~$48.11 — Claude $6.50, Codex $32.86, Cursor $8.75, Claude (subprocess) $0.00  |  Tokens: 86267k
 - **Issue**: #3146 — https://github.com/character-ai/larch/issues/3146
 - **PR**: #3168 — https://github.com/character-ai/larch/pull/3168
 - **Plan review**: N/A

--- a/larch-logs/implement/3F382B8B-A97C-4BF0-ACCC-74108521AF01/final-summary.md
+++ b/larch-logs/implement/3F382B8B-A97C-4BF0-ACCC-74108521AF01/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - Emergency: true
 - **Duration**: N/A
-- **Cost**: 💰 TOTAL ~$65.12 — Claude $22.73, Codex $9.27, Cursor $25.38, Claude (subprocess) $7.74  |  Tokens: 222489k
+- **Cost**: 💰 TOTAL ~$153.43 — Claude $23.54, Codex $105.77, Cursor $16.38, Claude (subprocess) $7.74  |  Tokens: 223942k
 - **Issue**: #3700 — https://github.com/character-ai/larch/issues/3700
 - **Plan review**: N/A
 - **Code review**: 32/80 accepted

--- a/larch-logs/implement/3F3BE316-C6AF-4E48-9EBD-FEAF0FE31E69/final-summary.md
+++ b/larch-logs/implement/3F3BE316-C6AF-4E48-9EBD-FEAF0FE31E69/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 02:34:49
-- **Cost**: 💰 TOTAL ~$53.19 — Claude $32.92, Codex $1.36, Cursor $18.91  |  Tokens: 108659k
+- **Cost**: 💰 TOTAL ~$59.74 — Claude $32.92, Codex $15.12, Cursor $11.70, Claude (subprocess) $0.00  |  Tokens: 108659k
 - **Issue**: #2957 — https://github.com/character-ai/larch/issues/2957
 - **PR**: #3016 — https://github.com/character-ai/larch/pull/3016
 - **Plan review**: N/A

--- a/larch-logs/implement/3FFDF47D-A3F5-4C2F-A2A4-0A25D605505E/final-summary.md
+++ b/larch-logs/implement/3FFDF47D-A3F5-4C2F-A2A4-0A25D605505E/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:52:54
-- **Cost**: 💰 TOTAL ~$7.68 — Claude $4.35, Codex $0.25, Cursor $3.08  |  Tokens: 15634k
+- **Cost**: 💰 TOTAL ~$9.09 — Claude $4.35, Codex $2.81, Cursor $1.93, Claude (subprocess) $0.00  |  Tokens: 15634k
 - **Issue**: #3250 — https://github.com/character-ai/larch/issues/3250
 - **Plan review**: N/A
 - **Code review**: 5/13 accepted

--- a/larch-logs/implement/400E3E18-BC93-456C-86C1-C3784D040C97/final-summary.md
+++ b/larch-logs/implement/400E3E18-BC93-456C-86C1-C3784D040C97/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 08:06:57
-- **Cost**: 💰 TOTAL ~$55.36 — Claude $4.60, Codex $5.13, Cursor $45.63  |  Tokens: 211051k
+- **Cost**: 💰 TOTAL ~$95.76 — Claude $6.44, Codex $59.57, Cursor $29.75, Claude (subprocess) $0.00  |  Tokens: 213646k
 - **Issue**: #3488 — https://github.com/character-ai/larch/issues/3488
 - **PR**: #3519 — https://github.com/character-ai/larch/pull/3519
 - **Plan review**: N/A

--- a/larch-logs/implement/406F6739-6D41-4D8F-B986-48015F82C9C7/final-summary.md
+++ b/larch-logs/implement/406F6739-6D41-4D8F-B986-48015F82C9C7/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 03:21:02
-- **Cost**: 💰 TOTAL ~$30.75 — Claude $11.34, Codex $0.58, Cursor $18.83  |  Tokens: 63418k
+- **Cost**: 💰 TOTAL ~$29.36 — Claude $11.34, Codex $6.45, Cursor $11.57, Claude (subprocess) $0.00  |  Tokens: 63418k
 - **Issue**: #3244 — https://github.com/character-ai/larch/issues/3244
 - **Plan review**: N/A
 - **Code review**: 60/99 accepted

--- a/larch-logs/implement/4074DEEC-EB5B-49A5-AE15-662A4F2F1B42/final-summary.md
+++ b/larch-logs/implement/4074DEEC-EB5B-49A5-AE15-662A4F2F1B42/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:26:42
-- **Cost**: 💰 TOTAL ~$2.49 — Claude $1.28, Codex $0.20, Cursor $1.01  |  Tokens: 5494k
+- **Cost**: 💰 TOTAL ~$4.28 — Claude $1.57, Codex $2.13, Cursor $0.58, Claude (subprocess) $0.00  |  Tokens: 5937k
 - **Issue**: #3493 — https://github.com/character-ai/larch/issues/3493
 - **Plan review**: N/A
 - **Code review**: 1/16 accepted

--- a/larch-logs/implement/40859CC3-EECC-40F4-A9D2-20C9F3362B53/final-summary.md
+++ b/larch-logs/implement/40859CC3-EECC-40F4-A9D2-20C9F3362B53/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 01:01:47
-- **Cost**: 💰 TOTAL ~$8.64 — Claude $4.09, Codex $0.00, Cursor $4.55  |  Tokens: 15820k
+- **Cost**: 💰 TOTAL ~$7.13 — Claude $4.09, Codex $0.00, Cursor $3.04, Claude (subprocess) $0.00  |  Tokens: 15820k
 - **Issue**: #3120 — https://github.com/character-ai/larch/issues/3120
 - **Plan review**: N/A
 - **Code review**: 2/12 accepted

--- a/larch-logs/implement/42B6FAB7-8FEF-4340-BDC8-926F9B047B1A/final-summary.md
+++ b/larch-logs/implement/42B6FAB7-8FEF-4340-BDC8-926F9B047B1A/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 01:05:59
-- **Cost**: 💰 TOTAL ~$9.25 — Claude $6.08, Codex $0.53, Cursor $2.64  |  Tokens: 11031k
+- **Cost**: 💰 TOTAL ~$7.95 — Claude $6.08, Codex $0.30, Cursor $1.57, Claude (subprocess) $0.00  |  Tokens: 11031k
 - **Issue**: #2764 — https://github.com/character-ai/larch/issues/2764
 - **Plan review**: N/A
 - **Code review**: N/A

--- a/larch-logs/implement/43B994EE-79FB-4060-82A5-BFC5A6948D59/final-summary.md
+++ b/larch-logs/implement/43B994EE-79FB-4060-82A5-BFC5A6948D59/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 02:44:35
-- **Cost**: 💰 TOTAL ~$27.31 — Claude $7.08, Codex $0.00, Cursor $20.23  |  Tokens: 56059k
+- **Cost**: 💰 TOTAL ~$20.66 — Claude $8.36, Codex $0.00, Cursor $12.30, Claude (subprocess) $0.00  |  Tokens: 58182k
 - **Issue**: #3366 — https://github.com/character-ai/larch/issues/3366
 - **PR**: #3400 — https://github.com/character-ai/larch/pull/3400
 - **Plan review**: N/A

--- a/larch-logs/implement/43D5110B-5B8A-425D-89D7-C571E55B4E0F/final-summary.md
+++ b/larch-logs/implement/43D5110B-5B8A-425D-89D7-C571E55B4E0F/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - Emergency: true
 - **Duration**: 00:06:40
-- **Cost**: 💰 TOTAL ~$2.38 — Claude $2.20, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.18  |  Tokens: 3367k
+- **Cost**: 💰 TOTAL ~$2.73 — Claude $2.55, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.18  |  Tokens: 3923k
 - **Issue**: #3758 — https://github.com/character-ai/larch/issues/3758
 - **PR**: #3762 — https://github.com/character-ai/larch/pull/3762
 - **Plan review**: N/A

--- a/larch-logs/implement/4529BA14-101B-45FB-9918-ECD9279DED51/final-summary.md
+++ b/larch-logs/implement/4529BA14-101B-45FB-9918-ECD9279DED51/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:21:53
-- **Cost**: 💰 TOTAL ~$4.18 — Claude $2.72, Codex $0.11, Cursor $1.35  |  Tokens: 6616k
+- **Cost**: 💰 TOTAL ~$5.84 — Claude $3.46, Codex $1.64, Cursor $0.74, Claude (subprocess) $0.00  |  Tokens: 8151k
 - **Issue**: #3181 — https://github.com/character-ai/larch/issues/3181
 - **PR**: #3193 — https://github.com/character-ai/larch/pull/3193
 - **Plan review**: N/A

--- a/larch-logs/implement/474AC264-195B-4396-BE25-7AC36EBF304F/final-summary.md
+++ b/larch-logs/implement/474AC264-195B-4396-BE25-7AC36EBF304F/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 09:16:16
-- **Cost**: 💰 TOTAL ~$12.45 — Claude $11.96, Codex $0.49, Cursor $0.00  |  Tokens: 25207k
+- **Cost**: 💰 TOTAL ~$17.51 — Claude $11.96, Codex $5.55, Cursor $0.00, Claude (subprocess) $0.00  |  Tokens: 25207k
 - **Issue**: #3247 — https://github.com/character-ai/larch/issues/3247
 - **Plan review**: N/A
 - **Code review**: N/A

--- a/larch-logs/implement/4759A98A-20A5-42E2-90C7-C88C3F8C3B7D/final-summary.md
+++ b/larch-logs/implement/4759A98A-20A5-42E2-90C7-C88C3F8C3B7D/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 01:42:12
-- **Cost**: 💰 TOTAL ~$10.04 — Claude $7.19, Codex $0.00, Cursor $2.85  |  Tokens: 14614k
+- **Cost**: 💰 TOTAL ~$11.96 — Claude $10.19, Codex $0.00, Cursor $1.77, Claude (subprocess) $0.00  |  Tokens: 17968k
 - **Issue**: #3273 — https://github.com/character-ai/larch/issues/3273
 - **PR**: #3293 — https://github.com/character-ai/larch/pull/3293
 - **Plan review**: N/A

--- a/larch-logs/implement/48563D6E-E68C-4E7C-8193-FA1475D0CA55/final-summary.md
+++ b/larch-logs/implement/48563D6E-E68C-4E7C-8193-FA1475D0CA55/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:32:19
-- **Cost**: 💰 TOTAL ~$12.88 — Claude $10.45, Codex $0.47, Cursor $1.96  |  Tokens: 25764k
+- **Cost**: 💰 TOTAL ~$17.09 — Claude $10.45, Codex $5.44, Cursor $1.20, Claude (subprocess) $0.00  |  Tokens: 25764k
 - **Issue**: #2991 — https://github.com/character-ai/larch/issues/2991
 - **Plan review**: N/A
 - **Code review**: 0/14 accepted

--- a/larch-logs/implement/4B01D795-26AB-4455-875A-496239BC8899/final-summary.md
+++ b/larch-logs/implement/4B01D795-26AB-4455-875A-496239BC8899/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - Emergency: true
 - **Duration**: 00:59:58
-- **Cost**: 💰 TOTAL ~$10.91 — Claude $7.93, Codex $0.59, Cursor $1.42, Claude (subprocess) $0.97  |  Tokens: 19965k
+- **Cost**: 💰 TOTAL ~$18.14 — Claude $9.65, Codex $6.64, Cursor $0.88, Claude (subprocess) $0.97  |  Tokens: 22530k
 - **Issue**: #3981 — https://github.com/character-ai/larch/issues/3981
 - **Plan review**: N/A
 - **Code review**: 1/1 accepted

--- a/larch-logs/implement/4B1232BC-BD4B-44B8-90D4-83EF6DD0EA57/final-summary.md
+++ b/larch-logs/implement/4B1232BC-BD4B-44B8-90D4-83EF6DD0EA57/final-summary.md
@@ -3,7 +3,7 @@
 - **Outcome**: bailed
 - **Mode**: N/A
 - **Duration**: 07:49:56
-- **Cost**: 💰 TOTAL ~$332.51 — Claude $251.46, Codex $12.08, Cursor $22.70, Claude (subprocess) $46.27  |  Tokens: 726149k
+- **Cost**: 💰 TOTAL ~$459.39 — Claude $255.49, Codex $141.89, Cursor $15.74, Claude (subprocess) $46.27  |  Tokens: 734090k
 - **Issue**: #3673 — https://github.com/character-ai/larch/issues/3673
 - **PR**: #4087 — https://github.com/character-ai/larch/pull/4087
 - **Plan review**: N/A

--- a/larch-logs/implement/4B2D0EC2-5565-4BF0-BDFB-23BA172E26DC/final-summary.md
+++ b/larch-logs/implement/4B2D0EC2-5565-4BF0-BDFB-23BA172E26DC/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - Emergency: true
 - **Duration**: N/A
-- **Cost**: 💰 TOTAL ~$8.20 — Claude $8.20, Codex $0.00, Cursor $0.00  |  Tokens: 14063k
+- **Cost**: 💰 TOTAL ~$9.12 — Claude $9.12, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.00  |  Tokens: 15627k
 - **Issue**: #3645 — https://github.com/character-ai/larch/issues/3645
 - **Plan review**: N/A
 - **Code review**: N/A

--- a/larch-logs/implement/4C3541E6-C95E-4489-B974-A1A173232D1B/final-summary.md
+++ b/larch-logs/implement/4C3541E6-C95E-4489-B974-A1A173232D1B/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:23:06
-- **Cost**: 💰 TOTAL ~$9.09 — Claude $7.19, Codex $0.20, Cursor $1.70  |  Tokens: 13958k
+- **Cost**: 💰 TOTAL ~$8.28 — Claude $7.19, Codex $0.11, Cursor $0.98, Claude (subprocess) $0.00  |  Tokens: 13958k
 - **Issue**: #2673 — https://github.com/character-ai/larch/issues/2673
 - **PR**: #2696 — https://github.com/character-ai/larch/pull/2696
 - **Plan review**: N/A

--- a/larch-logs/implement/4CCBA814-EF7C-4331-B614-38BDD5C4C08D/final-summary.md
+++ b/larch-logs/implement/4CCBA814-EF7C-4331-B614-38BDD5C4C08D/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - Emergency: true
 - **Duration**: 00:27:26
-- **Cost**: 💰 TOTAL ~$14.18 — Claude $13.76, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.42  |  Tokens: 15046k
+- **Cost**: 💰 TOTAL ~$15.31 — Claude $14.89, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.42  |  Tokens: 17060k
 - **Issue**: #4080 — https://github.com/character-ai/larch/issues/4080
 - **Plan review**: N/A
 - **Code review**: N/A

--- a/larch-logs/implement/4D8D093D-2E70-4CF8-A58B-88631FC94004/final-summary.md
+++ b/larch-logs/implement/4D8D093D-2E70-4CF8-A58B-88631FC94004/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:12:53
-- **Cost**: 💰 TOTAL ~$5.12 — Claude $4.26, Codex $0.10, Cursor $0.76  |  Tokens: 6600k
+- **Cost**: 💰 TOTAL ~$4.74 — Claude $4.26, Codex $0.06, Cursor $0.42, Claude (subprocess) $0.00  |  Tokens: 6600k
 - **Issue**: #2657 — https://github.com/character-ai/larch/issues/2657
 - **Plan review**: N/A
 - **Code review**: N/A

--- a/larch-logs/implement/4E6F8FF8-FFB7-4E4D-A763-77D95E1865BE/final-summary.md
+++ b/larch-logs/implement/4E6F8FF8-FFB7-4E4D-A763-77D95E1865BE/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 11:52:41
-- **Cost**: 💰 TOTAL ~$32.27 — Claude $19.85, Codex $0.00, Cursor $12.42  |  Tokens: 44859k
+- **Cost**: 💰 TOTAL ~$26.95 — Claude $19.85, Codex $0.00, Cursor $7.10, Claude (subprocess) $0.00  |  Tokens: 44859k
 - **Issue**: #3204 — https://github.com/character-ai/larch/issues/3204
 - **PR**: #3230 — https://github.com/character-ai/larch/pull/3230
 - **Plan review**: N/A

--- a/larch-logs/implement/4F9771C9-35AB-45DA-B053-99636CB25030/final-summary.md
+++ b/larch-logs/implement/4F9771C9-35AB-45DA-B053-99636CB25030/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:25:09
-- **Cost**: 💰 TOTAL ~$4.31 — Claude $2.48, Codex $0.00, Cursor $1.83  |  Tokens: 6367k
+- **Cost**: 💰 TOTAL ~$3.48 — Claude $2.48, Codex $0.00, Cursor $1.00, Claude (subprocess) $0.00  |  Tokens: 6367k
 - **Issue**: #3212 — https://github.com/character-ai/larch/issues/3212
 - **Plan review**: N/A
 - **Code review**: 2/19 accepted

--- a/larch-logs/implement/505A17EA-61FB-4372-9F96-3712FA43A792/final-summary.md
+++ b/larch-logs/implement/505A17EA-61FB-4372-9F96-3712FA43A792/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 02:24:48
-- **Cost**: 💰 TOTAL ~$17.91 — Claude $6.31, Codex $1.35, Cursor $10.25  |  Tokens: 46878k
+- **Cost**: 💰 TOTAL ~$27.67 — Claude $6.31, Codex $14.91, Cursor $6.45, Claude (subprocess) $0.00  |  Tokens: 46878k
 - **Issue**: #3514 — https://github.com/character-ai/larch/issues/3514
 - **PR**: #3540 — https://github.com/character-ai/larch/pull/3540
 - **Plan review**: N/A

--- a/larch-logs/implement/50B03CAC-D1E5-4758-9906-6A8F8749B3C3/final-summary.md
+++ b/larch-logs/implement/50B03CAC-D1E5-4758-9906-6A8F8749B3C3/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:26:53
-- **Cost**: 💰 TOTAL ~$12.26 — Claude $9.49, Codex $0.13, Cursor $2.64  |  Tokens: 21699k
+- **Cost**: 💰 TOTAL ~$12.38 — Claude $9.49, Codex $1.35, Cursor $1.54, Claude (subprocess) $0.00  |  Tokens: 21699k
 - **Issue**: #2899 — https://github.com/character-ai/larch/issues/2899
 - **Plan review**: N/A
 - **Code review**: 9/30 accepted

--- a/larch-logs/implement/512A7739-7E73-4202-A63B-863A7B8CDD03/final-summary.md
+++ b/larch-logs/implement/512A7739-7E73-4202-A63B-863A7B8CDD03/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 01:29:48
-- **Cost**: 💰 TOTAL ~$29.79 — Claude $14.95, Codex $1.75, Cursor $13.09  |  Tokens: 82374k
+- **Cost**: 💰 TOTAL ~$43.64 — Claude $14.95, Codex $20.01, Cursor $8.68, Claude (subprocess) $0.00  |  Tokens: 82374k
 - **Issue**: #2738 — https://github.com/character-ai/larch/issues/2738
 - **PR**: #3089 — https://github.com/character-ai/larch/pull/3089
 - **Plan review**: N/A

--- a/larch-logs/implement/5183A995-5222-4A9B-A2DE-E161848A0085/final-summary.md
+++ b/larch-logs/implement/5183A995-5222-4A9B-A2DE-E161848A0085/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:27:31
-- **Cost**: 💰 TOTAL ~$4.79 — Claude $1.51, Codex $0.00, Cursor $3.28  |  Tokens: 9225k
+- **Cost**: 💰 TOTAL ~$3.43 — Claude $1.51, Codex $0.00, Cursor $1.92, Claude (subprocess) $0.00  |  Tokens: 9225k
 - **Issue**: #3317 — https://github.com/character-ai/larch/issues/3317
 - **PR**: #3331 — https://github.com/character-ai/larch/pull/3331
 - **Plan review**: N/A

--- a/larch-logs/implement/52E1B2D6-1B11-46DB-ABA8-AB9B8DC40CCC/final-summary.md
+++ b/larch-logs/implement/52E1B2D6-1B11-46DB-ABA8-AB9B8DC40CCC/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:33:38
-- **Cost**: 💰 TOTAL ~$13.16 — Claude $5.13, Codex $0.08, Cursor $7.95  |  Tokens: 29683k
+- **Cost**: 💰 TOTAL ~$10.63 — Claude $5.13, Codex $0.04, Cursor $5.46, Claude (subprocess) $0.00  |  Tokens: 29683k
 - **Issue**: #2633 — https://github.com/character-ai/larch/issues/2633
 - **Plan review**: N/A
 - **Code review**: N/A

--- a/larch-logs/implement/53E8CB22-78F2-4972-A435-F7A55EF52FA1/final-summary.md
+++ b/larch-logs/implement/53E8CB22-78F2-4972-A435-F7A55EF52FA1/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:24:43
-- **Cost**: 💰 TOTAL ~$4.50 — Claude $2.68, Codex $0.37, Cursor $1.45  |  Tokens: 10649k
+- **Cost**: 💰 TOTAL ~$7.65 — Claude $2.68, Codex $4.14, Cursor $0.83, Claude (subprocess) $0.00  |  Tokens: 10649k
 - **Issue**: #2868 — https://github.com/character-ai/larch/issues/2868
 - **Plan review**: N/A
 - **Code review**: 3/7 accepted

--- a/larch-logs/implement/56AF0470-FFD4-420A-B4AE-E14E40E18558/final-summary.md
+++ b/larch-logs/implement/56AF0470-FFD4-420A-B4AE-E14E40E18558/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 02:35:22
-- **Cost**: 💰 TOTAL ~$34.83 — Claude $18.41, Codex $0.84, Cursor $15.58  |  Tokens: 77927k
+- **Cost**: 💰 TOTAL ~$41.70 — Claude $22.48, Codex $9.46, Cursor $9.76, Claude (subprocess) $0.00  |  Tokens: 85551k
 - **Issue**: #2737 — https://github.com/character-ai/larch/issues/2737
 - **PR**: #2978 — https://github.com/character-ai/larch/pull/2978
 - **Plan review**: N/A

--- a/larch-logs/implement/57509469-4081-4048-8833-D6316D7402AF/final-summary.md
+++ b/larch-logs/implement/57509469-4081-4048-8833-D6316D7402AF/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:58:50
-- **Cost**: 💰 TOTAL ~$17.89 — Claude $14.46, Codex $0.66, Cursor $2.77  |  Tokens: 37129k
+- **Cost**: 💰 TOTAL ~$24.24 — Claude $14.46, Codex $8.03, Cursor $1.75, Claude (subprocess) $0.00  |  Tokens: 37454k
 - **Issue**: #3143 — https://github.com/character-ai/larch/issues/3143
 - **PR**: #3154 — https://github.com/character-ai/larch/pull/3154
 - **Plan review**: N/A

--- a/larch-logs/implement/57797559-9368-4E52-9CDB-55B58AC1CE44/final-summary.md
+++ b/larch-logs/implement/57797559-9368-4E52-9CDB-55B58AC1CE44/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:35:15
-- **Cost**: 💰 TOTAL ~$8.48 — Claude $4.81, Codex $0.12, Cursor $3.55  |  Tokens: 13865k
+- **Cost**: 💰 TOTAL ~$7.15 — Claude $4.81, Codex $0.07, Cursor $2.27, Claude (subprocess) $0.00  |  Tokens: 13865k
 - **Issue**: #2665 — https://github.com/character-ai/larch/issues/2665
 - **Plan review**: N/A
 - **Code review**: N/A

--- a/larch-logs/implement/57D1F301-2601-4034-9AA6-D30792E6C5D3/final-summary.md
+++ b/larch-logs/implement/57D1F301-2601-4034-9AA6-D30792E6C5D3/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 03:30:21
-- **Cost**: 💰 TOTAL ~$144.62 — Claude $128.42, Codex $0.20, Cursor $16.00  |  Tokens: 271559k
+- **Cost**: 💰 TOTAL ~$140.82 — Claude $128.42, Codex $2.36, Cursor $10.04, Claude (subprocess) $0.00  |  Tokens: 271559k
 - **Issue**: #3175 — https://github.com/character-ai/larch/issues/3175
 - **PR**: #3205 — https://github.com/character-ai/larch/pull/3205
 - **Plan review**: N/A

--- a/larch-logs/implement/58C49F47-CE44-4846-A4A8-1F462ECA5D3F/final-summary.md
+++ b/larch-logs/implement/58C49F47-CE44-4846-A4A8-1F462ECA5D3F/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:31:05
-- **Cost**: 💰 TOTAL ~$28.22 — Claude $25.04, Codex $0.21, Cursor $2.97  |  Tokens: 52835k
+- **Cost**: 💰 TOTAL ~$29.31 — Claude $25.04, Codex $2.38, Cursor $1.89, Claude (subprocess) $0.00  |  Tokens: 52835k
 - **Issue**: #3126 — https://github.com/character-ai/larch/issues/3126
 - **Plan review**: N/A
 - **Code review**: 3/8 accepted

--- a/larch-logs/implement/5B5B0FE1-78E9-4C11-9CC9-70ABB2FB10FD/final-summary.md
+++ b/larch-logs/implement/5B5B0FE1-78E9-4C11-9CC9-70ABB2FB10FD/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:21:39
-- **Cost**: 💰 TOTAL ~$4.09 — Claude $3.26, Codex $0.11, Cursor $0.72  |  Tokens: 5599k
+- **Cost**: 💰 TOTAL ~$3.72 — Claude $3.26, Codex $0.06, Cursor $0.40, Claude (subprocess) $0.00  |  Tokens: 5599k
 - **Issue**: #2686 — https://github.com/character-ai/larch/issues/2686
 - **Plan review**: N/A
 - **Code review**: 3/4 accepted

--- a/larch-logs/implement/5BB0DF65-56BD-475C-9396-FA1DADBADC85/final-summary.md
+++ b/larch-logs/implement/5BB0DF65-56BD-475C-9396-FA1DADBADC85/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - Emergency: true
 - **Duration**: 01:58:30
-- **Cost**: 💰 TOTAL ~$73.82 — Claude $65.82, Codex $2.07, Cursor $5.93  |  Tokens: 140183k
+- **Cost**: 💰 TOTAL ~$99.89 — Claude $72.28, Codex $23.64, Cursor $3.97, Claude (subprocess) $0.00  |  Tokens: 149414k
 - **Issue**: #3637 — https://github.com/character-ai/larch/issues/3637
 - **Plan review**: N/A
 - **Code review**: 8/13 accepted

--- a/larch-logs/implement/5BE95470-E23E-48D4-89F1-6FACF6C22C1A/final-summary.md
+++ b/larch-logs/implement/5BE95470-E23E-48D4-89F1-6FACF6C22C1A/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 02:10:40
-- **Cost**: 💰 TOTAL ~$29.66 — Claude $11.56, Codex $0.74, Cursor $17.36  |  Tokens: 71840k
+- **Cost**: 💰 TOTAL ~$34.77 — Claude $14.78, Codex $8.80, Cursor $11.19, Claude (subprocess) $0.00  |  Tokens: 76430k
 - **Issue**: #3422 — https://github.com/character-ai/larch/issues/3422
 - **Plan review**: N/A
 - **Code review**: 18/28 accepted

--- a/larch-logs/implement/5CF39E2C-AAB5-4316-A4C6-719E02590A15/final-summary.md
+++ b/larch-logs/implement/5CF39E2C-AAB5-4316-A4C6-719E02590A15/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 01:21:24
-- **Cost**: 💰 TOTAL ~$13.00 — Claude $5.20, Codex $0.71, Cursor $7.09  |  Tokens: 30028k
+- **Cost**: 💰 TOTAL ~$17.55 — Claude $5.20, Codex $7.90, Cursor $4.45, Claude (subprocess) $0.00  |  Tokens: 30028k
 - **Issue**: #3155 — https://github.com/character-ai/larch/issues/3155
 - **Plan review**: N/A
 - **Code review**: 21/38 accepted

--- a/larch-logs/implement/5D9D6DD2-C3C0-49EB-B07E-0E4F8333EE7A/final-summary.md
+++ b/larch-logs/implement/5D9D6DD2-C3C0-49EB-B07E-0E4F8333EE7A/final-summary.md
@@ -3,7 +3,7 @@
 - **Outcome**: stalled
 - **Mode**: N/A
 - **Duration**: 03:37:00
-- **Cost**: 💰 TOTAL ~$65.69 — Claude $20.02, Codex $11.52, Cursor $26.17, Claude (subprocess) $7.98  |  Tokens: 289687k
+- **Cost**: 💰 TOTAL ~$185.12 — Claude $26.23, Codex $133.73, Cursor $17.18, Claude (subprocess) $7.98  |  Tokens: 300980k
 - **Issue**: #3668 — https://github.com/character-ai/larch/issues/3668
 - **PR**: #3791 — https://github.com/character-ai/larch/pull/3791
 - **Plan review**: N/A

--- a/larch-logs/implement/5E1F880E-4C39-420F-AEC7-64EF84154F7D/final-summary.md
+++ b/larch-logs/implement/5E1F880E-4C39-420F-AEC7-64EF84154F7D/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 02:12:51
-- **Cost**: 💰 TOTAL ~$16.44 — Claude $9.95, Codex $0.61, Cursor $5.88  |  Tokens: 27469k
+- **Cost**: 💰 TOTAL ~$15.72 — Claude $11.42, Codex $0.34, Cursor $3.96, Claude (subprocess) $0.00  |  Tokens: 27704k
 - **Issue**: #2672 — https://github.com/character-ai/larch/issues/2672
 - **PR**: #2791 — https://github.com/character-ai/larch/pull/2791
 - **Plan review**: N/A

--- a/larch-logs/implement/5FEB3AF2-A3D5-43B4-96DD-E39C0B6A1750/final-summary.md
+++ b/larch-logs/implement/5FEB3AF2-A3D5-43B4-96DD-E39C0B6A1750/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:54:12
-- **Cost**: 💰 TOTAL ~$31.10 — Claude $27.58, Codex $0.16, Cursor $3.36  |  Tokens: 56905k
+- **Cost**: 💰 TOTAL ~$31.48 — Claude $27.58, Codex $1.75, Cursor $2.15, Claude (subprocess) $0.00  |  Tokens: 56905k
 - **Issue**: #2995 — https://github.com/character-ai/larch/issues/2995
 - **Plan review**: N/A
 - **Code review**: 6/13 accepted

--- a/larch-logs/implement/608A570D-58B0-49BC-8B18-20376A473859/final-summary.md
+++ b/larch-logs/implement/608A570D-58B0-49BC-8B18-20376A473859/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:28:31
-- **Cost**: 💰 TOTAL ~$6.10 — Claude $3.79, Codex $0.15, Cursor $2.16  |  Tokens: 8773k
+- **Cost**: 💰 TOTAL ~$5.16 — Claude $3.79, Codex $0.08, Cursor $1.29, Claude (subprocess) $0.00  |  Tokens: 8773k
 - **Issue**: #2720 — https://github.com/character-ai/larch/issues/2720
 - **Plan review**: N/A
 - **Code review**: N/A

--- a/larch-logs/implement/60C1CFC1-0A16-4BC1-B8B8-DAEC0C39C45C/final-summary.md
+++ b/larch-logs/implement/60C1CFC1-0A16-4BC1-B8B8-DAEC0C39C45C/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - Emergency: true
 - **Duration**: 00:43:22
-- **Cost**: 💰 TOTAL ~$21.25 — Claude $21.25, Codex $0.00, Cursor $0.00  |  Tokens: 37112k
+- **Cost**: 💰 TOTAL ~$21.78 — Claude $21.78, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.00  |  Tokens: 37973k
 - **Issue**: #3650 — https://github.com/character-ai/larch/issues/3650
 - **Plan review**: N/A
 - **Code review**: N/A

--- a/larch-logs/implement/61121F37-9995-4F7B-8957-1F7D02DB99C2/final-summary.md
+++ b/larch-logs/implement/61121F37-9995-4F7B-8957-1F7D02DB99C2/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 02:09:22
-- **Cost**: 💰 TOTAL ~$29.06 — Claude $7.76, Codex $1.57, Cursor $19.73  |  Tokens: 81224k
+- **Cost**: 💰 TOTAL ~$38.37 — Claude $7.76, Codex $18.07, Cursor $12.54, Claude (subprocess) $0.00  |  Tokens: 81224k
 - **Issue**: #2837 — https://github.com/character-ai/larch/issues/2837
 - **Plan review**: N/A
 - **Code review**: 87/130 accepted

--- a/larch-logs/implement/624A5FE2-6AD2-4251-A52A-BC52E4B30441/final-summary.md
+++ b/larch-logs/implement/624A5FE2-6AD2-4251-A52A-BC52E4B30441/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 01:29:24
-- **Cost**: 💰 TOTAL ~$45.67 — Claude $33.62, Codex $2.85, Cursor $9.20  |  Tokens: 137108k
+- **Cost**: 💰 TOTAL ~$73.50 — Claude $33.62, Codex $34.09, Cursor $5.79, Claude (subprocess) $0.00  |  Tokens: 137108k
 - **Issue**: #2852 — https://github.com/character-ai/larch/issues/2852
 - **PR**: #2892 — https://github.com/character-ai/larch/pull/2892
 - **Plan review**: N/A

--- a/larch-logs/implement/625F4D0F-AEA8-435B-93C8-9EE599371BEA/final-summary.md
+++ b/larch-logs/implement/625F4D0F-AEA8-435B-93C8-9EE599371BEA/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:41:08
-- **Cost**: 💰 TOTAL ~$9.79 — Claude $6.76, Codex $0.74, Cursor $2.29  |  Tokens: 24443k
+- **Cost**: 💰 TOTAL ~$18.41 — Claude $6.76, Codex $10.26, Cursor $1.39, Claude (subprocess) $0.00  |  Tokens: 26644k
 - **Issue**: #2828 — https://github.com/character-ai/larch/issues/2828
 - **PR**: #3051 — https://github.com/character-ai/larch/pull/3051
 - **Plan review**: N/A

--- a/larch-logs/implement/63483964-E1FD-4E31-AAB8-38862F85FB08/final-summary.md
+++ b/larch-logs/implement/63483964-E1FD-4E31-AAB8-38862F85FB08/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:25:56
-- **Cost**: 💰 TOTAL ~$6.32 — Claude $4.26, Codex $0.18, Cursor $1.88  |  Tokens: 8886k
+- **Cost**: 💰 TOTAL ~$6.15 — Claude $5.04, Codex $0.10, Cursor $1.01, Claude (subprocess) $0.00  |  Tokens: 10038k
 - **Issue**: #2678 — https://github.com/character-ai/larch/issues/2678
 - **PR**: #2717 — https://github.com/character-ai/larch/pull/2717
 - **Plan review**: N/A

--- a/larch-logs/implement/638B2127-774F-46F3-BEC9-C8C679F0DFC2/final-summary.md
+++ b/larch-logs/implement/638B2127-774F-46F3-BEC9-C8C679F0DFC2/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:22:16
-- **Cost**: 💰 TOTAL ~$8.68 — Claude $3.87, Codex $0.04, Cursor $4.77  |  Tokens: 16636k
+- **Cost**: 💰 TOTAL ~$6.91 — Claude $3.87, Codex $0.02, Cursor $3.02, Claude (subprocess) $0.00  |  Tokens: 16636k
 - **Issue**: #2742 — https://github.com/character-ai/larch/issues/2742
 - **Plan review**: N/A
 - **Code review**: N/A

--- a/larch-logs/implement/65A80D2A-AB8C-4101-9EC2-FD407A10A6C0/final-summary.md
+++ b/larch-logs/implement/65A80D2A-AB8C-4101-9EC2-FD407A10A6C0/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - Emergency: true
 - **Duration**: 00:30:25
-- **Cost**: 💰 TOTAL ~$11.23 — Claude $10.47, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.76  |  Tokens: 17584k
+- **Cost**: 💰 TOTAL ~$11.80 — Claude $11.04, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.76  |  Tokens: 18608k
 - **Issue**: #4038 — https://github.com/character-ai/larch/issues/4038
 - **Plan review**: N/A
 - **Code review**: N/A

--- a/larch-logs/implement/66D47A58-2D0A-440C-B09C-CDC9168D5354/final-summary.md
+++ b/larch-logs/implement/66D47A58-2D0A-440C-B09C-CDC9168D5354/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 01:57:48
-- **Cost**: 💰 TOTAL ~$68.67 — Claude $52.32, Codex $1.11, Cursor $15.24  |  Tokens: 117394k
+- **Cost**: 💰 TOTAL ~$73.75 — Claude $52.32, Codex $12.33, Cursor $9.10, Claude (subprocess) $0.00  |  Tokens: 117394k
 - **Issue**: #2930 — https://github.com/character-ai/larch/issues/2930
 - **Plan review**: N/A
 - **Code review**: 40/71 accepted

--- a/larch-logs/implement/66E4CC76-3DF7-4772-810C-43EAF5B35CE5/final-summary.md
+++ b/larch-logs/implement/66E4CC76-3DF7-4772-810C-43EAF5B35CE5/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 01:50:45
-- **Cost**: 💰 TOTAL ~$42.17 — Claude $37.99, Codex $2.02, Cursor $2.16  |  Tokens: 106751k
+- **Cost**: 💰 TOTAL ~$63.88 — Claude $37.99, Codex $24.57, Cursor $1.32, Claude (subprocess) $0.00  |  Tokens: 106751k
 - **Issue**: #2963 — https://github.com/character-ai/larch/issues/2963
 - **Plan review**: N/A
 - **Code review**: N/A

--- a/larch-logs/implement/683D8FE5-F1C7-4B88-9E43-BFD422132996/final-summary.md
+++ b/larch-logs/implement/683D8FE5-F1C7-4B88-9E43-BFD422132996/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:30:40
-- **Cost**: 💰 TOTAL ~$7.75 — Claude $5.72, Codex $0.52, Cursor $1.51  |  Tokens: 17411k
+- **Cost**: 💰 TOTAL ~$12.55 — Claude $5.72, Codex $5.95, Cursor $0.88, Claude (subprocess) $0.00  |  Tokens: 17411k
 - **Issue**: #3032 — https://github.com/character-ai/larch/issues/3032
 - **PR**: #3058 — https://github.com/character-ai/larch/pull/3058
 - **Plan review**: N/A

--- a/larch-logs/implement/68F79B65-5C83-4BE0-A110-71E44121FD5F/final-summary.md
+++ b/larch-logs/implement/68F79B65-5C83-4BE0-A110-71E44121FD5F/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 02:40:59
-- **Cost**: 💰 TOTAL ~$26.17 — Claude $5.44, Codex $1.62, Cursor $19.11  |  Tokens: 54800k
+- **Cost**: 💰 TOTAL ~$19.08 — Claude $6.18, Codex $0.90, Cursor $12.00, Claude (subprocess) $0.00  |  Tokens: 55896k
 - **Issue**: #2671 — https://github.com/character-ai/larch/issues/2671
 - **Plan review**: N/A
 - **Code review**: 80/135 accepted

--- a/larch-logs/implement/69F51B25-3926-4FF9-8863-7CE68EB9C4B4/final-summary.md
+++ b/larch-logs/implement/69F51B25-3926-4FF9-8863-7CE68EB9C4B4/final-summary.md
@@ -3,7 +3,7 @@
 - **Outcome**: bailed
 - **Mode**: N/A
 - **Duration**: 00:42:19
-- **Cost**: 💰 TOTAL ~$4.22 — Claude $3.57, Codex $0.39, Cursor $0.00, Claude (subprocess) $0.26  |  Tokens: 9476k
+- **Cost**: 💰 TOTAL ~$8.27 — Claude $3.57, Codex $4.44, Cursor $0.00, Claude (subprocess) $0.26  |  Tokens: 9476k
 - **Issue**: #4010 — https://github.com/character-ai/larch/issues/4010
 - **PR**: #4041 — https://github.com/character-ai/larch/pull/4041
 - **Plan review**: N/A

--- a/larch-logs/implement/6A81F7CA-8248-4954-B0D3-F95358CC930C/final-summary.md
+++ b/larch-logs/implement/6A81F7CA-8248-4954-B0D3-F95358CC930C/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:54:26
-- **Cost**: 💰 TOTAL ~$7.82 — Claude $3.77, Codex $0.00, Cursor $4.05  |  Tokens: 15518k
+- **Cost**: 💰 TOTAL ~$6.71 — Claude $4.10, Codex $0.00, Cursor $2.61, Claude (subprocess) $0.00  |  Tokens: 15895k
 - **Issue**: #3476 — https://github.com/character-ai/larch/issues/3476
 - **Plan review**: N/A
 - **Code review**: 4/20 accepted

--- a/larch-logs/implement/6AD2682B-6C26-43C1-81AC-F7D792380452/final-summary.md
+++ b/larch-logs/implement/6AD2682B-6C26-43C1-81AC-F7D792380452/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 02:48:38
-- **Cost**: 💰 TOTAL ~$40.24 — Claude $16.35, Codex $2.23, Cursor $21.66  |  Tokens: 78795k
+- **Cost**: 💰 TOTAL ~$31.65 — Claude $16.35, Codex $1.24, Cursor $14.06, Claude (subprocess) $0.00  |  Tokens: 78795k
 - **Issue**: #2790 — https://github.com/character-ai/larch/issues/2790
 - **Plan review**: N/A
 - **Code review**: 66/107 accepted

--- a/larch-logs/implement/6B60210F-E29E-4E36-B7E7-3F3AB0ECC80F/final-summary.md
+++ b/larch-logs/implement/6B60210F-E29E-4E36-B7E7-3F3AB0ECC80F/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 02:32:59
-- **Cost**: 💰 TOTAL ~$28.25 — Claude $8.67, Codex $0.74, Cursor $18.84  |  Tokens: 65998k
+- **Cost**: 💰 TOTAL ~$30.95 — Claude $10.76, Codex $8.39, Cursor $11.80, Claude (subprocess) $0.00  |  Tokens: 67787k
 - **Issue**: #3234 — https://github.com/character-ai/larch/issues/3234
 - **PR**: #3268 — https://github.com/character-ai/larch/pull/3268
 - **Plan review**: N/A

--- a/larch-logs/implement/6C87D555-0C92-4C12-B66B-1ABEAA6985A7/final-summary.md
+++ b/larch-logs/implement/6C87D555-0C92-4C12-B66B-1ABEAA6985A7/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:37:55
-- **Cost**: 💰 TOTAL ~$5.61 — Claude $1.94, Codex $0.00, Cursor $3.67  |  Tokens: 11739k
+- **Cost**: 💰 TOTAL ~$4.18 — Claude $1.94, Codex $0.00, Cursor $2.24, Claude (subprocess) $0.00  |  Tokens: 11739k
 - **Issue**: #3386 — https://github.com/character-ai/larch/issues/3386
 - **Plan review**: N/A
 - **Code review**: 4/12 accepted

--- a/larch-logs/implement/6CBB2A88-B96E-40F0-9EF5-943F3DF1BC84/final-summary.md
+++ b/larch-logs/implement/6CBB2A88-B96E-40F0-9EF5-943F3DF1BC84/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - Emergency: true
 - **Duration**: 00:04:45
-- **Cost**: 💰 TOTAL ~$1.30 — Claude $1.15, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.15  |  Tokens: 1892k
+- **Cost**: 💰 TOTAL ~$1.59 — Claude $1.44, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.15  |  Tokens: 2375k
 - **Issue**: #4037 — https://github.com/character-ai/larch/issues/4037
 - **Plan review**: N/A
 - **Code review**: N/A

--- a/larch-logs/implement/6D83E065-C698-44A5-98A2-7894B6B5276E/final-summary.md
+++ b/larch-logs/implement/6D83E065-C698-44A5-98A2-7894B6B5276E/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 04:25:42
-- **Cost**: 💰 TOTAL ~$45.35 — Claude $11.75, Codex $2.89, Cursor $30.71  |  Tokens: 137279k
+- **Cost**: 💰 TOTAL ~$64.93 — Claude $11.88, Codex $33.63, Cursor $19.42, Claude (subprocess) $0.00  |  Tokens: 138074k
 - **Issue**: #3457 — https://github.com/character-ai/larch/issues/3457
 - **PR**: #3497 — https://github.com/character-ai/larch/pull/3497
 - **Plan review**: N/A

--- a/larch-logs/implement/6F83C91C-A5F3-4B82-AA43-718395E1FD3B/final-summary.md
+++ b/larch-logs/implement/6F83C91C-A5F3-4B82-AA43-718395E1FD3B/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:25:31
-- **Cost**: 💰 TOTAL ~$5.15 — Claude $2.78, Codex $0.16, Cursor $2.21  |  Tokens: 8447k
+- **Cost**: 💰 TOTAL ~$5.82 — Claude $2.78, Codex $1.70, Cursor $1.34, Claude (subprocess) $0.00  |  Tokens: 8447k
 - **Issue**: #3218 — https://github.com/character-ai/larch/issues/3218
 - **Plan review**: N/A
 - **Code review**: 3/8 accepted

--- a/larch-logs/implement/704607ED-E287-4DA5-A207-BE0B32809C61/final-summary.md
+++ b/larch-logs/implement/704607ED-E287-4DA5-A207-BE0B32809C61/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 04:20:59
-- **Cost**: 💰 TOTAL ~$10.10 — Claude $5.98, Codex $0.00, Cursor $4.12  |  Tokens: 17826k
+- **Cost**: 💰 TOTAL ~$8.71 — Claude $5.98, Codex $0.00, Cursor $2.73, Claude (subprocess) $0.00  |  Tokens: 17826k
 - **Issue**: #3369 — https://github.com/character-ai/larch/issues/3369
 - **Plan review**: N/A
 - **Code review**: 5/17 accepted

--- a/larch-logs/implement/731D4E20-0813-450A-B7D4-945713F64F3E/final-summary.md
+++ b/larch-logs/implement/731D4E20-0813-450A-B7D4-945713F64F3E/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - Emergency: true
 - **Duration**: 00:21:53
-- **Cost**: 💰 TOTAL ~$7.44 — Claude $7.12, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.32  |  Tokens: 11831k
+- **Cost**: 💰 TOTAL ~$7.56 — Claude $7.24, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.32  |  Tokens: 12020k
 - **Issue**: #3721 — https://github.com/character-ai/larch/issues/3721
 - **PR**: #3729 — https://github.com/character-ai/larch/pull/3729
 - **Plan review**: N/A

--- a/larch-logs/implement/73C32412-4330-42E5-8CE8-6F708D608DB4/final-summary.md
+++ b/larch-logs/implement/73C32412-4330-42E5-8CE8-6F708D608DB4/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 01:20:58
-- **Cost**: 💰 TOTAL ~$17.44 — Claude $3.61, Codex $0.00, Cursor $13.83  |  Tokens: 42921k
+- **Cost**: 💰 TOTAL ~$12.80 — Claude $3.61, Codex $0.00, Cursor $9.19, Claude (subprocess) $0.00  |  Tokens: 42921k
 - **Issue**: #3119 — https://github.com/character-ai/larch/issues/3119
 - **Plan review**: N/A
 - **Code review**: 24/37 accepted

--- a/larch-logs/implement/765F22DA-1912-496F-91D7-F97024E81BC6/final-summary.md
+++ b/larch-logs/implement/765F22DA-1912-496F-91D7-F97024E81BC6/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - Emergency: true
 - **Duration**: 01:13:45
-- **Cost**: 💰 TOTAL ~$50.95 — Claude $49.89, Codex $0.00, Cursor $0.00, Claude (subprocess) $1.06  |  Tokens: 76359k
+- **Cost**: 💰 TOTAL ~$54.49 — Claude $53.43, Codex $0.00, Cursor $0.00, Claude (subprocess) $1.06  |  Tokens: 82584k
 - **Issue**: #3713 — https://github.com/character-ai/larch/issues/3713
 - **PR**: #3759 — https://github.com/character-ai/larch/pull/3759
 - **Plan review**: N/A

--- a/larch-logs/implement/768E9DCE-6452-4E7D-850A-2ABA615188BA/final-summary.md
+++ b/larch-logs/implement/768E9DCE-6452-4E7D-850A-2ABA615188BA/final-summary.md
@@ -3,7 +3,7 @@
 - **Outcome**: stalled
 - **Mode**: N/A
 - **Duration**: N/A
-- **Cost**: 💰 TOTAL ~$108.56 — Claude $57.71, Codex $10.38, Cursor $14.81, Claude (subprocess) $25.66  |  Tokens: 334501k
+- **Cost**: 💰 TOTAL ~$278.97 — Claude $83.14, Codex $151.92, Cursor $11.97, Claude (subprocess) $31.94  |  Tokens: 431262k
 - **Issue**: #3671 — https://github.com/character-ai/larch/issues/3671
 - **Plan review**: N/A
 - **Code review**: 39/44 accepted

--- a/larch-logs/implement/77895BEE-3939-4381-BE68-2BFB318CB216/final-summary.md
+++ b/larch-logs/implement/77895BEE-3939-4381-BE68-2BFB318CB216/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:35:12
-- **Cost**: 💰 TOTAL ~$6.37 — Claude $2.82, Codex $0.06, Cursor $3.49  |  Tokens: 9317k
+- **Cost**: 💰 TOTAL ~$5.35 — Claude $2.82, Codex $0.60, Cursor $1.93, Claude (subprocess) $0.00  |  Tokens: 9317k
 - **Issue**: #3291 — https://github.com/character-ai/larch/issues/3291
 - **Plan review**: N/A
 - **Code review**: 13/25 accepted

--- a/larch-logs/implement/780E7161-FD59-4BCD-B097-D9BA4FB097CF/final-summary.md
+++ b/larch-logs/implement/780E7161-FD59-4BCD-B097-D9BA4FB097CF/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:37:28
-- **Cost**: 💰 TOTAL ~$5.45 — Claude $1.86, Codex $0.08, Cursor $3.51  |  Tokens: 12359k
+- **Cost**: 💰 TOTAL ~$5.25 — Claude $2.19, Codex $0.92, Cursor $2.14, Claude (subprocess) $0.00  |  Tokens: 12850k
 - **Issue**: #3506 — https://github.com/character-ai/larch/issues/3506
 - **Plan review**: N/A
 - **Code review**: 6/10 accepted

--- a/larch-logs/implement/7878A82F-6169-4110-AAC5-56AF5DAD81FF/final-summary.md
+++ b/larch-logs/implement/7878A82F-6169-4110-AAC5-56AF5DAD81FF/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - Emergency: true
 - **Duration**: 00:32:23
-- **Cost**: 💰 TOTAL ~$9.78 — Claude $5.09, Codex $0.59, Cursor $2.60, Claude (subprocess) $1.50  |  Tokens: 18058k
+- **Cost**: 💰 TOTAL ~$17.51 — Claude $8.02, Codex $6.38, Cursor $1.61, Claude (subprocess) $1.50  |  Tokens: 21703k
 - **Issue**: #3824 — https://github.com/character-ai/larch/issues/3824
 - **PR**: #3840 — https://github.com/character-ai/larch/pull/3840
 - **Plan review**: N/A

--- a/larch-logs/implement/7890C050-7E0E-4C72-9154-5EFD250044F4/final-summary.md
+++ b/larch-logs/implement/7890C050-7E0E-4C72-9154-5EFD250044F4/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:54:55
-- **Cost**: 💰 TOTAL ~$19.55 — Claude $17.68, Codex $0.22, Cursor $1.65  |  Tokens: 31168k
+- **Cost**: 💰 TOTAL ~$21.24 — Claude $17.83, Codex $2.51, Cursor $0.90, Claude (subprocess) $0.00  |  Tokens: 31452k
 - **Issue**: #3153 — https://github.com/character-ai/larch/issues/3153
 - **PR**: #3167 — https://github.com/character-ai/larch/pull/3167
 - **Plan review**: N/A

--- a/larch-logs/implement/79543DBF-FB39-41F2-BCB4-A8C979905FD4/final-summary.md
+++ b/larch-logs/implement/79543DBF-FB39-41F2-BCB4-A8C979905FD4/final-summary.md
@@ -3,7 +3,7 @@
 - **Outcome**: bailed
 - **Mode**: N/A
 - **Duration**: 04:28:24
-- **Cost**: 💰 TOTAL ~$48.66 — Claude $5.48, Codex $11.77, Cursor $24.07, Claude (subprocess) $7.34  |  Tokens: 269824k
+- **Cost**: 💰 TOTAL ~$169.56 — Claude $8.89, Codex $136.87, Cursor $16.46, Claude (subprocess) $7.34  |  Tokens: 275079k
 - **Issue**: #3683 — https://github.com/character-ai/larch/issues/3683
 - **Plan review**: N/A
 - **Code review**: 45/63 accepted

--- a/larch-logs/implement/7972B556-6BDA-4160-8AD8-6117DA0B321B/final-summary.md
+++ b/larch-logs/implement/7972B556-6BDA-4160-8AD8-6117DA0B321B/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:27:20
-- **Cost**: 💰 TOTAL ~$7.51 — Claude $4.77, Codex $0.14, Cursor $2.60  |  Tokens: 12999k
+- **Cost**: 💰 TOTAL ~$7.90 — Claude $4.77, Codex $1.58, Cursor $1.55, Claude (subprocess) $0.00  |  Tokens: 12999k
 - **Issue**: #3008 — https://github.com/character-ai/larch/issues/3008
 - **Plan review**: N/A
 - **Code review**: 3/7 accepted

--- a/larch-logs/implement/7B3CC7B2-FF10-4B60-8145-8E754F86AD8E/final-summary.md
+++ b/larch-logs/implement/7B3CC7B2-FF10-4B60-8145-8E754F86AD8E/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:28:39
-- **Cost**: 💰 TOTAL ~$8.32 — Claude $5.04, Codex $0.19, Cursor $3.09  |  Tokens: 17036k
+- **Cost**: 💰 TOTAL ~$9.10 — Claude $5.04, Codex $2.10, Cursor $1.96, Claude (subprocess) $0.00  |  Tokens: 17036k
 - **Issue**: #2667 — https://github.com/character-ai/larch/issues/2667
 - **Plan review**: N/A
 - **Code review**: 2/7 accepted

--- a/larch-logs/implement/7C07740C-4D87-4220-A290-3174BAB20204/final-summary.md
+++ b/larch-logs/implement/7C07740C-4D87-4220-A290-3174BAB20204/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:57:43
-- **Cost**: 💰 TOTAL ~$8.35 — Claude $6.66, Codex $0.20, Cursor $1.49  |  Tokens: 11412k
+- **Cost**: 💰 TOTAL ~$7.66 — Claude $6.66, Codex $0.11, Cursor $0.89, Claude (subprocess) $0.00  |  Tokens: 11412k
 - **Issue**: #2752 — https://github.com/character-ai/larch/issues/2752
 - **Plan review**: N/A
 - **Code review**: 3/4 accepted

--- a/larch-logs/implement/7C50577A-6540-4392-9C33-04BD69C64E8E/final-summary.md
+++ b/larch-logs/implement/7C50577A-6540-4392-9C33-04BD69C64E8E/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:21:18
-- **Cost**: 💰 TOTAL ~$5.57 — Claude $4.08, Codex $0.07, Cursor $1.42  |  Tokens: 9038k
+- **Cost**: 💰 TOTAL ~$5.63 — Claude $4.08, Codex $0.75, Cursor $0.80, Claude (subprocess) $0.00  |  Tokens: 9038k
 - **Issue**: #3092 — https://github.com/character-ai/larch/issues/3092
 - **Plan review**: N/A
 - **Code review**: 0/2 accepted

--- a/larch-logs/implement/7CE63F7E-0865-4F08-9A79-06D3B9F62C44/final-summary.md
+++ b/larch-logs/implement/7CE63F7E-0865-4F08-9A79-06D3B9F62C44/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 01:03:36
-- **Cost**: 💰 TOTAL ~$16.01 — Claude $11.23, Codex $1.36, Cursor $3.42  |  Tokens: 49989k
+- **Cost**: 💰 TOTAL ~$29.53 — Claude $11.23, Codex $16.07, Cursor $2.23, Claude (subprocess) $0.00  |  Tokens: 49989k
 - **Issue**: #2996 — https://github.com/character-ai/larch/issues/2996
 - **PR**: #3026 — https://github.com/character-ai/larch/pull/3026
 - **Plan review**: N/A

--- a/larch-logs/implement/7DBF6E99-8AC8-4BBF-BDE3-577D5A610C34/final-summary.md
+++ b/larch-logs/implement/7DBF6E99-8AC8-4BBF-BDE3-577D5A610C34/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 02:15:14
-- **Cost**: 💰 TOTAL ~$37.01 — Claude $2.73, Codex $2.30, Cursor $31.98  |  Tokens: 123307k
+- **Cost**: 💰 TOTAL ~$49.81 — Claude $2.73, Codex $26.16, Cursor $20.92, Claude (subprocess) $0.00  |  Tokens: 123307k
 - **Issue**: #3416 — https://github.com/character-ai/larch/issues/3416
 - **Plan review**: N/A
 - **Code review**: 27/49 accepted

--- a/larch-logs/implement/7E909AF6-F03F-4592-974F-8D126388F308/final-summary.md
+++ b/larch-logs/implement/7E909AF6-F03F-4592-974F-8D126388F308/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:45:11
-- **Cost**: 💰 TOTAL ~$7.16 — Claude $4.84, Codex $0.76, Cursor $1.56  |  Tokens: 19845k
+- **Cost**: 💰 TOTAL ~$19.08 — Claude $9.32, Codex $8.83, Cursor $0.93, Claude (subprocess) $0.00  |  Tokens: 26825k
 - **Issue**: #3065 — https://github.com/character-ai/larch/issues/3065
 - **PR**: #3095 — https://github.com/character-ai/larch/pull/3095
 - **Plan review**: N/A

--- a/larch-logs/implement/7F4FC0F3-A21D-44F8-A9DC-922494A33915/final-summary.md
+++ b/larch-logs/implement/7F4FC0F3-A21D-44F8-A9DC-922494A33915/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:25:27
-- **Cost**: 💰 TOTAL ~$4.17 — Claude $2.18, Codex $0.12, Cursor $1.87  |  Tokens: 6751k
+- **Cost**: 💰 TOTAL ~$4.49 — Claude $2.18, Codex $1.26, Cursor $1.05, Claude (subprocess) $0.00  |  Tokens: 6751k
 - **Issue**: #3229 — https://github.com/character-ai/larch/issues/3229
 - **Plan review**: N/A
 - **Code review**: 2/6 accepted

--- a/larch-logs/implement/7F92BA4A-B009-4629-A342-B006DFF98A68/final-summary.md
+++ b/larch-logs/implement/7F92BA4A-B009-4629-A342-B006DFF98A68/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - Emergency: true
 - **Duration**: N/A
-- **Cost**: 💰 TOTAL ~$3.88 — Claude $3.88, Codex $0.00, Cursor $0.00  |  Tokens: 4090k
+- **Cost**: 💰 TOTAL ~$4.97 — Claude $4.97, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.00  |  Tokens: 5853k
 - **Issue**: #3640 — https://github.com/character-ai/larch/issues/3640
 - **Plan review**: N/A
 - **Code review**: N/A

--- a/larch-logs/implement/7FCB7826-E22C-40C6-B7E8-FAF36644C213/final-summary.md
+++ b/larch-logs/implement/7FCB7826-E22C-40C6-B7E8-FAF36644C213/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 01:50:26
-- **Cost**: 💰 TOTAL ~$23.29 — Claude $6.75, Codex $0.00, Cursor $16.54  |  Tokens: 46214k
+- **Cost**: 💰 TOTAL ~$17.19 — Claude $7.19, Codex $0.00, Cursor $10.00, Claude (subprocess) $0.00  |  Tokens: 46897k
 - **Issue**: #3246 — https://github.com/character-ai/larch/issues/3246
 - **PR**: #3336 — https://github.com/character-ai/larch/pull/3336
 - **Plan review**: N/A

--- a/larch-logs/implement/8307126A-87FB-4AC5-A232-465360BB59D1/final-summary.md
+++ b/larch-logs/implement/8307126A-87FB-4AC5-A232-465360BB59D1/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 01:48:02
-- **Cost**: 💰 TOTAL ~$55.00 — Claude $41.00, Codex $0.87, Cursor $13.13  |  Tokens: 101785k
+- **Cost**: 💰 TOTAL ~$59.33 — Claude $41.00, Codex $9.71, Cursor $8.62, Claude (subprocess) $0.00  |  Tokens: 101785k
 - **Issue**: #2973 — https://github.com/character-ai/larch/issues/2973
 - **PR**: #3027 — https://github.com/character-ai/larch/pull/3027
 - **Plan review**: N/A

--- a/larch-logs/implement/832C266C-7FD0-4C5F-AE0A-7DB5B14438FB/final-summary.md
+++ b/larch-logs/implement/832C266C-7FD0-4C5F-AE0A-7DB5B14438FB/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:20:33
-- **Cost**: 💰 TOTAL ~$5.28 — Claude $3.89, Codex $0.12, Cursor $1.27  |  Tokens: 7513k
+- **Cost**: 💰 TOTAL ~$4.64 — Claude $3.89, Codex $0.07, Cursor $0.68, Claude (subprocess) $0.00  |  Tokens: 7513k
 - **Issue**: #2681 — https://github.com/character-ai/larch/issues/2681
 - **PR**: #2695 — https://github.com/character-ai/larch/pull/2695
 - **Plan review**: N/A

--- a/larch-logs/implement/84ECCDB7-DF31-48B7-A3A7-449A279ECFBE/final-summary.md
+++ b/larch-logs/implement/84ECCDB7-DF31-48B7-A3A7-449A279ECFBE/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:13:30
-- **Cost**: 💰 TOTAL ~$3.26 — Claude $1.69, Codex $0.07, Cursor $1.50  |  Tokens: 5935k
+- **Cost**: 💰 TOTAL ~$3.31 — Claude $1.69, Codex $0.75, Cursor $0.87, Claude (subprocess) $0.00  |  Tokens: 5935k
 - **Issue**: #3003 — https://github.com/character-ai/larch/issues/3003
 - **Plan review**: N/A
 - **Code review**: 0/12 accepted

--- a/larch-logs/implement/85387E6D-3D68-475D-A94D-C0DAB59CA864/final-summary.md
+++ b/larch-logs/implement/85387E6D-3D68-475D-A94D-C0DAB59CA864/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 01:31:22
-- **Cost**: 💰 TOTAL ~$49.65 — Claude $39.43, Codex $1.56, Cursor $8.66  |  Tokens: 113189k
+- **Cost**: 💰 TOTAL ~$63.01 — Claude $39.43, Codex $18.17, Cursor $5.41, Claude (subprocess) $0.00  |  Tokens: 113189k
 - **Issue**: #2840 — https://github.com/character-ai/larch/issues/2840
 - **PR**: #2950 — https://github.com/character-ai/larch/pull/2950
 - **Plan review**: N/A

--- a/larch-logs/implement/853FA091-99A1-4852-9E6A-13AE4084B765/final-summary.md
+++ b/larch-logs/implement/853FA091-99A1-4852-9E6A-13AE4084B765/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 03:09:10
-- **Cost**: 💰 TOTAL ~$79.84 — Claude $59.42, Codex $1.87, Cursor $18.55  |  Tokens: 168941k
+- **Cost**: 💰 TOTAL ~$93.72 — Claude $60.23, Codex $21.38, Cursor $12.11, Claude (subprocess) $0.00  |  Tokens: 170498k
 - **Issue**: #2956 — https://github.com/character-ai/larch/issues/2956
 - **PR**: #3020 — https://github.com/character-ai/larch/pull/3020
 - **Plan review**: N/A

--- a/larch-logs/implement/8603AFE4-7CCE-4769-B1A4-366D3EF5ECDC/final-summary.md
+++ b/larch-logs/implement/8603AFE4-7CCE-4769-B1A4-366D3EF5ECDC/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:00:21
-- **Cost**: 💰 TOTAL ~$2.64 — Claude $2.64, Codex $0.00, Cursor $0.00  |  Tokens: 4838k
+- **Cost**: 💰 TOTAL ~$8.33 — Claude $8.33, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.00  |  Tokens: 11637k
 - **Issue**: #2757 — https://github.com/character-ai/larch/issues/2757
 - **PR**: #2816 — https://github.com/character-ai/larch/pull/2816
 - **Plan review**: N/A

--- a/larch-logs/implement/86B752B0-F330-415B-AFC0-65B7A6AE57D2/final-summary.md
+++ b/larch-logs/implement/86B752B0-F330-415B-AFC0-65B7A6AE57D2/final-summary.md
@@ -3,7 +3,7 @@
 - **Outcome**: bailed
 - **Mode**: N/A
 - **Duration**: 04:09:26
-- **Cost**: 💰 TOTAL ~$79.86 — Claude $15.53, Codex $13.77, Cursor $35.76, Claude (subprocess) $14.80  |  Tokens: 346058k
+- **Cost**: 💰 TOTAL ~$221.63 — Claude $22.95, Codex $160.51, Cursor $23.37, Claude (subprocess) $14.80  |  Tokens: 357114k
 - **Issue**: #3988 — https://github.com/character-ai/larch/issues/3988
 - **PR**: #4056 — https://github.com/character-ai/larch/pull/4056
 - **Plan review**: N/A

--- a/larch-logs/implement/872C093F-794B-419B-B726-12A01250BCBB/final-summary.md
+++ b/larch-logs/implement/872C093F-794B-419B-B726-12A01250BCBB/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:57:03
-- **Cost**: 💰 TOTAL ~$21.51 — Claude $12.19, Codex $1.75, Cursor $7.57  |  Tokens: 66625k
+- **Cost**: 💰 TOTAL ~$37.71 — Claude $12.19, Codex $20.70, Cursor $4.82, Claude (subprocess) $0.00  |  Tokens: 66625k
 - **Issue**: #2675 — https://github.com/character-ai/larch/issues/2675
 - **Plan review**: N/A
 - **Code review**: 12/16 accepted

--- a/larch-logs/implement/87D27538-4EBC-4EFC-B8E4-9DE642695340/final-summary.md
+++ b/larch-logs/implement/87D27538-4EBC-4EFC-B8E4-9DE642695340/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:56:11
-- **Cost**: 💰 TOTAL ~$14.84 — Claude $11.04, Codex $0.83, Cursor $2.97  |  Tokens: 38277k
+- **Cost**: 💰 TOTAL ~$22.53 — Claude $11.04, Codex $9.87, Cursor $1.62, Claude (subprocess) $0.00  |  Tokens: 38277k
 - **Issue**: #2909 — https://github.com/character-ai/larch/issues/2909
 - **Plan review**: N/A
 - **Code review**: 10/18 accepted

--- a/larch-logs/implement/89CCE706-060D-4EBF-9FEE-90653AAC6C2A/final-summary.md
+++ b/larch-logs/implement/89CCE706-060D-4EBF-9FEE-90653AAC6C2A/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 03:52:59
-- **Cost**: 💰 TOTAL ~$49.76 — Claude $6.71, Codex $2.94, Cursor $40.11  |  Tokens: 164753k
+- **Cost**: 💰 TOTAL ~$72.10 — Claude $11.32, Codex $34.43, Cursor $26.35, Claude (subprocess) $0.00  |  Tokens: 172168k
 - **Issue**: #3483 — https://github.com/character-ai/larch/issues/3483
 - **PR**: #3505 — https://github.com/character-ai/larch/pull/3505
 - **Plan review**: N/A

--- a/larch-logs/implement/8A4084D2-3DF7-4EB0-98A3-A766757FF4B0/final-summary.md
+++ b/larch-logs/implement/8A4084D2-3DF7-4EB0-98A3-A766757FF4B0/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:56:51
-- **Cost**: 💰 TOTAL ~$13.99 — Claude $7.06, Codex $0.16, Cursor $6.77  |  Tokens: 25607k
+- **Cost**: 💰 TOTAL ~$12.95 — Claude $7.06, Codex $1.77, Cursor $4.12, Claude (subprocess) $0.00  |  Tokens: 25607k
 - **Issue**: #3231 — https://github.com/character-ai/larch/issues/3231
 - **Plan review**: N/A
 - **Code review**: 17/25 accepted

--- a/larch-logs/implement/8C4263AB-52D7-44E1-90AF-A0BDF6362CD5/final-summary.md
+++ b/larch-logs/implement/8C4263AB-52D7-44E1-90AF-A0BDF6362CD5/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 01:23:45
-- **Cost**: 💰 TOTAL ~$17.42 — Claude $9.39, Codex $1.14, Cursor $6.89  |  Tokens: 44116k
+- **Cost**: 💰 TOTAL ~$26.55 — Claude $9.39, Codex $12.84, Cursor $4.32, Claude (subprocess) $0.00  |  Tokens: 44116k
 - **Issue**: #3064 — https://github.com/character-ai/larch/issues/3064
 - **PR**: #3088 — https://github.com/character-ai/larch/pull/3088
 - **Plan review**: N/A

--- a/larch-logs/implement/9087695F-7471-44AE-B16A-E08A2BBBDAAD/final-summary.md
+++ b/larch-logs/implement/9087695F-7471-44AE-B16A-E08A2BBBDAAD/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 01:22:29
-- **Cost**: 💰 TOTAL ~$20.32 — Claude $13.32, Codex $0.23, Cursor $6.77  |  Tokens: 34090k
+- **Cost**: 💰 TOTAL ~$18.41 — Claude $13.65, Codex $0.13, Cursor $4.63, Claude (subprocess) $0.00  |  Tokens: 34668k
 - **Issue**: #2749 — https://github.com/character-ai/larch/issues/2749
 - **PR**: #2786 — https://github.com/character-ai/larch/pull/2786
 - **Plan review**: N/A

--- a/larch-logs/implement/91EB5232-894D-4037-AAFB-CBDA2BCBB676/final-summary.md
+++ b/larch-logs/implement/91EB5232-894D-4037-AAFB-CBDA2BCBB676/final-summary.md
@@ -3,7 +3,7 @@
 - **Outcome**: bailed
 - **Mode**: N/A
 - **Duration**: 01:44:06
-- **Cost**: 💰 TOTAL ~$12.85 — Claude $4.73, Codex $1.74, Cursor $4.11, Claude (subprocess) $2.27  |  Tokens: 44356k
+- **Cost**: 💰 TOTAL ~$32.87 — Claude $7.90, Codex $20.04, Cursor $2.66, Claude (subprocess) $2.27  |  Tokens: 46363k
 - **Issue**: #4011 — https://github.com/character-ai/larch/issues/4011
 - **PR**: #4063 — https://github.com/character-ai/larch/pull/4063
 - **Plan review**: N/A

--- a/larch-logs/implement/92C5CF40-7394-47F6-8801-5EEE3DDBA392/final-summary.md
+++ b/larch-logs/implement/92C5CF40-7394-47F6-8801-5EEE3DDBA392/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:19:13
-- **Cost**: 💰 TOTAL ~$5.20 — Claude $4.30, Codex $0.05, Cursor $0.85  |  Tokens: 8567k
+- **Cost**: 💰 TOTAL ~$5.27 — Claude $4.30, Codex $0.50, Cursor $0.47, Claude (subprocess) $0.00  |  Tokens: 8567k
 - **Issue**: #3160 — https://github.com/character-ai/larch/issues/3160
 - **PR**: #3171 — https://github.com/character-ai/larch/pull/3171
 - **Plan review**: N/A

--- a/larch-logs/implement/93ECABD5-3C78-48A4-A513-2637C778646A/final-summary.md
+++ b/larch-logs/implement/93ECABD5-3C78-48A4-A513-2637C778646A/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:20:00
-- **Cost**: 💰 TOTAL ~$4.93 — Claude $2.54, Codex $0.08, Cursor $2.31  |  Tokens: 9232k
+- **Cost**: 💰 TOTAL ~$4.83 — Claude $2.54, Codex $0.83, Cursor $1.46, Claude (subprocess) $0.00  |  Tokens: 9232k
 - **Issue**: #3176 — https://github.com/character-ai/larch/issues/3176
 - **Plan review**: N/A
 - **Code review**: 0/3 accepted

--- a/larch-logs/implement/93F42F62-225D-489F-8A7B-0AE6E9CB509C/final-summary.md
+++ b/larch-logs/implement/93F42F62-225D-489F-8A7B-0AE6E9CB509C/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 03:27:21
-- **Cost**: 💰 TOTAL ~$44.83 — Claude $5.27, Codex $2.13, Cursor $37.43  |  Tokens: 136457k
+- **Cost**: 💰 TOTAL ~$54.59 — Claude $5.81, Codex $23.91, Cursor $24.87, Claude (subprocess) $0.00  |  Tokens: 137254k
 - **Issue**: #3529 — https://github.com/character-ai/larch/issues/3529
 - **Plan review**: N/A
 - **Code review**: 47/83 accepted

--- a/larch-logs/implement/9563A912-2BA4-45D4-B895-31F975E04A55/final-summary.md
+++ b/larch-logs/implement/9563A912-2BA4-45D4-B895-31F975E04A55/final-summary.md
@@ -3,7 +3,7 @@
 - **Outcome**: stalled
 - **Mode**: N/A
 - **Duration**: 03:20:54
-- **Cost**: 💰 TOTAL ~$63.42 — Claude $13.95, Codex $8.51, Cursor $18.87, Claude (subprocess) $22.09  |  Tokens: 206015k
+- **Cost**: 💰 TOTAL ~$152.74 — Claude $20.21, Codex $98.08, Cursor $12.36, Claude (subprocess) $22.09  |  Tokens: 216359k
 - **Issue**: #3826 — https://github.com/character-ai/larch/issues/3826
 - **PR**: #3944 — https://github.com/character-ai/larch/pull/3944
 - **Plan review**: N/A

--- a/larch-logs/implement/95BBFEB9-2F24-4DDF-A00A-A44DE8A8D707/final-summary.md
+++ b/larch-logs/implement/95BBFEB9-2F24-4DDF-A00A-A44DE8A8D707/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - Emergency: true
 - **Duration**: 00:23:40
-- **Cost**: 💰 TOTAL ~$7.84 — Claude $7.49, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.35  |  Tokens: 10769k
+- **Cost**: 💰 TOTAL ~$10.93 — Claude $10.58, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.35  |  Tokens: 16159k
 - **Issue**: #3705 — https://github.com/character-ai/larch/issues/3705
 - **PR**: #3711 — https://github.com/character-ai/larch/pull/3711
 - **Plan review**: N/A

--- a/larch-logs/implement/96652F79-6D4D-4813-8CBA-B90052D7FAFD/final-summary.md
+++ b/larch-logs/implement/96652F79-6D4D-4813-8CBA-B90052D7FAFD/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 02:09:02
-- **Cost**: 💰 TOTAL ~$34.18 — Claude $5.80, Codex $2.34, Cursor $26.04  |  Tokens: 119249k
+- **Cost**: 💰 TOTAL ~$51.82 — Claude $6.79, Codex $27.05, Cursor $17.98, Claude (subprocess) $0.00  |  Tokens: 120560k
 - **Issue**: #3432 — https://github.com/character-ai/larch/issues/3432
 - **Plan review**: N/A
 - **Code review**: 34/59 accepted

--- a/larch-logs/implement/96AD92B5-31FE-4B0B-B56D-39A87134423D/final-summary.md
+++ b/larch-logs/implement/96AD92B5-31FE-4B0B-B56D-39A87134423D/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 01:15:09
-- **Cost**: 💰 TOTAL ~$32.31 — Claude $22.88, Codex $0.82, Cursor $8.61  |  Tokens: 64753k
+- **Cost**: 💰 TOTAL ~$37.23 — Claude $22.88, Codex $9.35, Cursor $5.00, Claude (subprocess) $0.00  |  Tokens: 64753k
 - **Issue**: #2848 — https://github.com/character-ai/larch/issues/2848
 - **PR**: #2890 — https://github.com/character-ai/larch/pull/2890
 - **Plan review**: N/A

--- a/larch-logs/implement/984F0AA4-4436-40F3-A82E-9D114C1A58B4/final-summary.md
+++ b/larch-logs/implement/984F0AA4-4436-40F3-A82E-9D114C1A58B4/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:51:56
-- **Cost**: 💰 TOTAL ~$14.99 — Claude $9.73, Codex $0.60, Cursor $4.66  |  Tokens: 31033k
+- **Cost**: 💰 TOTAL ~$19.31 — Claude $9.73, Codex $6.78, Cursor $2.80, Claude (subprocess) $0.00  |  Tokens: 31033k
 - **Issue**: #2958 — https://github.com/character-ai/larch/issues/2958
 - **Plan review**: N/A
 - **Code review**: 9/26 accepted

--- a/larch-logs/implement/98DF808B-BC0D-4942-A150-D4F6749DC4B3/final-summary.md
+++ b/larch-logs/implement/98DF808B-BC0D-4942-A150-D4F6749DC4B3/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:33:01
-- **Cost**: 💰 TOTAL ~$8.94 — Claude $4.18, Codex $0.23, Cursor $4.53  |  Tokens: 18490k
+- **Cost**: 💰 TOTAL ~$7.41 — Claude $4.18, Codex $0.13, Cursor $3.10, Claude (subprocess) $0.00  |  Tokens: 18490k
 - **Issue**: #2669 — https://github.com/character-ai/larch/issues/2669
 - **Plan review**: N/A
 - **Code review**: N/A

--- a/larch-logs/implement/996FF59E-D201-42A5-BE34-92CB639A9F2A/final-summary.md
+++ b/larch-logs/implement/996FF59E-D201-42A5-BE34-92CB639A9F2A/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 02:29:23
-- **Cost**: 💰 TOTAL ~$75.99 — Claude $58.14, Codex $0.21, Cursor $17.64  |  Tokens: 147150k
+- **Cost**: 💰 TOTAL ~$70.61 — Claude $58.14, Codex $0.11, Cursor $12.36, Claude (subprocess) $0.00  |  Tokens: 147150k
 - **Issue**: #2395 — https://github.com/character-ai/larch/issues/2395
 - **PR**: #2649 — https://github.com/character-ai/larch/pull/2649
 - **Plan review**: N/A

--- a/larch-logs/implement/999D0F6D-F192-456D-9D05-0D8488CAB783/final-summary.md
+++ b/larch-logs/implement/999D0F6D-F192-456D-9D05-0D8488CAB783/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 03:18:37
-- **Cost**: 💰 TOTAL ~$49.94 — Claude $31.03, Codex $1.98, Cursor $16.93  |  Tokens: 92049k
+- **Cost**: 💰 TOTAL ~$64.35 — Claude $31.03, Codex $22.64, Cursor $10.68, Claude (subprocess) $0.00  |  Tokens: 92049k
 - **Issue**: #3134 — https://github.com/character-ai/larch/issues/3134
 - **PR**: #3157 — https://github.com/character-ai/larch/pull/3157
 - **Plan review**: N/A

--- a/larch-logs/implement/999E9639-776C-4845-B96C-C88CDAE19802/final-summary.md
+++ b/larch-logs/implement/999E9639-776C-4845-B96C-C88CDAE19802/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:40:49
-- **Cost**: 💰 TOTAL ~$6.50 — Claude $4.68, Codex $0.17, Cursor $1.65  |  Tokens: 7701k
+- **Cost**: 💰 TOTAL ~$5.72 — Claude $4.68, Codex $0.09, Cursor $0.95, Claude (subprocess) $0.00  |  Tokens: 7701k
 - **Issue**: #2753 — https://github.com/character-ai/larch/issues/2753
 - **Plan review**: N/A
 - **Code review**: N/A

--- a/larch-logs/implement/99B77286-D5F5-47FD-922B-097CC29C3D23/final-summary.md
+++ b/larch-logs/implement/99B77286-D5F5-47FD-922B-097CC29C3D23/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - Emergency: true
 - **Duration**: 00:42:07
-- **Cost**: 💰 TOTAL ~$16.49 — Claude $10.23, Codex $0.69, Cursor $3.87, Claude (subprocess) $1.70  |  Tokens: 31329k
+- **Cost**: 💰 TOTAL ~$26.76 — Claude $15.02, Codex $7.56, Cursor $2.48, Claude (subprocess) $1.70  |  Tokens: 39574k
 - **Issue**: #3799 — https://github.com/character-ai/larch/issues/3799
 - **PR**: #3800 — https://github.com/character-ai/larch/pull/3800
 - **Plan review**: N/A

--- a/larch-logs/implement/9A1C14C0-A2FE-42F1-A092-7936E9BEB6F1/final-summary.md
+++ b/larch-logs/implement/9A1C14C0-A2FE-42F1-A092-7936E9BEB6F1/final-summary.md
@@ -3,7 +3,7 @@
 - **Outcome**: bailed
 - **Mode**: N/A
 - **Duration**: 05:40:18
-- **Cost**: 💰 TOTAL ~$63.67 — Claude $11.52, Codex $10.16, Cursor $33.02, Claude (subprocess) $8.97  |  Tokens: 268634k
+- **Cost**: 💰 TOTAL ~$162.54 — Claude $13.98, Codex $116.97, Cursor $22.62, Claude (subprocess) $8.97  |  Tokens: 272333k
 - **Issue**: #3927 — https://github.com/character-ai/larch/issues/3927
 - **PR**: #4089 — https://github.com/character-ai/larch/pull/4089
 - **Plan review**: N/A

--- a/larch-logs/implement/9CACF812-1A27-43F9-8655-DCE7BBA37BB5/final-summary.md
+++ b/larch-logs/implement/9CACF812-1A27-43F9-8655-DCE7BBA37BB5/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:34:46
-- **Cost**: 💰 TOTAL ~$10.70 — Claude $8.03, Codex $0.60, Cursor $2.07  |  Tokens: 24887k
+- **Cost**: 💰 TOTAL ~$16.23 — Claude $8.03, Codex $6.91, Cursor $1.29, Claude (subprocess) $0.00  |  Tokens: 24887k
 - **Issue**: #3013 — https://github.com/character-ai/larch/issues/3013
 - **PR**: #3056 — https://github.com/character-ai/larch/pull/3056
 - **Plan review**: N/A

--- a/larch-logs/implement/9DBAFE52-DCB3-4510-9468-70F24F4BEEB9/final-summary.md
+++ b/larch-logs/implement/9DBAFE52-DCB3-4510-9468-70F24F4BEEB9/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 01:06:07
-- **Cost**: 💰 TOTAL ~$26.66 — Claude $14.09, Codex $0.22, Cursor $12.35  |  Tokens: 50153k
+- **Cost**: 💰 TOTAL ~$27.97 — Claude $19.29, Codex $0.12, Cursor $8.56, Claude (subprocess) $0.00  |  Tokens: 56316k
 - **Issue**: #2676 — https://github.com/character-ai/larch/issues/2676
 - **PR**: #2746 — https://github.com/character-ai/larch/pull/2746
 - **Plan review**: N/A

--- a/larch-logs/implement/9E54281B-14E7-4B10-B629-88E9628F05ED/final-summary.md
+++ b/larch-logs/implement/9E54281B-14E7-4B10-B629-88E9628F05ED/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - Emergency: true
 - **Duration**: 00:11:14
-- **Cost**: 💰 TOTAL ~$4.25 — Claude $4.25, Codex $0.00, Cursor $0.00  |  Tokens: 6581k
+- **Cost**: 💰 TOTAL ~$4.25 — Claude $4.25, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.00  |  Tokens: 6581k
 - **Issue**: #3593 — https://github.com/character-ai/larch/issues/3593
 - **Plan review**: N/A
 - **Code review**: N/A

--- a/larch-logs/implement/9EE1AC19-012D-4798-8EB6-51F799ACFC25/final-summary.md
+++ b/larch-logs/implement/9EE1AC19-012D-4798-8EB6-51F799ACFC25/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 02:29:28
-- **Cost**: 💰 TOTAL ~$28.23 — Claude $7.53, Codex $0.00, Cursor $20.70  |  Tokens: 60994k
+- **Cost**: 💰 TOTAL ~$20.68 — Claude $7.53, Codex $0.00, Cursor $13.15, Claude (subprocess) $0.00  |  Tokens: 60994k
 - **Issue**: #3235 — https://github.com/character-ai/larch/issues/3235
 - **PR**: #3294 — https://github.com/character-ai/larch/pull/3294
 - **Plan review**: N/A

--- a/larch-logs/implement/A0F54582-D6F7-4FD1-B7BC-D1B2B7B226E7/final-summary.md
+++ b/larch-logs/implement/A0F54582-D6F7-4FD1-B7BC-D1B2B7B226E7/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 01:16:32
-- **Cost**: 💰 TOTAL ~$22.62 — Claude $11.64, Codex $0.71, Cursor $10.27  |  Tokens: 40028k
+- **Cost**: 💰 TOTAL ~$18.80 — Claude $11.64, Codex $0.39, Cursor $6.77, Claude (subprocess) $0.00  |  Tokens: 40028k
 - **Issue**: #2670 — https://github.com/character-ai/larch/issues/2670
 - **Plan review**: N/A
 - **Code review**: 22/40 accepted

--- a/larch-logs/implement/A13D0757-70AD-4A5C-A053-C2524FF3D8C3/final-summary.md
+++ b/larch-logs/implement/A13D0757-70AD-4A5C-A053-C2524FF3D8C3/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:30:44
-- **Cost**: 💰 TOTAL ~$13.14 — Claude $10.65, Codex $0.25, Cursor $2.24  |  Tokens: 25043k
+- **Cost**: 💰 TOTAL ~$24.39 — Claude $20.19, Codex $2.83, Cursor $1.37, Claude (subprocess) $0.00  |  Tokens: 40476k
 - **Issue**: #2807 — https://github.com/character-ai/larch/issues/2807
 - **PR**: #2949 — https://github.com/character-ai/larch/pull/2949
 - **Plan review**: N/A

--- a/larch-logs/implement/A322FFAE-04BB-4430-A270-D2F5F848345B/final-summary.md
+++ b/larch-logs/implement/A322FFAE-04BB-4430-A270-D2F5F848345B/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 02:29:50
-- **Cost**: 💰 TOTAL ~$24.16 — Claude $20.80, Codex $0.22, Cursor $3.14  |  Tokens: 36785k
+- **Cost**: 💰 TOTAL ~$25.25 — Claude $20.80, Codex $2.45, Cursor $2.00, Claude (subprocess) $0.00  |  Tokens: 36785k
 - **Issue**: #3091 — https://github.com/character-ai/larch/issues/3091
 - **PR**: #3123 — https://github.com/character-ai/larch/pull/3123
 - **Plan review**: N/A

--- a/larch-logs/implement/A335AEDF-60E9-454A-81C8-42F61809CA0F/final-summary.md
+++ b/larch-logs/implement/A335AEDF-60E9-454A-81C8-42F61809CA0F/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:56:17
-- **Cost**: 💰 TOTAL ~$36.34 — Claude $26.25, Codex $0.85, Cursor $9.24  |  Tokens: 78312k
+- **Cost**: 💰 TOTAL ~$56.20 — Claude $37.19, Codex $10.86, Cursor $8.15, Claude (subprocess) $0.00  |  Tokens: 108386k
 - **Issue**: #2881 — https://github.com/character-ai/larch/issues/2881
 - **PR**: #2940 — https://github.com/character-ai/larch/pull/2940
 - **Plan review**: N/A

--- a/larch-logs/implement/A3467B62-1786-4AFF-8592-C8DF44771B96/final-summary.md
+++ b/larch-logs/implement/A3467B62-1786-4AFF-8592-C8DF44771B96/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - Emergency: true
 - **Duration**: 00:11:08
-- **Cost**: 💰 TOTAL ~$3.53 — Claude $3.09, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.44  |  Tokens: 4711k
+- **Cost**: 💰 TOTAL ~$3.78 — Claude $3.34, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.44  |  Tokens: 5152k
 - **Issue**: #4023 — https://github.com/character-ai/larch/issues/4023
 - **Plan review**: N/A
 - **Code review**: N/A

--- a/larch-logs/implement/A48FB3A1-9E93-477A-A1AC-ADCCAA4DD098/final-summary.md
+++ b/larch-logs/implement/A48FB3A1-9E93-477A-A1AC-ADCCAA4DD098/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 01:08:46
-- **Cost**: 💰 TOTAL ~$17.68 — Claude $9.92, Codex $0.22, Cursor $7.54  |  Tokens: 33211k
+- **Cost**: 💰 TOTAL ~$15.08 — Claude $9.92, Codex $0.12, Cursor $5.04, Claude (subprocess) $0.00  |  Tokens: 33211k
 - **Issue**: #2637 — https://github.com/character-ai/larch/issues/2637
 - **Plan review**: N/A
 - **Code review**: 14/17 accepted

--- a/larch-logs/implement/A4BF0BB1-9F01-4EBE-852B-D339CE55DF49/final-summary.md
+++ b/larch-logs/implement/A4BF0BB1-9F01-4EBE-852B-D339CE55DF49/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 01:23:00
-- **Cost**: 💰 TOTAL ~$12.91 — Claude $11.12, Codex $0.18, Cursor $1.61  |  Tokens: 17974k
+- **Cost**: 💰 TOTAL ~$12.14 — Claude $11.12, Codex $0.10, Cursor $0.92, Claude (subprocess) $0.00  |  Tokens: 17974k
 - **Issue**: #2800 — https://github.com/character-ai/larch/issues/2800
 - **PR**: #2819 — https://github.com/character-ai/larch/pull/2819
 - **Plan review**: N/A

--- a/larch-logs/implement/A5E5DDFA-7854-4D6E-8503-E31D3983568B/final-summary.md
+++ b/larch-logs/implement/A5E5DDFA-7854-4D6E-8503-E31D3983568B/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:23:01
-- **Cost**: 💰 TOTAL ~$4.75 — Claude $3.56, Codex $0.14, Cursor $1.05  |  Tokens: 6383k
+- **Cost**: 💰 TOTAL ~$4.19 — Claude $3.56, Codex $0.08, Cursor $0.55, Claude (subprocess) $0.00  |  Tokens: 6383k
 - **Issue**: #2718 — https://github.com/character-ai/larch/issues/2718
 - **Plan review**: N/A
 - **Code review**: 2/4 accepted

--- a/larch-logs/implement/A6172AC2-1871-4B6D-A47B-AF77F3D427D0/final-summary.md
+++ b/larch-logs/implement/A6172AC2-1871-4B6D-A47B-AF77F3D427D0/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 02:59:47
-- **Cost**: 💰 TOTAL ~$29.65 — Claude $28.20, Codex $1.45, Cursor $0.00  |  Tokens: 57434k
+- **Cost**: 💰 TOTAL ~$44.60 — Claude $28.20, Codex $16.40, Cursor $0.00, Claude (subprocess) $0.00  |  Tokens: 57434k
 - **Issue**: #3446 — https://github.com/character-ai/larch/issues/3446
 - **Plan review**: N/A
 - **Code review**: 25/28 accepted

--- a/larch-logs/implement/A62932DA-EEC7-45C6-AA54-FF66E654C2F5/final-summary.md
+++ b/larch-logs/implement/A62932DA-EEC7-45C6-AA54-FF66E654C2F5/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:54:53
-- **Cost**: 💰 TOTAL ~$2.29 — Claude $1.86, Codex $0.43, Cursor $0.00  |  Tokens: 6322k
+- **Cost**: 💰 TOTAL ~$6.81 — Claude $2.09, Codex $4.72, Cursor $0.00, Claude (subprocess) $0.00  |  Tokens: 6683k
 - **Issue**: #3471 — https://github.com/character-ai/larch/issues/3471
 - **Plan review**: N/A
 - **Code review**: 1/19 accepted

--- a/larch-logs/implement/A635EF50-17F6-497D-943B-DE4D1856B464/final-summary.md
+++ b/larch-logs/implement/A635EF50-17F6-497D-943B-DE4D1856B464/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - Emergency: true
 - **Duration**: 00:56:24
-- **Cost**: 💰 TOTAL ~$64.86 — Claude $64.86, Codex $0.00, Cursor $0.00  |  Tokens: 115671k
+- **Cost**: 💰 TOTAL ~$65.35 — Claude $65.35, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.00  |  Tokens: 116564k
 - **Issue**: #3647 — https://github.com/character-ai/larch/issues/3647
 - **Plan review**: N/A
 - **Code review**: N/A

--- a/larch-logs/implement/A759DE7A-F265-4A1F-AAF5-E3F9ECE45D8E/final-summary.md
+++ b/larch-logs/implement/A759DE7A-F265-4A1F-AAF5-E3F9ECE45D8E/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 02:59:16
-- **Cost**: 💰 TOTAL ~$27.52 — Claude $7.47, Codex $0.82, Cursor $19.23  |  Tokens: 75756k
+- **Cost**: 💰 TOTAL ~$31.34 — Claude $9.29, Codex $9.67, Cursor $12.38, Claude (subprocess) $0.00  |  Tokens: 78936k
 - **Issue**: #3238 — https://github.com/character-ai/larch/issues/3238
 - **PR**: #3340 — https://github.com/character-ai/larch/pull/3340
 - **Plan review**: N/A

--- a/larch-logs/implement/A7FD6AAD-B170-4891-99E3-D61BD94AFFD1/final-summary.md
+++ b/larch-logs/implement/A7FD6AAD-B170-4891-99E3-D61BD94AFFD1/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 07:14:10
-- **Cost**: 💰 TOTAL ~$30.98 — Claude $10.63, Codex $0.00, Cursor $20.35  |  Tokens: 58722k
+- **Cost**: 💰 TOTAL ~$27.52 — Claude $14.87, Codex $0.00, Cursor $12.65, Claude (subprocess) $0.00  |  Tokens: 61726k
 - **Issue**: #3202 — https://github.com/character-ai/larch/issues/3202
 - **PR**: #3228 — https://github.com/character-ai/larch/pull/3228
 - **Plan review**: N/A

--- a/larch-logs/implement/A8E5F430-A318-4167-B0B0-924B6DB39811/final-summary.md
+++ b/larch-logs/implement/A8E5F430-A318-4167-B0B0-924B6DB39811/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:38:47
-- **Cost**: 💰 TOTAL ~$7.42 — Claude $3.31, Codex $0.21, Cursor $3.90  |  Tokens: 15279k
+- **Cost**: 💰 TOTAL ~$8.05 — Claude $3.31, Codex $2.26, Cursor $2.48, Claude (subprocess) $0.00  |  Tokens: 15279k
 - **Issue**: #3116 — https://github.com/character-ai/larch/issues/3116
 - **Plan review**: N/A
 - **Code review**: 7/10 accepted

--- a/larch-logs/implement/A90A3BA0-746B-472B-8EBA-5E190ADC5BA9/final-summary.md
+++ b/larch-logs/implement/A90A3BA0-746B-472B-8EBA-5E190ADC5BA9/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - Emergency: true
 - **Duration**: 00:04:54
-- **Cost**: 💰 TOTAL ~$1.44 — Claude $1.28, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.16  |  Tokens: 1845k
+- **Cost**: 💰 TOTAL ~$1.71 — Claude $1.55, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.16  |  Tokens: 2233k
 - **Issue**: #3701 — https://github.com/character-ai/larch/issues/3701
 - **Plan review**: N/A
 - **Code review**: N/A

--- a/larch-logs/implement/A98F8B4A-4027-4546-8EAE-F811175DDFB6/final-summary.md
+++ b/larch-logs/implement/A98F8B4A-4027-4546-8EAE-F811175DDFB6/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:15:07
-- **Cost**: 💰 TOTAL ~$6.20 — Claude $5.08, Codex $0.06, Cursor $1.06  |  Tokens: 10517k
+- **Cost**: 💰 TOTAL ~$6.34 — Claude $5.08, Codex $0.66, Cursor $0.60, Claude (subprocess) $0.00  |  Tokens: 10517k
 - **Issue**: #3161 — https://github.com/character-ai/larch/issues/3161
 - **PR**: #3170 — https://github.com/character-ai/larch/pull/3170
 - **Plan review**: N/A

--- a/larch-logs/implement/ACA45728-FC41-4E91-AD8F-94F5BCAA3467/final-summary.md
+++ b/larch-logs/implement/ACA45728-FC41-4E91-AD8F-94F5BCAA3467/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 05:28:09
-- **Cost**: 💰 TOTAL ~$150.72 — Claude $125.76, Codex $0.20, Cursor $24.76  |  Tokens: 277136k
+- **Cost**: 💰 TOTAL ~$146.75 — Claude $128.74, Codex $2.28, Cursor $15.73, Claude (subprocess) $0.00  |  Tokens: 282935k
 - **Issue**: #3227 — https://github.com/character-ai/larch/issues/3227
 - **PR**: #3270 — https://github.com/character-ai/larch/pull/3270
 - **Plan review**: N/A

--- a/larch-logs/implement/AD8E98EC-D87E-4151-8F2E-C111C70FE3BE/final-summary.md
+++ b/larch-logs/implement/AD8E98EC-D87E-4151-8F2E-C111C70FE3BE/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 01:51:01
-- **Cost**: 💰 TOTAL ~$14.11 — Claude $5.70, Codex $0.00, Cursor $8.41  |  Tokens: 27095k
+- **Cost**: 💰 TOTAL ~$12.53 — Claude $7.43, Codex $0.00, Cursor $5.10, Claude (subprocess) $0.00  |  Tokens: 29942k
 - **Issue**: #3393 — https://github.com/character-ai/larch/issues/3393
 - **PR**: #3399 — https://github.com/character-ai/larch/pull/3399
 - **Plan review**: N/A

--- a/larch-logs/implement/AD92FDB0-6310-4A04-AEE1-FF731CB490BF/final-summary.md
+++ b/larch-logs/implement/AD92FDB0-6310-4A04-AEE1-FF731CB490BF/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - Emergency: true
 - **Duration**: 00:22:07
-- **Cost**: 💰 TOTAL ~$13.55 — Claude $13.55, Codex $0.00, Cursor $0.00  |  Tokens: 23453k
+- **Cost**: 💰 TOTAL ~$13.82 — Claude $13.82, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.00  |  Tokens: 23908k
 - **Issue**: #3649 — https://github.com/character-ai/larch/issues/3649
 - **Plan review**: N/A
 - **Code review**: N/A

--- a/larch-logs/implement/AD9528B6-871D-4B2B-B860-A6FD23B44457/final-summary.md
+++ b/larch-logs/implement/AD9528B6-871D-4B2B-B860-A6FD23B44457/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:45:12
-- **Cost**: 💰 TOTAL ~$10.67 — Claude $3.79, Codex $0.00, Cursor $6.88  |  Tokens: 22707k
+- **Cost**: 💰 TOTAL ~$8.66 — Claude $4.06, Codex $0.00, Cursor $4.60, Claude (subprocess) $0.00  |  Tokens: 23046k
 - **Issue**: #3534 — https://github.com/character-ai/larch/issues/3534
 - **Plan review**: N/A
 - **Code review**: 4/20 accepted

--- a/larch-logs/implement/ADFFB544-3067-4228-9241-1EE423325DF3/final-summary.md
+++ b/larch-logs/implement/ADFFB544-3067-4228-9241-1EE423325DF3/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:17:35
-- **Cost**: 💰 TOTAL ~$5.63 — Claude $3.14, Codex $0.19, Cursor $2.30  |  Tokens: 8966k
+- **Cost**: 💰 TOTAL ~$4.59 — Claude $3.14, Codex $0.11, Cursor $1.34, Claude (subprocess) $0.00  |  Tokens: 8966k
 - **Issue**: #2654 — https://github.com/character-ai/larch/issues/2654
 - **Plan review**: N/A
 - **Code review**: N/A

--- a/larch-logs/implement/B038945C-DDE6-4D32-B9F3-30A7A136693D/final-summary.md
+++ b/larch-logs/implement/B038945C-DDE6-4D32-B9F3-30A7A136693D/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:43:40
-- **Cost**: 💰 TOTAL ~$8.36 — Claude $4.63, Codex $0.80, Cursor $2.93  |  Tokens: 25017k
+- **Cost**: 💰 TOTAL ~$15.71 — Claude $4.63, Codex $9.17, Cursor $1.91, Claude (subprocess) $0.00  |  Tokens: 25017k
 - **Issue**: #3077 — https://github.com/character-ai/larch/issues/3077
 - **Plan review**: N/A
 - **Code review**: 3/7 accepted

--- a/larch-logs/implement/B0C1CCA5-AFE8-49E7-892D-4946025FC7D2/final-summary.md
+++ b/larch-logs/implement/B0C1CCA5-AFE8-49E7-892D-4946025FC7D2/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:19:10
-- **Cost**: 💰 TOTAL ~$8.91 — Claude $5.87, Codex $0.05, Cursor $2.99  |  Tokens: 12729k
+- **Cost**: 💰 TOTAL ~$7.85 — Claude $5.87, Codex $0.03, Cursor $1.95, Claude (subprocess) $0.00  |  Tokens: 12729k
 - **Issue**: #2638 — https://github.com/character-ai/larch/issues/2638
 - **Plan review**: N/A
 - **Code review**: N/A

--- a/larch-logs/implement/B20A31FA-C741-4188-A791-C6784392D994/final-summary.md
+++ b/larch-logs/implement/B20A31FA-C741-4188-A791-C6784392D994/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 03:44:45
-- **Cost**: 💰 TOTAL ~$45.91 — Claude $3.11, Codex $3.67, Cursor $39.13  |  Tokens: 165097k
+- **Cost**: 💰 TOTAL ~$70.93 — Claude $3.11, Codex $42.38, Cursor $25.44, Claude (subprocess) $0.00  |  Tokens: 165097k
 - **Issue**: #3411 — https://github.com/character-ai/larch/issues/3411
 - **Plan review**: N/A
 - **Code review**: 66/101 accepted

--- a/larch-logs/implement/B2282715-DC9F-4948-8480-101F6F78FA71/final-summary.md
+++ b/larch-logs/implement/B2282715-DC9F-4948-8480-101F6F78FA71/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - Emergency: true
 - **Duration**: 00:18:52
-- **Cost**: 💰 TOTAL ~$12.02 — Claude $12.02, Codex $0.00, Cursor $0.00  |  Tokens: 18901k
+- **Cost**: 💰 TOTAL ~$14.76 — Claude $14.76, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.00  |  Tokens: 23937k
 - **Issue**: #3632 — https://github.com/character-ai/larch/issues/3632
 - **PR**: #3634 — https://github.com/character-ai/larch/pull/3634
 - **Plan review**: N/A

--- a/larch-logs/implement/B3DA9E8F-AB91-495D-972E-256E300B30AE/final-summary.md
+++ b/larch-logs/implement/B3DA9E8F-AB91-495D-972E-256E300B30AE/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:29:47
-- **Cost**: 💰 TOTAL ~$9.04 — Claude $6.95, Codex $0.36, Cursor $1.73  |  Tokens: 18032k
+- **Cost**: 💰 TOTAL ~$11.94 — Claude $6.95, Codex $3.99, Cursor $1.00, Claude (subprocess) $0.00  |  Tokens: 18032k
 - **Issue**: #2867 — https://github.com/character-ai/larch/issues/2867
 - **Plan review**: N/A
 - **Code review**: 6/9 accepted

--- a/larch-logs/implement/B404D7C4-076F-4053-9936-228C941DC05C/final-summary.md
+++ b/larch-logs/implement/B404D7C4-076F-4053-9936-228C941DC05C/final-summary.md
@@ -3,7 +3,7 @@
 - **Outcome**: bailed
 - **Mode**: N/A
 - **Duration**: 01:36:50
-- **Cost**: 💰 TOTAL ~$14.91 — Claude $5.69, Codex $2.42, Cursor $6.80  |  Tokens: 49720k
+- **Cost**: 💰 TOTAL ~$36.74 — Claude $5.69, Codex $26.75, Cursor $4.30, Claude (subprocess) $0.00  |  Tokens: 49720k
 - **Issue**: #3544 — https://github.com/character-ai/larch/issues/3544
 - **PR**: #3600 — https://github.com/character-ai/larch/pull/3600
 - **Plan review**: N/A

--- a/larch-logs/implement/B41E675E-8596-443A-8B06-CB80E34356B0/final-summary.md
+++ b/larch-logs/implement/B41E675E-8596-443A-8B06-CB80E34356B0/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 01:50:16
-- **Cost**: 💰 TOTAL ~$22.41 — Claude $12.44, Codex $1.40, Cursor $8.57  |  Tokens: 60207k
+- **Cost**: 💰 TOTAL ~$34.16 — Claude $12.44, Codex $16.23, Cursor $5.49, Claude (subprocess) $0.00  |  Tokens: 60207k
 - **Issue**: #2900 — https://github.com/character-ai/larch/issues/2900
 - **PR**: #3007 — https://github.com/character-ai/larch/pull/3007
 - **Plan review**: N/A

--- a/larch-logs/implement/B515EADC-79A1-491C-B6B7-9BC01B60F6FD/final-summary.md
+++ b/larch-logs/implement/B515EADC-79A1-491C-B6B7-9BC01B60F6FD/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - Emergency: true
 - **Duration**: 00:14:16
-- **Cost**: 💰 TOTAL ~$5.21 — Claude $5.21, Codex $0.00, Cursor $0.00  |  Tokens: 6350k
+- **Cost**: 💰 TOTAL ~$8.39 — Claude $8.39, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.00  |  Tokens: 11836k
 - **Issue**: #3596 — https://github.com/character-ai/larch/issues/3596
 - **PR**: #3608 — https://github.com/character-ai/larch/pull/3608
 - **Plan review**: N/A

--- a/larch-logs/implement/B70AE3A0-C7BD-4389-AA31-A8237E709DFD/final-summary.md
+++ b/larch-logs/implement/B70AE3A0-C7BD-4389-AA31-A8237E709DFD/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 05:19:13
-- **Cost**: 💰 TOTAL ~$47.53 — Claude $11.84, Codex $2.88, Cursor $32.81  |  Tokens: 145552k
+- **Cost**: 💰 TOTAL ~$73.20 — Claude $18.56, Codex $33.16, Cursor $21.48, Claude (subprocess) $0.00  |  Tokens: 153515k
 - **Issue**: #3466 — https://github.com/character-ai/larch/issues/3466
 - **PR**: #3492 — https://github.com/character-ai/larch/pull/3492
 - **Plan review**: N/A

--- a/larch-logs/implement/B74C7414-A51E-45DB-8ECD-2CEB4DCBC70B/final-summary.md
+++ b/larch-logs/implement/B74C7414-A51E-45DB-8ECD-2CEB4DCBC70B/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:43:36
-- **Cost**: 💰 TOTAL ~$9.82 — Claude $2.71, Codex $0.48, Cursor $6.63  |  Tokens: 22556k
+- **Cost**: 💰 TOTAL ~$12.03 — Claude $2.71, Codex $5.23, Cursor $4.09, Claude (subprocess) $0.00  |  Tokens: 22556k
 - **Issue**: #3288 — https://github.com/character-ai/larch/issues/3288
 - **Plan review**: N/A
 - **Code review**: 6/17 accepted

--- a/larch-logs/implement/B8C6997D-7ABB-4397-BCD4-49232EC63D02/final-summary.md
+++ b/larch-logs/implement/B8C6997D-7ABB-4397-BCD4-49232EC63D02/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - Emergency: true
 - **Duration**: 00:22:15
-- **Cost**: 💰 TOTAL ~$8.59 — Claude $8.59, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.00  |  Tokens: 13751k
+- **Cost**: 💰 TOTAL ~$8.97 — Claude $8.97, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.00  |  Tokens: 14373k
 - **Issue**: #3709 — https://github.com/character-ai/larch/issues/3709
 - **Plan review**: N/A
 - **Code review**: N/A

--- a/larch-logs/implement/B8EEF7CC-715C-4285-A6DC-D35B78177AD2/final-summary.md
+++ b/larch-logs/implement/B8EEF7CC-715C-4285-A6DC-D35B78177AD2/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 03:21:53
-- **Cost**: 💰 TOTAL ~$58.31 — Claude $14.50, Codex $3.72, Cursor $40.09  |  Tokens: 182145k
+- **Cost**: 💰 TOTAL ~$84.31 — Claude $14.72, Codex $42.95, Cursor $26.64, Claude (subprocess) $0.00  |  Tokens: 182854k
 - **Issue**: #3240 — https://github.com/character-ai/larch/issues/3240
 - **PR**: #3447 — https://github.com/character-ai/larch/pull/3447
 - **Plan review**: N/A

--- a/larch-logs/implement/B9BAF6D5-7791-4103-8A40-7104BBFC8303/final-summary.md
+++ b/larch-logs/implement/B9BAF6D5-7791-4103-8A40-7104BBFC8303/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 01:05:41
-- **Cost**: 💰 TOTAL ~$9.63 — Claude $6.34, Codex $0.59, Cursor $2.70  |  Tokens: 11509k
+- **Cost**: 💰 TOTAL ~$8.25 — Claude $6.34, Codex $0.33, Cursor $1.58, Claude (subprocess) $0.00  |  Tokens: 11509k
 - **Issue**: #2782 — https://github.com/character-ai/larch/issues/2782
 - **Plan review**: N/A
 - **Code review**: N/A

--- a/larch-logs/implement/BAA5D294-2183-4434-B0ED-06C23E3B57B3/final-summary.md
+++ b/larch-logs/implement/BAA5D294-2183-4434-B0ED-06C23E3B57B3/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:58:18
-- **Cost**: 💰 TOTAL ~$10.52 — Claude $4.57, Codex $0.56, Cursor $5.39  |  Tokens: 17737k
+- **Cost**: 💰 TOTAL ~$8.23 — Claude $4.57, Codex $0.31, Cursor $3.35, Claude (subprocess) $0.00  |  Tokens: 17737k
 - **Issue**: #2756 — https://github.com/character-ai/larch/issues/2756
 - **Plan review**: N/A
 - **Code review**: N/A

--- a/larch-logs/implement/BB3C5F31-A802-4F1B-A56C-1812B16EE0EC/final-summary.md
+++ b/larch-logs/implement/BB3C5F31-A802-4F1B-A56C-1812B16EE0EC/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - Emergency: true
 - **Duration**: 00:15:59
-- **Cost**: 💰 TOTAL ~$7.63 — Claude $7.02, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.61  |  Tokens: 10978k
+- **Cost**: 💰 TOTAL ~$8.00 — Claude $7.39, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.61  |  Tokens: 11595k
 - **Issue**: #3761 — https://github.com/character-ai/larch/issues/3761
 - **PR**: #3766 — https://github.com/character-ai/larch/pull/3766
 - **Plan review**: N/A

--- a/larch-logs/implement/BB4124F8-DF18-4304-A92A-FF1194F31A0B/final-summary.md
+++ b/larch-logs/implement/BB4124F8-DF18-4304-A92A-FF1194F31A0B/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 02:17:45
-- **Cost**: 💰 TOTAL ~$27.36 — Claude $2.90, Codex $0.00, Cursor $24.46  |  Tokens: 63750k
+- **Cost**: 💰 TOTAL ~$18.10 — Claude $2.90, Codex $0.00, Cursor $15.20, Claude (subprocess) $0.00  |  Tokens: 63750k
 - **Issue**: #3248 — https://github.com/character-ai/larch/issues/3248
 - **Plan review**: N/A
 - **Code review**: 54/102 accepted

--- a/larch-logs/implement/BB5D9059-8F36-494F-BB45-42E9912EE64D/final-summary.md
+++ b/larch-logs/implement/BB5D9059-8F36-494F-BB45-42E9912EE64D/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - Emergency: true
 - **Duration**: 00:10:34
-- **Cost**: 💰 TOTAL ~$4.10 — Claude $3.71, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.39  |  Tokens: 5499k
+- **Cost**: 💰 TOTAL ~$4.42 — Claude $4.03, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.39  |  Tokens: 6025k
 - **Issue**: #3718 — https://github.com/character-ai/larch/issues/3718
 - **Plan review**: N/A
 - **Code review**: N/A

--- a/larch-logs/implement/BC141FCF-42EF-4367-A029-A1C5C4463304/final-summary.md
+++ b/larch-logs/implement/BC141FCF-42EF-4367-A029-A1C5C4463304/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:35:06
-- **Cost**: 💰 TOTAL ~$17.48 — Claude $10.29, Codex $0.08, Cursor $7.11  |  Tokens: 36916k
+- **Cost**: 💰 TOTAL ~$16.64 — Claude $11.63, Codex $0.04, Cursor $4.97, Claude (subprocess) $0.00  |  Tokens: 37130k
 - **Issue**: #2740 — https://github.com/character-ai/larch/issues/2740
 - **PR**: #2760 — https://github.com/character-ai/larch/pull/2760
 - **Plan review**: N/A

--- a/larch-logs/implement/BD772253-9BF0-4046-BF8D-2ECF73B4C53F/final-summary.md
+++ b/larch-logs/implement/BD772253-9BF0-4046-BF8D-2ECF73B4C53F/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:48:21
-- **Cost**: 💰 TOTAL ~$6.06 — Claude $3.18, Codex $0.18, Cursor $2.70  |  Tokens: 11172k
+- **Cost**: 💰 TOTAL ~$6.84 — Claude $3.18, Codex $2.02, Cursor $1.64, Claude (subprocess) $0.00  |  Tokens: 11172k
 - **Issue**: #3166 — https://github.com/character-ai/larch/issues/3166
 - **Plan review**: N/A
 - **Code review**: 1/23 accepted

--- a/larch-logs/implement/BF2F3FDB-D26C-4DA3-B9F1-E9A6B41FB23A/final-summary.md
+++ b/larch-logs/implement/BF2F3FDB-D26C-4DA3-B9F1-E9A6B41FB23A/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:52:07
-- **Cost**: 💰 TOTAL ~$11.11 — Claude $6.43, Codex $0.44, Cursor $4.24  |  Tokens: 21070k
+- **Cost**: 💰 TOTAL ~$13.90 — Claude $6.43, Codex $4.91, Cursor $2.56, Claude (subprocess) $0.00  |  Tokens: 21070k
 - **Issue**: #2970 — https://github.com/character-ai/larch/issues/2970
 - **Plan review**: N/A
 - **Code review**: 13/22 accepted

--- a/larch-logs/implement/BF80C19C-E89B-4A13-8DE7-D68191F74E30/final-summary.md
+++ b/larch-logs/implement/BF80C19C-E89B-4A13-8DE7-D68191F74E30/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 02:48:45
-- **Cost**: 💰 TOTAL ~$14.97 — Claude $10.06, Codex $0.87, Cursor $4.04  |  Tokens: 39383k
+- **Cost**: 💰 TOTAL ~$22.90 — Claude $10.06, Codex $10.13, Cursor $2.71, Claude (subprocess) $0.00  |  Tokens: 39383k
 - **Issue**: #3420 — https://github.com/character-ai/larch/issues/3420
 - **Plan review**: N/A
 - **Code review**: 22/31 accepted

--- a/larch-logs/implement/C0BB5E2B-F914-40A8-B7B9-B15E251BB9B3/final-summary.md
+++ b/larch-logs/implement/C0BB5E2B-F914-40A8-B7B9-B15E251BB9B3/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:58:17
-- **Cost**: 💰 TOTAL ~$5.78 — Claude $2.18, Codex $0.00, Cursor $3.60  |  Tokens: 12161k
+- **Cost**: 💰 TOTAL ~$4.40 — Claude $2.18, Codex $0.00, Cursor $2.22, Claude (subprocess) $0.00  |  Tokens: 12161k
 - **Issue**: #3402 — https://github.com/character-ai/larch/issues/3402
 - **Plan review**: N/A
 - **Code review**: 1/19 accepted

--- a/larch-logs/implement/C1CA0391-6A71-4CE6-8424-B3FE5FF5D044/final-summary.md
+++ b/larch-logs/implement/C1CA0391-6A71-4CE6-8424-B3FE5FF5D044/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:35:02
-- **Cost**: 💰 TOTAL ~$17.47 — Claude $12.59, Codex $0.38, Cursor $4.50  |  Tokens: 32332k
+- **Cost**: 💰 TOTAL ~$19.38 — Claude $12.59, Codex $4.19, Cursor $2.60, Claude (subprocess) $0.00  |  Tokens: 32332k
 - **Issue**: #2962 — https://github.com/character-ai/larch/issues/2962
 - **Plan review**: N/A
 - **Code review**: 3/9 accepted

--- a/larch-logs/implement/C25C2756-68C0-4D02-A501-3A67AB4777AA/final-summary.md
+++ b/larch-logs/implement/C25C2756-68C0-4D02-A501-3A67AB4777AA/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:28:50
-- **Cost**: 💰 TOTAL ~$10.69 — Claude $8.34, Codex $0.30, Cursor $2.05  |  Tokens: 20688k
+- **Cost**: 💰 TOTAL ~$12.95 — Claude $8.34, Codex $3.36, Cursor $1.25, Claude (subprocess) $0.00  |  Tokens: 20688k
 - **Issue**: #2897 — https://github.com/character-ai/larch/issues/2897
 - **Plan review**: N/A
 - **Code review**: 7/10 accepted

--- a/larch-logs/implement/C2731E49-6FC7-46A7-B66C-5AE2CD7AF195/final-summary.md
+++ b/larch-logs/implement/C2731E49-6FC7-46A7-B66C-5AE2CD7AF195/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 02:38:06
-- **Cost**: 💰 TOTAL ~$45.32 — Claude $26.73, Codex $2.71, Cursor $15.88  |  Tokens: 122732k
+- **Cost**: 💰 TOTAL ~$68.15 — Claude $26.73, Codex $31.07, Cursor $10.35, Claude (subprocess) $0.00  |  Tokens: 122732k
 - **Issue**: #3041 — https://github.com/character-ai/larch/issues/3041
 - **PR**: #3099 — https://github.com/character-ai/larch/pull/3099
 - **Plan review**: N/A

--- a/larch-logs/implement/C39F3E54-DDF5-4DFD-A184-368D33806860/final-summary.md
+++ b/larch-logs/implement/C39F3E54-DDF5-4DFD-A184-368D33806860/final-summary.md
@@ -3,7 +3,7 @@
 - **Outcome**: bailed
 - **Mode**: N/A
 - **Duration**: 00:44:39
-- **Cost**: 💰 TOTAL ~$13.31 — Claude $3.64, Codex $1.69, Cursor $4.69, Claude (subprocess) $3.29  |  Tokens: 39201k
+- **Cost**: 💰 TOTAL ~$31.03 — Claude $5.67, Codex $19.08, Cursor $2.99, Claude (subprocess) $3.29  |  Tokens: 41885k
 - **Issue**: #3820 — https://github.com/character-ai/larch/issues/3820
 - **PR**: #3884 — https://github.com/character-ai/larch/pull/3884
 - **Plan review**: N/A

--- a/larch-logs/implement/C401DA1D-9EEE-4217-ACA4-A0893FF3DC1C/final-summary.md
+++ b/larch-logs/implement/C401DA1D-9EEE-4217-ACA4-A0893FF3DC1C/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:49:50
-- **Cost**: 💰 TOTAL ~$11.44 — Claude $8.68, Codex $0.26, Cursor $2.50  |  Tokens: 19178k
+- **Cost**: 💰 TOTAL ~$13.07 — Claude $8.68, Codex $2.86, Cursor $1.53, Claude (subprocess) $0.00  |  Tokens: 19178k
 - **Issue**: #3074 — https://github.com/character-ai/larch/issues/3074
 - **PR**: #3127 — https://github.com/character-ai/larch/pull/3127
 - **Plan review**: N/A

--- a/larch-logs/implement/C40A2AD5-8E0B-4A51-A1EB-4D11A9C369B1/final-summary.md
+++ b/larch-logs/implement/C40A2AD5-8E0B-4A51-A1EB-4D11A9C369B1/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:47:23
-- **Cost**: 💰 TOTAL ~$7.13 — Claude $4.90, Codex $0.21, Cursor $2.02  |  Tokens: 9705k
+- **Cost**: 💰 TOTAL ~$6.25 — Claude $4.90, Codex $0.11, Cursor $1.24, Claude (subprocess) $0.00  |  Tokens: 9705k
 - **Issue**: #2721 — https://github.com/character-ai/larch/issues/2721
 - **Plan review**: N/A
 - **Code review**: 5/7 accepted

--- a/larch-logs/implement/C42D98F3-3EA5-4ECB-A3C9-0358E1EC069F/final-summary.md
+++ b/larch-logs/implement/C42D98F3-3EA5-4ECB-A3C9-0358E1EC069F/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:22:59
-- **Cost**: 💰 TOTAL ~$6.95 — Claude $5.21, Codex $0.22, Cursor $1.52  |  Tokens: 12274k
+- **Cost**: 💰 TOTAL ~$8.52 — Claude $5.21, Codex $2.44, Cursor $0.87, Claude (subprocess) $0.00  |  Tokens: 12274k
 - **Issue**: #3039 — https://github.com/character-ai/larch/issues/3039
 - **PR**: #3054 — https://github.com/character-ai/larch/pull/3054
 - **Plan review**: N/A

--- a/larch-logs/implement/C52676AA-73B1-4046-AB64-44A1B3C19199/final-summary.md
+++ b/larch-logs/implement/C52676AA-73B1-4046-AB64-44A1B3C19199/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - Emergency: true
 - **Duration**: 00:14:46
-- **Cost**: 💰 TOTAL ~$5.22 — Claude $5.22, Codex $0.00, Cursor $0.00  |  Tokens: 7869k
+- **Cost**: 💰 TOTAL ~$5.22 — Claude $5.22, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.00  |  Tokens: 7869k
 - **Issue**: #3592 — https://github.com/character-ai/larch/issues/3592
 - **Plan review**: N/A
 - **Code review**: N/A

--- a/larch-logs/implement/C5A45718-D6CA-4DE5-80F3-FCA53FADC31C/final-summary.md
+++ b/larch-logs/implement/C5A45718-D6CA-4DE5-80F3-FCA53FADC31C/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:39:08
-- **Cost**: 💰 TOTAL ~$15.01 — Claude $9.87, Codex $0.26, Cursor $4.88  |  Tokens: 28208k
+- **Cost**: 💰 TOTAL ~$15.54 — Claude $9.87, Codex $2.78, Cursor $2.89, Claude (subprocess) $0.00  |  Tokens: 28208k
 - **Issue**: #2854 — https://github.com/character-ai/larch/issues/2854
 - **Plan review**: N/A
 - **Code review**: 2/12 accepted

--- a/larch-logs/implement/C654F123-92F5-4B69-ACBD-7A219490005E/final-summary.md
+++ b/larch-logs/implement/C654F123-92F5-4B69-ACBD-7A219490005E/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:25:42
-- **Cost**: 💰 TOTAL ~$5.34 — Claude $3.49, Codex $0.31, Cursor $1.54  |  Tokens: 7898k
+- **Cost**: 💰 TOTAL ~$4.53 — Claude $3.49, Codex $0.17, Cursor $0.87, Claude (subprocess) $0.00  |  Tokens: 7898k
 - **Issue**: #2692 — https://github.com/character-ai/larch/issues/2692
 - **Plan review**: N/A
 - **Code review**: N/A

--- a/larch-logs/implement/C76A30C4-5B12-40BB-9819-4723B2AD4E85/final-summary.md
+++ b/larch-logs/implement/C76A30C4-5B12-40BB-9819-4723B2AD4E85/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 01:27:41
-- **Cost**: 💰 TOTAL ~$21.12 — Claude $15.53, Codex $0.26, Cursor $5.33  |  Tokens: 40842k
+- **Cost**: 💰 TOTAL ~$22.01 — Claude $15.53, Codex $2.85, Cursor $3.63, Claude (subprocess) $0.00  |  Tokens: 40842k
 - **Issue**: #3118 — https://github.com/character-ai/larch/issues/3118
 - **PR**: #3186 — https://github.com/character-ai/larch/pull/3186
 - **Plan review**: N/A

--- a/larch-logs/implement/C9050C89-2197-45B9-AE3E-D30BDA147780/final-summary.md
+++ b/larch-logs/implement/C9050C89-2197-45B9-AE3E-D30BDA147780/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:20:25
-- **Cost**: 💰 TOTAL ~$6.17 — Claude $4.59, Codex $0.18, Cursor $1.40  |  Tokens: 11454k
+- **Cost**: 💰 TOTAL ~$7.36 — Claude $4.59, Codex $1.93, Cursor $0.84, Claude (subprocess) $0.00  |  Tokens: 11454k
 - **Issue**: #2878 — https://github.com/character-ai/larch/issues/2878
 - **Plan review**: N/A
 - **Code review**: 0/9 accepted

--- a/larch-logs/implement/C91B8C3F-41CC-44E9-8C13-718205A84DEE/final-summary.md
+++ b/larch-logs/implement/C91B8C3F-41CC-44E9-8C13-718205A84DEE/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 01:40:31
-- **Cost**: 💰 TOTAL ~$22.35 — Claude $18.89, Codex $1.23, Cursor $2.23  |  Tokens: 53207k
+- **Cost**: 💰 TOTAL ~$34.98 — Claude $18.89, Codex $14.80, Cursor $1.29, Claude (subprocess) $0.00  |  Tokens: 53207k
 - **Issue**: #2939 — https://github.com/character-ai/larch/issues/2939
 - **PR**: #3004 — https://github.com/character-ai/larch/pull/3004
 - **Plan review**: N/A

--- a/larch-logs/implement/C9FD7DCA-7897-4B90-894A-509B0AEFABEE/final-summary.md
+++ b/larch-logs/implement/C9FD7DCA-7897-4B90-894A-509B0AEFABEE/final-summary.md
@@ -3,7 +3,7 @@
 - **Outcome**: stalled
 - **Mode**: N/A
 - **Duration**: 06:21:18
-- **Cost**: 💰 TOTAL ~$80.88 — Claude $31.87, Codex $12.65, Cursor $25.13, Claude (subprocess) $11.23  |  Tokens: 307633k
+- **Cost**: 💰 TOTAL ~$210.27 — Claude $35.74, Codex $146.79, Cursor $16.51, Claude (subprocess) $11.23  |  Tokens: 314668k
 - **Issue**: #3796 — https://github.com/character-ai/larch/issues/3796
 - **PR**: #3879 — https://github.com/character-ai/larch/pull/3879
 - **Plan review**: N/A

--- a/larch-logs/implement/CCFADD0A-CC8A-4689-B0E1-7980DA2633DB/final-summary.md
+++ b/larch-logs/implement/CCFADD0A-CC8A-4689-B0E1-7980DA2633DB/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:47:44
-- **Cost**: 💰 TOTAL ~$21.16 — Claude $17.29, Codex $0.74, Cursor $3.13  |  Tokens: 33089k
+- **Cost**: 💰 TOTAL ~$19.68 — Claude $17.29, Codex $0.41, Cursor $1.98, Claude (subprocess) $0.00  |  Tokens: 33089k
 - **Issue**: #2803 — https://github.com/character-ai/larch/issues/2803
 - **PR**: #2838 — https://github.com/character-ai/larch/pull/2838
 - **Plan review**: N/A

--- a/larch-logs/implement/CD76DD42-D96C-4FFA-9F8B-8E8228F92830/final-summary.md
+++ b/larch-logs/implement/CD76DD42-D96C-4FFA-9F8B-8E8228F92830/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:36:20
-- **Cost**: 💰 TOTAL ~$14.02 — Claude $10.30, Codex $0.72, Cursor $3.00  |  Tokens: 32755k
+- **Cost**: 💰 TOTAL ~$20.27 — Claude $10.30, Codex $8.15, Cursor $1.82, Claude (subprocess) $0.00  |  Tokens: 32755k
 - **Issue**: #2935 — https://github.com/character-ai/larch/issues/2935
 - **Plan review**: N/A
 - **Code review**: 3/14 accepted

--- a/larch-logs/implement/CED83526-C053-4336-AEBB-312A95706689/final-summary.md
+++ b/larch-logs/implement/CED83526-C053-4336-AEBB-312A95706689/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 02:54:54
-- **Cost**: 💰 TOTAL ~$49.58 — Claude $23.19, Codex $2.58, Cursor $23.81  |  Tokens: 127473k
+- **Cost**: 💰 TOTAL ~$67.51 — Claude $23.19, Codex $29.19, Cursor $15.13, Claude (subprocess) $0.00  |  Tokens: 127473k
 - **Issue**: #2953 — https://github.com/character-ai/larch/issues/2953
 - **PR**: #3156 — https://github.com/character-ai/larch/pull/3156
 - **Plan review**: N/A

--- a/larch-logs/implement/D0D24DD6-D277-4091-A967-DE35D3454893/final-summary.md
+++ b/larch-logs/implement/D0D24DD6-D277-4091-A967-DE35D3454893/final-summary.md
@@ -3,7 +3,7 @@
 - **Outcome**: bailed
 - **Mode**: N/A
 - **Duration**: 05:07:25
-- **Cost**: 💰 TOTAL ~$169.26 — Claude $147.06, Codex $6.63, Cursor $12.42, Claude (subprocess) $3.15  |  Tokens: 400179k
+- **Cost**: 💰 TOTAL ~$237.51 — Claude $148.31, Codex $77.39, Cursor $8.66, Claude (subprocess) $3.15  |  Tokens: 402594k
 - **Issue**: #4019 — https://github.com/character-ai/larch/issues/4019
 - **Plan review**: N/A
 - **Code review**: 28/28 accepted

--- a/larch-logs/implement/D29B6ACF-C7FD-4B44-A51A-6E19F4D57F55/final-summary.md
+++ b/larch-logs/implement/D29B6ACF-C7FD-4B44-A51A-6E19F4D57F55/final-summary.md
@@ -3,7 +3,7 @@
 - **Outcome**: stalled
 - **Mode**: N/A
 - **Duration**: 02:21:02
-- **Cost**: 💰 TOTAL ~$51.18 — Claude $26.03, Codex $5.29, Cursor $13.29, Claude (subprocess) $6.57  |  Tokens: 156594k
+- **Cost**: 💰 TOTAL ~$110.83 — Claude $33.91, Codex $61.38, Cursor $8.97, Claude (subprocess) $6.57  |  Tokens: 162551k
 - **Issue**: #3674 — https://github.com/character-ai/larch/issues/3674
 - **PR**: #3985 — https://github.com/character-ai/larch/pull/3985
 - **Plan review**: N/A

--- a/larch-logs/implement/D2B74100-EE7D-4BED-B742-12A20F613F39/final-summary.md
+++ b/larch-logs/implement/D2B74100-EE7D-4BED-B742-12A20F613F39/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 05:34:40
-- **Cost**: 💰 TOTAL ~$48.67 — Claude $8.93, Codex $4.09, Cursor $35.65  |  Tokens: 182523k
+- **Cost**: 💰 TOTAL ~$80.51 — Claude $8.93, Codex $47.97, Cursor $23.61, Claude (subprocess) $0.00  |  Tokens: 182523k
 - **Issue**: #3453 — https://github.com/character-ai/larch/issues/3453
 - **PR**: #3498 — https://github.com/character-ai/larch/pull/3498
 - **Plan review**: N/A

--- a/larch-logs/implement/D48CF6D0-0699-4DC7-829E-9E675699BA85/final-summary.md
+++ b/larch-logs/implement/D48CF6D0-0699-4DC7-829E-9E675699BA85/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - Emergency: true
 - **Duration**: 03:26:50
-- **Cost**: 💰 TOTAL ~$106.42 — Claude $71.03, Codex $11.34, Cursor $24.05  |  Tokens: 325214k
+- **Cost**: 💰 TOTAL ~$218.20 — Claude $71.03, Codex $130.92, Cursor $16.25, Claude (subprocess) $0.00  |  Tokens: 325214k
 - **Issue**: #3628 — https://github.com/character-ai/larch/issues/3628
 - **Plan review**: N/A
 - **Code review**: 51/67 accepted

--- a/larch-logs/implement/D5EDA6F2-3E3C-490E-99EA-1773741FD23A/final-summary.md
+++ b/larch-logs/implement/D5EDA6F2-3E3C-490E-99EA-1773741FD23A/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - Emergency: true
 - **Duration**: 00:34:42
-- **Cost**: 💰 TOTAL ~$20.64 — Claude $20.19, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.45  |  Tokens: 34265k
+- **Cost**: 💰 TOTAL ~$21.13 — Claude $20.68, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.45  |  Tokens: 35112k
 - **Issue**: #3726 — https://github.com/character-ai/larch/issues/3726
 - **Plan review**: N/A
 - **Code review**: N/A

--- a/larch-logs/implement/D604A28E-86CA-4BA6-A161-74C72B205CA0/final-summary.md
+++ b/larch-logs/implement/D604A28E-86CA-4BA6-A161-74C72B205CA0/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:38:08
-- **Cost**: 💰 TOTAL ~$16.87 — Claude $7.74, Codex $0.54, Cursor $8.59  |  Tokens: 33865k
+- **Cost**: 💰 TOTAL ~$22.14 — Claude $11.19, Codex $5.95, Cursor $5.00, Claude (subprocess) $0.00  |  Tokens: 39438k
 - **Issue**: #2847 — https://github.com/character-ai/larch/issues/2847
 - **PR**: #2879 — https://github.com/character-ai/larch/pull/2879
 - **Plan review**: N/A

--- a/larch-logs/implement/D7B2836A-4009-44FE-90DA-93515A456C1B/final-summary.md
+++ b/larch-logs/implement/D7B2836A-4009-44FE-90DA-93515A456C1B/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 05:07:44
-- **Cost**: 💰 TOTAL ~$43.22 — Claude $11.72, Codex $1.50, Cursor $30.00  |  Tokens: 129323k
+- **Cost**: 💰 TOTAL ~$49.12 — Claude $11.72, Codex $17.89, Cursor $19.51, Claude (subprocess) $0.00  |  Tokens: 129323k
 - **Issue**: #3419 — https://github.com/character-ai/larch/issues/3419
 - **PR**: #3503 — https://github.com/character-ai/larch/pull/3503
 - **Plan review**: N/A

--- a/larch-logs/implement/D7D6C1BB-8714-4C88-90AE-4CE83A8BCC20/final-summary.md
+++ b/larch-logs/implement/D7D6C1BB-8714-4C88-90AE-4CE83A8BCC20/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - Emergency: true
 - **Duration**: 00:30:42
-- **Cost**: 💰 TOTAL ~$5.49 — Claude $5.49, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.00  |  Tokens: 9170k
+- **Cost**: 💰 TOTAL ~$5.89 — Claude $5.89, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.00  |  Tokens: 9798k
 - **Issue**: #3706 — https://github.com/character-ai/larch/issues/3706
 - **Plan review**: N/A
 - **Code review**: N/A

--- a/larch-logs/implement/D8212A9C-8D3F-4CDE-AC1C-EB353908F4F9/final-summary.md
+++ b/larch-logs/implement/D8212A9C-8D3F-4CDE-AC1C-EB353908F4F9/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 01:23:59
-- **Cost**: 💰 TOTAL ~$23.75 — Claude $13.19, Codex $0.00, Cursor $10.56  |  Tokens: 45569k
+- **Cost**: 💰 TOTAL ~$19.82 — Claude $13.19, Codex $0.00, Cursor $6.63, Claude (subprocess) $0.00  |  Tokens: 45569k
 - **Issue**: #3417 — https://github.com/character-ai/larch/issues/3417
 - **PR**: #3494 — https://github.com/character-ai/larch/pull/3494
 - **Plan review**: N/A

--- a/larch-logs/implement/D8E5087C-8115-4FFE-AA45-88BDBE2FDF99/final-summary.md
+++ b/larch-logs/implement/D8E5087C-8115-4FFE-AA45-88BDBE2FDF99/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:38:06
-- **Cost**: 💰 TOTAL ~$12.15 — Claude $7.52, Codex $0.32, Cursor $4.31  |  Tokens: 21690k
+- **Cost**: 💰 TOTAL ~$13.52 — Claude $7.52, Codex $3.59, Cursor $2.41, Claude (subprocess) $0.00  |  Tokens: 21690k
 - **Issue**: #2823 — https://github.com/character-ai/larch/issues/2823
 - **Plan review**: N/A
 - **Code review**: 4/16 accepted

--- a/larch-logs/implement/D99B33E1-23E9-425F-A815-C53791DE50EF/final-summary.md
+++ b/larch-logs/implement/D99B33E1-23E9-425F-A815-C53791DE50EF/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:52:08
-- **Cost**: 💰 TOTAL ~$12.90 — Claude $6.40, Codex $0.00, Cursor $6.50  |  Tokens: 17872k
+- **Cost**: 💰 TOTAL ~$9.93 — Claude $6.40, Codex $0.00, Cursor $3.53, Claude (subprocess) $0.00  |  Tokens: 17872k
 - **Issue**: #3195 — https://github.com/character-ai/larch/issues/3195
 - **PR**: #3217 — https://github.com/character-ai/larch/pull/3217
 - **Plan review**: N/A

--- a/larch-logs/implement/D9AAFF61-0BB7-4C14-B720-5CA3A1BE673B/final-summary.md
+++ b/larch-logs/implement/D9AAFF61-0BB7-4C14-B720-5CA3A1BE673B/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:27:52
-- **Cost**: 💰 TOTAL ~$5.65 — Claude $3.68, Codex $0.13, Cursor $1.84  |  Tokens: 9163k
+- **Cost**: 💰 TOTAL ~$6.14 — Claude $3.68, Codex $1.40, Cursor $1.06, Claude (subprocess) $0.00  |  Tokens: 9163k
 - **Issue**: #2977 — https://github.com/character-ai/larch/issues/2977
 - **Plan review**: N/A
 - **Code review**: 1/3 accepted

--- a/larch-logs/implement/DB1B2122-1496-4452-A956-676768E8A988/final-summary.md
+++ b/larch-logs/implement/DB1B2122-1496-4452-A956-676768E8A988/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 01:09:47
-- **Cost**: 💰 TOTAL ~$15.26 — Claude $7.54, Codex $0.20, Cursor $7.52  |  Tokens: 27445k
+- **Cost**: 💰 TOTAL ~$14.30 — Claude $7.54, Codex $2.28, Cursor $4.48, Claude (subprocess) $0.00  |  Tokens: 27445k
 - **Issue**: #3249 — https://github.com/character-ai/larch/issues/3249
 - **Plan review**: N/A
 - **Code review**: 16/27 accepted

--- a/larch-logs/implement/DC6ADBA9-D085-4C7C-BD87-7BBFAB0D074F/final-summary.md
+++ b/larch-logs/implement/DC6ADBA9-D085-4C7C-BD87-7BBFAB0D074F/final-summary.md
@@ -3,7 +3,7 @@
 - **Outcome**: stalled
 - **Mode**: N/A
 - **Duration**: 05:18:32
-- **Cost**: 💰 TOTAL ~$64.16 — Claude $12.44, Codex $14.00, Cursor $25.59, Claude (subprocess) $12.13  |  Tokens: 328636k
+- **Cost**: 💰 TOTAL ~$210.71 — Claude $18.03, Codex $163.46, Cursor $17.09, Claude (subprocess) $12.13  |  Tokens: 335823k
 - **Issue**: #3689 — https://github.com/character-ai/larch/issues/3689
 - **Plan review**: N/A
 - **Code review**: 78/87 accepted

--- a/larch-logs/implement/DDE4E370-CE67-4755-B4BD-5AA9F4910A4A/final-summary.md
+++ b/larch-logs/implement/DDE4E370-CE67-4755-B4BD-5AA9F4910A4A/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:33:56
-- **Cost**: 💰 TOTAL ~$11.75 — Claude $3.94, Codex $0.10, Cursor $7.71  |  Tokens: 29226k
+- **Cost**: 💰 TOTAL ~$9.49 — Claude $3.94, Codex $0.05, Cursor $5.50, Claude (subprocess) $0.00  |  Tokens: 29226k
 - **Issue**: #2714 — https://github.com/character-ai/larch/issues/2714
 - **Plan review**: N/A
 - **Code review**: N/A

--- a/larch-logs/implement/DEEF4F9B-37F1-40C3-AB56-4182507760D0/final-summary.md
+++ b/larch-logs/implement/DEEF4F9B-37F1-40C3-AB56-4182507760D0/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 03:19:45
-- **Cost**: 💰 TOTAL ~$44.77 — Claude $5.17, Codex $2.70, Cursor $36.90  |  Tokens: 141692k
+- **Cost**: 💰 TOTAL ~$61.06 — Claude $6.01, Codex $30.60, Cursor $24.45, Claude (subprocess) $0.00  |  Tokens: 141972k
 - **Issue**: #3421 — https://github.com/character-ai/larch/issues/3421
 - **PR**: #3518 — https://github.com/character-ai/larch/pull/3518
 - **Plan review**: N/A

--- a/larch-logs/implement/DF6AC322-D6AC-4C46-B979-4074D479B026/final-summary.md
+++ b/larch-logs/implement/DF6AC322-D6AC-4C46-B979-4074D479B026/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 04:38:45
-- **Cost**: 💰 TOTAL ~$50.64 — Claude $20.68, Codex $3.66, Cursor $26.30  |  Tokens: 147628k
+- **Cost**: 💰 TOTAL ~$80.44 — Claude $20.68, Codex $42.62, Cursor $17.14, Claude (subprocess) $0.00  |  Tokens: 147628k
 - **Issue**: #3504 — https://github.com/character-ai/larch/issues/3504
 - **PR**: #3557 — https://github.com/character-ai/larch/pull/3557
 - **Plan review**: N/A

--- a/larch-logs/implement/DF7E2EEF-9D67-4CA8-9D34-BDB622075294/final-summary.md
+++ b/larch-logs/implement/DF7E2EEF-9D67-4CA8-9D34-BDB622075294/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 03:30:49
-- **Cost**: 💰 TOTAL ~$34.74 — Claude $12.51, Codex $3.70, Cursor $18.53  |  Tokens: 118501k
+- **Cost**: 💰 TOTAL ~$75.32 — Claude $20.51, Codex $42.68, Cursor $12.13, Claude (subprocess) $0.00  |  Tokens: 131787k
 - **Issue**: #2871 — https://github.com/character-ai/larch/issues/2871
 - **PR**: #3142 — https://github.com/character-ai/larch/pull/3142
 - **Plan review**: N/A

--- a/larch-logs/implement/E0F6B1E7-CA9B-49D2-B113-2E0E501D2835/final-summary.md
+++ b/larch-logs/implement/E0F6B1E7-CA9B-49D2-B113-2E0E501D2835/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:45:22
-- **Cost**: 💰 TOTAL ~$12.60 — Claude $10.88, Codex $0.29, Cursor $1.43  |  Tokens: 21265k
+- **Cost**: 💰 TOTAL ~$14.96 — Claude $10.88, Codex $3.25, Cursor $0.83, Claude (subprocess) $0.00  |  Tokens: 21265k
 - **Issue**: #3035 — https://github.com/character-ai/larch/issues/3035
 - **PR**: #3057 — https://github.com/character-ai/larch/pull/3057
 - **Plan review**: N/A

--- a/larch-logs/implement/E25020E9-D3C1-432E-8CDC-22735697FB00/final-summary.md
+++ b/larch-logs/implement/E25020E9-D3C1-432E-8CDC-22735697FB00/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 02:43:25
-- **Cost**: 💰 TOTAL ~$74.85 — Claude $47.68, Codex $1.54, Cursor $25.63  |  Tokens: 157032k
+- **Cost**: 💰 TOTAL ~$88.91 — Claude $55.17, Codex $17.30, Cursor $16.44, Claude (subprocess) $0.00  |  Tokens: 170612k
 - **Issue**: #2959 — https://github.com/character-ai/larch/issues/2959
 - **PR**: #3028 — https://github.com/character-ai/larch/pull/3028
 - **Plan review**: N/A

--- a/larch-logs/implement/E2504F4E-CE36-4C30-9A3C-AFEB12C4DAF4/final-summary.md
+++ b/larch-logs/implement/E2504F4E-CE36-4C30-9A3C-AFEB12C4DAF4/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:20:28
-- **Cost**: 💰 TOTAL ~$11.46 — Claude $10.21, Codex $0.20, Cursor $1.05  |  Tokens: 18317k
+- **Cost**: 💰 TOTAL ~$12.93 — Claude $10.21, Codex $2.17, Cursor $0.55, Claude (subprocess) $0.00  |  Tokens: 18317k
 - **Issue**: #3050 — https://github.com/character-ai/larch/issues/3050
 - **PR**: #3081 — https://github.com/character-ai/larch/pull/3081
 - **Plan review**: N/A

--- a/larch-logs/implement/E4053DE4-148B-45E6-BB50-E44D8FE6A545/final-summary.md
+++ b/larch-logs/implement/E4053DE4-148B-45E6-BB50-E44D8FE6A545/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:27:56
-- **Cost**: 💰 TOTAL ~$8.03 — Claude $4.55, Codex $0.14, Cursor $3.34  |  Tokens: 14164k
+- **Cost**: 💰 TOTAL ~$8.12 — Claude $4.55, Codex $1.59, Cursor $1.98, Claude (subprocess) $0.00  |  Tokens: 14164k
 - **Issue**: #3172 — https://github.com/character-ai/larch/issues/3172
 - **PR**: #3183 — https://github.com/character-ai/larch/pull/3183
 - **Plan review**: N/A

--- a/larch-logs/implement/E4D7CB24-0808-4E1B-933D-0BA3B51FBB2B/final-summary.md
+++ b/larch-logs/implement/E4D7CB24-0808-4E1B-933D-0BA3B51FBB2B/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:27:45
-- **Cost**: 💰 TOTAL ~$4.84 — Claude $2.89, Codex $0.30, Cursor $1.65  |  Tokens: 10736k
+- **Cost**: 💰 TOTAL ~$7.22 — Claude $2.89, Codex $3.32, Cursor $1.01, Claude (subprocess) $0.00  |  Tokens: 10736k
 - **Issue**: #2975 — https://github.com/character-ai/larch/issues/2975
 - **Plan review**: N/A
 - **Code review**: 2/7 accepted

--- a/larch-logs/implement/E51F7948-DA4F-4568-B343-2921E89F7A7E/final-summary.md
+++ b/larch-logs/implement/E51F7948-DA4F-4568-B343-2921E89F7A7E/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 03:14:24
-- **Cost**: 💰 TOTAL ~$39.04 — Claude $15.60, Codex $0.35, Cursor $23.09  |  Tokens: 79772k
+- **Cost**: 💰 TOTAL ~$34.35 — Claude $15.60, Codex $4.07, Cursor $14.68, Claude (subprocess) $0.00  |  Tokens: 79772k
 - **Issue**: #3266 — https://github.com/character-ai/larch/issues/3266
 - **PR**: #3271 — https://github.com/character-ai/larch/pull/3271
 - **Plan review**: N/A

--- a/larch-logs/implement/E711879D-B313-4140-9F80-54CF7BADD5B3/final-summary.md
+++ b/larch-logs/implement/E711879D-B313-4140-9F80-54CF7BADD5B3/final-summary.md
@@ -3,7 +3,7 @@
 - **Outcome**: bailed
 - **Mode**: N/A
 - **Duration**: 01:06:58
-- **Cost**: 💰 TOTAL ~$11.91 — Claude $5.88, Codex $1.55, Cursor $4.48  |  Tokens: 38618k
+- **Cost**: 💰 TOTAL ~$29.17 — Claude $8.76, Codex $17.47, Cursor $2.94, Claude (subprocess) $0.00  |  Tokens: 42864k
 - **Issue**: #3563 — https://github.com/character-ai/larch/issues/3563
 - **Plan review**: N/A
 - **Code review**: 3/3 accepted

--- a/larch-logs/implement/E71397F6-47FB-4D39-9ED4-70F49DB42DA1/final-summary.md
+++ b/larch-logs/implement/E71397F6-47FB-4D39-9ED4-70F49DB42DA1/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 06:23:03
-- **Cost**: 💰 TOTAL ~$12.80 — Claude $4.59, Codex $1.40, Cursor $6.81  |  Tokens: 38366k
+- **Cost**: 💰 TOTAL ~$24.47 — Claude $4.59, Codex $15.85, Cursor $4.03, Claude (subprocess) $0.00  |  Tokens: 38366k
 - **Issue**: #3326 — https://github.com/character-ai/larch/issues/3326
 - **Plan review**: N/A
 - **Code review**: 19/37 accepted

--- a/larch-logs/implement/E7497EB1-BCF9-4AD9-9E06-212A4FC89813/final-summary.md
+++ b/larch-logs/implement/E7497EB1-BCF9-4AD9-9E06-212A4FC89813/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - Emergency: true
 - **Duration**: 00:43:26
-- **Cost**: 💰 TOTAL ~$21.21 — Claude $20.89, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.32  |  Tokens: 28398k
+- **Cost**: 💰 TOTAL ~$31.26 — Claude $30.94, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.32  |  Tokens: 43317k
 - **Issue**: #3774 — https://github.com/character-ai/larch/issues/3774
 - **PR**: #3775 — https://github.com/character-ai/larch/pull/3775
 - **Plan review**: N/A

--- a/larch-logs/implement/E8142857-92D4-49CC-9486-01F361A6CE32/final-summary.md
+++ b/larch-logs/implement/E8142857-92D4-49CC-9486-01F361A6CE32/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - Emergency: true
 - **Duration**: N/A
-- **Cost**: 💰 TOTAL ~$22.06 — Claude $21.33, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.73  |  Tokens: 34711k
+- **Cost**: 💰 TOTAL ~$25.62 — Claude $24.89, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.73  |  Tokens: 37792k
 - **Issue**: #3715 — https://github.com/character-ai/larch/issues/3715
 - **Plan review**: N/A
 - **Code review**: N/A

--- a/larch-logs/implement/E8A96042-67B3-4474-8DFC-75352833A03F/final-summary.md
+++ b/larch-logs/implement/E8A96042-67B3-4474-8DFC-75352833A03F/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 02:14:47
-- **Cost**: 💰 TOTAL ~$29.16 — Claude $6.50, Codex $0.68, Cursor $21.98  |  Tokens: 66457k
+- **Cost**: 💰 TOTAL ~$27.79 — Claude $6.50, Codex $7.56, Cursor $13.73, Claude (subprocess) $0.00  |  Tokens: 66457k
 - **Issue**: #3298 — https://github.com/character-ai/larch/issues/3298
 - **PR**: #3355 — https://github.com/character-ai/larch/pull/3355
 - **Plan review**: N/A

--- a/larch-logs/implement/E8E2DFA5-7E06-471F-94FA-E67F61857866/final-summary.md
+++ b/larch-logs/implement/E8E2DFA5-7E06-471F-94FA-E67F61857866/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:51:10
-- **Cost**: 💰 TOTAL ~$15.47 — Claude $13.42, Codex $0.09, Cursor $1.96  |  Tokens: 23522k
+- **Cost**: 💰 TOTAL ~$14.69 — Claude $13.42, Codex $0.05, Cursor $1.22, Claude (subprocess) $0.00  |  Tokens: 23522k
 - **Issue**: #2805 — https://github.com/character-ai/larch/issues/2805
 - **Plan review**: N/A
 - **Code review**: 3/8 accepted

--- a/larch-logs/implement/E8E9D10F-CDA8-423D-87A4-A1096692048E/final-summary.md
+++ b/larch-logs/implement/E8E9D10F-CDA8-423D-87A4-A1096692048E/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - Emergency: true
 - **Duration**: 00:58:15
-- **Cost**: 💰 TOTAL ~$41.85 — Claude $41.85, Codex $0.00, Cursor $0.00  |  Tokens: 75719k
+- **Cost**: 💰 TOTAL ~$47.67 — Claude $47.67, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.00  |  Tokens: 86565k
 - **Issue**: #3648 — https://github.com/character-ai/larch/issues/3648
 - **Plan review**: N/A
 - **Code review**: N/A

--- a/larch-logs/implement/E9322C2F-CC07-492C-AFE4-9BB55CBFF462/final-summary.md
+++ b/larch-logs/implement/E9322C2F-CC07-492C-AFE4-9BB55CBFF462/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:45:59
-- **Cost**: 💰 TOTAL ~$12.13 — Claude $8.93, Codex $0.26, Cursor $2.94  |  Tokens: 20665k
+- **Cost**: 💰 TOTAL ~$13.69 — Claude $8.93, Codex $2.91, Cursor $1.85, Claude (subprocess) $0.00  |  Tokens: 20665k
 - **Issue**: #3097 — https://github.com/character-ai/larch/issues/3097
 - **PR**: #3124 — https://github.com/character-ai/larch/pull/3124
 - **Plan review**: N/A

--- a/larch-logs/implement/EA920B4F-B07F-4F81-9073-2287B0CC5D2B/final-summary.md
+++ b/larch-logs/implement/EA920B4F-B07F-4F81-9073-2287B0CC5D2B/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:34:15
-- **Cost**: 💰 TOTAL ~$11.65 — Claude $8.58, Codex $0.46, Cursor $2.61  |  Tokens: 19323k
+- **Cost**: 💰 TOTAL ~$10.34 — Claude $8.58, Codex $0.26, Cursor $1.50, Claude (subprocess) $0.00  |  Tokens: 19323k
 - **Issue**: #2822 — https://github.com/character-ai/larch/issues/2822
 - **Plan review**: N/A
 - **Code review**: 0/9 accepted

--- a/larch-logs/implement/EBF09FB1-3025-4BF0-AA00-30D893666B9D/final-summary.md
+++ b/larch-logs/implement/EBF09FB1-3025-4BF0-AA00-30D893666B9D/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:23:09
-- **Cost**: 💰 TOTAL ~$5.45 — Claude $3.60, Codex $0.27, Cursor $1.58  |  Tokens: 10061k
+- **Cost**: 💰 TOTAL ~$7.56 — Claude $3.60, Codex $3.05, Cursor $0.91, Claude (subprocess) $0.00  |  Tokens: 10061k
 - **Issue**: #3059 — https://github.com/character-ai/larch/issues/3059
 - **Plan review**: N/A
 - **Code review**: 2/4 accepted

--- a/larch-logs/implement/EBF528A2-2247-4471-9AC4-F84560313930/final-summary.md
+++ b/larch-logs/implement/EBF528A2-2247-4471-9AC4-F84560313930/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:24:28
-- **Cost**: 💰 TOTAL ~$8.97 — Claude $6.58, Codex $0.22, Cursor $2.17  |  Tokens: 14817k
+- **Cost**: 💰 TOTAL ~$10.26 — Claude $6.58, Codex $2.43, Cursor $1.25, Claude (subprocess) $0.00  |  Tokens: 14817k
 - **Issue**: #2882 — https://github.com/character-ai/larch/issues/2882
 - **Plan review**: N/A
 - **Code review**: 1/5 accepted

--- a/larch-logs/implement/ED80302E-12AB-48F5-BEEE-FDF7F26F0CC1/final-summary.md
+++ b/larch-logs/implement/ED80302E-12AB-48F5-BEEE-FDF7F26F0CC1/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 05:15:49
-- **Cost**: 💰 TOTAL ~$90.32 — Claude $62.17, Codex $2.46, Cursor $25.69  |  Tokens: 199705k
+- **Cost**: 💰 TOTAL ~$107.98 — Claude $62.17, Codex $28.12, Cursor $17.69, Claude (subprocess) $0.00  |  Tokens: 199705k
 - **Issue**: #3117 — https://github.com/character-ai/larch/issues/3117
 - **PR**: #3169 — https://github.com/character-ai/larch/pull/3169
 - **Plan review**: N/A

--- a/larch-logs/implement/EDF42B22-17FE-4446-A53E-1FF993D0F94B/final-summary.md
+++ b/larch-logs/implement/EDF42B22-17FE-4446-A53E-1FF993D0F94B/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 01:06:01
-- **Cost**: 💰 TOTAL ~$17.74 — Claude $5.09, Codex $0.08, Cursor $12.57  |  Tokens: 45869k
+- **Cost**: 💰 TOTAL ~$14.13 — Claude $5.09, Codex $0.04, Cursor $9.00, Claude (subprocess) $0.00  |  Tokens: 45869k
 - **Issue**: #2632 — https://github.com/character-ai/larch/issues/2632
 - **Plan review**: N/A
 - **Code review**: N/A

--- a/larch-logs/implement/F02A83B6-E297-4E9B-9E4C-A4387C433FE4/final-summary.md
+++ b/larch-logs/implement/F02A83B6-E297-4E9B-9E4C-A4387C433FE4/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:55:06
-- **Cost**: 💰 TOTAL ~$18.18 — Claude $15.64, Codex $0.31, Cursor $2.23  |  Tokens: 21235k
+- **Cost**: 💰 TOTAL ~$23.62 — Claude $19.01, Codex $3.30, Cursor $1.31, Claude (subprocess) $0.00  |  Tokens: 25330k
 - **Issue**: #3431 — https://github.com/character-ai/larch/issues/3431
 - **PR**: #3464 — https://github.com/character-ai/larch/pull/3464
 - **Plan review**: N/A

--- a/larch-logs/implement/F033B8B0-C10B-4728-9BEE-122B9FD457AC/final-summary.md
+++ b/larch-logs/implement/F033B8B0-C10B-4728-9BEE-122B9FD457AC/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:35:24
-- **Cost**: 💰 TOTAL ~$4.31 — Claude $1.74, Codex $0.00, Cursor $2.57  |  Tokens: 8472k
+- **Cost**: 💰 TOTAL ~$3.27 — Claude $1.74, Codex $0.00, Cursor $1.53, Claude (subprocess) $0.00  |  Tokens: 8472k
 - **Issue**: #3367 — https://github.com/character-ai/larch/issues/3367
 - **Plan review**: N/A
 - **Code review**: 3/8 accepted

--- a/larch-logs/implement/F0A7CEA8-A0F3-40F7-9B3F-3A5E83AB79D6/final-summary.md
+++ b/larch-logs/implement/F0A7CEA8-A0F3-40F7-9B3F-3A5E83AB79D6/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:37:28
-- **Cost**: 💰 TOTAL ~$5.17 — Claude $1.65, Codex $0.06, Cursor $3.46  |  Tokens: 12099k
+- **Cost**: 💰 TOTAL ~$4.49 — Claude $1.65, Codex $0.67, Cursor $2.17, Claude (subprocess) $0.00  |  Tokens: 12099k
 - **Issue**: #3405 — https://github.com/character-ai/larch/issues/3405
 - **Plan review**: N/A
 - **Code review**: 1/5 accepted

--- a/larch-logs/implement/F13D3515-DC53-4985-8800-6630F4E8156B/final-summary.md
+++ b/larch-logs/implement/F13D3515-DC53-4985-8800-6630F4E8156B/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 02:28:02
-- **Cost**: 💰 TOTAL ~$23.94 — Claude $9.85, Codex $1.43, Cursor $12.66  |  Tokens: 40160k
+- **Cost**: 💰 TOTAL ~$18.36 — Claude $9.85, Codex $0.79, Cursor $7.72, Claude (subprocess) $0.00  |  Tokens: 40160k
 - **Issue**: #2736 — https://github.com/character-ai/larch/issues/2736
 - **Plan review**: N/A
 - **Code review**: 59/100 accepted

--- a/larch-logs/implement/F3F4951B-DF3D-4712-BFED-20C461142C5E/final-summary.md
+++ b/larch-logs/implement/F3F4951B-DF3D-4712-BFED-20C461142C5E/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 02:43:45
-- **Cost**: 💰 TOTAL ~$27.91 — Claude $20.93, Codex $0.71, Cursor $6.27  |  Tokens: 46199k
+- **Cost**: 💰 TOTAL ~$27.56 — Claude $23.11, Codex $0.39, Cursor $4.06, Claude (subprocess) $0.00  |  Tokens: 46547k
 - **Issue**: #2754 — https://github.com/character-ai/larch/issues/2754
 - **PR**: #2793 — https://github.com/character-ai/larch/pull/2793
 - **Plan review**: N/A

--- a/larch-logs/implement/F41A4F5F-7F7E-4BA7-AF77-E8F28A75F3AE/final-summary.md
+++ b/larch-logs/implement/F41A4F5F-7F7E-4BA7-AF77-E8F28A75F3AE/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - Emergency: true
 - **Duration**: 00:07:40
-- **Cost**: 💰 TOTAL ~$3.05 — Claude $2.57, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.48  |  Tokens: 4139k
+- **Cost**: 💰 TOTAL ~$3.40 — Claude $2.92, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.48  |  Tokens: 4728k
 - **Issue**: #3982 — https://github.com/character-ai/larch/issues/3982
 - **Plan review**: N/A
 - **Code review**: N/A

--- a/larch-logs/implement/F43613EC-CBF0-497D-8800-21965279B5AF/final-summary.md
+++ b/larch-logs/implement/F43613EC-CBF0-497D-8800-21965279B5AF/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - Emergency: true
 - **Duration**: 00:17:57
-- **Cost**: 💰 TOTAL ~$5.09 — Claude $5.09, Codex $0.00, Cursor $0.00  |  Tokens: 7261k
+- **Cost**: 💰 TOTAL ~$5.09 — Claude $5.09, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.00  |  Tokens: 7261k
 - **Issue**: #3591 — https://github.com/character-ai/larch/issues/3591
 - **PR**: #3610 — https://github.com/character-ai/larch/pull/3610
 - **Plan review**: N/A

--- a/larch-logs/implement/F50F0756-CD96-4B17-8053-20341D3AA988/final-summary.md
+++ b/larch-logs/implement/F50F0756-CD96-4B17-8053-20341D3AA988/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:24:41
-- **Cost**: 💰 TOTAL ~$5.08 — Claude $2.75, Codex $0.17, Cursor $2.16  |  Tokens: 9554k
+- **Cost**: 💰 TOTAL ~$9.42 — Claude $6.30, Codex $1.84, Cursor $1.28, Claude (subprocess) $0.00  |  Tokens: 14177k
 - **Issue**: #3538 — https://github.com/character-ai/larch/issues/3538
 - **Plan review**: N/A
 - **Code review**: 0/8 accepted

--- a/larch-logs/implement/F5A06848-213D-49E3-92F3-75AD0AF5A315/final-summary.md
+++ b/larch-logs/implement/F5A06848-213D-49E3-92F3-75AD0AF5A315/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:31:20
-- **Cost**: 💰 TOTAL ~$6.54 — Claude $4.57, Codex $0.36, Cursor $1.61  |  Tokens: 14581k
+- **Cost**: 💰 TOTAL ~$9.66 — Claude $4.57, Codex $4.10, Cursor $0.99, Claude (subprocess) $0.00  |  Tokens: 14581k
 - **Issue**: #3014 — https://github.com/character-ai/larch/issues/3014
 - **PR**: #3048 — https://github.com/character-ai/larch/pull/3048
 - **Plan review**: N/A

--- a/larch-logs/implement/F6A80A00-2615-45D7-8521-28993C351B32/final-summary.md
+++ b/larch-logs/implement/F6A80A00-2615-45D7-8521-28993C351B32/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 02:40:25
-- **Cost**: 💰 TOTAL ~$11.04 — Claude $7.24, Codex $0.59, Cursor $3.21  |  Tokens: 23732k
+- **Cost**: 💰 TOTAL ~$16.49 — Claude $7.24, Codex $7.31, Cursor $1.94, Claude (subprocess) $0.00  |  Tokens: 24488k
 - **Issue**: #2869 — https://github.com/character-ai/larch/issues/2869
 - **PR**: #3075 — https://github.com/character-ai/larch/pull/3075
 - **Plan review**: N/A

--- a/larch-logs/implement/F6CA1F7C-AC36-4F2F-B89E-1994A2814AB5/final-summary.md
+++ b/larch-logs/implement/F6CA1F7C-AC36-4F2F-B89E-1994A2814AB5/final-summary.md
@@ -3,7 +3,7 @@
 - **Outcome**: stalled
 - **Mode**: N/A
 - **Duration**: 03:37:27
-- **Cost**: 💰 TOTAL ~$42.25 — Claude $19.79, Codex $6.32, Cursor $10.24, Claude (subprocess) $5.90  |  Tokens: 163277k
+- **Cost**: 💰 TOTAL ~$109.51 — Claude $23.05, Codex $73.74, Cursor $6.82, Claude (subprocess) $5.90  |  Tokens: 166187k
 - **Issue**: #3926 — https://github.com/character-ai/larch/issues/3926
 - **PR**: #4031 — https://github.com/character-ai/larch/pull/4031
 - **Plan review**: N/A

--- a/larch-logs/implement/F717A890-9409-475B-9B67-4501A5BA4274/final-summary.md
+++ b/larch-logs/implement/F717A890-9409-475B-9B67-4501A5BA4274/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 03:28:50
-- **Cost**: 💰 TOTAL ~$31.97 — Claude $6.80, Codex $2.49, Cursor $22.68  |  Tokens: 101591k
+- **Cost**: 💰 TOTAL ~$50.20 — Claude $7.46, Codex $27.93, Cursor $14.81, Claude (subprocess) $0.00  |  Tokens: 102572k
 - **Issue**: #3448 — https://github.com/character-ai/larch/issues/3448
 - **Plan review**: N/A
 - **Code review**: 51/93 accepted

--- a/larch-logs/implement/F9A07665-293E-42F9-977E-0D0BC20EB8DC/final-summary.md
+++ b/larch-logs/implement/F9A07665-293E-42F9-977E-0D0BC20EB8DC/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 02:28:37
-- **Cost**: 💰 TOTAL ~$120.13 — Claude $106.19, Codex $1.02, Cursor $12.92  |  Tokens: 230050k
+- **Cost**: 💰 TOTAL ~$125.60 — Claude $106.19, Codex $11.47, Cursor $7.94, Claude (subprocess) $0.00  |  Tokens: 230050k
 - **Issue**: #2974 — https://github.com/character-ai/larch/issues/2974
 - **PR**: #3024 — https://github.com/character-ai/larch/pull/3024
 - **Plan review**: N/A

--- a/larch-logs/implement/FA25692E-DF5F-4EBF-95A3-78754D218B79/final-summary.md
+++ b/larch-logs/implement/FA25692E-DF5F-4EBF-95A3-78754D218B79/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 01:42:06
-- **Cost**: 💰 TOTAL ~$37.59 — Claude $17.47, Codex $1.80, Cursor $18.32  |  Tokens: 70211k
+- **Cost**: 💰 TOTAL ~$30.09 — Claude $17.47, Codex $1.00, Cursor $11.62, Claude (subprocess) $0.00  |  Tokens: 70211k
 - **Issue**: #2813 — https://github.com/character-ai/larch/issues/2813
 - **Plan review**: N/A
 - **Code review**: 27/87 accepted

--- a/larch-logs/implement/FA70EBE2-42D7-4780-90B2-C7221595613A/final-summary.md
+++ b/larch-logs/implement/FA70EBE2-42D7-4780-90B2-C7221595613A/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 09:53:11
-- **Cost**: 💰 TOTAL ~$19.44 — Claude $18.88, Codex $0.56, Cursor $0.00  |  Tokens: 34795k
+- **Cost**: 💰 TOTAL ~$25.31 — Claude $18.88, Codex $6.43, Cursor $0.00, Claude (subprocess) $0.00  |  Tokens: 34795k
 - **Issue**: #3348 — https://github.com/character-ai/larch/issues/3348
 - **Plan review**: N/A
 - **Code review**: N/A

--- a/larch-logs/implement/FB2CF4A2-D942-4781-8A94-0DA2FC23FED3/final-summary.md
+++ b/larch-logs/implement/FB2CF4A2-D942-4781-8A94-0DA2FC23FED3/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:42:27
-- **Cost**: 💰 TOTAL ~$7.82 — Claude $1.88, Codex $0.56, Cursor $5.38  |  Tokens: 22995k
+- **Cost**: 💰 TOTAL ~$11.46 — Claude $1.88, Codex $6.25, Cursor $3.33, Claude (subprocess) $0.00  |  Tokens: 22995k
 - **Issue**: #3441 — https://github.com/character-ai/larch/issues/3441
 - **Plan review**: N/A
 - **Code review**: 5/12 accepted

--- a/larch-logs/implement/FB634EB8-00E1-4536-BC44-961D67418EC8/final-summary.md
+++ b/larch-logs/implement/FB634EB8-00E1-4536-BC44-961D67418EC8/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 13:02:15
-- **Cost**: 💰 TOTAL ~$48.36 — Claude $1.67, Codex $5.23, Cursor $41.46  |  Tokens: 211579k
+- **Cost**: 💰 TOTAL ~$90.79 — Claude $1.67, Codex $61.57, Cursor $27.55, Claude (subprocess) $0.00  |  Tokens: 211579k
 - **Issue**: #3449 — https://github.com/character-ai/larch/issues/3449
 - **Plan review**: N/A
 - **Code review**: 101/139 accepted

--- a/larch-logs/implement/FBC090B7-85A9-475F-86D4-05D386F97DA1/final-summary.md
+++ b/larch-logs/implement/FBC090B7-85A9-475F-86D4-05D386F97DA1/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - Emergency: true
 - **Duration**: 00:20:09
-- **Cost**: 💰 TOTAL ~$10.79 — Claude $10.79, Codex $0.00, Cursor $0.00  |  Tokens: 17454k
+- **Cost**: 💰 TOTAL ~$12.97 — Claude $12.97, Codex $0.00, Cursor $0.00, Claude (subprocess) $0.00  |  Tokens: 21326k
 - **Issue**: #3618 — https://github.com/character-ai/larch/issues/3618
 - **PR**: #3659 — https://github.com/character-ai/larch/pull/3659
 - **Plan review**: N/A

--- a/larch-logs/implement/FC85DE8D-CBEF-4652-B425-FA0825CFDF24/final-summary.md
+++ b/larch-logs/implement/FC85DE8D-CBEF-4652-B425-FA0825CFDF24/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:17:29
-- **Cost**: 💰 TOTAL ~$10.38 — Claude $8.29, Codex $0.10, Cursor $1.99  |  Tokens: 17237k
+- **Cost**: 💰 TOTAL ~$10.36 — Claude $8.29, Codex $1.04, Cursor $1.03, Claude (subprocess) $0.00  |  Tokens: 17237k
 - **Issue**: #2843 — https://github.com/character-ai/larch/issues/2843
 - **Plan review**: N/A
 - **Code review**: N/A

--- a/larch-logs/implement/FC8A9906-F990-4BD0-AE51-6765FF1619D2/final-summary.md
+++ b/larch-logs/implement/FC8A9906-F990-4BD0-AE51-6765FF1619D2/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:14:45
-- **Cost**: 💰 TOTAL ~$3.26 — Claude $1.73, Codex $0.00, Cursor $1.53  |  Tokens: 5324k
+- **Cost**: 💰 TOTAL ~$2.55 — Claude $1.73, Codex $0.00, Cursor $0.82, Claude (subprocess) $0.00  |  Tokens: 5324k
 - **Issue**: #3190 — https://github.com/character-ai/larch/issues/3190
 - **Plan review**: N/A
 - **Code review**: 1/2 accepted

--- a/larch-logs/implement/FCD6A6CF-5857-4153-8C5C-FD3FBDD74FEC/final-summary.md
+++ b/larch-logs/implement/FCD6A6CF-5857-4153-8C5C-FD3FBDD74FEC/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 00:47:02
-- **Cost**: 💰 TOTAL ~$9.75 — Claude $4.02, Codex $0.00, Cursor $5.73  |  Tokens: 22775k
+- **Cost**: 💰 TOTAL ~$7.85 — Claude $4.02, Codex $0.00, Cursor $3.83, Claude (subprocess) $0.00  |  Tokens: 22775k
 - **Issue**: #3365 — https://github.com/character-ai/larch/issues/3365
 - **Plan review**: N/A
 - **Code review**: 7/13 accepted

--- a/larch-logs/implement/FE5E16D4-8426-41B5-9E6E-69C4296EA8B8/final-summary.md
+++ b/larch-logs/implement/FE5E16D4-8426-41B5-9E6E-69C4296EA8B8/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 01:36:57
-- **Cost**: 💰 TOTAL ~$32.47 — Claude $20.42, Codex $0.02, Cursor $12.03  |  Tokens: 66438k
+- **Cost**: 💰 TOTAL ~$30.08 — Claude $21.91, Codex $0.27, Cursor $7.90, Claude (subprocess) $0.00  |  Tokens: 69133k
 - **Issue**: #3337 — https://github.com/character-ai/larch/issues/3337
 - **PR**: #3351 — https://github.com/character-ai/larch/pull/3351
 - **Plan review**: N/A

--- a/larch-logs/implement/FF334421-C691-427F-A6D4-C4FE09E4D870/final-summary.md
+++ b/larch-logs/implement/FF334421-C691-427F-A6D4-C4FE09E4D870/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 05:12:10
-- **Cost**: 💰 TOTAL ~$77.81 — Claude $17.07, Codex $6.38, Cursor $54.36  |  Tokens: 297511k
+- **Cost**: 💰 TOTAL ~$129.76 — Claude $17.33, Codex $75.66, Cursor $36.77, Claude (subprocess) $0.00  |  Tokens: 297922k
 - **Issue**: #3462 — https://github.com/character-ai/larch/issues/3462
 - **PR**: #3567 — https://github.com/character-ai/larch/pull/3567
 - **Plan review**: N/A

--- a/larch-logs/implement/FF7A9D96-8E2D-4022-B6DE-BB3E89752256/final-summary.md
+++ b/larch-logs/implement/FF7A9D96-8E2D-4022-B6DE-BB3E89752256/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - **Path**: HARD
 - **Duration**: 01:34:30
-- **Cost**: 💰 TOTAL ~$15.11 — Claude $2.73, Codex $0.52, Cursor $11.86  |  Tokens: 32076k
+- **Cost**: 💰 TOTAL ~$15.31 — Claude $2.73, Codex $5.64, Cursor $6.94, Claude (subprocess) $0.00  |  Tokens: 32076k
 - **Issue**: #3297 — https://github.com/character-ai/larch/issues/3297
 - **Plan review**: N/A
 - **Code review**: 43/76 accepted


### PR DESCRIPTION
## What

Log-only PR. Retroactively corrects the frozen per-vendor **dollar amounts** in pre-v50 `final-summary.md` run reports. **473 files** changed (161 `/design` + 312 `/implement` with a non-trivial delta; 9 pure-Claude runs were already correct).

## Why

Vendor pricing was fixed in **#4093** (first released in **v50.0.0**, 2026-06-12): Codex was ~11× undervalued and Cursor ~1.5× overvalued. Runs on larch **≤ 49.0.19** froze the buggy dollar figures into `final-summary.md`. Token counts were always correct.

## How

Each run's cost is recomputed from its committed token report using the current pricing authority (`report_tokens_cost`) and the `- **Cost**:` line is rewritten (full-line recompute). Verified **idempotent**.

Aggregate correction: Codex `/implement` **$397 → $4,351** (11.0×), `/design` $139 → $1,040 (7.5×); Cursor ~0.6× both.

## Scope notes

- Touches only `larch-logs/**/final-summary.md` — no runtime/plugin surface.
- **Skipped 6** early-bail/failed runs with no committed token report (cannot reprice from committed data): `A13E2AE6` (design); `01DB9ED0`, `5046F78D`, `5534EF29`, `7F2B039A`, `C054CA4E` (implement).
- `session-transcript.jsonl` left untouched: its `💰` lines are pre-Step-7a intermediate prints or stall-recovery echoes of other runs, not the run's final cost.
- The `/report-tokens` analyzer already prices from tokens, so aggregate reports were unaffected; this only corrects the human-facing per-run summaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
