### PR TITLE
Release v52.4.20

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.4.19",
+  "version": "52.4.20",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## What's Changed

### Fixed
- Fixed accuracy and clarity in installation documentation.
- Fixed a deadlock in `/design` Step 3 where premature `run_in_background` notifications combined with hook task-output read denial could stall the step for up to 14 minutes.

### Added
- Added a git-stash-clear check to `/design`'s entry gate.

**Full changelog**: https://github.com/character-ai/larch/compare/v52.4.19...v52.4.20
