### PR TITLE
Release v52.5.12

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.5.11",
+  "version": "52.5.12",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Added

- Seeded `ARCHITECTURAL_INVARIANTS.md` with `INV-Gate-1` and `INV-Pause-1`. (#6635)

## Fixed

- Final run summary (Gantt report) now displays at the end of `/design` and `/implement` runs. (#6629)
- Step 3 bgjob orphan root cause addressed; ~123s orphan case no longer misroutes. (#6634)
- `/learn-from-bugs` default search no longer over-selects non-bug issues. (#6636)
