### PR TITLE
Release v52.1.16

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.1.15",
+  "version": "52.1.16",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Added

- **New lint forbids flat test modules at the repo root.** `lint-flat-tests` forbids flat `python/test_*.py` modules outside `python/tests/lint/` (only `test_support.py` is exempt); the last remaining flat test modules are relocated accordingly. ([#5902](https://github.com/character-ai/larch/pull/5902) via [#5869](https://github.com/character-ai/larch/issues/5869))

## Changed

- **Large runtime modules split into submodules.** `plan_quality.py`, `rendering.py`, `progress_report.py`, and `voting.py` are split into new private submodules, with the originals left as thin re-export shims. No behavioral change. ([#5899](https://github.com/character-ai/larch/pull/5899) via [#5870](https://github.com/character-ai/larch/issues/5870))

- **Run-log corpus reporting extracted; Claude source metadata tracked across sessions.** A new `run_log_corpus.py` module handles run-log corpus/token reporting. Session-env and design-log-publish handling now track and persist Claude source metadata (`claude-source.env`, `source-env.sh`) across session transcripts, and design-publish snapshots exclude the `larch-logs` subtree. ([#5905](https://github.com/character-ai/larch/pull/5905) via [#5871](https://github.com/character-ai/larch/issues/5871))

- **Skill-closure-growth lint extended to `/design`.** Conditional-section and mandatory-read-path checks, previously `/implement`-only, now also cover the `design` skill. Runtime markdown-like variable operands (e.g. `$VAR/`) are excluded from static path resolution. ([#5909](https://github.com/character-ai/larch/pull/5909) via [#5872](https://github.com/character-ai/larch/issues/5872))

- **Shared references extracted for `--run-id` and `session setup` docs.** Repeated `--run-id` flag and `session setup` output-key documentation across roughly 15 skill files are consolidated into two new shared references: `skills/shared/run-id-flag.md` and `skills/shared/session-setup-output.md`. ([#5912](https://github.com/character-ai/larch/pull/5912) via [#5883](https://github.com/character-ai/larch/issues/5883))

- **`/design` and `/implement` skill docs condensed for token footprint.** Prose is tightened across several skill reference docs and `SKILL.md` files, shrinking the skill-closure token footprint with no contract or behavior changes:
  - `skills/design/references/approval-gates.md` ([#5900](https://github.com/character-ai/larch/pull/5900) via [#5874](https://github.com/character-ai/larch/issues/5874))
  - `skills/design/references/finalize-step5.md`, removing a duplicated Step 5c abort-contract section ([#5906](https://github.com/character-ai/larch/pull/5906) via [#5876](https://github.com/character-ai/larch/issues/5876))
  - `skills/design/references/plan-review.md` ([#5907](https://github.com/character-ai/larch/pull/5907) via [#5875](https://github.com/character-ai/larch/issues/5875))
  - `skills/design/references/discussion-rounds.md` ([#5916](https://github.com/character-ai/larch/pull/5916) via [#5877](https://github.com/character-ai/larch/issues/5877))
  - `skills/design/references/outline.md` ([#5917](https://github.com/character-ai/larch/pull/5917) via [#5878](https://github.com/character-ai/larch/issues/5878))
  - `skills/design/references/flags.md`, and documents `--hard` as a rejected unknown flag ([#5919](https://github.com/character-ai/larch/pull/5919) via [#5879](https://github.com/character-ai/larch/issues/5879))
  - `skills/design/SKILL.md` (~17% reduction) ([#5920](https://github.com/character-ai/larch/pull/5920) via [#5881](https://github.com/character-ai/larch/issues/5881))
  - `skills/implement/SKILL.md`, deduplicating a repeated mandatory-read instruction in the Step 8+ ship matrix ([#5926](https://github.com/character-ai/larch/pull/5926) via [#5882](https://github.com/character-ai/larch/issues/5882))
  - `skills/shared/design-background-wait.md` ([#5928](https://github.com/character-ai/larch/pull/5928) via [#5880](https://github.com/character-ai/larch/issues/5880))

## Fixed

- **Background-wait guard directory scan scoped to session directories.** The bg-poll-guard hook's directory scan is now scoped to `larch-`, `claude-design-`, and `claude-implement-`-prefixed session directories instead of scanning all of `$TMPDIR` (tens of thousands of entries). Related hook timeouts are raised from 5s to 10s as a safety margin. ([#5890](https://github.com/character-ai/larch/pull/5890) via [#5868](https://github.com/character-ai/larch/issues/5868))

- **Design-structure line-count cap replaced with token-based lint.** `scripts/test-design-structure.sh`'s `wc -l`-based cap is replaced by the byte/token-based skill-closure-growth linter, with a blank-line-neutral "content token" metric so deleting blank lines alone can no longer create artificial ratchet headroom. ([#5901](https://github.com/character-ai/larch/pull/5901) via [#5873](https://github.com/character-ai/larch/issues/5873))

- **Killed `checks-commit-route` processes now recover instead of stalling.** A process killed before it could record `STALL_TRACKING` state is now detected via a dead-PID `.bg-wait-active` marker and classified as a retryable `transient-infra` stall (`checks-commit-route-retry`) instead of left unrecoverable. ([#5913](https://github.com/character-ai/larch/pull/5913) via [#5891](https://github.com/character-ai/larch/issues/5891))

- **`/implement` Step 4 commit short-circuits when nothing changed.** The commit leg now no-ops when target paths are already clean relative to HEAD, avoiding a redundant commit attempt. ([#5931](https://github.com/character-ai/larch/pull/5931) via [#5922](https://github.com/character-ai/larch/issues/5922))

- **No-progress circuit breaker scoped to the originating clone.** Turn-blocking now requires markers to come from the same repo clone, so a stale marker in another clone or subdirectory no longer blocks unrelated sessions. ([#5932](https://github.com/character-ai/larch/pull/5932) via [#5927](https://github.com/character-ai/larch/issues/5927))

- **Background-wait guard tmpdir probe now clone-aware.** The bg-poll-guard's tmpdir-variable probe-target check now requires correlation with the current clone/cwd before treating a generic `$DESIGN_TMPDIR`/`$IMPLEMENT_TMPDIR` mention as evidence of targeting a given session, preventing cross-clone false positives. ([#5934](https://github.com/character-ai/larch/pull/5934) via [#5925](https://github.com/character-ai/larch/issues/5925))
