### PR TITLE
Release v51.3.13

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "51.3.12",
+  "version": "51.3.13",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## What's Changed

### Fixed

- **`/design` Step 5c no longer refuses to publish after a zero-findings review.** When the plan-review loop exits with a degraded-panel / zero-findings condition, `ROUNDS_COMPLETED` is now written to `.step3-review-result.env`. Previously that key was absent, causing the Step 5c publish check to treat the review as having run zero rounds and refuse publication. (#5199)

### Changed

- **Out-of-scope observations per reviewer are now capped at 3.** All reviewer agents (and their pre-rendered prompt bodies) now report at most 3 OOS observations, keeping only the highest-materiality items. Overflow observations are dropped rather than summarized or appended. (#5198)

- **Self-review tally counts are now derived from artifact files.** `review-and-fix write-self-review-tally` reads accepted and rejected counts directly from `self-review-accepted.md` and `rejected-findings.md` under `--implement-tmpdir`. The `--accepted` and `--rejected` CLI flags are removed; the orchestrator skill no longer needs to grep-count and substitute integer literals. (#5200)

- **Design Step 2b.5 plan-size failures now self-log to `execution-issues.md`.** When the plan-size check exits non-zero, `design_lifecycle.py` captures the output, writes a `check-plan-size.validation.log` file, and appends an entry to `execution-issues.md` without prompt-side intervention. The corresponding `run-log append-failure` instructions have been removed from `skills/design/SKILL.md`. (#5201)

- **Compact reviewer-status table for design Step 3 is now rendered in Python.** A new renderer in `python/plan_review_round.py` produces the one-line status summary from `reviewer-status.tsv`; the logic no longer lives in SKILL.md prose. (#5202)
