### PR TITLE
Release v52.5.28

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.5.27",
+  "version": "52.5.28",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Changed

- Every Cursor/auto lane is replaced with Cursor/Composer 2.5. Auto is removed from the pricing table. This reverses #6721. Grok 4.5 (#6825) is unaffected. (#6886)

## Fixed

- The invariant/guideline assessment-note classifier no longer flags verbose, clean notes as violations. (#6885)
- `/implement` now persists `REPO_ROOT`, so ship no longer stalls at PR compose. (#6887)
- The trusted-artifact validation boundary is now complete and can no longer bypass ship-time validation. (#6889)
- The orchestrator no longer misattributes its own spawned-process file edits to a concurrent runner. (#6890)
