### PR TITLE
Release v52.7.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.7.0",
+  "version": "52.7.1",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Changed

- Unified plan-format ownership under a single owner, `plan_grammar.py`. ([#7048](https://github.com/character-ai/larch/pull/7048))
- Removed operator questions from the issue partitioning process. ([#7049](https://github.com/character-ai/larch/pull/7049))
- Removed the dead `design-step5` wrapper and a stale AGENTS pointer. ([#7051](https://github.com/character-ai/larch/pull/7051))
- Removed a stale `persist-post-plan-keys` reference. ([#7065](https://github.com/character-ai/larch/pull/7065))
