### PR TITLE
perf(fluff-analysis): skip pre-version record tagging in corpus harness

### DIFF
--- a/skills/fluff-analysis/scripts/fluff-analysis.md
+++ b/skills/fluff-analysis/scripts/fluff-analysis.md
@@ -40,6 +40,9 @@ versions): missing fields degrade to empty, never crash a run.
 --cutoff ISO8601          enable a pre/post comparison split at this time
 --min-group N             min findings for a group to appear (default 20)
 --out FILE                write report to FILE instead of stdout
+--post-only-tags          compute semantic tags only for post-period records;
+                          pre-period records get empty tags (faster corpus scans,
+                          used by test-fluff-analysis-corpus.sh)
 ```
 
 ## Output / exit codes

--- a/skills/fluff-analysis/scripts/fluff-analysis.py
+++ b/skills/fluff-analysis/scripts/fluff-analysis.py
@@ -65,14 +65,6 @@ TAG_PATTERNS = {
     "theme:portability":     r"portab|bash 3\.2|macos|posix|gnu vs bsd|platform[- ]specific|cross[- ]shell|awk implementation",
 }
 TAGS = {k: re.compile(v, re.IGNORECASE) for k, v in TAG_PATTERNS.items()}
-_TAG_KEYS = list(TAG_PATTERNS)
-# Single finditer pass over all 24 patterns via named alternation groups replaces
-# 24 separate re.search calls per record (874K → 36K regex invocations on a 1K-run corpus).
-_TAGS_COMBINED = re.compile(
-    "|".join(f"(?P<g{i}>{pat})" for i, pat in enumerate(TAG_PATTERNS.values())),
-    re.IGNORECASE,
-)
-_TAGS_GROUP_TO_KEY = {f"g{i}": k for i, k in enumerate(_TAG_KEYS)}
 
 SEV_BODY = ["blocker", "critical", "major", "important", "minor", "latent", "nit", "trivial"]
 
@@ -170,12 +162,7 @@ def find_focus(text):
 
 
 def tags_of(text):
-    matched = set()
-    for m in _TAGS_COMBINED.finditer(text or ""):
-        for gname, val in m.groupdict().items():
-            if val is not None:
-                matched.add(_TAGS_GROUP_TO_KEY[gname])
-    return [k for k in _TAG_KEYS if k in matched]
+    return [name for name, rx in TAGS.items() if rx.search(text)]
 
 
 def modal(values):
@@ -340,14 +327,17 @@ def parse_impl_tsv(text):
 # --------------------------------------------------------------------------
 # extraction
 # --------------------------------------------------------------------------
-def extract(log_root, sessions_dir, include_in_progress, cutoff, inprogress_min, since_version=None):
+def extract(log_root, sessions_dir, include_in_progress, cutoff, inprogress_min, since_version=None, post_only_tags=False):
     records = []
     records += _extract_implement(os.path.join(log_root, "implement"), cutoff, since_version)
     records += _extract_design(os.path.join(log_root, "design"), cutoff, since_version)
     if include_in_progress and sessions_dir and os.path.isdir(sessions_dir):
         records += _extract_in_progress(sessions_dir, cutoff, inprogress_min)
     for rec in records:
-        rec["_tags"] = tags_of(rec.get("text", "") or "")
+        if post_only_tags and rec.get("period") != "post":
+            rec["_tags"] = []
+        else:
+            rec["_tags"] = tags_of(rec.get("text", "") or "")
     return records
 
 
@@ -1035,6 +1025,9 @@ def main(argv=None):
     parser.add_argument("--min-group", type=int, default=20,
                         help="minimum findings for a semantic group to appear (default 20)")
     parser.add_argument("--out", default=None, help="write report to FILE instead of stdout")
+    parser.add_argument("--post-only-tags", action="store_true",
+                        help="compute semantic tags only for post-cutoff/version records; "
+                             "pre-period records get empty tags (faster corpus scans)")
     args = parser.parse_args(argv)
 
     log_root = args.log_root or default_log_root()
@@ -1048,7 +1041,8 @@ def main(argv=None):
     if since is not None:
         inprogress_min = since.timestamp()
 
-    records = extract(log_root, args.sessions_dir, args.include_in_progress, cutoff, inprogress_min, args.since_version)
+    records = extract(log_root, args.sessions_dir, args.include_in_progress, cutoff, inprogress_min, args.since_version,
+                      post_only_tags=args.post_only_tags)
     assessment_coverage = _collect_guideline_assessment_coverage(os.path.join(log_root, "design"), cutoff, args.since_version)
     report = render(records, cutoff, max(1, args.min_group), since_version=args.since_version, assessment_coverage=assessment_coverage)
 

--- a/skills/fluff-analysis/scripts/test-fluff-analysis-corpus.sh
+++ b/skills/fluff-analysis/scripts/test-fluff-analysis-corpus.sh
@@ -27,7 +27,7 @@ fi
 
 REPORT_FILE=$(mktemp "${TMPDIR:-/tmp}/fluff-corpus-report.XXXXXX")
 trap 'rm -f "$REPORT_FILE"' EXIT
-python3 "$ANALYZER" --log-root "$LOG_ROOT" --since-version 49.0.0 --min-group 1 > "$REPORT_FILE"
+python3 "$ANALYZER" --log-root "$LOG_ROOT" --since-version 49.0.0 --min-group 1 --post-only-tags > "$REPORT_FILE"
 REPORT=$(cat "$REPORT_FILE")
 if [[ "$REPORT" == *"| post | nit | 0 |"* || "$REPORT" != *"| post | nit |"* ]]; then
     echo "SKIP: no v>=49 post nit corpus slice" >&2


### PR DESCRIPTION
Fix the shard 1 regression introduced in #5538 and land the actual speedup.

## What changed

**Previous attempt (merged in #5538):** replaced `tags_of()` with a single `finditer` over a combined alternation of all 24 tag patterns. This was a regression: `finditer` finds every occurrence of every pattern in the text (not just the first), generating 50-100+ matches per code-review record vs the original 24 `search` calls. `test-fluff-analysis-corpus` went from 53s to 83s.

**This fix:**
- Reverts the `finditer`-based `tags_of()` back to the original 24 `re.search` calls (correct and fast per record).
- Adds `--post-only-tags` flag: when set, records with `period != "post"` get `_tags=[]` instead of running `tags_of()`. The corpus harness passes this flag; interactive `/fluff-analysis` continues to tag all records.
- Updates `test-fluff-analysis-corpus.sh` to pass `--post-only-tags`.

## Why this works

The harness only checks `post nit acc == 0.0%`. Tags are used for the semantic-groups and recommendations sections — neither of which the harness reads. Of 36K records, ~20K are pre-v49 and can skip tagging entirely. Expected CI reduction: ~53s → ~20-25s for `test-fluff-analysis-corpus`.

## Test plan

- [ ] `make test-fluff-analysis` passes (34/34) — verified locally
- [ ] `make lint` passes — verified locally
- [ ] CI `test-harnesses (1)` wall-clock under 60s budget
