### PR TITLE
Fix #7126: update stale python module paths in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,8 +35,8 @@ The plugin ships the repo. **Runtime surface**: `skills/`, `agents/`, `hooks/`, 
 - `docs/topology.md`; `skills/shared/topology.tsv`: generated projection and source rows
 - `docs/run-logs.md`; `docs/run-log-cli.md`; `docs/run-log-batches.md`: committed run-log contracts
 - `docs/issue-anchored-plan.md`: **LIVE** /design ↔ /implement wire format, clarification round-trip, and pause pointer
-- `python/tracking_issue.py`, `python/test_tracking_issue.py`, `python/cli.py tracking-issue ...`: tracking issue lifecycle
-- `python/cli.py plan-block read`, `python/cli.py named-block write --marker plan`, `python/cli.py clarify {state,comment-post,label}`, `python/test_issue_wire.py`, `python/test_clarify.py`: issue wire helpers and tests
+- `python/larch/issue/tracking_issue.py`, `python/tests/issue/test_tracking_issue.py`, `python/cli.py tracking-issue ...`: tracking issue lifecycle
+- `python/cli.py plan-block read`, `python/cli.py named-block write --marker plan`, `python/cli.py clarify {state,comment-post,label}`, `python/tests/issue/test_issue_wire.py`, `python/tests/design/test_clarify.py`: issue wire helpers and tests
 - `skills/triage/SKILL.md`; `python/cli.py triage {inspect,probe,apply}`: pre-design issue verification, immutable-main evidence, bounded probes, and fail-closed issue mutation
 - `.claude/skills/release/scripts/classify-bump.md`: release classification rules
 - `skills/shared/subskill-invocation.md`; `skills/shared/skill-design-principles.md`; `skills/shared/reviewer-templates.md`: shared skill and reviewer authorities


### PR DESCRIPTION
Fixes #7126

## Summary
- `python/tracking_issue.py` → `python/larch/issue/tracking_issue.py`
- `python/test_tracking_issue.py` → `python/tests/issue/test_tracking_issue.py`
- `python/test_issue_wire.py` → `python/tests/issue/test_issue_wire.py`
- `python/test_clarify.py` → `python/tests/design/test_clarify.py`

## Verification
All four referenced paths resolve on HEAD:
```
git cat-file -e HEAD:python/larch/issue/tracking_issue.py        # OK
git cat-file -e HEAD:python/tests/issue/test_tracking_issue.py   # OK
git cat-file -e HEAD:python/tests/issue/test_issue_wire.py       # OK
git cat-file -e HEAD:python/tests/design/test_clarify.py         # OK
```
No other flat `python/<name>.py` pointers remain in AGENTS.md (only `python/cli.py` and `python/README.md` references, which are correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)