### PR TITLE
Release v52.0.3

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.0.2",
+  "version": "52.0.3",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Changed

- **Architectural guidelines fed into review panels** (#5387): `render plan-review` and `render specialist` now include `ARCHITECTURAL_GUIDELINES.md` content as an untrusted aspirational context block. Reviewers receive the parsed entries framed as non-binding; entries cannot override `AGENTS.md`, skills, or the approved plan. The specialist render cache key includes the guideline block hash so a guideline change invalidates cached prompts.

- **Keyword-only arg enforcement for `github-issues-infra`** (#5388): Applies the keyword-only argument requirement (G-Py-3, part 8 of 10) to the `github-issues-infra` module. CLI entry points retain positional argv per G-CLI-1.

- **Composite Python verbs for post-background parse-branch chains** (#5390): Folds the remaining `md-to-py-V` Step 5 and Step 6 post-background parse-branch chains into two Python composite verbs: `checks-commit-route` and `checks-step5-resume`. Each leg runs in a killable subprocess with an independent timeout; the parent process group is killed on timeout so nested descendants cannot continue mutating the working tree after the deadline.

## Fixed

- **Codex cost overstatement for `gpt-5.4-mini`** (#5389): Codex tokens for the `gpt-5.4-mini` model were priced at `gpt-5.5` rates, overstating those tokens by 6.67x. Pricing now resolves by `(vendor, model)`. `token-report.json` carries a per-model Codex split; the final cost line and PR body show `Codex-5.5` and `Codex-mini` separately, summing to the Codex total.
