### PR TITLE
Release v51.3.12

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "51.3.11",
+  "version": "51.3.12",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## What's Changed

### Added
- **Keyword-only args lint for `python/`** — new AST-based lint (`lint_keyword_only`) warns when a function in `python/` non-test source has two or more non-`self`/`cls` parameters without a leading `*`. Wired into `make lint` and pre-commit with a baseline file for existing violations. New `make regen-keyword-only-baseline` target regenerates the baseline. (#5162)

### Changed
- **Ship-pr bails to main agent immediately on CI failure** — the CI monitor loop no longer downloads logs, classifies transients, or attempts inline fixes on a failed run; it hands off to the main agent via `first-fixer-non-health` directly. Removed the now-unused inline-fix parameters (`plan_file`, `launch_fn`, `ctx`, `transient_retries`) from the driver. (#5188)
- **Centralized the settle-wrapper rc dispatch table** — extracted the verbatim-duplicated return-code dispatch table (rc 0/1/10/11/12/13) from `approval-gates.md` and `discussion-rounds.md` into a new `skills/design/references/settle-rc-dispatch.md` shared reference. (#5189)
- **Deduplicated the final-summary marker-extraction instruction** — consolidated the repeated `LARCH_FINAL_SUMMARY_BEGIN`/`LARCH_FINAL_SUMMARY_END` extraction instruction from `skills/design/SKILL.md` into a new `skills/shared/final-summary-emit.md` shared reference. (#5187)

### Fixed
- **Design runs missing from `/report-tokens` cost reports** — runs that committed token ledger data (`larch-tokens-*.jsonl`) without finalizing `token-report-final.json` (the "flush" path) were silently omitted. Added a reader-side fallback in `report_tokens_scan.py` and added `larch-tokens-*.jsonl` to the design gc keep-set so these runs are now priced from the committed ledger. (#5185)
- **Ship-pr perpetual no-ci-checks-observed loop on open-pr resume** — on `open-pr` resume, the run-log flush step was re-running and committing incremental log churn as a new commit on each retry, moving HEAD and preventing CI from attaching. The fix skips the re-flush on resume so HEAD stays stable; the push step is kept as an idempotent reconcile. (#5191)
