### PR TITLE
Release v52.1.4

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.1.3",
+  "version": "52.1.4",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## What's Changed

### Fixed

- **Step 3 orchestrator empty-output spurious-notification bypass** (PR #5622): The orchestrator no longer probes the design sentinel on empty-output `<task-notification>` turns. `hook-bg-poll-guard.sh` deny emitters now use `printf` instead of `jq -cn`, eliminating silent deny suppression on `jq` runtime failures.

- **Code-flow diagram wrong `cli.py` path after `larch.git` packaging move** (PR #5623): `python/larch/git/pr_body.py` now resolves the larch CLI path as `Path(__file__).resolve().parents[2] / "cli.py"` (same pattern as other packaged modules), fixing silent metadata-post failures and loud diagram-generation errors introduced by the `larch.git` move.

- **AST ratchet linters failing after packaging moves** (PR #5624): `lint-subprocess-via-runner` and `lint-env-via-config-constant` now preserve the baseline reason by basename and semantic identity when a finding's file is relocated. This resolves lint-fix escalations that required main-agent intervention after each packaging PR.

- **`record-escalation` rejecting its own `--failure-detail-log`** (PR #5625): Stall-recovery `record-escalation` now treats `--failure-detail-log` as optional. Oversize logs are truncated into a tmpdir-local sidecar. Other validation misses record a specific skip token (`detail_log_skipped=failure-detail-log-<cause>`) without aborting the escalation ledger entry.

- **Claude CI lint-fix lane timing out on degraded auth** (PR #5626): `_run_claude_with_stdin` in `python/larch/agents/agents.py` now polls stderr during the first 60 seconds and fast-fails with `EXIT_TIMEOUT` when degraded-auth patterns are detected (e.g. `claude.ai connectors are disabled`, `apiKeyHelper failed`). Existing `lint-fix-main-agent-required` escalation behavior is preserved.

- **Findings aggregator semantic-validation failures** (PR #5627): The aggregator prompt now includes an explicit required-slot inventory section built from the parsed input blocks. The aggregator instruction set is strengthened to enforce slot-inventory membership for `Reviewer(s)` lines and `From <slot>:` revision bullets. This reduces the validation-failure rate that was consuming retries in design and implement runs.

- **Claude cost always priced at Opus 4.8 rates** (PR #5628): `/report-tokens` now prices the main Claude lane using the actual main-agent model from the run manifest (`claude-sonnet-4-6`, `claude-haiku-4-5`, `claude-fable-5`, or `claude-opus-4-8`). Subprocess lanes map historical `claude_*` raw roles to per-model rate rows. The default fallback remains `claude-opus-4-8` for unresolved models.

### Changed

- **`larch.implement` package** (PR #5611): The implement subsystem (`implement_dispatch`, `step_7a`, `implement_finalize`, `checks`, `ci`, `ci_monitor`, `ship`) moved from flat `python/` into `python/larch/implement/`. All importers and `cli.py` `_REGISTRY` entries repointed; no behavior change.

- **`larch.issue` and `larch.report` packages** (PR #5612): The issue subsystem (`combine_issues`, `audit_runs`, `tracking_issue`, `issue_wire`, `issue_create`) moved into `python/larch/issue/`. `timing.py` moved into `python/larch/report/`. Rules and path triggers updated.

- **`larch.review` package** (PR #5615): Review pipeline modules (`review_pipeline`, `plan_review`, `plan_review_panel`) moved into `python/larch/review/`. Topology doc and path-triggered rules updated.

- **`larch.design` package** (PR #5617): Design subsystem (`plan_scout`, `plan_quality`) moved into `python/larch/design/`. Topology doc and path-triggered rules updated.

- **`/design` Step 2a folded into Step 2b drafter** (PR #5630): Sentinel-write logic from Step 2a is now a helper called at the start of `step2b_drafter_main`. Drafter outcome routing is collapsed to a single `DRAFTER_NEXT_ACTION` directive prefixed by `STEP2B_DRAFTER_WRAPPER_ROWS_BEGIN=1`. Retired `DRAFTER_STATUS=succeeded/fallback/dirty-tree` machine rows are removed. Pause-save calls require a `PAUSE_OK=true` capture before any trusted action row is emitted.
