### PR TITLE
Fixes #5186: stop ship-pr no-ci-checks-observed log-flush loop

### DIFF
--- a/python/ship.py
+++ b/python/ship.py
@@ -1538,6 +1538,94 @@ def _ship_phase14_rebase(
         raise
 
 
+def _post_ensure_flush_and_push(
+    runner: Runner,
+    *,
+    working: RunContext,
+    resume: ResumePlan,
+    repo_root: str,
+) -> ShipResult | None:
+    """Flush run logs (fresh runs only) and push the post-PR head.
+
+    First-time (fresh) runs flush the run logs here so the implementation's
+    token/timing/transcript data is committed and lands in the squash merge. On
+    open-pr resume that flush already happened on the first invocation;
+    re-running it would commit this invocation's own incremental log churn as a
+    brand-new commit, move HEAD, and re-trigger CI on every retry. Because the
+    merge loop's empty-checks grace gives up before CI attaches to the new head,
+    that produces the perpetual no-ci-checks-observed loop of issue #5186. Skip
+    the re-flush on resume so HEAD stops moving; the push is kept and is
+    idempotent (a no-op when the remote already has this head, a one-time
+    reconcile when a prior invocation committed but failed to push), so CI
+    converges on a stable head and the loop is eliminated.
+
+    Returns a terminal ``ShipResult`` on flush or push failure, or ``None`` to
+    continue into the merge loop.
+    """
+    skip_reflush = resume.start == "open-pr"
+    _breadcrumb("post-ensure-pr", "Push" if skip_reflush else "Flush+Push")
+    if not skip_reflush:
+        post_ensure_refresh: run_logs.RefreshSkip = run_logs.flush_logs_pre(
+            runner,
+            working.with_(state_file=None),
+            cwd=repo_root,
+            strict_final_report=True,
+        )
+        if post_ensure_refresh.skipped:
+            if post_ensure_refresh.reason not in config.REFRESH_SKIP_POST_ENSURE_PR_OK:
+                _write_terminal_state(
+                    working,
+                    Outcome.STALLED,
+                    "post-ensure-pr",
+                    iteration=resume.iteration,
+                    rebase_count=resume.rebase_count,
+                    fix_attempts=resume.fix_attempts,
+                    transient_retries=resume.transient_retries,
+                )
+                return ShipResult(
+                    Outcome.STALLED,
+                    pr_number=working.pr_number,
+                    pr_url=working.pr_url,
+                    detail=f"post-ensure-pr flush skipped: {post_ensure_refresh.reason}",
+                )
+            _breadcrumb("warning", f"post-ensure-pr refresh skipped: {post_ensure_refresh.reason}")
+    try:
+        post_ensure_push = push.push_branch(runner, working, cwd=repo_root)
+    except ShipError as exc:
+        _write_terminal_state(
+            working,
+            Outcome.STALLED,
+            "post-ensure-pr-push",
+            iteration=resume.iteration,
+            rebase_count=resume.rebase_count,
+            fix_attempts=resume.fix_attempts,
+            transient_retries=resume.transient_retries,
+        )
+        return ShipResult(
+            Outcome.STALLED,
+            pr_number=working.pr_number,
+            pr_url=working.pr_url,
+            detail=f"post-ensure-pr push failed: {str(exc).strip()}",
+        )
+    if post_ensure_push.status != "pushed":
+        _write_terminal_state(
+            working,
+            Outcome.STALLED,
+            "post-ensure-pr-push",
+            iteration=resume.iteration,
+            rebase_count=resume.rebase_count,
+            fix_attempts=resume.fix_attempts,
+            transient_retries=resume.transient_retries,
+        )
+        return ShipResult(
+            Outcome.STALLED,
+            pr_number=working.pr_number,
+            pr_url=working.pr_url,
+            detail=f"post-ensure-pr push failed: {post_ensure_push.status}",
+        )
+    return None
+
+
 def run_ship(
     ctx: RunContext,
     *,
@@ -1727,65 +1815,9 @@ def run_ship(
                 detail=ensured.status,
             )
 
-        _breadcrumb("post-ensure-pr", "Flush+Push")
-        post_ensure_refresh: run_logs.RefreshSkip = run_logs.flush_logs_pre(
-            runner,
-            working.with_(state_file=None),
-            cwd=repo_root,
-            strict_final_report=True,
-        )
-        if post_ensure_refresh.skipped:
-            if post_ensure_refresh.reason not in config.REFRESH_SKIP_POST_ENSURE_PR_OK:
-                _write_terminal_state(
-                    working,
-                    Outcome.STALLED,
-                    "post-ensure-pr",
-                    iteration=resume.iteration,
-                    rebase_count=resume.rebase_count,
-                    fix_attempts=resume.fix_attempts,
-                    transient_retries=resume.transient_retries,
-                )
-                return ShipResult(
-                    Outcome.STALLED,
-                    pr_number=working.pr_number,
-                    pr_url=working.pr_url,
-                    detail=f"post-ensure-pr flush skipped: {post_ensure_refresh.reason}",
-                )
-            _breadcrumb("warning", f"post-ensure-pr refresh skipped: {post_ensure_refresh.reason}")
-        try:
-            post_ensure_push = push.push_branch(runner, working, cwd=repo_root)
-        except ShipError as exc:
-            _write_terminal_state(
-                working,
-                Outcome.STALLED,
-                "post-ensure-pr-push",
-                iteration=resume.iteration,
-                rebase_count=resume.rebase_count,
-                fix_attempts=resume.fix_attempts,
-                transient_retries=resume.transient_retries,
-            )
-            return ShipResult(
-                Outcome.STALLED,
-                pr_number=working.pr_number,
-                pr_url=working.pr_url,
-                detail=f"post-ensure-pr push failed: {str(exc).strip()}",
-            )
-        if post_ensure_push.status != "pushed":
-            _write_terminal_state(
-                working,
-                Outcome.STALLED,
-                "post-ensure-pr-push",
-                iteration=resume.iteration,
-                rebase_count=resume.rebase_count,
-                fix_attempts=resume.fix_attempts,
-                transient_retries=resume.transient_retries,
-            )
-            return ShipResult(
-                Outcome.STALLED,
-                pr_number=working.pr_number,
-                pr_url=working.pr_url,
-                detail=f"post-ensure-pr push failed: {post_ensure_push.status}",
-            )
+        post_ensure_terminal = _post_ensure_flush_and_push(runner, working=working, resume=resume, repo_root=repo_root)
+        if post_ensure_terminal is not None:
+            return post_ensure_terminal
 
         base_remote = "upstream" if working.forked or working.forked_target else "origin"
         preserve_counters = _merge_loop_uses_resume_counters(resume)
@@ -1939,10 +1971,11 @@ def run_ship(
                 bounded_empty_checks = (
                     empty_checks_grace > 0 or empty_checks_startup_deadline_sec > 0
                 )
-                if (
+                no_checks_stall = (
                     (monitor.result.detail or "") == config.CI_WAIT_BAIL_NO_CHECKS_OBSERVED
                     and bounded_empty_checks
-                ):
+                )
+                if no_checks_stall:
                     terminal_last_head = pre_monitor_head or ""
                 _write_terminal_state(
                     _bail_ctx,
@@ -1956,7 +1989,15 @@ def run_ship(
                     bail_failure_detail_log=_bail_detail_log,
                     last_monitored_head=terminal_last_head,
                 )
-                _publish_post_pr_terminal_snapshot(runner, _bail_ctx, cwd=repo_root)
+                # A no-ci-checks-observed stall is recoverable: the main agent
+                # re-invokes ship-pr, which re-monitors the same head. Publishing a
+                # terminal snapshot here would flush a fresh larch-logs commit and
+                # push it, moving HEAD and re-triggering CI before checks can attach
+                # -- the perpetual stall loop of issue #5186. Skip the snapshot so
+                # HEAD stays put and CI converges on a stable head; it is published
+                # once the run reaches a genuinely terminal state.
+                if not no_checks_stall:
+                    _publish_post_pr_terminal_snapshot(runner, _bail_ctx, cwd=repo_root)
                 return _step_result_to_ship(
                     monitor.result,
                     failed_run_id=monitor.failed_run_id or "",

--- a/python/test_ship.py
+++ b/python/test_ship.py
@@ -1101,6 +1101,155 @@ DRAFT=false
     assert "TRANSIENT_RETRIES=1\n" in state
 
 
+def _no_checks_loop_stubs(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    detail: str,
+    flush_calls: list[bool],
+    push_calls: list[bool],
+    snapshot_calls: list[bool],
+) -> None:
+    """Wire an open-pr resume that bails from the monitor with ``detail``."""
+    def recording_flush(*_args: object, **_kwargs: object) -> run_logs.RefreshSkip:
+        flush_calls.append(True)
+        return run_logs.RefreshSkip(skipped=False, reason="")
+
+    def recording_push(*_args: object, **_kwargs: object) -> ship.push.PushResult:
+        push_calls.append(True)
+        return ship.push.PushResult(remote="origin", attempts=1, status="pushed")
+
+    monkeypatch.setattr(ship.git, "current_branch", lambda *_a, **_k: "feat")
+    monkeypatch.setattr(ship.git, "try_rev_parse", lambda *_a, **_k: "h0")
+    monkeypatch.setattr(
+        ship.gh,
+        "pr_view",
+        lambda *_a, **_k: type("PR", (), {"number": 7, "url": "https://example.test/pr/7", "state": "OPEN", "head_ref": "feat"})(),
+    )
+    monkeypatch.setattr(ship.pr_body, "compose_pr_body", lambda **_k: "body")
+    monkeypatch.setattr(
+        ship.pr,
+        "ensure_pr",
+        lambda *_a, **_k: type("P", (), {"number": 7, "url": "https://example.test/pr/7", "status": "existing"})(),
+    )
+    monkeypatch.setattr(ship.git, "log_subject", lambda *_a, **_k: "Implement driver")
+    monkeypatch.setattr(ship.run_logs, "flush_logs_pre", recording_flush)
+    monkeypatch.setattr(ship.push, "push_branch", recording_push)
+    # Force a bounded empty-checks grace so a NO_CHECKS bail classifies as the
+    # recoverable stall the loop fix targets, independent of git head routing.
+    monkeypatch.setattr(
+        ship,
+        "_empty_checks_params_for_monitor",
+        lambda **_k: (config.CI_WAIT_POST_FIX_EMPTY_CHECKS_GRACE_SEC, 0),
+    )
+    monkeypatch.setattr(
+        ship,
+        "_publish_post_pr_terminal_snapshot",
+        lambda *_a, **_k: snapshot_calls.append(True),
+    )
+    monkeypatch.setattr(
+        ship.ci_monitor,
+        "monitor",
+        lambda *_a, **_k: type(
+            "M",
+            (),
+            {
+                "result": StepResult(Outcome.STALLED, detail),
+                "action": "bail",
+                "goto_rebase": False,
+                "did_fixing": False,
+                "transient_rerun_attempted": False,
+                "failed_run_id": None,
+                "ci_fix_rebase_pending": False,
+            },
+        )(),
+    )
+    monkeypatch.setattr(ship.finalize, "write_finalize_state", lambda *_a, **_k: None)
+
+
+def test_open_pr_resume_no_checks_stall_keeps_head_stable(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The no-ci-checks-observed loop is broken by holding HEAD steady (#5186).
+
+    On open-pr resume the post-ensure-pr re-flush is skipped, and on a
+    no-ci-checks-observed bail the terminal snapshot is skipped. Both sites
+    otherwise commit this invocation's own log churn and push it, moving HEAD and
+    re-triggering CI on every retry. With both skipped, no flush runs and only the
+    idempotent reconcile push is issued, so CI converges on a stable head.
+    First-time (fresh) flush is unaffected and is covered by
+    test_straight_merge_post_ensure_green_ci_committed_snapshot.
+    """
+    state_file = tmp_path / "ship-pr-state.sh"
+    _ = state_file.write_text(
+        "PHASE=ci-initial\nBRANCH_NAME=feat\nPR_NUMBER=7\n"
+        "PR_URL=https://example.test/pr/7\nMERGE=true\nDRAFT=false\nITERATION=4\n",
+        encoding="utf-8",
+    )
+    flush_calls: list[bool] = []
+    push_calls: list[bool] = []
+    snapshot_calls: list[bool] = []
+    _no_checks_loop_stubs(
+        monkeypatch,
+        detail=config.CI_WAIT_BAIL_NO_CHECKS_OBSERVED,
+        flush_calls=flush_calls,
+        push_calls=push_calls,
+        snapshot_calls=snapshot_calls,
+    )
+
+    result = ship.run_ship(
+        _ctx(tmp_path, branch="feat", branch_name="feat", state_file=str(state_file)),
+        runner=RecordingRunner(),
+        cwd=str(tmp_path),
+    )
+
+    assert result.outcome is Outcome.STALLED
+    assert result.detail == config.CI_WAIT_BAIL_NO_CHECKS_OBSERVED
+    # No flush: post-ensure re-flush skipped on resume, terminal snapshot skipped
+    # on the recoverable NO_CHECKS bail -- HEAD does not move.
+    assert not flush_calls
+    assert not snapshot_calls
+    # Only the idempotent reconcile push is issued.
+    assert push_calls == [True]
+
+
+def test_non_no_checks_bail_still_publishes_terminal_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A genuinely terminal bail still publishes the snapshot (guard for #5186).
+
+    The snapshot is only suppressed for the recoverable no-ci-checks-observed
+    stall; other terminal bails must still flush and push the final run logs.
+    """
+    state_file = tmp_path / "ship-pr-state.sh"
+    _ = state_file.write_text(
+        "PHASE=ci-initial\nBRANCH_NAME=feat\nPR_NUMBER=7\n"
+        "PR_URL=https://example.test/pr/7\nMERGE=true\nDRAFT=false\nITERATION=4\n",
+        encoding="utf-8",
+    )
+    flush_calls: list[bool] = []
+    push_calls: list[bool] = []
+    snapshot_calls: list[bool] = []
+    _no_checks_loop_stubs(
+        monkeypatch,
+        detail="ci-monitor",
+        flush_calls=flush_calls,
+        push_calls=push_calls,
+        snapshot_calls=snapshot_calls,
+    )
+
+    result = ship.run_ship(
+        _ctx(tmp_path, branch="feat", branch_name="feat", state_file=str(state_file)),
+        runner=RecordingRunner(),
+        cwd=str(tmp_path),
+    )
+
+    assert result.outcome is Outcome.STALLED
+    # Terminal snapshot still published for a non-NO_CHECKS bail.
+    assert snapshot_calls == [True]
+
+
 def test_merged_pr_resume_ignores_head_ref_mismatch(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
Fixes #5186

## Problem

Every ship-pr retry in the post-PR phase flushed run logs and pushed a new
head. Each new head re-triggered CI; the merge loop's empty-checks grace
expired before CI attached, so ship-pr stalled with `no-ci-checks-observed`.
The main agent re-invoked, a fresh flush commit was produced, and the cycle
repeated indefinitely (observed on #5111: 5+ consecutive flush commits, each
triggering a new CI run).

## Root cause: two flush+push sites, not one

The issue named the `post-ensure-pr` flush. Investigation found a **second**
loop engine: the terminal-snapshot publisher (`_publish_post_pr_terminal_snapshot`)
also flushes and pushes on the `NO_CHECKS` bail. Fixing only the first site
relocates the loop rather than ending it.

`pr_checks_all_pass` returns `False` on empty checks, so any new head (even a
`larch-logs/`-only flush commit) still needs CI before merge — confirming the
issue's recommended "move the flush after CI" option (a) does not eliminate the
loop on its own.

## Fix: hold HEAD steady across the recoverable cycle

- **`post-ensure-pr`**: skip the run-log re-flush on `open-pr` resume. The flush
  already ran on the first invocation; re-running it commits this invocation's
  own token/timing/transcript churn as a brand-new commit. The push stays and is
  idempotent (a no-op when the remote already has the head). **First-time (fresh)
  flush is unchanged**, so implementation logs still land in the squash merge.
- **terminal snapshot**: skip `_publish_post_pr_terminal_snapshot` on the
  recoverable `no-ci-checks-observed` bail (reusing the existing `bounded_empty_checks`
  / `NO_CHECKS` detection). Genuinely terminal bails still publish it.

With both sites neutralized, HEAD stops moving, the monitor patiently polls the
stable head (the `(0,0)`/`(0,300)` empty-checks paths wait for CI rather than
bailing), CI attaches, and the run merges.

A pure refactor extracts the post-ensure block into `_post_ensure_flush_and_push`
to keep `run_ship` under the complexity ratchet.

## Tradeoff (worth a reviewer's eye)

This intentionally removes the *incidental* new-head re-trigger that issue #4867
relied on to recover a truly-dropped GitHub `synchronize` event. #4867's
fast-detection bail is preserved, and `counters>0` runs still recover via the
poll-budget-exhausted path. Only a fresh-counters run with a genuinely dropped
event loses auto-recovery — it now surfaces as a bounded operator stall instead
of an infinite CI-burning loop, which is the explicit intent of #5186.

## Test plan

- [x] `make py-lint` (ruff, pyright 0/0, complexity ratchet, keyword-only, pylint 10/10)
- [x] `make py-test` (4677 passed, 52 skipped)
- [x] `make lint-only`
- [x] New `test_open_pr_resume_no_checks_stall_keeps_head_stable`: open-pr resume
  + `NO_CHECKS` bail performs no flush and no snapshot, only the idempotent push.
- [x] New `test_non_no_checks_bail_still_publishes_terminal_snapshot`: a
  non-`NO_CHECKS` terminal bail still publishes the snapshot (guard against
  over-suppression).
- [x] Existing fresh-run snapshot tests (`test_straight_merge_post_ensure_*`)
  confirm first-time flush is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
