### PR TITLE
Release v52.5.18

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.5.17",
+  "version": "52.5.18",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Added

- Agent-tool-contract lint for `/implement`: adds lint rules and guideline entries I-Agent-1, G-Ext-3, and G-Orch-6. (#6730)

## Changed

- Activate the `/design` run pointer to track active sessions. (#6716)
- Activate the `/implement` run pointer to track active sessions. (#6725)
- All reviewers now use `Cursor/auto` instead of `Cursor/Composer 2.5`. (#6734)

## Fixed

- Reduce symlink-following risk in predictable hook tmp-state writes. (#6714)
- Apply fully fd-pinned parent-chain handling to run-scoped writes. (#6720)
- Remove false `/implement` complaint when Codex skips the full lint and test suite (expected behavior). (#6731)
- Reduce TOCTOU window in temp state path creation and promotion. (#6733)
