### PR TITLE
Release v52.2.4

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.2.3",
+  "version": "52.2.4",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Fixed

- Collector cursor CMD_JSON retry could omit `NO_OPEN_BROWSER=1` (residual from #5972). (#6035)
- Closeout-time guideline pin lacked a refresh retry on drift (residual from #5969). (#6036)
- Done/merged resume reconciliation could return a spurious STALLED status (residual from #5970). (#6037)
- claude-ci retry had gaps for sentinel and permanent empty output (residual from #5971). (#6038)
- Relevant-checks failure digest was contentless for marker-less failures (residual from #5982). (#6039)
- Run-log summaries under-reported exec issues, warnings, and rejected counts. (#6040)
- Orphaned reviewer fragment, unbound `REVIEW_MODE`, and skipped telemetry (residuals from #5889). (#6042)
- Dead symlink check and a `first_tool` telemetry mislabel (residuals from #5974). (#6043)
- Terminal-stall closeout path did not pin the architectural-guidelines note. (#6044)
- Dead `_run_apply`, missing promised tests, and stale shard nodeids (residuals from #5888). (#6045)
- Closure classifier `index=0` and sentence-clause edge defects (latent, from #5975). (#6046)
- OOS-dropped real findings had no filing path; 0 OOS were filed across 11 audited runs. (#6048)
- Committed run logs omitted rejected and neutral finding bodies. (#6050)

## Changed

- Code-review voting panel now handles a single available vendor, falling back to main-agent adjudication when both vendors are down. (#6041)
