### PR TITLE
Fixes #6995: feed dispatcher manifest, not run-log manifest, to final-report coverage validator

### DIFF
--- a/python/larch/report/final_report.py
+++ b/python/larch/report/final_report.py
@@ -877,9 +877,13 @@ def write_final_report(
         ship=ship,
         final=final,
     )
-    plan_coverage_line = _plan_coverage_summary_line_or_empty(
-        implement_tmpdir, manifest_path=run_dir / "manifest.json"
-    )
+    # #6995: pass manifest_path=None so the coverage line resolves the
+    # *dispatcher* manifest (implement_tmpdir/manifest.json, which carries
+    # todos_left), not run_dir/manifest.json, which is the run-log manifest
+    # and legitimately omits todos_left. Feeding the run-log manifest to the
+    # scope-disposition validator raised "resolved manifest schema-invalid"
+    # and aborted the whole report.
+    plan_coverage_line = _plan_coverage_summary_line_or_empty(implement_tmpdir)
     summary_body = pr_body.render_run_summary(
         skill="implement",
         outcome=outcome,

--- a/python/tests/report/test_final_report.py
+++ b/python/tests/report/test_final_report.py
@@ -1357,3 +1357,49 @@ def test_plan_coverage_summary_stale_mismatch_propagates_invalid_persisted_cover
 
     with pytest.raises(ShipError, match="unreadable or malformed"):
         _ = final_report._plan_coverage_summary_line(tmp_path)
+
+
+def test_write_final_report_coverage_line_not_fed_run_log_manifest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Coverage line reads the dispatcher manifest, not the run-log manifest (#6995).
+
+    The run-log manifest (larch-logs/implement/<RUN_ID>/manifest.json) legitimately
+    omits todos_left; feeding it to the scope-disposition validator raises
+    'resolved manifest schema-invalid' and aborts the whole final report. The
+    render must let resolve_implement_manifest find the dispatcher manifest
+    (implement_tmpdir/manifest.json), which carries todos_left.
+    """
+    _write_minimal_state(tmp_path)
+    run_dir = tmp_path / "larch-logs" / "implement" / "run1"
+    run_dir.mkdir(parents=True)
+    (run_dir / "manifest.json").write_text(
+        json.dumps({"schema_version": 2, "status": "partial"}),  # no todos_left
+        encoding="utf-8",
+    )
+    (tmp_path / "session-env.sh").write_text(
+        f"REPO=o/r\nMODE=N/A\nREPO_ROOT={tmp_path}\n",
+        encoding="utf-8",
+    )
+    _stub_cost_and_assessment(monkeypatch)
+
+    seen_manifest_paths: list[object] = []
+
+    def fake_load_live_coverage(
+        *, tmpdir: Path, repo_root: Path, manifest_path: Path | None = None
+    ) -> None:
+        _ = tmpdir, repo_root
+        seen_manifest_paths.append(manifest_path)
+        # Mimic _load_manifest_todos_raw: the run-log manifest has no
+        # todos_left, so it is schema-invalid for the coverage validator.
+        if manifest_path is not None and manifest_path == run_dir / "manifest.json":
+            raise ShipError(f"resolved manifest schema-invalid: {manifest_path}")
+
+    monkeypatch.setattr(scope_disposition, "load_live_coverage", fake_load_live_coverage)
+
+    rc, _url, _err = final_report.write_final_report(tmp_path, comment_only=True)
+
+    assert rc == 0
+    assert run_dir / "manifest.json" not in seen_manifest_paths
+    summary = (tmp_path / "summary-final.md").read_text(encoding="utf-8")
+    assert "## /implement run run1" in summary


### PR DESCRIPTION
Fixes #6995

## Root cause

`write_final_report` passed `run_dir / "manifest.json"` (the **run-log** manifest, `larch-logs/implement/<RUN_ID>/manifest.json`) into `_plan_coverage_summary_line_or_empty`. That call chain reaches `_load_manifest_todos_raw`, which requires `todos_left` to be a list — a **dispatcher**-manifest field. The run-log manifest legitimately never carries `todos_left` (no writer in `run_log_manifest.py` emits it), so the validator raised `resolved manifest schema-invalid` and the error escaped the render's graceful-degradation wrapper (it only catches the exact stale-live-mismatch string). The whole final report aborted before `summary-final.md` was written.

## Why the three prior fixes did not work

- **#6908** added graceful degradation for the post-merge stale-live-coverage fingerprint drift — catches only `_STALE_LIVE_COVERAGE_MISMATCH`.
- **#6947** made the coverage line non-fatal, but reused the same single-string filter, so a non-stale failure still escaped.
- **#6979** made the failure loud (preserved `ERROR=`, printed the warning). Its own commit message admits the #6947 fix could not prevent a different `write_final_report` failure from vanishing the same way.

Each added a string-specific band-aid around `_plan_coverage_summary_line`. None corrected the wrong manifest argument, so the `schema-invalid` path still aborted the report.

## Fix

Pass `manifest_path=None` so `resolve_implement_manifest(implement_tmpdir, None)` resolves the **dispatcher** manifest (`implement_tmpdir/manifest.json`, which carries `todos_left`) — the schema the validator was designed for.

This is robust on every path:
- **live / post-merge**: dispatcher manifest present → valid `todos_left` → post-merge fingerprint drift degrades the optional coverage line to empty (the existing #6908/#6947 path).
- **post-hoc re-render** (`run_log_flush` → `write_final_report` with no dispatcher manifest): `resolve_implement_manifest` returns `None` → no todos read → coverage line degrades to empty.

The fail-closed `todos_left` contract for the dispatcher manifest (`test_validate_manifest_todos_schema_invalid_fails_closed`) is unchanged — this does **not** weaken the validator; it stops feeding it the wrong manifest.

## Test

New regression `test_write_final_report_coverage_line_not_fed_run_log_manifest` reproduces #6995: a run-log manifest without `todos_left` is no longer fed to the coverage validator, and `write_final_report` renders instead of aborting. Verified it fails on the pre-fix code with the exact `resolved manifest schema-invalid` error and passes with the fix.

## Test plan
- [x] `python3 -m pytest python/tests/report/test_final_report.py`
- [x] `python3 -m pytest python/tests/implement/test_scope_disposition.py`
- [x] `make py-lint`
