### PR TITLE
Release v52.1.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.1.1",
+  "version": "52.1.2",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Added

- **`/implement` reference split**: Step-18a.5 filing procedure, ship-pr OOS checkpoint router, and autonomous CI-fix body moved into new lazily-loaded reference files; adds section-scoped forbid guards and updates structure test harnesses. (#5532)

## Changed

- **`/analyze-issues` verdict mode**: adds mechanical verdict mode for token-allocation evidence with strict run eligibility and gate reporting; records a NO-GO ground-truth verdict artifact until the incentivized corpus and shipped-incentive gate are satisfied. (#5535)
- **`/design` and `/implement` recovery stubs slimmed**: detailed premature-notification recovery mechanics moved to lazily-loaded shared references; anti-polling harness pins strengthened for split design-versus-implement semantics and empty-notification qualifier regressions. (#5541)
- **Progress report precedence**: live Step 5 review rounds now take precedence over stale ship-pr state in `/implement` progress reports; ship-pr state remains the fallback when no Step 5 evidence is available. (#5542)
- **Fluff-analysis corpus harness**: skip tagging pre-version records to reduce unnecessary work. (#5546)
- **CI test shard rebalance**: harness and Python unit test shards rebalanced. (#5538)

## Fixed

- **Stale OOS audit files**: clear parent OOS audit files when a later review round has no dropped findings; preserve per-round audit generation and ballot contents for zero-drop pre-vote gates. (#5547)
- **Redundant Step 5 test runs removed**: remove post-apply full test suite runs from Step 5 review-round gates, eliminating roughly 12 minutes of unlabeled wall time per accepted finding per round. (#5548)
- **Degraded voting tally preservation**: preserve degraded voting tallies before retry overwrites them; commit degraded tally attempts as standard round run-log artifacts. (#5549)
