### PR TITLE
Release v52.3.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.3.0",
+  "version": "52.3.1",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Added

- Added a regression test verifying that a rebase with an unchanged feature diff preserves the staged architectural-guidelines note (#6143)

## Changed

- Moved `/design` flag parsing to a Python `parse-flags` envelope and demoted `flags.md` from eager closure loading (#6146)

## Fixed

- Fixed `/design` plan-review round-to-round artifacts (`oos-accepted-design.md`, `accepted-plan-findings-all.md`) resetting instead of cumulating across rounds (#6142)
- Fixed `/design` (without `-s`) timing out after 60 seconds while waiting for answers or approval; it now waits indefinitely (#6144)
- Fixed `/design`'s escalation-success reporter falling back to `compose-status-missing` instead of filing or failing loudly (#6145)
