### PR TITLE
chore(agnix-fix): drop stale persist-post-plan-keys ref

### DIFF
--- a/.claude/skills/agnix-fix/SKILL.md
+++ b/.claude/skills/agnix-fix/SKILL.md
@@ -28,7 +28,7 @@ This skill forwards to `/implement` (`skills/implement/SKILL.md`). Parse exit co
 | Code | Meaning |
 |------|---------|
 | **0** | Normal completion of the scripted path for that attempt. |
-| **2** | Operator-visible hard errors (argv, missing/malformed `larch:plan`, `gh` / plan helpers, `persist-post-plan-keys` / related validation, etc.). |
+| **2** | Operator-visible hard errors (argv, missing/malformed `larch:plan`, `gh` / plan helpers, etc.). |
 | **3** | **Preflight audit refused** — terminal for this attempt until upstream work resolves the plan/clarify state. On the normal clarify path, the operator must run `/design <N>` before retrying `/implement`. When `STATE=ambiguous` from `python3 "${CLAUDE_PLUGIN_ROOT}/python/cli.py" clarify state`, Preflight exits **3** **before** posting or labeling; the thread must be repaired manually — exit **3** does **not** imply a new clarify request was posted. |
 
 Do not treat every non-zero exit as a blind retry; route **3** back through `/design` / manual clarify repair, not generic re-invocation of `/implement` with the same inputs.


### PR DESCRIPTION
# Follow-up to #7051: last stale `persist-post-plan-keys` reference

`scripts/persist-post-plan-keys.sh` was removed during the v36→v52 contract-unification migration (#7051 cleaned the `AGENTS.md:67` pointer). This PR removes the final illustrative mention: the `agnix-fix` exit-code table listed `persist-post-plan-keys` / related validation as an exit-2 error source, but the script no longer exists.

## Change

- `.claude/skills/agnix-fix/SKILL.md:31` — drop `persist-post-plan-keys / related validation` from the exit-2 examples (dev-only skill).

After this, `persist-post-plan-keys` survives only in historical `larch-logs/` transcripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
