### PR TITLE
Release v52.1.9

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.1.8",
+  "version": "52.1.9",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Fixed

- **Reviewer-prune activates at round 3 again.** PR #5463 moved first-pruning to round 2 with a single-round evidence window, allowing a single unproductive ledger round to wipe the entire panel at round 2. Pruning now requires two prior rounds of evidence and activates no earlier than round 3, for both `/implement` code review and `/design` plan review. ([#5737](https://github.com/character-ai/larch/pull/5737))

- **Reviewer-prune ledger records accurate counts when classification tokens are bare.** Since v52.1.4, the aggregator emits bare slot labels (e.g., `cursor-specialist-correctness`) rather than suffixed filenames (e.g., `cursor-specialist-correctness-output.txt`). The prune join normalizer did not strip the `-output` suffix, so every round-1 count was recorded as zero and every combo was pruned at the activation round. `_normalize_code_label` now strips a trailing `-output` so both forms canonicalize to the bare label. ([#5746](https://github.com/character-ai/larch/pull/5746))

- **Step 7a code flow diagram failures now surface actionable diagnostics.** When the diagram subprocess exited non-zero, the warning always showed `tail=stderr:` with nothing after it because the Python launcher's own stderr (always empty) was read instead of the `claude` binary stderr sidecar file. The sidecar file is now read for diagnostic content, and transient failures retry up to four times with a short delay before the warning is emitted. ([#5743](https://github.com/character-ai/larch/pull/5743))
