### PR TITLE
chore(larch-logs): reprice Codex mini tokens in v52.0.0-v52.0.2 implement final summaries

### DIFF
--- a/larch-logs/implement/250EABE8-F408-4CC5-8413-C8B9776F03B3/final-summary.md
+++ b/larch-logs/implement/250EABE8-F408-4CC5-8413-C8B9776F03B3/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - Force: true
 - **Duration**: 01:33:26
-- **Cost**: 💰 TOTAL ~$22.05 — Claude $6.35, Codex $13.46, Cursor $1.59, Claude (subprocess) $0.65  |  Tokens: 26909k
+- **Cost**: 💰 TOTAL ~$10.61 — Claude $6.35, Codex $2.02, Cursor $1.59, Claude (subprocess) $0.65  |  Tokens: 26909k
 - **Issue**: #5367 — https://github.com/character-ai/larch/issues/5367
 - **Plan review**: N/A
 - **Dynamic archetypes**: static-only, pre-scouted-empty

--- a/larch-logs/implement/311DAB78-2E78-45C7-954D-F4058B7665F1/final-summary.md
+++ b/larch-logs/implement/311DAB78-2E78-45C7-954D-F4058B7665F1/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - Force: true
 - **Duration**: 00:11:25
-- **Cost**: 💰 TOTAL ~$4.96 — Claude $1.35, Codex $2.75, Cursor $0.59, Claude (subprocess) $0.27  |  Tokens: 5903k
+- **Cost**: 💰 TOTAL ~$2.62 — Claude $1.35, Codex $0.41, Cursor $0.59, Claude (subprocess) $0.27  |  Tokens: 5903k
 - **Issue**: #5365 — https://github.com/character-ai/larch/issues/5365
 - **Plan review**: N/A
 - **Dynamic archetypes**: static-only, pre-scouted-empty

--- a/larch-logs/implement/344FB7F3-156E-4534-A36D-77F53042A283/final-summary.md
+++ b/larch-logs/implement/344FB7F3-156E-4534-A36D-77F53042A283/final-summary.md
@@ -3,7 +3,7 @@
 - **Outcome**: bailed
 - **Mode**: N/A
 - **Duration**: 02:38:18
-- **Cost**: 💰 TOTAL ~$44.51 — Claude $3.84, Codex $36.53, Cursor $2.05, Claude (subprocess) $2.09  |  Tokens: 53264k
+- **Cost**: 💰 TOTAL ~$27.87 — Claude $3.84, Codex $19.89, Cursor $2.05, Claude (subprocess) $2.09  |  Tokens: 53264k
 - **Issue**: #5282 — https://github.com/character-ai/larch/issues/5282
 - **Plan review**: N/A
 - **Dynamic archetypes**: ok (1)

--- a/larch-logs/implement/35A45E9A-188E-4227-A449-0C1438415C22/final-summary.md
+++ b/larch-logs/implement/35A45E9A-188E-4227-A449-0C1438415C22/final-summary.md
@@ -3,7 +3,7 @@
 - **Outcome**: bailed
 - **Mode**: N/A
 - **Duration**: 01:35:44
-- **Cost**: 💰 TOTAL ~$40.47 — Claude $6.93, Codex $27.64, Cursor $4.34, Claude (subprocess) $1.56  |  Tokens: 56857k
+- **Cost**: 💰 TOTAL ~$25.15 — Claude $6.93, Codex $12.32, Cursor $4.34, Claude (subprocess) $1.56  |  Tokens: 56857k
 - **Issue**: #5321 — https://github.com/character-ai/larch/issues/5321
 - **Plan review**: N/A
 - **Dynamic archetypes**: ok (2)

--- a/larch-logs/implement/42A39E85-DAC2-466E-86F9-D5D6E98300E0/final-summary.md
+++ b/larch-logs/implement/42A39E85-DAC2-466E-86F9-D5D6E98300E0/final-summary.md
@@ -3,7 +3,7 @@
 - **Outcome**: bailed
 - **Mode**: N/A
 - **Duration**: 01:27:05
-- **Cost**: 💰 TOTAL ~$15.94 — Claude $3.08, Codex $10.52, Cursor $1.50, Claude (subprocess) $0.84  |  Tokens: 13964k
+- **Cost**: 💰 TOTAL ~$7.98 — Claude $3.08, Codex $2.56, Cursor $1.50, Claude (subprocess) $0.84  |  Tokens: 13964k
 - **Issue**: #5338 — https://github.com/character-ai/larch/issues/5338
 - **Plan review**: N/A
 - **Dynamic archetypes**: ok (1)

--- a/larch-logs/implement/6D6504DA-9F0E-41FF-9286-E51F70EC4399/final-summary.md
+++ b/larch-logs/implement/6D6504DA-9F0E-41FF-9286-E51F70EC4399/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - Force: true
 - **Duration**: 00:16:46
-- **Cost**: 💰 TOTAL ~$7.36 — Claude $2.31, Codex $3.61, Cursor $1.08, Claude (subprocess) $0.36  |  Tokens: 8141k
+- **Cost**: 💰 TOTAL ~$4.29 — Claude $2.31, Codex $0.54, Cursor $1.08, Claude (subprocess) $0.36  |  Tokens: 8141k
 - **Issue**: #5369 — https://github.com/character-ai/larch/issues/5369
 - **Plan review**: N/A
 - **Dynamic archetypes**: static-only, pre-scouted-empty

--- a/larch-logs/implement/A33FD3C3-14F7-4C8A-9B69-3E5ED5025C0C/final-summary.md
+++ b/larch-logs/implement/A33FD3C3-14F7-4C8A-9B69-3E5ED5025C0C/final-summary.md
@@ -3,7 +3,7 @@
 - **Outcome**: bailed
 - **Mode**: N/A
 - **Duration**: 00:30:34
-- **Cost**: 💰 TOTAL ~$13.57 — Claude $1.71, Codex $10.01, Cursor $1.34, Claude (subprocess) $0.51  |  Tokens: 16085k
+- **Cost**: 💰 TOTAL ~$8.04 — Claude $1.71, Codex $4.48, Cursor $1.34, Claude (subprocess) $0.51  |  Tokens: 16085k
 - **Issue**: #5335 — https://github.com/character-ai/larch/issues/5335
 - **Plan review**: N/A
 - **Dynamic archetypes**: ok (2)

--- a/larch-logs/implement/E44B66FF-794C-41AB-A5CD-AF74F05024EC/final-summary.md
+++ b/larch-logs/implement/E44B66FF-794C-41AB-A5CD-AF74F05024EC/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - Force: true
 - **Duration**: 02:39:23
-- **Cost**: 💰 TOTAL ~$77.85 — Claude $28.03, Codex $41.97, Cursor $6.25, Claude (subprocess) $1.60  |  Tokens: 103249k
+- **Cost**: 💰 TOTAL ~$42.17 — Claude $28.03, Codex $6.29, Cursor $6.25, Claude (subprocess) $1.60  |  Tokens: 103249k
 - **Issue**: #5386 — https://github.com/character-ai/larch/issues/5386
 - **Plan review**: N/A
 - **Dynamic archetypes**: ok (1)

--- a/larch-logs/implement/E79F3F0B-4459-48FB-8241-5DDB90ABF050/final-summary.md
+++ b/larch-logs/implement/E79F3F0B-4459-48FB-8241-5DDB90ABF050/final-summary.md
@@ -3,7 +3,7 @@
 - **Outcome**: bailed
 - **Mode**: N/A
 - **Duration**: 04:28:04
-- **Cost**: 💰 TOTAL ~$102.33 — Claude $6.49, Codex $74.81, Cursor $9.28, Claude (subprocess) $11.75  |  Tokens: 122133k
+- **Cost**: 💰 TOTAL ~$45.24 — Claude $6.49, Codex $17.72, Cursor $9.28, Claude (subprocess) $11.75  |  Tokens: 122133k
 - **Issue**: #5283 — https://github.com/character-ai/larch/issues/5283
 - **Plan review**: N/A
 - **Dynamic archetypes**: ok (2)

--- a/larch-logs/implement/F9C0D2BE-0B17-4827-BCEB-43881E44FA91/final-summary.md
+++ b/larch-logs/implement/F9C0D2BE-0B17-4827-BCEB-43881E44FA91/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - Force: true
 - **Duration**: 00:26:59
-- **Cost**: 💰 TOTAL ~$9.92 — Claude $2.15, Codex $6.03, Cursor $1.26, Claude (subprocess) $0.48  |  Tokens: 10237k
+- **Cost**: 💰 TOTAL ~$4.79 — Claude $2.15, Codex $0.90, Cursor $1.26, Claude (subprocess) $0.48  |  Tokens: 10237k
 - **Issue**: #5371 — https://github.com/character-ai/larch/issues/5371
 - **Plan review**: N/A
 - **Dynamic archetypes**: static-only, pre-scouted-empty

--- a/larch-logs/implement/FB9719D8-F1E4-46DC-A67B-AB27B844D4BF/final-summary.md
+++ b/larch-logs/implement/FB9719D8-F1E4-46DC-A67B-AB27B844D4BF/final-summary.md
@@ -4,7 +4,7 @@
 - **Mode**: N/A
 - Force: true
 - **Duration**: 00:11:28
-- **Cost**: 💰 TOTAL ~$4.62 — Claude $2.05, Codex $1.49, Cursor $0.73, Claude (subprocess) $0.35  |  Tokens: 6783k
+- **Cost**: 💰 TOTAL ~$3.35 — Claude $2.05, Codex $0.22, Cursor $0.73, Claude (subprocess) $0.35  |  Tokens: 6783k
 - **Issue**: #5376 — https://github.com/character-ai/larch/issues/5376
 - **Plan review**: N/A
 - **Dynamic archetypes**: static-only, pre-scouted-empty


### PR DESCRIPTION
## Summary

Reprices Codex `gpt-5.4-mini` tokens in the 11 implement run logs that executed under larch **v52.0.0-v52.0.2**, where mini tokens were priced at the `gpt-5.5` rate (6.67x too high). This is the run-log retrofit for the pricing fix in #5386 (shipped in v52.0.3).

## Why

- Mini routing (#5311) first shipped in **v52.0.0**. The pricing fix (#5386) only ships in **v52.0.3**. Runs in between froze overstated Codex figures into `final-summary.md`.
- The earlier #5122 pass repriced pre-v50 runs for a different Codex pricing bug; this is the analogous pass for the mini bug.

## Method

The exact per-model token split was never committed: the per-model ledger lives only in the session tmpdir and was reaped at ship, and the committed `token-report.json` carries per-step totals only. Codex tokens appear in exactly two steps, so the split is reconstructed by role routing:

- **Step 2 (implementation)** Codex -> `gpt-5.5` (the strong implementer)
- **Step 5 (code review)** Codex -> `gpt-5.4-mini` (reviewers/voters/fixers, #5311)

Corrected Codex cost is recomputed through the fixed pricing authority (`python/report_tokens_cost`). Only the `- **Cost**:` summary line changes, and within it only the **Codex** and **TOTAL** figures; Claude, Cursor, Claude (subprocess), and the token count are byte-identical (11 files, 1 line each). Per-round table Cost columns are left as-is, matching the #5122 precedent.

## Caveat

#5321 added one generic `gpt-5.5` reviewer in code-review rounds 1-2. Its review tokens are priced as mini here, because they are lumped into the Step 5 total with no per-slot counts to separate them. Corrected Codex figures are therefore a small **underestimate**, not exact.

## Scope notes

- Design runs in the window carry no baked dollar figures; unchanged.
- 2 implement runs (#5118, #5119) used zero Codex tokens; unaffected.
- No run has executed under v52.0.3 yet, so the window has no open upper edge.

## Affected runs (Codex cost, before -> after)

| Issue | Run | Codex before | Codex after |
|---|---|---|---|
| 5283 | E79F3F0B | $74.81 | $17.72 |
| 5386 | E44B66FF | $41.97 | $6.29 |
| 5282 | 344FB7F3 | $36.53 | $19.89 |
| 5321 | 35A45E9A | $27.64 | $12.32 |
| 5367 | 250EABE8 | $13.46 | $2.02 |
| 5338 | 42A39E85 | $10.52 | $2.56 |
| 5335 | A33FD3C3 | $10.01 | $4.48 |
| 5371 | F9C0D2BE | $6.03 | $0.90 |
| 5369 | 6D6504DA | $3.61 | $0.54 |
| 5365 | 311DAB78 | $2.75 | $0.41 |
| 5376 | FB9719D8 | $1.49 | $0.22 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
