### PR TITLE
Release v52.8.5

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.8.4",
+  "version": "52.8.5",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## v52.8.5

### Added

- Unified session and tmpdir builder contracts across the implement, design, and state cluster. (#7160)

### Fixed

- Canonicalized learn-from-bugs output paths on macOS TMPDIR. (#7150)
- Added a writer surface for learn-from-bugs origin markers. (#7153)
- Resolved a missing productive exit from the Step 8 re-author-required assessment terminal. (#7154)
- Emitted a bounded re-author reason from the Step 8 repair path. (#7162)
