### PR TITLE
Release v52.1.17

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.1.16",
+  "version": "52.1.17",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Fixed

- **No-progress `Stop` counter scoped to the owning repo clone.** The circuit breaker's turn counter previously summed `Stop` events across every concurrent clone's live wait markers, so an unrelated clone's slow-but-live wait could still arm and block the owning clone's own next prompt even after #5927 scoped the block decision itself. The counter now applies the same clone-ownership gate as the block path, so "N consecutive turns" reflects only the owning clone's turns. ([#5936](https://github.com/character-ai/larch/pull/5936))
