### PR TITLE
docs: drop the wholesale-local make lint mandate from AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ Plugin ships the entire repo. **Runtime surface**: `skills/`, `agents/`, `hooks/
 ## Editing rules
 
 - Respect `scripts/block-submodule-edit.sh`. If a hook blocks a write, investigate the underlying issue. The guard ships via `hooks/hooks.json` only; contributors need larch loaded as a plugin (`claude --plugin-dir .` or the local marketplace) to pick it up.
-- After any change, run `make lint`. When Python files change, also run `make py-lint` and `make py-test`.
+- Lint/test only the files you changed locally; CI runs the full lint/test sweep on push and gates merge.
 - Update `SECURITY.md` when security-relevant behavior changes.
 
 ## Common editing tasks


### PR DESCRIPTION
## What

Remove the **"After any change, run `make lint`"** directive from `AGENTS.md`
(Editing rules) and replace it with targeted-local guidance.

**Before:**
> After any change, run `make lint`. When Python files change, also run `make py-lint` and `make py-test`.

**After:**
> Lint/test only the files you changed locally; CI runs the full lint/test sweep on push and gates merge.

## Why

- **Wholesale local runs are slow and redundant.** CI runs the full `make lint`
  / `make py-test` suite on every push and gates merge, so a local full sweep
  adds minutes without adding coverage.
- **Local timing is unusable** for any balance/perf decision (different hardware,
  no isolation); CI is the source of truth.

Targeted local checks (the specific `make test-<name>`, the relevant pre-commit
hook, or `pytest path::test`) keep the validate-before-push intent without the
wholesale cost.

Docs only. Kept `AGENTS.md` under the 12,000-char `agnix` limit (now 11,986).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
