### PR TITLE
Fixes #7108: Strip markdown code fences before parsing assessment JSON

### DIFF
--- a/python/larch/implement/architectural_assessment.py
+++ b/python/larch/implement/architectural_assessment.py
@@ -31,6 +31,8 @@ _DIFF_HEADER_RE: Final = re.compile(r"^diff --git a/(\S+) b/(\S+)$")
 _IDENTIFIER_RE: Final = re.compile(r"^#{1,6}\s+((?:I|G)-[A-Za-z0-9-]+-\d+):", re.MULTILINE)
 _COMMIT_RE: Final = re.compile(r"^[0-9a-f]{40}$")
 _BASE_REF_RE: Final = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]*$")
+_FENCE_OPEN_RE: Final = re.compile(r"^`{3,}[A-Za-z0-9]*$")
+_FENCE_CLOSE_RE: Final = re.compile(r"^`{3,}$")
 _REAUTHOR_REASONS: Final[frozenset[str]] = frozenset({
     config.ASSESSMENT_REAUTHOR_REASON_INVALID_OUTCOME,
     config.ASSESSMENT_REAUTHOR_REASON_CLEAN_MISMATCH,
@@ -651,11 +653,30 @@ def _parse_result_row(  # noqa: C901 - strict schema validation checks each inde
     return AssessmentResult(kind, state, assessment, identifiers, evidence.head_sha, evidence.base_ref, evidence.diff_fingerprint, evidence.knowledge_sha256)
 
 
+def _strip_json_fence(raw: str) -> str:
+    """Strip one optional Markdown code fence wrapping a JSON payload.
+
+    A launcher may enclose its JSON envelope in a Markdown code fence: an
+    opening triple-backtick line (optionally tagged json) and a closing
+    triple-backtick line. Drop the leading fence line and the matching closing
+    fence line, plus any trailing prose after it, so json.loads sees the
+    enclosed payload. Input without a leading fence line is returned unchanged,
+    so non-fenced prose and truncated objects still fail closed in the caller.
+    """
+    lines = raw.strip().splitlines()
+    if not lines or _FENCE_OPEN_RE.fullmatch(lines[0].strip()) is None:
+        return raw
+    for index, line in enumerate(lines[1:], start=1):
+        if _FENCE_CLOSE_RE.fullmatch(line.strip()) is not None:
+            return "\n".join(lines[1:index]).strip()
+    return raw
+
+
 def _parse_results(  # type: ignore[reportUnusedFunction]  # reason: internal helper
     raw: str, evidences: Sequence[MaterializedEvidence]
 ) -> tuple[AssessmentResult, ...]:
     try:
-        decoded: object = json.loads(raw)
+        decoded: object = json.loads(_strip_json_fence(raw))
     except json.JSONDecodeError as exc:
         raise ValueError("assessment output is not exactly one JSON object") from exc
     if not isinstance(decoded, dict):
@@ -699,7 +720,7 @@ def _parse_results_independently(
 ) -> tuple[tuple[AssessmentResult, ...], dict[str, str]]:
     """Return valid result rows while isolating malformed or omitted kinds."""
     try:
-        decoded: object = json.loads(raw)
+        decoded: object = json.loads(_strip_json_fence(raw))
         if not isinstance(decoded, dict) or set(cast("dict[str, object]", decoded).keys()) != {"schema_version", "results"} or str(decoded.get("schema_version")) != "1":  # type: ignore[reportUnknownArgumentType, reportUnknownMemberType]  # reason: decoded is object from json.loads
             raise ValueError("assessment output envelope is invalid")
         rows = decoded.get("results")  # type: ignore[reportUnknownMemberType]  # reason: decoded is object from json.loads

--- a/python/tests/implement/test_architectural_assessment.py
+++ b/python/tests/implement/test_architectural_assessment.py
@@ -149,6 +149,40 @@ def test_parse_results_independently_rejects_unknown_extra_row() -> None:
     assert set(invalid) == {"guidelines"}
 
 
+def test_strip_json_fence_unwraps_optional_markdown_fence() -> None:
+    payload = '{"schema_version": "1", "results": []}'
+    assert assessment._strip_json_fence(f"```json\n{payload}\n```") == payload  # pyright: ignore[reportPrivateUsage]
+    assert assessment._strip_json_fence(f"```\n{payload}\n```") == payload  # pyright: ignore[reportPrivateUsage]
+    assert assessment._strip_json_fence(f"```json\n{payload}\n```\ntrailing note") == payload  # pyright: ignore[reportPrivateUsage]
+    assert assessment._strip_json_fence(payload) == payload  # pyright: ignore[reportPrivateUsage]
+    assert assessment._strip_json_fence("prose, not a fence") == "prose, not a fence"  # pyright: ignore[reportPrivateUsage]
+
+
+def test_parse_results_accepts_markdown_fenced_envelope() -> None:
+    invariant = _evidence(config.ASSESSMENT_KIND_INVARIANTS)
+    guideline = _evidence()
+    fenced = "```json\n" + _payload([invariant, guideline]) + "\n```"
+    parsed = assessment._parse_results(fenced, [guideline, invariant])  # pyright: ignore[reportPrivateUsage]
+    assert [row.kind for row in parsed] == ["invariants", "guidelines"]
+
+
+def test_parse_results_independently_accepts_fenced_json_with_trailing_prose() -> None:
+    evidence = _evidence()
+    fenced = "```json\n" + _payload([evidence]) + "\n```\nThat completes the review."
+    parsed, invalid = assessment._parse_results_independently(fenced, [evidence])  # pyright: ignore[reportPrivateUsage]
+    assert [row.kind for row in parsed] == ["guidelines"]
+    assert not invalid
+
+
+def test_parse_results_independently_rejects_unfenced_prose() -> None:
+    evidence = _evidence()
+    parsed, invalid = assessment._parse_results_independently(  # pyright: ignore[reportPrivateUsage]
+        "Here is my assessment: everything looks clean.", [evidence]
+    )
+    assert not parsed
+    assert set(invalid) == {"guidelines"}
+
+
 def test_prompt_evidence_paths_must_stay_under_granted_root(tmp_path: Path) -> None:
     evidence_dir = tmp_path / "evidence"
     evidence_dir.mkdir()
@@ -439,6 +473,23 @@ def test_waterfall_retries_invalid_json_then_stops_on_valid_deviation(monkeypatc
 
     assert result == ("guidelines:deviation",)
     assert (cursor.calls, codex.calls, claude.calls) == (1, 1, 0)
+
+
+def test_waterfall_accepts_markdown_fenced_clean_result(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    evidence = _run_evidence(tmp_path)
+    _stub_materialization(monkeypatch, {evidence.kind: evidence})
+    monkeypatch.setattr(assessment, "_persist_result", _ignore_persisted_result)
+    fenced = "```json\n" + _payload([evidence]) + "\n```"
+    cursor = _SequenceLauncher([assessment.LaunchResult(0, fenced, "")])
+
+    result = assessment.run(
+        kinds=[evidence.kind], repo_root=tmp_path, implement_tmpdir=tmp_path,
+        launchers={"cursor": cursor},
+        availability={"cursor": True, "codex": False, "claude": False},
+    )
+
+    assert result == ("guidelines:clean",)
+    assert cursor.calls == 1
 
 
 def test_waterfall_persists_unavailable_when_all_lanes_are_unavailable(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## What

Step 8's architectural assessment coordinator parsed launcher stdout with `json.loads` and no fence handling. When a lane wrapped its valid clean assessment in a markdown code fence (a triple-backtick opener, optionally tagged `json`, and a triple-backtick closer), the parse raised `Expecting value: line 1 column 1 (char 0)`. Both kinds then persisted `unavailable`, and the ship driver forced an `architectural-assessment-unavailable` operator-bail — discarding a correct assessment and blocking the PR.

Fixes #7108.

## Change

- Add `_strip_json_fence`: drops one optional leading fence line (triple backticks, optionally tagged `json`) and its matching closing fence line, plus any trailing prose after it. Input without a leading fence line is returned unchanged.
- Route both `_parse_results` and `_parse_results_independently` through it before `json.loads`, so the strict and independent parses stay consistent.
- Fail-closed behavior is unchanged: non-fenced prose, truncated JSON, and envelope/identity mismatches still raise, so the lane waterfall keeps advancing on genuinely malformed output.

## Tests

In `python/tests/implement/test_architectural_assessment.py`:
- `_strip_json_fence` unit cases: `json`-tagged fence, bare fence, fence with trailing prose, unfenced passthrough, non-fence passthrough.
- `_parse_results` and `_parse_results_independently` accept fenced envelopes; unfenced prose still fails closed.
- `test_waterfall_accepts_markdown_fenced_clean_result` reproduces the bug end-to-end: a fenced clean payload now yields `guidelines:clean` (was `guidelines:unavailable`).

Confirmed the three fence-dependent tests fail on the pre-fix code and pass after. Full module: 51 passed. `ruff`, `pyright`, and `make py-lint-checks-fast` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
