### PR TITLE
Release v52.5.15

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.5.14",
+  "version": "52.5.15",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## What's Changed in v52.5.15

### Added
- Added `lint_lifecycle_prefix_literal` with title-prefix constants (#6659)

### Fixed
- Fixed step5 result-env classifier mislabeling a stall as complete (#6660)
- Fixed Gantt chart truncation in the final report caused by the inflight row cap and `label_width` being applied to committed final-summary rows (#6661)
- Fixed zero-cost progress reports being unreachable during background-job chunked processing (#6664)

**Full changelog:** https://github.com/character-ai/larch/compare/v52.5.14...v52.5.15
