### PR TITLE
Fix flaky test_larch_log_commit_accepts_tmpdir_flag on push-to-main

### DIFF
--- a/python/tests/report/test_run_logs.py
+++ b/python/tests/report/test_run_logs.py
@@ -1973,7 +1973,17 @@ def test_larch_log_commit_rejects_bad_pre_scrub_violations(tmp_path: Path) -> No
     assert rc == 1
 
 
-def test_larch_log_commit_accepts_tmpdir_flag(tmp_path: Path) -> None:
+def test_larch_log_commit_accepts_tmpdir_flag(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Hermetic: run inside a temp feature-branch repo so the commit chokepoint's
+    # default-branch guard does not fire when the suite itself is checked out on
+    # main. Without this, `run-log commit` returns rc=1 ("refusing larch-log
+    # commit on default branch main") on every push-to-main CI run.
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo_on_feature(repo)
+    monkeypatch.chdir(repo)
     rc = run_logs.larch_log_commit_main(
         [
             "--log-root",


### PR DESCRIPTION
## Problem

`main` CI has failed on every push since #6488 merged. All failures are the same test, `tests/report/test_run_logs.py::test_larch_log_commit_accepts_tmpdir_flag`, failing `assert rc == 0` with `refusing larch-log commit on default branch main` on stderr.

It looked like a flake across shards (observed in shard 1 and shard 17), but it is deterministic:

- The test drives `larch_log_commit_main`, which runs git against the ambient checkout (`Path.cwd()`).
- `_commit_run` refuses to commit when HEAD is on a default branch, returning `rc=1`.
- So it fails on every `push`-to-`main` run (HEAD on `main`) and passes on PR runs (detached HEAD at the merge commit).
- The test is not pinned in `shard-assignments.json`, so it rides the round-robin fallback (`index % shard_count`). Its collection index drifts as the suite changes across commits, which is why the same test surfaced in different shards without any rebalance.

## Fix

Make the test hermetic: create a temp git repo on a `feature` branch and `chdir` into it before calling `larch_log_commit_main`, so the default-branch guard sees a non-default branch regardless of where the suite is checked out. This mirrors the existing `test_commit_run_refuses_placeholder_run_id` pattern (`_init_git_repo_on_feature`).

The production guard is correct behavior and is unchanged; only the test was non-hermetic.

## Verification

PR CI runs as a `pull_request` (detached HEAD), so it cannot exercise the failing condition. Verified locally in a worktree checked out on `main` (ambient HEAD = `main`):

- Old test on ambient-`main`: FAILS with `refusing larch-log commit on default branch main`.
- Fixed test on ambient-`main`: PASSES.

Also: full `tests/report/test_run_logs.py` (161 passed), ruff clean, pyright 0 errors on the changed file.
