### PR TITLE
Release v52.6.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.6.0",
+  "version": "52.6.1",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Added

- Prefix-literal lints now cover composition positions and prompt/script case variants. ([#6980](https://github.com/character-ai/larch/pull/6980))

## Fixed

- `learn-from-bugs` no longer degrades `####`-sectioned bug bodies to truncated text during digesting. ([#6966](https://github.com/character-ai/larch/pull/6966))
- `/implement`'s final report now renders failures loudly instead of silently after merge. ([#6984](https://github.com/character-ai/larch/pull/6984))
- The architectural assessment adapter no longer stalls PR creation permanently after a transient empty-stdout result. ([#6985](https://github.com/character-ai/larch/pull/6985))
