### PR TITLE
fix(implement): persist REPO_ROOT so ship does not stall at PR compose

### DIFF
--- a/python/complexity-baseline.json
+++ b/python/complexity-baseline.json
@@ -6501,7 +6501,7 @@
     "file": "larch/state/session_env.py",
     "code": "C901",
     "qualified_symbol": "write_env_main",
-    "metric": 31
+    "metric": 32
   },
   {
     "file": "larch/state/session_env.py",
@@ -6573,7 +6573,7 @@
     "file": "larch/state/session_env.py",
     "code": "PLR0912",
     "qualified_symbol": "write_env_main",
-    "metric": 30
+    "metric": 31
   },
   {
     "file": "larch/state/session_env.py",
@@ -6597,7 +6597,7 @@
     "file": "larch/state/session_env.py",
     "code": "PLR0915",
     "qualified_symbol": "write_env_main",
-    "metric": 86
+    "metric": 91
   },
   {
     "file": "larch/state/stall_recovery.py",

--- a/python/larch/state/bootstrap.py
+++ b/python/larch/state/bootstrap.py
@@ -344,6 +344,21 @@ class BootstrapState:
         return ""
 
 
+def _consumer_repo_root() -> str:
+    """Resolve the consumer repository root to persist as REPO_ROOT (never the plugin root)."""
+    git = shutil.which("git")
+    if git is not None:
+        result = _run([git, "rev-parse", "--show-toplevel"])
+        if result.returncode == 0:
+            top = result.stdout.strip()
+            if top:
+                return top
+    project_dir = os.environ.get("CLAUDE_PROJECT_DIR", "").strip()
+    if project_dir and Path(project_dir).is_absolute() and Path(project_dir).is_dir():
+        return project_dir
+    return ""
+
+
 def _write_base_session_env(st: BootstrapState) -> None:
     prior_claude_source = st.read_session(key="LARCH_CLAUDE_SOURCE_FILE")
     prior_auto_mode = st.read_session(key="LARCH_AUTO_MODE")
@@ -386,6 +401,9 @@ def _write_base_session_env(st: BootstrapState) -> None:
         args.extend(["--dynamic-archetypes", prior_dynamic_archetypes])
     if _valid_run_id(st.run_id):
         args.extend(["--run-id", st.run_id])
+    repo_root = _consumer_repo_root()
+    if repo_root:
+        args.extend(["--repo-root", repo_root])
     result = _cli(*args)
     if result.returncode != 0:
         st.emit_step_failed("write-session-env")

--- a/python/larch/state/session_env.py
+++ b/python/larch/state/session_env.py
@@ -44,6 +44,7 @@ TMP_ROOT = Path(TMP_FALLBACK)
 
 WRITE_ENV_KEYS = frozenset({
     "REPO",
+    "REPO_ROOT",
     "REPO_UNAVAILABLE",
     "FORKED_TARGET",
     "LARCH_EXTERNAL_HEALTH_CHECK_TIMEOUT",
@@ -634,6 +635,7 @@ def write_env_main(argv: list[str]) -> int:
     parser = argparse.ArgumentParser(prog="session write-env", add_help=False)
     parser.add_argument("--output")
     parser.add_argument("--repo", default="")
+    parser.add_argument("--repo-root", default="")
     parser.add_argument("--repo-unavailable")
     parser.add_argument("--codex-present", default="")
     parser.add_argument("--cursor-present", default="")
@@ -715,6 +717,10 @@ def write_env_main(argv: list[str]) -> int:
             data["LARCH_RUN_ID"] = args.run_id
         if plugin_root:
             data["LARCH_CLAUDE_PLUGIN_ROOT"] = plugin_root
+        repo_root = args.repo_root.strip() or os.environ.get("CLAUDE_PROJECT_DIR", "").strip() or os.environ.get("REPO_ROOT", "").strip()
+        if repo_root:
+            _validate_repo_root_value(value=repo_root, flag="--repo-root")
+            data["REPO_ROOT"] = repo_root
         _validate_writer_keys(data=data, allowed=WRITE_ENV_KEYS)
         _validate_no_newlines(data)
         if output == "/dev/null":

--- a/python/tests/implement/test_ship.py
+++ b/python/tests/implement/test_ship.py
@@ -7830,3 +7830,25 @@ def test_guideline_outcome_validator_rejects_deterministic_clean_paired_with_dev
         "assessment_kind": "deviation",
     })
     assert error is not None
+
+
+def test_persisted_repo_root_for_pr_returns_persisted_root_when_coverage_exists(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression for #6880: PR compose must not stall when a coverage artifact exists and REPO_ROOT is persisted."""
+    repo_root = tmp_path / "consumer"
+    repo_root.mkdir()
+    (tmp_path / "session-env.sh").write_text(f"REPO_ROOT={repo_root}\n", encoding="utf-8")
+    monkeypatch.setattr(ship.scope_disposition, "load_coverage", lambda _tmpdir: object())
+    ctx = _ctx(tmp_path)
+    assert ship._persisted_repo_root_for_pr(ctx) == repo_root.resolve()  # pyright: ignore[reportPrivateUsage]
+
+
+def test_persisted_repo_root_for_pr_still_stalls_without_persisted_root_when_coverage_exists(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The G-Root-1 guard stays intact: coverage present but no persisted root still raises."""
+    monkeypatch.setattr(ship.scope_disposition, "load_coverage", lambda _tmpdir: object())
+    ctx = _ctx(tmp_path)
+    with pytest.raises(ShipError, match="persisted repository root is required"):
+        ship._persisted_repo_root_for_pr(ctx)  # pyright: ignore[reportPrivateUsage]

--- a/python/tests/state/test_bootstrap.py
+++ b/python/tests/state/test_bootstrap.py
@@ -84,6 +84,30 @@ def test_write_base_session_env_preserves_claude_source_and_dynamic_keys(tmp_pat
     assert "--auto-mode" in write_env
 
 
+def test_write_base_session_env_passes_repo_root(tmp_path, monkeypatch) -> None:
+    """Regression for #6880: bootstrap persists REPO_ROOT so ship does not stall at PR compose."""
+    calls: list[tuple[str, ...]] = []
+
+    def fake_cli(*args: str, env=None):
+        _ = env
+        calls.append(args)
+        return subprocess.CompletedProcess(["cli", *args], 0, "", "")
+
+    monkeypatch.setattr(bootstrap, "_cli", fake_cli)
+    monkeypatch.setattr(bootstrap, "_consumer_repo_root", lambda: "/consumer/repo")
+    st = bootstrap.BootstrapState(
+        bootstrap.BootstrapOptions(up_to_phase="infra"),
+        implement_tmpdir=str(tmp_path),
+        repo="owner/repo",
+        repo_unavailable="false",
+        session_id="sid",
+    )
+    bootstrap._write_base_session_env(st)  # pyright: ignore[reportPrivateUsage]
+    write_env = next(call for call in calls if call[:2] == ("session", "write-env") and "--plugin-root-only" not in call)
+    assert "--repo-root" in write_env
+    assert write_env[write_env.index("--repo-root") + 1] == "/consumer/repo"
+
+
 def test_write_claude_source_snapshot_does_not_inject_larch_session_id(tmp_path, monkeypatch) -> None:
     calls: list[tuple[tuple[str, ...], object]] = []
 


### PR DESCRIPTION
## Summary

`/implement` never persisted `REPO_ROOT` into its session env, so at Step 8 ship the driver raised `persisted repository root is required for PR coverage validation` and stalled at PR body composition (`outcome=STALLED`, `pr_number=null`) whenever a coverage artifact existed — every normal run after Step 6. Fixes #6880.

## Root cause

- The `/design` session writer persists `REPO_ROOT`; the `/implement` `session write-env` writer had no `--repo-root` flag and never wrote it.
- `ship.py:_persisted_repo_root_for_pr` requires a persisted root when coverage exists (G-Root-1) and correctly refuses the ambient-cwd fallback in that case. The gap was missing persistence, not the guard.

## Fix

- `session_env.py`: allowlist `REPO_ROOT` in `WRITE_ENV_KEYS`, add a `--repo-root` flag to `write_env_main`, and resolve it as `--repo-root` → `CLAUDE_PROJECT_DIR` → `REPO_ROOT` env (validated), mirroring the `/design` writer.
- `bootstrap.py`: new `_consumer_repo_root()` resolves the consumer repo root from `git rev-parse --show-toplevel`, then `CLAUDE_PROJECT_DIR` (never the plugin root), and `_write_base_session_env` passes it as `--repo-root`.
- `ship.py` is unchanged — the G-Root-1 guard stays intact.

## Tests

- `test_bootstrap`: `_write_base_session_env` passes `--repo-root`.
- `test_ship`: PR compose returns the persisted root when coverage exists (no stall); still raises when coverage exists without a persisted root (guard intact).
- Regenerated the complexity baseline for `write_env_main` (+1 branch).

## Verification

- [x] `make py-lint` — pylint 10.00/10, pyright 0 errors
- [x] `make py-lint-checks-fast`
- [x] `pytest tests/state tests/implement tests/design` — 2489 passed, 12 skipped
