### PR TITLE
Fixes #6955: classify inline clean-lead assessment notes as clean

### DIFF
--- a/python/larch/core/architectural_guidelines.py
+++ b/python/larch/core/architectural_guidelines.py
@@ -58,6 +58,10 @@ _MARKDOWN_HEADING_RE = re.compile(r"^#{1,6}\s+\S")
 # anywhere in a note's prose, not just as a Markdown heading. See issue #6882.
 NOTE_INVARIANT_ID_RE = re.compile(r"I-[A-Za-z0-9-]+-\d+")
 NOTE_GUIDELINE_ID_RE = re.compile(r"G-[A-Za-z0-9-]+-\d+")
+# A note whose first sentence affirms "no violations/deviations" leads clean, so a
+# supporting I-*/G-* reference in that same sentence must not flip it to non-clean.
+# See issue #6955.
+_CLEAN_ASSESSMENT_LEAD_RE = re.compile(r"^\W*no\b[^.;\n]*\b(?:violation|deviation)s?\b", re.IGNORECASE)
 _WHY_RE = re.compile(r"^\s*-\s*Why:\s*(.+?)\s*$")
 _DEVIATE_RE = re.compile(r"^\s*-\s*Deviate when:\s*(.+?)\s*$")
 _MECHANIZED_RE = re.compile(r"^\s*-\s*Mechanized:\s*(.+?)\s*$")
@@ -1728,7 +1732,7 @@ def classify_assessment_prose(
     if not note.strip():
         return ""
     first_line: str = note.split("\n", 1)[0].strip()
-    if first_line == clean_lead:
+    if first_line == clean_lead or _CLEAN_ASSESSMENT_LEAD_RE.search(first_line):
         return config.ASSESSMENT_OUTCOME_CLEAN
     return non_clean_outcome if identifier_pattern.search(note) else config.ASSESSMENT_OUTCOME_CLEAN
 

--- a/python/tests/core/test_architectural_guidelines.py
+++ b/python/tests/core/test_architectural_guidelines.py
@@ -2247,6 +2247,13 @@ def test_validate_invariant_ship_outcome_record_accepts_violation() -> None:
         # A note that neither leads with the clean line nor names an invariant leans
         # clean rather than blocking the ship on ambiguous prose.
         ("No specific invariant applies to this diff.", "clean"),
+        # Issue #6955: a clean verdict that references a supporting I-* id in the same
+        # sentence still leads clean; the id must not flip it to violation.
+        ("No invariant violations identified. The change is consistent with I-Gate-1.", "clean"),
+        ("No invariant violations identified.", "clean"),
+        ("No violations found; the change respects I-Gate-1 and I-Gate-2.", "clean"),
+        # A note that leads with a violation statement naming an invariant stays violation.
+        ("I-Gate-1 is violated: the gate disarms on gated data.", "violation"),
     ],
 )
 def test_invariant_assessment_kind_tolerates_verbose_clean_notes(note: str, expected: str) -> None:
@@ -2825,3 +2832,19 @@ def test_explicit_clean_accepts_canonical_lead_with_identifier_rationale(tmp_pat
         diff_text="diff",
     )
     assert ag._read_env(tmp_path / ag.STAGED_ASSESSMENT_ENV)["ASSESSMENT_KIND"] == "clean"
+
+
+def test_explicit_clean_accepts_inline_clean_lead_with_invariant_id(tmp_path: Path) -> None:
+    # Issue #6955: a clean verdict phrased inline with a supporting I-* reference must
+    # not be rejected as a clean/prose mismatch and forced back into re-authoring.
+    note = "No invariant violations identified. The change is consistent with I-Gate-1."
+    ag.write_invariant_staged_assessment(
+        implement_tmpdir=tmp_path,
+        assessment_text=note,
+        assessed_head_sha="head",
+        diff_fingerprint_value=ag.diff_fingerprint("diff"),
+        base_ref="origin/main",
+        outcome="clean",
+        diff_text="diff",
+    )
+    assert ag._read_env(tmp_path / ag.INVARIANT_STAGED_ASSESSMENT_ENV)["ASSESSMENT_KIND"] == "clean"


### PR DESCRIPTION
## Summary

Fixes #6955. The Step 8 architectural-invariants consistency check misclassified a **clean** assessment note as a violation when the agent wrote the clean verdict and a supporting `I-*` reference in the same sentence — for example:

> No invariant violations identified. The change is consistent with I-Gate-1.

`classify_assessment_prose` only accepted a note as clean when its first line exactly equaled the canonical clean presentation line. Otherwise any `I-*`/`G-*` match anywhere in the note flipped it to the non-clean outcome. This is the residual gap left by #6882 and not closed by #6898.

After #6898 the misclassification no longer routes a hard `architectural-invariants-violation`. Instead it fails `_validate_authored_outcome` with `clean-outcome-prose-mismatch`, forcing a legitimately clean assessment back into re-authoring. Confirmed live: authoring `outcome=clean` with the note above raised `AssessmentReauthorRequired: clean-outcome-prose-mismatch` on `main`.

## Fix

Recognize a **leading clean affirmation** — a first sentence stating "no violations/deviations" — as clean even when it cites an invariant/guideline id in that same sentence. A note that leads with a violation statement (e.g. `I-Gate-1 is violated: ...`) still classifies as non-clean, and `"violates"` (verb) does not trip the affirmation, so genuine-violation detection is preserved.

The fix is one condition in the shared `classify_assessment_prose`, so it covers both the invariant and guideline classifiers and every consumer: the compatibility aliases and the `_validate_authored_outcome` write-path consistency gate.

## Tests

- `test_invariant_assessment_kind_tolerates_verbose_clean_notes`: added the issue's three regression cases — a single-sentence clean note that references an `I-*` id, a non-canonical clean phrasing, and a multi-id clean note — plus a violation-leading note that must stay `violation`.
- `test_explicit_clean_accepts_inline_clean_lead_with_invariant_id`: proves the write path (`write_invariant_staged_assessment`, `outcome=clean`) no longer rejects the issue's exact note.

Local: `test_architectural_guidelines.py` (387) + `test_ship.py` + `test_architectural_assessment.py` (15) pass; `ruff` and `pyright` clean on both changed files.

Closes #6955

🤖 Generated with [Claude Code](https://claude.com/claude-code)
