### PR TITLE
Release v52.4.11

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.4.10",
+  "version": "52.4.11",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Fixed

- OOS issue filing now gates on aggregate severity instead of per-item acceptance, fixing a case where OOS issues rarely filed. (#6319)
- Fixed a `/implement` terminal panel failure that marked TRIVIAL runs failed when the edge-cases reviewer produced non-substantive output on a doc-only diff. (#6326)
- Fixed a background grep that was killed by SIGURG after 38 minutes due to an incorrect relative path built from `IMPLEMENT_TMPDIR`. (#6328)

## Changed

- Hardened several latent OOS-tracked mechanisms: background-wait and hook parity, marker dedup, and write-tally staging. (#6321)
- Removed em-dashes from SKILL.md outline auto-approve breadcrumb text and `design_step5b.py` warning strings. (#6325)
