### PR TITLE
Fixes #7180: tolerate lowercase ledger_* keys in invariant-evidence route-handoff parse

### DIFF
--- a/python/larch/implement/invariant_evidence.py
+++ b/python/larch/implement/invariant_evidence.py
@@ -47,10 +47,16 @@ def _strict_kvs(path: Path) -> dict[str, str]:
     text = path.read_text(encoding="utf-8", errors="strict")
     rows: dict[str, str] = {}
     for raw in text.splitlines():
+        # Tolerate benign shell/env content (blank lines, comments, `export ` prefixes,
+        # lowercase ledger keys) by skipping it, matching read_key in step-8-ci-fixer.sh.
+        # Only raise on genuine integrity violations: a duplicate uppercase key or a
+        # control character in a value.
         if not raw or "=" not in raw:
-            raise EvidenceError("metadata contains a malformed row")
+            continue
         key, value = raw.split("=", 1)
-        if key in rows or not re.fullmatch(r"[A-Z][A-Z0-9_]*", key) or _CONTROL_RE.search(value):
+        if not re.fullmatch(r"[A-Z][A-Z0-9_]*", key):
+            continue
+        if key in rows or _CONTROL_RE.search(value):
             raise EvidenceError("metadata contains duplicate or unsafe data")
         rows[key] = value
     return rows

--- a/python/tests/implement/test_invariant_evidence.py
+++ b/python/tests/implement/test_invariant_evidence.py
@@ -79,6 +79,28 @@ def test_rejects_symlinked_route_handoff_without_partial_artifacts(tmp_path: Pat
     assert not (tmp_path / "architectural-invariants.md.identity.env").exists()
 
 
+def test_tolerates_lowercase_ledger_keys_in_route_handoff(tmp_path: Path) -> None:
+    argv = _args(tmp_path)
+    _ = (tmp_path / ".ship-route-exit-handoff.env").write_text(
+        "DETAIL=invariant failure\n"
+        "\n"
+        "ledger_ready=false\n"
+        "ledger_site=\n"
+        "ledger_trigger=\n"
+        "ledger_step=\n"
+        "ledger_phase=\n"
+        "ledger_dispatcher=\n"
+        "ledger_exit_code=\n"
+        "ledger_failure_detail_log=\n",
+        encoding="utf-8",
+    )
+    assert invariant_evidence.main(argv) == 0
+    body = (tmp_path / "architectural-invariants.md").read_text(encoding="utf-8")
+    assert "I-Test-1 was violated." in body
+    assert "invariant failure" in body
+    assert "ledger_" not in body
+
+
 def test_ignores_symlinked_legacy_identity_sidecar_temp(tmp_path: Path) -> None:
     argv = _args(tmp_path)
     outside = tmp_path.parent / "outside-identity.env"


### PR DESCRIPTION
Fixes #7180.

## Problem

`_strict_kvs` in `python/larch/implement/invariant_evidence.py` raised `EvidenceError` on any key not matching `[A-Z][A-Z0-9_]*` and on any blank or `=`-free line. The ship route handoff `.ship-route-exit-handoff.env` legitimately carries eight lowercase `ledger_*` rows (`ledger_ready`, `ledger_site`, `ledger_trigger`, `ledger_step`, `ledger_phase`, `ledger_dispatcher`, `ledger_exit_code`, `ledger_failure_detail_log`).

On the invariant-primary lane, `step-8-ci-fixer.sh --start` feeds that handoff to `ci materialize-invariant-evidence`, so the first lowercase row raised and the script bailed with `RESULT=operator-bail REASON=invariant-evidence-failed` before emitting `BGJOB_STATUS=STARTED`, blocking invariant-violation autonomous repair.

## Fix

Bring `_strict_kvs` into parity with the canonical `read_key` parser in `step-8-ci-fixer.sh`: skip blank and `=`-free lines and non-uppercase keys instead of raising, while keeping the duplicate-uppercase-key and control-character raises. This also resolves the triage open question by skipping blank lines for full `read_key` parity. The durable-note meta call site is unaffected: its keys are uppercase, and a duplicate `HEAD_SHA` still raises.

## Test

Added `test_tolerates_lowercase_ledger_keys_in_route_handoff`, which seeds the eight lowercase `ledger_*` rows plus a blank line beside the required uppercase `DETAIL` key and asserts `materialize` succeeds.

## Verification

- `pytest python/tests/implement/test_invariant_evidence.py`: 7 passed
- `ruff check` on the changed files: clean
- `pyright` on the changed files: 0 errors
- `pylint` on the changed files: 10.00/10
- `cli.py lint complexity-baseline`: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
