### PR TITLE
Fixes #7188: validate identity before reusing Step 5 result envs

### DIFF
--- a/python/larch/implement/checks_result_identity.py
+++ b/python/larch/implement/checks_result_identity.py
@@ -139,6 +139,16 @@ def identity_from_rows(
     )
 
 
+def result_identity_matches(rows: dict[str, str], *, live: ChecksInputIdentity) -> bool:
+    """True when a result env's identity rows match the live repository identity.
+
+    For result grammars without a terminal ``NEXT_ACTION`` row (e.g. Step 5), where
+    ``classify_completed_result`` does not apply.
+    """
+    persisted = identity_from_rows(rows, repo_root=live.repo_root)
+    return persisted is not None and identities_match(persisted, live)
+
+
 def read_env_rows(path: Path) -> dict[str, str]:
     """Parse a checks result/merge env through larch.io; raise on unsafe files."""
     if path.is_symlink():

--- a/python/larch/implement/dispatch_commit_route.py
+++ b/python/larch/implement/dispatch_commit_route.py
@@ -403,6 +403,48 @@ def _write_terminal_sentinel(*, tmpdir: Path, sentinel: str) -> None:
         path.write_text("", encoding="utf-8")
 
 
+def _step5_result_identity_rows(tmpdir: Path) -> str:
+    """Result-write-time identity rows for Step 5 reuse validation.
+
+    Step 5 mutates the tree (the coder commits fixes), so the identity is computed
+    at publish time, not launch time, to permit exact reuse when nothing changed
+    since the review completed. Returns "" when identity cannot be computed, so the
+    result is published without identity and a later re-entry fails closed to a re-run.
+    """
+    try:
+        identity = _checks_launch_identity(tmpdir=tmpdir)
+    except checks_result_identity.ChecksIdentityError:
+        return ""
+    return larch_io.format_kvs(identity.as_rows())
+
+
+def _publish_step5_child(*, tmpdir: Path, merge_env_raw: str, output: str) -> bool:
+    """Publish Step 5 child output plus result-write-time identity; True on success."""
+    identity_rows = _step5_result_identity_rows(tmpdir)
+    merged = output
+    if identity_rows:
+        if merged and not merged.endswith("\n"):
+            merged += "\n"
+        merged += identity_rows
+    try:
+        _publish_child_output(
+            tmpdir=tmpdir,
+            merge_env=_safe_merge_env(tmpdir=tmpdir, raw=merge_env_raw),
+            text=merged,
+        )
+    except (OSError, UnicodeError, ValueError):
+        return False
+    return True
+
+
+def _step5_result_identity_ok(*, tmpdir: Path, rows: dict[str, str]) -> bool:
+    """True when a completed Step 5 result env matches the live repository identity."""
+    try:
+        live = _checks_launch_identity(tmpdir=tmpdir)
+    except checks_result_identity.ChecksIdentityError:
+        return False
+    return checks_result_identity.result_identity_matches(rows, live=live)
+
 
 def step5_canonical_result_env_state(*, tmpdir: Path) -> str:
     """Classify only the canonical Step 5 review result grammar."""
@@ -427,6 +469,8 @@ def step5_canonical_result_env_state(*, tmpdir: Path) -> str:
     if rows.get("STEP") != _STEP5_REVIEW_STEP or not required.issubset(rows):
         return "stale"
     if rows.get(config.BGJOB_RC_KEY) == "0" and status == "complete":
+        if not _step5_result_identity_ok(tmpdir=tmpdir, rows=rows):
+            return "stale"
         return "complete"
     if status == "stall":
         return "stall"
@@ -446,6 +490,8 @@ def step5_resume_result_env_state(*, tmpdir: Path) -> str:
         and rows.get(config.BGJOB_RC_KEY) == "0"
         and rows.get("STEP5_REVIEW_STATUS") in {"complete", "stall"}
     ):
+        if not _step5_result_identity_ok(tmpdir=tmpdir, rows=rows):
+            return "stale"
         return "complete"
     return "stale"
 
@@ -508,13 +554,11 @@ def step5_review_main(argv: list[str] | None = None) -> int:
             print("step-5-review: --merge-result-env is required in child mode", file=sys.stderr)
             return 2
         rc, output = _capture_worker(lambda: _step5_review_worker(implement_tmpdir))
-        try:
-            _publish_child_output(
-                tmpdir=implement_tmpdir,
-                merge_env=_safe_merge_env(tmpdir=implement_tmpdir, raw=args.merge_result_env),
-                text=output,
-            )
-        except (OSError, UnicodeError, ValueError):
+        if not _publish_step5_child(
+            tmpdir=implement_tmpdir,
+            merge_env_raw=args.merge_result_env,
+            output=output,
+        ):
             return 2
         sys.stdout.write(output)
         return rc
@@ -1513,13 +1557,11 @@ def _step5_resume_child(args: argparse.Namespace, implement_tmpdir: Path) -> int
         print("step-5-resume: --merge-result-env is required in child mode", file=sys.stderr)
         return 2
     rc, output = _capture_worker(lambda: _step5_resume_worker(args, implement_tmpdir))
-    try:
-        _publish_child_output(
-            tmpdir=implement_tmpdir,
-            merge_env=_safe_merge_env(tmpdir=implement_tmpdir, raw=args.merge_result_env),
-            text=output,
-        )
-    except (OSError, UnicodeError, ValueError):
+    if not _publish_step5_child(
+        tmpdir=implement_tmpdir,
+        merge_env_raw=args.merge_result_env,
+        output=output,
+    ):
         return 2
     sys.stdout.write(output)
     return rc

--- a/python/tests/implement/test_implement_dispatch.py
+++ b/python/tests/implement/test_implement_dispatch.py
@@ -27,6 +27,7 @@ from larch.report import exec_issue_detail
 from larch.implement import implement_dispatch
 from larch.implement import ship_guidelines
 from larch.implement import (
+    checks_result_identity,
     dispatch_commit_route,
     dispatch_leg,
     dispatch_manifest,
@@ -289,6 +290,126 @@ def test_step5_review_stale_result_is_cleared_but_unsafe_result_is_refused(
     result.mkdir()
     assert dispatch_commit_route.step5_review_main([]) == 2
     assert result.is_dir()
+
+
+def _fixed_step5_identity(repo_root: Path) -> checks_result_identity.ChecksInputIdentity:
+    return checks_result_identity.ChecksInputIdentity(
+        head_sha="a" * 40,
+        tree_fingerprint="b" * 64,
+        fingerprint_schema=config.CHECKS_INPUT_FP_SCHEMA_V1,
+        repo_root=repo_root,
+    )
+
+
+def _write_step5_review_result(
+    tmp_path: Path, *, identity_rows: list[tuple[str, str]], status: str = "complete"
+) -> None:
+    bgjob = tmp_path / "bgjob"
+    bgjob.mkdir(exist_ok=True)
+    result = bgjob / "implement-step5-review.result.env"
+    rows = [
+        ("STEP5_REVIEW_STATUS", status),
+        ("STALL_TRACKING", "false"),
+        ("STALL_REASON", "none"),
+        ("ROUNDS_COMPLETED", "2"),
+        ("FINAL_ROUND_NUM", "2"),
+        ("FINAL_REVIEW_AND_FIX_STATUS", "complete"),
+        ("CODER_STATUS", "ok"),
+        ("FILES_CHANGED_HINT", "abc1234"),
+        ("EFFECTIVE_ROUND_CAP", "2"),
+        ("BGJOB_RC", "0"),
+        ("STEP", "implement-step5-review"),
+        *identity_rows,
+    ]
+    larch_io.write_kvs(path=result, values=rows)
+
+
+def test_step5_canonical_classifier_reuses_only_on_matching_identity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    live = _fixed_step5_identity(tmp_path)
+    monkeypatch.setattr(dispatch_commit_route, "_checks_launch_identity", lambda **_kwargs: live)
+
+    _write_step5_review_result(tmp_path, identity_rows=live.as_rows())
+    assert dispatch_commit_route.step5_canonical_result_env_state(tmpdir=tmp_path) == "complete"
+
+    stale_rows = [
+        (config.CHECKS_INPUT_HEAD_SHA_KEY, "c" * 40),
+        (config.CHECKS_INPUT_TREE_FP_KEY, "b" * 64),
+        (config.CHECKS_INPUT_FP_SCHEMA_KEY, config.CHECKS_INPUT_FP_SCHEMA_V1),
+    ]
+    _write_step5_review_result(tmp_path, identity_rows=stale_rows)
+    assert dispatch_commit_route.step5_canonical_result_env_state(tmpdir=tmp_path) == "stale"
+
+    _write_step5_review_result(tmp_path, identity_rows=[])
+    assert dispatch_commit_route.step5_canonical_result_env_state(tmpdir=tmp_path) == "stale"
+
+
+def test_step5_canonical_classifier_fails_closed_when_identity_uncomputable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    live = _fixed_step5_identity(tmp_path)
+
+    def raise_identity(**_kwargs: object) -> checks_result_identity.ChecksInputIdentity:
+        raise checks_result_identity.ChecksIdentityError("no session repo root")
+
+    monkeypatch.setattr(dispatch_commit_route, "_checks_launch_identity", raise_identity)
+    _write_step5_review_result(tmp_path, identity_rows=live.as_rows())
+    assert dispatch_commit_route.step5_canonical_result_env_state(tmpdir=tmp_path) == "stale"
+
+
+def test_step5_resume_classifier_reuses_only_on_matching_identity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    live = _fixed_step5_identity(tmp_path)
+    monkeypatch.setattr(dispatch_commit_route, "_checks_launch_identity", lambda **_kwargs: live)
+    bgjob = tmp_path / "bgjob"
+    bgjob.mkdir(exist_ok=True)
+    result = bgjob / "implement-step5-resume.result.env"
+
+    base = [
+        ("STEP5_REVIEW_STATUS", "complete"),
+        ("BGJOB_RC", "0"),
+        ("STEP", "implement-step5-resume"),
+    ]
+    larch_io.write_kvs(path=result, values=[*base, *live.as_rows()])
+    assert dispatch_commit_route.step5_resume_result_env_state(tmpdir=tmp_path) == "complete"
+
+    stale_rows = [
+        (config.CHECKS_INPUT_HEAD_SHA_KEY, "c" * 40),
+        (config.CHECKS_INPUT_TREE_FP_KEY, "b" * 64),
+        (config.CHECKS_INPUT_FP_SCHEMA_KEY, config.CHECKS_INPUT_FP_SCHEMA_V1),
+    ]
+    larch_io.write_kvs(path=result, values=[*base, *stale_rows])
+    assert dispatch_commit_route.step5_resume_result_env_state(tmpdir=tmp_path) == "stale"
+
+    larch_io.write_kvs(path=result, values=base)
+    assert dispatch_commit_route.step5_resume_result_env_state(tmpdir=tmp_path) == "stale"
+
+
+def test_step5_review_child_appends_result_identity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("IMPLEMENT_TMPDIR", str(tmp_path))
+    monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(Path(__file__).resolve().parents[3]))
+    live = _fixed_step5_identity(tmp_path)
+    monkeypatch.setattr(dispatch_commit_route, "_checks_launch_identity", lambda **_kwargs: live)
+    merge = tmp_path / "bgjob" / "implement-step5-review.merge.env"
+    merge.parent.mkdir(parents=True, exist_ok=True)
+
+    def fake_worker(_tmpdir: Path) -> int:
+        print("STEP5_REVIEW_STATUS=complete")
+        return 0
+
+    monkeypatch.setattr(dispatch_commit_route, "_step5_review_worker", fake_worker)
+
+    assert dispatch_commit_route.step5_review_main(
+        ["--bgjob-child", "--merge-result-env", str(merge)]
+    ) == 0
+    text = merge.read_text(encoding="utf-8")
+    assert "STEP5_REVIEW_STATUS=complete\n" in text
+    for key, value in live.as_rows():
+        assert f"{key}={value}\n" in text
 
 
 def test_resolve_implement_rater_model_prefers_codex_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

Closes #7188.

The Step 5 review/resume result classifiers in `dispatch_commit_route.py`
(`step5_canonical_result_env_state` / `step5_resume_result_env_state`) reused
completed bgjob result envs on KV grammar alone. They never compared the
recorded HEAD/tree identity against the live repo, so a stale result from an
earlier HEAD could be reused after the branch advanced (invariant **I-Stale-1**,
introduced by #7035 / PR #7175).

## Fix

Mirrors the existing Step 6 identity machinery, adapted for a step that
legitimately mutates the tree:

- **Child records identity at result-write time.** The Step 5 child appends
  identity rows (`CHECKS_INPUT_HEAD_SHA` / `_TREE_FP` / `_FP_SCHEMA`) to its
  merge env, which the bgjob daemon's `write_result` promotes into the result
  env. Identity is computed at publish time, **not** launch time — the Step 5
  coder commits fixes during the run, so only the post-fix identity permits a
  correct exact reuse on re-entry.
- **Classifiers validate identity lazily.** Both classifiers compute the live
  identity only on the would-be-`complete` branch and return `stale` on
  mismatch or absence, so `_prepare_step5_result` clears the env and a fresh
  job runs. Absent / stale / stall paths never touch git.
- **New reusable helper.** `checks_result_identity.result_identity_matches`
  covers result grammars that lack a terminal `NEXT_ACTION` row, where
  `classify_completed_result` does not apply.

**Fail-closed:** when identity cannot be computed, the result is published
without identity and a later re-entry re-runs review rather than trusting it.
An in-flight result written by pre-fix code (no identity rows) is treated as
stale on the first re-entry — a one-time, safe re-run.

## Tests

Added to `python/tests/implement/test_implement_dispatch.py`:

- canonical + resume classifiers reuse **only** on matching identity; reject
  mismatched and missing identity
- classifier fails closed to `stale` when identity is uncomputable
- Step 5 review child appends result-write-time identity rows to its merge env

Verified locally: targeted `test_implement_dispatch.py` (Step 5 + identity) and
`test_checks_result_identity.py` pass; `ruff`, `pyright`, `pylint` clean on the
changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
