### PR TITLE
Release v52.3.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.2.9",
+  "version": "52.3.0",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Added

- Added tiered review difficulty panels with 2/2/3 round-cap ceilings, escalation, and 1:30 audits (#6122)

## Fixed

- Fixed `/implement` dropping the architectural-guidelines note during a routine Step 8+ rebase (#6129)
- Fixed `/review` Step 4 RUN_ID validation duplicating `validate_run_id_slug` as inline Bash (#6133)
- Fixed a bg-poll-guard cross-clone block where a foreign session's live `.bg-wait-active` marker caused incorrect denials (#6135)
