### PR TITLE
Release v51.3.10

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "51.3.9",
+  "version": "51.3.10",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Added

- **Cross-round findings ledger**: new ephemeral `findings-ledger.tsv` per invocation injects a deduplicated list of prior-round suggestions into reviewer and judge prompts for `/implement` code review, `/review` diff mode, and `/design` plan review, reducing repeat suggestions across rounds.
- **`lint-consecutive-bash`**: new linter detects two adjacent bash tool-call fences separated only by blank lines or comments in `skills/*/SKILL.md` and `.claude/skills/*/SKILL.md`; wired to pre-commit, `make lint`, and CI.
- **Exec Issues and Warnings detail section**: `/design` and `/implement` final summaries now include `## Exec Issues and Warnings` with numbered per-entry rows and one-sentence LLM assessments; duplicate entries collapse with a count.
- **Run identity in summaries**: final run summaries now show `- **Main agent model**:`, `- **Effort**:`, and `- **Larch version**:` bullets captured from the run manifest at init time.

## Fixed

- **Aggregator retry on missing-reviewer failure**: `"input reviewers missing from merge output"` (validation rc=2) now triggers the existing retry loop (up to `_AGGREGATE_VALIDATION_RETRIES` re-dispatches) instead of degrading immediately and leaving `findings.md` unchanged.
- **Review pipeline salvage for format-divergent output**: reviewer TSV rows with 7 tab columns (one missing delimiter) are salvaged instead of rejecting the whole slot as `NOT_SUBSTANTIVE`; voter output formatted as a markdown table is parsed for votes instead of counting all items as `JUDGE_ERROR`.
- **Ship driver CI monitor**: `gh` status queries now have a subprocess timeout; a transition breadcrumb is emitted when polling exits, making a frozen or post-suspend monitor distinguishable from normal slow CI.
- **OOS issue rollups include full source bodies**: rolled-up OOS issues now include the full source body text verbatim; previously content was excerpted, stripping details.
- **Assessment via `launch-claude-subprocess`**: exec-issue assessment now invokes `python/cli.py agent launch-claude-subprocess` instead of bare `claude --print`, adding subprocess timeout caps, containment, and stderr capture.
- **State subsystem atomicity**: write paths in `run_logs.py` and `tokens.py` use `larch_io.atomic_write`; overly broad `suppress(Exception)` guards narrowed.
- **Incorrect cost footnote removed**: the "excludes main-agent Claude" note in the review phase detail table footer was factually incorrect and has been removed.
- **Duplicate-code CI job errors** in the dedicated workflow resolved.
- **`lint-consecutive-bash` correctness**: fence closer now accepts 0 to 3 leading spaces per CommonMark; example-fence carve-out limited to explicit WRONG/CORRECT labels; unclosed fence opener handling tightened.
- **`oos_filer` stable-ID and symlink-escape hardening**: stable-ID mapper count-reducing combine path covered by tests; symlink-escape guard added to `delete_identical_aggregator`.

## Changed

- **Duplicate-code CI job trigger**: push-to-main trigger disabled; job now requires manual `workflow_dispatch`.
- **`review_core`, `_shared_step2b_postplan_body`, `run_ship` refactor**: pure decision logic extracted from KEY=value emission and filesystem apply paths; frozen-dataclass result objects added; direct unit tests cover new decision helpers.
- **Type annotations, local variables (parts 2-4 of 10)**: added non-obvious local-variable type annotations to plan-review-execution modules, plan-review-quality modules, and voting-agents modules as part of the #5001 typing audit.
