### PR TITLE
Release v52.2.8

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.2.7",
+  "version": "52.2.8",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Changed

- Renamed the `/release` skill's `--approve`/`-a` argument to `--skip-approve`/`-s`, matching the `/design` skill's flag naming (#6096)

## Fixed

- Fixed a guard hook that could deny a task-output read immediately after a genuine completion notification (#6097)
- Addressed follow-up findings from the PR #6082 review concerning Gate B apply timing (#6100)
