### PR TITLE
Release v52.0.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.0.0",
+  "version": "52.0.1",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## What's Changed in v52.0.1

### Added

- **New architectural guidelines** (PR #5373): Seven new guidelines added to `ARCHITECTURAL_GUIDELINES.md` covering typed wrappers for external CLI calls (`G-Py-7`), postcondition verification after security-critical mutations (`G-Py-8`), explicit loop totality for bounded loops that must return (`G-Py-10`), centralized protocol literals in `config.py` (`G-Cfg-1`), wire-file I/O routing through `larch_io` helpers (`G-IO-1`), CLI entry registration as module-level `main` (`G-CLI-1`), and allowlist validation for untrusted strings in subprocess argv (`G-Sec-1`).

### Changed

- **`/design` dialectic moved to Gate C, now advisory-only** (PR #5370): The Step 2a.5 dialectic debater waterfall is replaced by a Gate C dialectic clarifier. The dialectic is advisory and display-only at Gate C; it does not edit repository files or `plan.txt`. `SECURITY.md` updated to reflect this: "review and sketches" external-delegation wording now correctly excludes dialectic, which uses a distinct trust boundary. Makefile test filter updated to include `dialectic_instructions`.
- **Cursor and Codex review effort no longer risk-gated** (PR #5374): Cursor review prompts now include `/max-mode on.` unconditionally, not only for high-risk diffs. Codex `--with-effort` is always passed to review launchers regardless of diff classification.

### Fixed

- **Gate C preview script reference corrected in docs** (PR #5372): `docs/configuration-and-permissions.md` now references `design-step3b-tail.sh` instead of the stale `design-step4b-preview.sh` for the Gate C preview path.

**Full Changelog**: https://github.com/character-ai/larch/compare/v52.0.0...v52.0.1
