### PR TITLE
Release v51.3.16

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "51.3.15",
+  "version": "51.3.16",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Fixed

- **Corrected high-severity `+2` scoring rule in documentation.** `docs/point-competition.md` and `docs/voting-process.md` previously described the `+2` award condition as requiring any YES voter to assign panel severity `blocker` or `major`. The actual implementation (`python/voting.py`) and the canonical voting protocol (`skills/shared/voting-protocol.md`) require a strict majority of YES voters to assign that severity. Both docs now match the code. ([#5235](https://github.com/character-ai/larch/pull/5235))

- **Suppressed spurious architectural-guidelines Warning for the clean case.** When `ARCHITECTURAL_GUIDELINES.md` was consulted and no deviations were found, `/implement` appended the clean note to `execution-issues.md` under `Warnings`, causing a misleading warning in the final summary. The clean case now prints to chat only; a `Warnings` entry is appended only when actual deviations are identified. ([#5236](https://github.com/character-ai/larch/pull/5236))
