### PR TITLE
Release v52.4.8

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.4.7",
+  "version": "52.4.8",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## v52.4.8

### Fixed

- **design**: Corrected the trap replacement in the design step3 review script to include `.bg-wait-active` removal, preventing permanent hook denial and a notification re-delivery loop. ([#6284](https://github.com/character-ai/larch/pull/6284))
- **hooks**: Fixed the generic-read counter in `hook-anti-read-poll.sh` to key by session hash, preventing cross-session counter collisions. ([#6285](https://github.com/character-ai/larch/pull/6285))

### Changed

- **test**: Stub incidental verbs in the design step3 fake plugin harness to cut harness token cost. ([#6280](https://github.com/character-ai/larch/pull/6280))
