### PR TITLE
docs: un-retire the harness leg of /rebalance-tests

### DIFF
--- a/.claude/skills/rebalance-tests/SKILL.md
+++ b/.claude/skills/rebalance-tests/SKILL.md
@@ -26,15 +26,15 @@ All flags are optional. The default kind is `all`. The default branch prefix is
 
 ## Kinds
 
-- `harness`: **Retired** (#5429 — the 5 bash-only shards are small enough to
-  assign by hand; `LARCH_HARNESS_TIMING`-based LPT packing is no longer needed).
-  The flag is still accepted but produces no useful output now that pytest-wrapper
-  targets are removed from the shards.
+- `harness`: Rebalances the `test-harnesses-N` shard lists in the `Makefile` by
+  LPT-packing measured `LARCH_HARNESS_TIMING` medians, then verifies real
+  per-shard CI job wall-clock (jobs API) against `--max-shard-wall-clock`
+  (default 60s). The wall-clock and sum-spread reports are warning-only.
 - `python`: Rebalances pytest nodeid assignments from `--durations=0` timing
   rows into `python/shard-assignments.json`. Verification fails closed on zero
   parseable rows, incomplete shard coverage, or spread over threshold.
-- `all`: Rebalances both artifacts in one PR. Harness leg is a no-op (see above).
-  The Python leg drives any non-zero verification exit.
+- `all`: Rebalances both artifacts in one PR. Harness verification is
+  warning-only; the Python leg drives any non-zero verification exit.
 
 ## Safety gates
 

--- a/docs/linting.md
+++ b/docs/linting.md
@@ -84,15 +84,24 @@ When adding a new pre-commit hook, decide explicitly whether `lint`, the dedicat
 
 `make test-harnesses` remains the local umbrella target and runs every regression harness wired into the `test-harnesses-N` shards plus the partition guard (`make test-harness-shards-coverage` reports the active inventory; the `Makefile` is the source of truth). CI fans the same inventory out across five parallel matrix cells named `test-harnesses (1)` through `test-harnesses (5)`, each invoking `make test-harnesses-N`.
 
-The shard lists live directly in `Makefile`. After #5429 the 5 shards contain only bash harnesses; assignment is by hand with roughly equal count. New bash harnesses must be assigned to exactly one `test-harnesses-N:` prerequisite list; `make test-harness-shards-coverage` checks for missing, orphaned, duplicated, wrapped, or non-standard harness entries. The matrix uses `fail-fast: false`, so all five shards finish even after one fails. This spends more CI minutes but preserves complete diagnostics.
+The shard lists live directly in `Makefile`. After #5429 the 5 shards contain only bash harnesses; rebalance them by measured CI timing with `/rebalance-tests --kind harness` (see Refreshing shard balance below). New bash harnesses must be assigned to exactly one `test-harnesses-N:` prerequisite list; `make test-harness-shards-coverage` checks for missing, orphaned, duplicated, wrapped, or non-standard harness entries. The matrix uses `fail-fast: false`, so all five shards finish even after one fails. This spends more CI minutes but preserves complete diagnostics.
 
 Local ordering changed: under `make test-harnesses` and therefore `make lint`, harnesses now execute in shard order (`test-harnesses-1`, then `test-harnesses-2`, and so on), not in the old single prerequisite-list order. Direct `make test-X` invocations are unchanged. CI shards run on separate VMs; local `make -j20 test-harnesses` can run shard targets concurrently, so fixed `/tmp` paths in individual harnesses remain a local-parallelism limitation even though the CI split is isolated.
 
 ### Refreshing shard balance
 
-The 5 bash-only harness shards (#5429) are small enough to manage by hand:
-append new targets to any shard and run `make test-harness-shards-coverage` to
-verify. No rebalancing tooling is needed for harness shards.
+Rebalance the harness shards by measured CI timing with the `/rebalance-tests`
+dev skill (`.claude/skills/rebalance-tests/`):
+
+```bash
+python3 .claude/skills/rebalance-tests/scripts/rebalance.py --kind harness
+```
+
+Harness mode LPT-packs `LARCH_HARNESS_TIMING` medians into the `test-harnesses-N`
+shard lists and verifies real per-shard CI job wall-clock against
+`--max-shard-wall-clock` (default 60s); the wall-clock report is warning-only. To
+add a single new target, append it to any shard, run `make
+test-harness-shards-coverage` to verify the partition, then rebalance by timing.
 
 For Python unit test shards, use the `/rebalance-tests` dev skill
 (`.claude/skills/rebalance-tests/`):


### PR DESCRIPTION
## What

Un-retire the **harness leg** of `/rebalance-tests` in the docs. The code was
never removed — only `SKILL.md` and `docs/linting.md` falsely called it retired.

## Why

`#5429` deprecated the harness leg in two docs, but:

- **The code is fully live.** `_prepare_harness_plan` LPT-packs
  `LARCH_HARNESS_TIMING` medians into the `test-harnesses-N` Makefile shards;
  `_verify_harness` checks real per-shard CI job wall-clock against
  `--max-shard-wall-clock` (default 60s).
- **The script contract doc already agreed.** `scripts/rebalance.md` documents
  "### Harness leg" as active with warning-only verification. So `#5429` left a
  doc inconsistency.
- **CI proves the tooling is needed.** Hand-balancing the 5 harness shards by
  count left **shard 3 at 68–72s, over the 60s budget**. `/rebalance-tests
  --kind harness` repacked all shards to **~49–51s, spread 2s** (PR #5555).

## Changes

- `SKILL.md` "Kinds": `harness` and `all` now describe active, warning-only
  harness rebalancing (no longer "Retired" / "no-op").
- `docs/linting.md`: "Refreshing shard balance" now points at `/rebalance-tests
  --kind harness` instead of "No rebalancing tooling is needed."

Docs only. No code or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
