### PR TITLE
Release v52.5.27

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.5.26",
+  "version": "52.5.27",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Added

- Step 8 assessment gets a bgjob adapter and an offline test harness. (#6883)

## Fixed

- `/design` publish-tail diagnostics recover cleanly now, with salvage reconciliation. (#6877)
- `/implement` no longer loops forever on halt-scope-disposition. The loop had blocked PR creation and filed spurious follow-up issues. (#6879)
