### PR TITLE
Release v52.1.14

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.1.13",
+  "version": "52.1.14",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Fixed

- **Gantt charts absent from final reports.** `write_implement_round_meta` was dropped when `_run_round` moved to `round_runner.py`. `_completed_round_dirs()` found no `round-meta.json` and suppressed all Gantt output. Restored the call in `round_runner.py`. (PR #5844)

- **Reviewer attribution credited slot name instead of executing tool on vendor fallback.** When a vendor was unavailable and its slots fell back to another tool, the final-summary Top Reviewers list and reviewer-status table still showed the original slot label. The fix reads `TOOL=` from `collector-results.env` and reconciles it into the attribution labels. (PR #5849)

- **Code-review voter waterfall not uniform across all three slots.** Voter-1 was dispatched once outside `dispatch_waterfall` with no runtime-failure fallback; a billing-class runtime exit dropped the slot rather than re-dispatching to the next tier. The terminal Claude tier also lacked ballot-file read access, causing ≥80% `JUDGE_ERROR` and panel collapse to 0 judges. Voter-1 now flows through the shared waterfall, and the Claude tier receives the required read permission. (PR #5850)

- **`implement/SKILL.md` Step 8b recovery prose named a non-existent failure class.** The round-IX prose compression changed `transient-infra` / `step8-shippr` to `merge-conflict`, which is not a classifier return value anywhere in the codebase. Restored the correct classification name and the manual-resolution operator action. (PR #5846)

- **`AGENTS.md` em-dash prohibition softened in round-IX prose trim.** The hard `Never use em dashes. Use periods, commas, colons, or semicolons instead.` rule was folded into a soft `Avoid` list item, dropping the alternative-punctuation guidance. Restored the hard prohibition and its guidance. (PR #5848)

## Changed

- **`skill-closure-baseline.json` regenerated.** The baseline was captured before a prior SKILL.md compression and was ~16% loose on the implement token gate. Regenerated against the current skill files and added a STRICT freshness test that asserts the committed baseline matches a fresh scan. (PR #5845)

- **`design/SKILL.md` prose compression completed.** A prior PR removed blank lines only; the prose compression that was the stated goal was not delivered. Converted verbose clauses to imperatives and compressed the anti-halt paragraph, while preserving load-bearing NEVER/anti-halt duplication. (PR #5847)
