### PR TITLE
Release v52.5.8

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.5.7",
+  "version": "52.5.8",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Changed

- Migrate stall recovery and state classifiers to bgjob registry liveness (#6524 chunk 9/11) ([#6593](https://github.com/character-ai/larch/pull/6593))

## Fixed

- Fix `/implement` Step 5 review background job orphaned at around 123 seconds on every attempt; review now produces output ([#6592](https://github.com/character-ai/larch/pull/6592))
- Fix round reviewer-timing chart to include phase2/phase3 vendor-fallback runs ([#6594](https://github.com/character-ai/larch/pull/6594))
- Fix `bgjob wait` with empty `--tmpdir` resolving to current directory and returning missing-registry for live daemons ([#6596](https://github.com/character-ai/larch/pull/6596))
- Fix voter `OOS_N` relabeling of `FINDING_N` items causing per-item `JUDGE_ERROR`s ([#6597](https://github.com/character-ai/larch/pull/6597))
- Fix under-quorum degraded vote to retry only affected items instead of the full panel ([#6598](https://github.com/character-ai/larch/pull/6598))
- Fix Codex policy-rejection watcher false-positives on quoted grep output ([#6599](https://github.com/character-ai/larch/pull/6599))
