### PR TITLE
Release v52.4.5

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.4.4",
+  "version": "52.4.5",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Changed

- Density-passed generated prompt scaffolds across the /design and /implement pipelines: aggregator prompts (design and implement contexts), design plan-review prompt builders, and implement specialist/voter prompt scaffolds. ([#6239](https://github.com/character-ai/larch/pull/6239), [#6241](https://github.com/character-ai/larch/pull/6241), [#6242](https://github.com/character-ai/larch/pull/6242))
- /design escalation handling now includes a main-agent recovery path for step3-review sessions that require main-agent-apply. ([#6247](https://github.com/character-ai/larch/pull/6247))

## Fixed

- Hardened skill-closure ledger historical-parsing edge cases identified in round-1 review. ([#6240](https://github.com/character-ai/larch/pull/6240))
- /design Step 3 review loops now survive external harness stops, with signal-aware handling. ([#6246](https://github.com/character-ai/larch/pull/6246))
- Fixed difficulty-tiers voting write-tally failing silently in live runs (since v52.2.4), where run-root `code-review-tally.json` never landed. ([#6248](https://github.com/character-ai/larch/pull/6248))
