### PR TITLE
Release v52.1.6

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.1.5",
+  "version": "52.1.6",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## What's changed in v52.1.6

### Fixed

- **Packaging migration importer scan** now covers `skills/**/*.py` files that extend `sys.path` to include `python/`. Previously the scan was scoped to `python/` only, causing a `ModuleNotFoundError` in the `test-fluff-analysis-corpus` CI harness after flat modules were deleted. (PR #5702)
- **hook-bg-poll-guard and hook-no-progress-guard** now correctly engage in production. Both guards were resolving the Claude session PID to `$PPID` (the hook runner's parent) instead of the real session PID, so the `.bg-wait-active` marker was rejected as "not mine" on every invocation, silently bypassing all anti-spurious-notification protections. (PR #5703)
- **Self-review commit** no longer stalls with `ERROR=dirty tree after review fix commit`. The residual dirty-tree branch after a partial review-fix commit is now handled explicitly. (PR #5706)
- **Committed final-summary** no longer mislabels stalled-then-shipped `/implement` runs as `stalled`. The `stalled` outcome path now correctly detects a recovered and merged run, matching the earlier fix for the analogous `bailed` mislabel. (PR #5708)
- **/design Step 6** no longer reports a missing step-5c status sidecar after a premature task notification. The root cause was a race where the harness fired a "completed" notification before `_step5c_render_final_summary` finished writing its terminal sentinel. (PR #5709)
- **/design plan-voter** no longer emits empty output (exit 124) on approximately 14% of runs. The voter timeout and subprocess failure path are addressed so the review panel degrades gracefully rather than silently dropping results. (PR #5712)

### Changed

- **8 residual flat runtime modules** have been moved into the `larch.*` package namespace and `design_legacy.py` has been removed. This completes the packaging migration umbrella started in #4982. (PR #5685)
- **PLR0911 return-count lint regressions** that are isolated to a single function are now routed to external lint-fix coders with shared consolidation guidance. Complexity-baseline escalation is preserved for metric growth and non-PLR0911 regressions. (PR #5704)
- **Step 7a code-flow launcher failures** are now classified as health/auth errors when Claude auth degrades, surfacing a cleaner diagnostic. The best-effort code-flow diagram timeout is shortened to reduce wasted wall-clock time. (PR #5705)
- **Architectural guideline notes** are now refreshed from the latest staged diff metadata before the final pin, so they survive harmless HEAD drift without being dropped. Strict fail-closed validation is preserved when artifacts, repo roots, base refs, or live diffs are missing. (PR #5707)
