### PR TITLE
test(design): stub incidental verbs in step3 fake plugin to cut harness cost

### DIFF
--- a/skills/design/scripts/test-design-step3-review.sh
+++ b/skills/design/scripts/test-design-step3-review.sh
@@ -20,6 +20,7 @@ EOFSTUB
   chmod +x "$dir/skills/design/scripts/plan-review-loop-stub.sh"
   cat >"$dir/python/cli.py" <<'CLIPY'
 #!/usr/bin/env python3
+import json
 import os
 import subprocess
 import sys
@@ -28,6 +29,24 @@ BAKED_REAL_ROOT = "__LARCH_TEST_REAL_ROOT__"
 if len(sys.argv) >= 3 and sys.argv[1] == "plan-review" and sys.argv[2] == "run" and "--record-report-evidence" not in sys.argv[3:]:
     run_sh = os.path.join(os.environ.get("CLAUDE_PLUGIN_ROOT", ""), "skills", "design", "scripts", "plan-review-loop-stub.sh")
     sys.exit(subprocess.call(["/bin/bash", run_sh]))
+# #6258 harness speedup: stub the wrapper's incidental plumbing verbs locally so
+# each subtest pays one real cli.py cold-start (normalize-status, the SUT) instead
+# of ~5. These verbs are never asserted by make_fake_step3_plugin subtests (the
+# kill-helper ordering test and the detach tests use their own cli.py). scope-anchor
+# validate and normalize-status still forward to the real CLI to preserve coverage.
+if len(sys.argv) >= 3 and sys.argv[1] == "session" and sys.argv[2] in ("validate-design-tmpdir", "kill-background-processes"):
+    sys.exit(0)
+if len(sys.argv) >= 3 and sys.argv[1] == "plan-review" and sys.argv[2] == "write-loop-identity":
+    # Faithful drop-in: write the identity sidecar the real verb writes, so the
+    # wrapper's normal-path identity handling is unchanged.
+    try:
+        design_tmpdir = sys.argv[sys.argv.index("--design-tmpdir") + 1]
+        pid = int(sys.argv[sys.argv.index("--pid") + 1])
+        with open(os.path.join(design_tmpdir, ".step3-loop-identity.json"), "w", encoding="utf-8") as handle:
+            json.dump({"pid": pid, "pgid": pid, "start_time": "stub", "command_signature": "plan-review run", "expected_signature": "plan-review run"}, handle)
+    except (ValueError, OSError):
+        pass
+    sys.exit(0)
 real_root = os.environ.get("LARCH_TEST_REAL_REPO_ROOT") or BAKED_REAL_ROOT
 real_cli = os.path.join(real_root, "python", "cli.py")
 if real_cli and os.path.isfile(real_cli):


### PR DESCRIPTION
## What's Changed

Follow-up to the `test-design-step3-review` de-flake in #6258. That harness is the slowest in its CI shard (~24s; next-slowest sibling is 5.5s).

### Changed

- The shared `make_fake_step3_plugin` fake now stubs three incidental wrapper plumbing verbs locally — `session validate-design-tmpdir`, `session kill-background-processes`, and `plan-review write-loop-identity` — so each subtest pays **one** real `cli.py` cold-start (`normalize-status`, the SUT) instead of ~5.

### Why

Every `make_fake` subtest runs the full wrapper, which forwarded all five verbs to the real CLI even though only `normalize-status` is under test. The other four are pure plumbing.

### Coverage-preserving

- The stubbed verbs are never asserted by `make_fake` subtests. The kill-helper ordering test and the detach tests use their own `cli.py` and are untouched.
- `scope-anchor validate` and `normalize-status` still forward to the real CLI.
- The `write-loop-identity` stub writes the same identity sidecar the real verb writes, so the wrapper's normal-path identity handling is unchanged.

This is the coverage-safe optimization. Converting the per-status subtests to direct `normalize-status` calls was considered and rejected: some (D_LEGACY, D_SYNTH) assert the wrapper's `#4724` EXIT-trap sentinel and are genuine integration tests, and the rest would duplicate `test_plan_review.py`.

## Verification

- All 24 subtests pass; 3 back-to-back local runs clean (no new flakiness).
- `make shellcheck`, `make lint-bash32`, and `lint-bare-grep-probe` pass.
- Expected CI: ~24s → ~20-21s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
