### PR TITLE
Fixes #7125: count firm headings in plan coverage for section-less plans

### DIFF
--- a/python/larch/issue/issue_wire.py
+++ b/python/larch/issue/issue_wire.py
@@ -373,8 +373,6 @@ def extract_scope_paths(*, plan_text: str, use_fallback: bool = True, include_op
         event.generic_level_two and re.match(r"^##\s+Files to modify(?:/create)?\s*$", event.text)
         for event in events
     )
-    if not use_fallback and not has_scope_section:
-        return []
     in_section = not has_scope_section
     seen: list[str] = []
     for event in events:

--- a/python/monkeypatch-facade-binding-baseline.json
+++ b/python/monkeypatch-facade-binding-baseline.json
@@ -5635,7 +5635,7 @@
   },
   {
     "file": "tests/implement/test_implement_dispatch.py",
-    "qualified_symbol": "test_step2_dispatch_plan_coverage_no_warning_without_files_section_and_unrelated_heading",
+    "qualified_symbol": "test_step2_dispatch_plan_coverage_counts_firm_heading_without_files_section",
     "facade_module": "larch.implement.dispatch_step2",
     "attribute": "_materialize_oos",
     "defining_module": "larch.implement.dispatch_manifest",
@@ -5644,7 +5644,7 @@
   },
   {
     "file": "tests/implement/test_implement_dispatch.py",
-    "qualified_symbol": "test_step2_dispatch_plan_coverage_no_warning_without_files_section_and_unrelated_heading",
+    "qualified_symbol": "test_step2_dispatch_plan_coverage_counts_firm_heading_without_files_section",
     "facade_module": "larch.implement.dispatch_step2",
     "attribute": "_normalize_scout",
     "defining_module": "larch.implement.dispatch_manifest",
@@ -5653,7 +5653,7 @@
   },
   {
     "file": "tests/implement/test_implement_dispatch.py",
-    "qualified_symbol": "test_step2_dispatch_plan_coverage_no_warning_without_files_section_and_unrelated_heading",
+    "qualified_symbol": "test_step2_dispatch_plan_coverage_counts_firm_heading_without_files_section",
     "facade_module": "larch.implement.implement_dispatch",
     "attribute": "_materialize_oos",
     "defining_module": "larch.implement.dispatch_manifest",
@@ -5662,7 +5662,7 @@
   },
   {
     "file": "tests/implement/test_implement_dispatch.py",
-    "qualified_symbol": "test_step2_dispatch_plan_coverage_no_warning_without_files_section_and_unrelated_heading",
+    "qualified_symbol": "test_step2_dispatch_plan_coverage_counts_firm_heading_without_files_section",
     "facade_module": "larch.implement.implement_dispatch",
     "attribute": "_normalize_scout",
     "defining_module": "larch.implement.dispatch_manifest",
@@ -5671,7 +5671,7 @@
   },
   {
     "file": "tests/implement/test_implement_dispatch.py",
-    "qualified_symbol": "test_step2_dispatch_plan_coverage_no_warning_without_files_section_and_unrelated_heading",
+    "qualified_symbol": "test_step2_dispatch_plan_coverage_counts_firm_heading_without_files_section",
     "facade_module": "larch.implement.implement_dispatch",
     "attribute": "_run_launcher",
     "defining_module": "larch.implement.dispatch_step2",

--- a/python/shard-assignments.json
+++ b/python/shard-assignments.json
@@ -531,7 +531,7 @@
   "tests/implement/test_implement_dispatch.py::test_step2_dispatch_plan_coverage_no_warning_for_optional_only_scope": 13,
   "tests/implement/test_implement_dispatch.py::test_step2_dispatch_plan_coverage_no_warning_when_all_plan_paths_touched": 9,
   "tests/implement/test_implement_dispatch.py::test_step2_dispatch_plan_coverage_no_warning_without_explicit_scope": 16,
-  "tests/implement/test_implement_dispatch.py::test_step2_dispatch_plan_coverage_no_warning_without_files_section_and_unrelated_heading": 1,
+  "tests/implement/test_implement_dispatch.py::test_step2_dispatch_plan_coverage_counts_firm_heading_without_files_section": 1,
   "tests/implement/test_implement_dispatch.py::test_step2_dispatch_plan_coverage_warns_for_untouched_plan_path": 14,
   "tests/implement/test_implement_dispatch.py::test_step2_dispatch_plan_read_failure_suppresses_coverage_kv": 11,
   "tests/implement/test_implement_dispatch.py::test_step2_dispatch_prelaunch_staged_index_blocks_recovery": 4,

--- a/python/tests/implement/test_implement_dispatch.py
+++ b/python/tests/implement/test_implement_dispatch.py
@@ -7340,9 +7340,12 @@ def test_step2_dispatch_plan_coverage_no_warning_without_explicit_scope(
     assert "PLAN_FIDELITY_FORCED=false" in out
 
 
-def test_step2_dispatch_plan_coverage_no_warning_without_files_section_and_unrelated_heading(
+def test_step2_dispatch_plan_coverage_counts_firm_heading_without_files_section(
     repo: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
+    # Regression for #7125: a vetted plan may list files as bare firm
+    # `### UPDATED:` headings with no `## Files to modify/create` section.
+    # Coverage must count those firm headings (total=1 here), not report 0/0.
     tmp = _session(tmp_path)
     (tmp / "plan.txt").write_text(
         "## Plan\n"
@@ -7377,8 +7380,13 @@ def test_step2_dispatch_plan_coverage_no_warning_without_files_section_and_unrel
     assert rc == 0
     out = capsys.readouterr().out
     assert "STATUS=complete" in out
-    assert "PLAN_COVERAGE_DISPOSITION_REQUIRED=false" in out
-    assert "PLAN_FIDELITY_FORCED=false" in out
+    # docs/expected.md is a firm plan path; only README.md was touched, so the
+    # plan path is untouched and the disposition gate must fire.
+    assert "PLAN_COVERAGE_TOTAL=1" in out
+    assert "PLAN_COVERAGE_TOUCHED=0" in out
+    assert "PLAN_COVERAGE_UNTOUCHED=1" in out
+    assert "PLAN_COVERAGE_DISPOSITION_REQUIRED=true" in out
+    assert "PLAN_FIDELITY_FORCED=true" in out
 
 
 def test_step2_dispatch_git_probe_failure_suppresses_plan_and_undeclared_warnings(

--- a/python/tests/issue/test_issue_wire.py
+++ b/python/tests/issue/test_issue_wire.py
@@ -536,7 +536,16 @@ def test_extract_scope_paths_and_cli_errors(tmp_path: Path, capsys: pytest.Captu
     assert issue_wire.extract_scope_paths(plan_text=empty.read_text(encoding="utf-8")) == ["skills/design/SKILL.md"]
     assert issue_wire.extract_scope_paths(plan_text=empty.read_text(encoding="utf-8"), use_fallback=False) == []
     scopeless = "## Plan\n### UPDATED: `docs/expected.md`\n## Acceptance\n"
-    assert issue_wire.extract_scope_paths(plan_text=scopeless, use_fallback=False) == []
+    assert issue_wire.extract_scope_paths(plan_text=scopeless, use_fallback=False) == ["docs/expected.md"]
+    multi_scopeless = (
+        "## Plan\n"
+        "### UPDATED: `a/one.py`\n"
+        "### NEW: `b/two.md`\n"
+        "### REWRITTEN: c/three.sh (legacy)\n"
+        "### MAY_UPDATE: `d/opt.py`\n"
+        "## Acceptance\n"
+    )
+    assert issue_wire.extract_scope_paths(plan_text=multi_scopeless, use_fallback=False, include_optional=False) == ["a/one.py", "b/two.md", "c/three.sh"]
     optional = tmp_path / "optional.md"
     _ = optional.write_text(plan, encoding="utf-8")
     assert issue_wire.plan_scope_paths_main(["--plan-file", str(optional)]) == 0


### PR DESCRIPTION
Fixes #7125

## Summary

`extract_scope_paths(..., use_fallback=False)` returned `[]` for any vetted plan that listed files only as bare firm `### UPDATED:` / `### NEW:` / `### REWRITTEN:` headings with no `## Files to modify/create` section. An early return short-circuited the firm-heading scan before it ran.

Plan coverage (`scope_disposition._firm_plan_paths`, `dispatch_step2._explicit_plan_scope_paths`) and the `/design` decompose path all call with `use_fallback=False`, so such plans reported `PLAN_COVERAGE_TOTAL=0`, forcing `band=advisory` and silently disabling both the proceed-partial / bail-rescope disposition gate and forced plan-fidelity review.

## Fix

Remove the early return in `extract_scope_paths` so the firm-heading scan always runs. The tail already gates only the hardcoded `_SCOPE_PATH_FALLBACK` list by `use_fallback`, so:

- Section-less plans now yield their firm paths under both fallback modes.
- Plans that do have a `## Files to modify/create` section keep section-bounded scanning, unchanged.
- Default (`use_fallback=True`) callers are unaffected — the early return never fired for them.

`docs/issue-anchored-plan.md` documents the scope section as optional, so the fix belongs in extraction rather than in `/design` authoring (per triage).

## Tests

- Updated the pinned `scopeless` assertion in `test_issue_wire.py` (`[]` → `["docs/expected.md"]`) and added a multi-heading regression (`UPDATED` / `NEW` / `REWRITTEN`, with `MAY_UPDATE` correctly excluded under `include_optional=False`).
- Repurposed the section-less dispatch coverage test into `test_step2_dispatch_plan_coverage_counts_firm_heading_without_files_section`, asserting `PLAN_COVERAGE_TOTAL=1` and that the disposition gate fires when the firm plan path is untouched.
- Renamed that test in the `monkeypatch-facade-binding` and `shard-assignments` baselines.

Verified locally: `make py-lint` green, affected pytest files green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
