### PR TITLE
Release v52.8.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.8.0",
+  "version": "52.8.1",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Added

- Add `issue_list_read` and issue close/view/edit wrappers to `gh.py`. (#7102)
- Add the core scan pipeline: models, discovery, source load, and detect. (#7110)

## Changed

- Extend `plan_grammar.py` with a `TRAILER_KEYS`-derived preflight regex, promised consumer tests, and fence-state consolidation. (#7105)
- Complete deferred `/implement` plan work. (#7112)
- Mark the salvage provenance spoofing report as out of scope. (#7103)
- Mark plan marker grammar bypass unification as out of scope. (#7104)

## Fixed

- Fix architectural assessment lacking a fallback waterfall for transient tool failures. (#7106)
