### PR TITLE
Release v52.4.13

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.4.12",
+  "version": "52.4.13",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Added

- Added a merit ("worth doing?") judgment gate to `/combine-issues --oos`. (#6365)

## Fixed

- Fixed `/design` and `/implement` sometimes filing OOS issues without the mandatory `[OOS]` title prefix. (#6363)

## Changed

- Locked readability style: removed em dashes from a MANDATORY directive line and added an em-dash output lint. (#6352)
