### PR TITLE
Release v52.5.4

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.5.3",
+  "version": "52.5.4",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Added

- Background-job (bgjob) transport and background-launch guard for the `/implement` workflow ([#6522](https://github.com/character-ai/larch/pull/6522))

## Fixed

- In-run guard to prevent `/implement` from merging when the main branch is broken or flaky ([#6518](https://github.com/character-ai/larch/pull/6518))
- Empty-invariants ship stall in `/implement` ([#6522](https://github.com/character-ai/larch/pull/6522))
