### PR TITLE
Fixes #6947: emit final report when plan-coverage line can't be computed

### DIFF
--- a/larch-logs/shared/learn-from-bugs-state.json
+++ b/larch-logs/shared/learn-from-bugs-state.json
@@ -1,10 +1,10 @@
 {
-  "highest_closed_issue_number_scanned": 6826,
+  "highest_closed_issue_number_scanned": 6899,
   "repo": "character-ai/larch",
-  "run_date": "2026-07-11T04:51:13Z",
-  "scan_started_at": "2026-07-11T04:44:51Z",
+  "run_date": "2026-07-11T19:23:08Z",
+  "scan_started_at": "2026-07-11T19:18:06Z",
   "schema_version": 1,
   "search": "[BUG] in:title",
-  "selected_count": 24,
+  "selected_count": 14,
   "state": "closed"
 }

--- a/python/complexity-baseline.json
+++ b/python/complexity-baseline.json
@@ -4317,7 +4317,7 @@
     "file": "larch/report/final_report.py",
     "code": "PLR0915",
     "qualified_symbol": "write_final_report",
-    "metric": 62
+    "metric": 63
   },
   {
     "file": "larch/report/gc_run_logs.py",

--- a/python/larch/report/final_report.py
+++ b/python/larch/report/final_report.py
@@ -18,6 +18,7 @@ from typing import cast
 from larch.core import architectural_guidelines
 from larch.state import closeout
 from larch.core import config
+from larch.core import logging_util
 from larch.report import exec_issue_detail
 from larch import io as larch_io
 from larch.git import pr_body
@@ -576,6 +577,34 @@ def _plan_coverage_summary_line(
         f"todos_left: {coverage.todos_left_count}{followup}"
     )
 
+
+def _plan_coverage_summary_line_or_empty(
+    implement_tmpdir: Path, *, manifest_path: Path | None = None
+) -> str:
+    """Optional plan-coverage line for the final report; never fatal.
+
+    The final report is written after merge, when live coverage no longer
+    matches the persisted fingerprint (the same stale-live mismatch #6908
+    recovers in teardown). That expected mismatch must not abort the whole
+    report before summary-final.md is written, so degrade to an empty line.
+    Genuine integrity failures (corrupt or unreadable artifacts) are not stale
+    mismatches and still propagate so they fail loudly.
+    """
+    try:
+        return _plan_coverage_summary_line(
+            implement_tmpdir, manifest_path=manifest_path
+        )
+    except ShipError as exc:
+        if not _is_stale_live_coverage_mismatch(exc):
+            raise
+        logging_util.BreadcrumbWriter().emit(
+            "final report: live coverage no longer matches repository inputs; "
+            "omitting optional plan-coverage line",
+            quiet=False,
+        )
+        return ""
+
+
 def _manifest_pr_number(data: Mapping[str, object]) -> int:
     for key in ("pr_number", "PR_NUMBER"):
         value = data.get(key)
@@ -848,6 +877,9 @@ def write_final_report(
         ship=ship,
         final=final,
     )
+    plan_coverage_line = _plan_coverage_summary_line_or_empty(
+        implement_tmpdir, manifest_path=run_dir / "manifest.json"
+    )
     summary_body = pr_body.render_run_summary(
         skill="implement",
         outcome=outcome,
@@ -860,9 +892,7 @@ def write_final_report(
         pr_number=pr_number,
         pr_url=pr_url,
         plan_review_line=derived["plan_review_line"],
-        plan_coverage_line=_plan_coverage_summary_line(
-            implement_tmpdir, manifest_path=run_dir / "manifest.json"
-        ),
+        plan_coverage_line=plan_coverage_line,
         difficulty_line=_difficulty_summary_line(run_dir),
         dynamic_archetypes_line=_dynamic_archetypes_line(implement_tmpdir),
         code_review_line=derived["code_review_line"],

--- a/python/tests/report/test_final_report.py
+++ b/python/tests/report/test_final_report.py
@@ -1111,9 +1111,15 @@ def test_plan_coverage_summary_propagates_non_mismatch_ship_error(
         _ = final_report._plan_coverage_summary_line(tmp_path)
 
 
-def test_write_final_report_fails_before_post_merge_on_stale_mismatch(
+def test_write_final_report_omits_coverage_line_on_stale_mismatch_without_sentinel(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    """Stale post-merge coverage must not abort the final report (#6947).
+
+    With no post-merge-sentinel, _plan_coverage_summary_line re-raises the
+    stale-live mismatch; write_final_report degrades the optional coverage line
+    to empty and still writes summary-final.md.
+    """
     _write_minimal_state(tmp_path)
     (tmp_path / "session-env.sh").write_text(
         f"REPO=o/r\nMODE=N/A\nREPO_ROOT={tmp_path}\n",
@@ -1126,7 +1132,37 @@ def test_write_final_report_fails_before_post_merge_on_stale_mismatch(
         raise ShipError("coverage artifact does not match live repository inputs")
 
     monkeypatch.setattr(scope_disposition, "load_live_coverage", boom)
-    with pytest.raises(ShipError, match="coverage artifact does not match live repository inputs"):
+
+    rc, url, err = final_report.write_final_report(tmp_path, comment_only=True)
+
+    assert (rc, url, err) == (0, "", "")
+    summary = (tmp_path / "summary-final.md").read_text(encoding="utf-8")
+    assert "## /implement run run1" in summary
+    assert "**Plan coverage**" not in summary
+
+
+def test_write_final_report_propagates_non_mismatch_coverage_ship_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Genuine coverage-integrity failures still fail the report loudly (#6947).
+
+    Only the canonical stale-live mismatch degrades; a corrupt/unreadable
+    coverage artifact must not be silently swallowed.
+    """
+    _write_minimal_state(tmp_path)
+    (tmp_path / "session-env.sh").write_text(
+        f"REPO=o/r\nMODE=N/A\nREPO_ROOT={tmp_path}\n",
+        encoding="utf-8",
+    )
+    _stub_cost_and_assessment(monkeypatch)
+
+    def boom(*, tmpdir: Path, repo_root: Path, manifest_path: Path | None = None) -> None:
+        _ = tmpdir, repo_root, manifest_path
+        raise ShipError("coverage artifact unreadable or malformed: bad json")
+
+    monkeypatch.setattr(scope_disposition, "load_live_coverage", boom)
+
+    with pytest.raises(ShipError, match="unreadable or malformed"):
         _ = final_report.write_final_report(tmp_path, comment_only=True)
 
 


### PR DESCRIPTION
## Summary

Fixes #6947.

The final report was silently dropped at the end of a successful `/implement --merge` run. `write_final_report` passed `_plan_coverage_summary_line`'s result straight into `render_run_summary`, so a `ShipError` from that optional line aborted the whole report before `summary-final.md` was written, even though the PR had already merged.

After a merge the live tree no longer matches the persisted coverage fingerprint, so `_plan_coverage_summary_line` raises the canonical stale-live mismatch (`coverage artifact does not match live repository inputs`) whenever the `post-merge-sentinel` is absent or persisted coverage is `None` (the two failure modes named in the issue).

## Fix

`write_final_report` now computes the coverage line through a new `_plan_coverage_summary_line_or_empty` helper, which:

- degrades the canonical stale-live mismatch to an omitted line (emitting a breadcrumb), matching the #6908 teardown recovery, so `summary-final.md` is still written and the report is emitted;
- re-raises every other `ShipError` (corrupt or unreadable artifacts), preserving the trusted-artifact boundary so genuine integrity failures still fail loudly.

The coverage line is informational and optional; it should never be able to abort an after-merge report.

## Note on the issue's root-cause analysis

The issue's suggested fix #1 ("align `_plan_coverage_summary_line`'s recovery gate with teardown's `allow_persisted_recovery=True`") rests on a misread. Teardown (`finalize.py:750`) also gates on the sentinel: `allow_persisted_recovery=(tmpdir / "post-merge-sentinel").is_file()`. The two paths were already aligned, so relaxing the gate would weaken the trust boundary. This PR implements suggested fix #2 (graceful degradation of the optional line) instead.

## Tests

- `test_write_final_report_omits_coverage_line_on_stale_mismatch_without_sentinel`: stale mismatch, no sentinel, now returns rc=0, writes `summary-final.md`, and omits the `**Plan coverage**` line. This flips the former `test_write_final_report_fails_before_post_merge_on_stale_mismatch`, which asserted a raise and encoded the bug.
- `test_write_final_report_propagates_non_mismatch_coverage_ship_error`: a corrupt-artifact `ShipError` still propagates.
- Full `python/tests/report/test_final_report.py` passes (45 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
