### PR TITLE
Release v52.4.12

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.4.11",
+  "version": "52.4.12",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Fixed

- Prevent re-notification loop triggered by non-empty premature task notifications during long `/design` step-3 reviews while the review script is still running (#6332)

## Changed

- Replaced remaining em-dash occurrences with ASCII hyphens across skill output surfaces (#6338)
- Hardened background-wait Step 3 completion-marker handling to close gaps identified in prior reviews (#6345)
- Added parent-ascent guard to `lint-bare-grep-probe.sh` to cover additional probe-detection gaps (#6354)
- Extended the repeat-fingerprint silent-yield rule to cover Tier-1 probe prose, ambiguous contract surfaces, missing contract tests, and anti-pattern titles (#6355)
- Improved `/design` plan-review validation and out-of-scope filing behavior (#6357)
