### PR TITLE
Fixes #7229: route unresolved PR-suffix commits through pulls fallback

### DIFF
--- a/python/larch/release/release_prepare.py
+++ b/python/larch/release/release_prepare.py
@@ -182,25 +182,28 @@ def main(argv: list[str] | None = None) -> int:
     pr_list_file.write_text("", encoding="utf-8")
     written: set[int] = set()
     ignored: set[int] = set()
-    missing: list[str] = []
+    unresolved: set[int] = set()
     for n in pr_nums:
         pr = _gh_json(["pr", "view", str(n), "--repo", args.repo, "--json", "number,title,labels,author,url"])
         if not isinstance(pr, dict):
-            missing.append(str(n))
+            # A trailing (#N) can be a human-authored issue reference the squash-merge
+            # subject kept verbatim, not the merged PR number, so a gh pr view miss is not
+            # fatal: record it as unresolved and let the commits-to-pulls fallback below
+            # resolve the real PR instead of trusting the suffix.
+            unresolved.add(n)
             continue
         if str(pr.get("title", "")).startswith(config.TRANSPARENT_LARCH_LOGS_SUBJECT_PREFIX):
             ignored.add(int(pr.get("number", n)))
             continue
         _write_pr_row(path=pr_list_file, repo=args.repo, pr=pr)
         written.add(int(pr.get("number", n)))
-    if missing:
-        return _emit_error("pr-metadata-incomplete", f"could not fetch PR metadata for: {' '.join(missing)}")
     orphan_shas: list[str] = []
     for line in _git("log", f"{baseline}..origin/main", "--format=%H %s").stdout.splitlines():
         if not line.strip():
             continue
         sha, _, subj = line.partition(" ")
-        if _PR_SUFFIX_RE.search(subj):
+        m = _PR_SUFFIX_RE.search(subj)
+        if m and int(m.group(1)) not in unresolved:
             continue
         api = proc.run(["gh", "api", f"repos/{args.repo}/commits/{sha}/pulls"])
         if api.returncode != 0:

--- a/python/tests/release/test_release.py
+++ b/python/tests/release/test_release.py
@@ -408,10 +408,35 @@ def test_release_prepare_origin_repo_mismatch(monkeypatch: pytest.MonkeyPatch, t
 
 def test_release_prepare_pr_metadata_incomplete(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     repo_root = Path(release_prepare.__file__).resolve().parents[3]
-    runner = ReleasePrepareRunner(repo_root)
+    # A gh pr view miss now routes the commit to the commits-to-pulls fallback; the
+    # pr-metadata-incomplete error survives only when that API lookup itself fails.
+    runner = ReleasePrepareRunner(repo_root, api_rc=1)
     _prepare_common(monkeypatch, runner, pr_view=None)
     assert release_prepare.main(["--repo", "o/r", "--out-dir", str(tmp_path)]) == 1
     assert "ERROR=pr-metadata-incomplete" in capsys.readouterr().out
+
+
+def test_release_prepare_recovers_when_suffix_is_issue_number(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    # The squash-merge subject ends in the closed issue number (#7217), not the merged PR
+    # number, so gh pr view 7217 misses. The commit must still resolve to the real PR
+    # (#7221) via the commits-to-pulls fallback rather than aborting the whole prepare step.
+    repo_root = Path(release_prepare.__file__).resolve().parents[3]
+    pulls = json.dumps([{"number": 7221, "title": "Re-point ci-fix to the fix ladder (#7217)", "labels": [], "user": {"login": "me"}, "html_url": "u7221"}])
+    runner = ReleasePrepareRunner(
+        repo_root,
+        log_subjects="Re-point ci-fix to the fix ladder (#7217)\n",
+        log_hash_subjects="da0d9c Re-point ci-fix to the fix ladder (#7217)\n",
+        api_stdout=pulls,
+    )
+    _prepare_common(monkeypatch, runner, pr_view=None)
+    assert release_prepare.main(["--repo", "o/r", "--out-dir", str(tmp_path)]) == 0
+    captured = capsys.readouterr()
+    assert "NOTE: commit da0d9c resolved to PR #7221 via GitHub API" in captured.err
+    out = dict(line.split("=", 1) for line in captured.out.splitlines())
+    assert out["PR_COUNT"] == "1"
+    assert (tmp_path / "pr-list.tsv").read_text(encoding="utf-8").splitlines() == [
+        "7221\tRe-point ci-fix to the fix ladder (#7217)\t\tme\tu7221"
+    ]
 
 
 def test_release_prepare_commit_to_pulls_note(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:


### PR DESCRIPTION
Fixes #7229.

## Problem

`release prepare` read the trailing `(#N)` from every commit subject and trusted it as the merged PR number (`_PR_SUFFIX_RE`, applied at `release_prepare.py:180`). When a squash-merge subject keeps a human-authored issue reference verbatim (for example `... (#7217)`) without GitHub appending the real `(#7221)` suffix, `gh pr view 7217` misses and the whole step aborted with `ERROR=pr-metadata-incomplete`. The commits-to-pulls API fallback that exists for exactly this case never ran, because it was gated on the regex finding no match.

## Fix

Treat a matched `(#N)` as a hint, not ground truth:

- On a `gh pr view` miss, record the number as `unresolved` instead of aborting.
- In the fallback loop, route a commit through the commits-to-pulls API when its suffix is missing **or** unresolved, so the real PR resolves via the GitHub API and is written normally (with the existing `NOTE:` stderr line).
- `pr-metadata-incomplete` now surfaces only when the commits-to-pulls API lookup itself fails; a commit that resolves to no PR is still flagged as `unmatched-commits`.

## Tests

- New `test_release_prepare_recovers_when_suffix_is_issue_number`: subject ends in the closed issue number `(#7217)`, `gh pr view` misses, and the commit resolves to PR `#7221` via the API.
- Repointed `test_release_prepare_pr_metadata_incomplete` at the surviving API-failure path.
- Full `tests/release/test_release.py` passes (39 tests); ruff and pyright clean on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
