### PR TITLE
Fix #6931: harden Step 8 CI fixer against preemptive bails and test-rename baselines

### DIFF
--- a/python/larch/agents/_ci_launcher.py
+++ b/python/larch/agents/_ci_launcher.py
@@ -205,6 +205,7 @@ def _ci_prompt(*, tool: str, args: argparse.Namespace) -> str:
     else:
         role_guidance = (
             "Reproduce the failing check locally when a command is available in the failure log. Prefer the narrowest relevant test or lint command before broader checks. Look for common larch failure patterns: stale sidecars, missing run-log artifacts, retry-classification drift, dirty-tree guards, and shell/Python parity regressions.\n"
+            "When a lint failure is a baseline ratchet (for example monkeypatch-facade-binding failing because a test was renamed), repair it by regenerating the committed baseline with `python3 python/cli.py lint <lint-name> --write`; this preserves existing per-row reasons and migrates test-symbol renames, so prefer it over hand-editing the JSON. Only edit source when the lint genuinely flags a new violation.\n"
         )
     return (
         f"You are using {tool} to {role_line}.\n"

--- a/python/larch/lint/lint_monkeypatch_facade_binding.py
+++ b/python/larch/lint/lint_monkeypatch_facade_binding.py
@@ -622,6 +622,52 @@ def _record_key(record: Record) -> tuple[str, str, str, str, str, int]:
     )
 
 
+def _rename_fingerprint(
+    key: tuple[str, str, str, str, str, int],
+) -> tuple[str, str, str, str, int]:
+    """Drop ``qualified_symbol`` (index 1) from a baseline identity.
+
+    Two monkeypatch findings that differ only in the test function that owns
+    them (a rename) share this fingerprint, so a stale baseline row can be
+    paired with the live finding that replaced it without matching on the
+    symbol an external implementer renamed.
+    """
+    return (key[0], key[2], key[3], key[4], key[5])
+
+
+def _rename_pairs(
+    baseline_records: list[Record],
+    new_findings: list[Finding],
+    live_keys: frozenset[tuple[str, str, str, str, str, int]],
+) -> dict[tuple[str, str, str, str, int], tuple[str, str]]:
+    """Pair stale baseline rows with new live findings across a test rename.
+
+    Returns ``fingerprint -> (old qualified_symbol, reason)`` for the stale
+    baseline rows (rows whose full identity is no longer live). A pair forms
+    only when exactly one stale row and exactly one new finding share the
+    fingerprint, so an ambiguous rename (two rows or two findings sharing it)
+    still requires an explicit reason instead of a silent carry-over.
+    """
+    stale_counts: dict[tuple[str, str, str, str, int], int] = {}
+    stale_rows: dict[tuple[str, str, str, str, int], Record] = {}
+    for record in baseline_records:
+        full = _record_key(record)
+        if full in live_keys:
+            continue
+        fingerprint = _rename_fingerprint(full)
+        stale_counts[fingerprint] = stale_counts.get(fingerprint, 0) + 1
+        stale_rows[fingerprint] = record
+    new_counts: dict[tuple[str, str, str, str, int], int] = {}
+    for finding in new_findings:
+        fingerprint = _rename_fingerprint(finding.key())
+        new_counts[fingerprint] = new_counts.get(fingerprint, 0) + 1
+    return {
+        fingerprint: (stale_rows[fingerprint]["qualified_symbol"], stale_rows[fingerprint]["reason"])
+        for fingerprint, count in stale_counts.items()
+        if count == 1 and new_counts.get(fingerprint, 0) == 1
+    }
+
+
 def _finding_sort_key(finding: Finding) -> tuple[str, str, str, str, str, int]:
     return finding.key()
 
@@ -726,14 +772,20 @@ def _records_for_write(
     baseline_path: Path,
     initial_reason: str | None,
 ) -> list[Record]:
-    preserved: dict[tuple[str, str, str, str, str, int], str] = {}
+    baseline_records: list[Record] = []
     if baseline_path.is_file():
-        preserved = {_record_key(record): record["reason"] for record in load_baseline(baseline_path)}
+        baseline_records = load_baseline(baseline_path)
+    preserved = {_record_key(record): record["reason"] for record in baseline_records}
+    active = sorted(_active_findings(findings), key=_finding_sort_key)
+    live_keys = frozenset(finding.key() for finding in active)
+    new_findings = [finding for finding in active if finding.key() not in preserved]
+    rename_pairs = _rename_pairs(baseline_records, new_findings, live_keys)
     reason_default = initial_reason.strip() if initial_reason is not None else None
     records: list[Record] = []
     missing: list[str] = []
-    for finding in sorted(_active_findings(findings), key=_finding_sort_key):
-        reason = preserved.get(finding.key()) or reason_default
+    for finding in active:
+        pair = rename_pairs.get(_rename_fingerprint(finding.key()))
+        reason = preserved.get(finding.key()) or (pair[1] if pair else None) or reason_default
         if reason is None:
             missing.append(format_key(finding.key()))
             continue
@@ -788,14 +840,17 @@ def _run_check(python_dir: Path, *, baseline_path: Path) -> int:
     except BaselineError as exc:
         print(f"lint-monkeypatch-facade-binding: {exc}", file=sys.stderr)
         return TOOL_FAILURE_EXIT
+    active = sorted(_active_findings(findings), key=_finding_sort_key)
     baseline_keys = frozenset(_record_key(record) for record in baseline_records)
     new_findings: list[Finding] = []
     warned: list[Finding] = []
-    for finding in sorted(_active_findings(findings), key=_finding_sort_key):
+    for finding in active:
         if finding.key() in baseline_keys:
             warned.append(finding)
         else:
             new_findings.append(finding)
+    live_keys = frozenset(finding.key() for finding in active)
+    rename_pairs = _rename_pairs(baseline_records, new_findings, live_keys)
     for finding in warned:
         print(
             "warning: "
@@ -805,11 +860,20 @@ def _run_check(python_dir: Path, *, baseline_path: Path) -> int:
             file=sys.stderr,
         )
     for finding in new_findings:
+        pair = rename_pairs.get(_rename_fingerprint(finding.key()))
+        suffix = ""
+        if pair is not None:
+            suffix = (
+                f"; likely rename of baselined symbol '{pair[0]}' to "
+                f"'{finding.qualified_symbol}', run "
+                "`python3 python/cli.py lint monkeypatch-facade-binding --write` "
+                "to migrate the baseline"
+            )
         print(
             f"{finding.file}:{finding.lineno}:{finding.qualified_symbol} patches "
             f"{finding.facade_module}.{finding.attribute}, imported from {finding.defining_module} "
             f"occurrence {finding.occurrence}; patch the defining module, or patch the "
-            "consuming module's own binding",
+            f"consuming module's own binding{suffix}",
             file=sys.stderr,
         )
     return 1 if new_findings else 0

--- a/python/tests/lint/test_lint_monkeypatch_facade_binding.py
+++ b/python/tests/lint/test_lint_monkeypatch_facade_binding.py
@@ -497,3 +497,79 @@ def test_absent_baseline_bootstrap_succeeds(tmp_path: Path) -> None:
     assert lmfb.main(["--root", str(tmp_path), "--write", "--initial-reason", "bootstrap"]) == 0
     rows = json.loads((tmp_path / "python" / lmfb.BASELINE_FILENAME).read_text(encoding="utf-8"))
     assert rows == [_record(reason="bootstrap")]
+
+
+def test_write_migrates_renamed_test_symbol(tmp_path: Path) -> None:
+    """An external implementer renaming a test must not strand its baseline row.
+
+    The stale row (old symbol) is paired with the new live finding by the
+    identity that survives a rename, and its reason is carried over so the
+    regen succeeds without ``--initial-reason``.
+    """
+    _write_project(
+        tmp_path,
+        files=_base_files(
+            """
+            from larch import facade
+
+            def test_patch_renamed(monkeypatch):
+                monkeypatch.setattr(facade, "target", lambda: None)
+            """
+        ),
+        baseline=[_record(qualified_symbol="test_patch", reason="grandfathered rename")],
+    )
+
+    assert lmfb.main(["--root", str(tmp_path), "--write"]) == 0
+    rows = json.loads((tmp_path / "python" / lmfb.BASELINE_FILENAME).read_text(encoding="utf-8"))
+    assert rows == [_record(qualified_symbol="test_patch_renamed", reason="grandfathered rename")]
+
+
+def test_check_mode_hints_at_rename_migration(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _write_project(
+        tmp_path,
+        files=_base_files(
+            """
+            from larch import facade
+
+            def test_patch_renamed(monkeypatch):
+                monkeypatch.setattr(facade, "target", lambda: None)
+            """
+        ),
+        baseline=[_record(qualified_symbol="test_patch", reason="grandfathered rename")],
+    )
+
+    assert lmfb.main(["--root", str(tmp_path)]) == 1
+    err = capsys.readouterr().err
+    assert "likely rename of baselined symbol 'test_patch' to 'test_patch_renamed'" in err
+    assert "lint monkeypatch-facade-binding --write" in err
+
+
+def test_write_rename_ambiguous_requires_reason(tmp_path: Path) -> None:
+    """Two same-fingerprint renames cannot be paired unambiguously.
+
+    With two stale rows and two new findings sharing one fingerprint, neither
+    carries over; the regen still demands an explicit reason.
+    """
+    _write_project(
+        tmp_path,
+        files=_base_files(
+            """
+            from larch import facade
+
+            def test_a2(monkeypatch):
+                monkeypatch.setattr(facade, "target", lambda: None)
+
+            def test_b2(monkeypatch):
+                monkeypatch.setattr(facade, "target", lambda: None)
+            """
+        ),
+        baseline=[
+            _record(qualified_symbol="test_a", reason="first rename"),
+            _record(qualified_symbol="test_b", reason="second rename"),
+        ],
+    )
+
+    assert lmfb.main(["--root", str(tmp_path), "--write"]) == 2
+

--- a/python/tests/lint/test_lint_monkeypatch_facade_binding.py
+++ b/python/tests/lint/test_lint_monkeypatch_facade_binding.py
@@ -572,4 +572,3 @@ def test_write_rename_ambiguous_requires_reason(tmp_path: Path) -> None:
     )
 
     assert lmfb.main(["--root", str(tmp_path), "--write"]) == 2
-

--- a/skills/implement/scripts/step-8-ci-fixer.sh
+++ b/skills/implement/scripts/step-8-ci-fixer.sh
@@ -16,7 +16,11 @@ path=Path(sys.argv[2])
 if not path.is_file() or path.is_symlink(): raise SystemExit(0)
 seen={}
 for raw in path.read_text(encoding="utf-8", errors="strict").splitlines():
-    if not raw or "=" not in raw: raise SystemExit(2)
+    # Tolerate benign shell/env content (blank lines, comments, `export ` prefixes,
+    # lowercase ledger keys) by skipping it. Only raise on genuine integrity
+    # violations: a duplicate uppercase key or a control character in a value.
+    if not raw or "=" not in raw:
+        continue
     key,value=raw.split("=",1)
     if not re.fullmatch(r"[A-Z][A-Z0-9_]*",key):
         continue
@@ -105,9 +109,14 @@ import re, sys
 def rows(path):
     out={}
     for raw in Path(path).read_text(encoding="utf-8",errors="strict").splitlines():
-        if not raw or "=" not in raw: raise SystemExit(2)
+        # Tolerate benign lines (blank, comment, non-uppercase) like read_key;
+        # only a duplicate uppercase key is an integrity violation.
+        if not raw or "=" not in raw:
+            continue
         key,value=raw.split("=",1)
-        if key in out or not re.fullmatch(r"[A-Z][A-Z0-9_]*",key): raise SystemExit(2)
+        if not re.fullmatch(r"[A-Z][A-Z0-9_]*",key):
+            continue
+        if key in out: raise SystemExit(2)
         out[key]=value
     return out
 left,right=rows(sys.argv[1]),rows(sys.argv[2])


### PR DESCRIPTION
Fixes #6931

## Summary

Makes the `/implement` Step 8 CI fixer attempt every repairable CI failure autonomously and bail to the operator only after an attempted fix genuinely fails — never preemptively on benign handoff input. Adds a deterministic repair for the monkeypatch-facade-binding class (test renames).

## Changes by work item

### 1. No preemptive bails — `skills/implement/scripts/step-8-ci-fixer.sh`

`read_key` and the finalize envelope validator (`rows()`) raised `SystemExit(2)` on benign shell/env content: blank lines, comment lines, `export ` prefixes, and lowercase ledger keys. The lowercase-key case is the original `invalid-route-handoff` bail that forced operator intervention for a one-line lint fix. Both parsers now skip benign lines with `continue` and raise only on genuine integrity violations:

- duplicate uppercase key, and
- a control character in a value.

All other `fail` paths were audited and are genuine preconditions (security path confinement, missing required data, value-format validation of run ids / heads / fingerprints needed to proceed). Verified: reading `NEEDS_USER_REASON` / `CI_FAILURE_SCOPE` / `FAILED_RUN_ID` from the exact lowercase-ledger handoff in the issue's evidence now succeeds (previously bailed before any bgjob started).

### 2 & 3. Broaden repair vocabulary + auto-handle test renames — `python/larch/lint/lint_monkeypatch_facade_binding.py`, `python/larch/agents/_ci_launcher.py`

When an external implementer (Codex/Cursor) renames a test, the baseline's `qualified_symbol` goes stale and a new un-baselined finding fails CI. The lint's own message ("patch the defining module") misleads for grandfathered renames.

- `--write` now pairs the stale baseline row with the new live finding by the identity that survives a rename `(file, facade_module, attribute, defining_module, occurrence)` and carries over the reason. So `make regen-monkeypatch-facade-binding-baseline` and the CI-fix agent no longer need a hand-supplied `--initial-reason` for a rename.
- Pairing is strictly 1:1 (exactly one stale row **and** one new finding per fingerprint); ambiguous renames still require an explicit reason — no silent carry-over.
- Check mode prints a `likely rename of baselined symbol 'X' to 'Y'` hint with the migrate command.
- The CI-fix agent prompt (`_ci_prompt`) now points at baseline regeneration via `python3 python/cli.py lint <lint-name> --write`, preferring it over hand-editing the JSON.

### 4. Shipped-plugin currency

Confirmed the installed plugin v52.5.30 still carries the old buggy `read_key` (raises on non-uppercase keys). The `read_key` tolerance is unreleased on `main` (post-v52.5.30, via #6918 and this change) and ships in the next release, so the false bail cannot recur from plugin staleness once released. No version bump in this PR — releases are cut separately.

## Verification

- `python3 -m pytest python/tests/lint/test_lint_monkeypatch_facade_binding.py` — 34 passed (31 existing + 3 new: rename migrate, check-mode hint, ambiguous-rename-requires-reason).
- `python3 -m pytest python/tests/agents/test_agents.py python/tests/implement/test_ci.py` — 298 passed.
- `ruff check` and `pyright` clean on changed files.
- `bash scripts/lint-bash32.sh skills/implement/scripts/step-8-ci-fixer.sh` — pass.
- `bash scripts/test-implement-step8-exit3-first-fixer.sh` — PASS.
- Real `lint monkeypatch-facade-binding` against the repo baseline — exit 0 (no new findings).
- Functional test of the patched `read_key`/`rows()` against crafted benign + duplicate-key inputs.
