### PR TITLE
Scope no-progress Stop counter to owning repo clone (#5927 follow-up)

### DIFF
--- a/scripts/hook-no-progress-guard.md
+++ b/scripts/hook-no-progress-guard.md
@@ -8,9 +8,9 @@ prose "still waiting" turns that are invisible to `PreToolUse` hooks.
 
 Two event handlers in one script:
 
-- **Stop handler**: counts consecutive turn-ends while any bg-wait marker is live. When the count
-  reaches `LARCH_NO_PROGRESS_GUARD_THRESHOLD` (default 5), arms a `no-progress-circuit-breaker-armed`
-  flag in the marker directory.
+- **Stop handler**: counts consecutive turn-ends while any bg-wait marker owned by the current repo
+  clone is live. When the count reaches `LARCH_NO_PROGRESS_GUARD_THRESHOLD` (default 5), arms a
+  `no-progress-circuit-breaker-armed` flag in the marker directory.
 - **UserPromptSubmit handler**: before each new turn, checks every live marker for an armed flag
   that cannot be proven to belong to a different repo clone. If found, blocks the turn with an
   operator-visible message containing the count, threshold, and marker path.
@@ -33,7 +33,7 @@ removed by the EXIT trap), so a genuine completion notification is never blocked
   dirs and exceed the hook's timeout under concurrent load. The `~/.cache/larch/sessions`
   branch is unaffected.
 - Scopes live markers by their session tmpdir under `~/.cache/larch/sessions/` plus `kill -0` PID-liveness and marker age, not by `CLAUDE_PID` matching (#5684). The old `CLAUDE_PID` equality check rejected every marker in production (the hook's `PPID`/input never matched the stored value), so the breaker never armed. The marker still records `CLAUDE_PID` as debug metadata but the hook no longer reads it.
-- `UserPromptSubmit` blocking is scoped by repo-clone identity when it is knowable (#5927): it reads the candidate marker's sibling `.larch-keepalive` `CLONE_PATH=` value (the same identity file `session_env.py` writes at bootstrap) and skips that marker only when its canonicalized `CLONE_PATH` is not the same clone tree as the current session's canonicalized `cwd` (also read from the hook's own JSON input, mirroring `hook-bg-poll-guard.sh`). Same-clone means exact path match or either path is a subdirectory of the other, so a prompt from `/repo/docs` still matches a marker whose `CLONE_PATH` is `/repo`. A marker with no readable `CLONE_PATH`, or a current invocation with no readable `cwd`, is treated as same-clone and still blocks — unknown identity never introduces a new false negative, it only preserves the pre-fix global-blocking behavior. The `Stop` handler's turn counting remains global and unscoped; only the `UserPromptSubmit` block decision is clone-scoped.
+- Both handlers are scoped by repo-clone identity when it is knowable (#5927 and its follow-up): they read the candidate marker's sibling `.larch-keepalive` `CLONE_PATH=` value (the same identity file `session_env.py` writes at bootstrap) via `marker_foreign_clone` and skip that marker only when its canonicalized `CLONE_PATH` is not the same clone tree as the current session's canonicalized `cwd` (also read from the hook's own JSON input, mirroring `hook-bg-poll-guard.sh`). Same-clone means exact path match or either path is a subdirectory of the other, so a prompt from `/repo/docs` still matches a marker whose `CLONE_PATH` is `/repo`. `UserPromptSubmit` skips the block for a foreign-clone marker; `Stop` skips the turn count for a foreign-clone marker, so an unrelated clone's slow-but-live wait neither arms nor consumes this marker's breaker and cannot make the owning clone block its own next prompt. A marker with no readable `CLONE_PATH`, or an invocation with no readable `cwd`, is treated as same-clone and still counts/blocks — unknown identity never introduces a new false negative, it only preserves the pre-fix global behavior.
 - Checks `is_step_completed` (terminal sentinel present) before declaring a marker live, mirroring
   the release logic in `hook-bg-poll-guard.sh` (#4431, #4450 race-condition fix). It covers
   design Step 3, Step 4 tail, Step 5c, and final-summary markers, plus implement Step 3 checks,
@@ -66,4 +66,5 @@ Covered by `scripts/test-hook-no-progress-guard.sh`, wired through
 
 Update this file when: the event types handled change, the counter/breaker file names or locations
 change, the threshold default changes, `is_step_completed` sentinel coverage changes, or the
-clone-scoping identity source (`.larch-keepalive` `CLONE_PATH`) changes.
+clone-scoping identity source (`.larch-keepalive` `CLONE_PATH`) or the set of handlers that apply
+it changes.

--- a/scripts/hook-no-progress-guard.sh
+++ b/scripts/hook-no-progress-guard.sh
@@ -254,11 +254,23 @@ json_block_prompt() {
 }
 
 if [ "$event_type" = "Stop" ]; then
-  # Count this turn for every live bg-wait marker. Arm the circuit breaker when threshold reached.
+  # Count this turn only for live bg-wait markers owned by this repo clone. The
+  # UserPromptSubmit block below is already clone-scoped (#5927); scoping the
+  # counter the same way makes "N consecutive turns" mean N turns in the owning
+  # clone, not N Stop events summed across every concurrent clone. Otherwise an
+  # unrelated clone's slow-but-live wait arms this marker's breaker from other
+  # sessions' turn activity, and the owning clone then blocks its own next prompt
+  # (#5927 follow-up). marker_foreign_clone skips only when the marker's clone
+  # identity is known and differs, so a marker with no/unparsable .larch-keepalive
+  # still counts and the owning session's breaker is never weakened.
+  cwd=$(printf '%s' "$INPUT" | jq -r '.cwd // ""' 2>/dev/null) || cwd=""
+  cwd_canon=""
+  [ -n "$cwd" ] && cwd_canon=$(canonical_dir "$cwd" 2>/dev/null || true)
   while IFS= read -r marker || [ -n "$marker" ]; do
     [ -n "$marker" ] || continue
     is_marker_live "$marker" || continue
     dir="$LIVE_MARKER_DIR"
+    marker_foreign_clone "$dir" "$cwd_canon" && continue
     cnt=$(counter_bump "$dir")
     if [ "$cnt" -ge "$THRESHOLD" ]; then
       touch "$dir/no-progress-circuit-breaker-armed" 2>/dev/null || true

--- a/scripts/test-hook-no-progress-guard.sh
+++ b/scripts/test-hook-no-progress-guard.sh
@@ -419,6 +419,62 @@ case "$out" in
 esac
 rm -f "$D/no-progress-circuit-breaker-armed" "$D/no-progress-turns.count" "$MARKER"
 
+# --- T21: Stop-path counter is clone-scoped (#5927 follow-up) ---
+# A Stop fired from a FOREIGN clone must not increment an unrelated clone's
+# marker counter. Previously every clone's Stop bumped every live marker, so a
+# slow-but-live wait armed its own breaker from other clones' turn activity and
+# the owning clone then blocked its own next prompt. A Stop from the marker's
+# OWN clone must still increment (owning-session protection preserved).
+D_SCOPE="$TMP/claude-design-scopeclone-marker"
+mkdir -p "$D_SCOPE"
+CLONE_SCOPE="$TMP/scope-owner-repo"
+CLONE_FOREIGN="$TMP/scope-foreign-repo"
+mkdir -p "$CLONE_SCOPE" "$CLONE_FOREIGN"
+MARKER_SCOPE="$D_SCOPE/.bg-wait-active"
+printf '%s\n' "PID=$$" "CLAUDE_PID=$$" "START_EPOCH=$(( $(date +%s) - 10 ))" "STEP=design-step3-review" "TIMEOUT_S=21600" >"$MARKER_SCOPE"
+printf 'CLONE_PATH=%s\nSESSION_ID=test-scope-owner\n' "$CLONE_SCOPE" >"$D_SCOPE/.larch-keepalive"
+
+out=$(printf '{"stop_hook_active":false,"cwd":"%s"}' "$CLONE_FOREIGN" | LARCH_BG_POLL_GUARD_MARKER="$MARKER_SCOPE" "$HOOK")
+cnt=$(cat "$D_SCOPE/no-progress-turns.count" 2>/dev/null || echo 0)
+if [ -z "$out" ] && [ "$cnt" -eq 0 ]; then
+  pass "T21: Stop from foreign clone does not increment unrelated marker counter"
+else
+  fail "T21: foreign-clone Stop must not count: out='$out' cnt=$cnt"
+fi
+
+out=$(printf '{"stop_hook_active":false,"cwd":"%s"}' "$CLONE_SCOPE" | LARCH_BG_POLL_GUARD_MARKER="$MARKER_SCOPE" "$HOOK")
+cnt=$(cat "$D_SCOPE/no-progress-turns.count" 2>/dev/null || echo 0)
+if [ -z "$out" ] && [ "$cnt" -eq 1 ]; then
+  pass "T21: Stop from owning clone still increments marker counter"
+else
+  fail "T21: owning-clone Stop must count: out='$out' cnt=$cnt"
+fi
+
+# Repeated foreign-clone Stops must never arm an unrelated marker's breaker,
+# even at a low threshold — this is the core cross-session-arming regression.
+rm -f "$D_SCOPE/no-progress-turns.count" "$D_SCOPE/no-progress-circuit-breaker-armed"
+for _ in 1 2 3; do
+  printf '{"stop_hook_active":false,"cwd":"%s"}' "$CLONE_FOREIGN" | \
+    LARCH_BG_POLL_GUARD_MARKER="$MARKER_SCOPE" LARCH_NO_PROGRESS_GUARD_THRESHOLD=2 "$HOOK" >/dev/null
+done
+if [ ! -f "$D_SCOPE/no-progress-circuit-breaker-armed" ]; then
+  pass "T21: repeated foreign-clone Stops never arm an unrelated marker's breaker"
+else
+  fail "T21: foreign-clone Stops armed an unrelated marker's breaker"
+fi
+
+# Fail-safe default: a marker with no .larch-keepalive (unknown clone identity)
+# must still count from any cwd, so the owning session's breaker is never lost.
+rm -f "$D_SCOPE/.larch-keepalive" "$D_SCOPE/no-progress-turns.count" "$D_SCOPE/no-progress-circuit-breaker-armed"
+out=$(printf '{"stop_hook_active":false,"cwd":"%s"}' "$CLONE_FOREIGN" | LARCH_BG_POLL_GUARD_MARKER="$MARKER_SCOPE" "$HOOK")
+cnt=$(cat "$D_SCOPE/no-progress-turns.count" 2>/dev/null || echo 0)
+if [ -z "$out" ] && [ "$cnt" -eq 1 ]; then
+  pass "T21: marker without .larch-keepalive still counts from any cwd (fail-safe default)"
+else
+  fail "T21: unknown-identity marker must still count: out='$out' cnt=$cnt"
+fi
+rm -f "$MARKER_SCOPE"
+
 # --- Summary ---
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## Summary

Follow-up to #5927. That fix stopped a no-progress circuit breaker armed in one
larch clone from blocking **other** clones, but it scoped only the
`UserPromptSubmit` **block** decision, not the `Stop` **counter** that arms the
breaker.

`hook-no-progress-guard.sh`'s `Stop` handler bumped `no-progress-turns.count` for
**every** live `.bg-wait-active` marker across all clones. So a marker's counter
measured total `Stop` events across every concurrent session, not the owning
clone's turns. With several sessions active, a healthy-but-slow `/design` or
`/implement` wait could have its breaker armed by unrelated clones' turn activity
— and after #5927 the armed breaker still blocks the **owning** clone's own next
prompt. This is very likely how the original incident accrued "8 consecutive
turns" on a `/design` that was merely slow, not spinning.

## Fix

Apply the existing `marker_foreign_clone` gate (introduced in #5927) to the `Stop`
counter loop, exactly as the `UserPromptSubmit` block path already does:

- Read `cwd` from the hook's own JSON input (present on `Stop` events).
- Skip counting a marker whose sibling `.larch-keepalive` `CLONE_PATH` is provably
  a different repo clone.
- Unknown identity (no/unparsable keepalive, or missing `cwd`) still counts, so
  the owning session's breaker is never weakened.

Result: `"N consecutive turns"` now means N turns in the **owning** clone, not N
`Stop` events summed across every concurrent clone. Both handlers are now
clone-scoped through one shared helper.

## Scope

- `scripts/hook-no-progress-guard.sh` — gate the `Stop` counter loop with
  `marker_foreign_clone`.
- `scripts/test-hook-no-progress-guard.sh` — add **T21**: foreign-clone `Stop`
  does not count/arm; owning-clone `Stop` still counts; keepalive-less marker
  still counts (fail-safe).
- `scripts/hook-no-progress-guard.md` — the doc previously stated the `Stop`
  counter "remains global and unscoped"; updated to reflect clone-scoping.

Deliberately **not** in scope: unifying #5925's `hook-bg-poll-guard.sh`
basename-tag scoping onto the same `.larch-keepalive CLONE_PATH` mechanism (a
separate robustness improvement for same-basename clones).

## Testing

Covered by CI (`test-hook-no-progress-guard`, shard 3; `lint-bash32`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
