### PR TITLE
Release v52.0.4

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.0.3",
+  "version": "52.0.4",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## What's Changed

### Changed

- Removed generic Codex reviewer from all review rounds, reverting the addition introduced in issue #5321 (#5417)
- Updated README with Primary Flow and Support Skills sections (#5396)
- Expanded Python test CI matrix to 16 shards (#5412)
- Rebalanced CI test shards (#5411, #5416)

### Fixed

- Fixed keyword-only arguments bug and Pyright import resolution in the rebalance tooling (#5413)
- Excluded `shard-assignments.json` from retired-scripts lint (#5415)

**Full changelog**: https://github.com/character-ai/larch/compare/v52.0.3...v52.0.4
