### PR TITLE
Release v52.5.19

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.5.18",
+  "version": "52.5.19",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Changed

- Switch production reader/writer to the active-run path ([#6740](https://github.com/character-ai/larch/pull/6740))
- Ship real-process bgjob harness; close remaining acceptance gaps from #6524 and #6516 ([#6742](https://github.com/character-ai/larch/pull/6742))
- Reverse the order of the summary table and review-details section (including Gantt chart) in `/design` and `/implement` final reports ([#6743](https://github.com/character-ai/larch/pull/6743))
