### PR TITLE
Release v52.1.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.1.0",
+  "version": "52.1.1",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Fixed

- **Aggregator preamble-substring failures now retry instead of stalling.** When the review aggregator produced output with `FINDING_` references in a preamble but no conforming `### FINDING_N:` blocks, the `preamble_finding_substring` validation failure was mapped to the non-retryable code path, exhausting the retry budget after one attempt and stalling Step 5. It now maps to the retryable path so the aggregator re-dispatches with validator feedback up to the retry budget. (`python/review_aggregate.py`, `python/test_review_aggregate.py`)

- **`/design` Step 3 sentinel probe no longer fires on every spurious empty-output notification.** During a plan-review wait, the orchestrator was probing the `step-3-terminal` sentinel on every spurious `<task-notification>` turn, including turns where the task output was empty, burning O(N) turns. A per-sentinel consecutive-probe-denial counter in `hook-bg-poll-guard.sh` now blocks repeated foreground probes until the sentinel is present; prompt wording in `design-background-wait.md` and `skills/design/SKILL.md` was tightened to match. (`scripts/hook-bg-poll-guard.sh`, `scripts/hook-bg-poll-guard.md`, `python/design_lifecycle.py`, `skills/design/SKILL.md`, `skills/design/scripts/design-step3-review.sh`, `skills/shared/design-background-wait.md`)

- **`design-step3-review.sh` spurious empty-output notifications reduced further.** The `#5240` fix (stderr redirect during `wait`) was insufficient to suppress all spurious task-notifications from `set -m` monitor mode. Further changes to `design-step3-review.sh` and its contract reduce the remaining notification sources. (`skills/design/scripts/design-step3-review.sh`, `skills/design/scripts/design-step3-review.md`, `skills/design/SKILL.md`, `skills/design/scripts/test-design-step3-review.sh`)

- **Stall-recovery Tier A dedup marker no longer dropped by the issue parser.** The marker was prepended before the `### title` heading, which caused `parse_issue_input` to discard it. The composition path now places the marker on the line immediately after the title heading so the parser retains it. (`python/stall_recovery.py`, `python/test_stall_recovery.py`)

- **Pre-vote dropped security-tagged OOS blocks no longer committed to public run logs.** Security-tagged blocks that are dropped before voting were written to `oos-dropped-before-vote.md` alongside public OOS findings and included in committed run-log artifacts. They are now routed to a local-only `oos-dropped-security-local.md` sidecar and never written to public boundary files. (`python/voting.py`, `python/review_pipeline.py`, `python/test_voting.py`, `python/test_review_pipeline.py`, `SECURITY.md`)

- **Stall-recovery round-retry Gantt no longer merges windows from stalled and retry attempts.** When the Step 5 review loop stalled with `aggregator-validation-exhausted` and the stall recovery retried the same round in the same session, both attempts wrote `v1 round` entries for the same round number to the shared timing ledger. `_timing_round_windows` computed the window as `(min(all starts), max(all ends))`, producing a single wide chart where post-aggregation validation probes appeared far from their originating aggregator. The round identification now differentiates stalled and retry attempts so each Gantt section renders within its own window. (`python/progress_report.py`, `python/review_and_fix.py`)

- **Lint-fix loop no longer exhausts its timeout on complexity-baseline regressions.** When the lint-fix loop ran `python/cli.py lint complexity-baseline` and encountered real metric-growth or new-identity regression rows, the loop kept retrying until the timeout fired (exit 124), escalating to the main agent with a stall. A narrow complexity-baseline regression detector in the lint-fix path now returns `main-agent-required` with `failure_reason="complexity-baseline-regression"` immediately, without dispatching any external coder. (`python/checks.py`)

## Changed

- **VCS modules moved into `larch.git` subpackage (packaging 2/9).** `git`, `gh`, `repo_roots`, `rebase`, `push`, `pr`, `pr_body`, and `merge` moved from the flat `python/` directory into `python/larch/git/`. All importers across the Python codebase, the `cli.py` registry, `rebalance-tests/scripts/rebalance.py`, and consumer-doc path references in `.claude/rules/topology-generation.md` and `docs/topology.md` were updated. No behavior change; only the import paths changed. (`python/larch/git/`, `python/cli.py`, `.claude/rules/topology-generation.md`, `docs/topology.md`, `.claude/skills/rebalance-tests/scripts/rebalance.py`)

- **Value-weighted prune gate now activates from round 2 (was round 3).** The reviewer conditional-spawning pruning gate previously skipped rounds 1 and 2, first pruning in round 3. It now allows pruning in round 2 when one prior launched round's evidence exists, while rounds 3-4 still require two recent launched rounds. The net prune gate uses value-weighted accepted points minus rejected counts. Docs updated to reflect the extended window and corrected the description of the pruning net score. (`python/review_pipeline.py`, `docs/point-competition.md`, `python/test_review_pipeline.py`)

- **`SECURITY.md` updated with external tool delegation posture.** Documented the sandbox modes for Codex and Cursor review and sketch delegation, the `CURSOR_DEGRADED_RESPONSE` sentinel, and the degraded-response waterfall fallback behavior. (`SECURITY.md`)
