### PR TITLE
Release v51.3.20

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "51.3.19",
+  "version": "51.3.20",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Fixed

- **Design-run log PRs auto-sweep on session start.** `scripts/sweep-design-logs.sh` is now registered as a SessionStart hook. It runs the design-log PR sweep as a detached background process at every `startup`, `resume`, `clear`, and `compact` event, so chore PRs no longer accumulate unmerged between manual sweeps. (PR #5314)

- **`--merge` flag propagated through Step 5 stall recovery.** When `/implement --merge` hit a code-review stall and recovered via `transient-infra/step5-review`, the recovery path was hard-coding `MERGE=false` in `ship-pr-state.sh`, causing the CI+merge loop to be skipped. The recovery path now propagates the operator's merge intent correctly. (PR #5315)

- **OOS step-5b dispatch fails closed on unknown `NEXT_ACTION`.** A silent `rc=0` path with no `NEXT_ACTION` in the OOS step-5b dispatch has been replaced with an explicit `rc=2` exit and `STEP5B_STATUS=unknown-oos-status`, matching the fail-loudly guideline. (PR #5318)

- **Concurrency guard added to `implement run-dispatch`.** `run_dispatch_main` now acquires a `dispatch.lock` file before proceeding. Concurrent dispatches to the same `IMPLEMENT_TMPDIR` now fail fast on the second caller instead of both proceeding and overwriting each other's manifest outputs. (PR #5320)

- **Security OOS detector covers accepted "Focus area" form.** The detector was missing the space-separated `Focus area` field used in accepted OOS security items. It now matches that form so accepted security OOS items are no longer passed through undetected. (PR #5323)

- **`review-and-fix` commit pinned to repository root.** `_stage_and_commit_round` in `python/review_and_fix.py` now runs all git operations from the repo root rather than inheriting the process CWD. Previously, when the CWD was a subdirectory such as `python/`, repo-relative paths could not be resolved and the commit failed silently with `CODER_STATUS=failed`. (PR #5325)

- **`dispatch.lock` OSError correctly distinguishes permission failures from contention.** An `OSError` during lock acquisition was misreported as contention. Distinct OS errors now propagate with accurate context. (PR #5327)

## Changed

- **`plan-review.md` slimmed to reduce Step 3 context load.** Rendered-string duplicates and dead loop prose have been removed from `skills/design/references/plan-review.md`. The file is pulled into context on every Step 3 review round; removing duplicated content that is already owned by runtime renderers in `python/plan_review.py` cuts unnecessary tokens on the hottest `/design` path. (PR #5317)

- **Heartbeat thread lifecycle tested under blocking lint-fix.** New tests in `python/test_checks.py` cover periodic emission, stop/join ordering, and cleanup during a long blocking `run_lint_fix`, filling a gap where regressions in that path could ship undetected. (PR #5319)

- **SessionStart admin-merge hook: regression tests and security entry added.** A test harness in `scripts/test-sweep-design-logs.sh` now pins the always-exit-0 and spawn contract for the hook, and `SECURITY.md` now documents the background admin-merge behavior so operators auditing the hook security surface see it. (PR #5326)

- **Voting-agents modules enforce keyword-only arguments.** All in-scope `def` and `async def` functions with two or more non-`self`/`cls` parameters in `python/agents.py`, `python/voting.py`, and related voting-agents files now use a leading `*` to require callers to pass arguments by name. This is part 4 of the keyword-only enforcement series (#5002). (PR #5328)
