### PR TITLE
Fix #7145: add writer surface for learn-from-bugs origin markers

### DIFF
--- a/ARCHITECTURAL_GUIDELINES.md
+++ b/ARCHITECTURAL_GUIDELINES.md
@@ -317,7 +317,7 @@ These guidelines are aspirational. Surface meaningful deviations in design or im
 
 ### G-Md-4: File a bug report with structured Summary, Root cause analysis, and Suggested fix(es) sections
 - Why: title-only and pasted-run-summary bug reports carry no root-cause statement, so /analyze-bugs cannot verify their fixes and /learn-from-bugs cannot cluster them (#6115, #6192, #5753); in the 2026-07-11 mining window, the structured minority of reports drove every recurring-cluster identification.
-- Guidance: state what broke, why it broke, and the suggested fix under those three headings; paste evidence such as run summaries or transcripts below the headings, not instead of them. When the reporter cannot yet explain the root cause, say so explicitly under Root cause analysis rather than omitting the section.
+- Guidance: state what broke, why it broke, and the suggested fix under those three headings; paste evidence such as run summaries or transcripts below the headings, not instead of them. When the reporter cannot yet explain the root cause, say so explicitly under Root cause analysis rather than omitting the section. When the introducing change is known, name it in Root cause analysis with one canonical phrase: `introduced by #N`, `introduced by PR #N`, `introduced in #N`, `incomplete fix of #N`, `persists after #N`, or `residual of #N`; the /learn-from-bugs origin classifier matches only these phrases.
 - Deviate when: capturing a live failure before evidence evaporates; file the stub immediately, then backfill the sections before the issue closes.
 
 ## Migration discipline

--- a/python/larch/issue/learn_from_bugs.py
+++ b/python/larch/issue/learn_from_bugs.py
@@ -88,9 +88,13 @@ REGISTRY_KEY_LENGTH: Final = 2
 
 # Origin extraction: referenced residual markers (first match in source order wins).
 # Supported PR spacing: "PR #N" and "PR#N" only.
+# Two prose surfaces enumerate these phrases for reporters: the G-Md-4 entry in
+# ARCHITECTURAL_GUIDELINES.md and the /bug body template in skills/bug/SKILL.md.
+# Sweep all three surfaces together when the phrase set changes (G-Wire-3, G-Md-2).
 _ORIGIN_REF_PATTERNS: Final = (
     re.compile(r"introduced\s+by\s+PR\s*#(\d+)", re.IGNORECASE),
     re.compile(r"introduced\s+by\s+#(\d+)", re.IGNORECASE),
+    re.compile(r"introduced\s+in\s+#(\d+)", re.IGNORECASE),
     re.compile(r"incomplete\s+fix\s+of\s+#(\d+)", re.IGNORECASE),
     re.compile(r"persists\s+after\s+#(\d+)", re.IGNORECASE),
     re.compile(r"residual\s+of\s+#(\d+)", re.IGNORECASE),

--- a/python/tests/issue/test_learn_from_bugs.py
+++ b/python/tests/issue/test_learn_from_bugs.py
@@ -1411,6 +1411,8 @@ def test_filed_issue_rejects_malformed_json_response(stdout: str) -> None:
         ("introduced by PR #99", 99),
         ("introduced by PR#88", 88),
         ("introduced by pr #12", 12),
+        ("introduced in #77", 77),
+        ("Introduced in #12", 12),
         ("incomplete fix of #55", 55),
         ("Incomplete Fix Of #55", 55),
         ("persists after #100", 100),
@@ -1431,6 +1433,12 @@ def test_origin_bare_regression_has_null_ref() -> None:
 
 def test_origin_no_marker_is_unknown() -> None:
     body = "## Root cause\n\nA plain logic error with no residual language.\n"
+    origin = learn_from_bugs.classify_origin(title="[BUG] x", body=body)
+    assert origin == learn_from_bugs.Origin(kind="unknown", ref=None)
+
+
+def test_origin_introduced_in_requires_adjacency() -> None:
+    body = "## Root cause analysis\n\nThe defect was introduced early in #12 of the port.\n"
     origin = learn_from_bugs.classify_origin(title="[BUG] x", body=body)
     assert origin == learn_from_bugs.Origin(kind="unknown", ref=None)
 

--- a/skills/bug/SKILL.md
+++ b/skills/bug/SKILL.md
@@ -131,7 +131,7 @@ Use `Write` to create `$BUG_TMPDIR/bug-issue-body.md` with exactly these ten `##
 
 ## Root cause analysis
 
-<Likely root cause. If uncertain, state uncertainty explicitly and explain why.>
+<Likely root cause. If uncertain, state uncertainty explicitly and explain why. When the introducing change is known, name it with one canonical origin phrase: "introduced by #N", "introduced by PR #N", "introduced in #N", "incomplete fix of #N", "persists after #N", or "residual of #N".>
 
 ## Evidence
 


### PR DESCRIPTION
## Summary

Fixes #7145.

`/learn-from-bugs` classifies each mined bug's origin and prints a mandatory origin headline, but the classifier recognized an introducing change only through the canonical phrases in `_ORIGIN_REF_PATTERNS`. No writer surface published those phrases, so reporters stated introducing changes in free prose, the classifier returned `unknown`, and the headline understated the regression ratio (the 2026-07-12 run reported `regression: 0`, `unknown: 10`, though #6263 and #6632 self-declared their introducing change).

This adds the missing writer surface plus one conservative selector variant. Four coordinated edits:

1. **G-Md-4** (`ARCHITECTURAL_GUIDELINES.md`): appended one sentence naming the six canonical origin phrases in Root cause analysis; the rest of the entry is byte-unchanged.
2. **`/bug` template** (`skills/bug/SKILL.md`): the Root cause analysis placeholder now lists the same six phrases.
3. **`_ORIGIN_REF_PATTERNS`** (`python/larch/issue/learn_from_bugs.py`): added the conservative `introduced in #N` pattern immediately after `introduced by #N`, and extended the comment block to name the two prose surfaces so a future phrase change sweeps all three (G-Wire-3, G-Md-2).
4. **Tests** (`python/tests/issue/test_learn_from_bugs.py`): added `("introduced in #77", 77)` and `("Introduced in #12", 12)` positives, plus a negative asserting `introduced early in #12` (non-adjacent) stays `unknown`.

Per the issue's fixed decisions: no fuzzy or date-tolerant patterns (`Introduced 2026-07-05 in #6465` stays unmatched by design), no backfill of historical issues or committed run reports, and the two prose surfaces are kept identical to each other and consistent with `_ORIGIN_REF_PATTERNS` plus the documented `PR#N` spacing variant.

## Testing

- `python3 -m pytest python/tests/issue/test_learn_from_bugs.py -k origin` → 33 passed, 88 deselected.
