### PR TITLE
Release v52.8.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.7.1",
+  "version": "52.8.0",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Added

- Add a Testkit foundation: shared paths, runners, and process stubs for plugin tests. (#7085)
- Add `/triage`: root-cause, verify, and update an issue to design-ready before `/design` runs. (#7096)

## Changed

- Unify repo-resolution logic onto `gh.resolve_repo`. (#7090)
- Mandate `run_log_corpus` for run-log scanners. (#7093)
- Unify `larch:plan` marker ownership in issue-wire handling. (#7095)

## Fixed

- Fix `review-and-fix commit-fixes --stage-all` exiting 1 when review-delta paths are clean and only regenerated baselines are dirty. (#7087)
- Fix a CI fixer lane crash after a post-reship lineage: a stale `fixer-rounds.tsv` tripped the foreign-identity guard. (#7089)
- Fix `/implement` operator-bail recovery leaving the final report wrong, the manifest mid-update, and the terminal emit lost. (#7091)
- Fix the Codex version-gate check: it now surfaces in Step 0 and `/status` instead of passing silently while launches fail on old CLI versions. (#7092)
- Fix architectural assessment returning "unavailable" with an empty diagnostic detail field. (#7094)
