### PR TITLE
Release v52.1.11

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.1.10",
+  "version": "52.1.11",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Added

- Added architectural guideline requiring strong typing for all Python local variable declarations. (#5803)
- Added `articles/PLAN.md`: a series plan for short articles on agentic skill engineering using Larch as a worked example. (#5802)

## Changed

- Enforced Python package import-direction layering: a linter now prevents leaf packages from importing upward into core packages, catching silent cycles at CI time. (#5799)
- Split eight large god-modules into focused submodules to reduce per-edit context and merge-conflict surface:
  - `larch/agents/agents.py` (6,677 LOC) (#5809)
  - `larch/design/design_lifecycle.py` (5,172 LOC) (#5806)
  - `larch/issue/analyze_issues.py` (3,546 LOC) (#5800)
  - `larch/implement/implement_dispatch.py` (3,469 LOC) (#5808)
  - `larch/review/review_and_fix.py` (3,363 LOC) (#5810)
  - `larch/review/review_pipeline.py` (3,104 LOC) (#5812)
  - `larch/state/stall_recovery.py` (2,905 LOC) (#5813)
  - `larch/implement/checks.py` (2,881 LOC) (#5811)
- `/implement` Step 8 (ship-pr) now writes a `.bg-wait-active` marker so notification-storm hooks cover the longest background fence. (#5807)

## Fixed

- `/design` final summaries no longer traverse task-notification stdout when the body is large; a path pointer with empty readiness markers is emitted instead and the summary is displayed via Read. (#5798)
- Architectural-guideline notes are correctly re-pinned in final summaries after post-merge HEAD drift; the closeout step no longer re-pins against main. (#5794)
- Removed stale `plan-review-tally.json` and `version-bump-reasoning.md` entries from `docs/run-logs-required-files.tsv`; the `audit-runs` required-file-presence scan no longer reports failure on every run. (#5805)
- Audit-runs report titles are now truncated to fit GitHub's 256-character limit, preventing `Title too long` rejections on large-batch audits. (#5801)
- Cursor lanes no longer launch the Cursor.app GUI window during `/implement`; the `NO_OPEN_BROWSER` environment variable now suppresses the browser open. (#5804)
