### PR TITLE
Fixes #7179: model reviewer collection phase in timing Gantt

### DIFF
--- a/python/complexity-baseline.json
+++ b/python/complexity-baseline.json
@@ -5301,7 +5301,7 @@
     "file": "larch/review/plan_review_round.py",
     "code": "PLR0915",
     "qualified_symbol": "execute_round",
-    "metric": 136
+    "metric": 138
   },
   {
     "file": "larch/review/plan_review_tally.py",
@@ -5583,7 +5583,7 @@
     "file": "larch/review/review_core_body.py",
     "code": "PLR0915",
     "qualified_symbol": "_review_core_body",
-    "metric": 244
+    "metric": 246
   },
   {
     "file": "larch/review/review_dispatch_panel.py",

--- a/python/larch/report/progress_report.py
+++ b/python/larch/report/progress_report.py
@@ -1141,6 +1141,7 @@ def _derive_progress_label(
         "cursor-plan-autofix": "cursor/apply",
         "gate-b-apply": "gate-b/apply",
         "voter-dispatch-prep": "voter-dispatch-prep",
+        "reviewer-collect": "reviewer-collect",
     }
     if kind in kind_labels:
         return kind_labels[kind]

--- a/python/larch/report/timing.py
+++ b/python/larch/report/timing.py
@@ -30,6 +30,7 @@ TIMING_TASK_KINDS_ALLOWED: frozenset[str] = frozenset({
     "codex-plan-voter", "cursor-plan-voter", "claude-plan-voter", "claude-plan-draft",
     "claude-code-voter", "claude-plan-generic", "claude-decomp-generic", "claude-voter-1-parse-retry",
     "codex-plan-autofix", "cursor-plan-autofix", "gate-b-apply", "voter-dispatch-prep",
+    "reviewer-collect",
     "codex-review-voter", "cursor-review-voter",
     "claude-phase3-correctness", "claude-phase3-edge-cases", "claude-phase3-testing",
     "claude-phase3-structure", "claude-phase3-plan-fidelity", "claude-phase3-aggregator",

--- a/python/larch/review/dispatch_shared.py
+++ b/python/larch/review/dispatch_shared.py
@@ -67,6 +67,36 @@ def path_for_wire(path: Path | None) -> str:
     return "" if path is None else str(path)
 
 
+def _record_pipeline_span(  # noqa: PLR0913 - the six span fields are all load-bearing and not worth bundling for two callers
+    *,
+    ledger: Path | None,
+    skill: str,
+    task_kind: str,
+    start_s: float,
+    end_s: float,
+    output: str,
+) -> None:
+    """Best-effort append of one synthetic pipeline-phase vendor row.
+
+    Shared by the recorders that model a serial span running between two instrumented model
+    calls (voter dispatch prep before the voters, reviewer collection before the aggregator).
+    The row carries the neutral ``claude`` vendor and a ``complete`` status so the Gantt draws
+    it as a labeled bar filling what would otherwise be a blank band. Timing is diagnostic, so
+    a missing ledger or a write error is skipped rather than raised.
+    """
+    if ledger is None or not ledger.is_file():
+        return
+    with suppress(OSError, ValueError):
+        TimingLedger(ledger, skill=skill).record_vendor_task(
+            vendor="claude",
+            task_kind=task_kind,
+            start_s=start_s,
+            end_s=end_s,
+            output=output,
+            status="complete",
+        )
+
+
 def record_voter_dispatch_prep(
     *,
     ledger: Path | None,
@@ -84,17 +114,43 @@ def record_voter_dispatch_prep(
     bars instead of the render work that fills it (issue #7166). Timing is diagnostic, so a
     missing ledger or a write error is skipped rather than raised.
     """
-    if ledger is None or not ledger.is_file():
-        return
-    with suppress(OSError, ValueError):
-        TimingLedger(ledger, skill=skill).record_vendor_task(
-            vendor="claude",
-            task_kind="voter-dispatch-prep",
-            start_s=prep_start,
-            end_s=prep_end,
-            output=f"voter-dispatch-prep-round-{round_num}.out",
-            status="complete",
-        )
+    _record_pipeline_span(
+        ledger=ledger,
+        skill=skill,
+        task_kind="voter-dispatch-prep",
+        start_s=prep_start,
+        end_s=prep_end,
+        output=f"voter-dispatch-prep-round-{round_num}.out",
+    )
+
+
+def record_reviewer_collect(
+    *,
+    ledger: Path | None,
+    skill: str,
+    collect_start: float,
+    collect_end: float,
+    round_num: int,
+) -> None:
+    """Record the reviewers-to-aggregator window as a ``reviewer-collect`` vendor row.
+
+    The window covers the serial work each review round runs after the last reviewer finishes
+    and before the aggregator model call starts: waiting for reviewer stragglers, collecting
+    and de-duplicating reviewer outputs, the failure-threshold check, and nit pruning. A
+    reviewer captures its ``end_s`` when its model call finishes and the aggregator captures
+    its ``start_s`` only when its model call begins, so without this row the Gantt shows a
+    blank band between the reviewer bars and the aggregator bar instead of the collection work
+    that fills it (issue #7179). Timing is diagnostic, so a missing ledger or a write error is
+    skipped rather than raised.
+    """
+    _record_pipeline_span(
+        ledger=ledger,
+        skill=skill,
+        task_kind="reviewer-collect",
+        start_s=collect_start,
+        end_s=collect_end,
+        output=f"reviewer-collect-round-{round_num}.out",
+    )
 
 
 def topology_slots(topology_key: str) -> tuple[config.SlotDefault, ...]:

--- a/python/larch/review/plan_review_round.py
+++ b/python/larch/review/plan_review_round.py
@@ -10,6 +10,7 @@ import re
 import shutil
 import subprocess
 import sys
+import time
 from pathlib import Path
 from typing import cast
 
@@ -18,6 +19,7 @@ from larch import io as larch_io
 from larch.core import config, logging_util
 from larch.report import progress_file
 from larch.review import review_aggregate
+from larch.review.dispatch_shared import record_reviewer_collect
 from larch.review.review_types import is_canonical_heading, parse_blocks
 from larch.review import voting
 from larch.review.plan_review_common import resolve_plan_review_tier
@@ -889,6 +891,10 @@ def execute_round(
         step="3",
         text=f"round {round_num}: launching reviewers",
     )
+    # panel-dispatch returns once the last reviewer finishes, so this stamp opens the
+    # reviewers-to-aggregator window: collection, dedup, and nit-prune below runs here, before
+    # the aggregator model call records its own start_s (issue #7179).
+    collect_start = time.time()
     out_lines.append(panel.stdout)
     if panel.returncode != 0:
         # Do not swallow the panel dispatcher's stderr (issue #4747): re-surface it so
@@ -990,6 +996,16 @@ def execute_round(
     in_scope = findings_path.read_text(encoding="utf-8", errors="replace") if findings_path.is_file() else ""
     oos_md = oos_path.read_text(encoding="utf-8", errors="replace") if oos_path.is_file() else ""
 
+    # The reviewers-to-aggregator window closes here, just before the aggregator model call.
+    # Record it against the design timing ledger the reviewers and aggregator use so the /design
+    # Gantt shows the collection work as a labeled bar instead of a blank gap (issue #7179).
+    record_reviewer_collect(
+        ledger=design / "timing-ledger.tsv",
+        skill="design",
+        collect_start=collect_start,
+        collect_end=time.time(),
+        round_num=round_num,
+    )
     agg = _run_cli_with_progress(
         argv=[
             "review",

--- a/python/larch/review/review_core_body.py
+++ b/python/larch/review/review_core_body.py
@@ -9,12 +9,15 @@ import contextlib
 import os
 import re
 import shutil
+import time
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 
 from larch.core import config, logging_util, proc
 from larch.calibration import difficulty
 from larch.report import progress_file
+from larch.report.timing import resolve_timing_ledger_path
+from larch.review.dispatch_shared import record_reviewer_collect
 from larch.review.review_pipeline_shared import (
     ReviewCommands,
     ReviewCoreBranchContext,
@@ -837,6 +840,10 @@ def _review_core_body(
         dispatch_args.extend(["--competition-notice-file", str(competition)])
     _progress_note(tmpdir=progress_tmpdir, step="5", text=f"round {round_num}: reviewer panel dispatch running")
     dispatch_result = _call_maybe_override(command=commands.dispatch, review_name="dispatch-panel", args=dispatch_args)
+    # dispatch-panel returns once the last reviewer's model call finishes, so this stamp opens the
+    # reviewers-to-aggregator window: the collection, threshold, and nit-prune work below runs here,
+    # before the aggregator model call records its own start_s (issue #7179).
+    collect_start = time.time()
     dispatch_out = review_tmpdir / "review-core-dispatch.env"
     _write_text(path=dispatch_out, text=dispatch_result.stdout)
     if dispatch_result.returncode != 0:
@@ -1038,6 +1045,17 @@ def _review_core_body(
     if _get(parsed=parsed, key="--plan-file"):
         aggregate_args.extend(["--plan-file", _get(parsed=parsed, key="--plan-file")])
     _progress_note(tmpdir=progress_tmpdir, step="5", text=f"round {round_num}: aggregating reviewer findings")
+    # The reviewers-to-aggregator window closes here, just before the aggregator model call starts.
+    # Record it against the same ledger the reviewers and aggregator use so the Gantt shows the
+    # collection work as a labeled bar instead of a blank gap (issue #7179). Reached only on the
+    # aggregating path; the earlier zero-findings and threshold returns never open a gap to fill.
+    record_reviewer_collect(
+        ledger=resolve_timing_ledger_path(),
+        skill=os.environ.get("LARCH_TIMING_SKILL", "implement"),
+        collect_start=collect_start,
+        collect_end=time.time(),
+        round_num=round_num,
+    )
     aggregate_result = _run_command_string(command=commands.aggregate, args=aggregate_args) if commands.aggregate else _call_maybe_override(command="", review_name="aggregate-findings", args=aggregate_args)
     aggregate_out = review_tmpdir / "review-core-aggregate.env"
     _write_text(path=aggregate_out, text=aggregate_result.stdout)

--- a/python/tests/report/test_review_phase_detail.py
+++ b/python/tests/report/test_review_phase_detail.py
@@ -550,6 +550,8 @@ def test_progress_label_fallbacks_and_manifest_precedence(tmp_path: Path) -> Non
     # Issue #7166: the synthetic voter pre-dispatch row keeps its label from the task kind
     # regardless of the neutral claude vendor stamped on the row.
     assert progress_report._derive_progress_label(output="voter-dispatch-prep-round-1.out", vendor="claude", kind="voter-dispatch-prep") == "voter-dispatch-prep"
+    # Issue #7179: the synthetic reviewer-collect row likewise labels from the task kind.
+    assert progress_report._derive_progress_label(output="reviewer-collect-round-1.out", vendor="claude", kind="reviewer-collect") == "reviewer-collect"
 
     output = tmp_path / "codex-output.txt"
     manifest = tmp_path / "panel-manifest.ndjson"
@@ -1523,6 +1525,28 @@ def test_render_phase_detail_gantt_labels_voter_dispatch_prep(tmp_path: Path) ->
     assert "codex/validity-vote" in rendered
     prep_line = next(line for line in rendered.splitlines() if "voter-dispatch-prep" in line)
     assert "█" in prep_line
+
+
+def test_render_phase_detail_gantt_labels_reviewer_collect(tmp_path: Path) -> None:
+    # Issue #7179: the reviewers-to-aggregator window is recorded as a reviewer-collect vendor
+    # row so the Gantt fills the band between the reviewer bars and the aggregator bar instead
+    # of leaving it blank. Reviewers finish at 160, aggregator starts at 260, and the
+    # reviewer-collect bar fills the [160, 260] gap that would otherwise be empty.
+    root = tmp_path / "rounds"
+    _write_round_meta(root / "round-1")
+    timing = tmp_path / "timing-ledger.tsv"
+    _write_round_timing(timing, skill="implement", round_num=1, start_s=100, end_s=320)
+    _write_vendor_timing(timing, "codex-correctness-output.txt", 100, 160, vendor="codex", kind="codex-review")
+    _write_vendor_timing(timing, "reviewer-collect-round-1.out", 160, 260, vendor="claude", kind="reviewer-collect")
+    _write_vendor_timing(timing, "aggregator-output.txt", 260, 300, vendor="claude", kind="claude-phase3-aggregator")
+
+    rendered = progress_report.render_phase_detail(rounds_root=root, skill="implement", timing_ledger=timing)
+
+    assert "### Round 1 reviewer timing" in rendered
+    assert "reviewer-collect" in rendered
+    assert "aggregator" in rendered
+    collect_line = next(line for line in rendered.splitlines() if "reviewer-collect" in line)
+    assert "█" in collect_line
 
 
 def test_render_phase_detail_splits_gantt_per_attempt(tmp_path: Path) -> None:

--- a/python/tests/report/test_timing.py
+++ b/python/tests/report/test_timing.py
@@ -62,6 +62,23 @@ def test_timing_vendor_task_accepts_voter_dispatch_prep(tmp_path: Path, capsys: 
     assert row[5:11] == ["claude", "voter-dispatch-prep", "40", "207", "167", "voter-dispatch-prep-round-2.out"]
 
 
+def test_timing_vendor_task_accepts_reviewer_collect(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    # Issue #7179: the reviewers-to-aggregator collection phase is recorded as its own vendor row
+    # so the Gantt shows it instead of a blank gap between the reviewers and the aggregator.
+    ledger = tmp_path / "timing-ledger.tsv"
+    timing.TimingLedger(ledger, skill="implement").record_vendor_task(
+        vendor="claude",
+        task_kind="reviewer-collect",
+        start_s=164,
+        end_s=348,
+        output="reviewer-collect-round-2.out",
+    )
+    assert "unknown task-kind" not in capsys.readouterr().err
+    row = ledger.read_text(encoding="utf-8").strip().split("\t")
+    assert row[0:2] == ["v1", "vendor"]
+    assert row[5:11] == ["claude", "reviewer-collect", "164", "348", "184", "reviewer-collect-round-2.out"]
+
+
 def test_timing_report_design_omits_workflow_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     ledger = tmp_path / "timing-ledger.tsv"
     _ = ledger.write_text(

--- a/python/tests/review/test_dispatch_shared.py
+++ b/python/tests/review/test_dispatch_shared.py
@@ -266,6 +266,31 @@ def test_record_voter_dispatch_prep_skips_when_ledger_missing(tmp_path: Path) ->
     )
 
 
+def test_record_reviewer_collect_appends_row_to_existing_ledger(tmp_path: Path) -> None:
+    # Issue #7179: the reviewers-to-aggregator window lands as a claude/reviewer-collect vendor row.
+    ledger = tmp_path / "timing-ledger.tsv"
+    _ = ledger.write_text("", encoding="utf-8")
+    dispatch_shared.record_reviewer_collect(
+        ledger=ledger, skill="implement", collect_start=164, collect_end=348, round_num=2
+    )
+    row = ledger.read_text(encoding="utf-8").strip().split("\t")
+    assert row[0:2] == ["v1", "vendor"]
+    assert row[5:11] == ["claude", "reviewer-collect", "164", "348", "184", "reviewer-collect-round-2.out"]
+
+
+def test_record_reviewer_collect_skips_when_ledger_missing(tmp_path: Path) -> None:
+    # A diagnostic row must never create a stray ledger when the real ledger is absent
+    # (e.g. a bare /review with no timing ledger), and a None ledger is a silent no-op.
+    absent = tmp_path / "timing-ledger.tsv"
+    dispatch_shared.record_reviewer_collect(
+        ledger=absent, skill="implement", collect_start=1, collect_end=2, round_num=1
+    )
+    assert not absent.exists()
+    dispatch_shared.record_reviewer_collect(
+        ledger=None, skill="design", collect_start=1, collect_end=2, round_num=1
+    )
+
+
 def test_final_emitter_uses_logging_and_code_review_order(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     emitted: list[tuple[str, str]] = []
 

--- a/python/tests/review/test_plan_review_round.py
+++ b/python/tests/review/test_plan_review_round.py
@@ -661,6 +661,92 @@ def test_execute_round_propagates_degraded_warning_with_mixed_manifest(
     assert values["INVALID_SLOT_PANEL_WARNING"] == "panel degraded"
 
 
+def test_execute_round_records_reviewer_collect_row(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Issue #7179: the /design plan-review round records the reviewers-to-aggregator window as a
+    # reviewer-collect vendor row in the design timing ledger, so the /design Gantt shows the
+    # collection work as a labeled bar instead of a blank gap before the aggregator bar.
+    design = tmp_path
+    plan = design / "plan.txt"
+    feature = design / "feature-description.txt"
+    _ = plan.write_text("plan\n", encoding="utf-8")
+    _ = feature.write_text("feature\n", encoding="utf-8")
+    ledger = design / "timing-ledger.tsv"
+    _ = ledger.write_text("", encoding="utf-8")  # reviewers create this in prod; pre-create to pass the is_file gate
+    paths = design / "panel-paths.txt"
+    reviewer_file = design / "cursor-plan-arch-output.txt"
+    sidecar = design / "cursor-plan-arch.sidecar.tsv"
+    _write_sidecar(
+        sidecar,
+        [
+            {
+                "scope": "in_scope",
+                "severity": "major",
+                "focus_area": "correctness",
+                "location": "python/x.py:1",
+                "what": "Real finding",
+                "scenario_or_breakage": "breaks the plan",
+                "suggested_fix": "fix it",
+            }
+        ],
+    )
+
+    def fake_run_cli(argv: list[str], *, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+        _ = env
+        if argv[:2] == ["plan-review", "panel-dispatch"]:
+            _ = paths.write_text(str(reviewer_file) + "\n", encoding="utf-8")
+            _ = (design / "plan-review-slots.ndjson").write_text(
+                f'{{"slot":"cursor-plan-arch","output":"{reviewer_file}"}}\n',
+                encoding="utf-8",
+            )
+            return subprocess.CompletedProcess(argv, 0, f"PANEL_PRUNED_EMPTY=false\nPANEL_PATHS_FILE={paths}\n", "")
+        if argv[:2] == ["agent", "collect-results"]:
+            record = collect_results.CollectorRecord(
+                reviewer_file=str(reviewer_file),
+                tool="cursor",
+                status="OK",
+                exit_code="0",
+                structured_sidecar=str(sidecar),
+            )
+            return subprocess.CompletedProcess(argv, 0, _collector_text([record]), "")
+        if argv[:2] == ["review", "aggregate-findings"]:
+            _ = (design / "ballot.txt").write_text("### FINDING_1:\n", encoding="utf-8")
+            return subprocess.CompletedProcess(argv, 0, "REASON=ok\nAGGREGATED=true\n", "")
+        if argv[:2] == ["review", "prune-nit-findings"]:
+            return _prune_nit_findings_fake(argv)
+        if argv[:2] == ["plan-review", "voter-dispatch"]:
+            return subprocess.CompletedProcess(
+                argv,
+                0,
+                f"DISPATCH_OK=true\nVOTER_1_PATH={design / 'codex-validity-vote-output.txt'}\nVOTER_1_TOOL=codex-validity\nVOTER_1_STATUS=launched\n",
+                "",
+            )
+        if argv[:2] == ["plan-review", "tally"]:
+            _ = (design / "accepted-plan-findings.md").write_text("", encoding="utf-8")
+            return subprocess.CompletedProcess(argv, 0, "TALLY_PLAN_REVIEW_STATUS=ok\n", "")
+        return subprocess.CompletedProcess(argv, 0, "", "")
+
+    monkeypatch.setattr(plan_review_round, "_run_cli", fake_run_cli)
+
+    rc, _values = plan_review_round.execute_round(
+        design=design,
+        round_num=1,
+        prune_round_num=1,
+        codex_present="true",
+        cursor_present="true",
+        plan_file=plan,
+        feature_file=feature,
+    )
+
+    assert rc == 0
+    collect_row = next(line for line in ledger.read_text(encoding="utf-8").splitlines() if "reviewer-collect" in line).split("\t")
+    assert collect_row[3] == "design"
+    assert collect_row[5:7] == ["claude", "reviewer-collect"]
+    assert collect_row[10] == "reviewer-collect-round-1.out"
+
+
 def test_parse_collector_records_keyvalue_anchored() -> None:
     """parse_collector_records reads KEY=VALUE blocks by key and ignores leading diagnostics."""
     rec_a = collect_results.CollectorRecord(

--- a/python/tests/review/test_review_pipeline.py
+++ b/python/tests/review/test_review_pipeline.py
@@ -259,6 +259,52 @@ def test_review_core_body_fix_required_returns_duplicate_classification(tmp_path
     assert keys.index("VOTER_1_TOOL") < keys.index("FINDINGS_CLASSIFICATION_TSV_FILE") < keys.index("REVIEW_CORE_STATUS")
 
 
+def _reviewer_collect_ledger(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, *, name: str) -> Path:
+    # Point resolve_timing_ledger_path at a pre-created ledger through REVIEW_TMPDIR (its last
+    # fallback key, and the only one with no other side effect in the review-core body), so the
+    # test drives the real resolution the reviewers and aggregator use rather than a patched
+    # binding. Clear the higher-priority keys so REVIEW_TMPDIR is the one that resolves.
+    ledger_dir = tmp_path / name
+    ledger_dir.mkdir()
+    ledger = ledger_dir / "timing-ledger.tsv"
+    _ = ledger.write_text("", encoding="utf-8")  # reviewers create this in prod; pre-create to pass the is_file gate
+    for key in ("LARCH_TIMING_LEDGER", "LARCH_TIMING_SKILL", "IMPLEMENT_TMPDIR", "SESSION_ENV_PATH", "DESIGN_TMPDIR"):
+        monkeypatch.delenv(key, raising=False)
+    return ledger
+
+
+def test_review_core_body_records_reviewer_collect_row(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Issue #7179: on the aggregating path, the reviewers-to-aggregator window lands as a
+    # reviewer-collect vendor row in the same timing ledger the reviewers and aggregator use, so
+    # the Gantt shows it instead of a blank gap between the reviewer bars and the aggregator bar.
+    ledger = _reviewer_collect_ledger(tmp_path, monkeypatch, name="timing-home")
+
+    result = _run_review_core_body_direct(
+        tmp_path, monkeypatch, findings=1, accepted=1, outdir_name="body-collect",
+        extra_env={"REVIEW_TMPDIR": str(ledger.parent)},
+    )
+
+    assert result.status == review_pipeline.ReviewCoreStatus.fix_required
+    collect_row = next(line for line in ledger.read_text(encoding="utf-8").splitlines() if "reviewer-collect" in line).split("\t")
+    assert collect_row[3] == "implement"
+    assert collect_row[5:7] == ["claude", "reviewer-collect"]
+    assert collect_row[10] == "reviewer-collect-round-1.out"
+
+
+def test_review_core_body_skips_reviewer_collect_on_zero_findings(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # The zero-findings path returns before the aggregator, so there is no reviewers-to-aggregator
+    # gap to fill and no reviewer-collect row should be written (issue #7179).
+    ledger = _reviewer_collect_ledger(tmp_path, monkeypatch, name="timing-home-zero")
+
+    result = _run_review_core_body_direct(
+        tmp_path, monkeypatch, findings=0, accepted=0, outdir_name="body-collect-zero",
+        extra_env={"REVIEW_TMPDIR": str(ledger.parent)},
+    )
+
+    assert result.status == review_pipeline.ReviewCoreStatus.zero_findings
+    assert "reviewer-collect" not in ledger.read_text(encoding="utf-8")
+
+
 def test_review_core_body_forwards_parse_failed_count(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     result = _run_review_core_body_direct(
         tmp_path,


### PR DESCRIPTION
Fixes #7179

## Problem

The `/implement` and `/design` final-report Gantt charts show a wide blank band between the reviewer bars and the aggregator bar. That band is not idle — it is the serial **reviewers-to-aggregator window**: after the last reviewer's model call finishes and before the aggregator's model call starts, the pipeline waits for reviewer stragglers, collects and de-duplicates reviewer outputs, runs the failure-threshold check, and prunes nits. A reviewer records its `end_s` when its model call finishes and the aggregator records its `start_s` only when its model call begins, so that window fell into an unmodeled gap in the timing ledger and rendered as blank space.

This is the same class of bug as #7166 (`voter-dispatch-prep`), which modeled the aggregator-to-voters gap. #7179 was blocked by #7166 and is now unblocked; this PR fills the remaining reviewers-to-aggregator gap using the same approach (the issue's preferred **option A**).

## Change

Record the reviewers-to-aggregator window as a `reviewer-collect` vendor row so the chart shows it instead of a gap:

- **`dispatch_shared`** — factor the #7166 best-effort writer into a shared `_record_pipeline_span` helper; `record_voter_dispatch_prep` now delegates to it, and a new `record_reviewer_collect` records the reviewers-to-aggregator window. The row appends only when a real timing ledger already exists (diagnostic-only; a missing ledger or write error is skipped, never raised).
- **`review_core_body._review_core_body`** (`/implement`) — stamp `collect_start` right after `dispatch-panel` returns and record `[collect_start .. before aggregate]` against `LARCH_TIMING_LEDGER`. Reached only on the aggregating path; the zero-findings and threshold returns never open a gap to fill.
- **`plan_review_round.execute_round`** (`/design`) — record the same window against the design timing ledger, resolving the issue's open question 3 (the design plan-review path has the same reviewers-to-aggregator structure).
- **`timing`** — allow the `reviewer-collect` task-kind.
- **`progress_report`** — label the row `reviewer-collect` in the Gantt.
- **`complexity-baseline`** — bump `execute_round` and `_review_core_body` PLR0915 for the two added instrumentation statements each.

No review behavior changes; the collection work still runs where it did. This closes the charting bug (the reported symptom) without reordering the pipeline.

## Tests

- `record_reviewer_collect` appends the `claude/reviewer-collect` row and skips when the ledger is absent or `None`.
- `reviewer-collect` is accepted as a timing task-kind (no `unknown task-kind` warning).
- Gantt label and full-render coverage: the `reviewer-collect` bar fills the `[reviewers .. aggregator]` band.
- `/implement` records the row on the aggregating path and **skips** it on the zero-findings path.
- `/design` `execute_round` records the row against the design timing ledger.

All 426 tests across the touched suites pass; `ruff`, `pyright`, and the fast AST-ratchet lint suite are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
