### PR TITLE
Fixes #7201: Parser-backed ballot-heading unification in voting.py

### DIFF
--- a/python/larch/review/voting.py
+++ b/python/larch/review/voting.py
@@ -25,7 +25,13 @@ from larch import io as larch_io
 from larch.core import logging_util
 from larch.core import proc
 from larch.core import redact
-from larch.review.review_types import JudgeSeverity, ReviewVote, is_security_block_text
+from larch.review.review_types import (
+    JudgeSeverity,
+    ParsedBlock,
+    ReviewVote,
+    is_security_block_text,
+    parse_blocks,
+)
 
 LONG_EXTS = "cc|cfg|cjs|cpp|css|csv|cs|dart|gradle|groovy|go|html|htm|hpp|java|json|jsx|js|kt|lua|mjs|mk|mm|md|php|pl|proto|py|rb|rs|sass|scala|scss|sh|sql|swift|toml|tsx|tsv|ts|vue|xml|yaml|yml"
 SHORT_EXTS = "lock|env|txt|c|h|m|r"
@@ -585,45 +591,43 @@ def _safe_tsv_cell(value: str) -> str:
     return re.sub(r"[\t\r\n]+", " ", value).strip()
 
 
+def _parsed_ballot_blocks(text: str) -> list[ParsedBlock]:
+    """Parse ballot items with the shared canonical reviewer-item grammar."""
+    return parse_blocks(text, boundary="item-heading")
+
+
 def _ballot_blocks(text: str) -> dict[str, str]:
     blocks: dict[str, str] = {}
-    current_id = ""
-    current_lines: list[str] = []
-    for raw in text.splitlines(keepends=True):
-        match = BALLOT_HEADING_RE.match(raw.rstrip("\n"))
-        if match:
-            if current_id:
-                blocks[current_id] = "".join(current_lines)
-            current_id = match.group(1)
-            if current_id in blocks:
-                raise ValueError(f"duplicate ballot heading {current_id}")
-            current_lines = [raw]
-        elif current_id:
-            current_lines.append(raw)
-    if current_id:
-        blocks[current_id] = "".join(current_lines)
+    for parsed in _parsed_ballot_blocks(text):
+        if parsed.item_id in blocks:
+            raise ValueError(f"duplicate ballot heading {parsed.item_id}")
+        blocks[parsed.item_id] = parsed.block
     return blocks
 
 
 def neutralize_reviewer_attribution(*, text: str, token: str = "anonymous") -> str:  # noqa: S107
-    lines: list[str] = []
-    in_block = False
-    block_attribution_done = False
-    for raw in text.splitlines(keepends=True):
-        line = raw.removesuffix("\n")
-        newline = "\n" if raw.endswith("\n") else ""
-        if BALLOT_HEADING_RE.match(line):
-            in_block = True
-            block_attribution_done = False
-            lines.append(raw)
-            continue
-        match = REVIEWER_ATTRIBUTION_RE.match(line)
-        if in_block and match and not block_attribution_done:
-            lines.append(f"{match.group('prefix')}{token}{match.group('trailing')}{newline}")
-            block_attribution_done = True
-        else:
-            lines.append(raw)
-    return "".join(lines)
+    def neutralize_block(block: str) -> str:
+        lines: list[str] = []
+        attribution_done = False
+        for raw in block.splitlines(keepends=True):
+            line = raw.removesuffix("\n")
+            newline = "\n" if raw.endswith("\n") else ""
+            match = REVIEWER_ATTRIBUTION_RE.match(line)
+            if match and not attribution_done:
+                lines.append(f"{match.group('prefix')}{token}{match.group('trailing')}{newline}")
+                attribution_done = True
+            else:
+                lines.append(raw)
+        return "".join(lines)
+
+    output: list[str] = []
+    cursor = 0
+    for parsed in _parsed_ballot_blocks(text):
+        output.append(text[cursor : parsed.start])
+        output.append(neutralize_block(parsed.block))
+        cursor = parsed.end
+    output.append(text[cursor:])
+    return "".join(output)
 
 
 def _ballot_sha256(text: str) -> str:
@@ -707,17 +711,12 @@ def _is_neutral_reviewer(value: str) -> bool:
 
 
 def ballot_text_is_neutralized(text: str) -> bool:
-    in_block = False
-    for line in text.splitlines():
-        if BALLOT_HEADING_RE.match(line):
-            in_block = True
-            continue
-        if not in_block:
-            continue
-        match = REVIEWER_ATTRIBUTION_RE.match(line)
-        if match:
-            value = match.group("value").replace("*", "").strip().lower()
-            return value == "anonymous"
+    for parsed in _parsed_ballot_blocks(text):
+        for line in parsed.block.splitlines():
+            match = REVIEWER_ATTRIBUTION_RE.match(line)
+            if match:
+                value = match.group("value").replace("*", "").strip().lower()
+                return value == "anonymous"
     return False
 
 
@@ -813,10 +812,13 @@ def restore_reviewer_attribution(*, block_text: str, reviewer_line: str) -> str:
             if _is_neutral_reviewer(_normalize_reviewer_value(match.group("value"))):
                 lines[idx] = reviewer_line + newline
             return "".join(lines)
-    for idx, raw in enumerate(lines):
-        if BALLOT_HEADING_RE.match(raw.rstrip("\n")):
-            lines.insert(idx + 1, reviewer_line + "\n")
-            return "".join(lines)
+    parsed = _parsed_ballot_blocks(block_text)
+    if parsed:
+        first = parsed[0]
+        heading_end = block_text.find("\n", first.start)
+        if heading_end >= 0:
+            return block_text[: heading_end + 1] + reviewer_line + "\n" + block_text[heading_end + 1 :]
+        return block_text + "\n" + reviewer_line + "\n"
     return reviewer_line + "\n" + block_text
 
 
@@ -912,23 +914,14 @@ def panel_tier_main(argv: list[str]) -> int:
 def split_ballot(*, ballot_file: str | Path, out_dir: str | Path) -> None:
     out_path = Path(out_dir)
     out_path.mkdir(parents=True, exist_ok=True)
-    seen: set[str] = set()
-    current: Path | None = None
-    with Path(ballot_file).open(encoding="utf-8", errors="replace") as handle:
-        for raw in handle:
-            line = raw.rstrip("\n")
-            match = BALLOT_HEADING_RE.match(line)
-            if match:
-                item_id = match.group(1)
-                if item_id in seen:
-                    print(f"duplicate ballot heading {item_id}", file=sys.stderr)
-                    raise SystemExit(1)
-                seen.add(item_id)
-                current = out_path / f"{item_id}.md"
-                current.write_text(raw, encoding="utf-8")
-            elif current is not None:
-                with current.open("a", encoding="utf-8") as output:
-                    output.write(raw)
+    text = Path(ballot_file).read_text(encoding="utf-8", errors="replace")
+    try:
+        blocks = _ballot_blocks(text)
+    except ValueError as exc:
+        print(exc, file=sys.stderr)
+        raise SystemExit(1) from exc
+    for item_id, block in blocks.items():
+        (out_path / f"{item_id}.md").write_text(block, encoding="utf-8")
 
 
 def split_ballot_main(argv: list[str]) -> int:

--- a/python/markdown-heading-fence-state-baseline.json
+++ b/python/markdown-heading-fence-state-baseline.json
@@ -1,9 +1,0 @@
-[
-  {
-    "file": "larch/review/voting.py",
-    "qualified_symbol": "ballot_text_is_neutralized",
-    "pattern_name": "BALLOT_HEADING_RE",
-    "occurrence": 1,
-    "reason": "grandfathered heading regex without fence state pre-G-Md-3 ratchet"
-  }
-]

--- a/python/tests/review/test_voting.py
+++ b/python/tests/review/test_voting.py
@@ -83,6 +83,61 @@ def test_reviewer_security_and_split_ballot(tmp_path: Path) -> None:
     assert "duplicate ballot heading FINDING_1" in result.stderr
 
 
+def test_ballot_blocks_use_canonical_parser_and_exact_item_slices(tmp_path: Path) -> None:
+    ballot_text = (
+        "Preamble stays outside ballot blocks.\n"
+        "```markdown\n"
+        "### FINDING_99: fenced heading\n"
+        "```\n"
+        "###   FINDING_1: spaced heading\n"
+        "- **Reviewer**: Codex-Structure\n"
+        "body one\n"
+        "###\tOOS_2:\ttab heading\n"
+        "- **Reviewer**: Cursor-Testing\n"
+        "body two\n"
+    )
+    expected = {
+        "FINDING_1": "###   FINDING_1: spaced heading\n- **Reviewer**: Codex-Structure\nbody one\n",
+        "OOS_2": "###\tOOS_2:\ttab heading\n- **Reviewer**: Cursor-Testing\nbody two\n",
+    }
+
+    assert voting._ballot_blocks(ballot_text) == expected
+    parsed_ids = [block.item_id for block in voting._parsed_ballot_blocks(ballot_text)]
+    assert parsed_ids == ["FINDING_1", "OOS_2"]
+    assert voting.proposer_map_from_ballot(ballot_text) == {
+        "FINDING_1": ("Codex-Structure", "- **Reviewer**: Codex-Structure"),
+        "OOS_2": ("Cursor-Testing", "- **Reviewer**: Cursor-Testing"),
+    }
+
+    ballot = tmp_path / "ballot.md"
+    ballot.write_text(ballot_text, encoding="utf-8")
+    out_dir = tmp_path / "blocks"
+    voting.split_ballot(ballot_file=ballot, out_dir=out_dir)
+    assert (out_dir / "FINDING_1.md").read_text(encoding="utf-8") == expected["FINDING_1"]
+    assert (out_dir / "OOS_2.md").read_text(encoding="utf-8") == expected["OOS_2"]
+
+
+def test_ballot_parser_rejects_canonical_whitespace_duplicate_and_missing_proposer() -> None:
+    duplicate = "### FINDING_1: one\n### \tFINDING_1: duplicate\n"
+    with pytest.raises(ValueError, match="duplicate ballot heading FINDING_1"):
+        voting._ballot_blocks(duplicate)
+
+    missing_proposer = "### \tFINDING_1: one\n- **Concern**: missing reviewer\n"
+    with pytest.raises(ValueError, match="proposer map missing item"):
+        voting.validate_proposer_map_coverage(
+            ballot_text=missing_proposer,
+            proposer_map=voting.proposer_map_from_ballot(missing_proposer),
+        )
+
+
+def test_neutralization_uses_canonical_whitespace_heading() -> None:
+    ballot = "### \tFINDING_1: one\n- **Reviewer**: Codex-Structure\n"
+    neutral = voting.neutralize_reviewer_attribution(text=ballot)
+
+    assert neutral == "### \tFINDING_1: one\n- **Reviewer**: anonymous\n"
+    assert voting.ballot_text_is_neutralized(neutral)
+
+
 @pytest.mark.parametrize(
     "text",
     [

--- a/python/tests/review/test_voting.py
+++ b/python/tests/review/test_voting.py
@@ -101,9 +101,6 @@ def test_ballot_blocks_use_canonical_parser_and_exact_item_slices(tmp_path: Path
         "OOS_2": "###\tOOS_2:\ttab heading\n- **Reviewer**: Cursor-Testing\nbody two\n",
     }
 
-    assert voting._ballot_blocks(ballot_text) == expected
-    parsed_ids = [block.item_id for block in voting._parsed_ballot_blocks(ballot_text)]
-    assert parsed_ids == ["FINDING_1", "OOS_2"]
     assert voting.proposer_map_from_ballot(ballot_text) == {
         "FINDING_1": ("Codex-Structure", "- **Reviewer**: Codex-Structure"),
         "OOS_2": ("Cursor-Testing", "- **Reviewer**: Cursor-Testing"),
@@ -117,10 +114,16 @@ def test_ballot_blocks_use_canonical_parser_and_exact_item_slices(tmp_path: Path
     assert (out_dir / "OOS_2.md").read_text(encoding="utf-8") == expected["OOS_2"]
 
 
-def test_ballot_parser_rejects_canonical_whitespace_duplicate_and_missing_proposer() -> None:
+def test_ballot_parser_rejects_canonical_whitespace_duplicate_and_missing_proposer(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     duplicate = "### FINDING_1: one\n### \tFINDING_1: duplicate\n"
-    with pytest.raises(ValueError, match="duplicate ballot heading FINDING_1"):
-        voting._ballot_blocks(duplicate)
+    ballot = tmp_path / "duplicate.md"
+    ballot.write_text(duplicate, encoding="utf-8")
+    with pytest.raises(SystemExit, match="1"):
+        voting.split_ballot(ballot_file=ballot, out_dir=tmp_path / "blocks")
+    assert capsys.readouterr().err == "duplicate ballot heading FINDING_1\n"
 
     missing_proposer = "### \tFINDING_1: one\n- **Concern**: missing reviewer\n"
     with pytest.raises(ValueError, match="proposer map missing item"):


### PR DESCRIPTION
Routes voting ballot heading consumers through the canonical parser and adds parity coverage for fences, whitespace, tabs, duplicates, and attribution handling.

Fixes #7201