### PR TITLE
Release v52.5.16

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.5.15",
+  "version": "52.5.16",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## What's Changed in v52.5.16

### Changed

- Optimized CI wall-clock to approximately 1 minute (#6669)
- Removed retired live-discovery and mid-run report code (#6691)

### Fixed

- Disposition validation bypass through PR mutation entry points (#6682)
- Review phase breadcrumbs not logged for status line progress report in `/design`, `/implement`, and `/review` (#6688)
- Toolless agent fabricated verdicts in `analyze-bugs` triage (#6689)
- Postmerge transient retry rebased a closed PR (#6690)
