### PR TITLE
Release v52.4.17

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.4.16",
+  "version": "52.4.17",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Fixed

- Addressed gaps in the guideline-outcome classifier, step8-reachable logic, and audit scan coverage ([#6440](https://github.com/character-ai/larch/pull/6440))
- Fixed `gh run-logs` output truncation that cut off at 100 lines and hid most failing CI check details ([#6442](https://github.com/character-ai/larch/pull/6442))
