### PR TITLE
Release v52.5.25

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.5.24",
+  "version": "52.5.25",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## What's Changed

### Added
- Dormant CI-fixer lane with bgjob wrapper (#6849)
- Step 8 assessment lane foundation: assessment state, pre-filter, and outcome infrastructure (#6853)

### Changed
- `/implement` Step 2 MODERATE tier coder updated to Cursor grok-4.5; adds grok-4.5 rate row (#6843)
- Grok-aware Cursor pricing and cost wiring (#6851)
- Lint-fix waterfall hardening (#6850)

### Fixed
- Statusline no longer shows stale status at job start or Claude start (#6844)
