### PR TITLE
Release v52.2.3

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.2.2",
+  "version": "52.2.3",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Changed

- Converted the settle-rc and step2b5-rc dispatch tables to Python stdout envelopes as part of the ongoing Markdown-to-Python migration. (#6015)
- Moved `/design` gate copy rendering to Python at gate time, shrinking `approval-gates.md`'s eager closure. (#6017)
- Compressed prose in `code-reviewer.md` and `orchestrator-aggregator.md`. (#6032)
