### PR TITLE
Release v52.4.10

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.4.9",
+  "version": "52.4.10",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## v52.4.10

### Changed

- Updated difficulty-tier field-verification criteria: corrected version-floor and notes requirements. (#6299)
- Removed em-dashes from `/design` and `/implement` status prints, report templates, and the Python run-summary layer. (#6311, #6312)
- Applied the readability directive to code-reviewer agents. (#6313)

### Fixed

- Applied a rollup of minor corrections across three capped out-of-scope items. (#6315)
