### PR TITLE
Release v52.9.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.8.5",
+  "version": "52.9.0",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Added

- Specialist review archetype for `/design`, `/implement`, and `/review` that checks architectural guidelines and invariants compliance. (#7170)

## Changed

- Repointed issue-list callers to `gh.issue_list_read` and removed `issue_create._json_documents`. (#7163)
- Repointed issue view, edit, and close raw-argv callers to `gh` wrappers. (#7164)
- Parameterized the snapshot family by `(root, prefix)`. (#7173)
- Added a shared panel/voter dispatch layer. (#7174)
- Kind-parameterized the guidelines/invariants twins. (#7177)
- Converted `/design` bgjob adapters to thin wrappers. (#7182)
- Converted `/implement` bgjob adapters to thin wrappers. (#7175)

## Fixed

- `/learn-from-bugs` leaving modified and committed `learn-from-bugs-state.json` in the tree. (#7169)
- False-positive exec-issue "merge and CI watch skipped" written during assessment-reship ship re-entry. (#7181)
- `redact()` newline breaking the triage apply-close comment read-back. (#7183)
- Reviewer timing Gantt gap between aggregator and voters from serial pre-dispatch prompt rendering. (#7184)
- `_strict_kvs` raising on lowercase `ledger_*` keys in route handoff, which blocked the invariant-primary CI fixer start. (#7185)
- Gaps in the reviewer timing Gantt from uninstrumented pipeline stages. (#7187)
- Step 5 result classifiers reusing completed envs without identity validation. (#7190)
- `/learn-from-bugs` state publication: unverified repo identity and reverted lifecycle refreshes. (#7186)
- Symlink trust gaps in design session-env sourcing and ship outcome sidecar writes. (#7189)
