### PR TITLE
Release v52.4.16

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.4.15",
+  "version": "52.4.16",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Changed

- OOS pipeline: voting, classification, and security sidecar updates (#6418)
- Reviewer OOS proposal tooling (#6420)
- OOS filing: 3-level severity, source emit-cut, and judge file gate (#6430)

## Fixed

- Tool Failures miscategorization and duplicate execution-issues writes in architectural guidelines (#6416)
- Guideline-note drop invisible to committed run logs; audit tooling falsely reported the feature healthy (#6427)
- Step 6 repair-loop returned stall instead of main-agent-edit on no-changes-stale lint (#6431)
- Structural ruff failures now short-circuit before external lint-fix dispatch in checks repair-loop (#6435)
