### PR TITLE
Fix #7146: canonicalize learn-from-bugs out paths for macOS TMPDIR

### DIFF
--- a/python/larch/issue/learn_from_bugs.py
+++ b/python/larch/issue/learn_from_bugs.py
@@ -1021,18 +1021,30 @@ def run_prepare(runner: Runner, request: PrepareRequest) -> dict[str, object]:
     digests = [build_digest(issue) for issue in issues]
     out_dir = request.out_dir
     out_dir.mkdir(parents=True, exist_ok=True)
+    out_dir = out_dir.resolve()
     digest_path = out_dir / "digest.jsonl"
-    with digest_path.open("w", encoding="utf-8") as handle:
-        for digest in digests:
-            handle.write(json.dumps(digest.to_json()) + "\n")
+    larch_io.atomic_write(
+        digest_path,
+        "".join(json.dumps(digest.to_json()) + "\n" for digest in digests),
+        prefix=f".{digest_path.name}.",
+        nofollow=True,
+    )
     coverage = coverage_index(request.root)
     coverage_path = out_dir / "coverage-index.json"
-    coverage_path.write_text(
-        json.dumps(coverage.to_json(), indent=2) + "\n", encoding="utf-8"
+    larch_io.atomic_write(
+        coverage_path,
+        json.dumps(coverage.to_json(), indent=2) + "\n",
+        prefix=f".{coverage_path.name}.",
+        nofollow=True,
     )
     headline = render_origin_headline(digests)
     headline_path = out_dir / "origin-headline.md"
-    headline_path.write_text(headline, encoding="utf-8")
+    larch_io.atomic_write(
+        headline_path,
+        headline,
+        prefix=f".{headline_path.name}.",
+        nofollow=True,
+    )
     # Measure the full serialized digest payload the model reads, including origin.
     digest_chars = sum(len(json.dumps(digest.to_json())) for digest in digests)
     structured = sum(1 for digest in digests if digest.structured)
@@ -1399,8 +1411,10 @@ def check_proposals_main(argv: list[str]) -> int:
         )
     proposals = () if state is None else state.proposals
     checked = check_proposals(_runner(), proposals, root, args.repo)
-    proposals_out = Path(args.proposals_out)
-    adoption_out = Path(args.adoption_out)
+    raw_proposals_out = Path(args.proposals_out).expanduser()
+    proposals_out = raw_proposals_out.parent.resolve() / raw_proposals_out.name
+    raw_adoption_out = Path(args.adoption_out).expanduser()
+    adoption_out = raw_adoption_out.parent.resolve() / raw_adoption_out.name
     larch_io.atomic_write(
         proposals_out,
         "".join(json.dumps(item.to_json()) + "\n" for item in checked),

--- a/python/tests/issue/test_learn_from_bugs.py
+++ b/python/tests/issue/test_learn_from_bugs.py
@@ -1253,7 +1253,8 @@ def test_check_proposals_main_accepts_symlinked_ancestor_out_dir(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     """A symlinked out-path ancestor (like the /var -> /private/var Mac spelling)
-    is canonicalized instead of refused; artifacts land in the real directory."""
+    is canonicalized instead of refused; artifacts land in the real directory.
+    """
     real = tmp_path / "real"
     real.mkdir()
     alias = tmp_path / "alias"

--- a/python/tests/issue/test_learn_from_bugs.py
+++ b/python/tests/issue/test_learn_from_bugs.py
@@ -1246,6 +1246,110 @@ def test_check_proposals_main_rejects_repository_mismatch(tmp_path: Path) -> Non
         )
 
 
+# --- Out-path canonicalization (macOS default TMPDIR symlink) ---------------
+
+
+def test_check_proposals_main_accepts_symlinked_ancestor_out_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A symlinked out-path ancestor (like the /var -> /private/var Mac spelling)
+    is canonicalized instead of refused; artifacts land in the real directory."""
+    real = tmp_path / "real"
+    real.mkdir()
+    alias = tmp_path / "alias"
+    alias.symlink_to(real, target_is_directory=True)
+    proposals_out = alias / "checked-proposals.jsonl"
+    adoption_out = alias / "adoption-summary.md"
+    monkeypatch.setattr(
+        learn_from_bugs, "_runner", lambda: RecordingRunner(responses=[], strict=True)
+    )
+
+    rc = learn_from_bugs.check_proposals_main(
+        [
+            "--root",
+            str(tmp_path),
+            "--repo",
+            "o/r",
+            "--proposals-out",
+            str(proposals_out),
+            "--adoption-out",
+            str(adoption_out),
+        ]
+    )
+
+    assert rc == 0
+    assert (real / "checked-proposals.jsonl").is_file()
+    assert (real / "adoption-summary.md").is_file()
+    out = dict(line.split("=", 1) for line in capsys.readouterr().out.splitlines() if "=" in line)
+    assert Path(out["CHECKED_PROPOSALS_PATH"]) == real.resolve() / "checked-proposals.jsonl"
+    assert Path(out["ADOPTION_SUMMARY_PATH"]) == real.resolve() / "adoption-summary.md"
+
+
+def test_prepare_main_accepts_symlinked_ancestor_out_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The sibling prepare verb also canonicalizes a symlinked --out ancestor."""
+    real = tmp_path / "real"
+    real.mkdir()
+    alias = tmp_path / "alias"
+    alias.symlink_to(real, target_is_directory=True)
+    rows = [_issue(1, "[BUG] a", STRUCTURED_BODY)]
+    runner = RecordingRunner(responses=[_result(json.dumps(rows))], strict=True)
+    monkeypatch.setattr(learn_from_bugs, "_runner", lambda: runner)
+
+    rc = learn_from_bugs.prepare_main(
+        [
+            "--search",
+            learn_from_bugs.DEFAULT_SEARCH,
+            "--repo",
+            "o/r",
+            "--out",
+            str(alias / "run"),
+            "--root",
+            str(tmp_path),
+        ]
+    )
+
+    assert rc == 0
+    assert (real / "run" / "digest.jsonl").is_file()
+    assert (real / "run" / "coverage-index.json").is_file()
+    assert (real / "run" / "origin-headline.md").is_file()
+    out = dict(line.split("=", 1) for line in capsys.readouterr().out.splitlines() if "=" in line)
+    assert Path(out["DIGEST_PATH"]) == real.resolve() / "run" / "digest.jsonl"
+
+
+def test_check_proposals_main_refuses_symlinked_destination_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """G-Sec-4: a pre-created symlink at the destination leaf is still refused."""
+    real = tmp_path / "real"
+    real.mkdir()
+    elsewhere = tmp_path / "elsewhere.jsonl"
+    proposals_out = real / "checked-proposals.jsonl"
+    proposals_out.symlink_to(elsewhere)
+    adoption_out = real / "adoption-summary.md"
+    monkeypatch.setattr(
+        learn_from_bugs, "_runner", lambda: RecordingRunner(responses=[], strict=True)
+    )
+
+    with pytest.raises(OSError, match="symlink"):
+        learn_from_bugs.check_proposals_main(
+            [
+                "--root",
+                str(tmp_path),
+                "--repo",
+                "o/r",
+                "--proposals-out",
+                str(proposals_out),
+                "--adoption-out",
+                str(adoption_out),
+            ]
+        )
+
+    assert not elsewhere.exists()
+    assert not adoption_out.exists()
+
+
 def test_checked_adoption_becomes_orphaned_after_target_is_removed(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

Fixes #7146.

On stock macOS, `learn-from-bugs check-proposals` crashed with `OSError: refusing symlinked path or ancestor: /var` whenever `--proposals-out`/`--adoption-out` pointed into the default `$TMPDIR` (a `/var/folders/...` path; `/var` is a symlink to `/private/var`). The sibling `prepare` verb wrote the same directory with plain `open`/`write_text` and no policy, so it succeeded where `check-proposals` failed closed — the `/learn-from-bugs` skill's Step 2.5 broke immediately after its Step 2 succeeded.

## Change

- `check_proposals_main` canonicalizes each out path by resolving its parent and reattaching the leaf name. A symlinked destination file is still refused (G-Sec-4), but a symlinked ancestor of a real, caller-created scratch dir no longer trips the guard.
- `run_prepare` resolves `out_dir` after `mkdir` and routes `digest.jsonl`, `coverage-index.json`, and `origin-headline.md` through `larch_io.atomic_write`, aligning both sibling verbs on one write policy.
- `assert_no_symlink_path_or_ancestors` and `atomic_write` in `python/larch/io.py` are byte-unchanged; no change to `skills/learn-from-bugs/SKILL.md`.

## Tests

New portable tests in `python/tests/issue/test_learn_from_bugs.py` (explicit `alias -> real` directory symlink, no `/var` dependency):

- `check-proposals` and `prepare` both accept a symlinked out-path ancestor and write into the real directory.
- A pre-created symlink at the destination leaf is still refused.

`python3 -m pytest python/tests/issue/test_learn_from_bugs.py` → 118 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
