### PR TITLE
fix(lint): exclude shard-assignments.json from retired-scripts lint

### DIFF
--- a/python/migration_lint.py
+++ b/python/migration_lint.py
@@ -27,7 +27,10 @@ import proc
 _MANIFEST_DEFAULT = "python/migrated-scripts.tsv"
 _EXCLUSION_SEGMENTS = frozenset({"larch-logs"})
 _EXCLUSION_FILES = frozenset({"CHANGELOG.md"})
-_EXCLUSION_PATHS = frozenset({".claude-plugin/plugin.json"})
+_EXCLUSION_PATHS = frozenset({
+    ".claude-plugin/plugin.json",
+    "python/shard-assignments.json",  # pytest nodeids contain retired names as test data, not references
+})
 _EMBEDDED_LEGACY_MODULES = (
     "python/plan_review.py",
     "python/plan_review_panel.py",


### PR DESCRIPTION
Parametrized test nodeids in `python/shard-assignments.json` embed retired path names as test data (e.g. `test_retired_script_names_are_not_allowlisted[scripts/check-reviewers.sh]`), not as live references. The retired-scripts linter was flagging the file as a false positive.

Adds `python/shard-assignments.json` to `_EXCLUSION_PATHS` in `migration_lint.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)