### PR TITLE
Release v52.2.5

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.2.4",
+  "version": "52.2.5",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Added

- Difficulty-tier rating capture and a difficulty run-log schema. (#6064)

## Changed

- Compressed voting-protocol.md and the voter prompt templates for conciseness (md-to-py round XI). (#6055)
- Compressed reviewer-templates.md and realigned the agents/reviewer-*.md derivatives (md-to-py round XI). (#6058)

## Fixed

- Empty-ballot degraded-vote banner triggered a guaranteed-waste full panel retry. (#6054)
- ship-pr merge conflicts routed to Step 16/18 teardown instead of the correct CI-failure path. (#6057)
- Ship-time architectural-guidelines note could be dropped on HEAD drift, including the recovery-retry path. (#6060)
- Guideline-pin drift races persisted outside the ship path, covering closeout re-materialization, the note_fingerprint_stale fallback, and non-atomic materialize_implementation_diff. (#6069)
