### PR TITLE
Release v52.2.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.2.0",
+  "version": "52.2.1",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
### Changed

- Removes an orphaned `implement step-0-bootstrap` CLI entry point that duplicated the live bootstrap-invoke argv plumbing. (#5959)
- Overhauls the `/release` skill. (#5960)
- Caps reviews at 2 rounds, front-loads round 1, and reworks reviewer pruning to use round-2-on-round-1 data. (#5965)

### Fixed

- Fixes bg-wait coverage gaps: `brainstorm` and `/research` fences were unmarked, causing lint escapes. (#5956)
- Fixes `/review` vendor-fallback reviewer attribution not being reconciled outside of `/design`. (#5964)
