### PR TITLE
Fixes #6882: tolerant invariant/guideline assessment-note classifier

### DIFF
--- a/python/larch/core/architectural_guidelines.py
+++ b/python/larch/core/architectural_guidelines.py
@@ -54,6 +54,10 @@ _STATUS_VALUES = {"present", "absent", "invalid"}
 GUIDELINE_HEADING_RE = re.compile(r"^###\s+(G-[A-Za-z0-9-]+-\d+):\s*(.+?)\s*$", re.MULTILINE)
 INVARIANT_HEADING_RE = re.compile(r"^#{1,6}\s+(I-[A-Za-z0-9-]+-\d+):\s*(.+?)\s*$", re.MULTILINE)
 _MARKDOWN_HEADING_RE = re.compile(r"^#{1,6}\s+\S")
+# Loose id matchers for assessment-note classification: any I-*/G-* entry referenced
+# anywhere in a note's prose, not just as a Markdown heading. See issue #6882.
+NOTE_INVARIANT_ID_RE = re.compile(r"I-[A-Za-z0-9-]+-\d+")
+NOTE_GUIDELINE_ID_RE = re.compile(r"G-[A-Za-z0-9-]+-\d+")
 _WHY_RE = re.compile(r"^\s*-\s*Why:\s*(.+?)\s*$")
 _DEVIATE_RE = re.compile(r"^\s*-\s*Deviate when:\s*(.+?)\s*$")
 _MECHANIZED_RE = re.compile(r"^\s*-\s*Mechanized:\s*(.+?)\s*$")
@@ -1716,11 +1720,16 @@ def _write_compose_materialization_metadata(
 
 
 def _invariant_assessment_kind(note: str) -> str:
+    # Tolerant classification (issue #6882): a clean note may carry rationale beyond
+    # the exact presentation line, so a note whose first line is the clean note is
+    # clean even when later prose references an I-* entry. A note is a violation only
+    # when it names a specific I-* invariant without leading with the clean line.
     if not note.strip():
         return ""
-    if note.rstrip("\n") == CLEAN_INVARIANT_PRESENTATION_NOTE:
+    first_line = note.split("\n", 1)[0].strip()
+    if first_line == CLEAN_INVARIANT_PRESENTATION_NOTE:
         return "clean"
-    return "violation"
+    return "violation" if NOTE_INVARIANT_ID_RE.search(note) else "clean"
 
 
 def _write_invariant_compose_materialization_metadata(

--- a/python/larch/implement/ship_guidelines.py
+++ b/python/larch/implement/ship_guidelines.py
@@ -149,19 +149,29 @@ class InvariantsShipOutcome:
 
 
 def _assessment_kind(note: str) -> str:
+    # Tolerant classification (issue #6882): a clean note may carry rationale beyond
+    # the exact presentation line, so a note whose first line is the clean note is
+    # clean even when later prose references a G-* entry. A note is a deviation only
+    # when it names a specific G-* guideline without leading with the clean line.
     if not note.strip():
         return ""
-    if note.rstrip("\n") == architectural_guidelines.CLEAN_PRESENTATION_NOTE:
+    first_line = note.split("\n", 1)[0].strip()
+    if first_line == architectural_guidelines.CLEAN_PRESENTATION_NOTE:
         return "clean"
-    return "deviation"
+    return "deviation" if architectural_guidelines.NOTE_GUIDELINE_ID_RE.search(note) else "clean"
 
 
 def _invariant_assessment_kind(note: str) -> str:
+    # Tolerant classification (issue #6882): a clean note may carry rationale beyond
+    # the exact presentation line, so a note whose first line is the clean note is
+    # clean even when later prose references an I-* entry. A note is a violation only
+    # when it names a specific I-* invariant without leading with the clean line.
     if not note.strip():
         return ""
-    if note.rstrip("\n") == architectural_guidelines.CLEAN_INVARIANT_PRESENTATION_NOTE:
+    first_line = note.split("\n", 1)[0].strip()
+    if first_line == architectural_guidelines.CLEAN_INVARIANT_PRESENTATION_NOTE:
         return "clean"
-    return "violation"
+    return "violation" if architectural_guidelines.NOTE_INVARIANT_ID_RE.search(note) else "clean"
 
 
 def _bounded_detail(text: str) -> str:

--- a/python/skill-closure-baseline.json
+++ b/python/skill-closure-baseline.json
@@ -41,8 +41,8 @@
     "closure_content_estimated_tokens": 44631,
     "closure_estimated_tokens": 44749,
     "closure_lines": 1318,
-    "conditional_content_estimated_tokens": 25516,
-    "conditional_estimated_tokens": 25579,
+    "conditional_content_estimated_tokens": 25674,
+    "conditional_estimated_tokens": 25737,
     "conditional_files": [
       "skills/implement/references/extracted-script-registry.md",
       "skills/implement/references/bootstrap-recovery.md",

--- a/python/tests/core/test_architectural_guidelines.py
+++ b/python/tests/core/test_architectural_guidelines.py
@@ -2144,6 +2144,33 @@ def test_validate_invariant_ship_outcome_record_accepts_violation() -> None:
 
 
 @pytest.mark.parametrize(
+    ("note", "expected"),
+    [
+        ("", ""),
+        ("   \n  ", ""),
+        (ag.CLEAN_INVARIANT_PRESENTATION_NOTE, "clean"),
+        (ag.CLEAN_INVARIANT_PRESENTATION_NOTE + "\n", "clean"),
+        # Issue #6882: a clean note may carry rationale beyond the exact line.
+        (ag.CLEAN_INVARIANT_PRESENTATION_NOTE + "\nThe adapter realizes the invariant.", "clean"),
+        # The reported case: rationale that even references an I-* entry stays clean
+        # because the first line is the clean sentence.
+        (ag.CLEAN_INVARIANT_PRESENTATION_NOTE + "\nThe adapter realizes I-Stale-1 by caching.", "clean"),
+        # A clean first line with trailing whitespace still classifies as clean.
+        (ag.CLEAN_INVARIANT_PRESENTATION_NOTE + "  \nextra rationale", "clean"),
+        # A note that names a specific invariant, without leading with the clean line,
+        # is the violation signal per the documented contract.
+        ("I-Test-1: violated by the new cache", "violation"),
+        ("- I-Stale-1: stale fingerprint slips through\n- I-Fresh-2: not refreshed", "violation"),
+        # A note that neither leads with the clean line nor names an invariant leans
+        # clean rather than blocking the ship on ambiguous prose.
+        ("No specific invariant applies to this diff.", "clean"),
+    ],
+)
+def test_invariant_assessment_kind_tolerates_verbose_clean_notes(note: str, expected: str) -> None:
+    assert ag._invariant_assessment_kind(note) == expected
+
+
+@pytest.mark.parametrize(
     ("path", "expected"),
     [
         ("larch-logs/run/log.txt", True),

--- a/python/tests/implement/test_ship.py
+++ b/python/tests/implement/test_ship.py
@@ -6423,7 +6423,7 @@ def test_load_or_prepare_guidelines_note_drops_on_redaction_failure(
 def test_guideline_ship_outcome_sidecar_pinned_and_clean(tmp_path: Path) -> None:
     pinned = ship_guidelines.write_guideline_ship_outcome(
         implement_tmpdir=str(tmp_path),
-        result=ship.GuidelinesGateResult(note="Deviation note", guidelines_status="present"),
+        result=ship.GuidelinesGateResult(note="- G-Py-1: deviates by adding shell composition", guidelines_status="present"),
         head_sha="abc123",
         base_ref="origin/main",
     )
@@ -7279,7 +7279,7 @@ def test_open_pr_resume_clears_stale_guideline_outcome_sidecar_before_gate(
     def fake_gate(**_kwargs: object) -> ship.GuidelinesGateResult:
         order.append("gate")
         assert not stale.exists()
-        return ship.GuidelinesGateResult(note="Guidelines warning", guidelines_status="present")
+        return ship.GuidelinesGateResult(note="- G-Py-1: deviation warning", guidelines_status="present")
 
     def fake_flush(*_args: object, **_kwargs: object) -> run_logs.RefreshSkip:
         order.append("flush")
@@ -7385,7 +7385,7 @@ def test_open_pr_resume_no_logs_commit_keeps_guideline_outcome_sidecar_and_skips
 
     def fake_gate(**_kwargs: object) -> ship.GuidelinesGateResult:
         order.append("gate")
-        return ship.GuidelinesGateResult(note="Guidelines warning", guidelines_status="present")
+        return ship.GuidelinesGateResult(note="- G-Py-1: deviation warning", guidelines_status="present")
 
     def fake_compose(**_kwargs: object) -> str:
         order.append("compose")

--- a/python/tests/implement/test_ship.py
+++ b/python/tests/implement/test_ship.py
@@ -7776,6 +7776,50 @@ def test_invariant_authored_violation_takes_precedence_over_unavailable() -> Non
     assert violation.outcome == ship_guidelines.OUTCOME_VIOLATION
 
 
+def test_invariant_assessment_kind_tolerates_verbose_clean_note() -> None:
+    # Issue #6882: a clean note may carry rationale beyond the exact line, even
+    # rationale that references an I-* entry, and must still classify as clean.
+    verbose_clean = (
+        ship.architectural_guidelines.CLEAN_INVARIANT_PRESENTATION_NOTE
+        + "\nThe adapter realizes I-Stale-1 by caching the fingerprint."
+    )
+    assert ship_guidelines._invariant_assessment_kind(verbose_clean) == "clean"
+    assert ship_guidelines._invariant_assessment_kind("I-Stale-1: violated") == "violation"
+    assert ship_guidelines._invariant_assessment_kind(
+        ship.architectural_guidelines.CLEAN_INVARIANT_PRESENTATION_NOTE
+    ) == "clean"
+
+
+def test_guideline_assessment_kind_tolerates_verbose_clean_note() -> None:
+    verbose_clean = (
+        ship.architectural_guidelines.CLEAN_PRESENTATION_NOTE
+        + "\nThis path respects G-Py-1 by avoiding shell composition."
+    )
+    assert ship_guidelines._assessment_kind(verbose_clean) == "clean"
+    assert ship_guidelines._assessment_kind("G-Py-1: deviates because of X") == "deviation"
+
+
+def test_invariant_ship_outcome_verbose_clean_note_is_clean_not_violation() -> None:
+    # Regression for the reported ship-blocking path (#6882): a verbose clean note
+    # must route to a clean outcome, not NEXT_ACTION=ci-fix with a violation reason.
+    verbose_clean = (
+        ship.architectural_guidelines.CLEAN_INVARIANT_PRESENTATION_NOTE
+        + "\nThe adapter realizes I-Stale-1 by caching the fingerprint."
+    )
+    outcome = ship_guidelines._classify_invariant_ship_outcome(
+        result=ship_guidelines.InvariantsGateResult(
+            note=verbose_clean,
+            invariants_status="present",
+            note_state=ship_guidelines.config.NOTE_STATE_AUTHORED,
+        ),
+        head_sha="abc",
+        base_ref="origin/main",
+    )
+    assert outcome.outcome == ship_guidelines.OUTCOME_CLEAN
+    assert outcome.reason == ship_guidelines.REASON_CLEAN_NOTE
+    assert outcome.assessment_kind == "clean"
+
+
 def test_guideline_outcome_validator_rejects_unavailable_with_clean_assessment_kind() -> None:
     error = ship.architectural_guidelines.validate_guideline_ship_outcome_record({
         "schema_version": "1", "phase": "implement", "step": "8",

--- a/skills/implement/references/architectural-guidelines-present.md
+++ b/skills/implement/references/architectural-guidelines-present.md
@@ -17,8 +17,8 @@ Required artifacts:
 
 Write exactly one assessment body to `$IMPLEMENT_TMPDIR/architectural-guideline-assessment-draft.md`:
 
-- Clean path: `Consulted ARCHITECTURAL_GUIDELINES.md; no deviations identified.`
-- Deviation path: a short bullet list naming each deviation and rationale.
+- Clean path: `Consulted ARCHITECTURAL_GUIDELINES.md; no deviations identified.` Optional rationale may follow on subsequent lines; the durable wrapper classifies the note as clean when its first line is this clean sentence, even if later prose references a `G-*` entry.
+- Deviation path: a short bullet list naming each deviation and rationale. A note is classified as a deviation only when it names a specific `G-*` guideline and does not lead with the clean sentence.
 
 If deviations are genuine, also append the deviation notes under `Warnings` with the pinned helper:
 

--- a/skills/implement/references/architectural-invariants-present.md
+++ b/skills/implement/references/architectural-invariants-present.md
@@ -17,8 +17,8 @@ Required artifacts:
 
 Write exactly one assessment body to `$IMPLEMENT_TMPDIR/architectural-invariant-assessment-draft.md`:
 
-- Clean path: `Consulted ARCHITECTURAL_INVARIANTS.md; no violations identified.`
-- Violation path: concise bullets naming each violated `I-*` entry and why the current final diff violates it.
+- Clean path: `Consulted ARCHITECTURAL_INVARIANTS.md; no violations identified.` Optional rationale may follow on subsequent lines; the durable wrapper classifies the note as clean when its first line is this clean sentence, even if later prose references an `I-*` entry.
+- Violation path: concise bullets naming each violated `I-*` entry and why the current final diff violates it. A note is classified as a violation only when it names a specific `I-*` invariant and does not lead with the clean sentence.
 
 Persist the durable note with this wrapper:
 


### PR DESCRIPTION
## Summary

Fixes #6882.

The Step 8 assessment-note classifiers classified a note as `clean` only on an exact byte match to the clean presentation note and treated every other note as a violation (invariants) or deviation (guidelines). A clean note that added rationale was misclassified as `outcome=violation`, routing the ship driver to `ci-fix` with `needs_user_reason=architectural-invariants-violation` and blocking PR creation. The reported note led with the prescribed clean sentence and then referenced `I-Stale-1` in its rationale, which the exact-match classifier could not distinguish from a real violation list.

## Change

Classify by structure, not exact prose equality:

- A note whose first line is the clean presentation sentence is `clean`, even when later prose references an `I-*`/`G-*` entry. This handles a clean note with rationale, including the reported case where rationale mentions an invariant id.
- Otherwise a note is `violation`/`deviation` only when it names a specific `I-*`/`G-*` id. Ambiguous prose (no clean lead, no marker) leans `clean` rather than blocking the ship.

Applied to all three exact-match classifiers:

- `python/larch/core/architectural_guidelines.py` `_invariant_assessment_kind`
- `python/larch/implement/ship_guidelines.py` `_assessment_kind` (guidelines) and `_invariant_assessment_kind`

The id-detection patterns are shared as public `NOTE_INVARIANT_ID_RE` / `NOTE_GUIDELINE_ID_RE` on `architectural_guidelines` so the classifiers stay in sync. The reference docs (`architectural-invariants-present.md`, `architectural-guidelines-present.md`) now state that the clean line may carry trailing rationale and how classification resolves.

## Tests

Regression tests added:

- `test_invariant_assessment_kind_tolerates_verbose_clean_notes` (parametrized): empty, exact clean, clean plus rationale, clean plus rationale that references `I-Stale-1`, trailing whitespace, marker-named violations (single and bullet list), and ambiguous-prose-leans-clean.
- `test_invariant_assessment_kind_tolerates_verbose_clean_note` / `test_guideline_assessment_kind_tolerates_verbose_clean_note`: direct classifier checks for both kinds in `ship_guidelines`.
- `test_invariant_ship_outcome_verbose_clean_note_is_clean_not_violation`: end-to-end through `_classify_invariant_ship_outcome`, asserting a verbose clean note routes to `outcome=clean` (not `ci-fix`/violation). This is the reported ship-blocking path.

## Notes

Keyword-based "asserts a violation" detection is intentionally avoided: the clean presentation note itself contains the word "violations" ("no violations identified"), so any keyword match would false-trigger on clean notes. The id marker is the safe non-clean signal, and it matches the documented contract that violation/deviation notes name specific `I-*`/`G-*` entries.
