### PR TITLE
Release v52.0.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.0.1",
+  "version": "52.0.2",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Changed

- **Rounds 1 and 2 now include an unconditional generic Codex reviewer** across `/design`, `/implement`, and `/review` panels. The slot runs regardless of specialist Codex availability. In `/design` it writes `codex-plan-generic-output.txt` through a rendered plan-review prompt; in `/implement` and `/review` it writes `codex-generalist-output.txt` through the code-reviewer archetype. Both use `model_role=default` rather than the specialist `review` role. The `codex-round1-adherence` audit scan now passes for generic Codex rows in rounds 1–2 and fails only when a generic slot (`generalist` or `codex-plan-generic`) appears in round 3 or later; specialist and dynamic Codex rows in round 3+ remain allowed.
