### PR TITLE
Release v52.4.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.3.1",
+  "version": "52.4.0",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Added

- Added a difficulty-calibration analyzer for difficulty tiers. (#6150)

## Changed

- Hardened bg-poll-guard and added test coverage, following up on #6108 and #6135. (#6171)
- /implement now runs CI-first: local checks are slimmed to ruff and pyright, and the CI-fix cap is raised to 30. (#6186)

## Fixed

- Fixed docs that incorrectly described tally-error recovery as restore-without-restore. (#6149)
- Fixed /design not outputting a final report in some runs. (#6151)
- Fixed /analyze-bugs reports hiding deep verdicts behind a mechanical NEEDS_DEEP status. (#6168)
- Fixed /design Step 0-pre phrasing that invited an incorrect standalone parse-flags step. (#6184)
