### PR TITLE
Release v52.1.3

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.1.2",
+  "version": "52.1.3",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Added

- **`/voter-calibration` era segmentation**: new `--era {all,pre,post}` and `--era-since-date YYYY-MM-DD` flags segment calibration reports into pre- and post-incentive corpora. When `--era` is absent, the existing single-report output is unchanged. The era boundary is resolved automatically from the shipped calibration-incentive issue via the plugin source repo, with a clear message and graceful degradation when the boundary cannot be determined. ([#5577](https://github.com/character-ai/larch/pull/5577))
- **Voter prompt-feedback incentive (Option A)**: wires the Option A prompt-feedback incentive mechanism and updates the ground-truth-verdict precondition gate to reference issue #5544. ([#5600](https://github.com/character-ai/larch/pull/5600))

## Fixed

- **Cursor plan-review fake-clean `no_issues_found`**: two root causes addressed. When an in-process auth-preflight silently drops the token-read, Cursor slots returned a bare `{"no_issues_found": true}` sentinel with near-zero input tokens. Larch now detects this via an input-token floor check and flags the slot as degraded rather than accepting the sentinel as a genuine clean review. Applied to all Cursor review slots via `_review_cursor_postprocess`. ([#5553](https://github.com/character-ai/larch/pull/5553))
- **Codex lint-fix 300 s timeout on `exec_command` policy rejection**: when the Codex sandbox blocks `exec_command`, the child no longer stalls for 300 seconds. The event-stream watcher now detects `exec_command failed` / `blocked by policy` / `Rejected(` evidence, writes `FAILURE_CLASS=policy-rejection`, terminates the child immediately, and treats the rejection as non-retryable. Codex lint-fix is now edit-only; parent orchestrator runs verification outside the sandbox. ([#5576](https://github.com/character-ai/larch/pull/5576))
- **Dynamic archetype reviewers excluded from failure threshold and slot accounting**: dynamic archetype reviewer slots are now included in failure threshold checks and slot accounting. Dropped-slot artifacts (waterfall `*.dropped-slots` ledgers and bounded `dropped-*-*.txt` diagnostics) are committed as round artifacts through the existing `redact.redact()` path. ([#5578](https://github.com/character-ai/larch/pull/5578))
- **Blank Gantt gaps from missing timing in post-apply and lint-fix loops**: post-apply checks and lint-fix loops now record timing, eliminating the silent blank gaps that appeared in review-round Gantt diagrams when these steps ran. ([#5580](https://github.com/character-ai/larch/pull/5580))
- **Corrupted Gantt diagram**: fixes a rendering defect in `gantt.py` that produced a malformed Gantt output. ([#5596](https://github.com/character-ai/larch/pull/5596))

## Changed

- **CI test resharding**: reshards test-harnesses to 5 shards and python-tests to 20 shards, rebalances both harness and python shard distributions, and shards python-lint across 3 runners behind a gate for parallel execution. ([#5552](https://github.com/character-ai/larch/pull/5552), [#5554](https://github.com/character-ai/larch/pull/5554), [#5555](https://github.com/character-ai/larch/pull/5555), [#5556](https://github.com/character-ai/larch/pull/5556))
- **Agent launchers moved to `larch.agents` package** (packaging 4/9): `agent_voters.py`, `agent_waterfall.py`, `agents.py`, `collect_results.py`, and `review_dispatch.py` move from `python/` into `python/larch/agents/`. Imports updated across all callers. ([#5597](https://github.com/character-ai/larch/pull/5597))
- **`/design` anti-halt preamble slimmed**: the always-loaded `/design` anti-halt preamble points the generic core at a shared `#anti-halt` anchor and deduplicates the final-summary binding, reducing load-time token cost. ([#5575](https://github.com/character-ai/larch/pull/5575))
- **`/design` Step 3/Gate prose deduplicated**: settle-rc fallback tables, Gate-B-bypass restatement, and the two Step 3 entry fences are deduplicated; emits a `STEP4_MODE` directive. ([#5592](https://github.com/character-ai/larch/pull/5592))
- **`/implement` terminal Steps 16-18 fence chain folded**: pins to step-16-17, gates to finalize, and refreshes execution-issues to oos-checkpoint. ([#5598](https://github.com/character-ai/larch/pull/5598))
- **`/implement` ship references trimmed**: drops the dead `/issue` oos-pipeline load on the Python path; splits branch-only ship-pr-exit-matrix sections into separate on-demand references. ([#5594](https://github.com/character-ai/larch/pull/5594))
- **Rare-path `/implement` bodies relocated**: the `--self-review` mode block and the Step 0 dirty-recovery/degraded-prompt body move to on-entry references, loaded only when those paths are entered. ([#5595](https://github.com/character-ai/larch/pull/5595))
- **Shared references split**: dialectic-protocol legacy choreography, voting-protocol dead voter argv, and progress-reporting nested-only step-prefix are split into separate reference files. ([#5591](https://github.com/character-ai/larch/pull/5591))
- **Three orphaned reference files retired**: `ci-fix-failure-patterns`, `focus-area-prompt`, and `codex-manifest-schema` digest files had no runtime loader and are removed. ([#5581](https://github.com/character-ai/larch/pull/5581))
- **Docs**: un-retires the harness leg of `/rebalance-tests` docs and drops the wholesale-local `make lint` mandate from `AGENTS.md`. ([#5557](https://github.com/character-ai/larch/pull/5557), [#5559](https://github.com/character-ai/larch/pull/5559))
- **OOS rollup**: aggregates 2 capped out-of-scope items. ([#5593](https://github.com/character-ai/larch/pull/5593))
