### PR TITLE
Release v52.5.6

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.5.5",
+  "version": "52.5.6",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Added

- **Plan-correctness reviewer for all difficulty levels**: Added a Cursor/auto reviewer with a plan-correctness and completeness profile to all three difficulty levels. (#6565)
- **Autonomous CI-fix loop in `ship-pr`**: `ship-pr` now runs up to 30 rounds of autonomous CI-fix sub-agent attempts before bailing to the main agent. (#6570)

## Changed

- **`/implement` Steps 3, 6, and 7a migrated to bgjob**: These `/implement` check legs now run as background jobs using bgjob start/wait instead of inline execution. (#6562)
- **`/design` Step 3 plan-review loop migrated to bgjob**: The plan-review loop in `/design` Step 3 now uses bgjob start/wait. (#6563)
- **`/design` Steps 4, 5c, and 6 liveness migrated to bgjob**: The tail of Step 4, Step 5c, and the Step 6 liveness checks in `/design` now use bgjob. (#6571)

## Fixed

- **`check-size` hard-trigger hardening**: The check-size hard trigger could be self-disarmed; it is now hardened alongside the existing gate. (#6567)
- **Stale `REPO` leaking into fresh Step 0b**: A stale route-state `REPO` value could leak into a new Step 0b session; this is now cleared on session start. (#6569)
