### PR TITLE
Release v52.6.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.5.33",
+  "version": "52.6.0",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Added

- Add an explicit outcome field to architectural assessment notes. ([#6963](https://github.com/character-ai/larch/pull/6963))

## Changed

- Enhance `/learn-from-bugs`. ([#6958](https://github.com/character-ai/larch/pull/6958))

## Fixed

- Stop `/implement`'s CI fixer from orphaning correct uncommitted edits as no-progress. ([#6962](https://github.com/character-ai/larch/pull/6962))
- Stop `/implement`'s invariant gate from misclassifying a clean assessment note as a violation. ([#6964](https://github.com/character-ai/larch/pull/6964))
