### PR TITLE
Fixes #7113: retry clean-outcome prose mismatch and push ci-fixer commits

### DIFF
--- a/python/larch/implement/architectural_assessment.py
+++ b/python/larch/implement/architectural_assessment.py
@@ -38,6 +38,18 @@ _REAUTHOR_REASONS: Final[frozenset[str]] = frozenset({
     config.ASSESSMENT_REAUTHOR_REASON_CLEAN_MISMATCH,
     config.ASSESSMENT_REAUTHOR_REASON_MISSING_METADATA,
 })
+# A clean-outcome prose mismatch is a formatting defect, not an architectural
+# verdict: the lane confirmed `clean` but cited a G-*/I-* identifier in the
+# supporting prose. Re-author once with this constraint appended so the retry
+# keeps the clean verdict while dropping the identifier reference. See issue #7113.
+_CLEAN_PROSE_CONSTRAINT: Final = (
+    "\n\nADDITIONAL CONSTRAINT FOR THIS RETRY: A previous attempt marked a result "
+    "`clean` while its assessment text cited a `G-*` or `I-*` identifier, which the "
+    "coordinator treats as a deviation/violation signal. For every `clean` result, "
+    "write the assessment in plain prose that mentions NO `G-*` or `I-*` identifier "
+    "anywhere; affirm the clean verdict in one plain sentence and cite `G-*`/`I-*` "
+    "identifiers only inside `deviation` or `violation` results."
+)
 
 
 @dataclass(frozen=True)
@@ -578,7 +590,12 @@ def _validate_launch_evidence(*, evidence_dir: Path, copied: dict[str, tuple[Pat
         raise OSError("unsafe launch agent contract")
 
 
-def _launch_prompt(evidences: Sequence[MaterializedEvidence], copied: dict[str, tuple[Path, Path]]) -> str:
+def _launch_prompt(
+    evidences: Sequence[MaterializedEvidence],
+    copied: dict[str, tuple[Path, Path]],
+    *,
+    clean_prose_constraint: bool = False,
+) -> str:
     requests: list[dict[str, str]] = []
     for evidence in evidences:
         diff_path, knowledge_path = copied[evidence.kind]
@@ -593,7 +610,12 @@ def _launch_prompt(evidences: Sequence[MaterializedEvidence], copied: dict[str, 
                 "knowledge_path": str(knowledge_path),
             }
         )
-    return _AGENT_PROMPT.read_text(encoding="utf-8") + "\n\nREQUESTS_JSON=" + json.dumps(requests, separators=(",", ":"))
+    prompt = _AGENT_PROMPT.read_text(encoding="utf-8")
+    if clean_prose_constraint:
+        # Keep REQUESTS_JSON last: _validate_prompt_evidence_paths parses the
+        # suffix after the final REQUESTS_JSON marker, so the constraint precedes it.
+        prompt += _CLEAN_PROSE_CONSTRAINT
+    return prompt + "\n\nREQUESTS_JSON=" + json.dumps(requests, separators=(",", ":"))
 
 
 def _validate_prompt_evidence_paths(prompt: str, *, evidence_dir: Path) -> None:
@@ -1062,6 +1084,8 @@ def _attempt_lane(
     tool: str,
     unresolved: Sequence[MaterializedEvidence],
     context: LaneContext,
+    *,
+    clean_prose_constraint: bool = False,
 ) -> LaneOutcome:
     outcome = LaneOutcome()
     try:
@@ -1069,7 +1093,7 @@ def _attempt_lane(
     except OSError as exc:
         outcome = LaneOutcome(unavailable_detail=str(exc))
     else:
-        prompt = _launch_prompt(unresolved, context.copied)
+        prompt = _launch_prompt(unresolved, context.copied, clean_prose_constraint=clean_prose_constraint)
         _validate_prompt_evidence_paths(prompt, evidence_dir=context.evidence_dir)
         launcher = context.launchers.get(tool)
         if launcher is None:
@@ -1117,6 +1141,30 @@ def _record_unresolved_lane_rows(
     return [evidence for evidence in unresolved if evidence.kind not in statuses]
 
 
+def _clean_mismatch_retry_evidence(
+    results: Sequence[AssessmentResult],
+    *,
+    evidence_by_kind: Mapping[str, MaterializedEvidence],
+    statuses: Mapping[str, str],
+    retried: set[str],
+) -> list[MaterializedEvidence]:
+    """Return evidence for clean-outcome-prose-mismatch kinds not yet retried.
+
+    A clean-outcome prose mismatch is a formatting defect (the lane confirmed
+    ``clean`` but cited an identifier), so the coordinator re-authors it once with
+    the tightened clean-prose prompt instead of terminating the run. Kinds already
+    retried are excluded, capping the retry at one per kind. See issue #7113.
+    """
+    retry: list[MaterializedEvidence] = []
+    mismatch_status = _reauthor_status(config.ASSESSMENT_REAUTHOR_REASON_CLEAN_MISMATCH)
+    for result in results:
+        if result.kind in retried:
+            continue
+        if statuses.get(result.kind) == mismatch_status:
+            retry.append(evidence_by_kind[result.kind])
+    return retry
+
+
 def _run_waterfall(
     pending: Sequence[MaterializedEvidence],
     *,
@@ -1132,6 +1180,7 @@ def _run_waterfall(
     context = LaneContext(copied, evidence_dir, repo_root, implement_tmpdir, launchers)
     unresolved: list[MaterializedEvidence] = list(pending)
     attempted: list[str] = []
+    clean_retried: set[str] = set()
     latest_detail: dict[str, str] = {evidence.kind: "no assessment lane was available" for evidence in pending}
     while unresolved:
         selection = external_defaults.next_untried_tier(
@@ -1160,6 +1209,30 @@ def _run_waterfall(
             repo_root=repo_root,
             implement_tmpdir=implement_tmpdir,
         )
+        retry_evidence = _clean_mismatch_retry_evidence(
+            outcome.results,
+            evidence_by_kind=evidence_by_kind,
+            statuses=statuses,
+            retried=clean_retried,
+        )
+        if retry_evidence:
+            # Clean-outcome prose mismatch is a formatting defect; re-author once
+            # in-lane with the tightened clean-prose prompt before giving up. See #7113.
+            clean_retried.update(evidence.kind for evidence in retry_evidence)
+            retry_outcome = _attempt_lane(
+                tool,
+                retry_evidence,
+                context,
+                clean_prose_constraint=True,
+            )
+            if not retry_outcome.unavailable_detail:
+                _persist_authored_results(
+                    retry_outcome.results,
+                    evidence_by_kind=evidence_by_kind,
+                    statuses=statuses,
+                    repo_root=repo_root,
+                    implement_tmpdir=implement_tmpdir,
+                )
         unresolved = _record_unresolved_lane_rows(
             unresolved,
             outcome=outcome,

--- a/python/skill-closure-baseline.json
+++ b/python/skill-closure-baseline.json
@@ -41,8 +41,8 @@
     "closure_content_estimated_tokens": 46303,
     "closure_estimated_tokens": 46423,
     "closure_lines": 1341,
-    "conditional_content_estimated_tokens": 24341,
-    "conditional_estimated_tokens": 24399,
+    "conditional_content_estimated_tokens": 24445,
+    "conditional_estimated_tokens": 24504,
     "conditional_files": [
       "skills/implement/references/extracted-script-registry.md",
       "skills/implement/references/bootstrap-recovery.md",
@@ -56,7 +56,7 @@
       "skills/implement/references/conflict-resolution.md",
       "skills/implement/references/stall-recovery.md"
     ],
-    "conditional_lines": 719,
+    "conditional_lines": 721,
     "files": [
       "skills/implement/SKILL.md",
       "skills/shared/readability-style.md",

--- a/python/tests/implement/test_architectural_assessment.py
+++ b/python/tests/implement/test_architectural_assessment.py
@@ -390,15 +390,22 @@ class _SequenceLauncher:
         return result
 
 
-def _payload(evidences: list[assessment.MaterializedEvidence], *, states: dict[str, str] | None = None) -> str:
+def _payload(
+    evidences: list[assessment.MaterializedEvidence],
+    *,
+    states: dict[str, str] | None = None,
+    assessments: dict[str, str] | None = None,
+) -> str:
     outcomes = states or {}
+    texts = assessments or {}
     rows: list[dict[str, object]] = []
     for evidence in evidences:
         state = outcomes.get(evidence.kind, "clean")
+        default_text = "No violations identified." if state == "clean" else "An architectural requirement applies."
         rows.append({
             "kind": evidence.kind,
             "state": state,
-            "assessment": "No violations identified." if state == "clean" else "An architectural requirement applies.",
+            "assessment": texts.get(evidence.kind, default_text),
             "identifiers": [] if state == "clean" else sorted(evidence.identifiers),
             "head_sha": evidence.head_sha,
             "base_ref": evidence.base_ref,
@@ -535,6 +542,80 @@ def test_waterfall_attempts_each_available_lane_once_in_order(monkeypatch: pytes
 
     assert result == ("guidelines:clean",)
     assert order == ["cursor", "codex", "claude"]
+
+
+def _persist_rejecting_clean_prose_with_identifier(
+    result: assessment.AssessmentResult, *, repo_root: Path, implement_tmpdir: Path
+) -> None:
+    """Mirror the real validator: clean prose citing a G-*/I-* ID is a clean-mismatch."""
+    _ = (repo_root, implement_tmpdir)
+    if result.state == "clean" and ("G-" in result.assessment or "I-" in result.assessment):
+        raise assessment._ReauthorRequired(config.ASSESSMENT_REAUTHOR_REASON_CLEAN_MISMATCH)  # pyright: ignore[reportPrivateUsage]
+
+
+def test_waterfall_retries_clean_outcome_prose_mismatch_then_succeeds(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    evidence = _run_evidence(tmp_path)
+    _stub_materialization(monkeypatch, {evidence.kind: evidence})
+    monkeypatch.setattr(assessment, "_persist_result", _persist_rejecting_clean_prose_with_identifier)
+    # First launch affirms clean but cites a G-* identifier (clean-mismatch); the
+    # retry drops the identifier and passes the validator.
+    cursor = _SequenceLauncher([
+        assessment.LaunchResult(0, _payload([evidence], assessments={"guidelines": "Clean; G-Py-4 is satisfied."}), ""),
+        assessment.LaunchResult(0, _payload([evidence], assessments={"guidelines": "No deviations identified."}), ""),
+    ])
+
+    result = assessment.run(
+        kinds=[evidence.kind], repo_root=tmp_path, implement_tmpdir=tmp_path,
+        launchers={"cursor": cursor}, availability={"cursor": True, "codex": False, "claude": False},
+    )
+
+    assert result == ("guidelines:clean",)
+    assert cursor.calls == 2
+    # The retry launch carried the tightened clean-prose constraint.
+    assert assessment._CLEAN_PROSE_CONSTRAINT in cursor.requests[-1].prompt  # pyright: ignore[reportPrivateUsage]
+    assert assessment._CLEAN_PROSE_CONSTRAINT not in cursor.requests[0].prompt  # pyright: ignore[reportPrivateUsage]
+
+
+def test_waterfall_caps_clean_outcome_retry_at_one_attempt(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    evidence = _run_evidence(tmp_path)
+    _stub_materialization(monkeypatch, {evidence.kind: evidence})
+    monkeypatch.setattr(assessment, "_persist_result", _persist_rejecting_clean_prose_with_identifier)
+    # Both the original attempt and the retry cite a G-* identifier, so the retry
+    # also mismatches and the run terminates with re-author-required (capped at one retry).
+    cursor = _SequenceLauncher([
+        assessment.LaunchResult(0, _payload([evidence], assessments={"guidelines": "Clean; G-Py-4 is satisfied."}), ""),
+        assessment.LaunchResult(0, _payload([evidence], assessments={"guidelines": "Still clean per G-Py-4."}), ""),
+    ])
+
+    result = assessment.run(
+        kinds=[evidence.kind], repo_root=tmp_path, implement_tmpdir=tmp_path,
+        launchers={"cursor": cursor}, availability={"cursor": True, "codex": True, "claude": True},
+    )
+
+    assert result == ("guidelines:re-author-required:clean-outcome-prose-mismatch",)
+    # One original attempt plus one capped retry; later lanes do not re-attempt a reauthor-marked kind.
+    assert cursor.calls == 2
+
+
+def test_waterfall_does_not_retry_non_clean_mismatch_reauthor(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    evidence = _run_evidence(tmp_path)
+    _stub_materialization(monkeypatch, {evidence.kind: evidence})
+
+    def persist(_result: assessment.AssessmentResult, *, repo_root: Path, implement_tmpdir: Path) -> None:
+        _ = (repo_root, implement_tmpdir)
+        raise assessment._ReauthorRequired(config.ASSESSMENT_REAUTHOR_REASON_INVALID_OUTCOME)  # pyright: ignore[reportPrivateUsage]
+
+    monkeypatch.setattr(assessment, "_persist_result", persist)
+    cursor = _SequenceLauncher([assessment.LaunchResult(0, _payload([evidence]), "")])
+
+    result = assessment.run(
+        kinds=[evidence.kind], repo_root=tmp_path, implement_tmpdir=tmp_path,
+        launchers={"cursor": cursor}, availability={"cursor": True, "codex": True, "claude": True},
+    )
+
+    # A non-clean-mismatch reauthor reason is terminal: no retry, lane called once.
+    assert result == (f"guidelines:{assessment._reauthor_status(config.ASSESSMENT_REAUTHOR_REASON_INVALID_OUTCOME)}",)  # pyright: ignore[reportPrivateUsage]
+    assert cursor.calls == 1
 
 
 def test_recorded_binary_availability_outranks_path_drift(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/skills/implement/references/ship-pr-ci-fix.md
+++ b/skills/implement/references/ship-pr-ci-fix.md
@@ -36,6 +36,8 @@ For a crashed lane, apply this precedence:
 
 Route `RESULT=reship` through the existing Step 8 ship bgjob. Route `RESULT=retry-next-tool` through a fresh start, byte-identical wait loop, and finalize cycle. Capture its new dynamic `STEP`; never reuse the crashed step. The wrapper retains stable lineage while binding the new launch to the current `HEAD` and diff fingerprint. Route exhausted tiers through `RESULT=operator-bail` with bail reason `ci-fix-exhausted`; route every crash-finalization validation or persistence failure through the existing operator-bail gate.
 
+`step-8-ci-fixer.sh --finalize` pushes the lane-owned salvage commit to origin via `python3 "${CLAUDE_PLUGIN_ROOT}/python/cli.py" push branch` before emitting `RESULT=reship`, so a later terminal exit (for example an architectural assessment gate) cannot strand the fix locally and leave PR CI looking at the pre-fixer diff. A push failure fails closed as `RESULT=operator-bail` with reason `fixer-reship-push-failed`.
+
 Do not rerun architectural-guidelines Phase A and do not call guideline invalidate or pin helpers. The main agent must not read default-path CI evidence, invariant evidence, merge envelopes, `fixer-status.env`, lane transcripts, daemon stdout or stderr logs, or failure digests. It must not run `gh run-logs`, `ci distill-log`, Agent-tool fixer rounds, or edit repository files on this path.
 
 ## Kill switch

--- a/skills/implement/scripts/step-8-ci-fixer.sh
+++ b/skills/implement/scripts/step-8-ci-fixer.sh
@@ -150,6 +150,13 @@ PY
   LIVE_HEAD=$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null) || fail invalid-live-head
   [ "$FINAL_HEAD" = "$LIVE_HEAD" ] || fail final-head-drift
   printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$ATTEMPT" "$TIER" "$STARTING_HEAD" "$INPUT_FINGERPRINT" "$(printf '%s\n' "$OUT" | sed -n 's/^RESULT=//p')" "$(printf '%s\n' "$OUT" | sed -n 's/^FINAL_HEAD=//p')" >>"$LINEAGE"
+  RESULT_VAL=$(printf '%s\n' "$OUT" | sed -n 's/^RESULT=//p')
+  if [ "$RESULT_VAL" = "reship" ]; then
+    # Push the lane-owned salvage commit before ship re-entry so a later terminal
+    # exit (e.g. an architectural assessment gate) cannot strand the fix locally
+    # and leave PR CI looking at the pre-fixer diff. Fail closed on push failure. See #7113.
+    ( cd "$REPO_ROOT" && python3 "$CLAUDE_PLUGIN_ROOT/python/cli.py" push branch ) >/dev/null 2>&1 || fail fixer-reship-push-failed
+  fi
   printf '%s\n' "$OUT"
   exit 0
 fi


### PR DESCRIPTION
Fixes #7113

## Summary

`/implement --merge` terminated with `outcome=pr-created` (reported DONE) after the architectural assessment adapter returned `re-author-required:clean-outcome-prose-mismatch`, because the Step 8 route for `re-author-required` is unconditionally terminal. Two bugs collaborated; this PR fixes both.

## Bug 1 — assessment adapter did not retry on clean-outcome-prose-mismatch

The mismatch is a formatting defect, not an architectural verdict: the lane confirmed `clean` but cited a `G-*`/`I-*` identifier in the supporting prose, so `classify_assessment_prose` flipped it to `deviation` and `_validate_authored_outcome` raised `AssessmentReauthorRequired(CLEAN_MISMATCH)`. The waterfall marked the kind final with no retry, the envelope became `re-author-required`, and the run exited without completing the merge loop.

**Fix A** (`python/larch/implement/architectural_assessment.py`): the waterfall now re-authors a kind once in-lane with a tightened clean-prose prompt when it would otherwise terminate with `re-author-required:clean-outcome-prose-mismatch`. The retry is capped at one attempt per kind; `re-author-required` is emitted only after the retry also fails. A non-clean-mismatch reauthor reason (e.g. `invalid-explicit-outcome`) stays terminal. The SKILL.md and exit-matrix terminal rule is unchanged because the retry absorbs the false positive inside the adapter (per the issue triage).

## Bug 2 — ci-fixer commits not pushed to origin before the assessment gate

The ci-fixer's locally committed salvage edit was never pushed to origin before the ship driver re-invoked the assessment gate, so any terminal exit stranded the fix locally and left PR CI looking at the pre-fixer diff.

**Fix B** (`skills/implement/scripts/step-8-ci-fixer.sh --finalize`): when `RESULT=reship`, push the lane-owned salvage commit to origin via `python/cli.py push branch` before emitting the result. A push failure fails closed as `RESULT=operator-bail` with reason `fixer-reship-push-failed`. The new step is documented in `skills/implement/references/ship-pr-ci-fix.md`.

## Out of scope

Fix C (extending the clean-lead carve-out in `classify_assessment_prose`) is behind #6998, which rewrites the classifier/validator twins; this PR keeps classifier changes out of scope per the triage.

## Testing

- `python/tests/implement/test_architectural_assessment.py` — 3 new tests (retry succeeds; retry capped at one when it also mismatches; non-clean-mismatch reauthor stays terminal with no retry). Full file: 54 passed.
- `python/tests/implement/{test_ci,test_ship,test_implement_dispatch}.py` + `python/tests/core/test_architectural_guidelines.py` — 874 passed, no regressions.
- `ruff`, `pyright` clean on changed Python.
- `bash -n` under bash 3.2.57, `lint-bash32`, `shellcheck`, and the `test-implement-step8-exit3-first-fixer.sh` structure harness pass on the changed script/reference.
- `make lint-tier1a-size` and pre-commit hooks on the changed files pass.
