### PR TITLE
Release v52.1.8

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.1.7",
+  "version": "52.1.8",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Changed

- Relevant-check routing now maps the anti-polling test script and its related documentation files (`AGENTS.md`, `skills/design/SKILL.md`, `skills/shared/orchestrator-never.md`, `skills/shared/design-background-wait.md`, `skills/implement/SKILL.md`) to the `test-implement-anti-polling-rule` CI target, so edits to those surfaces trigger the focused test.
- Internal report and rendering modules (`python/larch/report/final_report.py`, `progress_report.py`, `review_phase_detail.py`, `python/larch/rendering/gantt.py`, `python/larch/implement/checks.py`) now have self-referential routing entries that fall back to `py-test`, ensuring owner tests run on future edits.
- Pattern matching in `_patterns_match` skips non-wildcard glob patterns when the candidate path's depth differs from the pattern's depth, preserving full union semantics while preventing spurious cross-depth matches.

## Fixed

- Added regression tests covering: pre-commit failure short-circuits later check phases; Gantt chart renders visible relative bars for minimal overlapping rows; progress-report phase-detail includes expected Gantt output; review-aggregate validator correctly rejects missing reviewer slots and missing severity fields.
