### PR TITLE
Fix #7144: emit bounded re-author reason from Step 8 repair path

### DIFF
--- a/python/larch/implement/architectural_assessment.py
+++ b/python/larch/implement/architectural_assessment.py
@@ -860,22 +860,38 @@ def _repair_current_outcome(kind: str, *, repo_root: Path, implement_tmpdir: Pat
     """Repair a missing outcome sidecar without replacing a current durable note."""
     if _git_read(repo_root, ["rev-parse", "HEAD"]) != head_sha:
         raise _HeadDrift("HEAD changed before current-outcome repair")
+    # A note the repair path cannot certify is stale: invalidate it so the next pass
+    # re-materializes and re-authors (mirroring _persist_authored_results), and return
+    # a bounded re-author reason the Step 8 adapter grammar accepts, not a bare token
+    # that the grammar rejects and hard-stops the run as fail-closed. See #7144.
+    invalidator = (
+        architectural_guidelines.invalidate_invariant_implement_note
+        if kind == config.ASSESSMENT_KIND_INVARIANTS
+        else architectural_guidelines.invalidate_implement_note
+    )
     metadata = architectural_guidelines.invariant_durable_note_metadata(implement_tmpdir) if kind == config.ASSESSMENT_KIND_INVARIANTS else architectural_guidelines.durable_note_metadata(implement_tmpdir)
     note_path = architectural_guidelines.invariant_durable_note_path(implement_tmpdir) if kind == config.ASSESSMENT_KIND_INVARIANTS else architectural_guidelines.durable_note_path(implement_tmpdir)
     state = metadata.get("ASSESSMENT_KIND", "")
     allowed = {"clean", "violation"} if kind == config.ASSESSMENT_KIND_INVARIANTS else {"clean", "deviation"}
     if state not in allowed:
-        return config.ASSESSMENT_RESULT_REAUTHOR_REQUIRED
+        invalidator(implement_tmpdir)
+        return _reauthor_status(config.ASSESSMENT_REAUTHOR_REASON_INVALID_OUTCOME)
     try:
         note = _read_regular(note_path, root=implement_tmpdir)
     except (OSError, UnicodeDecodeError, ValueError):
-        return config.ASSESSMENT_RESULT_REAUTHOR_REQUIRED
+        invalidator(implement_tmpdir)
+        return _reauthor_status(config.ASSESSMENT_REAUTHOR_REASON_MISSING_METADATA)
     if not architectural_guidelines.authored_outcome_valid(
         note=note,
         outcome=state,
         invariant=kind == config.ASSESSMENT_KIND_INVARIANTS,
     ):
-        return config.ASSESSMENT_RESULT_REAUTHOR_REQUIRED
+        invalidator(implement_tmpdir)
+        return _reauthor_status(
+            config.ASSESSMENT_REAUTHOR_REASON_CLEAN_MISMATCH
+            if state == "clean"
+            else config.ASSESSMENT_REAUTHOR_REASON_INVALID_OUTCOME
+        )
     if not _outcome_valid(kind, implement_tmpdir, metadata):
         result = AssessmentResult(kind, state, note, (), head_sha, metadata["BASE_REF"], "", "")
         _write_outcome(kind, implement_tmpdir=implement_tmpdir, result=result)

--- a/python/tests/implement/test_architectural_assessment.py
+++ b/python/tests/implement/test_architectural_assessment.py
@@ -971,3 +971,86 @@ def test_discard_unavailable_coverage_uses_guideline_invalidator(monkeypatch: py
     monkeypatch.setattr(assessment.architectural_guidelines, "invalidate_implement_note", _fake_invalidate)
     assessment._discard_unavailable_coverage(config.ASSESSMENT_KIND_GUIDELINES, implement_tmpdir=tmp_path)  # pyright: ignore[reportPrivateUsage]
     assert invalidated == [tmp_path]
+
+
+def _repair_stubs(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, *, kind: str, state: str, invalidated: list[Path]) -> None:
+    head = "a" * 40
+
+    def _head(*_args: object, **_kwargs: object) -> str:
+        return head
+
+    def _meta(_tmpdir: Path) -> dict[str, str]:
+        return {"BASE_REF": "origin/main", "ASSESSMENT_KIND": state}
+
+    def _note_path(_tmpdir: Path) -> Path:
+        return tmp_path / "note.md"
+
+    def _fake_invalidate(tmpdir: Path) -> None:
+        invalidated.append(tmpdir)
+
+    monkeypatch.setattr(assessment, "_git_read", _head)
+    if kind == config.ASSESSMENT_KIND_INVARIANTS:
+        monkeypatch.setattr(assessment.architectural_guidelines, "invariant_durable_note_metadata", _meta)
+        monkeypatch.setattr(assessment.architectural_guidelines, "invariant_durable_note_path", _note_path)
+        monkeypatch.setattr(assessment.architectural_guidelines, "invalidate_invariant_implement_note", _fake_invalidate)
+    else:
+        monkeypatch.setattr(assessment.architectural_guidelines, "durable_note_metadata", _meta)
+        monkeypatch.setattr(assessment.architectural_guidelines, "durable_note_path", _note_path)
+        monkeypatch.setattr(assessment.architectural_guidelines, "invalidate_implement_note", _fake_invalidate)
+
+
+def test_repair_current_outcome_invalid_kind_reauthors_and_invalidates(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    invalidated: list[Path] = []
+    _repair_stubs(monkeypatch, tmp_path, kind=config.ASSESSMENT_KIND_GUIDELINES, state="bogus", invalidated=invalidated)
+    status = assessment._repair_current_outcome(  # pyright: ignore[reportPrivateUsage]
+        config.ASSESSMENT_KIND_GUIDELINES, repo_root=tmp_path, implement_tmpdir=tmp_path, head_sha="a" * 40
+    )
+    assert status == assessment._reauthor_status(config.ASSESSMENT_REAUTHOR_REASON_INVALID_OUTCOME)  # pyright: ignore[reportPrivateUsage]
+    assert invalidated == [tmp_path]
+
+
+def test_repair_current_outcome_unreadable_note_reauthors_and_invalidates(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    invalidated: list[Path] = []
+    _repair_stubs(monkeypatch, tmp_path, kind=config.ASSESSMENT_KIND_INVARIANTS, state="clean", invalidated=invalidated)
+
+    def _unreadable(_path: Path, **_kwargs: object) -> str:
+        raise OSError("note unreadable")
+
+    monkeypatch.setattr(assessment, "_read_regular", _unreadable)
+    status = assessment._repair_current_outcome(  # pyright: ignore[reportPrivateUsage]
+        config.ASSESSMENT_KIND_INVARIANTS, repo_root=tmp_path, implement_tmpdir=tmp_path, head_sha="a" * 40
+    )
+    assert status == assessment._reauthor_status(config.ASSESSMENT_REAUTHOR_REASON_MISSING_METADATA)  # pyright: ignore[reportPrivateUsage]
+    assert invalidated == [tmp_path]
+
+
+def test_repair_current_outcome_clean_classification_mismatch_reauthors_and_invalidates(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    invalidated: list[Path] = []
+    _repair_stubs(monkeypatch, tmp_path, kind=config.ASSESSMENT_KIND_GUIDELINES, state="clean", invalidated=invalidated)
+
+    def _note_text(_path: Path, **_kwargs: object) -> str:
+        return "clean note prose that mentions G-Py-4"
+
+    monkeypatch.setattr(assessment, "_read_regular", _note_text)
+    monkeypatch.setattr(assessment.architectural_guidelines, "authored_outcome_valid", lambda **_kwargs: False)  # type: ignore[reportUnknownLambdaType, reportUnknownArgumentType]
+    status = assessment._repair_current_outcome(  # pyright: ignore[reportPrivateUsage]
+        config.ASSESSMENT_KIND_GUIDELINES, repo_root=tmp_path, implement_tmpdir=tmp_path, head_sha="a" * 40
+    )
+    assert status == assessment._reauthor_status(config.ASSESSMENT_REAUTHOR_REASON_CLEAN_MISMATCH)  # pyright: ignore[reportPrivateUsage]
+    assert invalidated == [tmp_path]
+
+
+def test_repair_current_outcome_non_clean_classification_mismatch_reauthors_and_invalidates(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    invalidated: list[Path] = []
+    _repair_stubs(monkeypatch, tmp_path, kind=config.ASSESSMENT_KIND_GUIDELINES, state="deviation", invalidated=invalidated)
+
+    def _note_text(_path: Path, **_kwargs: object) -> str:
+        return "deviation note prose"
+
+    monkeypatch.setattr(assessment, "_read_regular", _note_text)
+    monkeypatch.setattr(assessment.architectural_guidelines, "authored_outcome_valid", lambda **_kwargs: False)  # type: ignore[reportUnknownLambdaType, reportUnknownArgumentType]
+    status = assessment._repair_current_outcome(  # pyright: ignore[reportPrivateUsage]
+        config.ASSESSMENT_KIND_GUIDELINES, repo_root=tmp_path, implement_tmpdir=tmp_path, head_sha="a" * 40
+    )
+    assert status == assessment._reauthor_status(config.ASSESSMENT_REAUTHOR_REASON_INVALID_OUTCOME)  # pyright: ignore[reportPrivateUsage]
+    assert invalidated == [tmp_path]

--- a/skills/implement/scripts/test-step-8-assessment.sh
+++ b/skills/implement/scripts/test-step-8-assessment.sh
@@ -677,6 +677,24 @@ else
   fail "fresh: kinds got=$KINDS_GOT"
 fi
 
+# --- bare re-author token is rejected by the adapter grammar (regression: #7144) ---
+# The Step 8 repair path once emitted a bare `re-author-required` with no bounded reason.
+# The grammar requires the reasoned three-part token, so the child fails coverage validation
+# and the adapter publishes fail-closed. The Python fix stops the coordinator from emitting
+# the bare form; this pins the adapter contract that still rejects it (versus the reasoned
+# form accepted by fresh-reauthor above).
+setup_impl bare-reauthor
+printf 'run-child\n' >"$IMPL_TMP/.test-start-mode"
+printf 'ARCHITECTURAL_ASSESSMENT_STATUS=re-author-required\nARCHITECTURAL_ASSESSMENT_RESULTS=invariants:re-author-required,guidelines:clean\n' \
+  >"$IMPL_TMP/.test-assessment-stdout"
+set +e
+BARE_OUT=$(run_helper 2>"$TMP_ROOT/bare-reauthor.err")
+BARE_RC=$?
+set -e
+assert_rc "$BARE_RC" 0 'bare-reauthor: adapter exits 0'
+assert_contains 'ASSESSMENT_STATUS=fail-closed' "$BARE_OUT" 'bare-reauthor: bare token fails closed'
+assert_contains 'coverage mismatch' "$(cat "$IMPL_TMP/child-stderr.txt" 2>/dev/null)" 'bare-reauthor: grammar rejects bare re-author token'
+
 # --- completed rejoin success ---
 setup_impl rejoin-ok
 FP_EXPECTED=$(expected_fingerprint)


### PR DESCRIPTION
Fixes #7144.

## Problem

`_repair_current_outcome` in `python/larch/implement/architectural_assessment.py` returned the bare constant `re-author-required` (no `:reason` suffix) on its three failure branches. The Step 8 adapter grammar in `step-8-assessment.sh` requires the reasoned three-part token `kind:re-author-required:<bounded-reason>`, so the coordinator's otherwise-successful output was rejected as an `ASSESSMENT_RESULTS coverage mismatch`. The condition is deterministic, so attempt 2 failed identically and the run hard-stopped as an opaque `fail-closed` — a diagnostic that points at coverage, not at the stale note. The repair path also never invalidated the offending durable note, so every later Step 8 entry for the same HEAD/base repeated the hard stop.

Its blocker, #7143 (bounded re-author reassessment cycle), merged first via #7154.

## Fix

Each of the three repair branches now:

1. Invalidates the durable note with the kind-appropriate invalidator, mirroring `_persist_authored_results`.
2. Returns `_reauthor_status(...)` with a bounded reason the adapter grammar accepts:
   - `invalid-explicit-outcome` — `ASSESSMENT_KIND` outside the allowed set
   - `missing-or-invalid-outcome-metadata` — unreadable note
   - `clean-outcome-prose-mismatch` (or `invalid-explicit-outcome` when the recorded outcome is not `clean`) — prose classification mismatch

With the note invalidated, the next coordinator pass re-materializes and re-authors within #7143's bounded reassessment cycle instead of looping on the same current-but-invalid note. The three existing bounded reasons cover every branch, so no new `config.py` constant or Bash grammar change is needed (the vocabulary-fork cleanup remains #7037's scope).

## Scope

Ships the mandatory reasoned-terminal + invalidation form (issue suggested fixes 1, 2, 4). The optional "stronger form" (suggested fix 3 — in-run fall-through to materialization within the same coordinator run) is deferred: with #7143's cycle plus note invalidation, the stale note already heals across the reassessment cycle without a terminal hard stop, so the in-run optimization is out of scope here (it maps to the issue's open question about bgjob budget).

## Testing

- `python/tests/implement/test_architectural_assessment.py`: four new unit tests, one per repair branch — asserting the reasoned status and note invalidation, covering both invalidators and the clean vs. non-clean sub-case. `pytest tests/implement/test_architectural_assessment.py` → 60 passed.
- `skills/implement/scripts/test-step-8-assessment.sh`: new `bare-reauthor` regression pinning that the adapter grammar rejects a bare `re-author-required` token (fails closed with a coverage-mismatch diagnostic), complementing the existing `fresh-reauthor` case that accepts the reasoned form. Harness → 128 passed, 0 failed.
- `ruff` and `pyright` clean on the changed Python files; `shellcheck` clean on the changed harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
