### PR TITLE
Release v51.3.11

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "51.3.10",
+  "version": "51.3.11",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## v51.3.11

### Fixed

- **OOS filer body-size guard**: The body-size check now uses UTF-8 byte sizing rather than character length, preventing `gh issue create` failures when multibyte content passes the character cap but exceeds GitHub's byte limit. Oversized OOS bodies are split across multiple issues instead of silently truncated, so all source observations are preserved. Multi-part idempotent retry now records all part URLs in the run-log ndjson rather than overwriting with only the first matched part. (PR #5164)

### Changed

- **Python type annotations**: Added explicit type annotations to non-obvious local variables across six Python module groups as part of the #5001 G-Py-2 audit: design-lifecycle (part 1/10, PR #5146), ship-pr-release (part 5/10, PR #5166), CI (part 6/10, PR #5165), github-issues-infra (part 8/10, PR #5176), session-bootstrap-cli (part 9/10, PR #5178), and research-implement-lints (part 10/10, PR #5177). Annotation-only diffs; no logic changes; pyright strict and all tests remain green.
