### PR TITLE
Release v52.5.32

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.5.31",
+  "version": "52.5.32",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Added

- Added public routing and pricing documentation (#6942).

## Changed

- Removed extraneous breadcrumb and report log lines (#6944).

## Fixed

- Fixed larch skills filing bug issues with a `[Bug]` title prefix instead of `[BUG]` (#6945).
- Fixed incorrect `TierSelectResult` field names in the `/implement` step-8 CI fixer (#6948).
