### PR TITLE
Release v51.3.21

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "51.3.20",
+  "version": "51.3.21",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Fixed

- **`/implement --emergency` and `--self-review` no longer emit a spurious bypass warning.** Previously every emergency bypass was logged as a `Warnings` entry even when the bypass was intentional. Now only malformed bypass logs (invalid-format case) produce a warning. ([#5329](https://github.com/character-ai/larch/pull/5343))

- **Stale `under_quorum_items` warning retracted after successful degraded-panel retry.** When a code-review round 1 panel was detected as degraded and retried with a fresh panel, the initial tally warning persisted in the final run summary as a false positive. After a clean retry (JERR=0 in the final tally), no `under_quorum_items` warning is surfaced. ([#5334](https://github.com/character-ai/larch/pull/5346))

## Changed

- **`MANDATORY — READ ENTIRE FILE` reference loads in `/design` are now conditional.** Several unconditional force-loads (e.g., `execution-issues-tracking.md`, `summary-comment-template.md`, `phantom-probe.md`, `settle-rc-dispatch.md`) are now gated on the condition that actually needs them, reducing per-turn context load in the `/design` skill. ([#5273](https://github.com/character-ai/larch/pull/5344))

## Tests

- **Added cwd regression coverage for the lint-fix commit path.** New test asserts that `_commit_lint_fix_delta_paths` passes the repo root as the commit working directory, covering the path that previously lacked explicit cwd test guard. ([#5324](https://github.com/character-ai/larch/pull/5342))
