### PR TITLE
Add /learn-from-bugs skill: mine closed bugs into prevention proposals

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,12 @@ larch ships **public skills** with the plugin (`skills/`); **private** skills li
     <tr><td colspan="2">Recover verified real rejected code-review findings from committed run logs and file issues by default. Security-sensitive findings are not public-filed, OOS-deferred findings are excluded, and the stable <code>finding_hash</code> uses file plus concern only, excluding run metadata and filesystem state.</td></tr>
     <tr><td colspan="2"><hr></td></tr>
     <tr>
+      <td><a href="docs/skills.md#learn-from-bugs"><code>/learn-from-bugs</code></a></td>
+      <td><code>[-n COUNT] [--state closed|open|all] [--repo OWNER/REPO] [--search QUERY] [description]</code></td>
+    </tr>
+    <tr><td colspan="2">Mine a repository's closed bug reports for recurring root-cause patterns, then propose preventions ranked by mechanical enforceability: lint rules, architectural invariants, guideline entries, and issues to file for still-broken code. Report-only by default: it compresses each body to a compact root-cause digest, maps every recurring principle to the repo's existing coverage (guidelines, <code>.claude/rules/</code>, lints) before proposing the residual gap, and runs the synthesis inline with no sub-agent fan-out. Repository and GitHub changes are gated behind explicit approval; filing goes through <code>/issue</code>.</td></tr>
+    <tr><td colspan="2"><hr></td></tr>
+    <tr>
       <td><a href="docs/skills.md#difficulty-calibration"><code>/difficulty-calibration</code></a></td>
       <td><code>[--log-root DIR] [--out FILE]</code></td>
     </tr>

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -168,6 +168,14 @@ Create one or more GitHub issues with LLM-based semantic duplicate detection. Su
 
 **Default-on inter-issue blocker-dependency analysis** (issue #546): unless `--no-dedup` is set, every invocation analyzes the new item(s) against existing OPEN issues and applies hard GitHub-native blocker dependencies via the Issue Dependencies REST API on detected pairs (merge-conflict risk or "must land first"). Hard-fail with retries (3 tries, 10s/30s sleeps); on retry exhaustion the failed item is rolled back (orphan close) — when multiple items are processed, unrelated items continue — and the run exits non-zero if any item failed, yielding a clean "create-then-close" recovery rather than a dangling issue with missing dependency wiring.
 
+### `/learn-from-bugs`
+
+**Arguments**: `[-n COUNT] [--state closed|open|all] [--repo OWNER/REPO] [--search QUERY] [verbal description]`
+
+**Source**: [`skills/learn-from-bugs/SKILL.md`](../skills/learn-from-bugs/SKILL.md)
+
+Mine a repository's closed bug reports for recurring root-cause patterns, then propose preventions ranked by how mechanically enforceable they are. Report-only by default: it compresses each issue body to a compact root-cause digest (dropping the appended `/design` plan so a full backlog stays affordable to read), clusters the causes, and writes one report to a scratch run directory. The report maps each recurring principle to the repo's existing coverage (guidelines, `.claude/rules/`, lints) before proposing anything, so proposals are the residual gap rather than a duplicate. Proposals are grouped as mechanical lint rules, architectural invariants (each classified by best home: lint, rule, invariants-file, or guideline), guideline entries, and issues to file for still-broken code. Defaults to `[BUG]`-titled issues; an optional verbal description or `--search` narrows the mined set. Every repository or GitHub change is gated behind an explicit operator approval, and issue filing goes through `/issue`. The synthesis runs inline with no sub-agent fan-out.
+
 ### `/pause`
 
 **Arguments**: *(none)*

--- a/python/larch/cli.py
+++ b/python/larch/cli.py
@@ -112,6 +112,8 @@ _REGISTRY: dict[tuple[str, str], tuple[str, str]] = {
     ("analyze-bugs", "prefetch"): ("larch.issue.analyze_bugs", "prefetch_main"),
     ("analyze-bugs", "ledger"): ("larch.issue.analyze_bugs", "ledger_main"),
     ("analyze-bugs", "report"): ("larch.issue.analyze_bugs", "report_main"),
+    ("learn-from-bugs", "prepare"): ("larch.issue.learn_from_bugs", "prepare_main"),
+    ("learn-from-bugs", "coverage-index"): ("larch.issue.learn_from_bugs", "coverage_index_main"),
     ("rejected-analysis", "prepare"): ("larch.issue.rejected_analysis", "prepare_main"),
     ("rejected-analysis", "ingest-verdict"): ("larch.issue.rejected_analysis", "ingest_verdict_main"),
     ("rejected-analysis", "finalize"): ("larch.issue.rejected_analysis", "finalize_main"),

--- a/python/larch/issue/learn_from_bugs.py
+++ b/python/larch/issue/learn_from_bugs.py
@@ -1,0 +1,345 @@
+# argparse add_argument() and file write_text()/write() results are intentionally discarded.
+# pyright: reportUnusedCallResult=false
+"""Mine closed issues for recurring root causes and propose preventions.
+
+Backs the ``/learn-from-bugs`` skill. GitHub access goes through the
+``larch.core.proc.Runner`` seam so the digest and coverage-index logic stay
+unit-testable offline. The module never reads a full issue backlog into a model:
+it compresses each body to a compact root-cause digest first (an average
+``[BUG]`` body is dominated by an appended ``/design`` plan, which this drops),
+so the synthesis step reads a small fraction of the raw tokens.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final, cast
+
+from larch.core.proc import ProcRunner, Runner
+from larch.issue.analyze_bugs import resolve_repo
+
+DEFAULT_SEARCH: Final = "[BUG] in:title"
+DEFAULT_STATE: Final = "closed"
+DEFAULT_LIMIT: Final = 50
+
+# Per-section char caps for the compact digest.
+SUMMARY_CAP: Final = 600
+ROOT_CAUSE_CAP: Final = 1000
+FIX_CAP: Final = 400
+FREEFORM_CAP: Final = 1100
+# A diagnostic prefix shorter than this means the body is only the appended plan;
+# the bug's signal then lives in its title.
+TITLE_ONLY_PREFIX_MAX: Final = 40
+
+# Diagnostic sections to keep, each with its cap. Deduped by the heading's first
+# word so "root cause" and "root cause analysis" do not both land.
+WANT_SECTIONS: Final = (
+    ("summary", SUMMARY_CAP),
+    ("root cause analysis", ROOT_CAUSE_CAP),
+    ("root cause", ROOT_CAUSE_CAP),
+    ("suggested fix(es)", FIX_CAP),
+    ("suggested fix", FIX_CAP),
+)
+
+# Earliest match marks where the appended /design plan begins; everything before
+# it is the diagnostic report we mine.
+_BOUNDARY_PATTERNS: Final = (
+    re.compile(r"<!--\s*larch:plan:start", re.IGNORECASE),
+    re.compile(r"^##\s+Plan\s*$", re.IGNORECASE | re.MULTILINE),
+    re.compile(r"^##\s+Approach\s*$", re.IGNORECASE | re.MULTILINE),
+    re.compile(r"^###\s+(?:NEW|UPDATED|REWRITTEN|MAY_UPDATE):", re.IGNORECASE | re.MULTILINE),
+)
+_HEADING_RE: Final = re.compile(r"^#{2,3}\s+(.+?)\s*$", re.MULTILINE)
+_DONE_PREFIX_RE: Final = re.compile(r"^\[DONE\]\s*")
+
+# Coverage-index scanners: match a repo's existing enforcement surface so the
+# report can flag proposals that already have coverage.
+_GUIDELINE_ID_RE: Final = re.compile(r"^#{2,4}\s+(G-[A-Za-z0-9]+-\d+):\s*(.+?)\s*$", re.MULTILINE)
+_INVARIANT_ID_RE: Final = re.compile(r"^#{2,4}\s+((?:INV|I)-[A-Za-z0-9]*-?\d+):\s*(.+?)\s*$", re.MULTILINE)
+
+
+class LearnFromBugsError(RuntimeError):
+    """Raised when issue mining cannot proceed."""
+
+
+@dataclass(frozen=True)
+class BugDigest:
+    number: int
+    title: str
+    closed_at: str
+    url: str
+    state: str
+    structured: bool
+    prefix_chars: int
+    sections: Mapping[str, str]
+
+    def to_json(self) -> dict[str, object]:
+        return {
+            "number": self.number,
+            "title": self.title,
+            "closed_at": self.closed_at,
+            "url": self.url,
+            "state": self.state,
+            "structured": self.structured,
+            "prefix_chars": self.prefix_chars,
+            "sections": dict(self.sections),
+        }
+
+
+@dataclass(frozen=True)
+class CoverageIndex:
+    """The target repo's existing enforcement surface, for dedup in the report."""
+
+    guidelines: tuple[tuple[str, str], ...]
+    invariants: tuple[tuple[str, str], ...]
+    rules: tuple[tuple[str, str], ...]
+    python_lints: tuple[str, ...]
+    script_lints: tuple[str, ...]
+
+    def to_json(self) -> dict[str, object]:
+        return {
+            "guidelines": [list(item) for item in self.guidelines],
+            "invariants": [list(item) for item in self.invariants],
+            "rules": [list(item) for item in self.rules],
+            "python_lints": list(self.python_lints),
+            "script_lints": list(self.script_lints),
+        }
+
+
+@dataclass(frozen=True)
+class PrepareRequest:
+    search: str
+    state: str
+    limit: int
+    repo_explicit: str
+    out_dir: Path
+    root: Path
+
+
+def _runner() -> Runner:
+    return ProcRunner()
+
+
+# --- Digest extraction (offline, pure) --------------------------------------
+
+
+def diagnostic_prefix(body: str) -> str:
+    """Return the body up to the appended ``/design`` plan, or the whole body."""
+    cuts = [match.start() for pattern in _BOUNDARY_PATTERNS for match in [pattern.search(body)] if match]
+    return body[: min(cuts)] if cuts else body
+
+
+def _split_sections(prefix: str) -> dict[str, str]:
+    heads = list(_HEADING_RE.finditer(prefix))
+    out: dict[str, str] = {}
+    for index, head in enumerate(heads):
+        name = head.group(1).replace("`", "").strip().lower()
+        start = head.end()
+        end = heads[index + 1].start() if index + 1 < len(heads) else len(prefix)
+        out[name] = prefix[start:end].strip()
+    return out
+
+
+def _squeeze(text: str, cap: int) -> str:
+    collapsed = re.sub(r"\n{2,}", "\n", text).strip()
+    return collapsed[:cap] + ("…" if len(collapsed) > cap else "")
+
+
+def _pick_sections(prefix: str) -> tuple[dict[str, str], bool]:
+    """Return (kept sections, structured?), falling back to freeform or title-only."""
+    found = _split_sections(prefix)
+    picked: dict[str, str] = {}
+    seen_roots: set[str] = set()
+    for want, cap in WANT_SECTIONS:
+        root = want.split()[0]
+        if want in found and root not in seen_roots:
+            picked[want] = _squeeze(found[want], cap)
+            seen_roots.add(root)
+    if picked:
+        return picked, True
+    if len(prefix.strip()) < TITLE_ONLY_PREFIX_MAX:
+        return {"_title_only": ""}, False
+    return {"_freeform": _squeeze(prefix, FREEFORM_CAP)}, False
+
+
+def build_digest(issue: Mapping[str, object]) -> BugDigest:
+    """Compress one raw issue row (from ``gh issue list --json``) to a digest."""
+    body = str(issue.get("body") or "")
+    prefix = diagnostic_prefix(body)
+    sections, structured = _pick_sections(prefix)
+    title = _DONE_PREFIX_RE.sub("", str(issue.get("title") or ""))
+    closed_at = str(issue.get("closedAt") or issue.get("closed_at") or "")[:10]
+    number_raw = issue.get("number")
+    number = int(number_raw) if isinstance(number_raw, (int, str)) and str(number_raw).isdigit() else 0
+    return BugDigest(
+        number=number,
+        title=title,
+        closed_at=closed_at,
+        url=str(issue.get("url") or ""),
+        state=str(issue.get("state") or ""),
+        structured=structured,
+        prefix_chars=len(prefix),
+        sections=sections,
+    )
+
+
+# --- Issue listing (through the Runner seam) --------------------------------
+
+
+def _issue_list_argv(*, search: str, state: str, limit: int, repo: str) -> list[str]:
+    return [
+        "gh",
+        "issue",
+        "list",
+        "--repo",
+        repo,
+        "--search",
+        search,
+        "--state",
+        state,
+        "--limit",
+        str(limit),
+        "--json",
+        "number,title,body,closedAt,url,state",
+    ]
+
+
+def list_issues(runner: Runner, *, search: str, state: str, limit: int, repo: str) -> list[dict[str, object]]:
+    result = runner.run(_issue_list_argv(search=search, state=state, limit=limit, repo=repo))
+    if result.returncode != 0:
+        raise LearnFromBugsError(f"gh issue list failed: {(result.stderr or result.stdout).strip()}")
+    try:
+        parsed = json.loads(result.stdout or "[]")
+    except json.JSONDecodeError as exc:
+        raise LearnFromBugsError(f"gh issue list returned invalid JSON: {exc}") from exc
+    if not isinstance(parsed, list):
+        raise LearnFromBugsError("gh issue list did not return a JSON array")
+    rows: list[dict[str, object]] = []
+    for row in cast("list[object]", parsed):
+        if isinstance(row, dict):
+            rows.append(cast("dict[str, object]", row))
+    return rows
+
+
+# --- Coverage index (offline, pure) -----------------------------------------
+
+
+def _scan_marked_ids(path: Path, pattern: re.Pattern[str]) -> tuple[tuple[str, str], ...]:
+    if not path.is_file():
+        return ()
+    text = path.read_text(encoding="utf-8", errors="replace")
+    return tuple((match.group(1), match.group(2)) for match in pattern.finditer(text))
+
+
+def _scan_rules(rules_dir: Path) -> tuple[tuple[str, str], ...]:
+    if not rules_dir.is_dir():
+        return ()
+    rows: list[tuple[str, str]] = []
+    for path in sorted(rules_dir.glob("*.md")):
+        heading = ""
+        for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+            if line.startswith("# "):
+                heading = line[2:].strip()
+                break
+        rows.append((path.name, heading))
+    return tuple(rows)
+
+
+def _scan_lint_names(directory: Path, glob: str, prefix: str) -> tuple[str, ...]:
+    if not directory.is_dir():
+        return ()
+    return tuple(sorted(path.stem for path in directory.glob(glob) if path.stem.startswith(prefix)))
+
+
+def coverage_index(root: Path) -> CoverageIndex:
+    """Scan the repo root for existing guidelines, invariants, rules, and lints."""
+    return CoverageIndex(
+        guidelines=_scan_marked_ids(root / "ARCHITECTURAL_GUIDELINES.md", _GUIDELINE_ID_RE),
+        invariants=_scan_marked_ids(root / "ARCHITECTURAL_INVARIANTS.md", _INVARIANT_ID_RE),
+        rules=_scan_rules(root / ".claude" / "rules"),
+        python_lints=_scan_lint_names(root / "python" / "larch" / "lint", "lint_*.py", "lint_"),
+        script_lints=_scan_lint_names(root / "scripts", "lint-*", "lint-"),
+    )
+
+
+# --- Orchestration cores + cli mains ----------------------------------------
+
+
+def run_prepare(runner: Runner, request: PrepareRequest) -> dict[str, object]:
+    """Fetch, digest, and coverage-index; write artifacts; return KV stats."""
+    repo = resolve_repo(runner, request.repo_explicit)
+    issues = list_issues(runner, search=request.search, state=request.state, limit=request.limit, repo=repo)
+    digests = [build_digest(issue) for issue in issues]
+    out_dir = request.out_dir
+    out_dir.mkdir(parents=True, exist_ok=True)
+    digest_path = out_dir / "digest.jsonl"
+    with digest_path.open("w", encoding="utf-8") as handle:
+        for digest in digests:
+            handle.write(json.dumps(digest.to_json()) + "\n")
+    coverage = coverage_index(request.root)
+    coverage_path = out_dir / "coverage-index.json"
+    coverage_path.write_text(json.dumps(coverage.to_json(), indent=2) + "\n", encoding="utf-8")
+    digest_chars = sum(len(json.dumps(digest.to_json()["sections"])) for digest in digests)
+    structured = sum(1 for digest in digests if digest.structured)
+    return {
+        "RUN_DIR": str(out_dir),
+        "DIGEST_PATH": str(digest_path),
+        "COVERAGE_INDEX_PATH": str(coverage_path),
+        "REPO": repo,
+        "SEARCH": request.search,
+        "STATE": request.state,
+        "ISSUES_SELECTED": len(digests),
+        "STRUCTURED": structured,
+        "FREEFORM_OR_TITLE_ONLY": len(digests) - structured,
+        "DIGEST_CHARS": digest_chars,
+        "DIGEST_TOKENS_EST": digest_chars // 4,
+        "GUIDELINES_INDEXED": len(coverage.guidelines),
+        "INVARIANTS_INDEXED": len(coverage.invariants),
+        "RULES_INDEXED": len(coverage.rules),
+        "PYTHON_LINTS_INDEXED": len(coverage.python_lints),
+        "SCRIPT_LINTS_INDEXED": len(coverage.script_lints),
+    }
+
+
+def _print_kv(pairs: Mapping[str, object]) -> None:
+    for key, value in pairs.items():
+        print(f"{key}={value}")
+
+
+def prepare_main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(prog="learn-from-bugs prepare")
+    parser.add_argument("--search", default=DEFAULT_SEARCH)
+    parser.add_argument("--state", default=DEFAULT_STATE)
+    parser.add_argument("--limit", type=int, default=DEFAULT_LIMIT)
+    parser.add_argument("--repo", default="")
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--root", default=".")
+    args = parser.parse_args(argv)
+    request = PrepareRequest(
+        search=args.search,
+        state=args.state,
+        limit=args.limit,
+        repo_explicit=args.repo,
+        out_dir=Path(args.out),
+        root=Path(args.root),
+    )
+    _print_kv(run_prepare(_runner(), request))
+    return 0
+
+
+def coverage_index_main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(prog="learn-from-bugs coverage-index")
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--out", default="")
+    args = parser.parse_args(argv)
+    coverage = coverage_index(Path(args.root))
+    payload = json.dumps(coverage.to_json(), indent=2)
+    if args.out:
+        Path(args.out).write_text(payload + "\n", encoding="utf-8")
+    print(payload)
+    return 0

--- a/python/larch/issue/learn_from_bugs.py
+++ b/python/larch/issue/learn_from_bugs.py
@@ -219,11 +219,7 @@ def list_issues(runner: Runner, *, search: str, state: str, limit: int, repo: st
         raise LearnFromBugsError(f"gh issue list returned invalid JSON: {exc}") from exc
     if not isinstance(parsed, list):
         raise LearnFromBugsError("gh issue list did not return a JSON array")
-    rows: list[dict[str, object]] = []
-    for row in cast("list[object]", parsed):
-        if isinstance(row, dict):
-            rows.append(cast("dict[str, object]", row))
-    return rows
+    return [cast("dict[str, object]", row) for row in cast("list[object]", parsed) if isinstance(row, dict)]
 
 
 # --- Coverage index (offline, pure) -----------------------------------------

--- a/python/tests/issue/test_learn_from_bugs.py
+++ b/python/tests/issue/test_learn_from_bugs.py
@@ -1,0 +1,165 @@
+# pyright: reportUnknownArgumentType=false, reportUnknownMemberType=false, reportUnusedCallResult=false
+"""Offline tests for learn_from_bugs.py."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from larch.core.proc import CommandResult
+from larch.issue import learn_from_bugs
+from test_support import RecordingRunner
+
+
+def _result(stdout: str = "", rc: int = 0, stderr: str = "") -> CommandResult:
+    return CommandResult(("cmd",), rc, stdout, stderr, 0.01)
+
+
+STRUCTURED_BODY = """## Summary
+
+A widget broke.
+
+## Root cause analysis
+
+The reader parsed `https://` but the writer emits `OOS_FILE_MAP\\t`.
+
+## Suggested fix(es)
+
+Match the writer prefix.
+
+<!-- larch:plan:start -->
+## Plan
+## Approach
+Do the thing.
+### UPDATED: python/larch/foo.py
+lots of plan bytes that must be dropped
+"""
+
+FREEFORM_BODY = """**Summary.** Something went wrong in the flush path and nobody noticed.
+
+More detail about the failure that is not under a recognized heading.
+"""
+
+TITLE_ONLY_BODY = "<!-- larch:plan:start -->\n## Plan\n## Approach\nonly a plan here\n"
+
+
+def _issue(number: int, title: str, body: str, *, state: str = "CLOSED") -> dict[str, object]:
+    return {
+        "number": number,
+        "title": title,
+        "body": body,
+        "url": f"https://github.com/o/r/issues/{number}",
+        "closedAt": "2026-07-01T00:00:00Z",
+        "state": state,
+    }
+
+
+def test_diagnostic_prefix_cuts_at_plan_marker() -> None:
+    prefix = learn_from_bugs.diagnostic_prefix(STRUCTURED_BODY)
+    assert "larch:plan:start" not in prefix
+    assert "must be dropped" not in prefix
+    assert "Root cause analysis" in prefix
+
+
+def test_build_digest_structured_keeps_signal_sections() -> None:
+    digest = learn_from_bugs.build_digest(_issue(10, "[DONE] [BUG] widget", STRUCTURED_BODY))
+    assert digest.structured is True
+    assert digest.number == 10
+    assert digest.title == "[BUG] widget"  # [DONE] stripped
+    assert set(digest.sections) == {"summary", "root cause analysis", "suggested fix(es)"}
+    assert "OOS_FILE_MAP" in digest.sections["root cause analysis"]
+
+
+def test_build_digest_freeform_fallback() -> None:
+    digest = learn_from_bugs.build_digest(_issue(11, "[BUG] flush", FREEFORM_BODY))
+    assert digest.structured is False
+    assert "_freeform" in digest.sections
+    assert "flush path" in digest.sections["_freeform"]
+
+
+def test_build_digest_title_only_when_body_is_plan_only() -> None:
+    digest = learn_from_bugs.build_digest(_issue(12, "[BUG] plan-only", TITLE_ONLY_BODY))
+    assert digest.structured is False
+    assert digest.sections == {"_title_only": ""}
+
+
+def test_build_digest_truncates_long_section() -> None:
+    body = "## Summary\n\n" + ("A" * 800) + "\n\n<!-- larch:plan:start -->\n## Plan\n"
+    digest = learn_from_bugs.build_digest(_issue(20, "[BUG] long", body))
+    summary = digest.sections["summary"]
+    assert summary.endswith("…")
+    assert len(summary) == learn_from_bugs.SUMMARY_CAP + 1  # cap chars + ellipsis
+
+
+def test_list_issues_parses_json_array() -> None:
+    rows = [_issue(1, "[BUG] a", "b1"), _issue(2, "[BUG] b", "b2")]
+    runner = RecordingRunner(responses=[_result(json.dumps(rows))], strict=True)
+    out = learn_from_bugs.list_issues(runner, search="[BUG] in:title", state="closed", limit=5, repo="o/r")
+    assert [row["number"] for row in out] == [1, 2]
+    assert runner.calls[0][:3] == ["gh", "issue", "list"]
+    assert "--search" in runner.calls[0]
+
+
+def test_list_issues_raises_on_gh_failure() -> None:
+    runner = RecordingRunner(responses=[_result(rc=1, stderr="boom")], strict=True)
+    with pytest.raises(learn_from_bugs.LearnFromBugsError, match="boom"):
+        learn_from_bugs.list_issues(runner, search="x", state="closed", limit=1, repo="o/r")
+
+
+def test_coverage_index_scans_repo_surface(tmp_path: Path) -> None:
+    (tmp_path / "ARCHITECTURAL_GUIDELINES.md").write_text(
+        "### G-Py-1: Do a thing\n\ntext\n### G-Wire-1: Another\n", encoding="utf-8")
+    rules = tmp_path / ".claude" / "rules"
+    rules.mkdir(parents=True)
+    (rules / "some-rule.md").write_text("# Some Rule\n\nbody\n", encoding="utf-8")
+    lintdir = tmp_path / "python" / "larch" / "lint"
+    lintdir.mkdir(parents=True)
+    (lintdir / "lint_foo.py").write_text("x = 1\n", encoding="utf-8")
+    (lintdir / "helper.py").write_text("x = 1\n", encoding="utf-8")  # not lint_-prefixed
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    (scripts / "lint-bar.sh").write_text("echo\n", encoding="utf-8")
+
+    cov = learn_from_bugs.coverage_index(tmp_path)
+    assert cov.guidelines == (("G-Py-1", "Do a thing"), ("G-Wire-1", "Another"))
+    assert cov.invariants == ()  # file absent yet, must not error
+    assert cov.rules == (("some-rule.md", "Some Rule"),)
+    assert cov.python_lints == ("lint_foo",)
+    assert cov.script_lints == ("lint-bar",)
+
+
+def test_coverage_index_absent_files_yield_empty(tmp_path: Path) -> None:
+    cov = learn_from_bugs.coverage_index(tmp_path)
+    assert cov.to_json() == {
+        "guidelines": [],
+        "invariants": [],
+        "rules": [],
+        "python_lints": [],
+        "script_lints": [],
+    }
+
+
+def test_run_prepare_writes_artifacts_and_stats(tmp_path: Path) -> None:
+    rows = [_issue(1, "[BUG] a", STRUCTURED_BODY), _issue(2, "[BUG] b", FREEFORM_BODY)]
+    runner = RecordingRunner(responses=[_result(json.dumps(rows))], strict=True)
+    out_dir = tmp_path / "run"
+    request = learn_from_bugs.PrepareRequest(
+        search="[BUG] in:title",
+        state="closed",
+        limit=10,
+        repo_explicit="o/r",
+        out_dir=out_dir,
+        root=tmp_path,
+    )
+    stats = learn_from_bugs.run_prepare(runner, request)
+    assert stats["ISSUES_SELECTED"] == 2
+    assert stats["STRUCTURED"] == 1
+    assert stats["REPO"] == "o/r"
+    digest_lines = (out_dir / "digest.jsonl").read_text(encoding="utf-8").strip().splitlines()
+    assert len(digest_lines) == 2
+    first = json.loads(digest_lines[0])
+    assert first["number"] == 1
+    assert first["structured"] is True
+    assert (out_dir / "coverage-index.json").is_file()

--- a/python/tests/issue/test_learn_from_bugs.py
+++ b/python/tests/issue/test_learn_from_bugs.py
@@ -124,7 +124,7 @@ def test_coverage_index_scans_repo_surface(tmp_path: Path) -> None:
 
     cov = learn_from_bugs.coverage_index(tmp_path)
     assert cov.guidelines == (("G-Py-1", "Do a thing"), ("G-Wire-1", "Another"))
-    assert cov.invariants == ()  # file absent yet, must not error
+    assert not cov.invariants  # file absent yet, must not error
     assert cov.rules == (("some-rule.md", "Some Rule"),)
     assert cov.python_lints == ("lint_foo",)
     assert cov.script_lints == ("lint-bar",)

--- a/skills/learn-from-bugs/SKILL.md
+++ b/skills/learn-from-bugs/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: learn-from-bugs
+description: "Use when mining a repo's closed bugs for recurring root causes to propose lint rules, invariants, guideline entries, and fixes for still-broken code. Defaults to [BUG]; optional verbal filter."
+argument-hint: "[-n COUNT] [--state closed|open|all] [--repo OWNER/REPO] [--search QUERY] [verbal description of issues to mine]"
+allowed-tools: Bash, Read, Grep, Glob, Write, Edit, AskUserQuestion, Skill
+---
+
+# Learn From Bugs
+
+**MANDATORY: READ ENTIRE FILE before composing user-facing prose: `${CLAUDE_PLUGIN_ROOT}/skills/shared/readability-style.md`.**
+
+Mine a repository's closed bug reports for recurring root-cause patterns, then propose preventions ranked by how mechanically enforceable they are. The workflow is **report-only by default**: it reads issues and the repo, writes one report to a scratch run directory, and makes no repository or GitHub change until the operator approves a specific follow-up.
+
+The engine keeps this cheap. It never reads full issue bodies into context: `learn-from-bugs prepare` compresses each body to a compact root-cause digest first (dropping the appended `/design` plan, which dominates the bytes), so the synthesis reads a small fraction of the raw tokens. The prepared stats print a `DIGEST_TOKENS_EST` so the operator can size a run before spending.
+
+**No sub-agents.** Do the clustering and synthesis inline in this session. Do not spawn `Task`/`Agent` fan-out; the digest is small enough to read directly, and fan-out is the expensive failure mode this skill exists to avoid.
+
+**Anti-halt continuation reminder.** After any child `Skill` call (for example `/issue`) returns, IMMEDIATELY continue with this skill's next numbered step. Do not end the turn on the child's cleanup output, and do not write a handoff or status recap. → shared/subskill-invocation.md#anti-halt
+
+## Contract
+
+- Flags: `-n COUNT` (issues to mine, default 50), `--state` (default `closed`), `--repo OWNER/REPO`, `--search QUERY` (explicit gh search that overrides the verbal description).
+- Everything else in `$ARGUMENTS` is a **verbal description** of which issues to mine. Translate it into a `gh` search expression. With no description and no `--search`, mine `[BUG] in:title`.
+- Report-only by default. Every repository or GitHub mutation is gated behind an explicit operator approval in Step 5.
+- File issues only through `/issue` (never `gh issue create` directly).
+- Cite issues by number and refer to code by symbol, not line number. Do not paste machine-local absolute paths or hardcode counts that will drift; read live counts from the prepared stats and coverage index.
+
+<!-- step:1 - Resolve the search -->
+## Step 1 - Resolve the search
+
+Parse `$ARGUMENTS`. Pull out `-n`, `--state`, `--repo`, and `--search` if present. Treat the remaining prose as the verbal description.
+
+Decide the gh search query:
+
+- If `--search QUERY` was given, use it verbatim.
+- Else if a verbal description was given, translate it to a gh search expression. Prefer `in:title` for prefix-style descriptions and `in:title,body` for topical ones. Example: "stall bugs in implement" becomes `[BUG] stall implement in:title,body`.
+- Else use the default `[BUG] in:title`.
+
+State the resolved query and count back to the operator in one line before proceeding.
+
+<!-- step:2 - Prepare the digest and coverage index -->
+## Step 2 - Prepare the digest and coverage index
+
+Create a scratch run directory and run the prepare verb. Pass the plugin's `cli.py` via `${CLAUDE_PLUGIN_ROOT}`, and scan the **target** repository (the current working directory) for its existing enforcement surface.
+
+```bash
+RUN_DIR=$(mktemp -d "${TMPDIR:-/tmp}/learn-from-bugs.XXXXXX")
+python3 "${CLAUDE_PLUGIN_ROOT}/python/cli.py" learn-from-bugs prepare \
+  --search "$RESOLVED_SEARCH" \
+  --state "$STATE" \
+  --limit "$COUNT" \
+  --out "$RUN_DIR" \
+  --root "$PWD"
+```
+
+Parse only whole-line `KEY=value` records from stdout: `DIGEST_PATH`, `COVERAGE_INDEX_PATH`, `REPO`, `ISSUES_SELECTED`, `STRUCTURED`, `FREEFORM_OR_TITLE_ONLY`, `DIGEST_TOKENS_EST`, and the `*_INDEXED` counts. Abort if `DIGEST_PATH` is missing.
+
+If `DIGEST_TOKENS_EST` is large relative to the budget the operator signalled, say so and offer to lower `-n` before reading.
+
+<!-- step:3 - Read and cluster -->
+## Step 3 - Read and cluster
+
+Read `DIGEST_PATH` (one JSON record per line: `number`, `title`, `sections` with `summary` / `root cause analysis` / `suggested fix(es)`, or a `_freeform` / `_title_only` fallback). Read `COVERAGE_INDEX_PATH` (the target repo's `guidelines`, `invariants`, `rules`, `python_lints`, `script_lints`).
+
+Cluster the root causes into recurring patterns. For each cluster, note the member issue numbers and a one-line mechanism. A pattern that appears once is an anecdote; a pattern across several issues is a candidate for prevention.
+
+<!-- step:4 - Write the report -->
+## Step 4 - Write the report
+
+Write `${RUN_DIR}/report.md` with these sections, in order. The dedup section is mandatory and comes before any proposal, so proposals are always the residual, never a duplicate of existing coverage.
+
+1. **Scope and cost.** Resolved search, `REPO`, `ISSUES_SELECTED`, structured-vs-fallback split, and the token cost actually spent reading the digest.
+2. **Root-cause clusters.** Each recurring pattern, its member issues, and its mechanism, ordered by frequency.
+3. **Already covered (dedup).** For every principle the clusters imply, map it to existing coverage from the coverage index: the guideline id, the `.claude/rules/` file, and the lint that already enforces it. This is the filter that keeps the proposals below honest.
+4. **Proposed mechanical lint rules.** Residual gaps only, ranked by precision times frequency. For each: the rule, the backing issues, an estimated false-positive risk, and whether it needs a shrinking reason-bearing baseline for existing violations rather than a hard ban.
+5. **Proposed architectural invariants.** Never-violate candidates. For each, give a **best-home classification**: `lint` if it is mechanizable, `rule` if it is path-scoped and best delivered as a `.claude/rules/` reminder when the relevant file is touched, `invariants-file` if it is never-violate but neither mechanizable nor cleanly path-scoped, or `guideline` if it is really aspirational. This classification is what tells the operator whether a standalone `ARCHITECTURAL_INVARIANTS.md` is warranted or whether rules already cover the need.
+6. **Proposed guideline entries.** Aspirational residuals, written in the target repo's guideline style if it has one (for larch, the terse `G-<Area>-<N>: <imperative>. Why. Deviate when.` form).
+7. **Issues to file.** Concrete still-broken code the mining surfaced, for example a fix that was scoped to one call site while identical sites remain, phrased as a fileable problem statement with evidence.
+
+Print the report to the operator and the `RUN_DIR` path.
+
+<!-- step:5 - Follow-up gates -->
+## Step 5 - Follow-up gates
+
+Stop here by default. Then offer follow-ups, each behind its own explicit approval. Never bundle them.
+
+- **File issues.** For the Step 4 "Issues to file" items the operator approves, invoke `/issue` via the Skill tool once with the drafted bodies. Do not call `gh issue create` directly.
+- **Append guideline entries.** On approval, `Edit` the target repo's guideline file to append the approved entries, matching its existing numbering and style.
+- **Create or extend the invariants file.** Only if the operator confirms an `ARCHITECTURAL_INVARIANTS.md` should exist, create or append it with the approved never-violate entries. If the operator instead prefers rules, draft the `.claude/rules/*.md` files instead.
+- **Scaffold a lint.** On approval, scaffold a proposed lint and its test under the repo's lint conventions, then hand the real implementation to `/design` and `/implement`. Do not wire it into CI in this skill.
+
+If the operator approves nothing, end after the report.


### PR DESCRIPTION
Fixes #6464

## What

Adds a public `/learn-from-bugs` skill that mines a repository's closed bug backlog for recurring root causes and proposes preventions, ranked by mechanical enforceability: lint rules, architectural invariants, guideline entries, and issues to file for still-broken code.

## Why

A naive "read the last N `[BUG]` issues and extrapolate rules" pass is expensive (full bodies, sub-agent fan-out; a prior ad-hoc run cost $300+ per #6103). This skill makes it cheap and repeatable by compressing each body to a compact root-cause digest (cutting at the `<!-- larch:plan:start -->` boundary to drop the appended `/design` plan, which is the byte bulk) and synthesizing inline with no sub-agent fan-out.

## How

- `python/larch/issue/learn_from_bugs.py` behind `cli.py learn-from-bugs prepare|coverage-index`:
  - Digests each issue (Summary / Root cause analysis / Suggested fix, with freeform and title-only fallbacks).
  - Scans the target repo's existing enforcement surface (guidelines, `.claude/rules/`, python + script lints) so the report proposes only the residual gap, never a duplicate. Forward-compatible with a future `ARCHITECTURAL_INVARIANTS.md`.
  - GitHub access via the `Runner` seam; the digest and coverage logic are offline-testable.
- `skills/learn-from-bugs/SKILL.md` (public): report-only by default, a mandatory "already covered" dedup section, and a best-home classification (lint / rule / invariants-file / guideline) for each never-violate candidate, so the report actively informs whether a standalone `ARCHITECTURAL_INVARIANTS.md` is warranted or whether `.claude/rules/` already cover the need. Follow-up mutations (file issues via `/issue`, append guidelines, create the invariants file, scaffold a lint) are each gated behind explicit operator approval.
- Docs: README skill table plus `docs/skills.md` entry.

## Tests

- `python/tests/issue/test_learn_from_bugs.py` (10 offline cases).
- ruff, pyright, and the full pre-commit gate pass on all changed files.

## Notes

The actual mining run over a full backlog is intended to run in a fresh session (report-only), to keep this build's context lean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
