### PR TITLE
Release v52.5.21

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.5.20",
+  "version": "52.5.21",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Added

- Lint: flag guideline entries with no exception clause as invariant-promotion candidates. (#6786)

## Changed

- Slim mechanically-enforced guideline entries in the normalized prompt payload. (#6783)
- Review-phase breadcrumbs in `/design` and `/implement` status reports always include the review round. (#6787)

## Fixed

- `/design` now persists architectural-invariant assessments. The `persist-design-assessment` verb previously had no caller. (#6789)
