### PR TITLE
Release v52.5.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.5.0",
+  "version": "52.5.1",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Added

- Seeded `ARCHITECTURAL_INVARIANTS.md` as a new documentation file for architectural invariants.
- Architectural knowledge is now fed to the coder and reviewers in tiers.

## Changed

- `/learn-from-bugs` now emits full, append-ready wording for guidelines and invariants.
- Removed `.claude/rules/`: each rule is now routed to a hook, lint rule, guideline, or invariant.

## Fixed

- `design-step3b-tail.sh`: `elif command grep` under `set -e` aborted on macOS Bash 3.2; corrected.
- 37 tempfile sites in `python/larch` lacked `dir=`, exposing `TMPDIR`; fixed and added lint coverage.
- Spurious task-notification loop no longer suppressed: circuit-breaker threshold and event scope corrected.
