### PR TITLE
Release v51.3.15

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "51.3.14",
+  "version": "51.3.15",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Fixed

- **Step 5c publish blocked after `zero-findings-degraded-panel` exit** (#5210): The `zero-findings-degraded-panel` branch omitted `ROUNDS_COMPLETED` and `REVIEW_ROUND_COUNT` from `.step3-review-result.env`, causing `review_provenance()` to read `rounds_completed=0` and block the plan-block write with a misleading `VALIDATE_STATUS=defects-found` envelope. Both keys are now written on that path. ([#5224](https://github.com/character-ai/larch/pull/5224))

- **Aggregator rc=2 "block missing reviewer attribution line" fell through to single-shot degrade** (#5222): When a merged FINDING block lacked its `**Reviewer(s)**:` line, `_validate_aggregate_output` returned bare `rc=2`, which bypassed the retry loop. A new `_MISSING_ATTRIBUTION_RC` constant maps this case to the retryable set, consistent with the `_MISSING_REVIEWER_RC` fix in #5077. ([#5225](https://github.com/character-ai/larch/pull/5225))

- **Redundant CI-triggering pushes and false `no-ci-checks-observed` stall on behind-main branches** (#5217): A fresh run emitted up to three head-moving pushes before the first CI run could finish. On a behind-main branch the monitor rebased mid-CI, then bailed with exit 4 `no-ci-checks-observed` because the 120s post-rebase empty-checks window expired before GitHub registered checks on the force-pushed head. The ship-pr driver and CI monitor were corrected to produce exactly one push on a clean run; a behind-main branch is no longer considered a reason to rebase during CI. ([#5226](https://github.com/character-ai/larch/pull/5226))

- **`chore(larch-logs)` PRs were not being merged** (#5213): A bug in `design_log_ship.py` and `gh.py` caused larch run-log housekeeping PRs to stall without merging. `docs/run-logs.md` was updated to document the corrected behavior. ([#5232](https://github.com/character-ai/larch/pull/5232))

## Changed

- **Final summary Warnings and Exec Issues show descriptive detail** (#5203): The final-summary block previously listed bare filenames under Warnings and Exec Issues. It now renders descriptive text, matching the display quality of other summary sections. ([#5220](https://github.com/character-ai/larch/pull/5220))

- **`ship pre-driver` verb ported to Python** (#5153): Guard, seed, and OOS logic from three Bash fences in the ship-pr flow is now behind `python3 python/cli.py ship pre-driver`, advancing the sh-to-py migration. ([#5221](https://github.com/character-ai/larch/pull/5221))

- **`checks repair-loop` verb added** (#5148): A new `python3 python/cli.py checks repair-loop` verb implements the Step 3/6 repeat-until-clean-or-stall semantics. It accepts `--site`, `--tmpdir`, and `--checks-log`, emits `NEXT_ACTION={continue,main-agent-edit,stall}`, and collapses duplicated repair-loop prose across five SKILL.md call sites into one canonical reference. ([#5223](https://github.com/character-ai/larch/pull/5223))

- **step-5-resume parallel `commit-fixes` calls now have allowlist, porcelain gate, and deferred KV relay** (#5206): Parallel `python/cli.py implement step-5-resume` calls to `commit-fixes --stage-all` previously lacked a `COMMIT_OUTCOME` allowlist, a porcelain gate, and deferred KV relay. All three are now in place. ([#5227](https://github.com/character-ai/larch/pull/5227))

- **Architectural-guidelines presentation note emitted from Python** (#5154): `design_postplan.py` now emits the architectural-guidelines note directly, replacing the prompt-side prose path and continuing the md-to-py-IV migration series. ([#5229](https://github.com/character-ai/larch/pull/5229))

- **review-points-overhaul-II: panel severity made informative** (#5124): Panel severity now uses a rubric and majority-YES aggregation, giving code reviewers a more informative signal. ([#5231](https://github.com/character-ai/larch/pull/5231))
