### PR TITLE
Release v52.4.3

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.4.2",
+  "version": "52.4.3",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Added

- Added a per-merge closure-growth attribution ledger for the md-to-py migration. (#6216)
- Added per-section scaffold and payload instrumentation for generated slot prompts. (#6223)

## Changed

- Clarified follow-up scope for stale tracking-comment risk and review-flagged gaps from issue #6115. (#6208)
- Extended checks-digest savings measurement to the design validator loop. (#6214)
- Clarified review coverage gaps around the step-5 bash wrapper and the review-and-fix step5 --difficulty plan. (#6215)

## Fixed

- Fixed /design failing to file a bug message. (#6218)
- Fixed cross-clone process kill sending signals to stale or recycled processes. (#6222)
