### PR TITLE
Release v52.4.4

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.4.3",
+  "version": "52.4.4",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Changed

- Closed a dropped-file ratchet audit gap for sentinel-host-table.md, step2b-drafter-failsafe.md, and dialectic-clarifier.md. (#6226)
- Extended specialist payload accounting to include the inlined competition notice used by measure-panel-cost. (#6230)

## Fixed

- Fixed /design Step 5c difficulty-metadata validation failures caused by the external-vendor drafter-subprocess path in Step 2b. (#6227)
