### PR TITLE
Release v52.5.24

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.5.23",
+  "version": "52.5.24",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Fixed

- `/design` Step 5c oversize-override recovery now works correctly when review revises the plan. (#6815)
- Step 2 dispatcher commits no longer abort on file-modifying client pre-commit hooks. (#6816)
- Repair-loop exhaustion now emits `NEXT_ACTION=main-agent-edit` instead of `NEXT_ACTION=stall`. (#6831)
- Codex now reports `STATUS=bailed` on quota exit instead of `STATUS=complete`. (#6833)

## Changed

- `/design` splits and lazy-loads large reference docs for approval gates and plan review. (#6824)

## Added

- Shared fixer contracts and tier selection. (#6829)
