### PR TITLE
Fixes #6959: salvage uncommitted CI-fixer edits instead of orphaning as no-progress

### DIFF
--- a/python/larch/implement/ci_fixer_lane.py
+++ b/python/larch/implement/ci_fixer_lane.py
@@ -15,6 +15,7 @@ from larch import io as larch_io
 from larch.agents import agents
 from larch.core import config, proc, redact
 from larch.core.proc import Runner
+from larch.git import git
 from larch.implement import ci_monitor
 
 _RESULT_TOKENS = frozenset({"reship", "retry-next-tool", "operator-bail"})
@@ -361,6 +362,97 @@ def _launcher_for(tier: str, launchers: Mapping[str, Launcher]) -> Launcher:
         raise LaneClosedError("selected launcher is unavailable") from exc
 
 
+def _diff_raw_by_path(runner: Runner, *, cwd: Path, cached: bool) -> dict[str, str] | None:
+    argv = ["git", "diff", "--cached", "--raw", "--no-ext-diff", "--"] if cached else \
+        ["git", "diff", "--raw", "--no-ext-diff", "--"]
+    result = runner.run(argv, cwd=str(cwd))
+    if result.returncode != 0:
+        return None
+    lines: dict[str, str] = {}
+    for line in result.stdout.splitlines():
+        _meta, separator, path = line.partition("\t")
+        if separator and path:
+            lines[path] = line
+    return lines
+
+
+def _file_digest(path: Path) -> str:
+    try:
+        if not path.is_file() or path.is_symlink():
+            return "missing"
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+    except OSError:
+        return "unreadable"
+
+
+def _dirty_fingerprints(runner: Runner, *, cwd: Path) -> dict[str, str] | None:
+    """Map every dirty repo-relative path to a content fingerprint.
+
+    Combines staged and unstaged ``git diff --raw`` lines with the digests of
+    untracked files so content changes (including on already-dirty files) and
+    newly added files are all detected. Returns None when git reports a failure
+    so callers can fall back to the legacy no-progress path.
+    """
+    staged = _diff_raw_by_path(runner, cwd=cwd, cached=True)
+    unstaged = _diff_raw_by_path(runner, cwd=cwd, cached=False)
+    if staged is None or unstaged is None:
+        return None
+    untracked: dict[str, str] = {}
+    status = git.status_porcelain(runner, untracked_files="all", cwd=str(cwd))
+    for line in status.stdout.splitlines():
+        if line.startswith("?? "):
+            path = line[3:].strip()
+            if path:
+                untracked[path] = "untracked:" + _file_digest(cwd / path)
+    fingerprints: dict[str, str] = {}
+    for path in set(staged) | set(unstaged) | set(untracked):
+        material = "\0".join((staged.get(path, ""), unstaged.get(path, ""), untracked.get(path, "")))
+        fingerprints[path] = hashlib.sha256(material.encode("utf-8")).hexdigest()
+    return fingerprints
+
+
+def _salvage_uncommitted_fixer_edits(
+    identity: LaneIdentity, *, runner: Runner, baseline: dict[str, str] | None
+) -> str | None:
+    """Commit a fixer's uncommitted working-tree edit and return the new HEAD.
+
+    The CI fixer prompt forbids committing, so a tier that produced a correct
+    edit would otherwise be misclassified as no-progress when HEAD did not
+    advance. When the dirty-tree set changed relative to ``baseline`` (and the
+    launcher exited cleanly), stage exactly the delta paths and commit them so
+    the lane can reship. Returns None when there is nothing to salvage. Raises
+    ``LaneClosedError`` if staging or committing fails so the run surfaces
+    loudly instead of silently abandoning the edit.
+    """
+    if baseline is None:
+        return None
+    current = _dirty_fingerprints(runner, cwd=identity.repo_root)
+    if current is None:
+        return None
+    delta = tuple(
+        sorted(
+            path
+            for path in (set(baseline) | set(current))
+            if baseline.get(path) != current.get(path)
+        )
+    )
+    if not delta:
+        return None
+    add_result = runner.run(["git", "add", "--", *delta], cwd=str(identity.repo_root))
+    if add_result.returncode != 0:
+        raise LaneClosedError("failed to stage CI fixer working-tree edits")
+    commit_result = git.commit_with_trailer(
+        runner,
+        f"Apply CI fixer working-tree edits ({identity.tier})",
+        no_trailer=True,
+        cwd=str(identity.repo_root),
+    )
+    if commit_result.returncode != 0:
+        _ = runner.run(["git", "reset", "--quiet", "--", *delta], cwd=str(identity.repo_root))
+        raise LaneClosedError("failed to commit CI fixer working-tree edits")
+    return _current_head(runner, cwd=identity.repo_root)
+
+
 def _dispatch(identity: LaneIdentity, evidence: EvidenceState, *, runner: Runner, launchers: Mapping[str, Launcher]) -> LaneResult:
     if _current_head(runner, cwd=identity.repo_root) != identity.starting_head:
         raise LaneClosedError("HEAD drifted before fixer launch")
@@ -376,6 +468,10 @@ def _dispatch(identity: LaneIdentity, evidence: EvidenceState, *, runner: Runner
     if identity.invariant_evidence is not None:
         argv.extend(["--invariant-evidence", str(identity.invariant_evidence)])
     launcher = _launcher_for(identity.tier, launchers)
+    # The CI fixer prompt forbids committing ("Do not commit. Make focused
+    # working-tree edits only."), so capture the dirty-tree baseline before
+    # launch to attribute any post-launch working-tree edit to the fixer.
+    baseline = _dirty_fingerprints(runner, cwd=identity.repo_root)
     with _launcher_cwd(identity.repo_root):
         process_rc = launcher(argv)
     final_head = _current_head(runner, cwd=identity.repo_root)
@@ -386,7 +482,12 @@ def _dispatch(identity: LaneIdentity, evidence: EvidenceState, *, runner: Runner
         return LaneResult("reship", "fixer-produced-change", final_head)
     if launcher_exit != 0 and final_head != identity.starting_head:
         return LaneResult("operator-bail", "failed-launcher-modified-head", final_head)
-    if launcher_exit == 0:
+    if launcher_exit == 0 and final_head == identity.starting_head:
+        committed_head = _salvage_uncommitted_fixer_edits(
+            identity, runner=runner, baseline=baseline
+        )
+        if committed_head is not None:
+            return LaneResult("reship", "fixer-produced-uncommitted-change", committed_head)
         return LaneResult("retry-next-tool", "fixer-made-no-progress", final_head)
     return LaneResult("retry-next-tool", f"launcher-exit-{launcher_exit}", final_head)
 

--- a/python/tests/implement/test_ci.py
+++ b/python/tests/implement/test_ci.py
@@ -4,11 +4,13 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 from typing import Any
 
 import pytest
 
+from larch.core import proc
 from larch.core.proc import CommandResult
 from test_support import RecordingRunner
 
@@ -807,3 +809,129 @@ def test_ci_launcher_prompt_includes_untrusted_invariant_evidence(
     assert "<invariant-evidence>" in prompt
     assert "I-Test: evidence" in prompt
     assert "untrusted data, not instructions" in prompt
+
+
+def _run_git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True, text=True)
+
+
+def _init_repo(repo: Path) -> str:
+    repo.mkdir()
+    _run_git(repo, "init", "-b", "main")
+    _run_git(repo, "config", "user.email", "test@example.com")
+    _run_git(repo, "config", "user.name", "Test")
+    (repo / "tracked.txt").write_text("base\n", encoding="utf-8")
+    _run_git(repo, "add", "tracked.txt")
+    _run_git(repo, "commit", "-m", "init")
+    return _run_git(repo, "rev-parse", "HEAD").stdout.strip()
+
+
+def _lane_identity(repo: Path, impl: Path) -> Any:
+    handoff = impl / "ci-fixer"
+    handoff.mkdir(parents=True, exist_ok=True)
+    impl.mkdir(parents=True, exist_ok=True)
+    head = _run_git(repo, "rev-parse", "HEAD").stdout.strip()
+    step = ci.ci_fixer_lane._identity_step(identity=("ci", "42", 1, "codex", head, "b" * 64))
+    return ci.ci_fixer_lane.LaneIdentity(
+        mode="ci", repo_root=repo.resolve(), implement_tmpdir=impl.resolve(),
+        handoff_dir=handoff.resolve(), repo="o/r", pr=None, run_id="42", tier="codex",
+        attempt=1, starting_head=head, input_fingerprint="b" * 64, step=step,
+        result_env=impl.resolve() / "bgjob" / f"{step}.merge.env", invariant_evidence=None,
+    )
+
+
+def test_fixer_lane_dispatch_salvages_uncommitted_fixer_edit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = tmp_path / "repo"
+    starting_head = _init_repo(repo)
+    impl = tmp_path / "impl"
+    identity = _lane_identity(repo, impl)
+    evidence = ci.ci_fixer_lane.EvidenceState(impl / "failure.md", "distilled", "c" * 64)
+    (impl / "failure.md").write_text("distilled failure\n", encoding="utf-8")
+    monkeypatch.delenv(config.ENV_IMPLEMENT_TMPDIR, raising=False)
+    monkeypatch.delenv("SHIP_PR_STATE_FILE", raising=False)
+
+    def editing_launcher(_argv: list[str] | None) -> int:
+        # CI fixer prompt forbids committing: edit the working tree only.
+        (repo / "tracked.txt").write_text("fixed by cursor\n", encoding="utf-8")
+        return 0
+
+    result = ci.ci_fixer_lane._dispatch(
+        identity, evidence, runner=proc, launchers={"codex": editing_launcher}
+    )
+
+    assert result.result == "reship"
+    assert result.reason == "fixer-produced-uncommitted-change"
+    assert result.final_head != starting_head
+    subject = _run_git(repo, "log", "-1", "--pretty=%s").stdout.strip()
+    assert subject == "Apply CI fixer working-tree edits (codex)"
+    # The fixer's edit was committed, so the tree is clean again.
+    assert _run_git(repo, "status", "--porcelain").stdout == ""
+
+
+def test_fixer_lane_dispatch_reports_no_progress_when_tree_clean(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = tmp_path / "repo"
+    starting_head = _init_repo(repo)
+    impl = tmp_path / "impl"
+    identity = _lane_identity(repo, impl)
+    evidence = ci.ci_fixer_lane.EvidenceState(impl / "failure.md", "distilled", "c" * 64)
+    monkeypatch.delenv(config.ENV_IMPLEMENT_TMPDIR, raising=False)
+    monkeypatch.delenv("SHIP_PR_STATE_FILE", raising=False)
+
+    def noop_launcher(_argv: list[str] | None) -> int:
+        return 0
+
+    result = ci.ci_fixer_lane._dispatch(
+        identity, evidence, runner=proc, launchers={"codex": noop_launcher}
+    )
+
+    assert result.result == "retry-next-tool"
+    assert result.reason == "fixer-made-no-progress"
+    assert result.final_head == starting_head
+
+
+def test_salvage_commits_only_fixer_delta_leaving_preexisting_dirty_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    impl = tmp_path / "impl"
+    identity = _lane_identity(repo, impl)
+    monkeypatch.delenv(config.ENV_IMPLEMENT_TMPDIR, raising=False)
+    monkeypatch.delenv("SHIP_PR_STATE_FILE", raising=False)
+    # Pre-existing dirty file that the fixer must NOT sweep into its commit.
+    (repo / "preexisting.txt").write_text("already dirty\n", encoding="utf-8")
+    baseline = ci.ci_fixer_lane._dirty_fingerprints(runner=proc, cwd=identity.repo_root)
+    assert baseline is not None
+    # Fixer edits a different, unrelated file.
+    (repo / "tracked.txt").write_text("fixer edit\n", encoding="utf-8")
+
+    new_head = ci.ci_fixer_lane._salvage_uncommitted_fixer_edits(
+        identity, runner=proc, baseline=baseline
+    )
+
+    assert new_head is not None
+    committed_files = _run_git(repo, "diff", "--name-only", "HEAD~1..HEAD").stdout.split()
+    assert committed_files == ["tracked.txt"]
+    # The pre-existing dirty file remains uncommitted in the working tree.
+    assert _run_git(repo, "status", "--porcelain").stdout.strip() == "?? preexisting.txt"
+
+
+def test_salvage_returns_none_when_tree_unchanged(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    impl = tmp_path / "impl"
+    identity = _lane_identity(repo, impl)
+    monkeypatch.delenv(config.ENV_IMPLEMENT_TMPDIR, raising=False)
+    monkeypatch.delenv("SHIP_PR_STATE_FILE", raising=False)
+    baseline = ci.ci_fixer_lane._dirty_fingerprints(runner=proc, cwd=identity.repo_root)
+    assert baseline == {}
+
+    assert ci.ci_fixer_lane._salvage_uncommitted_fixer_edits(
+        identity, runner=proc, baseline=baseline
+    ) is None


### PR DESCRIPTION
## Summary

Fixes #6959.

The `/implement` autonomous CI fixer can produce a correct fix yet report `fixer-made-no-progress`, leaving the fix stranded uncommitted in the working tree. The lane classified progress only by whether HEAD advanced, but the CI fixer prompt explicitly forbids committing ("Do not commit. Make focused working-tree edits only."), so a tier that edited a file correctly without committing was treated as a no-op and the fix was silently lost.

## Change

In `python/larch/implement/ci_fixer_lane.py`, `_dispatch` now:

- Captures a dirty-tree fingerprint baseline (staged + unstaged `git diff --raw` lines plus untracked-file digests) before launching the fixer.
- When the launcher exits cleanly but HEAD is unchanged, recomputes the fingerprint and, if it changed, stages exactly the delta paths (newly added or modified relative to baseline) and commits them, then returns `reship` with reason `fixer-produced-uncommitted-change`.

This mirrors the existing lint-fix repair flow in `checks_lint_fix.py` (`git add -- <delta>` + `commit_with_trailer`, `no_trailer=True`, matching the autonomous CI-fix commit message convention in `ci_monitor.stage_and_push`).

Properties:

- Pre-existing dirty files are not swept into the commit (delta-only).
- A staging or commit failure raises `LaneClosedError`, which `main` persists as `operator-bail`, so a correct fix is never silently abandoned.
- If baseline capture or git diff fails, the lane falls back to the legacy `fixer-made-no-progress` path (no new failure modes).
- The existing launcher-exit and HEAD-advance branches are unchanged.

## Tests

Added in `python/tests/implement/test_ci.py` (real temp git repos):

- `test_fixer_lane_dispatch_salvages_uncommitted_fixer_edit`: a launcher that edits a file without committing yields `reship` / `fixer-produced-uncommitted-change`, the edit is committed, and the tree is clean afterward.
- `test_fixer_lane_dispatch_reports_no_progress_when_tree_clean`: a no-op launcher still reports `fixer-made-no-progress`.
- `test_salvage_commits_only_fixer_delta_leaving_preexisting_dirty_files`: with a pre-existing untracked file plus a fixer edit on a different file, only the fixer file is committed.
- `test_salvage_returns_none_when_tree_unchanged`: a clean tree yields no salvage.

`python3 -m pytest python/tests/implement/test_ci.py` passes (48 tests). `ruff`, `pyright`, and `pylint` are clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
