### PR TITLE
Release v52.1.15

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.1.14",
+  "version": "52.1.15",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Fixed

- **Cursor cost under-reporting corrected.** The cost machinery now applies the Teams plan $0.25/M per-token surcharge for non-auto Cursor invocations (`composer-2.5`), raising effective rates to $0.75/$0.45/$2.75 per M (input/cache-read/output). An Auto mode rate card ($1.25/$0.25/$6.00, no surcharge) is added. Cursor mode is now recorded per invocation so the report can distinguish auto vs pinned-model usage. ([#5861](https://github.com/character-ai/larch/pull/5861) via [#5854](https://github.com/character-ai/larch/issues/5854))

- **Historical Cursor cost figures in run logs retro-corrected.** Committed `larch-logs/` run summaries that embedded Cursor dollar amounts at the old un-surcharged rates are rewritten to reflect corrected pricing. ([#5860](https://github.com/character-ai/larch/pull/5860) via [#5853](https://github.com/character-ai/larch/issues/5853))

- **Vendor `totals.cache_read` no longer serialized as null in token-report.json.** A serialization bug caused the `cache_read` field in per-vendor totals to appear as null. ([#5865](https://github.com/character-ai/larch/pull/5865) via [#5852](https://github.com/character-ai/larch/issues/5852))

- **Recovery-paths NUL pathspec now includes `git mv` source path.** `_parse_porcelain_z` previously discarded the rename source path from `R` entries in `git status --porcelain=v1 -z` output. The source path was then absent from the `--pathspec-from-file` commit in Step 4, leaving staged deletions uncommitted and causing `assert_clean_worktree` to stall the ship driver before push. ([#5866](https://github.com/character-ai/larch/pull/5866) via [#5863](https://github.com/character-ai/larch/issues/5863))

## Changed

- **Ruff complexity enforcement re-tightened after package splits.** Per-file ruff complexity ignore entries in `python/ruff.toml` are trimmed to only the codes still present in the regenerated baseline for each production path after recent package splits. ([#5864](https://github.com/character-ai/larch/pull/5864) via [#5778](https://github.com/character-ai/larch/issues/5778))

- **Stale "postbump" terminology clarified.** Prose in the implement skill and related scripts is reworded from "pre-bump/post-bump" to "pre-ship". Python code symbols that carry the `postbump` name now have one-line comments noting that no version bump occurs; `/release` owns versions. ([#5859](https://github.com/character-ai/larch/pull/5859) via [#5842](https://github.com/character-ai/larch/issues/5842))
