### PR TITLE
Release v52.5.3

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.5.2",
+  "version": "52.5.3",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Changed

- `/design` now runs a main-agent audit of accepted plan-review findings at Gate C (#6515)
- Review costs reduced: smaller voter pool for `/design`, adjusted model slot configuration, and pinned dynamics (#6513)
- `ARCHITECTURAL_INVARIANTS.md` is now wired to mirror `ARCHITECTURAL_GUIDELINES.md` across all consumers (#6510)
- Markdown-to-Python migration (Phase XII): first heatmap-driven eager-reference demotion round; blocked pending 50 post-repair runs or 2026-07-17 (#6504)

## Fixed

- Step 5 spurious-notification loop: a stdout banner was triggering premature task-notifications, and the no-progress circuit breaker was not arming correctly for `/implement` steps (#6517)
