### PR TITLE
Fixes #7109: fall back to IMPLEMENT_TMPDIR env when --tmpdir expands empty

### DIFF
--- a/python/larch/implement/checks_lint_fix.py
+++ b/python/larch/implement/checks_lint_fix.py
@@ -227,7 +227,7 @@ def checks_lint_fix_main(argv: list[str] | None = None) -> int:
     _ = parser.add_argument("--repo-root", default="")
     _ = parser.add_argument("--run-parent", default="")
     args = parser.parse_args(argv)
-    canonical_tmp = validate_tmpdir(args.tmpdir)
+    canonical_tmp = validate_tmpdir(args.tmpdir or os.environ.get("IMPLEMENT_TMPDIR", ""))
     if canonical_tmp is None:
         print("LINT_FIX_STATUS=failed")
         print("FAILURE_REASON=tmpdir-validation")
@@ -350,7 +350,7 @@ def checks_repair_loop_main(argv: list[str] | None = None) -> int:  # noqa: PLR0
     _ = parser.add_argument("--checks-log", required=True)
     _ = parser.add_argument("--repo-root", default="")
     args = parser.parse_args(argv)
-    canonical_tmp = validate_tmpdir(args.tmpdir)
+    canonical_tmp = validate_tmpdir(args.tmpdir or os.environ.get("IMPLEMENT_TMPDIR", ""))
     if canonical_tmp is None:
         print("NEXT_ACTION=stall")
         print("LOOP_STATUS=tmpdir-validation")
@@ -456,7 +456,7 @@ def checks_self_edit_log_main(argv: list[str] | None = None) -> int:
     _ = parser.add_argument("--path", default="")
     _ = parser.add_argument("--repo-root", default="")
     args = parser.parse_args(argv)
-    canonical_tmp = validate_tmpdir(args.tmpdir)
+    canonical_tmp = validate_tmpdir(args.tmpdir or os.environ.get("IMPLEMENT_TMPDIR", ""))
     if canonical_tmp is None:
         print("SELF_EDIT_LOG_STATUS=tmpdir-validation")
         return 2

--- a/python/larch/implement/checks_lint_fix.py
+++ b/python/larch/implement/checks_lint_fix.py
@@ -227,7 +227,7 @@ def checks_lint_fix_main(argv: list[str] | None = None) -> int:
     _ = parser.add_argument("--repo-root", default="")
     _ = parser.add_argument("--run-parent", default="")
     args = parser.parse_args(argv)
-    canonical_tmp = validate_tmpdir(args.tmpdir or os.environ.get("IMPLEMENT_TMPDIR", ""))
+    canonical_tmp = validate_tmpdir(args.tmpdir or os.environ.get(config.ENV_IMPLEMENT_TMPDIR, ""))
     if canonical_tmp is None:
         print("LINT_FIX_STATUS=failed")
         print("FAILURE_REASON=tmpdir-validation")
@@ -350,7 +350,7 @@ def checks_repair_loop_main(argv: list[str] | None = None) -> int:  # noqa: PLR0
     _ = parser.add_argument("--checks-log", required=True)
     _ = parser.add_argument("--repo-root", default="")
     args = parser.parse_args(argv)
-    canonical_tmp = validate_tmpdir(args.tmpdir or os.environ.get("IMPLEMENT_TMPDIR", ""))
+    canonical_tmp = validate_tmpdir(args.tmpdir or os.environ.get(config.ENV_IMPLEMENT_TMPDIR, ""))
     if canonical_tmp is None:
         print("NEXT_ACTION=stall")
         print("LOOP_STATUS=tmpdir-validation")
@@ -456,7 +456,7 @@ def checks_self_edit_log_main(argv: list[str] | None = None) -> int:
     _ = parser.add_argument("--path", default="")
     _ = parser.add_argument("--repo-root", default="")
     args = parser.parse_args(argv)
-    canonical_tmp = validate_tmpdir(args.tmpdir or os.environ.get("IMPLEMENT_TMPDIR", ""))
+    canonical_tmp = validate_tmpdir(args.tmpdir or os.environ.get(config.ENV_IMPLEMENT_TMPDIR, ""))
     if canonical_tmp is None:
         print("SELF_EDIT_LOG_STATUS=tmpdir-validation")
         return 2

--- a/python/skill-closure-baseline.json
+++ b/python/skill-closure-baseline.json
@@ -41,8 +41,8 @@
     "closure_content_estimated_tokens": 46303,
     "closure_estimated_tokens": 46423,
     "closure_lines": 1341,
-    "conditional_content_estimated_tokens": 24330,
-    "conditional_estimated_tokens": 24388,
+    "conditional_content_estimated_tokens": 24341,
+    "conditional_estimated_tokens": 24399,
     "conditional_files": [
       "skills/implement/references/extracted-script-registry.md",
       "skills/implement/references/bootstrap-recovery.md",

--- a/python/tests/implement/test_checks.py
+++ b/python/tests/implement/test_checks.py
@@ -4768,6 +4768,36 @@ def test_checks_repair_loop_main_validation_failure_emits_stall(
     assert "LOOP_STATUS=tmpdir-validation" in out
 
 
+def test_checks_repair_loop_main_empty_tmpdir_falls_back_to_env(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # A fresh Bash block expands an unset $IMPLEMENT_TMPDIR to an empty --tmpdir
+    # argument. The stable launcher exports IMPLEMENT_TMPDIR to this process, so
+    # the entrypoint must fall back to the env var instead of stalling at
+    # LOOP_STATUS=tmpdir-validation. Progression to the next validation gate
+    # (checks-site-validation) proves the env fallback resolved the tmpdir.
+    session = _checks_session(tmp_path, monkeypatch)
+    monkeypatch.setenv("IMPLEMENT_TMPDIR", str(session))
+    rc = checks.checks_repair_loop_main([
+        "--tmpdir",
+        "",
+        "--site",
+        "step6",
+        "--checks-site",
+        "../bad",
+        "--checks-log",
+        str(session / "initial.redacted.log"),
+        "--repo-root",
+        str(tmp_path),
+    ])
+    out = capsys.readouterr().out
+    assert rc == 2
+    assert "LOOP_STATUS=checks-site-validation" in out
+    assert "LOOP_STATUS=tmpdir-validation" not in out
+
+
 def test_checks_repair_loop_main_rejects_invalid_checks_site(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/skills/implement/references/checks-repair-loop.md
+++ b/skills/implement/references/checks-repair-loop.md
@@ -20,7 +20,7 @@ Then route to the default stall semantics in section 4: set `STALL_TRACKING=true
 When `REDACTED_LOG_FILE` is present, run:
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT}/python/cli.py" checks repair-loop --tmpdir "$IMPLEMENT_TMPDIR" --site <lint-site> [--checks-site <capture-site>] --checks-log "$REDACTED_LOG_FILE"
+"$HOME/.cache/larch/sessions/implement-run-$PPID.sh" python/cli.py checks repair-loop --tmpdir "$IMPLEMENT_TMPDIR" --site <lint-site> [--checks-site <capture-site>] --checks-log "$REDACTED_LOG_FILE"
 ```
 
 Bind and reuse the pinned site pair for every invocation in section 4, including post-main-agent re-entries:
@@ -125,7 +125,7 @@ The `checks repair-loop` lint-fix tiers and the Step 3 pre-commit ruff autofix e
 Before concluding that a tracked file which changed between two of your own actions was touched by a concurrent or external runner — and before halting or asking the operator about a parallel session on that basis — consult the log:
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT}/python/cli.py" checks self-edit-log show --tmpdir "$IMPLEMENT_TMPDIR" --path <changed-path> --repo-root "$(git rev-parse --show-toplevel)"
+"$HOME/.cache/larch/sessions/implement-run-$PPID.sh" python/cli.py checks self-edit-log show --tmpdir "$IMPLEMENT_TMPDIR" --path <changed-path> --repo-root "$(git rev-parse --show-toplevel)"
 ```
 
 - `SELF_EDIT_ATTRIBUTED=true`: one of this run's own spawned subprocesses changed that path. Do not treat it as an external edit and do not halt for a concurrent runner on that path.


### PR DESCRIPTION
Closes #7109

## Problem

`checks repair-loop` stalled at `LOOP_STATUS=tmpdir-validation` (exit 2) when the stable-launcher invocation `--tmpdir "$IMPLEMENT_TMPDIR"` expanded to an empty string in a fresh Bash block (`$IMPLEMENT_TMPDIR` is unset there). `validate_tmpdir("")` returns `None`, so the loop printed `NEXT_ACTION=stall` and exited before attempting any repair. The stall classifier then saw the original check `EXIT_CODE=1` and classified as `contract-failure` / `RESUME_HINT=none`, forcing a terminal stall for a run that had a trivially fixable lint failure.

The same empty-arg hazard existed in the sibling `lint-fix` and `self-edit-log` entrypoints.

## Fix

- **`checks_lint_fix.py`** — in `checks_repair_loop_main`, `checks_lint_fix_main`, and `checks_self_edit_log_main`, fall back to `os.environ.get("IMPLEMENT_TMPDIR", "")` when `args.tmpdir` is empty. The stable launcher (`implement-run-$PPID.sh`) exports `IMPLEMENT_TMPDIR` to its child process, so the env var rescues launcher-mediated calls. Mirrors the `checks_run_relevant_main` argparse default at `checks_run_relevant.py:1404`.
- **`checks-repair-loop.md`** — switch the documented `repair-loop` and `self-edit-log show` fences to the stable-launcher form (`"$HOME/.cache/larch/sessions/implement-run-$PPID.sh" python/cli.py ...`), matching the existing `recovery-paths` fence in the same file. This carries a valid tmpdir in a fresh Bash block.
- **`test_checks.py`** — add `test_checks_repair_loop_main_empty_tmpdir_falls_back_to_env`, which proves the fallback resolves the tmpdir by showing the loop progresses past tmpdir-validation to the next gate (`checks-site-validation`).

## Verification

- `ruff check` on changed Python files: pass
- `pyright` on `checks_lint_fix.py`: 0 errors
- `pytest python/tests/implement/test_checks.py`: 163 passed
- `markdownlint` on the changed doc: pass

## Scope note

The issue's secondary suggestion (route `LOOP_STATUS=tmpdir-validation` to a transient/infra classifier class instead of inheriting `contract-failure`) is intentionally deferred: the primary env-fallback makes `tmpdir-validation` unreachable in normal launcher-mediated flows, and the issue marks the classifier change "verify during /design". Tracing the `_classify.py` trigger conditions is out of scope for this surgical fix.
