### PR TITLE
Release v52.2.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.1.17",
+  "version": "52.2.0",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
### Added

- Adds automatic conflict resolution for postbump rebase conflicts confined to known regeneratable generated files, starting with `skill-closure-baseline.json`. Regenerates the file and continues the rebase instead of stalling. Conflicts outside the allow-list still stall, but now report `CONFLICT_FILES` for the operator. (#5949)
- Adds a `reference_capture_status` column to the realized-cost token report, marking each row `measured` or `not-yet-measured` so a zero reference-read count can be told apart from a run with no transcript capture at all. (#5951)

### Changed

- Trims verbosity across `/implement` reference docs (conflict-resolution, self-review, ship-pr-exit-matrix, stall-recovery, step18-cleanup), cutting the implement skill closure by about 300 tokens with no behavior change. (#5944)
- Decouples `--force` from coder selection on `/implement`: `--force` no longer forces `coder=claude`, it only downgrades the plan-adequacy Preflight gates. A new `--self-implement` flag now forces `coder=claude` independent of `--force`. (#5953)

### Fixed

- Fixes stall-recovery misclassification: a checks-commit-route child killed by signal, or with an unresolvable exit code, at Step 3 was classified as a permanent contract failure. It's now classified as transient infrastructure and automatically retried. Step 6 detects the same pattern but is not auto-retried. (#5938)
- Fixes `/cleanup` to also sweep `$TMPDIR`, not just `/tmp`. On macOS, `$TMPDIR` is a per-user path distinct from `/tmp` and is where Python's `tempfile.mkdtemp()` actually creates directories, so leaked temp dirs there were never reclaimed. Also nests the review-tally temp block directory under the review's own tmpdir instead of the system temp root. (#5945)
- Fixes a hook performance bug (recurrence of #5868) in `hook-bg-poll-guard.sh` and `hook-no-progress-guard.sh`: marker discovery spawned one `find` subprocess per matched session directory, and at scale the spawn overhead alone could exceed the hook's timeout. Discovery now runs a single `find` over all matched directories. (#5946)
- Fixes stale "pre-bump flush" terminology in run-log docs to "pre-ship log flush," and strengthens a PR-list title test to use non-contiguous PR numbers. (#5947)
- Fixes a cross-clone false positive in the background-poll guard: Monitor/TaskOutput calls, and reads of a session's own just-completed background task output, were blocked whenever an unrelated repo clone had a live wait marker. Both are now scoped to same-clone correlation. (#5948)
- Fixes retroactive Cursor cost correction to match the live pricer: the old retro-fixer applied the Teams surcharge to cache-read tokens only, using hardcoded rates. It now sources the same rate row as the live pricer, applying the surcharge consistently across input, cache-read, and output. (#5951)
