### PR TITLE
Release v52.1.13

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.1.12",
+  "version": "52.1.13",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Added

- **`lint-skill-description-length` linter** (#5829): New pre-commit hook and `python3 python/cli.py lint skill-description-length` Makefile target validate that SKILL.md `description:` fields stay within a character limit. Six dev-only skill descriptions shortened to comply.
- **SKILL.md closure growth ratchet** (#5831): `lint-skill-closure-growth` pre-commit hook and `python3 python/cli.py lint skill-closure-growth` fail when `/design` or `/implement` markdown closure metrics grow past a stored baseline. Added `make skill-closure-size`, `make lint-skill-closure-growth`, and `make regen-skill-closure-baseline` targets. Added `pytest` to CI test harness requirements.
- **`lint-bg-wait-coverage` linter** (#5832, #5833): Pre-commit hook and `python3 python/cli.py lint bg-wait-coverage` enforce background-wait marker coverage across `/design`, `/implement`, `/review`, and `/review-and-fix` skill files.

## Changed

- **Tier-1a doc compression** (#5832): Compressed `AGENTS.md`, `BASH_AUTHORING.md`, and `KARPATHY_CLAUDE.md` in place. Prose shortened; no load-bearing contracts removed.
- **CI Tier-1a size ratchet step** (#5832): Added `make lint-tier1a-size` as a dedicated CI workflow step in `.github/workflows/ci.yaml`.
- **`docs/linting.md`** (#5831, #5832): Added sections for the SKILL.md closure growth ratchet and the `lint-bg-wait-coverage` linter.
