### PR TITLE
Release v52.0.5

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.0.4",
+  "version": "52.0.5",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Fixed

- **`/design` Step 5c PUBLISH_RC=4 bug.** Step 5c no longer fails with `PUBLISH_RC=4` / `VALIDATE_STATUS=defects-found` when `composed-plan.md` is not yet written before the driver launches. The fix clarifies the composition responsibility boundary in `design_lifecycle.py` and `review_pipeline.py` so the driver no longer fails closed on a missing file it cannot control. (PR #5439, issue #5422)

## Changed

- **`/implement` 7.r rebase checkpoint folded into Step 6 composite.** The standalone Step 7.r foreground fence is removed from `skills/implement/SKILL.md`. The `checks-commit-route` composite now runs the rebase checkpoint internally when `--rebase-checkpoint-7r` is set, relaying `CHECKPOINT_NEXT` / `REBASE_OUTCOME` / `CONFLICT_FILES` before emitting `NEXT_ACTION=continue`. This saves one foreground turn per `FILES_CHANGED=true` run. `python/implement_dispatch.py` gains the `--rebase-checkpoint-7r` / `--forked-target` flags; `Slot` gains a `model_role` field; `rebase-checkpoint-routing.md` and `checks-repair-loop.md` are updated to reflect the new call site. (PR #5441, issue #5399)

- **CI harness shards reduced from 20 to 6.** The Python-backed pytest wrapper targets are removed from `Makefile` (they were the bulk of the old 20 shards). `.github/workflows/ci.yaml` now runs 6 shards and drops the ripgrep install steps. `pytest` is removed from `requirements-test-harnesses.txt`. The `harness` kind in `/rebalance-tests` is retired; the flag is still accepted but produces no output. (PR #5433, issue #5429)

- **`/audit-runs` design scan extended with guideline-assessment check.** `scans-design.tsv` gains a `guideline-assessment` row. `/audit-runs` now reports whether the committed Gate C `architectural-guideline-assessment.md` artifact is present and non-empty. `docs/run-logs.md` documents the new artifact, updates the GC consumer-core keep set to retain it, and adds a design architectural guideline assessment section. `SECURITY.md` documents the safe Gate C write path via `persist-design-assessment`. (PR #5453, issue #5336)

- **External reviewer registry documentation updated.** `docs/external-reviewers.md` replaces generic fallback descriptions with specific registry role names for each phase (e.g. `design.plan_review_panel`, `review.panel`, `review.fix_coder`). New rows added for brainstorm framing/scope, decompose panel, decompose aggregator, and findings aggregator phases. Dynamic-archetype scout rows now reference `review.dynamic_archetype_scout` and `design.plan_archetype_scout`. (PR #5423, issue #4139)

- **`generic_codex_static_row` test added to harness targets.** The new test case is included in both `test-dispatch-panel-core` (PR #5441) and `test-dispatch-panel-core-dynamic` (PR #5450) Makefile targets so the generic Codex static row is covered in both panel dispatch suites. (PRs #5441 #5450, issues #5399 #5418)

- **9 slowest Python tests sped up.** `test_agent_waterfall.py` replaces subprocess `_run()` with in-process `_run_direct()` for `test_phase2_and_phase3_fallbacks` and `test_posix_ere_result_gate_and_caphit_bypass`. The Claude stub heredoc is replaced with a `printf` one-liner. `test_step0_wrapper_runs_without_non_interactive_flag` now reads the script source instead of running the script. (PR #5446, issue #5428)

- **Run logs for 11 implementation attempts.** PRs #5430 #5431 #5432 #5434 #5436 #5437 #5445 #5449 #5451 #5452 #5454 contribute `/implement` execution artifacts for in-flight issues (#5403 #5398 #5120 #5400 #5121 #5402 #5435 #5442 #5440 #5448 #5444); the associated implementations did not fully land in this release.
