### PR TITLE
Fix broken mock targets in two flush_logs_pre tests

### DIFF
--- a/python/tests/report/test_run_logs.py
+++ b/python/tests/report/test_run_logs.py
@@ -897,10 +897,10 @@ def test_flush_logs_pre_commit_exception_returns_commit_skip(
     def noop(*_a: object, **_k: object) -> None:
         return None
 
-    monkeypatch.setattr(run_logs, "_commit_run", fail_commit)
-    monkeypatch.setattr(run_logs, "_write_final_report", noop)
-    monkeypatch.setattr(run_logs, "capture_session_transcript", noop)
-    monkeypatch.setattr(run_logs, "_render_ledger_reports", noop)
+    monkeypatch.setattr(run_log_flush, "_commit_run", fail_commit)  # type: ignore[arg-type]
+    monkeypatch.setattr(run_log_flush, "_write_final_report", noop)  # type: ignore[arg-type]
+    monkeypatch.setattr(run_log_flush, "capture_session_transcript", noop)  # type: ignore[arg-type]
+    monkeypatch.setattr(run_log_flush, "_render_ledger_reports", noop)  # type: ignore[arg-type]
     skip = run_logs.flush_logs_pre(runner=RecordingRunner(), ctx=ctx, cwd=str(tmp_path))
     assert skip.skipped is True
     assert skip.reason == config.REFRESH_SKIP_COMMIT_FAILED
@@ -1320,7 +1320,7 @@ def test_flush_logs_pre_strict_final_report_error_returns_recovery_failed(
     def fail_report(*_a: object, **_k: object) -> None:
         raise ShipError("reconcile failed")
 
-    monkeypatch.setattr(run_logs, "_write_final_report", fail_report)
+    monkeypatch.setattr(run_log_flush, "_write_final_report", fail_report)  # type: ignore[arg-type]
 
     skip = run_logs.flush_logs_pre(runner=RecordingRunner(), ctx=ctx, cwd=str(tmp_path), strict_final_report=True)
 


### PR DESCRIPTION
## Summary

- Two `flush_logs_pre` tests monkeypatched `run_logs._commit_run` and `run_logs._write_final_report` instead of `run_log_flush._commit_run` and `run_log_flush._write_final_report`.
- `flush_logs_pre` lives in `run_log_flush` and resolves those names from its own module namespace, so the `run_logs.X` patches were no-ops.
- Both tests accidentally passed: the commit test hit real `_commit_run` on a non-repo `tmp_path` (same `ShipError` outcome); the strict-final-report test hit real `_write_final_report` with missing sidecar files (same `ShipError` outcome).
- Fix: retarget all four `setattr` calls in `test_flush_logs_pre_commit_exception_returns_commit_skip` and the one in `test_flush_logs_pre_strict_final_report_error_returns_recovery_failed` to `run_log_flush`.

## Test plan

- [x] `python -m pytest tests/report/test_run_logs.py::test_flush_logs_pre_commit_exception_returns_commit_skip tests/report/test_run_logs.py::test_flush_logs_pre_strict_final_report_error_returns_recovery_failed -x -q` passes (2 passed, 0.48s).
- [ ] CI green on push.

Closes #6494

🤖 Generated with [Claude Code](https://claude.com/claude-code)
