### PR TITLE
Release v52.5.13

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.5.12",
+  "version": "52.5.13",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## What's Changed

### Added

- Appended new architectural guideline entries G-Py-15, G-Cfg-3, G-Orch-5, and G-Obs-5 (#6641)

### Fixed

- Fixed invariant-ID regex mismatch between the `learn-from-bugs` coverage indexer and the architectural-invariants reader that caused INV-* headings to be miscounted (#6648)
- Fixed `/implement` Step 5 coverage gate triggering on NOT_SUBSTANTIVE returns from a TRIVIAL single reviewer, and prevented the step5-review recovery path from replaying a cached stall so that retries can advance (#6651)
- Fixed `/design` re-review after a plan edit to use the updated plan instead of a cached pre-edit verdict (#6653)
