### PR TITLE
Fixes #7074: needs-user ship handoff no longer rendered as DONE; successful lint-fix no longer branded a Tool Failure

### DIFF
--- a/python/complexity-baseline.json
+++ b/python/complexity-baseline.json
@@ -4311,7 +4311,7 @@
     "file": "larch/report/final_report.py",
     "code": "PLR0915",
     "qualified_symbol": "write_final_report",
-    "metric": 63
+    "metric": 64
   },
   {
     "file": "larch/report/gc_run_logs.py",

--- a/python/larch/git/pr_body.py
+++ b/python/larch/git/pr_body.py
@@ -78,6 +78,31 @@ def _map_outcome_display(outcome: str) -> str:
     return outcome
 
 
+def _needs_user_outcome_display(*, reason: str, next_action: str) -> str:
+    """Distinct outcome for a terminal needs-user ship handoff (#7074).
+
+    A needs-user bail (e.g. architectural assessments unavailable) creates the PR
+    but skips the merge and CI watch. That must not render as ``✅ DONE``.
+    """
+    pending = f"; pending: {next_action}" if next_action else ""
+    return f"⚠️ NEEDS USER — merge and CI watch skipped (reason: {reason}{pending})"
+
+
+def _summary_outcome_display(*, outcome: str, kwargs: Mapping[str, object]) -> str:
+    """Outcome display line for the run summary; distinct on a needs-user handoff (#7074).
+
+    The caller passes ``needs_user_reason`` only when a terminal needs-user ship
+    handoff applies, so its presence alone selects the needs-user display.
+    """
+    needs_user_reason = str(kwargs.get("needs_user_reason") or "")
+    if needs_user_reason:
+        return _needs_user_outcome_display(
+            reason=needs_user_reason,
+            next_action=str(kwargs.get("needs_user_next_action") or ""),
+        )
+    return _map_outcome_display(outcome)
+
+
 def _bounded_warning_detail(text: str) -> str:
     detail = " ".join(text.split()) or "no-output"
     if len(detail) > _WARNING_TAIL_LIMIT:
@@ -675,7 +700,10 @@ def render_run_summary(**kwargs: object) -> str:
     if not run_logs_path and run_id != "unknown" and outcome not in {"failed-publish", "publish-skipped"}:
         run_logs_path = f"larch-logs/{skill}/{run_id}/"
     lines = [f"## /{skill} run {run_id}: {outcome}", ""]
-    lines.append(f"- **Outcome**: {_map_outcome_display(outcome)}")
+    # #7074: a terminal needs-user ship handoff (merge + CI watch skipped) must not
+    # render as ✅ DONE. _summary_outcome_display picks the needs-user display when
+    # the caller supplies the handoff reason.
+    lines.append(f"- **Outcome**: {_summary_outcome_display(outcome=outcome, kwargs=kwargs)}")
     if skill != "design" and kwargs.get("workflow_path"):
         lines.append(f"- **Path**: {kwargs.get('workflow_path')}")
     if force:

--- a/python/larch/implement/checks_lint_fix.py
+++ b/python/larch/implement/checks_lint_fix.py
@@ -1262,21 +1262,30 @@ def _classify_attempt_issue(*, launcher_rc: int, run_dir: Path, log_name: str, u
     """Return a bounded failure classification before writing public evidence."""
     if launcher_rc == config.PROC_TIMEOUT_EXIT_CODE:
         return "timeout"
+    # #7074: classify only failed or useless attempts. A green fix (launcher exited
+    # 0 with a useful delta) is never an execution issue, so do not token-match its
+    # transcript — coder prose routinely names repo files like `preflight.py`.
+    if launcher_rc == 0 and useful_delta:
+        return ""
+    # Anchor token matching to launcher stderr only, not the full attempt log. The
+    # attempt log is the coder transcript; its prose collides with repo file names
+    # (`preflight.py`) and diagnostic phrases ("... not found"). Launcher failures
+    # (missing binary, auth/preflight) surface on stderr.
     text = ""
-    for path in (run_dir / log_name, run_dir / f"{log_name}.stderr-tail"):
-        try:
-            if path.is_file() and not path.is_symlink():
-                text += path.read_text(encoding="utf-8", errors="replace")[-8192:]
-        except OSError:
-            pass
+    stderr_tail = run_dir / f"{log_name}.stderr-tail"
+    try:
+        if stderr_tail.is_file() and not stderr_tail.is_symlink():
+            text = stderr_tail.read_text(encoding="utf-8", errors="replace")[-8192:]
+    except OSError:
+        pass
     lowered = text.lower()
-    if any(token in lowered for token in ("not found", "no such file", "missing binary", "command not found")):
+    if any(token in lowered for token in ("no such file", "missing binary", "command not found")):
         return "missing-binary"
-    if any(token in lowered for token in ("authentication", "not authenticated", "unauthorized", "login required", "preflight")):
+    if any(token in lowered for token in ("not authenticated", "unauthorized", "login required", "authentication")):
         return "authentication-preflight"
     if launcher_rc != 0:
         return "launcher-failure"
-    return "" if useful_delta else "no-op"
+    return "no-op"
 
 
 def _with_tier_ledger(outcome: FixOutcome, tier_ledger: Path) -> FixOutcome:
@@ -1315,7 +1324,10 @@ def _append_attempt_execution_issue(
     if attempt_log:
         try:
             text = Path(attempt_log).read_text(encoding="utf-8", errors="replace")
-            detail = text[-4096:].strip() or detail
+            # #7074: collapse the transcript tail to a single line so its own
+            # bullet lines ("- ...") do not become standalone exec-issue items and
+            # inflate the summary's exec-issue count. One appended row = one item.
+            detail = " ".join(text[-4096:].split()) or detail
         except OSError:
             pass
     entry = redact.redact(

--- a/python/larch/implement/dispatch_commit_route.py
+++ b/python/larch/implement/dispatch_commit_route.py
@@ -345,6 +345,11 @@ def _commit_route_log_failure(
     exit_code: int,
     output_file: Path,
 ) -> None:
+    # #7074: the append-failure emitter renders "**Step <site>: ...**", so passing
+    # the machine key "step7" produced the doubled "Step step7". Strip the leading
+    # "step" from these commit-route site keys (step7 -> 7, step5-self-review ->
+    # 5-self-review) so the rendered bullet reads "Step 7:", not "Step step7:".
+    display_site = site_name.removeprefix("step") or site_name
     result = _invoke_cli(
         [
             "run-log",
@@ -352,7 +357,7 @@ def _commit_route_log_failure(
             "--log",
             str(implement_tmpdir / "execution-issues.md"),
             "--site",
-            site_name,
+            display_site,
             "--tool",
             "python/cli.py review-and-fix commit-fixes --stage-all",
             "--exit-code",

--- a/python/larch/report/final_report.py
+++ b/python/larch/report/final_report.py
@@ -21,6 +21,7 @@ from larch.core import config
 from larch.core import logging_util
 from larch.report import exec_issue_detail
 from larch import io as larch_io
+from larch.issue import execution_issues
 from larch.git import pr_body
 from larch.report import report_tokens_cost
 from larch.report import review_phase_detail
@@ -837,6 +838,60 @@ def _reconcile_manifest_for_terminal_report(
     return 0, ""
 
 
+# Outcomes where the merge actually completed; a stale needs-user handoff must not
+# override these into a needs-user display (#7074).
+_MERGE_COMPLETED_OUTCOMES = frozenset({"merged", "force-merged-externally"})
+
+
+def _needs_user_ship_handoff(implement_tmpdir: Path, *, outcome: str) -> tuple[str, str] | None:
+    """Return ``(reason, next_action)`` for a terminal needs-user ship handoff (#7074).
+
+    A needs-user bail (e.g. architectural assessments unavailable) creates the PR but
+    skips the merge and CI watch, so the summary must not read ``✅ DONE``. The signal
+    is ``NEEDS_USER_REASON`` in the committed ``.ship-route-exit-handoff.env``. Returns
+    None when the merge completed or no needs-user reason is recorded.
+    """
+    if outcome in _MERGE_COMPLETED_OUTCOMES:
+        return None
+    handoff = implement_tmpdir / ".ship-route-exit-handoff.env"
+    reason = _read_kv(path=handoff, key="NEEDS_USER_REASON")
+    if not reason:
+        return None
+    return reason, _read_kv(path=handoff, key="NEXT_ACTION")
+
+
+def _append_needs_user_execution_issue(
+    implement_tmpdir: Path, *, reason: str, next_action: str
+) -> None:
+    """Append an exec-issues row naming the skipped merge/CI watch and pending action (#7074).
+
+    Without this the operator cannot learn from the summary itself that the PR still
+    needs action. Idempotent: ``append_execution_issue`` dedupes on the exact entry.
+    """
+    pending = f"; pending NEXT_ACTION={next_action}" if next_action else ""
+    entry = f"- ship route: merge and CI watch skipped — needs user (reason: {reason}{pending})"
+    with contextlib.suppress(OSError):
+        execution_issues.append_execution_issue(
+            implement_tmpdir / "execution-issues.md",
+            category="Tool Failures",
+            entry=entry,
+        )
+
+
+def _prime_needs_user_execution_issue(implement_tmpdir: Path, *, outcome: str) -> tuple[str, str]:
+    """Append the needs-user exec-issues row when the handoff applies (#7074).
+
+    Returns ``(reason, next_action)`` (both empty when it does not apply). Callers
+    must load the issue counts *after* this so the appended row is counted.
+    """
+    needs_user = _needs_user_ship_handoff(implement_tmpdir, outcome=outcome)
+    if needs_user is None:
+        return "", ""
+    reason, next_action = needs_user
+    _append_needs_user_execution_issue(implement_tmpdir, reason=reason, next_action=next_action)
+    return reason, next_action
+
+
 def write_final_report(
     implement_tmpdir: Path,
     *,
@@ -857,7 +912,6 @@ def write_final_report(
     pr_number = _read_kv(path=ship, key="PR_NUMBER") or _read_kv(path=final, key="PR_NUMBER")
     pr_url = _read_kv(path=ship, key="PR_URL", default="N/A") or _read_kv(path=final, key="PR_URL", default="N/A")
     issue_url = f"https://github.com/{repo}/issues/{issue}" if repo and issue and issue != "0" else ""
-    run_dir, load_result, exec_count, warn_count = _issue_load_result_for_run(implement_tmpdir=implement_tmpdir, run_id=run_id)
     derived = _derive_final_report_fields(
         implement_tmpdir,
         run_id=run_id or "unknown",
@@ -876,6 +930,15 @@ def write_final_report(
         outcome=outcome_values.get("IMPLEMENT_NORMALIZED_OUTCOME", "bailed"),
         ship=ship,
         final=final,
+    )
+    # #7074: a terminal needs-user ship handoff creates the PR but skips the merge
+    # and CI watch, so it must not render as ✅ DONE. Prime the exec-issues row from
+    # the committed handoff *before* loading the issue counts so the row is counted.
+    needs_user_reason, needs_user_next_action = _prime_needs_user_execution_issue(
+        implement_tmpdir, outcome=outcome
+    )
+    run_dir, load_result, exec_count, warn_count = _issue_load_result_for_run(
+        implement_tmpdir=implement_tmpdir, run_id=run_id
     )
     # #6995: pass manifest_path=None so the coverage line resolves the
     # *dispatcher* manifest (implement_tmpdir/manifest.json, which carries
@@ -911,6 +974,8 @@ def write_final_report(
         run_logs_path=f"larch-logs/implement/{run_id}/" if run_id else "N/A",
         force_requested=_read_kv(path=run_flags, key="FORCE_REQUESTED", default="false"),
         merge_downgraded=outcome_values.get("IMPLEMENT_MERGE_DOWNGRADED", "false"),
+        needs_user_reason=needs_user_reason,
+        needs_user_next_action=needs_user_next_action,
         manifest_path=str(run_dir / "manifest.json"),
         **cost_fields,
     )

--- a/python/tests/git/test_pr_body.py
+++ b/python/tests/git/test_pr_body.py
@@ -615,6 +615,35 @@ def test_render_run_summary_includes_cost_line() -> None:
     assert "**Cost note**:" not in body
 
 
+def test_render_run_summary_needs_user_outcome_not_done() -> None:
+    # #7074: a terminal needs-user ship handoff must not render as ✅ DONE even
+    # though the outcome token stays pr-created.
+    body = pr_body.render_run_summary(
+        skill="implement",
+        outcome="pr-created",
+        run_id="run1",
+        needs_user_reason="architectural-assessments",
+        needs_user_next_action="assessments",
+        cost_unavailable=True,
+    )
+    outcome_line = next(line for line in body.splitlines() if "**Outcome**" in line)
+    assert "✅ DONE" not in outcome_line
+    assert "NEEDS USER" in outcome_line
+    assert "architectural-assessments" in outcome_line
+    assert "assessments" in outcome_line
+
+
+def test_render_run_summary_pr_created_stays_done_without_handoff() -> None:
+    body = pr_body.render_run_summary(
+        skill="implement",
+        outcome="pr-created",
+        run_id="run1",
+        cost_unavailable=True,
+    )
+    outcome_line = next(line for line in body.splitlines() if "**Outcome**" in line)
+    assert outcome_line.strip() == "- **Outcome**: ✅ DONE"
+
+
 def test_render_run_summary_glm_main_lane_plan_estimate() -> None:
     # Token Claude $15.00 → estimated $1.00; TOTAL replaces Claude with estimate:
     # 38.23 - 15.00 + 1.00 = 24.23

--- a/python/tests/implement/test_checks.py
+++ b/python/tests/implement/test_checks.py
@@ -5245,3 +5245,79 @@ def test_repair_loop_action_stalls_only_named_pre_ship_exhaustion(tmp_path: Path
         checks_log="",
         allowed_tmpdir=tmp_path,
     ) == "main-agent-edit"
+
+
+def _classify(tmp_path: Path, *, launcher_rc: int, useful_delta: bool, log: str = "", stderr_tail: str = "") -> str:
+    (tmp_path / "claude.log").write_text(log, encoding="utf-8")
+    (tmp_path / "claude.log.stderr-tail").write_text(stderr_tail, encoding="utf-8")
+    return _clf._classify_attempt_issue(  # pyright: ignore[reportPrivateUsage]
+        launcher_rc=launcher_rc, run_dir=tmp_path, log_name="claude.log", useful_delta=useful_delta,
+    )
+
+
+def test_classify_attempt_issue_green_fix_never_classified(tmp_path: Path) -> None:
+    # #7074: a succeeded fix with a useful delta is not an execution issue, even
+    # when its transcript names a repo file like preflight.py.
+    assert _classify(
+        tmp_path,
+        launcher_rc=0,
+        useful_delta=True,
+        log="I did not touch the unrelated `preflight.py` working-tree change.\n",
+        stderr_tail="",
+    ) == ""
+
+
+def test_classify_attempt_issue_ignores_transcript_prose(tmp_path: Path) -> None:
+    # #7074: token matching is anchored to stderr-tail. preflight.py / "not found"
+    # in the coder transcript (main log) must not brand a failed attempt.
+    assert _classify(
+        tmp_path,
+        launcher_rc=1,
+        useful_delta=False,
+        log="touched preflight.py; metadata not found earlier in the run\n",
+        stderr_tail="",
+    ) == "launcher-failure"
+
+
+def test_classify_attempt_issue_auth_on_stderr_still_flagged(tmp_path: Path) -> None:
+    assert _classify(
+        tmp_path,
+        launcher_rc=1,
+        useful_delta=False,
+        stderr_tail="Error: not authenticated. login required.\n",
+    ) == "authentication-preflight"
+
+
+def test_classify_attempt_issue_bare_not_found_dropped(tmp_path: Path) -> None:
+    # #7074: the bare "not found" token is dropped; "metadata not found" prose on
+    # stderr must not misclassify as missing-binary.
+    assert _classify(
+        tmp_path,
+        launcher_rc=1,
+        useful_delta=False,
+        stderr_tail="runtime model error gpt-5.6-sol metadata not found\n",
+    ) == "launcher-failure"
+    # A genuine missing binary still classifies.
+    assert _classify(
+        tmp_path,
+        launcher_rc=1,
+        useful_delta=False,
+        stderr_tail="claude: command not found\n",
+    ) == "missing-binary"
+
+
+def test_append_attempt_execution_issue_is_single_line(tmp_path: Path) -> None:
+    # #7074: a multi-line transcript tail must collapse to one bullet so its own
+    # "- ..." lines do not inflate the summary's exec-issue count.
+    attempt = tmp_path / "attempt.log"
+    attempt.write_text(
+        "Verification complete:\n- pyright: 0 errors\n- ruff: All checks passed!\nFIXED: foo.py\n",
+        encoding="utf-8",
+    )
+    issue_log = tmp_path / "execution-issues.md"
+    _clf._append_attempt_execution_issue(  # pyright: ignore[reportPrivateUsage]
+        issue_log=issue_log, tier="claude", issue_kind="authentication-preflight", attempt_log=str(attempt),
+    )
+    bullets = [line for line in issue_log.read_text(encoding="utf-8").splitlines() if line.startswith("- ")]
+    assert len(bullets) == 1
+    assert bullets[0].startswith("- lint-fix tier=claude category=authentication-preflight;")

--- a/python/tests/implement/test_implement_dispatch.py
+++ b/python/tests/implement/test_implement_dispatch.py
@@ -3560,11 +3560,11 @@ def test_commit_route_success_relays_continue(
 
 
 @pytest.mark.parametrize(
-    ("site", "stall_step", "bail_reason"),
+    ("site", "stall_step", "bail_reason", "display_site"),
     [
-        ("step5-self-review", "5", "review-fix-commit-failed"),
-        ("step5-resume-handoff", "5", "resume-handoff-commit-failed"),
-        ("step7", "7", "review-fix-commit-failed"),
+        ("step5-self-review", "5", "review-fix-commit-failed", "5-self-review"),
+        ("step5-resume-handoff", "5", "resume-handoff-commit-failed", "5-resume-handoff"),
+        ("step7", "7", "review-fix-commit-failed", "7"),
     ],
 )
 @pytest.mark.parametrize(
@@ -3582,6 +3582,7 @@ def test_commit_route_failure_seeds_stall_and_logs_redacted(
     site: str,
     stall_step: str,
     bail_reason: str,
+    display_site: str,
     commit_stdout: str,
 ) -> None:
     impl, invoke_calls, _seed_calls = _setup_commit_route(
@@ -3605,6 +3606,11 @@ def test_commit_route_failure_seeds_stall_and_logs_redacted(
     log_calls = [call for call in invoke_calls if call[:2] == ["run-log", "append-failure"]]
     assert len(log_calls) == 1
     assert "--redact" in log_calls[0]
+    # #7074: the machine site key ("step7") must be de-prefixed for the emitter so
+    # the rendered bullet reads "Step 7:", not the doubled "Step step7:".
+    site_arg = log_calls[0][log_calls[0].index("--site") + 1]
+    assert site_arg == display_site
+    assert not site_arg.startswith("step")
 
 
 @pytest.mark.parametrize(("porcelain_stdout", "porcelain_rc"), [(" M leftover.txt\n", 0), ("", 1)])

--- a/python/tests/report/test_final_report.py
+++ b/python/tests/report/test_final_report.py
@@ -122,6 +122,52 @@ def test_write_final_report_module_renders_summary(tmp_path: Path, monkeypatch) 
     assert "## /implement run run1" in (tmp_path / "summary-final.md").read_text(encoding="utf-8")
 
 
+def test_needs_user_ship_handoff_reader(tmp_path: Path) -> None:
+    (tmp_path / ".ship-route-exit-handoff.env").write_text(
+        "NEEDS_USER_REASON=architectural-assessments\nNEXT_ACTION=assessments\n", encoding="utf-8",
+    )
+    assert final_report._needs_user_ship_handoff(tmp_path, outcome="pr-created") == (
+        "architectural-assessments",
+        "assessments",
+    )
+    # #7074: a stale handoff must not override a merge-completed outcome.
+    assert final_report._needs_user_ship_handoff(tmp_path, outcome="merged") is None
+
+
+def test_needs_user_ship_handoff_absent_or_no_reason(tmp_path: Path) -> None:
+    assert final_report._needs_user_ship_handoff(tmp_path, outcome="pr-created") is None
+    # A plain (non-needs-user) handoff carries no NEEDS_USER_REASON.
+    (tmp_path / ".ship-route-exit-handoff.env").write_text("NEXT_ACTION=reship\n", encoding="utf-8")
+    assert final_report._needs_user_ship_handoff(tmp_path, outcome="pr-created") is None
+
+
+def test_write_final_report_renders_needs_user_from_handoff(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    # #7074: a terminal needs-user ship handoff (merge + CI watch skipped) must
+    # render a distinct outcome and an exec-issues row, not ✅ DONE.
+    _write_minimal_state(tmp_path)
+    _stub_cost_and_assessment(monkeypatch)
+    (tmp_path / ".ship-route-exit-handoff.env").write_text(
+        "NEEDS_USER_REASON=architectural-assessments\nNEXT_ACTION=assessments\nDETAIL=invariants,guidelines\n",
+        encoding="utf-8",
+    )
+    rc, _url, err = final_report.write_final_report(tmp_path, comment_only=True)
+    assert (rc, err) == (0, "")
+    summary = (tmp_path / "summary-final.md").read_text(encoding="utf-8")
+    outcome_line = next(line for line in summary.splitlines() if "**Outcome**" in line)
+    assert "NEEDS USER" in outcome_line
+    assert "✅ DONE" not in outcome_line
+    assert "merge and CI watch skipped" in summary
+    assert "pending NEXT_ACTION=assessments" in summary
+
+
+def test_write_final_report_no_handoff_keeps_normal_outcome(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    _write_minimal_state(tmp_path)
+    _stub_cost_and_assessment(monkeypatch)
+    rc, _url, err = final_report.write_final_report(tmp_path, comment_only=True)
+    assert (rc, err) == (0, "")
+    assert "NEEDS USER" not in (tmp_path / "summary-final.md").read_text(encoding="utf-8")
+
+
 def test_write_final_report_renders_cursor_cost_lanes(tmp_path: Path) -> None:
     _write_minimal_state(tmp_path)
     run_dir = tmp_path / "larch-logs" / "implement" / "run1"


### PR DESCRIPTION
## Summary

Fixes two `/implement` run-reporting defects from the 2026-07-12 runs, both of which misstate run state to the operator. Verified against the committed run logs on immutable main (`91AB98AA…` and `F438D8FB…`).

Closes #7074

## Defect 1 — needs-user ship handoff rendered as `✅ DONE`

A terminal needs-user bail (e.g. architectural assessments unavailable) creates the PR but skips the merge and CI watch. The committed `final-summary.md` still read `Outcome: ✅ DONE` under a `pr-created` heading, with no exec-issues trace of the skipped merge — indistinguishable from a fully-merged run.

**Root cause:** `render_run_summary` maps `pr-created` straight to `✅ DONE` and never reads the needs-user handoff. The distinguishing signal (`NEEDS_USER_REASON`) lives in the committed `.ship-route-exit-handoff.env`, which the report ignored. Both the bailed run (`91AB`) and the recovered-then-merged run (`F438`) carry the identical handoff, so the summary is a point-in-time snapshot at the pause.

**Fix** (`final_report.py`, `pr_body.py`):
- `write_final_report` reads `NEEDS_USER_REASON` / `NEXT_ACTION` from the handoff. When present **and** the outcome is not merge-completed (`merged` / `force-merged-externally` — a guard against a stale handoff on a genuinely merged re-flush), it renders a distinct `⚠️ NEEDS USER — merge and CI watch skipped (reason: …; pending: …)` outcome instead of `✅ DONE`.
- It appends an exec-issues row (`ship route: merge and CI watch skipped — needs user …; pending NEXT_ACTION=…`) so the operator learns from the summary itself that the PR needs action. The row is primed before the issue-count load, so it is counted and rendered; the append is idempotent.

## Defect 2 — successful lint-fix branded a Tool Failure

The claude lint-fix tier fixed the sole pyright failure and verified green, yet the run logged `lint-fix tier=claude category=authentication-preflight` under Tool Failures. `_classify_attempt_issue` substring-matched the coder transcript before consulting `launcher_rc`/`useful_delta`; the bare `preflight` token matched the repo file name in the prose *"I did not touch the unrelated `preflight.py`"*.

**Fix** (`checks_lint_fix.py`):
- Classify only failed or useless attempts: a green fix (`launcher_rc == 0` and a useful delta) returns early with no classification.
- Anchor token matching to the launcher `.stderr-tail` only, not the full transcript.
- Drop the bare `preflight` and `not found` tokens (both collide with repo/diagnostic prose such as `preflight.py` and `metadata not found`); keep the specific `command not found` / `no such file` / auth tokens.

**Cosmetic:**
- Collapse a multi-line attempt-log tail to a single line so its own `- …` bullets no longer become standalone exec-issue items and inflate the count (one appended row = one item).
- Fix the doubled `Step step7` prefix: the commit-route site key is de-prefixed for the append-failure emitter (`step7 → 7`), so the bullet reads `Step 7:`.

## Scope

Per the issue's authoritative **Scope split**, this PR covers: at-bail outcome rendering, the missing exec-issues row for the skipped merge/CI watch, the lint-fix misclassification, and the two cosmetic artifacts. The looser "Fix outline" also mentions rendering the Architectural sections with a "dropped: unavailable" note; that is the assessment-execution surface owned by #7097 and is intentionally left out of this rendering/classifier change.

## Tests

- `pr_body`: needs-user outcome renders distinctly; `pr-created` without a handoff still renders `✅ DONE`.
- `final_report`: handoff reader (pr-created → reason; merged → suppressed; no reason → None); integration — `write_final_report` renders NEEDS USER + the exec-issues row from a handoff, and stays normal without one.
- `checks_lint_fix`: green fix never classified; transcript prose ignored (stderr-anchored); auth-on-stderr still flagged; bare `not found` dropped while `command not found` still classifies; multi-line row collapses to one bullet.
- `dispatch`: commit-route append-failure `--site` is de-prefixed for all three sites.

Local `make py-lint-main` green and all changed-file-scoped suites pass (`complexity-baseline` bumped by one statement for `write_final_report`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
