### PR TITLE
Fixes #7166: model voter pre-dispatch phase in timing Gantt

### DIFF
--- a/python/larch/agents/agent_voters.py
+++ b/python/larch/agents/agent_voters.py
@@ -9,6 +9,7 @@ import os
 import re
 import sys
 import tempfile
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from collections.abc import Mapping, Sequence
@@ -27,10 +28,12 @@ from larch.review.dispatch_shared import (
     emit_final_voter_kvs,
     fresh_calibration_snapshot,
     path_for_wire,
+    record_voter_dispatch_prep,
     resolved_model_for_row,
     topology_voter_policies,
     validate_parse_rate_result,
 )
+from larch.report.timing import resolve_timing_ledger_path
 from larch.report.tokens import build_panel_dispatch_env, read_panel_payload_bytes, resolve_panel_artifact_dir
 
 _PLUGIN_ROOT = Path(__file__).resolve().parents[3]
@@ -413,6 +416,7 @@ def _state_from_bindings(*, bindings: Mapping[str, agent_waterfall.SlotOutputBin
 
 
 def dispatch_voters(opts: Options) -> int:
+    prep_start = time.time()
     _validate_options(opts)
     if not _cli_path().is_file():
         _err(f"agent dispatch-voters: missing python/cli.py at {_cli_path()}")
@@ -446,7 +450,18 @@ def dispatch_voters(opts: Options) -> int:
         calibration_stats_file=calibration_stats_file,
     )
     manifest = _write_voter_waterfall_manifest(review_tmpdir=review_tmpdir, policies=launched_policies, prompt_files=prompt_files, payload_files=payload_files, tier=opts.tier)
+    # The serial calibration + render + manifest work above is the pre-dispatch window; a voter
+    # records its start_s only after the waterfall spawns it, so record the window explicitly to
+    # keep the Gantt from showing a blank gap between the aggregator and the voters (issue #7166).
+    prep_end = time.time()
     waterfall_output = _dispatch_waterfall(opts=opts, manifest=manifest, ctx_args=ctx_args, review_tmpdir=review_tmpdir)
+    record_voter_dispatch_prep(
+        ledger=resolve_timing_ledger_path(),
+        skill=os.environ.get("LARCH_TIMING_SKILL", "implement"),
+        prep_start=prep_start,
+        prep_end=prep_end,
+        round_num=opts.round_num,
+    )
     _outputs, _tools, dispatch_ok = _parse_waterfall_output(waterfall_output)
     bindings = agent_waterfall.bind_manifest_slot_outputs(manifest_path=manifest, wf_kv=_kv_from_waterfall(waterfall_output))
 

--- a/python/larch/report/progress_report.py
+++ b/python/larch/report/progress_report.py
@@ -1140,6 +1140,7 @@ def _derive_progress_label(
         "cursor-review-fix": "cursor/apply",
         "cursor-plan-autofix": "cursor/apply",
         "gate-b-apply": "gate-b/apply",
+        "voter-dispatch-prep": "voter-dispatch-prep",
     }
     if kind in kind_labels:
         return kind_labels[kind]

--- a/python/larch/report/timing.py
+++ b/python/larch/report/timing.py
@@ -29,7 +29,7 @@ TIMING_TASK_KINDS_ALLOWED: frozenset[str] = frozenset({
     "cursor-plan-arch", "cursor-plan-innovation", "cursor-plan-pragmatic", "cursor-plan-requirements",
     "codex-plan-voter", "cursor-plan-voter", "claude-plan-voter", "claude-plan-draft",
     "claude-code-voter", "claude-plan-generic", "claude-decomp-generic", "claude-voter-1-parse-retry",
-    "codex-plan-autofix", "cursor-plan-autofix", "gate-b-apply",
+    "codex-plan-autofix", "cursor-plan-autofix", "gate-b-apply", "voter-dispatch-prep",
     "codex-review-voter", "cursor-review-voter",
     "claude-phase3-correctness", "claude-phase3-edge-cases", "claude-phase3-testing",
     "claude-phase3-structure", "claude-phase3-plan-fidelity", "claude-phase3-aggregator",

--- a/python/larch/review/dispatch_shared.py
+++ b/python/larch/review/dispatch_shared.py
@@ -13,6 +13,7 @@ from typing import Literal, Protocol, cast
 
 from larch.agents import _launch_failure
 from larch.core import config, external_defaults, logging_util
+from larch.report.timing import TimingLedger
 from larch.review import _voting_calibration, voting
 
 VoterRowLayout = Literal["code_review_sequential", "plan_review_interleaved"]
@@ -64,6 +65,36 @@ class DispatchState:
 def path_for_wire(path: Path | None) -> str:
     """Serialize an optional path only when it crosses a wire boundary."""
     return "" if path is None else str(path)
+
+
+def record_voter_dispatch_prep(
+    *,
+    ledger: Path | None,
+    skill: str,
+    prep_start: float,
+    prep_end: float,
+    round_num: int,
+) -> None:
+    """Record the serial voter pre-dispatch window as a ``voter-dispatch-prep`` vendor row.
+
+    The window covers the blocking work each dispatcher runs before the waterfall spawns any
+    voter: the calibration snapshot, the per-slot/tool ``render voter`` subprocess calls, and
+    the manifest write. A voter captures its own ``start_s`` only after that phase completes,
+    so without this row the Gantt shows a blank band between the aggregator bar and the voter
+    bars instead of the render work that fills it (issue #7166). Timing is diagnostic, so a
+    missing ledger or a write error is skipped rather than raised.
+    """
+    if ledger is None or not ledger.is_file():
+        return
+    with suppress(OSError, ValueError):
+        TimingLedger(ledger, skill=skill).record_vendor_task(
+            vendor="claude",
+            task_kind="voter-dispatch-prep",
+            start_s=prep_start,
+            end_s=prep_end,
+            output=f"voter-dispatch-prep-round-{round_num}.out",
+            status="complete",
+        )
 
 
 def topology_slots(topology_key: str) -> tuple[config.SlotDefault, ...]:

--- a/python/larch/review/plan_review_panel.py
+++ b/python/larch/review/plan_review_panel.py
@@ -12,6 +12,7 @@ import os
 import re
 import subprocess
 import sys
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from collections.abc import Mapping, Sequence
@@ -34,6 +35,7 @@ from larch.review.dispatch_shared import (
     VoterSlotPolicy,
     emit_final_voter_kvs,
     fresh_calibration_snapshot,
+    record_voter_dispatch_prep,
     resolved_model_for_row,
     topology_slots,
     topology_voter_policies,
@@ -933,6 +935,7 @@ def dispatch_voters(argv: Sequence[str]) -> int:  # noqa: C901,PLR0912,PLR0915,R
         parser.exit(2, "cli.py plan-review voter-dispatch: --round-num must be positive\n")
     if ns.codex_available not in {"true", "false"} or ns.cursor_available not in {"true", "false"}:
         parser.exit(2, "cli.py plan-review voter-dispatch: availability flags must be true or false\n")
+    prep_start = time.time()
     round_dir = design / "plan-review" / f"round-{ns.round_num}"
     round_dir.mkdir(parents=True, exist_ok=True)
     panel_env = build_panel_dispatch_env(
@@ -1057,10 +1060,22 @@ def dispatch_voters(argv: Sequence[str]) -> int:  # noqa: C901,PLR0912,PLR0915,R
         "--claude-read-tools-add-dir",
         str(design),
     ]
+    # Pre-dispatch window closes here: the calibration snapshot, serial render voter calls, and
+    # manifest write are done, and the waterfall is about to spawn the voters that record their
+    # own start_s. Record the window so the design Gantt shows it instead of a blank gap between
+    # the aggregator and the voters (issue #7166).
+    prep_end = time.time()
     wf = larch_proc.run(
         wf_args,
         cwd=str(_REPO_ROOT),
         env=panel_env,
+    )
+    record_voter_dispatch_prep(
+        ledger=design / "timing-ledger.tsv",
+        skill="design",
+        prep_start=prep_start,
+        prep_end=prep_end,
+        round_num=ns.round_num,
     )
     waterfall_output = wf.stdout
     wf_kv = _parse_kv(waterfall_output)

--- a/python/tests/agents/test_agent_voters.py
+++ b/python/tests/agents/test_agent_voters.py
@@ -270,6 +270,40 @@ def test_voter_prompts_use_nested_implement_ledger_root(tmp_path: Path, monkeypa
 
 
 @pytest.mark.voter_happy
+def test_dispatch_records_voter_dispatch_prep_row(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Issue #7166: the serial pre-dispatch phase (calibration + render + manifest) lands as a
+    # voter-dispatch-prep vendor row in the same timing ledger the voters use, so the Gantt
+    # shows it instead of a blank gap between the aggregator bar and the voter bars.
+    impl = tmp_path / "impl"
+    review = impl / "round-1"
+    review.mkdir(parents=True)
+    ledger = impl / "timing-ledger.tsv"
+    _ = ledger.write_text("", encoding="utf-8")  # voters create this in prod; pre-create to pass the is_file gate
+    ballot = tmp_path / "ballot.md"
+    ballot.write_text("### FINDING_1: one\n", encoding="utf-8")
+    _install_harness(monkeypatch, tmp_path, review)
+    monkeypatch.setenv("IMPLEMENT_TMPDIR", str(impl))
+    monkeypatch.delenv("LARCH_TIMING_LEDGER", raising=False)
+    monkeypatch.delenv("LARCH_TIMING_SKILL", raising=False)
+    clock = {"n": 0}
+    stamps = [1000.0, 1167.0]
+
+    def _fake_time() -> float:
+        value = stamps[min(clock["n"], len(stamps) - 1)]
+        clock["n"] += 1
+        return value
+
+    monkeypatch.setattr(agent_voters.time, "time", _fake_time)
+
+    assert agent_voters.dispatch_voters(_opts(ballot, review)) == 0
+
+    text = ledger.read_text(encoding="utf-8")
+    prep_row = next(line for line in text.splitlines() if "voter-dispatch-prep" in line).split("\t")
+    assert prep_row[3] == "implement"
+    assert prep_row[5:11] == ["claude", "voter-dispatch-prep", "1000", "1167", "167", "voter-dispatch-prep-round-1.out"]
+
+
+@pytest.mark.voter_happy
 def test_render_failure_aborts_before_launch(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     review = tmp_path / "review"
     ballot = tmp_path / "ballot.md"

--- a/python/tests/report/test_review_phase_detail.py
+++ b/python/tests/report/test_review_phase_detail.py
@@ -547,6 +547,9 @@ def test_progress_label_fallbacks_and_manifest_precedence(tmp_path: Path) -> Non
     )
     assert progress_report._derive_progress_label(output="coder-codex.log", vendor="codex", kind="codex-review-fix") == "codex/apply"
     assert progress_report._derive_progress_label(output="coder-cursor.log", vendor="cursor", kind="cursor-review-fix") == "cursor/apply"
+    # Issue #7166: the synthetic voter pre-dispatch row keeps its label from the task kind
+    # regardless of the neutral claude vendor stamped on the row.
+    assert progress_report._derive_progress_label(output="voter-dispatch-prep-round-1.out", vendor="claude", kind="voter-dispatch-prep") == "voter-dispatch-prep"
 
     output = tmp_path / "codex-output.txt"
     manifest = tmp_path / "panel-manifest.ndjson"
@@ -1498,6 +1501,28 @@ def test_render_phase_detail_design_gantt_labels_gate_b_apply(tmp_path: Path) ->
     assert "### Round 1 reviewer timing" in rendered
     assert "gate-b/apply" in rendered
     assert "window 0:00-2:20 (140s)" in rendered
+
+
+def test_render_phase_detail_gantt_labels_voter_dispatch_prep(tmp_path: Path) -> None:
+    # Issue #7166: the serial pre-dispatch render window is recorded as a voter-dispatch-prep
+    # vendor row so the Gantt fills the band between the aggregator bar and the voter bars
+    # instead of leaving it blank.
+    root = tmp_path / "rounds"
+    _write_round_meta(root / "round-1")
+    timing = tmp_path / "timing-ledger.tsv"
+    _write_round_timing(timing, skill="implement", round_num=1, start_s=100, end_s=300)
+    _write_vendor_timing(timing, "aggregator-output.txt", 120, 160, vendor="claude", kind="claude-phase3-aggregator")
+    _write_vendor_timing(timing, "voter-dispatch-prep-round-1.out", 160, 260, vendor="claude", kind="voter-dispatch-prep")
+    _write_vendor_timing(timing, "codex-validity-vote-output.txt", 260, 290, vendor="codex", kind="codex-review-voter")
+
+    rendered = progress_report.render_phase_detail(rounds_root=root, skill="implement", timing_ledger=timing)
+
+    assert "### Round 1 reviewer timing" in rendered
+    assert "aggregator" in rendered
+    assert "voter-dispatch-prep" in rendered
+    assert "codex/validity-vote" in rendered
+    prep_line = next(line for line in rendered.splitlines() if "voter-dispatch-prep" in line)
+    assert "█" in prep_line
 
 
 def test_render_phase_detail_splits_gantt_per_attempt(tmp_path: Path) -> None:

--- a/python/tests/report/test_timing.py
+++ b/python/tests/report/test_timing.py
@@ -45,6 +45,23 @@ def test_timing_vendor_task_accepts_gate_b_apply(tmp_path: Path, capsys: pytest.
     assert row[5:11] == ["claude", "gate-b-apply", "20", "35", "15", "gate-b-apply-round-1.out"]
 
 
+def test_timing_vendor_task_accepts_voter_dispatch_prep(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    # Issue #7166: the serial voter pre-dispatch phase is recorded as its own vendor row so the
+    # Gantt shows it instead of a blank gap between the aggregator and the voters.
+    ledger = tmp_path / "timing-ledger.tsv"
+    timing.TimingLedger(ledger, skill="implement").record_vendor_task(
+        vendor="claude",
+        task_kind="voter-dispatch-prep",
+        start_s=40,
+        end_s=207,
+        output="voter-dispatch-prep-round-2.out",
+    )
+    assert "unknown task-kind" not in capsys.readouterr().err
+    row = ledger.read_text(encoding="utf-8").strip().split("\t")
+    assert row[0:2] == ["v1", "vendor"]
+    assert row[5:11] == ["claude", "voter-dispatch-prep", "40", "207", "167", "voter-dispatch-prep-round-2.out"]
+
+
 def test_timing_report_design_omits_workflow_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     ledger = tmp_path / "timing-ledger.tsv"
     _ = ledger.write_text(

--- a/python/tests/review/test_dispatch_shared.py
+++ b/python/tests/review/test_dispatch_shared.py
@@ -241,6 +241,31 @@ def _state(tmp_path: Path) -> dispatch_shared.DispatchState:
     )
 
 
+def test_record_voter_dispatch_prep_appends_row_to_existing_ledger(tmp_path: Path) -> None:
+    # Issue #7166: the pre-dispatch window lands as a claude/voter-dispatch-prep vendor row.
+    ledger = tmp_path / "timing-ledger.tsv"
+    _ = ledger.write_text("", encoding="utf-8")
+    dispatch_shared.record_voter_dispatch_prep(
+        ledger=ledger, skill="implement", prep_start=40, prep_end=207, round_num=3
+    )
+    row = ledger.read_text(encoding="utf-8").strip().split("\t")
+    assert row[0:2] == ["v1", "vendor"]
+    assert row[5:11] == ["claude", "voter-dispatch-prep", "40", "207", "167", "voter-dispatch-prep-round-3.out"]
+
+
+def test_record_voter_dispatch_prep_skips_when_ledger_missing(tmp_path: Path) -> None:
+    # A diagnostic row must never create a stray ledger when the real ledger is absent
+    # (e.g. a bare /review with no timing ledger), and a None ledger is a silent no-op.
+    absent = tmp_path / "timing-ledger.tsv"
+    dispatch_shared.record_voter_dispatch_prep(
+        ledger=absent, skill="implement", prep_start=1, prep_end=2, round_num=1
+    )
+    assert not absent.exists()
+    dispatch_shared.record_voter_dispatch_prep(
+        ledger=None, skill="design", prep_start=1, prep_end=2, round_num=1
+    )
+
+
 def test_final_emitter_uses_logging_and_code_review_order(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     emitted: list[tuple[str, str]] = []
 

--- a/python/tests/review/test_plan_review_panel.py
+++ b/python/tests/review/test_plan_review_panel.py
@@ -814,6 +814,62 @@ def test_dispatch_voters_calibration_wiring_harness(tmp_path: Path, monkeypatch:
         assert (design / basename).is_file()
 
 
+def test_dispatch_voters_records_voter_dispatch_prep_row(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Issue #7166 (open question 3): the design plan-review voter dispatch shares the serial
+    # pre-dispatch phase, so it records a voter-dispatch-prep vendor row into the design timing
+    # ledger, keeping the /design Gantt from showing a blank gap before the voter bars.
+    design = tmp_path / "design-prep"
+    design.mkdir()
+    _ = (design / "source-env.sh").write_text(f"REPO_ROOT={tmp_path}\n", encoding="utf-8")
+    ledger = design / "timing-ledger.tsv"
+    _ = ledger.write_text("", encoding="utf-8")  # voters create this in prod; pre-create to pass the is_file gate
+    ballot = design / "ballot.txt"
+    _ = ballot.write_text("### FINDING_1: test\n", encoding="utf-8")
+    cp = plan_review_panel.subprocess.CompletedProcess
+
+    def _fake_run(argv: object, **_kwargs: object) -> object:
+        a = [str(x) for x in argv]  # type: ignore[union-attr]
+        verb = tuple(a[2:4]) if len(a) >= 4 else ()
+        if verb == ("render", "voter"):
+            return cp(a, 0, stdout="prompt\nRead the ballot from this path: /x\n", stderr="")
+        if verb == ("agent", "dispatch-waterfall"):
+            outs: list[str] = []
+            for i, tok in enumerate(a):
+                if tok == "--slots-file" and i + 1 < len(a) and Path(a[i + 1]).is_file():
+                    for line in Path(a[i + 1]).read_text(encoding="utf-8").splitlines():
+                        if not line.strip():
+                            continue
+                        out = str(json.loads(line)["output"])
+                        _ = Path(out).write_text("vote\n", encoding="utf-8")
+                        _ = Path(out + ".done").write_text("0\n", encoding="utf-8")
+                        outs.append(out)
+            stdout = "ALL_OUTPUT_FILES=" + " ".join(outs) + "\nALL_OUTPUT_TOOLS=" + " ".join(["codex"] * len(outs)) + "\nDISPATCH_OK=true\n"
+            return cp(a, 0, stdout=stdout, stderr="")
+        if verb == ("voting", "effective-judges"):
+            return cp(a, 0, stdout="3\n", stderr="")
+        return cp(a, 0, stdout="", stderr="")
+
+    monkeypatch.setenv("LARCH_VOTER_CALIBRATION_FEEDBACK", "0")
+    monkeypatch.delenv("LARCH_CONSUMER_REPO", raising=False)
+    monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+    monkeypatch.setattr(plan_review_panel.subprocess, "run", _fake_run)
+    monkeypatch.setattr(plan_review_panel, "_parse_rate_retry", lambda **_k: "OK")  # type: ignore[arg-type]
+
+    rc = plan_review_panel.dispatch_voters([
+        "--ballot-file", str(ballot),
+        "--design-tmpdir", str(design),
+        "--codex-available", "true",
+        "--cursor-available", "true",
+        "--round-num", "1",
+    ])
+
+    assert rc == 0
+    prep_row = next(line for line in ledger.read_text(encoding="utf-8").splitlines() if "voter-dispatch-prep" in line).split("\t")
+    assert prep_row[3] == "design"
+    assert prep_row[5:7] == ["claude", "voter-dispatch-prep"]
+    assert prep_row[10] == "voter-dispatch-prep-round-1.out"
+
+
 def test_dispatch_voters_enqueues_both_slots_when_codex_down(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     # issue #5817: with Codex down but Cursor up, voter-2 (Codex-primary) is no
     # longer dropped -- both slots are enqueued and the waterfall (no


### PR DESCRIPTION
Fixes #7166

## What

The `/implement` and `/design` final-report Gantt charts show a wide blank band between the `aggregator` bar and the voter (`*-vote`) bars — up to ~167s at HARD tier. That band is not idle time. It is the serial voter **pre-dispatch** phase (calibration snapshot, per-slot/tool `render voter` calls, manifest write) that runs inside the dispatcher before the waterfall spawns any voter. A voter records its `start_s` only after it is spawned, so the render window fell into an unmodeled gap in the timing ledger and drew as blank space.

This implements the issue's **option 1** (timing annotation, no behavior change): record the pre-dispatch window as its own vendor row so the chart shows it.

## Changes

- **`dispatch_shared.record_voter_dispatch_prep`** — shared, best-effort writer. Appends a `claude` / `voter-dispatch-prep` vendor row only when a real timing ledger already exists; a missing ledger or write error is skipped (timing is diagnostic).
- **`agent_voters.dispatch_voters`** (`/implement`) — captures the window `[entry .. just before the waterfall]` and records it, resolving the ledger via `LARCH_TIMING_LEDGER` (the same ledger the voters use).
- **`plan_review_panel.dispatch_voters`** (`/design`) — records the same window against the design timing ledger. This **resolves the issue's open question 3**: the design plan-review dispatch has the identical serial pre-dispatch structure.
- **`timing`** — allow the `voter-dispatch-prep` task-kind.
- **`progress_report`** — label the row `voter-dispatch-prep` in the Gantt.

Dispatch behavior is unchanged (the renders still run serially); only the ledger now models the phase, so the chart is honest instead of misleading. Options 2 (parallelize renders) and 3 (thread an earlier `start_s`) are deliberately out of scope — they are performance changes, not required to fix the reported charting bug, and option 3 would touch `_review_launcher.py` which #7031 is migrating.

## Testing

- `dispatch_shared`: helper writes the row to an existing ledger; no-ops (and never creates a stray ledger) when the ledger is absent or `None`.
- `timing`: `record_vendor_task` accepts `voter-dispatch-prep` with no unknown-task-kind warning.
- `progress_report`: `_derive_progress_label` maps the kind to `voter-dispatch-prep`; end-to-end Gantt renders the bar between the aggregator and voter bars.
- `agent_voters` / `plan_review_panel`: integration tests drive each dispatcher and assert the prep row lands in the correct ledger with the right skill/vendor/kind.
- Full `report/` + `lint/` suites and all affected suites green; `ruff` and `pyright` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
