### PR TITLE
Release v52.2.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.2.1",
+  "version": "52.2.2",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## v52.2.2

### Fixed
- `/design` vendor auto-fix Cursor lane now sets `NO_OPEN_BROWSER=1`, preventing a Cursor.app GUI popup from firing during that lane (#5996)
- Staged-assessment refresh no longer silently drops the guideline note on fingerprint drift; the ship-time retry now recovers correctly (#5997)
- claude-ci lint-fix retry now also fires on empty-output "No messages returned from query" failures, not just exit 124 (#5998)
- Stalled-then-shipped runs no longer stay mis-recorded as "Outcome: stalled"; post-ship re-evaluation is now implemented (#6004)
- Closed the remaining TMPDIR leak sites and added cleanup so `$TMPDIR` no longer grows unboundedly (#6007)

### Changed
- Availability policy: review-stage self-review now applies when both reviewers are down; conflict-resolution self-review is scoped separately (#5999)
- Extended the closure report and token ratchet to `/review` and panel-tier sources; fixed eager-classifier gaps (#6009)
- Rebalanced cost across coder, aggregator, and plan-revision roles (#6010)

### Added
- Cache-efficiency outlier report comparing `cache_create` versus `cache_read` per step (#6005)
- Python failure-triage digest for relevant-checks repair loops (#6011)
- Per-slot rendered prompt byte instrumentation for panel-tier realized measurement (#6012)
