### PR TITLE
Fixes #7122: gate CI-fixer reship on cross-cycle failing-job progress

### DIFF
--- a/python/larch/core/config.py
+++ b/python/larch/core/config.py
@@ -874,6 +874,10 @@ CI_FIXER_DISTILLED_FAILURE_FILE: Final = "distilled-failure.md"
 CI_FIXER_STATUS_FILE: Final = "fixer-status.env"
 CI_FIXER_ROUNDS_FILE: Final = "fixer-rounds.tsv"
 CI_FIXER_BAIL_FILE: Final = "fixer-bail.md"
+# Persisted failing-job signature for cross-cycle no-progress detection. Keyed
+# stably by mode+repo (one PR per implement session), NOT by the failed CI run
+# id, so it survives the reship that triggers a fresh CI run (#7122).
+CI_FIXER_SIGNATURE_FILE: Final = "fixer-signature"
 CI_FIX_ROLE: Final = "fix"
 CI_FIXABLE_JOBS: Final[frozenset[str]] = frozenset({
     "lint",

--- a/python/larch/implement/ci_fixer_lane.py
+++ b/python/larch/implement/ci_fixer_lane.py
@@ -15,7 +15,7 @@ from pathlib import Path
 
 from larch import io as larch_io
 from larch.agents import agents
-from larch.core import config, external_defaults, proc, redact
+from larch.core import config, external_defaults, logging_util, proc, redact
 from larch.core.proc import Runner
 from larch.git import git
 from larch.implement import ci_monitor
@@ -32,6 +32,12 @@ _SALVAGE_STEP_TRAILER = "Larch-Salvage-Step"
 _SALVAGE_STEP_TRAILER_RE = re.compile(
     rf"^{re.escape(_SALVAGE_STEP_TRAILER)}:[ \t]*(.*)$", re.MULTILINE
 )
+# Operator-bail reason when a fixer edit did not shrink the failing CI job set
+# versus the prior reship, so the lane stops reshipping a non-fixing edit (#7122).
+_NO_PROGRESS_REASON = "fixer-no-cross-cycle-progress"
+# A persisted signature row is "<count>\t<sha256>\t<name>..."; the first two
+# fields are the count and digest, the rest are sanitized failing-job names.
+_SIGNATURE_HEADER_FIELDS = 2
 
 Launcher = Callable[[list[str] | None], int]
 
@@ -447,33 +453,36 @@ def _dirty_fingerprints(runner: Runner, *, cwd: Path) -> dict[str, str] | None:
     return fingerprints
 
 
-def _salvage_uncommitted_fixer_edits(
+def _salvage_delta(
     identity: LaneIdentity, *, runner: Runner, baseline: dict[str, str] | None
-) -> str | None:
-    """Commit a fixer's uncommitted working-tree edit and return the new HEAD.
+) -> tuple[str, ...]:
+    """Return the sorted repo-relative paths a fixer edit dirtied versus ``baseline``.
 
-    The CI fixer prompt forbids committing, so a tier that produced a correct
-    edit would otherwise be misclassified as no-progress when HEAD did not
-    advance. When the dirty-tree set changed relative to ``baseline`` (and the
-    launcher exited cleanly), stage exactly the delta paths and commit them so
-    the lane can reship. Returns None when there is nothing to salvage. Raises
-    ``LaneClosedError`` if staging or committing fails so the run surfaces
-    loudly instead of silently abandoning the edit.
+    Non-committing detection shared by the reship gate and the salvage commit so
+    a non-fixing edit can be rejected before it is committed. Returns ``()`` when
+    there is nothing to salvage or the dirty set cannot be measured (callers fall
+    back to the legacy no-progress path).
     """
     if baseline is None:
-        return None
+        return ()
     current = _dirty_fingerprints(runner, cwd=identity.repo_root)
     if current is None:
-        return None
-    delta = tuple(
-        sorted(
-            path
-            for path in (set(baseline) | set(current))
-            if baseline.get(path) != current.get(path)
-        )
-    )
-    if not delta:
-        return None
+        return ()
+    return tuple(sorted(
+        path
+        for path in (set(baseline) | set(current))
+        if baseline.get(path) != current.get(path)
+    ))
+
+
+def _commit_salvage(identity: LaneIdentity, *, runner: Runner, delta: tuple[str, ...]) -> str:
+    """Stage ``delta`` and commit it as a lane-owned salvage edit (#6959).
+
+    The CI fixer prompt forbids committing, so a tier that produced a correct edit
+    would otherwise be misclassified as no-progress when HEAD did not advance.
+    Raises ``LaneClosedError`` if staging or committing fails so the run surfaces
+    loudly instead of silently abandoning the edit.
+    """
     add_result = runner.run(["git", "add", "--", *delta], cwd=str(identity.repo_root))
     if add_result.returncode != 0:
         raise LaneClosedError("failed to stage CI fixer working-tree edits")
@@ -490,6 +499,136 @@ def _salvage_uncommitted_fixer_edits(
         _ = runner.run(["git", "reset", "--quiet", "--", *delta], cwd=str(identity.repo_root))
         raise LaneClosedError("failed to commit CI fixer working-tree edits")
     return _current_head(runner, cwd=identity.repo_root)
+
+
+def _signature_store_path(identity: LaneIdentity) -> Path:
+    key = hashlib.sha256(f"{identity.mode}\0{identity.repo}".encode()).hexdigest()[:20]
+    return identity.handoff_dir / f"{config.CI_FIXER_SIGNATURE_FILE}-{key}.tsv"
+
+
+def _failing_job_signature(
+    runner: Runner, *, run_id: str, repo: str, cwd: str
+) -> frozenset[str] | None:
+    """Return the set of failing CI job names for ``run_id``, or None when unavailable.
+
+    This set is the cross-cycle progress signal: a reship is only progress when
+    it strictly shrinks versus the prior reship. Returns None on any gh/parse
+    failure so the caller fails open (reship) rather than wedging the loop on a
+    measurement gap.
+    """
+    try:
+        jobs, state = ci_monitor.read_failed_jobs(runner, run_id=run_id, repo=repo, cwd=cwd)
+    except Exception:  # pylint: disable=broad-except  # gh failures must fail open, not wedge the loop
+        return None
+    if state != "ready":
+        return None
+    names = {logging_util.sanitize_diagnostic_line(job.name) for job in jobs}
+    names.discard("")
+    return frozenset(names) if names else None
+
+
+def _parse_signature_store(text: str) -> frozenset[str] | None:
+    """Parse a persisted signature row, or None when malformed (self-heal)."""
+    lines = text.splitlines()
+    if len(lines) != 1:
+        return None
+    parts = lines[0].split("\t")
+    if (
+        len(parts) < _SIGNATURE_HEADER_FIELDS
+        or not parts[0].isdigit()
+        or not re.fullmatch(r"[0-9a-f]{64}", parts[1])
+    ):
+        return None
+    names = parts[_SIGNATURE_HEADER_FIELDS:]
+    if int(parts[0]) != len(names) or any(not name or _contains_control(name) for name in names):
+        return None
+    if hashlib.sha256("\t".join(names).encode("utf-8")).hexdigest() != parts[1]:
+        return None
+    return frozenset(names)
+
+
+def _read_prior_signature(identity: LaneIdentity) -> frozenset[str] | None:
+    """Read the last reship's failing-job signature, or None when absent/unreadable.
+
+    Fails open (None) on a missing, symlinked, oversized, or malformed store so
+    corruption self-heals on the next reship instead of wedging the lane.
+    """
+    path = _signature_store_path(identity)
+    if not path.exists() or path.is_symlink() or not path.is_file():
+        return None
+    try:
+        if path.stat().st_size > _MAX_EVIDENCE_BYTES:
+            return None
+        text = path.read_text(encoding="utf-8", errors="strict")
+    except (OSError, UnicodeDecodeError):
+        return None
+    return _parse_signature_store(text)
+
+
+def _persist_signature(identity: LaneIdentity, signature: frozenset[str]) -> None:
+    if not signature:
+        return
+    names = sorted(signature)
+    for name in names:
+        if _contains_control(name):
+            raise LaneClosedError("refusing to persist an unsafe CI fixer failing-job signature")
+    digest = hashlib.sha256("\t".join(names).encode("utf-8")).hexdigest()
+    line = f"{len(names)}\t{digest}\t" + "\t".join(names) + "\n"
+    larch_io.atomic_write(_signature_store_path(identity), line, mode=0o600, nofollow=True)
+
+
+def _progress_gate(
+    identity: LaneIdentity, *, runner: Runner
+) -> tuple[bool, frozenset[str] | None]:
+    """Decide whether a fixer edit may reship based on cross-cycle failing-job progress.
+
+    Returns ``(allow_reship, current_signature)``. Fails open (allow) when the
+    current failing set cannot be measured, so a measurement gap never wedges the
+    loop. A reship is progress only when no prior signature exists or the current
+    failing set is a strict subset of the prior reship's set; an equal, larger, or
+    incomparable set means the edit did not clear the failing gate (#7122).
+    """
+    current = _failing_job_signature(
+        runner, run_id=identity.run_id, repo=identity.repo, cwd=str(identity.repo_root)
+    )
+    if current is None:
+        return True, None
+    prior = _read_prior_signature(identity)
+    if prior is None or current < prior:
+        return True, current
+    return False, current
+
+
+def _gated_reship(
+    identity: LaneIdentity, *, runner: Runner, final_head: str, reason: str
+) -> LaneResult:
+    """Apply the cross-cycle progress gate to an already-attributed fixer change."""
+    allow, current_sig = _progress_gate(identity, runner=runner)
+    if not allow:
+        return LaneResult("operator-bail", _NO_PROGRESS_REASON, final_head)
+    if current_sig is not None:
+        _persist_signature(identity, current_sig)
+    return LaneResult("reship", reason, final_head)
+
+
+def _gated_salvage_reship(
+    identity: LaneIdentity, *, runner: Runner, delta: tuple[str, ...], uncommitted_head: str
+) -> LaneResult:
+    """Gate, then salvage-commit and reship a fixer's uncommitted working-tree edit.
+
+    The gate runs before the salvage commit so a non-fixing edit is rejected
+    (operator-bail) and left uncommitted instead of being committed and reshipped
+    forever (#7122). Preserves #6959 on the progress path.
+    """
+    allow, current_sig = _progress_gate(identity, runner=runner)
+    if not allow:
+        return LaneResult("operator-bail", _NO_PROGRESS_REASON, uncommitted_head)
+    committed_head = _commit_salvage(identity, runner=runner, delta=delta)
+    if not _salvage_provenance_valid(identity, runner=runner, live_head=committed_head):
+        raise SalvageProvenanceError("CI fixer salvage commit provenance is unverified")
+    if current_sig is not None:
+        _persist_signature(identity, current_sig)
+    return LaneResult("reship", "fixer-produced-uncommitted-change", committed_head)
 
 
 def _dispatch(identity: LaneIdentity, evidence: EvidenceState, *, runner: Runner, launchers: Mapping[str, Launcher]) -> LaneResult:
@@ -520,19 +659,15 @@ def _dispatch(identity: LaneIdentity, evidence: EvidenceState, *, runner: Runner
     if launcher_exit == 0 and final_head != identity.starting_head:
         if not _salvage_provenance_valid(identity, runner=runner, live_head=final_head):
             raise SalvageProvenanceError("CI fixer salvage commit provenance is unverified")
-        return LaneResult("reship", "fixer-produced-change", final_head)
+        return _gated_reship(identity, runner=runner, final_head=final_head, reason="fixer-produced-change")
     if launcher_exit != 0 and final_head != identity.starting_head:
         return LaneResult("operator-bail", "failed-launcher-modified-head", final_head)
     if launcher_exit == 0 and final_head == identity.starting_head:
-        committed_head = _salvage_uncommitted_fixer_edits(
-            identity, runner=runner, baseline=baseline
-        )
-        if committed_head is not None:
-            if not _salvage_provenance_valid(
-                identity, runner=runner, live_head=committed_head
-            ):
-                raise SalvageProvenanceError("CI fixer salvage commit provenance is unverified")
-            return LaneResult("reship", "fixer-produced-uncommitted-change", committed_head)
+        delta = _salvage_delta(identity, runner=runner, baseline=baseline)
+        if delta:
+            return _gated_salvage_reship(
+                identity, runner=runner, delta=delta, uncommitted_head=final_head
+            )
         return LaneResult("retry-next-tool", "fixer-made-no-progress", final_head)
     return LaneResult("retry-next-tool", f"launcher-exit-{launcher_exit}", final_head)
 

--- a/python/tests/implement/test_ci.py
+++ b/python/tests/implement/test_ci.py
@@ -871,6 +871,11 @@ def test_fixer_lane_dispatch_salvages_uncommitted_fixer_edit(
     (impl / "failure.md").write_text("distilled failure\n", encoding="utf-8")
     monkeypatch.delenv(config.ENV_IMPLEMENT_TMPDIR, raising=False)
     monkeypatch.delenv("SHIP_PR_STATE_FILE", raising=False)
+    monkeypatch.setattr(
+        ci.ci_fixer_lane.ci_monitor,
+        "read_failed_jobs",
+        lambda *_args, **_kwargs: ((), "error"),
+    )
 
     def editing_launcher(_argv: list[str] | None) -> int:
         # CI fixer prompt forbids committing: edit the working tree only.
@@ -892,12 +897,19 @@ def test_fixer_lane_dispatch_salvages_uncommitted_fixer_edit(
     assert _run_git(repo, "status", "--porcelain").stdout == ""
 
 
-def test_fixer_lane_dispatch_accepts_lane_bound_direct_head_change(tmp_path: Path) -> None:
+def test_fixer_lane_dispatch_accepts_lane_bound_direct_head_change(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     repo = tmp_path / "repo"
     _init_repo(repo)
     impl = tmp_path / "impl"
     identity = _lane_identity(repo, impl)
     evidence = ci.ci_fixer_lane.EvidenceState(impl / "failure.md", "distilled", "c" * 64)
+    monkeypatch.setattr(
+        ci.ci_fixer_lane.ci_monitor,
+        "read_failed_jobs",
+        lambda *_args, **_kwargs: ((), "error"),
+    )
 
     def committing_launcher(_argv: list[str] | None) -> int:
         (repo / "tracked.txt").write_text("fixed directly\n", encoding="utf-8")
@@ -953,14 +965,20 @@ def test_fixer_lane_dispatch_rejects_unverified_uncommitted_salvage(
         (repo / "tracked.txt").write_text(f"{provenance}\n", encoding="utf-8")
         return 0
 
+    monkeypatch.setattr(
+        ci.ci_fixer_lane.ci_monitor,
+        "read_failed_jobs",
+        lambda *_args, **_kwargs: ((), "error"),
+    )
+
     def malformed_salvage(
         salvage_identity: ci.ci_fixer_lane.LaneIdentity,
         *,
         runner: proc.Runner,
-        baseline: dict[str, str] | None,
+        delta: tuple[str, ...],
     ) -> str:
         assert runner is proc
-        assert baseline == {}
+        assert "tracked.txt" in delta
         _run_git(repo, "add", "tracked.txt")
         _run_git(
             repo,
@@ -970,9 +988,7 @@ def test_fixer_lane_dispatch_rejects_unverified_uncommitted_salvage(
         )
         return _run_git(repo, "rev-parse", "HEAD").stdout.strip()
 
-    monkeypatch.setattr(
-        ci.ci_fixer_lane, "_salvage_uncommitted_fixer_edits", malformed_salvage
-    )
+    monkeypatch.setattr(ci.ci_fixer_lane, "_commit_salvage", malformed_salvage)
     with pytest.raises(ci.ci_fixer_lane.LaneClosedError, match="provenance is unverified"):
         ci.ci_fixer_lane._dispatch(
             identity, evidence, runner=proc, launchers={"codex": editing_launcher}
@@ -995,6 +1011,12 @@ def test_fixer_lane_dispatch_salvage_provenance_verification_failure_raises(
     def editing_launcher(_argv: list[str] | None) -> int:
         (repo / "tracked.txt").write_text("valid edit\n", encoding="utf-8")
         return 0
+
+    monkeypatch.setattr(
+        ci.ci_fixer_lane.ci_monitor,
+        "read_failed_jobs",
+        lambda *_args, **_kwargs: ((), "error"),
+    )
 
     def reject_provenance(
         _identity: ci.ci_fixer_lane.LaneIdentity | ci.ci_fixer_lane.CrashFinalizeIdentity,
@@ -1089,9 +1111,9 @@ def test_salvage_commits_only_fixer_delta_leaving_preexisting_dirty_files(
     # Fixer edits a different, unrelated file.
     (repo / "tracked.txt").write_text("fixer edit\n", encoding="utf-8")
 
-    new_head = ci.ci_fixer_lane._salvage_uncommitted_fixer_edits(
-        identity, runner=proc, baseline=baseline
-    )
+    delta = ci.ci_fixer_lane._salvage_delta(identity, runner=proc, baseline=baseline)
+    assert delta
+    new_head = ci.ci_fixer_lane._commit_salvage(identity, runner=proc, delta=delta)
 
     assert new_head is not None
     committed_files = _run_git(repo, "diff", "--name-only", "HEAD~1..HEAD").stdout.split()
@@ -1112,9 +1134,7 @@ def test_salvage_returns_none_when_tree_unchanged(
     baseline = ci.ci_fixer_lane._dirty_fingerprints(runner=proc, cwd=identity.repo_root)
     assert baseline == {}
 
-    assert ci.ci_fixer_lane._salvage_uncommitted_fixer_edits(
-        identity, runner=proc, baseline=baseline
-    ) is None
+    assert not ci.ci_fixer_lane._salvage_delta(identity, runner=proc, baseline=baseline)
 
 
 def _crash_identity(

--- a/python/tests/implement/test_ci_fixer_lane.py
+++ b/python/tests/implement/test_ci_fixer_lane.py
@@ -1,0 +1,320 @@
+# pyright: reportPrivateUsage=false, reportUnusedCallResult=false
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pytest
+
+from larch.core import proc
+from larch.git import gh
+from larch.implement import ci_fixer_lane
+from larch.implement.ci_fixer_lane import EvidenceState, LaneIdentity
+
+_STEP = "implement-step8-ci-fixer-1-codex-test"
+_FINGERPRINT = "c" * 64
+
+
+def _identity(
+    tmp_path: Path,
+    *,
+    repo_root: Path | None = None,
+    starting_head: str = "a" * 40,
+    run_id: str = "42",
+) -> LaneIdentity:
+    handoff = tmp_path / "ci-fixer"
+    handoff.mkdir(mode=0o700, exist_ok=True)
+    return LaneIdentity(
+        mode="ci",
+        repo_root=repo_root if repo_root is not None else tmp_path / "repo",
+        implement_tmpdir=tmp_path,
+        handoff_dir=handoff,
+        repo="owner/repo",
+        pr=42,
+        run_id=run_id,
+        tier="codex",
+        attempt=1,
+        starting_head=starting_head,
+        input_fingerprint=_FINGERPRINT,
+        step=_STEP,
+        result_env=tmp_path / "bgjob" / "x.merge.env",
+        invariant_evidence=None,
+    )
+
+
+def _jobs(*names: str) -> tuple[gh.FailedJob, ...]:
+    return tuple(gh.FailedJob(name=name, conclusion="failure") for name in names)
+
+
+def _patch_jobs(monkeypatch: pytest.MonkeyPatch, jobs: tuple[gh.FailedJob, ...], state: str = "ready") -> None:
+    def _impl(_runner: object, **_kwargs: object) -> tuple[tuple[gh.FailedJob, ...], str]:
+        return jobs, state
+
+    monkeypatch.setattr(ci_fixer_lane.ci_monitor, "read_failed_jobs", _impl)
+
+
+def test_progress_gate_first_cycle_allows_reship_and_persists(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    identity = _identity(tmp_path)
+    _patch_jobs(monkeypatch, _jobs("python-lint (1)", "python-lint (2)"))
+
+    allow, current = ci_fixer_lane._progress_gate(identity, runner=proc)
+    assert allow is True
+    assert current is not None
+    assert current == frozenset({"python-lint (1)", "python-lint (2)"})
+    ci_fixer_lane._persist_signature(identity, current)
+    assert ci_fixer_lane._read_prior_signature(identity) == current
+
+
+def test_progress_gate_repeat_equal_signature_blocks_reship(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    identity = _identity(tmp_path)
+    ci_fixer_lane._persist_signature(identity, frozenset({"python-lint (1)", "python-lint (2)"}))
+    _patch_jobs(monkeypatch, _jobs("python-lint (1)", "python-lint (2)"))
+
+    allow, current = ci_fixer_lane._progress_gate(identity, runner=proc)
+    assert allow is False
+    assert current == frozenset({"python-lint (1)", "python-lint (2)"})
+
+
+def test_progress_gate_strict_subset_is_progress(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    identity = _identity(tmp_path)
+    ci_fixer_lane._persist_signature(
+        identity, frozenset({"python-lint (1)", "python-lint (2)", "python-tests (3)"})
+    )
+    _patch_jobs(monkeypatch, _jobs("python-lint (1)", "python-lint (2)"))
+
+    allow, current = ci_fixer_lane._progress_gate(identity, runner=proc)
+    assert allow is True
+    assert current == frozenset({"python-lint (1)", "python-lint (2)"})
+
+
+def test_progress_gate_superset_is_no_progress(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    identity = _identity(tmp_path)
+    ci_fixer_lane._persist_signature(identity, frozenset({"python-lint (1)"}))
+    _patch_jobs(monkeypatch, _jobs("python-lint (1)", "python-tests (2)"))
+
+    allow, _ = ci_fixer_lane._progress_gate(identity, runner=proc)
+    assert allow is False
+
+
+def test_progress_gate_incomparable_is_no_progress(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    identity = _identity(tmp_path)
+    ci_fixer_lane._persist_signature(identity, frozenset({"python-lint (1)"}))
+    _patch_jobs(monkeypatch, _jobs("python-tests (2)"))
+
+    allow, _ = ci_fixer_lane._progress_gate(identity, runner=proc)
+    assert allow is False
+
+
+def test_progress_gate_unavailable_signature_fails_open(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    identity = _identity(tmp_path)
+    ci_fixer_lane._persist_signature(identity, frozenset({"python-lint (1)"}))
+    _patch_jobs(monkeypatch, (), state="error")
+
+    allow, current = ci_fixer_lane._progress_gate(identity, runner=proc)
+    assert allow is True
+    assert current is None
+
+
+def test_progress_gate_read_jobs_exception_fails_open(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    identity = _identity(tmp_path)
+    ci_fixer_lane._persist_signature(identity, frozenset({"python-lint (1)"}))
+
+    def _boom(_runner: object, **_kwargs: object) -> tuple[tuple[gh.FailedJob, ...], str]:
+        raise OSError("gh unavailable")
+
+    monkeypatch.setattr(ci_fixer_lane.ci_monitor, "read_failed_jobs", _boom)
+
+    allow, current = ci_fixer_lane._progress_gate(identity, runner=proc)
+    assert allow is True
+    assert current is None
+
+
+def test_signature_store_roundtrip(tmp_path: Path) -> None:
+    identity = _identity(tmp_path)
+    assert ci_fixer_lane._read_prior_signature(identity) is None
+    signature = frozenset({"python-lint (1)", "python-lint (2)"})
+    ci_fixer_lane._persist_signature(identity, signature)
+    assert ci_fixer_lane._read_prior_signature(identity) == signature
+
+
+def test_signature_store_self_heals_on_corruption(tmp_path: Path) -> None:
+    identity = _identity(tmp_path)
+    ci_fixer_lane._persist_signature(identity, frozenset({"python-lint (1)"}))
+    store = ci_fixer_lane._signature_store_path(identity)
+    store.write_text("garbage-not-a-signature\n", encoding="utf-8")
+
+    assert ci_fixer_lane._read_prior_signature(identity) is None
+    ci_fixer_lane._persist_signature(identity, frozenset({"python-lint (2)"}))
+    assert ci_fixer_lane._read_prior_signature(identity) == frozenset({"python-lint (2)"})
+
+
+def test_signature_store_tampered_digest_returns_none(tmp_path: Path) -> None:
+    identity = _identity(tmp_path)
+    ci_fixer_lane._persist_signature(identity, frozenset({"python-lint (1)"}))
+    store = ci_fixer_lane._signature_store_path(identity)
+    store.write_text(f"1\t{'0' * 64}\tpython-lint (1)\n", encoding="utf-8")
+
+    assert ci_fixer_lane._read_prior_signature(identity) is None
+
+
+def test_signature_store_rejects_symlink(tmp_path: Path) -> None:
+    identity = _identity(tmp_path)
+    outside = tmp_path.parent / "outside-signature.tsv"
+    outside.write_text(f"0\t{'0' * 64}\n", encoding="utf-8")
+    store = ci_fixer_lane._signature_store_path(identity)
+    store.symlink_to(outside)
+
+    assert ci_fixer_lane._read_prior_signature(identity) is None
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=str(repo), capture_output=True, text=True, check=True,
+    )
+    return result.stdout.strip()
+
+
+def _seed_repo(repo: Path) -> str:
+    repo.mkdir(parents=True, exist_ok=True)
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "fixer-test@example.com")
+    _git(repo, "config", "user.name", "fixer-test")
+    (repo / "README").write_text("seed\n", encoding="utf-8")
+    _git(repo, "add", "README")
+    _git(repo, "commit", "-q", "-m", "seed")
+    return _git(repo, "rev-parse", "HEAD")
+
+
+def _make_identity(repo: Path, impl: Path, handoff: Path, starting_head: str) -> LaneIdentity:
+    return LaneIdentity(
+        mode="ci",
+        repo_root=repo,
+        implement_tmpdir=impl,
+        handoff_dir=handoff,
+        repo="owner/repo",
+        pr=42,
+        run_id="42",
+        tier="codex",
+        attempt=1,
+        starting_head=starting_head,
+        input_fingerprint=_FINGERPRINT,
+        step=_STEP,
+        result_env=impl / "bgjob" / "x.merge.env",
+        invariant_evidence=None,
+    )
+
+
+def _edit_producing_launcher(repo: Path):
+    """A fake launcher that exits clean and leaves an uncommitted working-tree edit."""
+    calls = {"n": 0}
+
+    def launch(argv: list[str] | None) -> int:
+        assert argv is not None
+        output = argv[argv.index("--output") + 1]
+        Path(output).with_suffix(Path(output).suffix + ".done").write_text("0\n", encoding="utf-8")
+        (repo / "README").write_text(f"fixer attempt {calls['n']}\n", encoding="utf-8")
+        calls["n"] += 1
+        return 0
+
+    return launch
+
+
+def test_dispatch_breaks_loop_on_persistent_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = tmp_path / "repo"
+    head = _seed_repo(repo)
+    impl = tmp_path / "impl"
+    impl.mkdir()
+    handoff = impl / "ci-fixer"
+    handoff.mkdir(mode=0o700)
+    (handoff / "distilled-failure.md").write_text(
+        "# Distilled CI failure\ncomplexity-baseline FAILED\n", encoding="utf-8"
+    )
+    evidence = EvidenceState(
+        path=handoff / "distilled-failure.md", kind="distilled", digest="d" * 64,
+    )
+    persistent = _jobs("python-lint (1)", "python-lint (2)")
+    _patch_jobs(monkeypatch, persistent)
+    launcher = _edit_producing_launcher(repo)
+
+    # Cycle 1: no prior signature -> reship and persist the failing set.
+    first = ci_fixer_lane._dispatch(
+        _make_identity(repo, impl, handoff, head),
+        evidence,
+        runner=proc,
+        launchers={"codex": launcher},
+    )
+    assert first.result == "reship"
+    assert first.reason == "fixer-produced-uncommitted-change"
+    assert first.final_head != head
+    assert ci_fixer_lane._read_prior_signature(_make_identity(repo, impl, handoff, head)) == frozenset(
+        {"python-lint (1)", "python-lint (2)"}
+    )
+
+    # Cycle 2: identical failing set after the reship -> bail instead of reship again.
+    second = ci_fixer_lane._dispatch(
+        _make_identity(repo, impl, handoff, first.final_head),
+        evidence,
+        runner=proc,
+        launchers={"codex": launcher},
+    )
+    assert second.result == "operator-bail"
+    assert second.reason == "fixer-no-cross-cycle-progress"
+
+
+def test_dispatch_keeps_reshipping_when_failure_set_shrinks(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = tmp_path / "repo"
+    head = _seed_repo(repo)
+    impl = tmp_path / "impl"
+    impl.mkdir()
+    handoff = impl / "ci-fixer"
+    handoff.mkdir(mode=0o700)
+    (handoff / "distilled-failure.md").write_text("# fail\n", encoding="utf-8")
+    evidence = EvidenceState(
+        path=handoff / "distilled-failure.md", kind="distilled", digest="d" * 64,
+    )
+
+    state = {"jobs": _jobs("python-lint (1)", "python-lint (2)", "python-tests (3)")}
+
+    def _read(_runner: object, **_kwargs: object) -> tuple[tuple[gh.FailedJob, ...], str]:
+        return state["jobs"], "ready"
+
+    monkeypatch.setattr(ci_fixer_lane.ci_monitor, "read_failed_jobs", _read)
+    launcher = _edit_producing_launcher(repo)
+
+    first = ci_fixer_lane._dispatch(
+        _make_identity(repo, impl, handoff, head), evidence, runner=proc, launchers={"codex": launcher}
+    )
+    assert first.result == "reship"
+
+    # The fixer cleared one job: a strict subset is real progress -> reship again.
+    state["jobs"] = _jobs("python-lint (1)", "python-lint (2)")
+    second = ci_fixer_lane._dispatch(
+        _make_identity(repo, impl, handoff, first.final_head),
+        evidence,
+        runner=proc,
+        launchers={"codex": launcher},
+    )
+    assert second.result == "reship"
+    assert ci_fixer_lane._read_prior_signature(
+        _make_identity(repo, impl, handoff, first.final_head)
+    ) == frozenset({"python-lint (1)", "python-lint (2)"})


### PR DESCRIPTION
Closes #7122

## Problem

The Step 8 delegated CI-fixer loops without converging when a PR's CI fails on
a lint gate that runs only in CI (the `complexity-baseline` ratchet and pylint).
The lane treated *any* working-tree edit as progress and returned `reship`; CI
re-ran and failed on the same gate; the run re-entered the fixer fresh and
reshipped again — indefinitely, until a human intervened.

Root cause (confirmed in the issue): in `ci_fixer_lane.py` `_dispatch()`, both
the `fixer-produced-change` and `fixer-produced-uncommitted-change` paths returned
`reship` for any edit, and nothing re-evaluated the failing CI gate before
reshipping.

## Fix

Add a cross-cycle failing-job-signature no-progress gate to `_dispatch`, so a
fixer edit is only accepted as a reship when it actually shrinks the set of
failing CI jobs versus the prior reship.

- After a fixer edit is identified (HEAD moved, or salvageable uncommitted
  delta), compute the current failing-job signature via
  `ci_monitor.read_failed_jobs` and compare it to the last reship's signature.
- **Progress** (`reship` + persist new signature): no prior signature yet, or the
  current failing set is a *strict subset* of the prior set.
- **No progress** (`operator-bail`, reason `fixer-no-cross-cycle-progress`): the
  failing set is equal, larger, or incomparable — the edit did not clear the
  failing gate, so the lane stops instead of reshipping forever.
- **Fail open** (`reship`): when the failing set cannot be measured (gh/parse
  failure), so a measurement gap never wedges the loop.

The signature is persisted in the handoff dir keyed stably by `mode+repo` (one
PR per implement session), **not** by the failed CI run id, so it survives the
reship that triggers a fresh CI run — the property the old per-run lineage lacked.

#6959's salvage-uncommitted-edits behavior is preserved: the salvage is split
into `_salvage_delta` (non-committing detection) and `_commit_salvage` (commit),
and the gate runs *before* the salvage commit so a non-fixing edit is rejected
and left uncommitted rather than committed and reshipped.

This breaks the reported loop within at most two cycles: the first reship
records the failing signature; the next identical failure bails to the operator
instead of reshipping again.

## Scope

This PR fixes the convergence defect (defect 1 in the issue) by adding the
cross-cycle no-progress gate. The second cooperating defect — the retry lineage
keyed to the per-run CI id, so the tier waterfall never advances across runs
(`step-8-ci-fixer.sh`) — is intentionally left for a follow-up; the signature
gate alone breaks the infinite loop because it does not depend on the lineage
key. Local re-validation of the failing gate (suggested fix 1) is also left for
follow-up; the signature gate handles all persistent failures, including those
not locally reproducible.

## Tests

- New `python/tests/implement/test_ci_fixer_lane.py`: unit tests for
  `_progress_gate` (first-cycle reship+persist, repeat-equal bail, strict-subset
  progress, superset/incomparable bail, gh-unavailable and exception fail-open),
  the signature store (round-trip, corruption self-heal, tampered digest, symlink
  rejection), and two `_dispatch` integration tests against a real git repo that
  prove the loop breaks (persistent failure → cycle 1 reship, cycle 2 operator-bail)
  and that a shrinking failure set keeps reshipping (real progress).
- Updated `python/tests/implement/test_ci.py` for the `_salvage_delta` /
  `_commit_salvage` split and to stub `read_failed_jobs` so the dispatch tests
  stay hermetic.

`make py-lint-checks-fast`, `make py-typecheck`, pylint shards 1–3,
`complexity-baseline`, and the `test-step-8-ci-fixer.sh` harness all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
