### PR TITLE
Release v51.3.17

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "51.3.16",
+  "version": "51.3.17",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Added

- **Reviewer-impact analysis**: added per-vendor unique accepted review contribution tracking to `/fluff-analysis` and related analysis tooling. (#5248)
- **Codex coder-vs-reviewer cost report**: added a new `report-tokens` sub-report breaking down Codex token spend by coder vs. reviewer role. (#5259)
- **Keyword-only args in design-lifecycle modules**: enforced `*`-only parameters on all qualifying functions across 17 design-lifecycle Python source files (~11,652 lines). Part 1 of 10 of the #5002 keyword-only enforcement sweep. (#5265)

## Changed

- **Rebase-checkpoint probe now emits `CHECKPOINT_NEXT`**: `push checkpoint-probe` and `bootstrap.py` emit `CHECKPOINT_NEXT=continue|load-routing` so the `/implement` orchestrator can skip loading `rebase-checkpoint-routing.md` on clean rebase paths without consulting the routing document. `SKILL.md` Rebase Checkpoint Macro updated to document the directive. (md-to-py-IV #5158, PR #5251)
- **Voter severity calibration report**: added a per-voter YES-vote severity distribution scoreboard to all voter-agreement render sites. Tracks blocker/major/minor/nit/uncertain/missing rates per voter and flags voters whose high-severity rate exceeds 90%. Part of review-points-overhaul-II. (#5125, PR #5253)
- **Gate B severity rendering in Python**: migrated `/design --per-round-approval` Gate B severity classification (structured and fallback concern-text rubric), per-finding display rows, and the findings table into `python/plan_review.py`. The orchestrator now reads `NEXT_ACTION=gate-b` and calls `gate-b-counts`/`gate-b-finding-line` verbs instead of re-classifying findings from prose. (md-to-py-IV #5157, PR #5257)
- **`BOOTSTRAP_NEXT` routing directive from implement bootstrap**: `python/bootstrap.py` now emits `BOOTSTRAP_NEXT=step2|degraded-prompt|rebase-routing|dirty-recovery|cleanup` on every exit-0 bootstrap envelope. `python/preflight.py` absorbs envelope schema validation. Reduces routing logic the orchestrator must re-derive from prose. (md-to-py-IV #5155, PR #5258)
- **`NEXT_ACTION` from Step 8 ship-exit and OOS-checkpoint**: added `ship route-exit` and `implement step-8-oos-checkpoint` Python verbs that emit exactly one `NEXT_ACTION=` on every path. Step 8 ship wrapper tees stdout to a durable sidecar; `route-exit` reads the sidecar to emit post-driver routing. Added `test-step-8-oos-checkpoint` Makefile target and CI shard entry. (md-to-py-IV #5149, PR #5261)
- **Design Step 3 post-loop routing collapsed to `NEXT_ACTION`**: `normalize-status` now emits and persists `NEXT_ACTION=step3b|step3b-bypass|mav|gate-b|postplan-operator|final-summary:*` for all terminal status paths. The `SKILL.md` post-loop branch matrix replaced with a compact routing table; `--mode single` references retired. (md-to-py-IV #5156, PR #5262)
- **Prune-to-empty panels now converge the review loop**: when reviewer pruning removes all slots from a round, both `/design` Step 3 and `/implement` Step 5 now treat the empty panel as a convergence signal rather than forcing an additional round. `docs/configuration-and-permissions.md` updated to document this behavior. (#5255, PR #5263)

## Fixed

- **Spurious `Warnings` entry from deferred-commit transcript capture**: the deferred-commit success path in `python/run_logs.py` no longer appends a Warnings entry to `execution-issues.md`; it prints `SESSION_TRANSCRIPT_STATUS=captured` directly, matching the non-deferred path. (#5238, PR #5242)
- **Spurious task-notifications from background review processes**: review launcher scripts (`design-step3-review.sh`, `step-5-review.sh`) redirected bash job-control stderr output away from the task output stream. `AGENTS.md` task-notification recovery convention updated: when task output is empty, end the turn without probing rather than running a sentinel probe. (#5240, PR #5247)
- **Orchestrators no longer probe on premature empty task-notifications**: `/design` Step 3, Step 5c, and Final Summary recovery protocols updated to match the `/implement` NEVER #8 contract — end the turn immediately with no tool calls when the task-notification carries empty output. Prevents O(notifications) wasted probe turns. (#5241, PR #5254)
- **OOS issues filed via the review path had empty Description body**: `parse_issue_input` now captures FINDING-block field labels (`Concern`, `Reviewer(s)`) as body content when no `Description` line is present. `oos_filer.py` now skips malformed items with empty body and surfaces a `Tool Failures` breadcrumb rather than filing an empty public issue. (#5260, PR #5266)
- **Reviewer Gantt chart was missing the Cursor apply step**: the timing Gantt now includes the segment where Cursor applies accepted review suggestions, which was previously rendered as a blank gap of up to 15 minutes. (#5264, PR #5267)
