### PR TITLE
Release v52.1.10

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.1.9",
+  "version": "52.1.10",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Changed

- `/design`: deduplicated Step 3 prose and replaced the superseded `STEP3_REVIEW_LOOP_STATUS` routing with the canonical `NEXT_ACTION` field; removed the dead `### Step 3 report-gate routing` block (#5749)
- `/implement`: collapsed Step 5 checks-failed duplicated blocks into a single shared macro invocation; condensed exit-code 3 sub-case prose to a pointer into `preflight-plan-audit.md` (#5750)
- `/design`: moved always-loaded Python-internal prose (auto-error reporting, sentinel folded-contract notes) out of `SKILL.md` into dedicated reference files (#5751)
- `/design`: split Gate B explicit-mode prompts into a separate reference that is loaded only when `approve_requested=true` and accepted findings are non-empty; default-mode load unchanged (#5755)
- `/design`: elided the `step1d5` entry fence on the brainstorm-off path to reduce always-loaded context (#5756)
- `/implement`: relocated rare-path bodies (`--force` BYPASS grammar, arch-guidelines present-path) to on-entry references (#5757)
- `/design` + `/implement`: removed always-loaded G004/S030 reachability inventories from both `SKILL.md` files; silenced via `agent-lint.toml` excludes (#5758)
- `/implement`: folded Step 6 entry and checks-commit-route into one directive-emitting composite (#5762)
- `/implement`: split the Code Reviewer archetype in `reviewer-templates.md` off the conflict-path whole-file load (#5763)

## Fixed

- Fixed a no-path `rg`/`grep` probe that hung on stdin when backgrounded, orphaning the subprocess; all affected probes now receive an explicit path argument (#5760)

## Internal

- Removed 45 backward-compat `sys.modules` shims from `python/`; repointed flat test imports to `larch.*` package paths (#5761)
- Retired four orphaned reference files (`dialectic-legacy`, `pr-body-template`, `step-16-17-sentinel`, `summary-comment-template`) that had no runtime loader (#5759)
