### PR TITLE
Fixes #6875: stabilize /implement scope-disposition against rebase/flush drift

### DIFF
--- a/larch-logs/shared/learn-from-bugs-state.json
+++ b/larch-logs/shared/learn-from-bugs-state.json
@@ -1,0 +1,10 @@
+{
+  "highest_closed_issue_number_scanned": 6826,
+  "repo": "character-ai/larch",
+  "run_date": "2026-07-11T04:51:13Z",
+  "scan_started_at": "2026-07-11T04:44:51Z",
+  "schema_version": 1,
+  "search": "[BUG] in:title",
+  "selected_count": 24,
+  "state": "closed"
+}

--- a/python/larch/implement/scope_disposition.py
+++ b/python/larch/implement/scope_disposition.py
@@ -255,9 +255,28 @@ def _git(runner: Runner, argv: Sequence[str], *, cwd: Path) -> CommandResult:
     return runner.run(["git", *argv], cwd=str(cwd))
 
 
+def _merge_base_baseline(*, repo_root: Path, runner: Runner) -> str:
+    """Return the live merge-base of origin/main and HEAD, or '' if unavailable.
+
+    The session-start baseline captured in ``step2-baseline.txt`` is frozen at
+    Step 2 and never refreshed when the feature branch is later rebased onto a
+    newer main. After such a rebase it no longer equals HEAD's merge-base with
+    the base branch, so ``diff baseline..HEAD`` would span origin/main's own
+    source evolution. Refreshing to the live merge-base restricts the diff to
+    the feature branch's own changes. The step2 file remains the fallback for
+    environments without an origin/main ref (no upstream remote, shallow clone,
+    test fixtures).
+    """
+    result = _git(runner, ["merge-base", "origin/main", "HEAD"], cwd=repo_root)
+    if result.returncode != 0:
+        return ""
+    return result.stdout.strip()
+
+
 def _baseline_sha(*, tmpdir: Path, repo_root: Path, runner: Runner) -> str:
-    _ = repo_root
-    _ = runner
+    refreshed = _merge_base_baseline(repo_root=repo_root, runner=runner)
+    if refreshed:
+        return refreshed
     baseline_file = tmpdir / "step2-baseline.txt"
     try:
         raw = larch_io.read_trusted_text(
@@ -369,9 +388,16 @@ def compute_coverage(
 ) -> PlanCoverage:
     effective_plan = plan_file or tmpdir / "plan.txt"
     plan_paths = _firm_plan_paths(effective_plan)
-    touched = touched_paths_since_baseline(
+    raw_touched = touched_paths_since_baseline(
         tmpdir=tmpdir, repo_root=repo_root, runner=runner
     )
+    # Coverage and its fingerprint must stay stable across relaunches. The raw
+    # diff set spans origin/main's own evolution plus the ship driver's
+    # larch-logs flush commits, so it drifts on every relaunch and would
+    # invalidate a recorded disposition. Keep only plan paths: non-plan paths
+    # (run logs, upstream source churn) cannot affect plan coverage.
+    plan_set = frozenset(plan_paths)
+    touched = tuple(path for path in raw_touched if path in plan_set)
     touched_set = set(touched)
     untouched_paths = tuple(path for path in plan_paths if path not in touched_set)
     total = len(plan_paths)
@@ -854,6 +880,32 @@ def _write_scope_run_log(
     _ = _require_cli_success(result, label="run-log write scope-disposition")
 
 
+def _existing_matching_followup(
+    tmpdir: Path, fingerprint: str
+) -> FollowupIssue | None:
+    """Return a previously filed proceed-partial follow-up for this coverage.
+
+    Guards the scope-disposition loop: if ``record`` is invoked repeatedly for
+    the same plan coverage (identical fingerprint), reuse the follow-up issue
+    already filed instead of opening a new one. Returns None when no durable
+    proceed-partial disposition exists or its fingerprint differs.
+    """
+    try:
+        record = load_disposition(tmpdir)
+    except ShipError:
+        return None
+    if (
+        record is None
+        or record.disposition != "proceed-partial"
+        or record.fingerprint != fingerprint
+        or not record.followup_issue_number
+    ):
+        return None
+    return FollowupIssue(
+        number=record.followup_issue_number, url=record.followup_issue_url
+    )
+
+
 def record_disposition(  # noqa: PLR0913
     *,
     tmpdir: Path,
@@ -878,21 +930,25 @@ def record_disposition(  # noqa: PLR0913
     if disposition == "proceed-partial":
         if not repo or not tracking_issue_number.isdigit():
             raise ShipError("proceed-partial requires --repo and --tracking-issue")
-        followup = _create_followup_issue(
-            tmpdir=tmpdir,
-            repo=repo,
-            tracking_issue_number=tracking_issue_number,
-            coverage=active_coverage,
-        )
-        _append_cross_links(
-            tmpdir=tmpdir,
-            repo=repo,
-            tracking_issue_number=tracking_issue_number,
-            followup=followup,
-        )
-        _add_block_relation(
-            repo=repo, tracking_issue_number=tracking_issue_number, followup=followup
-        )
+        existing = _existing_matching_followup(tmpdir, active_coverage.fingerprint)
+        if existing is not None:
+            followup = existing
+        else:
+            followup = _create_followup_issue(
+                tmpdir=tmpdir,
+                repo=repo,
+                tracking_issue_number=tracking_issue_number,
+                coverage=active_coverage,
+            )
+            _append_cross_links(
+                tmpdir=tmpdir,
+                repo=repo,
+                tracking_issue_number=tracking_issue_number,
+                followup=followup,
+            )
+            _add_block_relation(
+                repo=repo, tracking_issue_number=tracking_issue_number, followup=followup
+            )
     record = DispositionRecord(
         disposition=disposition,
         fingerprint=active_coverage.fingerprint,

--- a/python/tests/implement/test_scope_disposition.py
+++ b/python/tests/implement/test_scope_disposition.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from collections.abc import Sequence
 
@@ -11,9 +12,17 @@ from larch.implement import scope_disposition
 
 
 class FakeRunner:
-    def __init__(self, *, diff_paths: Sequence[str], status_z: str = "") -> None:
+    def __init__(
+        self,
+        *,
+        diff_paths: Sequence[str],
+        status_z: str = "",
+        merge_base: str = "",
+    ) -> None:
         self.diff_paths = tuple(diff_paths)
         self.status_z = status_z
+        self.merge_base = merge_base
+        self.calls: list[tuple[str, ...]] = []
 
     def run(
         self,
@@ -28,14 +37,17 @@ class FakeRunner:
     ) -> CommandResult:
         _ = timeout, cwd, env, check, stdout, stderr
         args = tuple(argv)
+        self.calls.append(args)
         if args[:3] == ("git", "diff", "--name-only"):
             return CommandResult(
                 args, 0, "".join(f"{path}\n" for path in self.diff_paths), "", 0.0
             )
         if args[:3] == ("git", "status", "--porcelain=v1"):
             return CommandResult(args, 0, self.status_z, "", 0.0)
-        if args[:3] == ("git", "merge-base", "HEAD"):
-            return CommandResult(args, 1, "", "no origin", 0.0)
+        if args[:2] == ("git", "merge-base"):
+            if self.merge_base:
+                return CommandResult(args, 0, f"{self.merge_base}\n", "", 0.0)
+            return CommandResult(args, 1, "", "no merge-base", 0.0)
         if args[:3] == ("git", "rev-parse", "HEAD"):
             return CommandResult(args, 0, "HEADSHA\n", "", 0.0)
         return CommandResult(args, 1, "", "unexpected", 0.0)
@@ -221,6 +233,65 @@ def test_compute_requires_step2_baseline(tmp_path: Path) -> None:
         )
 
 
+def test_compute_coverage_ignores_non_plan_and_run_log_paths(tmp_path: Path) -> None:
+    plan_file = tmp_path / "plan.txt"
+    _ = plan_file.write_text(_plan(["src/a.py", "src/b.py"]), encoding="utf-8")
+    _ = (tmp_path / "step2-baseline.txt").write_text("BASE\n", encoding="utf-8")
+    noisy = [
+        "src/a.py",
+        "src/b.py",
+        "larch-logs/run-9A845BA3/implement/scope-disposition.json",
+        "python/larch/implement/origin_main_evolution.py",
+        "docs/changelog-upstream.md",
+    ]
+    coverage = scope_disposition.compute_and_write_coverage(
+        tmpdir=tmp_path,
+        repo_root=tmp_path,
+        plan_file=plan_file,
+        runner=FakeRunner(diff_paths=noisy),
+    )
+
+    assert coverage.touched_paths == ("src/a.py", "src/b.py")
+    assert coverage.total == 2
+    assert coverage.untouched == 0
+    clean = scope_disposition.compute_coverage(
+        tmpdir=tmp_path,
+        repo_root=tmp_path,
+        plan_file=plan_file,
+        runner=FakeRunner(diff_paths=["src/a.py", "src/b.py"]),
+    )
+    assert clean.fingerprint == coverage.fingerprint
+
+
+def test_baseline_prefers_origin_main_merge_base(tmp_path: Path) -> None:
+    _ = (tmp_path / "step2-baseline.txt").write_text("STEP2BASE\n", encoding="utf-8")
+    runner = FakeRunner(diff_paths=["src/a.py"], merge_base="FRESHMB")
+
+    _ = scope_disposition.touched_paths_since_baseline(
+        tmpdir=tmp_path, repo_root=tmp_path, runner=runner
+    )
+
+    merge_base_calls = [call for call in runner.calls if call[:2] == ("git", "merge-base")]
+    assert merge_base_calls
+    assert merge_base_calls[0][2:] == ("origin/main", "HEAD")
+    diff_calls = [call for call in runner.calls if call[:3] == ("git", "diff", "--name-only")]
+    assert diff_calls
+    assert diff_calls[0][3] == "FRESHMB..HEAD"
+
+
+def test_baseline_falls_back_to_step2_without_origin_main(tmp_path: Path) -> None:
+    _ = (tmp_path / "step2-baseline.txt").write_text("STEP2BASE\n", encoding="utf-8")
+    runner = FakeRunner(diff_paths=["src/a.py"])
+
+    _ = scope_disposition.touched_paths_since_baseline(
+        tmpdir=tmp_path, repo_root=tmp_path, runner=runner
+    )
+
+    diff_calls = [call for call in runner.calls if call[:3] == ("git", "diff", "--name-only")]
+    assert diff_calls
+    assert diff_calls[0][3] == "STEP2BASE..HEAD"
+
+
 def test_record_proceed_partial_is_durable_after_all_side_effects(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -342,6 +413,49 @@ def test_record_proceed_partial_failure_leaves_no_disposition(
         )
 
     assert not scope_disposition.disposition_path(tmp_path).exists()
+
+
+def test_record_proceed_partial_dedups_followup_on_matching_fingerprint(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    coverage = _coverage_fixture(tmp_path, required=True)
+    scope_disposition.write_coverage(coverage, tmpdir=tmp_path)
+    _ = (tmp_path / "scope-disposition.json").write_text(
+        json.dumps(
+            {
+                "disposition": "proceed-partial",
+                "fingerprint": coverage.fingerprint,
+                "followup_issue_number": "99",
+                "followup_issue_url": "https://example.test/issues/99",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    calls: list[tuple[str, ...]] = []
+
+    def fake_run_cli(argv: Sequence[str]) -> CommandResult:
+        args = tuple(argv)
+        calls.append(args)
+        return CommandResult(args, 0, "OK=true\n", "", 0.0)
+
+    monkeypatch.setattr(scope_disposition, "_run_cli", fake_run_cli)
+
+    record = scope_disposition.record_disposition(
+        tmpdir=tmp_path,
+        disposition="proceed-partial",
+        repo_root=tmp_path,
+        coverage=coverage,
+        repo="owner/repo",
+        tracking_issue_number="12",
+        run_id="run-xyz",
+    )
+
+    assert record.followup_issue_number == "99"
+    assert record.followup_issue_url == "https://example.test/issues/99"
+    assert not any(call[:2] == ("issue", "create-one") for call in calls)
+    assert not any(call[:2] == ("tracking-issue", "append-comment") for call in calls)
+    assert not any(call[:2] == ("issue", "add-blocked-by") for call in calls)
 
 
 def test_validate_detects_stale_fingerprint(tmp_path: Path) -> None:


### PR DESCRIPTION
Fixes #6875

## Summary

`/implement` Step 8 ship looped forever on `halt-scope-disposition` after a post-Step-2 rebase, never creating the PR and filing a new spurious follow-up issue on every iteration (#6870, #6874 in the reported run). This stabilizes the scope-disposition gate so a single `proceed-partial` record satisfies it and the ship proceeds to PR/CI/merge.

## Root cause

The coverage fingerprint hashed the full `baseline..HEAD` touched-path set. That baseline is the session-start HEAD captured at Step 2 (`step2-baseline.txt`) and never refreshed after the feature branch is rebased onto a newer main. After rebase, `diff baseline..HEAD` spans (a) origin/main's own source evolution and (b) the ship driver's `larch-logs/` flush commits. The touched set therefore inflates to hundreds/thousands of paths and changes on every relaunch/flush, so the fingerprint stored by `scope-disposition record` can never match the recomputed one and the recorded disposition is invalidated every time. `scope-disposition record` also had no dedup, so each iteration filed a fresh follow-up.

## Changes (`python/larch/implement/scope_disposition.py`)

- **Narrow coverage to plan paths.** `compute_coverage` now intersects the raw touched set with `plan_paths` before storing/fingerprinting. Non-plan paths (run logs, upstream source churn) can no longer drift the fingerprint or the persisted-vs-live comparison. This is the core loop-breaker.
- **Refresh the baseline to the live merge-base.** `_baseline_sha` now prefers `git merge-base origin/main HEAD`, restricting the diff to the feature branch's own changes after any post-Step-2 rebase. `step2-baseline.txt` remains the fallback when `origin/main` is unavailable (no upstream remote, shallow clone, test fixtures).
- **Deduplicate follow-up filing.** `record_disposition` reuses an existing `proceed-partial` follow-up whose fingerprint matches instead of opening a new issue when invoked repeatedly for the same coverage.

## Tests (`python/tests/implement/test_scope_disposition.py`)

Added coverage for all three fixes:
- plan-path narrowing: non-plan and `larch-logs/**` paths are excluded; identical plan coverage yields an identical fingerprint despite a noisier diff set.
- baseline refresh: `origin/main` merge-base is preferred when available; step2 fallback is used when it is not.
- follow-up dedup: a repeated `proceed-partial` record with a matching fingerprint reuses the existing issue and files no new issue/cross-link/block relation.

Existing tests preserved; `FakeRunner` extended with a configurable `merge_base` and call recording. ruff clean on both files; the source file adds no complexity-baseline findings.

## Out of scope

The issue's fourth suggestion (tightening blocking-TODO detection so already-implemented work isn't flagged as `todos_left`) is intentionally left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
