### PR TITLE
Release v52.8.3

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.8.2",
+  "version": "52.8.3",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Added
- Added parameterized skill structure tests for contract unification. (#7131)

## Fixed
- Fixed repair-loop stalls when IMPLEMENT_TMPDIR is unexpanded through the stable launcher. (#7123)
- Fixed architectural assessment marking clean results unavailable on markdown-fenced JSON. (#7124)
- Fixed /implement run reporting: a needs-user ship handoff showed as DONE, and a successful lint-fix logged as a Tool Failure. (#7127)
- Fixed stale Python module paths in AGENTS.md. (#7128)
- Fixed plan-coverage reporting 0/0 for plans without a Files-to-modify/create section. (#7132)
- Fixed /implement --merge terminating with pr-created after a clean-outcome prose mismatch following a ci-fixer reship. (#7133)
- Fixed the Step 8 CI-fixer loop not converging on CI-only lint gates. (#7135)
