### PR TITLE
Release v52.5.5

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.5.4",
+  "version": "52.5.5",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Added

- `/design` plan-size guardrail: large plans are split into serial part-issues before `/implement` runs. (#6554)

## Changed

- Background-job (bgjob) migration: wait contract, real-process harness, and writer-parity lint are rescoped as part of the bgjob migration series (#6524, chunk 1/11). (#6545)
- Review and plan-review engines now emit bgjob merge-result KVs (#6524, chunk 2/11). (#6546)
- `/research` and validation lanes migrated to per-lane bgjob slugs (#6524, chunk 10/11). (#6555)
- Skills table in README sorted alphabetically by skill name and reconciled with `skills.md`. (#6552)

## Fixed

- `/design` pause: snapshot now includes `.completed/` to prevent false Step 5c provenance refusals. (#6558)
- `/design` resume: source-env `ISSUE_NUMBER` and `REPO` are now restored correctly; Step 5c publish no longer exits with code 5. (#6561)
