### PR TITLE
Release v52.5.10

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.5.9",
+  "version": "52.5.10",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## v52.5.10

### Changed

- `/design` final-summary and brainstorm lanes now run as background jobs. (#6605)

### Fixed

- `/analyze-bugs` title matching now handles case variations and fixed-bug prefixes (`[DONE] [BUG]`, `[Bug]`), so previously fixed bugs are no longer invisible to the scan. (#6606)
- Codex policy-rejection sanitizer no longer misses completed-command fragments at the 32KB tail boundary. (#6607)
