### PR TITLE
Emergency repair: fix bgjob wait TOCTOU race causing test-bgjob flake

### DIFF
--- a/python/larch/bgjob/wait.py
+++ b/python/larch/bgjob/wait.py
@@ -66,6 +66,13 @@ def wait_once(*, tmpdir: Path, step: str, max_wait_s: int, run_id: str | None = 
                 return 0
             daemon_live = registry.daemon_liveness(entry)
             if not daemon_live.live:
+                # Re-check result after daemon exit: daemon may have written the result
+                # between our first check and the liveness check (TOCTOU race).
+                rows = _read_result(result_path)
+                if rows is not None:
+                    out_rows = [(config.BGJOB_STATUS_KEY, config.BGJOB_STATUS_DONE), *rows.items()]
+                    _print_rows(out_rows)
+                    return 0
                 tail = _log_tail(entry.stderr_log)
                 _print_rows(
                     [

--- a/python/larch/bgjob/wait.py
+++ b/python/larch/bgjob/wait.py
@@ -66,13 +66,10 @@ def wait_once(*, tmpdir: Path, step: str, max_wait_s: int, run_id: str | None = 
                 return 0
             daemon_live = registry.daemon_liveness(entry)
             if not daemon_live.live:
-                # Re-check result after daemon exit: daemon may have written the result
-                # between our first check and the liveness check (TOCTOU race).
-                rows = _read_result(result_path)
-                if rows is not None:
-                    out_rows = [(config.BGJOB_STATUS_KEY, config.BGJOB_STATUS_DONE), *rows.items()]
-                    _print_rows(out_rows)
-                    return 0
+                # Re-check result after daemon exit: close the TOCTOU race between
+                # the daemon writing its result and this waiter's liveness check.
+                if _read_result(result_path) is not None:
+                    continue  # loop back; result check at top will print DONE and return
                 tail = _log_tail(entry.stderr_log)
                 _print_rows(
                     [


### PR DESCRIPTION
## Summary

Emergency repair for merged PR #6761 (issue #6732).

The post-merge push-to-main CI failed with a race condition in `python/larch/bgjob/wait.py`. When the bgjob daemon exits between wait_once's result-file check and the liveness check, wait_once incorrectly returned `BGJOB_STATUS=DEAD` instead of reading the now-available result file.

**Fix**: After detecting a dead daemon (PID gone), re-check the result file before returning DEAD. Closes the TOCTOU window.

**Root cause**: Pre-existing race in `wait_once` — not introduced by PR #6761. Fix confined to `python/larch/bgjob/wait.py` (+7 lines).

## Test plan

- `python -m pytest python/ -k bgjob -x -q` passes (66 tests)
- CI passes including `test-bgjob` shard
