### PR TITLE
Release v51.3.14

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "51.3.13",
+  "version": "51.3.14",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Fixed

- `/design` now immediately continues to Step 5 (finalize) after Gate C Approve, without waiting for a follow-up user message; the anti-halt directive is now explicit and covers the panel-failure acknowledgment relabel as well (#5214)
- Plan size check failures in the `postplan-emit --with-plan-size` path now self-log to `execution-issues.md`; previously these failures were dropped silently (#5212)
- `review-and-fix commit-fixes` now emits `COMMIT_OUTCOME=ok|noop|failed` on every exit path for deterministic orchestrator routing; git status probes are now fail-safe, returning a probe-failure signal rather than silently treating a failed probe as a clean tree (#5216)

## Changed

- Type annotations added to non-obvious local variables across 19 files in the reports/run-logs/tokens domain (part 7 of 10 of the local-variable typing audit, #5001) (#5215)
