### PR TITLE
Release v51.3.19

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "51.3.18",
+  "version": "51.3.19",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## What's Changed

### Changed

- Reduced always-loaded context size by compressing the anti-halt preamble shared by `/design` and `/implement` (md-to-py-V, PR #5292)
- Relocated always-loaded catalogs out of `/implement` and `/design` prose into referenced anchors (md-to-py-V, PR #5293)
- Ported design OOS-skip and settle rc-by-site dispatch directives from prose to Python (md-to-py-V, PR #5297)
- Folded commit-route dispatch (`COMMIT_OUTCOME` → `NEXT_ACTION`) into the commit verb in Python, removing the inline prose branch table (md-to-py-V, PR #5300)
- Deduped `/design` Step 3 hot-path prose into shared anchors (md-to-py-V, PR #5301)
- Consolidated final-summary emission into a shared anchor reused by `/implement` (md-to-py-V, PR #5303)
- Enforced keyword-only arguments on plan-review-execution functions (`#5002` part 2/10, PR #5294)
- Enforced keyword-only arguments on plan-review-quality functions (`#5002` part 3/10, PR #5304)
- Made the reviewer precision signal load-bearing in the prune gate so low-precision reviewers are dropped before voting (review-points-overhaul-II, PR #5295)
- Added a ground-truth voter loop that scores review findings against realized outcomes using the findings ledger (review-points-overhaul-II, PR #5302)

### Fixed

- Fixed the checks repair-loop emitting no stdout while the lint-fix agent runs, which caused the process to appear hung for up to 40 minutes (PR #5299)
