### PR TITLE
Release v52.5.23

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.5.22",
+  "version": "52.5.23",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Fixed

- Step 2 token mark was not written during implement runs; coder cost landed in Step 0 instead.
- `/implement --merge`: a client pre-commit hook aborted the run-log commit, stalling ship before PR creation; step 8 shippr recovery deadlocked on a pre-terminal stalled label.

## Changed

- Model policy updated for GPT-5.6: difficulty routing, review panels, voters, and fixers.
