### PR TITLE
Release v52.4.15

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.4.14",
+  "version": "52.4.15",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Changed

- `/combine-issues`: merit-gate follow-ups including frontmatter and catalog sync, and rescue ambiguity handling (#6381)
- `/implement`: follow-up fixes for ship-rebase guards, step-3 background-wait timeout deduplication, run-report precedence, write-final-report CI, and SECURITY marker (#6391)
- Restored OOS voting; `/implement` and `/design` now always file one unifying OOS issue (#6396)

## Fixed

- Architectural-guideline assessment was silently skipped on roughly 12% of `--skip-approve` runs (#6392)
- Gate B apply row was never written to the design round Gantt (#6393)
- `/design` and `/implement` incorrectly prompted for confirmation before filing OOS items (#6394)
- Architectural-guideline note was dropped on roughly 62% of shipped PRs; assessment is now re-authored at compose time (#6400)
