### PR TITLE
Release v52.1.7

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.1.6",
+  "version": "52.1.7",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Added

- `/fluff-analysis` now includes false-negative and under-acceptance metrics (neutral-rate, important-reject-rate) in review telemetry, with a TSV-primary implement corpus and symmetric OOS exclusion for design and implement. (#5716)
- OOS issues carrying correctness or regression deferrals are now tagged with `oos-correctness` during implement and design filing. The label state is preserved across design reruns, and `/analyze-issues` surfaces open high-risk OOS issues in a dedicated backlog section. (#5724)

## Changed

- Reviewer prompts include a high-severity neutral rescue rule: when exactly one judge votes YES on a `blocker` or `major` finding, the tally routes that neutral to OOS artifacts instead of dropping it. Single-YES findings at lower severities still drop. All reviewer agents and pre-rendered bodies updated. (#5717)

## Fixed

- Narrowed the Claude degraded-auth fast-fail regex to exclude the benign `claude.ai connectors are disabled` informational message, preventing false-positive exit-124 kills of healthy voter subprocesses. (#5718)
- Self-review commit-fixes no longer classifies a dirty working tree with no collected review-delta paths as a Tool Failure; the outcome is now `noop`, matching the clean-tree noop case. (#5720)
- Plan-review voter prompt now includes an explicit "Proceed immediately" directive that forbids any preamble or acknowledgement before the first vote line, preventing the voter from intermittently outputting canned acknowledgements instead of casting votes. (#5721)
- Code-flow diagram generator and claude-ci lint-fixer now retry once on empty output or exit-124 transients, matching the retry behavior already in place for the design plan-review voter. A `code-flow-diagram.retried` sidecar is written for observability. (#5722)
