### PR TITLE
Release v52.5.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.5.1",
+  "version": "52.5.2",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Fixed

- Stabilized a flaky `test_larch_log_commit_accepts_tmpdir_flag` test that failed intermittently on push-to-main.
- Corrected broken mock targets in two `flush_logs_pre` unit tests.
- Stopped spurious `/design` Step 3 review notifications from processing multiple times in one turn when the task-output clamp was already active, preventing unnecessary token consumption.

## Changed

- Restored the autonomous plan-revision waterfall in `/design` Step 3.
- Added lint rules, invariants, and guideline entries derived from the `learn-from-bugs` analysis.
