### PR TITLE
fix(implement): correct TierSelectResult field names in step-8 CI fixer

### DIFF
--- a/python/tests/core/test_external_role_defaults.py
+++ b/python/tests/core/test_external_role_defaults.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import dataclasses
+import re
 from pathlib import Path
 
 from larch.core import config
@@ -234,3 +236,24 @@ def test_fixer_lane_budget_reserves_a_full_timeout_per_configured_tier() -> None
             len(external_defaults.tool_order(role_id))
             * config.FIXER_LANE_TIMEOUT_SEC
         )
+
+
+def test_step8_ci_fixer_shell_snippet_reads_canonical_tier_fields() -> None:
+    """Guard the shell-embedded tier-selection print against dataclass drift.
+
+    skills/implement/scripts/step-8-ci-fixer.sh prints the TierSelectResult
+    fields with an inline ``python3 - <<PY`` snippet. When that snippet read
+    the stale names ``result.tier``/``result.reason`` it raised AttributeError
+    and routed every PR CI failure to operator-bail (issue #6946). A rename on
+    either side must trip this test instead of silently regressing at runtime.
+    """
+    script = (
+        Path(__file__).resolve().parents[3]
+        / "skills/implement/scripts/step-8-ci-fixer.sh"
+    ).read_text(encoding="utf-8")
+    print_lines = [line for line in script.splitlines() if "result.action" in line]
+    assert len(print_lines) == 1
+    referenced = set(re.findall(r"result\.([a-z_]+)", print_lines[0]))
+    valid = {f.name for f in dataclasses.fields(external_defaults.TierSelectResult)}
+    assert referenced == {"action", "selected_tier", "failure_reason"}
+    assert referenced <= valid

--- a/skills/implement/scripts/step-8-ci-fixer.sh
+++ b/skills/implement/scripts/step-8-ci-fixer.sh
@@ -173,7 +173,7 @@ import shutil,sys
 sys.path.insert(0,str(Path(sys.argv[1])/"python"))
 from larch.core import external_defaults
 result=external_defaults.next_untried_tier("implement.ci_recovery_fixer",tuple(filter(None,sys.argv[2].split(','))),codex_present=shutil.which("codex") is not None,cursor_present=shutil.which("cursor") is not None,claude_present=shutil.which("claude") is not None)
-print(f"{result.action}\t{result.tier}\t{result.reason}")
+print(f"{result.action}\t{result.selected_tier}\t{result.failure_reason}")
 PY
 ) || fail tier-selection-failed
 ACTION=$(printf '%s' "$SELECT" | cut -f1); TIER=$(printf '%s' "$SELECT" | cut -f2); REASON=$(printf '%s' "$SELECT" | cut -f3)


### PR DESCRIPTION
## Summary

Fixes the Step 8 autonomous CI fixer crash that routed every `/implement --merge` PR CI failure to `operator-bail`.

`skills/implement/scripts/step-8-ci-fixer.sh` selects the next untried fixer tier with an inline `python3 - <<PY` snippet that reads fields off a `TierSelectResult`. It read the stale names `result.tier` and `result.reason`, but the dataclass fields are `selected_tier` and `failure_reason`. The `AttributeError` was caught by the wrapper's `fail()` helper and rendered as `RESULT=operator-bail REASON=tier-selection-failed` (exit 0), so autonomous CI repair never launched a fixer tier.

## Changes

- `skills/implement/scripts/step-8-ci-fixer.sh:176` — `result.tier` → `result.selected_tier`, `result.reason` → `result.failure_reason`. Both were wrong; fixing only `.tier` would move the crash to `.reason`. This matches the Python twin caller at `python/larch/implement/checks_lint_fix.py:1606`, which already uses `selected_tier`.
- `python/tests/core/test_external_role_defaults.py` — regression test asserting that the fields the shell snippet references all exist on the `TierSelectResult` dataclass, so the shell-to-dataclass contract cannot silently drift again.

## Verification

- Ran the exact embedded snippet against the repo: now prints `selected\t<tier>\t` with exit 0 (previously raised `AttributeError`).
- `pytest tests/core/test_external_role_defaults.py` → 14 passed.
- `ruff check` and `pyright` clean on the changed test file; `bash -n` clean on the shell script.

Fixes #6946
