### PR TITLE
Release v52.6.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.6.1",
+  "version": "52.6.2",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Added

- Bug-fix close criteria for the bug treadmill: harness repro plus class-coverage review.
- Chronic-zone analytics and a risk-routed deep queue for analyze-bugs.
- Proposal adoption tracking for learn-from-bugs.

## Fixed

- final-report rendering when the run-log manifest is missing `todos_left` fed to the scope-disposition validator.
