### PR TITLE
Release v52.5.17

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.5.16",
+  "version": "52.5.17",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Added

- **G-Mig-1 guideline**: Added `G-Mig-1` to `ARCHITECTURAL_GUIDELINES.md` to inventory environmental assumptions before a platform migration. (#6699)
- **Regression-ratchet lints**: Added two new lints: renderer golden-test coverage and guidelines-note wrapper bypass. (#6701)
- **Run-scoped progress primitives**: Added dormant run-scoped progress primitives for future use. (#6703)
- **Post-flush manifest completeness check**: A missing required run-log artifact is now a recorded execution issue instead of a silent status string. (#6704)

## Changed

- **Spurious-task-notification defense stack removed**: Removed the defense stack after bgjob waits landed. (#6706)

## Fixed

- **`/issue` batch parser**: Fixed a bug where the batch parser split items on `###` lines inside fenced code blocks. (#6694)
