### PR TITLE
Release v52.5.20

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.5.19",
+  "version": "52.5.20",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## v52.5.20

### Fixed

- Fixed `parse_invariant_entries` dropping invariant bodies; design drafting, Gate C, and review prompts now receive complete invariant text. (PR #6763)
- Fixed Gate C architectural-guideline assessments missing on roughly 20% of approved `/design` runs; the check is now enforced fail-closed at publish. (PR #6775)
- Fixed stale larch status breadcrumb appearing on Claude startup in a clone where a prior `/design` run was recorded. (PR #6778)

### Added

- Added invariant I-Stale-1: persisted step results are keyed on their inputs and invalidated when inputs change. (PR #6762)
- Added guideline G-Root-1: resolve repo roots from run state instead of ambient working directory. (PR #6771)
- Added suppression-reason lint for G-Py-11, enabling mechanical enforcement. (PR #6779)
- Larch run-log issues now include the source design-run issue number in their title and body. (PR #6776)
- Added a prompt to trigger `/learn-from-bugs` when the closed-bug backlog accumulates. (PR #6781)

### Changed

- Addressed residual TOCTOU windows around `chmod` and `mktemp`. (PR #6761)
- Review prompts skip the guidelines block at TRIVIAL difficulty. (PR #6772)
- Promoted G-Orch-4 and G-Obs-4 from guidelines to invariants. (PR #6777)
- Merged Step 8 invariant and guideline compose-time assessments into a single relaunch round. (PR #6780)
