### PR TITLE
Release v52.0.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "51.3.21",
+  "version": "52.0.0",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",
@@ -38,7 +38,7 @@
     "codex_effort": {
       "title": "Codex Effort",
       "type": "string",
-      "description": "Codex reasoning effort at launch sites that pass --with-effort or use internal effort-enabled launchers (review, implementation, voting, health probe): minimal, low, medium, or high. Unlike model routing, there are no per-role effort variants—review, vote, and fix roles share this same effort level. Also accepted via LARCH_CODEX_EFFORT env var. When unset, defaults to 'high' at those launch sites. launch-codex-exec callers that omit --with-effort (design drafter, /research lanes, plan autofix, lint-fix) ignore this setting.",
+      "description": "Codex reasoning effort at launch sites that pass --with-effort or use internal effort-enabled launchers (review, implementation, voting, health probe): minimal, low, medium, or high. Unlike model routing, there are no per-role effort variants\u2014review, vote, and fix roles share this same effort level. Also accepted via LARCH_CODEX_EFFORT env var. When unset, defaults to 'high' at those launch sites. launch-codex-exec callers that omit --with-effort (design drafter, /research lanes, plan autofix, lint-fix) ignore this setting.",
       "sensitive": false
     }
   }


### PR DESCRIPTION
## Breaking Changes

- **`/implement --emergency` renamed to `--force|-f`** (#5340): The flag that skips the plan-adequacy audit and downgrades Preflight gates to warn-and-proceed is now `--force` (short form `-f`). All agent prompts, implementer agents, and docs updated. Users passing `--emergency` must switch to `--force` or `-f`.

## Added

- **Role-specific Codex model env vars** (#5311): Three new env vars control Codex model selection per role. `LARCH_CODEX_REVIEW_MODEL` (plan-review and code-review Codex slots), `LARCH_CODEX_VOTE_MODEL` (Codex voting slots), and `LARCH_CODEX_FIX_MODEL` (Codex plan revision, plan autofix, and review-fix application) all default to `gpt-5.4-mini`. `LARCH_CODEX_MODEL` now applies only to untagged launches (Step 2 implementer, brainstorm, negotiations). Role-specific keys are ignored by `LARCH_CODEX_MODEL` and vice versa.

## Changed

- **Code-review voting: plan-fidelity and pragmatism move to Codex-primary** (#5311): Voter slots `v2` and `v3` on the code-review path are now `codex-plan-fidelity` and `codex-pragmatism` with Cursor fallback. Validity (`v1`) stays Cursor-primary. The `claude` fallback on slot 1 triggers only when both external tools are unavailable. Updated `docs/voting-process.md`, `docs/external-reviewers.md`, and `docs/run-logs.md`.

- **`/implement` SKILL: Checks Failure and Durable Bail macros** (#5274): Two orchestrator macros added to `skills/implement/SKILL.md`. The "Checks Failure Entry Macro" standardizes checks-failure entry at Steps 3, 5 self-review, 5 MAV, and 5 coder-main-agent-required. The "Durable Bail to Step 18 Macro" standardizes timing capture, forced `STALL_TRACKING=true`, durable-state seeding, and skip-to-Step-18 routing from terminal stalls. Step 5 `stall` branch prose simplified to delegate seeding and timing to the macro. `checks-repair-loop.md` updated accordingly.

- **`LARCH_CODEX_EFFORT` scope clarified** (#5351): The `codex_effort` plugin option and `LARCH_CODEX_EFFORT` env var apply only at launch sites that pass `--with-effort` or use effort-enabled launchers (code review, implementation, voting, health probe, review-fix). Design Codex drafter, `/research` lanes, plan-command autofix, and lint-fix callers omit `--with-effort` and ignore this setting. Docs and `plugin.json` updated to match.

- **Keyword-only argument enforcement for CI/checks/harness modules** (#5117): Functions with two or more non-`self`/`cls` parameters in `python/ci.py`, `python/checks.py`, `python/ci_agentic_fix.py`, `python/ci_monitor.py`, `python/harness_ci_timing.py`, `python/harness_makefile.py`, `python/harness_shard_packer.py`, `python/pytest_ci_timing.py`, `python/pytest_sharding.py`, `python/stall_recovery.py`, and `.claude/skills/rebalance-tests/scripts/rebalance.py` now take keyword-only arguments. Call sites and tests updated. `python/keyword-only-baseline.json` updated.

## Fixed

- **Makefile `test-tally-code-votes` filter** (#5345): Test selector updated from `not emit` to `not emit_tally` to avoid over-excluding tests whose names contain `emit` as a substring but are not the tally-emit group.
