### PR TITLE
Release v52.1.5

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.1.4",
+  "version": "52.1.5",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Added

- **`/implement` bg-wait markers and terminal sentinels**: Steps 3 and 5 now write `.bg-wait-active` markers and `.completed/step-3-terminal` / `.completed/step-5-terminal` sentinels on exit. `hooks.json` and `hook-bg-poll-guard.sh` extended to deny `Monitor` and `TaskOutput` tool calls while any bg-wait is active, preventing premature-notification storms. (#5657)

## Changed

- **`/implement` Step 3+4+4.r composite**: Steps 3, 4, and 4.r folded into a single `checks-commit-route` composite; Step 2 entry telemetry and post-dispatch/rebase-routing parse-then-branch collapsed (md-to-py-VII). (#5613)
- **`/design` Step 5c diagram sanitizer**: Diagram sanitizer folded into Step 5c; `oos-step5b` dispatch table removed (md-to-py-VII). (#5666)
- **Python packaging capstone**: All 60+ flat Python runtime modules reorganized into coherent `larch.*` sub-packages (`larch.cli`, `larch.rendering`, `larch.release`, `larch.lint`, `larch.research`, `larch.calibration`). `python/cli.py` is now a thin entry-point shim; consumer invocations are unchanged. (#5653)

## Fixed

- **Truncated sidecar evidence**: Truncated sidecar evidence was not consumed by classify or Tier A compose-report. (#5658)
- **ship-pr-ci breadcrumbs never committed**: Publish gate was blocking the staging step, so breadcrumbs were never committed. (#5660)
- **`/implement` escalation complexity regression**: Codex increased `step2b_drafter_main` complexity beyond the baseline after folding step2a logic. (#5661)
- **`/design` Step 3 spurious task-notification**: Eliminated a spurious task-notification source in Step 3. (#5663)
- **ship-pr-ci monitor false-pass**: Monitor counted skipped and cancelled checks as passing; merge loop stalled at cap. (#5664)
- **Plan-review finding drop on transient Claude voter failure**: All findings were dropped when the Claude voter failed transiently, even when Codex and Cursor both voted. (#5665)
- **Self-review commit-route false stall**: False stall occurred when a snapshot was written after the inline fix. (#5668)
- **ship-pr-ci orchestrator hang**: Orchestrator hung at the CI-fix/conflict handoff with no observable signal. (#5669)
- **Universal no-progress circuit breaker**: Hard-cap on consecutive no-progress iterations now enforced. (#5670)
- **Merged runs logged as bailed/partial**: Runs that merged successfully were recorded as bailed or partial in committed logs. (#5671)
- **`/implement` terminal lint violations**: Two lint violations (orphaned skill files, missing readability-preamble directives) were left unfixable by automated repair at the terminal escalation level. (#5672)
