### PR TITLE
Fixes #7172: close symlink trust gaps in design session-env sourcing and ship outcome sidecar writes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -352,7 +352,7 @@ test-harnesses-3: test-design-step3-mav test-prompt-template-invariants test-imp
 
 test-harnesses-4: test-extinct-notification-stack test-gate-b-apply-mode test-step3-orchestrator-fence test-hook-anti-read-poll test-fluff-analysis test-token-vendor-scrapers test-cleanup-sessionstart test-bgjob test-flush-vendor-failure-diagnostics test-implement-fence-shape test-plan-adequacy-audit test-implement-step2-routing test-sessionstart-statusline test-implement-rebase-macro test-brainstorm-prompts
 
-test-harnesses-5: test-step3-review-cap test-findings-classification test-step-18 test-design-step3-entry test-file-failure-report-cross-repo test-check-topology-rule-paths test-external-tool-registry test-pipe-sigpipe-safety test-block-submodule test-pause-skill test-quick-mode-docs-sync test-audit-edit-write test-step-8-oos-checkpoint test-anti-halt test-implement-cleanup-roundtrip
+test-harnesses-5: test-step3-review-cap test-findings-classification test-step-18 test-design-step3-entry test-design-step3-entry-symlink test-file-failure-report-cross-repo test-check-topology-rule-paths test-external-tool-registry test-pipe-sigpipe-safety test-block-submodule test-pause-skill test-quick-mode-docs-sync test-audit-edit-write test-step-8-oos-checkpoint test-anti-halt test-implement-cleanup-roundtrip
 
 test-pipe-sigpipe-safety:
 	python3 python/cli.py timing harness-mark --label $@ -- bash scripts/test-pipe-sigpipe-safety.sh
@@ -1305,7 +1305,7 @@ trufflehog:
 setup:
 	pre-commit install
 
-.PHONY: test-design-stage-terminal-state test-design-failure-report test-design-step-final-summary test-design-step3-review test-design-step3b-tail test-design-step3-entry test-design-step0-init test-design-step5c test-design-step6 test-design-step-validator-autofix
+.PHONY: test-design-stage-terminal-state test-design-failure-report test-design-step-final-summary test-design-step3-review test-design-step3b-tail test-design-step3-entry test-design-step3-entry-symlink test-design-step0-init test-design-step5c test-design-step6 test-design-step-validator-autofix
 
 test-design-stage-terminal-state:
 	python3 python/cli.py timing harness-mark --label $@ -- python3 -m pytest python/tests/design/test_design_lifecycle.py -k 'stage_terminal_state or capture_contract or clarify_hard_halt'
@@ -1324,6 +1324,9 @@ test-design-step3b-tail:
 
 test-design-step3-entry:
 	python3 python/cli.py timing harness-mark --label $@ -- bash skills/design/scripts/test-design-step3-entry.sh
+
+test-design-step3-entry-symlink:
+	python3 python/cli.py timing harness-mark --label $@ -- bash skills/design/scripts/test-design-step3-entry-symlink.sh
 
 test-design-step0-init:
 	python3 python/cli.py timing harness-mark --label $@ -- python3 -m pytest python/tests/design/test_design_lifecycle.py -k 'step0_parse or step0_session or step0_route or step0_init or step0_abort or step0_ap or step0c or step1d7 or step1e or pause_save or bash_quoted or decode_bash_percent_q or degraded_tools or relay_degraded or require_design or resolve_repo or wrapper or core_style_ctx'

--- a/python/larch/cli.py
+++ b/python/larch/cli.py
@@ -634,6 +634,7 @@ _REGISTRY: dict[tuple[str, str], tuple[str, str]] = {
     ("session", "write-design-env"): ("larch.state.session_env", "write_design_env_main"),
     ("session", "check-live-mutation-auth"): ("larch.state.session_env", "check_live_mutation_auth_main"),
     ("session", "validate-design-tmpdir"): ("larch.state.session_env", "validate_design_tmpdir_main"),
+    ("session", "resolve-trusted-design-env"): ("larch.state.session_env", "resolve_trusted_design_env_main"),
     ("session", "write-implement-env"): ("larch.state.session_env", "write_implement_env_main"),
     ("session", "clear-implement-pointer"): ("larch.state.session_env", "clear_implement_pointer_main"),
     ("session", "write-run-params"): ("larch.state.session_env", "write_run_params_main"),

--- a/python/larch/implement/ship_guidelines.py
+++ b/python/larch/implement/ship_guidelines.py
@@ -203,13 +203,6 @@ def read_unavailable_outcome_detail(
     return _bounded_detail(detail)
 
 
-def _write_json_atomic(*, path: Path, data: dict[str, object]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_name(path.name + ".tmp")
-    _ = tmp.write_text(json.dumps(data, sort_keys=True, separators=(",", ":")) + "\n", encoding="utf-8")
-    _ = tmp.replace(path)
-
-
 def mark_operator_waived_outcomes(
     *, implement_tmpdir: str, kinds: frozenset[str]
 ) -> frozenset[str]:
@@ -339,9 +332,11 @@ def _write_ship_outcome(
     outcome = _classify_assessment_ship_outcome(
         result=result, head_sha=head_sha, base_ref=base_ref, kind=kind
     )
-    _write_json_atomic(
-        path=Path(implement_tmpdir) / kind.ship_outcome_sidecar,
-        data=outcome.as_json(),
+    tmpdir = Path(implement_tmpdir)
+    larch_io.trusted_atomic_write(
+        tmpdir / kind.ship_outcome_sidecar,
+        json.dumps(outcome.as_json(), sort_keys=True, separators=(",", ":")) + "\n",
+        root=tmpdir,
     )
     return outcome
 

--- a/python/larch/state/session_env.py
+++ b/python/larch/state/session_env.py
@@ -1121,6 +1121,34 @@ def resolve_trusted_design_session_env_source(*, path: Path, claude_pid: str) ->
     return resolved if resolved.is_file() else None
 
 
+def resolve_trusted_design_env_main(argv: list[str]) -> int:
+    """Resolve a PID-keyed design session-env symlink to a trusted regular file.
+
+    Wraps :func:`resolve_trusted_design_session_env_source` for the design
+    wrappers, which dot-source the resolved target instead of the raw symlink so
+    a swapped link or replaced target cannot redirect what gets sourced.
+    Prints ``TRUSTED_SOURCE=<path>`` on success and exits non-zero when the link
+    is absent or fails the trusted-link validation.
+    """
+    parser = argparse.ArgumentParser(prog="session resolve-trusted-design-env", add_help=False)
+    parser.add_argument("--session-env-path", required=True)
+    parser.add_argument("--claude-pid", default="")
+    try:
+        args = parser.parse_args(argv)
+    except SystemExit:
+        return 2
+    if args.claude_pid and not re.match(r"^[1-9][0-9]{0,6}$", args.claude_pid):
+        _plain_err("Invalid --claude-pid: must be a positive integer of at most 7 decimal digits")
+        return 2
+    resolved = resolve_trusted_design_session_env_source(
+        path=Path(args.session_env_path), claude_pid=args.claude_pid
+    )
+    if resolved is None:
+        return 1
+    print(f"TRUSTED_SOURCE={resolved}")
+    return 0
+
+
 def write_design_env_main(argv: list[str]) -> int:
     parser = argparse.ArgumentParser(prog="session write-design-env", add_help=False)
     for flag in ("output", "design-tmpdir", "session-id", "run-id", "codex-present", "cursor-present", "codex-available", "cursor-available", "codex-binary-found", "cursor-binary-found", "repo", "repo-root", "issue-number", "claude-pid", "claude-source-file", "live-mutation-ok"):

--- a/python/skill-closure-baseline.json
+++ b/python/skill-closure-baseline.json
@@ -1,7 +1,7 @@
 [
   {
-    "closure_content_estimated_tokens": 51927,
-    "closure_estimated_tokens": 52077,
+    "closure_content_estimated_tokens": 51938,
+    "closure_estimated_tokens": 52088,
     "closure_lines": 1710,
     "conditional_content_estimated_tokens": 18770,
     "conditional_estimated_tokens": 18839,
@@ -33,8 +33,8 @@
       "skills/design/references/finalize-step5.md"
     ],
     "skill": "design",
-    "skill_md_content_estimated_tokens": 25791,
-    "skill_md_estimated_tokens": 25845,
+    "skill_md_content_estimated_tokens": 25802,
+    "skill_md_estimated_tokens": 25856,
     "skill_md_lines": 690
   },
   {

--- a/python/tests/implement/test_ship.py
+++ b/python/tests/implement/test_ship.py
@@ -7143,6 +7143,45 @@ def test_guideline_ship_outcome_blank_head_sha_raises_before_write(tmp_path: Pat
     assert not (tmp_path / ship.architectural_guidelines.GUIDELINE_SHIP_OUTCOME_SIDECAR).exists()
 
 
+def test_guideline_ship_outcome_sidecar_rejects_swapped_symlink(tmp_path: Path) -> None:
+    target = tmp_path / "evil-guideline.json"
+    target.write_text("pwned", encoding="utf-8")
+    link = tmp_path / ship.architectural_guidelines.GUIDELINE_SHIP_OUTCOME_SIDECAR
+    link.symlink_to(target)
+
+    with pytest.raises(OSError, match="not a regular file"):
+        ship_guidelines.write_guideline_ship_outcome(
+            implement_tmpdir=str(tmp_path),
+            result=ship.GuidelinesGateResult(guidelines_status="absent"),
+            head_sha="abc123",
+            base_ref="origin/main",
+        )
+
+    assert link.is_symlink()
+    assert target.read_text(encoding="utf-8") == "pwned"
+
+
+def test_invariant_ship_outcome_sidecar_rejects_swapped_symlink(tmp_path: Path) -> None:
+    target = tmp_path / "evil-invariant.json"
+    target.write_text("pwned", encoding="utf-8")
+    link = tmp_path / ship.architectural_guidelines.INVARIANT_SHIP_OUTCOME_SIDECAR
+    link.symlink_to(target)
+
+    with pytest.raises(OSError, match="not a regular file"):
+        ship_guidelines.write_invariant_ship_outcome(
+            implement_tmpdir=str(tmp_path),
+            result=ship_guidelines.InvariantsGateResult(
+                invariants_status="present",
+                assessment_kind="clean",
+                reason=ship_guidelines.REASON_INVARIANTS_EMPTY,
+            ),
+            head_sha="abc123",
+            base_ref="origin/main",
+        )
+
+    assert link.is_symlink()
+    assert target.read_text(encoding="utf-8") == "pwned"
+
 def test_load_or_prepare_guidelines_note_skips_assessment_on_prepare_failure(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/python/tests/state/test_session_env.py
+++ b/python/tests/state/test_session_env.py
@@ -386,6 +386,58 @@ def test_write_design_env_source_safe_and_home_symlink(tmp_path: Path) -> None:
     assert 'design step-final-summary --session-env-path "$SESSION_ENV_PATH" --claude-pid "$CLAUDE_PID" "$@"' in launcher_text
 
 
+def test_resolve_trusted_design_env_refuses_swapped_symlink(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    sessions = home / ".cache" / "larch" / "sessions"
+    sessions.mkdir(parents=True)
+    real_target = sessions / "real-env-12345.sh"
+    real_target.write_text("export DESIGN_TMPDIR=/tmp\n", encoding="utf-8")
+    link = sessions / "current-design-env-12345.sh"
+    link.symlink_to(real_target)
+    env = {"HOME": str(home), "XDG_CACHE_HOME": str(tmp_path / "xdg")}
+
+    valid = run_cli(
+        "resolve-trusted-design-env",
+        "--session-env-path",
+        str(link),
+        "--claude-pid",
+        "12345",
+        env=env,
+    )
+    assert valid.returncode == 0, valid.stderr
+    assert valid.stdout.startswith("TRUSTED_SOURCE=")
+    resolved_path = Path(valid.stdout[len("TRUSTED_SOURCE=") :].strip())
+    assert resolved_path.is_file()
+    assert resolved_path.samefile(real_target)
+
+    swapped = sessions / "current-design-env-99999.sh"
+    swapped.symlink_to(real_target)
+    refused = run_cli(
+        "resolve-trusted-design-env",
+        "--session-env-path",
+        str(swapped),
+        "--claude-pid",
+        "12345",
+        env=env,
+    )
+    assert refused.returncode == 1
+
+    link.unlink()
+    link.symlink_to(sessions / "missing.sh")
+    refused_target = run_cli(
+        "resolve-trusted-design-env",
+        "--session-env-path",
+        str(link),
+        "--claude-pid",
+        "12345",
+        env=env,
+    )
+    assert refused_target.returncode == 1
+
+    no_pid = run_cli("resolve-trusted-design-env", "--session-env-path", str(swapped), env=env)
+    assert no_pid.returncode == 1
+
+
 def test_write_design_env_exports_explicit_repo_root(tmp_path: Path) -> None:
     home = tmp_path / "home"
     home.mkdir()

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -682,7 +682,7 @@ Branch on `_autofix_status` per `validator-failure.md`. If auto-repair does not 
 <!-- compatibility grep note: `design-step2b-drafter.sh` now owns Step 2a exact sentinel validation through the launcher mapping to `python/cli.py design step2b-drafter`. -->
 <!-- compatibility grep note: `design-step2b-postplan.sh --site step2b --snapshot-original --session-env-path "$SESSION_ENV_PATH" --claude-pid "$CLAUDE_PID" --plugin-root "$CLAUDE_PLUGIN_ROOT"` maps to `python/cli.py design step2b-postplan --site step2b --snapshot-original`. -->
 <!-- lint references: skills/design/scripts/design-step3b-sanitize.md skills/design/scripts/design-step3b-sanitize.sh -->
-<!-- agent-lint references: scripts/check-plan-size.md, scripts/test-check-plan-size.md, scripts/scout-plan-archetypes-prompt.txt, scripts/test-brainstorm-prompts.md, scripts/test-brainstorm-prompts.sh -->
+<!-- agent-lint references: scripts/check-plan-size.md, scripts/test-check-plan-size.md, scripts/scout-plan-archetypes-prompt.txt, scripts/test-brainstorm-prompts.md, scripts/test-brainstorm-prompts.sh, scripts/test-design-step3-entry-symlink.sh -->
 
 <!-- agent-lint references:
 - skills/design/scripts/test-step3-orchestrator-fence.md

--- a/skills/design/scripts/design-step3-entry-preview.sh
+++ b/skills/design/scripts/design-step3-entry-preview.sh
@@ -75,7 +75,33 @@ design_require_plugin_root() {
 }
 
 design_source_env_optional() {
-  if [ -n "${SESSION_ENV_PATH:-}" ] && [ -f "$SESSION_ENV_PATH" ]; then
+  if [ -z "${SESSION_ENV_PATH:-}" ]; then
+    return 0
+  fi
+  if [ -L "$SESSION_ENV_PATH" ]; then
+    # PID-keyed symlink: resolve through the trusted session resolver so a
+    # swapped link or replaced target cannot redirect what gets dot-sourced.
+    if [ -z "${CLAUDE_PLUGIN_ROOT:-}" ] || [ -z "${CLAUDE_PID:-}" ]; then
+      printf '%s\n' "/design wrapper: refusing session-env symlink without plugin root and PID" >&2
+      exit 1
+    fi
+    _resolved_env_line="$(python3 "$CLAUDE_PLUGIN_ROOT/python/cli.py" session resolve-trusted-design-env \
+      --session-env-path "$SESSION_ENV_PATH" --claude-pid "$CLAUDE_PID" 2>/dev/null)" || {
+      printf '%s\n' "/design wrapper: refusing untrusted session-env symlink: $SESSION_ENV_PATH" >&2
+      exit 1
+    }
+    case "$_resolved_env_line" in
+      TRUSTED_SOURCE=*) ;;
+      *) printf '%s\n' "/design wrapper: unresolvable session-env symlink: $SESSION_ENV_PATH" >&2; exit 1 ;;
+    esac
+    _resolved_env="${_resolved_env_line#TRUSTED_SOURCE=}"
+    if [ -f "$_resolved_env" ]; then
+      # shellcheck source=/dev/null
+      . "$_resolved_env"
+    fi
+    return 0
+  fi
+  if [ -f "$SESSION_ENV_PATH" ]; then
     # shellcheck source=/dev/null
     . "$SESSION_ENV_PATH"
   fi

--- a/skills/design/scripts/design-step3-entry-state.sh
+++ b/skills/design/scripts/design-step3-entry-state.sh
@@ -75,7 +75,33 @@ design_require_plugin_root() {
 }
 
 design_source_env_optional() {
-  if [ -n "${SESSION_ENV_PATH:-}" ] && [ -f "$SESSION_ENV_PATH" ]; then
+  if [ -z "${SESSION_ENV_PATH:-}" ]; then
+    return 0
+  fi
+  if [ -L "$SESSION_ENV_PATH" ]; then
+    # PID-keyed symlink: resolve through the trusted session resolver so a
+    # swapped link or replaced target cannot redirect what gets dot-sourced.
+    if [ -z "${CLAUDE_PLUGIN_ROOT:-}" ] || [ -z "${CLAUDE_PID:-}" ]; then
+      printf '%s\n' "/design wrapper: refusing session-env symlink without plugin root and PID" >&2
+      exit 1
+    fi
+    _resolved_env_line="$(python3 "$CLAUDE_PLUGIN_ROOT/python/cli.py" session resolve-trusted-design-env \
+      --session-env-path "$SESSION_ENV_PATH" --claude-pid "$CLAUDE_PID" 2>/dev/null)" || {
+      printf '%s\n' "/design wrapper: refusing untrusted session-env symlink: $SESSION_ENV_PATH" >&2
+      exit 1
+    }
+    case "$_resolved_env_line" in
+      TRUSTED_SOURCE=*) ;;
+      *) printf '%s\n' "/design wrapper: unresolvable session-env symlink: $SESSION_ENV_PATH" >&2; exit 1 ;;
+    esac
+    _resolved_env="${_resolved_env_line#TRUSTED_SOURCE=}"
+    if [ -f "$_resolved_env" ]; then
+      # shellcheck source=/dev/null
+      . "$_resolved_env"
+    fi
+    return 0
+  fi
+  if [ -f "$SESSION_ENV_PATH" ]; then
     # shellcheck source=/dev/null
     . "$SESSION_ENV_PATH"
   fi

--- a/skills/design/scripts/test-design-step3-entry-symlink.sh
+++ b/skills/design/scripts/test-design-step3-entry-symlink.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# test-design-step3-entry-symlink.sh — swapped session-env symlink must be refused
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd -P)"
+STATE="$ROOT/skills/design/scripts/design-step3-entry-state.sh"
+PREVIEW="$ROOT/skills/design/scripts/design-step3-entry-preview.sh"
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+pass() { printf 'PASS: %s\n' "$*"; }
+
+HOME_DIR="$(mktemp -d "${TMPDIR:-/tmp}/test-step3-symlink-home.XXXXXX")"
+SESSIONS="$HOME_DIR/.cache/larch/sessions"
+mkdir -p "$SESSIONS"
+printf 'export DESIGN_TMPDIR=/tmp\n' >"$SESSIONS/real-env.sh"
+# Swapped symlink: wrong PID key (99999) for the supplied PID (12345), so the
+# trusted resolver must refuse and the wrapper must fail closed at source time.
+SWAPPED="$SESSIONS/current-design-env-99999.sh"
+ln -s "$SESSIONS/real-env.sh" "$SWAPPED"
+
+set +e
+env HOME="$HOME_DIR" CLAUDE_PLUGIN_ROOT="$ROOT" \
+  "$STATE" --session-env-path "$SWAPPED" --claude-pid 12345 2>"$HOME_DIR/state.err"
+state_rc=$?
+env HOME="$HOME_DIR" CLAUDE_PLUGIN_ROOT="$ROOT" \
+  "$PREVIEW" --session-env-path "$SWAPPED" --claude-pid 12345 2>"$HOME_DIR/preview.err"
+preview_rc=$?
+set -e
+
+[[ "$state_rc" -ne 0 ]] || fail "entry-state accepted swapped session-env symlink (rc=$state_rc)"
+grep -Fq 'refusing untrusted session-env symlink' "$HOME_DIR/state.err" \
+  || fail "entry-state did not log refusal: $(cat "$HOME_DIR/state.err")"
+[[ "$preview_rc" -ne 0 ]] || fail "entry-preview accepted swapped session-env symlink (rc=$preview_rc)"
+grep -Fq 'refusing untrusted session-env symlink' "$HOME_DIR/preview.err" \
+  || fail "entry-preview did not log refusal: $(cat "$HOME_DIR/preview.err")"
+
+rm -rf "$HOME_DIR"
+pass 'Step 3 entry wrappers refuse a swapped session-env symlink'
+pass 'design-step3-entry-symlink checks passed'


### PR DESCRIPTION
Fixes #7172

Closes two symlink-trust gaps where larch's managed mutable paths bypassed the
guarded helpers at use time.

## Item 1: design Step 3 wrappers dot-sourced the session env unvalidated

`design_source_env_optional` in `design-step3-entry-state.sh` and
`design-step3-entry-preview.sh` ran `. "$SESSION_ENV_PATH"` whenever the
PID-keyed symlink existed, re-checking nothing at source time. A swapped link
or replaced target in the user-writable cache directory would execute shell
inside the orchestrator.

The wrappers now resolve the symlink through a new `session
resolve-trusted-design-env` verb (which exposes
`resolve_trusted_design_session_env_source`) and fail closed on a swapped link
or non-regular target, then dot-source the resolved regular file. Non-symlink
paths keep the legacy source-if-present behavior.

## Item 2: ship outcome sidecar writes skipped the trusted-root helpers

`write_guideline_ship_outcome` / `write_invariant_ship_outcome` (now the shared
parameterized `_write_ship_outcome` after #7177) wrote the Step 8 sidecar
through `_write_json_atomic`, which did a raw `mkdir`/`write_text`/`replace`
under `IMPLEMENT_TMPDIR` with no symlink or trusted-root checks. A symlink
planted at the sidecar path, its `.tmp` sibling, or an ancestor directory
redirected the write outside the tmpdir.

Both writes now go through `larch_io.trusted_atomic_write(..., root=tmpdir)`,
matching the sibling `mark_operator_waived_outcomes` write path and the
symlink-rejecting read path.

## Tests

- `test_resolve_trusted_design_env_refuses_swapped_symlink`: the resolver verb
  accepts a valid PID-keyed symlink and refuses a swapped path, a swapped
  target, and a missing PID.
- `test_guideline_ship_outcome_sidecar_rejects_swapped_symlink` /
  `test_invariant_ship_outcome_sidecar_rejects_swapped_symlink`: a symlink
  planted at the sidecar path is refused and the target is left untouched.
- `test-design-step3-entry-symlink` (registered harness): both Step 3 entry
  wrappers refuse a swapped session-env symlink.
