### PR TITLE
Fixes #7171: strip stale NEEDS_USER_REASON on assessment reship

### DIFF
--- a/python/larch/implement/dispatch_ship.py
+++ b/python/larch/implement/dispatch_ship.py
@@ -953,9 +953,13 @@ def _normalize_assessment_handoff(*, implement_tmpdir: Path) -> tuple[str, tuple
         raise ValueError("assessment kinds must not contain empty or duplicate tokens")
     kinds = normalize_kinds(requested)
     canonical = ",".join(kinds)
+    # #7171: strip the stale NEEDS_USER_REASON while normalizing so the assessment
+    # reship does not read it as a terminal needs-user bail. This gate is being
+    # resolved by running the assessments; a genuine bail (unavailable or violation)
+    # bypasses this path and re-emits its own reason on a fresh route-exit.
     rewritten = [
         line for line in lines
-        if not line.startswith(("NEXT_ACTION=", "DETAIL=", "DETAIL_FILE="))
+        if not line.startswith(("NEXT_ACTION=", "DETAIL=", "DETAIL_FILE=", "NEEDS_USER_REASON="))
     ]
     rewritten.extend(("NEXT_ACTION=assessments", f"DETAIL={canonical}"))
     try:

--- a/python/tests/implement/test_implement_dispatch.py
+++ b/python/tests/implement/test_implement_dispatch.py
@@ -590,6 +590,28 @@ def test_ship_normalize_assessment_handoff_canonicalizes_kind_order(
     assert handoff.read_text(encoding="utf-8") == "NEXT_ACTION=assessments\nDETAIL=invariants,guidelines\n"
 
 
+def test_ship_normalize_assessment_handoff_strips_stale_needs_user_reason(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # #7171: the assessments route-exit records NEEDS_USER_REASON=architectural-assessments.
+    # Normalizing the reship handoff must drop it so the resumed ship run does not read a
+    # stale terminal needs-user bail and append a false-positive "merge and CI watch skipped"
+    # exec-issue row. Unrelated keys are preserved.
+    tmp = make_implement_tmpdir(tmp_path)
+    handoff = tmp / ".ship-route-exit-handoff.env"
+    _ = handoff.write_text(
+        "KEEP=value\nNEEDS_USER_REASON=architectural-assessments\n"
+        "NEXT_ACTION=assessments\nDETAIL=guidelines,invariants\n",
+        encoding="utf-8",
+    )
+
+    assert implement_dispatch.ship_normalize_assessment_handoff_main(["--implement-tmpdir", str(tmp)]) == 0
+
+    assert capsys.readouterr().out == "NEXT_ACTION=assessments\nASSESSMENT_REQUESTED_KINDS=invariants,guidelines\n"
+    assert handoff.read_text(encoding="utf-8") == "KEEP=value\nNEXT_ACTION=assessments\nDETAIL=invariants,guidelines\n"
+
+
 def test_ship_normalize_assessment_handoff_rejects_noncanonical_kinds(tmp_path: Path) -> None:
     tmp = make_implement_tmpdir(tmp_path)
     handoff = tmp / ".ship-route-exit-handoff.env"


### PR DESCRIPTION
Fixes #7171.

## Problem

During an assessment reship, the ship route-exit records
`NEEDS_USER_REASON=architectural-assessments` in `.ship-route-exit-handoff.env`.
`_normalize_assessment_handoff` rewrote that handoff (canonicalizing
`NEXT_ACTION`/`DETAIL`) but preserved the `NEEDS_USER_REASON` line. When the
resumed fresh ship run wrote its intermediate reports, `_needs_user_ship_handoff`
read the stale reason (the run's outcome was still `pr-created`, not `merged`, so
it did not short-circuit) and `_prime_needs_user_execution_issue` appended a
false-positive `ship route: merge and CI watch skipped — needs user` exec-issue
row. Because `append_execution_issue` only appends, the row persisted into the
final run summary even after the PR admin-merged.

## Fix

Strip `NEEDS_USER_REASON` inside `_normalize_assessment_handoff` alongside the
existing `NEXT_ACTION`/`DETAIL`/`DETAIL_FILE` keys. This clears the stale reason
at its source, so every downstream reader sees a clean handoff: the comment-only
progress write (`write_final_report_comment`, `ship.py`) and the pre-push
full-report flushes (`_stage_pre_commit`, `run_log_flush.py`) alike. This is why
the source-clear is preferred over gating only the comment-only path: the triage
addendum showed a full `write_final_report` also runs inside the stale window.

The normalize path runs only for the resumable assessment gates
(`assessments`/`invariants-assessment`/`guidelines-assessment`), where the
needs-user marker is being resolved by running the assessments. Genuine terminal
bails take different routes and re-emit their own reason on a fresh route-exit, so
they keep their exec-issue row:

- `architectural-assessment-unavailable` routes to `operator-bail`
- `architectural-invariants-violation` routes to `ci-fix`

## Testing

- New regression test `test_ship_normalize_assessment_handoff_strips_stale_needs_user_reason`
  asserts the stale `NEEDS_USER_REASON` is dropped while unrelated keys are preserved.
- `python -m pytest tests/implement/test_implement_dispatch.py` (392 passed) and
  `tests/report/test_final_report.py` pass.
- `ruff`, `pyright`, `pylint` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
