### PR TITLE
Release v52.1.12

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.1.11",
+  "version": "52.1.12",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Fixed

- **Voter waterfall for `/design` and `/review` judge panels** (PR #5824): voter slots previously dropped a judge when the primary external tool was unavailable. Now every external voter slot degrades through a full waterfall. Voter 1 (validity) tries Cursor, then Codex, then Claude. Voters 2 and 3 (plan-fidelity, pragmatism) try Codex, then Cursor, then Claude. The voter 1 `.done` sentinel and the `_launch_voter1_external` helper now handle both Cursor and Codex as the base tool.

## Changed

- **Split `larch/report/run_logs.py`** (PR #5821): decomposed the 3,266-LOC god-module into `run_log_batch.py`, `run_log_commit.py`, `run_log_flush.py`, and `run_log_manifest.py`. CLI and consumer contracts unchanged.

- **Split `larch/implement/ship.py`** (PR #5822): decomposed the 2,816-LOC god-module into `ship_guidelines.py`, `ship_merge.py`, `ship_pr.py`, `ship_result.py`, `ship_resume.py`, `ship_seed.py`, and `ship_state.py`. CLI and consumer contracts unchanged.

- **Split `larch/review/plan_review.py`** (PR #5826): decomposed the 2,872-LOC god-module; extracted `plan_review_loop.py` and sibling modules. Updated `docs/topology.md` and the topology-generation rule to reference the new files. CLI and consumer contracts unchanged.

- **Migrated flat test files to `python/tests/` package tree** (PR #5825): relocated 148 flat `python/test_*.py` modules to a mirrored `python/tests/<domain>/` hierarchy. Updated Makefile targets to reference the new paths. Added `python/tests/` to `.gitleaks.toml` exclusions. No behavior change.
