### PR TITLE
Release v52.1.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.0.6",
+  "version": "52.1.0",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Added

- **`/rejected-analysis` skill**: recovers verified real rejected code-review findings from committed run logs and files issues. Security-sensitive findings are not public-filed. The `finding_hash` uses file plus concern only, excluding run metadata. A committed `larch-logs/rejected-analysis-ledger.tsv` guards against repeated filing. (PR #5496, issue #5462; PR #5500, issue #5467)

- **Two Python AST lint ratchets**: `lint subprocess-via-runner` blocks direct `subprocess.run`/`Popen`/`check_output`/`call` calls outside `python/larch/core/proc.py`; `lint env-via-config-constant` blocks bare env-name literals that match an existing `config.ENV_*` constant. Both ship as pre-commit hooks, `make py-lint-main` checks, and baseline/exemption files. (PR #5481, issue #5339)

- **Voter severity Calibration Score**: `/voter-calibration` gains `--high-severity-threshold` and a per-voter Calibration Score. Voters whose blocker/major tagging rate exceeds the threshold see standing decline linearly toward zero. (PR #5492, issue #5461; PR #5498, issue #5470)

- **Shared verbosity-control anchor** (`skills/shared/verbosity-control.md`): deduplicates the universal verbosity rules (empty Bash `description`, terse 3-5-word Agent `description`, no prose between tool outputs) across `/design` and `/implement` SKILL.md files, reducing always-loaded bytes. (PR #5472, issue #5406)

## Changed

- **Review diff base uses `origin/main`**: `gather_branch_context` now fetches and resolves the remote-tracking ref before computing `git merge-base HEAD origin/main`, preventing mid-run diff contamination when concurrent PRs advance `origin/main` while a branch rebases. (PR #5475, issue #5460)

- **`/design` rare-path bodies moved to on-entry references**: sentinel host-table, validator-failure, Step 2b.5 rc-handling, and drafter fail-safe bodies relocated to `skills/design/references/` files and loaded only on the branches that need them. (PR #5479, issue #5407)

- **Python `larch/core` package migration**: `proc.py`, `redact.py`, `logging_util.py`, `config.py`, and related modules moved to `python/larch/core/`. Import paths in callers updated accordingly. (PR #5480, issue #5167)

- **Plan-mandated deliverable carve-out in reviewer prompts**: reviewer agents (code-robustness, plan-fidelity, security-structure-tests) now treat plan-listed deliverables as In-Scope when absent from the diff, with a citation required. (PR #5497, issue #5486)

- **CI linters updated for `larch/core` layout**: `lint_subprocess_via_runner.py` and `lint_env_via_config_constant.py` single-source the runner and config module paths via `RUNNER_RELPATH`/`CONFIG_RELPATH` constants, tracking the flat-to-package migration. (PR #5487)

## Fixed

- **Corrupted Gantt chart** in `/implement` review-round timing display. (PR #5490, issue #5473)

- **Composite skip wiring**: `_run_relevant_checks_for_site` now passes `--allow-skip` to `checks run-relevant`; `CHECKS_COMMIT_ROUTE_OUTER_TIMEOUT_MS` corrected to the sum of its per-leg deadlines. (PR #5491, issue #5468)

- **`/implement` final-summary key bindings** corrected. (PR #5494, issue #5477)
