### PR TITLE
Release v52.2.9

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.2.8",
+  "version": "52.2.9",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Added

- Added `/analyze-bugs` for tiered, low-cost verification of closed bug fixes (#6123)

## Changed

- Restored dyslexia-optimized readability style across all larch skills (#6124)

## Fixed

- Addressed out-of-scope follow-ups from the #5976 review covering Step 4 log-root, transcript, heatmap, and Step 18 (#6105)
- Fixed Markdown rendering that stripped bare `$1`/`$2` awk tokens from inline code (#6121)
- Fixed `/implement` Bash fences failing (exit 127) after Step 0 due to an `$IMPLEMENT_TMPDIR` issue (#6125)
