### PR TITLE
fix(rebalance): keyword-only args bug + Pyright import resolution

### DIFF
--- a/.claude/skills/rebalance-tests/SKILL.md
+++ b/.claude/skills/rebalance-tests/SKILL.md
@@ -114,3 +114,7 @@ Forward all args from the skill invocation to the script unchanged.
 
 Unit tests live alongside the modules. Run with `make py-test` or targeted
 pytest commands under `python/`.
+
+`scripts/pyrightconfig.json` sets `extraPaths` so IDEs resolve the `python/`
+imports in `scripts/rebalance.py` without following the runtime `sys.path`
+insert.

--- a/.claude/skills/rebalance-tests/scripts/pyrightconfig.json
+++ b/.claude/skills/rebalance-tests/scripts/pyrightconfig.json
@@ -1,0 +1,4 @@
+{
+  "pythonVersion": "3.11",
+  "extraPaths": ["../../../../python"]
+}

--- a/.claude/skills/rebalance-tests/scripts/rebalance.py
+++ b/.claude/skills/rebalance-tests/scripts/rebalance.py
@@ -593,7 +593,7 @@ def _prepare_harness_plan(args: argparse.Namespace, repo: str, makefile_path: Pa
     medians = compute_medians(all_timing_rows)
     print(f"  Medians computed for {len(medians)} targets")
 
-    untimed = untimed_targets(all_shard_targets, medians)
+    untimed = untimed_targets(all_shard_targets=all_shard_targets, medians=medians)
     if untimed:
         print(
             f"\nERROR: refusing to rebalance — {len(untimed)} shard target(s) "


### PR DESCRIPTION
- `untimed_targets()` requires keyword-only args; fixes positional call (runtime crash)
- `pyrightconfig.json` added so IDEs resolve `python/` imports without following the runtime `sys.path` insert
- SKILL.md updated to reference `pyrightconfig.json` (agent-lint S030)

🤖 Generated with [Claude Code](https://claude.com/claude-code)