### PR TITLE
Release v52.0.6

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.0.5",
+  "version": "52.0.6",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## v52.0.6

### Changed

- **`/implement` Preflight item 5 (AUDIT=refuse clarify-flow relocated)**: The clarify-state / comment-post / label bullet list is moved from `skills/implement/SKILL.md` item 5 into a dedicated "Clarify-request flow after `AUDIT=refuse`" section in `skills/implement/references/preflight-plan-audit.md`. Item 5 in SKILL.md is now a one-line pointer to that section. No behavior change; exit-3 contract, forked-target `--repo` threading, and ordering rules are preserved verbatim. (#5404)

- **`/design` plan-review panel matrix decoupled from SKILL.md**: The hardcoded archetype matrix (Arch, Innovation, Pragmatic, Requirements round-gating) is removed from `skills/design/SKILL.md` prose and moved to a new "Static plan-review slots" section in `skills/design/references/plan-review.md`, which is now the prose authority for static archetype identity, round-gating details, and dispatch contracts. SKILL.md retains generic wording ("static external slots from the panel manifest") and the MANDATORY normative-source line is extended to list panel topology and static slot identity alongside the existing dedup, artifact, and adjudication contracts. (#5393)
