### PR TITLE
Release v52.4.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.4.0",
+  "version": "52.4.1",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Added

- Added stalled-run test-harness coverage for difficulty tiers. (#6202)

## Changed

- Improved cache-prefix stability for the claude_sub agent in /implement Steps 3 and 5. (#6193)
- Removed rendered gate copy from approval-gates.md, banking token savings from #5983. (#6198)
- The closure classifier now tracks demoted references. flags.md sits in neither ratchet tier. (#6201)

## Fixed

- Fixed /implement Step 5's loop skipping the code-review batch flush on complete and cap-hit. (#6195)
- Fixed research's read-only hook leaking across skills and blocking writes outside /tmp. (#6196)
- Fixed session-transcript capture, which had produced zero committed transcripts since 2026-07-01. (#6197)
- Restored a security-triage caution line dropped from implementer prompts. (#6200)
