### PR TITLE
Release v52.5.31

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.5.30",
+  "version": "52.5.31",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Changed

- Replaced the deprecated `codex --full-auto` flag with `--sandbox workspace-write` (#6932).
- Hardened the Step 8 CI fixer against preemptive bails and test-rename baselines (#6937).
- Activated the combined Step 8 assessment route (#6939).

## Fixed

- Fixed a CI-fixer invalid-route-handoff bug when handoff files contain lowercase ledger keys (#6918).
- Fixed scope-disposition residual issues: hardcoded `origin/main` references and churn counted as coverage (#6922).
- Fixed a coverage artifact mismatch in teardown after an inline CI-fix commit, which caused missing final reports (#6923).
- Fixed an `/implement` post-merge log flush failure when the local checkout moves to `main` after an admin merge (#6924).
- Fixed a stall classifier that over-matched preterminal-outcome during the postmerge phase, causing spurious reships and terminal reports after successful merges (#6925).
- Fixed in-dev `/implement` runs filing real GitHub issues from fixture data (#6934).
- Fixed post-merge-on-main resume to route to finalization instead of checkout-mismatch (#6936).
