### PR TITLE
chore(ci): expand python-tests matrix to 16 shards

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -604,7 +604,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.11"]
-        shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -617,10 +617,10 @@ jobs:
           PIP_RETRIES: "5"
           PIP_DEFAULT_TIMEOUT: "30"
         run: pip install -r python/requirements-test.txt
-      - name: Run Python tests (shard ${{ matrix.shard }} of 10)
+      - name: Run Python tests (shard ${{ matrix.shard }} of 16)
         env:
           PYTEST_SHARD_ID: ${{ matrix.shard }}
-          PYTEST_SHARD_COUNT: "10"
+          PYTEST_SHARD_COUNT: "16"
         run: make py-test
 
   # Aggregate gate for the python-tests matrix (see test-harnesses-gate for the

--- a/docs/linting.md
+++ b/docs/linting.md
@@ -96,7 +96,7 @@ leg in memory. Harness work rejects untimed targets, then runs
 `_select_packed_workload`, `pack`, and warning-only `_check_feasibility` before
 `write_shards`. Python work rejects empty timing rows, dedupes retried shard
 attempts before medians, and validates `--n-python-shards` against the observed
-`python-tests` matrix shard count. The current matrix count is 10, and the parser
+`python-tests` matrix shard count. The current matrix count is 16, and the parser
 prefers the `shard X of N` total from CI logs over the maximum shard id seen in
 rows. Under `--kind all`, every selected gate must pass before the first write.
 


### PR DESCRIPTION
Expands the `python-tests` CI matrix from 10 to 16 shards. The shard-assignments rebalance will follow in a separate PR once this lands and CI runs with the new count.

- `ci.yaml`: matrix list, step name, and `PYTEST_SHARD_COUNT` updated to 16
- `docs/linting.md`: prose count updated to match

🤖 Generated with [Claude Code](https://claude.com/claude-code)