### PR TITLE
Fixes #7178: preserve caller newline intent in gh body writes

### DIFF
--- a/python/larch/git/gh.py
+++ b/python/larch/git/gh.py
@@ -266,7 +266,10 @@ def _as_int(value: object, *, context: str, field: str) -> int:
 
 
 def _fail_closed_redacted(text: str, *, context: str) -> str:
-    redacted = redact.redact(text)
+    # redact_outbound preserves the caller's trailing-newline intent so a
+    # body composed without one (e.g. triage's marked_comment) reads back
+    # byte-identical; redact() would append "\n" and break exact read-back.
+    redacted = redact.redact_outbound(text)
     if "[content truncated" in redacted:
         msg = f"redaction failed for {context}"
         raise ShipError(msg)

--- a/python/tests/git/test_gh.py
+++ b/python/tests/git/test_gh.py
@@ -1189,6 +1189,27 @@ def test_body_file_args_fail_closed_on_truncation(
         _ = gh.pr_edit_body(runner, 1, "secret", repo="o/r")
 
 
+@pytest.mark.parametrize(
+    "body",
+    [
+        "<!-- larch:triage-verdict:duplicate -->\nDuplicate of #8.",
+        "issue body with an intentional trailing newline\n",
+    ],
+)
+def test_body_file_args_preserves_caller_trailing_newline_intent(body: str) -> None:
+    """A gh body is written byte-identically, newline-terminated or not.
+
+    Regression for the triage close read-back failure: redact() appended a
+    trailing newline to every gh body write, so triage's `marked_comment`
+    (stripped, so it has none) failed exact read-back with EXIT_POSTCONDITION
+    and left the issue open with an orphan verdict comment. redact_outbound()
+    preserves the caller's newline intent so the comment reads back as posted.
+    """
+    with gh._body_file_args(body) as (flag, path):  # pyright: ignore[reportPrivateUsage]
+        assert flag == "--body-file"
+        assert Path(path).read_text(encoding="utf-8") == body
+
+
 def test_pr_checks_text_fallback_word_boundaries() -> None:
     assert gh._pr_checks_text_all_pass("ci\tpass\t0\t0\n")  # pyright: ignore[reportPrivateUsage]
     assert not gh._pr_checks_text_all_pass("ci\tfail\t0\t0\n")  # pyright: ignore[reportPrivateUsage]


### PR DESCRIPTION
Closes #7178

## Problem

`triage apply` with a close verdict (`duplicate`, `already-fixed`, `invalid`) posted the verification comment, then **always** failed its postcondition with `ERROR=triage comment failed exact read-back` (exit 8, `EXIT_POSTCONDITION`). The comment landed, the close never ran, and the issue was left open with an orphan verdict comment. A rerun wedged on `conflicting triage verdict marker already exists`.

Root cause: `redact()` appends a trailing newline to line-oriented output (awk parity), so every gh body-file write got a newline the composed body did not have. `triage` builds `marked_comment` with `.strip()` (no trailing newline), GitHub stored `marked_comment + "\n"`, and the exact-membership read-back (`marked_comment not in current_comments`) missed on that one byte.

## Fix

Switch `_fail_closed_redacted` (the single redaction chokepoint for every gh body-file write) from `redact.redact` to `redact.redact_outbound`. `redact_outbound` runs the same secret/tmpdir redaction passes but preserves the caller's trailing-newline intent, so bodies write byte-identically and read back as posted.

- Preferred **Option 1** from the issue.
- The fail-closed `"[content truncated"` guard is unchanged — `redact_outbound` calls `redact` internally, so a truncation marker still trips it.
- Also removes the latent `valid`-path hazard the issue flagged: `issue_edit` shares `_body_file_args`, so its `current.body == new_body` read-back was exposed to the same mismatch.

## Test

Added a parametrized regression test that round-trips a body **with** and **without** a trailing newline through `_body_file_args` and asserts byte-identical write-out — the exact read-back the triage postcondition depends on.

## Validation

- `pytest` full suite: 8839 passed, 48 skipped.
- `ruff`, `pyright`, `pylint` (10.00/10) clean on changed files; fast AST-ratchet lint suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
