### PR TITLE
Fixes #7111: Add [TRIAGED] title prefix after successful triage

### DIFF
--- a/python/larch/issue/triage.py
+++ b/python/larch/issue/triage.py
@@ -16,6 +16,7 @@ from urllib.parse import urlparse
 from larch.core import proc, redact
 from larch.core.proc import CommandResult, Runner
 from larch.git import gh
+from larch.issue.title_match import BUG_PREFIX
 from larch.state.session_env import check_live_mutation_auth
 
 EXIT_USAGE: Final = 2
@@ -42,6 +43,8 @@ _LIFECYCLE_PREFIX_RE: Final = re.compile(
     r"^\[(?:IMPLEMENTING|DONE|DESIGNING|DESIGNED|STALLED|IN PROGRESS|PLANNED)\]\s+",
     re.IGNORECASE,
 )
+_BUG_PREFIX_RE: Final = re.compile(r"^" + re.escape(BUG_PREFIX) + r"\s*", re.IGNORECASE)
+_TRIAGED_MARKER_RE: Final = re.compile(r"\[TRIAGED\]", re.IGNORECASE)
 _PROTECTED_MARKER_RE: Final = re.compile(r"<!--\s*larch:", re.IGNORECASE)
 _SECURITY_RE: Final = re.compile(
     r"\b(?:credential(?:s)?|secret(?:s)?|api[ -]?key|auth(?:entication|orization)? bypass|"
@@ -392,6 +395,16 @@ def _read_after_mutation(
     return current
 
 
+def _triaged_title(title: str) -> str:
+    """Return title with [TRIAGED] inserted after [BUG] prefix, or prepended."""
+    if _TRIAGED_MARKER_RE.search(title):
+        return title
+    match = _BUG_PREFIX_RE.match(title)
+    if match:
+        return f"{BUG_PREFIX} [TRIAGED] {title[match.end():]}"
+    return f"[TRIAGED] {title}"
+
+
 def _valid_apply(
     runner: Runner,
     *,
@@ -402,7 +415,8 @@ def _valid_apply(
 ) -> IssueSnapshot:
     block = sanitize_outbound(artifact_text, allow_triage_block=True)
     new_body = _replace_triage_block(snapshot.body, block)
-    if new_body == snapshot.body:
+    new_title = _triaged_title(snapshot.title)
+    if new_body == snapshot.body and new_title == snapshot.title:
         return snapshot
     snapshot = _recheck_valid_snapshot(
         runner, snapshot=snapshot, issue=issue, repo=repo
@@ -411,7 +425,8 @@ def _valid_apply(
         runner,
         str(issue),
         repo=repo,
-        body=new_body,
+        title=new_title if new_title != snapshot.title else None,
+        body=new_body if new_body != snapshot.body else None,
     )
     if body_result.returncode != 0:
         raise TriageError(
@@ -421,7 +436,7 @@ def _valid_apply(
     current = _read_after_mutation(runner, issue=issue, repo=repo, previous=snapshot)
     if (
         current.body != new_body
-        or current.title != snapshot.title
+        or current.title != new_title
         or current.state != "OPEN"
     ):
         raise TriageError(

--- a/python/tests/issue/test_triage.py
+++ b/python/tests/issue/test_triage.py
@@ -101,6 +101,7 @@ def test_valid_apply_preserves_original_and_verifies_readback(
         "Original report\n\n<!-- larch:triage:start -->\n"
         "## Summary\n\nCorrected diagnosis.\n<!-- larch:triage:end -->\n"
     )
+    expected_title = "[TRIAGED] Bug report"
 
     def fake_run(argv: list[str], **_: object) -> proc.CommandResult:
         nonlocal calls
@@ -111,11 +112,17 @@ def test_valid_apply_preserves_original_and_verifies_readback(
             return _result(argv, stdout=_snapshot())
         if calls == 5:
             assert argv[:4] == ["gh", "issue", "edit", "7"]
+            assert "--title" in argv
+            assert argv[argv.index("--title") + 1] == expected_title
             assert Path(argv[-1]).read_text(encoding="utf-8") == expected_body
             return _result(argv)
         return _result(
             argv,
-            stdout=_snapshot(body=expected_body, updated_at="2026-07-12T10:00:01Z"),
+            stdout=_snapshot(
+                body=expected_body,
+                title=expected_title,
+                updated_at="2026-07-12T10:00:01Z",
+            ),
         )
 
     monkeypatch.setattr(triage.proc, "run", fake_run)
@@ -140,6 +147,75 @@ def test_valid_apply_preserves_original_and_verifies_readback(
     assert "TRIAGE_VERDICT=valid" in output
     assert "ISSUE_UPDATED=true" in output
     assert "UPDATED_AT=2026-07-12T10:00:01Z" in output
+
+
+def test_valid_apply_bug_prefix_title_gets_triaged_infix(
+    monkeypatch: Any,
+    capsys: Any,
+    triage_root: Path,
+) -> None:
+    body_file = triage_root / "body.md"
+    body_file.write_text("## Summary\n\nRoot cause.", encoding="utf-8")
+    calls = 0
+    expected_body = (
+        "Original report\n\n<!-- larch:triage:start -->\n"
+        "## Summary\n\nRoot cause.\n<!-- larch:triage:end -->\n"
+    )
+    expected_title = "[BUG] [TRIAGED] Crash on startup"
+
+    def fake_run(argv: list[str], **_: object) -> proc.CommandResult:
+        nonlocal calls
+        calls += 1
+        if argv[:3] == ["gh", "api", "/repos/owner/repo/issues/7/comments"]:
+            return _result(argv, stdout="[]")
+        if calls in {1, 3}:
+            return _result(argv, stdout=_snapshot(title="[BUG] Crash on startup"))
+        if calls == 5:
+            assert "--title" in argv
+            assert argv[argv.index("--title") + 1] == expected_title
+            return _result(argv)
+        return _result(
+            argv,
+            stdout=_snapshot(
+                body=expected_body,
+                title=expected_title,
+                updated_at="2026-07-12T10:00:01Z",
+            ),
+        )
+
+    monkeypatch.setattr(triage.proc, "run", fake_run)
+    rc = triage.apply_main(
+        [
+            "7",
+            "--repo",
+            "owner/repo",
+            "--verdict",
+            "valid",
+            "--expected-updated-at",
+            "2026-07-12T10:00:00Z",
+            "--triage-root",
+            str(triage_root),
+            "--body-file",
+            str(body_file),
+            "--operator-invoked",
+        ],
+    )
+    assert rc == 0
+    assert "ISSUE_UPDATED=true" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    ("title", "expected"),
+    [
+        ("[BUG] Crash on startup", "[BUG] [TRIAGED] Crash on startup"),
+        ("[BUG]  Extra space", "[BUG] [TRIAGED] Extra space"),
+        ("Plain issue", "[TRIAGED] Plain issue"),
+        ("[BUG] [TRIAGED] Already done", "[BUG] [TRIAGED] Already done"),
+        ("[TRIAGED] Already done", "[TRIAGED] Already done"),
+    ],
+)
+def test_triaged_title(title: str, expected: str) -> None:
+    assert triage._triaged_title(title) == expected  # pyright: ignore[reportPrivateUsage]
 
 
 def test_stale_snapshot_refuses_before_mutation(
@@ -347,7 +423,7 @@ def test_valid_apply_reports_a_verified_noop(monkeypatch: Any, capsys: Any, tria
         calls.append(argv)
         if argv[:3] == ["gh", "api", "/repos/owner/repo/issues/7/comments"]:
             return _result(argv, stdout="[]")
-        return _result(argv, stdout=_snapshot(body=existing_body))
+        return _result(argv, stdout=_snapshot(body=existing_body, title="[TRIAGED] Bug report"))
 
     monkeypatch.setattr(triage.proc, "run", fake_run)
     assert triage.apply_main([


### PR DESCRIPTION
## Summary

- `_valid_apply` now computes `new_title` via `_triaged_title()` and passes it to `gh.issue_edit` alongside the body update
- `[BUG] Some issue` → `[BUG] [TRIAGED] Some issue`; any other title → `[TRIAGED] <title>`
- Idempotent: if `[TRIAGED]` is already present the title is unchanged
- Uses `BUG_PREFIX` from `title_match` to satisfy the `lifecycle-prefix-literal` lint rule

## Test plan

- [x] `test_valid_apply_preserves_original_and_verifies_readback` — updated to assert `--title "[TRIAGED] Bug report"` in edit call and read-back
- [x] `test_valid_apply_bug_prefix_title_gets_triaged_infix` — new: verifies `[BUG] Crash on startup` → `[BUG] [TRIAGED] Crash on startup`
- [x] `test_triaged_title` — parametrized unit test for the helper covering both prefix cases and the idempotent no-op
- [x] `test_valid_apply_reports_a_verified_noop` — updated: snapshot uses `[TRIAGED]` title so both body and title are already in target state
- [x] All 38 triage tests pass; pylint 10/10; pyright clean

Closes #7111

🤖 Generated with [Claude Code](https://claude.com/claude-code)
