### PR TITLE
Release v52.2.6

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.2.5",
+  "version": "52.2.6",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Added
- Runs now write a `session-transcript.jsonl` file so the reference heatmap accrues data across runs (#6084)

## Changed
- Prose-compressed the implementer agent prompts (`_implementer-base`, `codex-implementer`, `cursor-implementer`) (#6083)

## Fixed
- Guideline-pin helpers now have direct unit tests and structural coverage for drift and failure cases (#6079)
- `/design` plan-review Claude voter subprocesses were sometimes falsely marked `NOT_SUBSTANTIVE` (#6081)
- `/design` plan-review round Gantt chart hid Gate B apply time as an unlabeled segment (#6082)
- Architectural-guideline drop warnings could silently miss committed run logs due to flush timing and swallowed appends (#6086)
