### PR TITLE
Fixes #7206: analyze-bugs sweep prepare foundation

### DIFF
--- a/python/larch/cli.py
+++ b/python/larch/cli.py
@@ -120,6 +120,7 @@ _REGISTRY: dict[tuple[str, str], tuple[str, str]] = {
     ("analyze-bugs", "prefetch"): ("larch.issue.analyze_bugs", "prefetch_main"),
     ("analyze-bugs", "ledger"): ("larch.issue.analyze_bugs", "ledger_main"),
     ("analyze-bugs", "report"): ("larch.issue.analyze_bugs", "report_main"),
+    ("analyze-bugs", "sweep"): ("larch.issue.analyze_bugs", "sweep_main"),
     ("learn-from-bugs", "prepare"): ("larch.issue.learn_from_bugs", "prepare_main"),
     ("learn-from-bugs", "coverage-index"): ("larch.issue.learn_from_bugs", "coverage_index_main"),
     ("learn-from-bugs", "read-state"): ("larch.issue.learn_from_bugs", "read_state_main"),

--- a/python/larch/issue/analyze_bugs.py
+++ b/python/larch/issue/analyze_bugs.py
@@ -62,6 +62,30 @@ MARKER_PHRASE_RE: Final = re.compile(
 ISSUE_REFERENCE_RE: Final = re.compile(r"(?<![A-Za-z0-9])#([1-9][0-9]*)")
 BASELINE_PATH_RE: Final = re.compile(r"^python/[^/]+-baseline\.json$")
 VERIFIED_PREDICATE_VERSION: Final = "final-tier-non-pending-v1"
+SWEEP_SCHEMA_VERSION: Final = 1
+SWEEP_DEFAULT_MAX: Final = 20
+SWEEP_INITIAL_WINDOW_SECONDS: Final = 48 * 60 * 60
+SWEEP_DIFF_CAP: Final = DEFAULT_DIFF_CAP
+SWEEP_SYMBOL_CAP: Final = 40
+SWEEP_CONSUMER_CAP: Final = 40
+SWEEP_PENDING_CAP: Final = 1_000
+SWEEP_STATE_FILENAME: Final = "sweep-state.json"
+SWEEP_FINDER_RAW_NAME: Final = "sweep-finder.jsonl"
+SWEEP_REFUTER_RAW_NAME: Final = "sweep-refuter.jsonl"
+SWEEP_SELECTED_MANIFEST_NAME: Final = "sweep-selected-merges.json"
+SWEEP_BUNDLE_MANIFEST_NAME: Final = "sweep-bundle-paths.json"
+SWEEP_PREPARE_SUMMARY_NAME: Final = "sweep-prepare.json"
+SWEEP_SEVERITIES: Final = ("high", "medium", "low")
+SWEEP_CONFIDENCES: Final = ("high", "medium", "low")
+SWEEP_REFUTER_VERDICTS: Final = ("survives", "refuted")
+SWEEP_LOG_FIELDS: Final = 3
+FULL_SHA_RE: Final = re.compile(r"^[0-9a-f]{40}$")
+SWEEP_TIMESTAMP_RE: Final = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+SWEEP_FLUSH_SUBJECT_RE: Final = re.compile(r"^chore\(larch-logs\)")
+SWEEP_RELEASE_SUBJECT_RE: Final = re.compile(r"^Release v")
+SWEEP_PY_DEF_RE: Final = re.compile(r"^\+\s*(?:async\s+)?def\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(")
+SWEEP_PY_CLASS_RE: Final = re.compile(r"^\+\s*class\s+([A-Za-z_][A-Za-z0-9_]*)\s*[:(]")
+SWEEP_PY_CONST_RE: Final = re.compile(r"^\+\s*([A-Z][A-Z0-9_]{2,})\s*=")
 
 
 @dataclass(frozen=True)
@@ -248,6 +272,124 @@ class RunSnapshot:
     chronic_zones: tuple[str, ...]
     chain_edges: tuple[str, ...]
     verified_predicate: str = VERIFIED_PREDICATE_VERSION
+
+
+@dataclass(frozen=True)
+class SweepState:
+    last_sweep_sha: str
+    last_sweep_at: str
+    schema_version: int
+    pending_shas: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class SweepPendingEntry:
+    sha: str
+
+
+@dataclass(frozen=True)
+class SweepCommit:
+    merge_sha: str
+    base_sha: str
+    subject: str
+    touched_paths: tuple[str, ...]
+    diff_size: int
+    capped_diff: str
+    diff_truncated: bool
+    changed_symbols: tuple[str, ...]
+    symbols_truncated: bool
+    chronic_zones: tuple[str, ...]
+    is_chronic: bool
+    history_order: int
+    commit_time: int
+
+
+@dataclass(frozen=True)
+class SweepConsumerHit:
+    path: str
+    line: int
+    text: str
+
+
+@dataclass(frozen=True)
+class SweepBundle:
+    pinned_tip: str
+    merge_sha: str
+    base_sha: str
+    subject: str
+    touched_files: tuple[str, ...]
+    chronic_tags: tuple[str, ...]
+    capped_diff: str
+    truncation_notices: tuple[str, ...]
+    changed_symbols: tuple[str, ...]
+    consumers: tuple[SweepConsumerHit, ...]
+    consumers_truncated: bool
+    bundle_path: str
+
+
+@dataclass(frozen=True)
+class SweepFinding:
+    file: str
+    symbol: str
+    description: str
+    severity: str
+    confidence: str
+
+
+@dataclass(frozen=True)
+class SweepFinderRow:
+    merge_sha: str
+    findings: tuple[SweepFinding, ...]
+
+
+@dataclass(frozen=True)
+class SweepRefutationResult:
+    merge_sha: str
+    finding_index: int
+    verdict: str
+
+
+@dataclass(frozen=True)
+class SweepRefuterQueueRow:
+    merge_sha: str
+    finding_index: int
+    file: str
+    symbol: str
+    description: str
+    severity: str
+    confidence: str
+
+
+@dataclass(frozen=True)
+class SweepCandidate:
+    merge_sha: str
+    file: str
+    symbol: str
+    description: str
+    severity: str
+    confidence: str
+
+
+@dataclass(frozen=True)
+class SweepValidatedArtifact:
+    pinned_tip: str
+    selected_manifest_path: str
+    selected_count: int
+    skipped_count: int
+    pending_shas: tuple[str, ...]
+    coverage_incomplete: bool
+    candidates: tuple[SweepCandidate, ...]
+
+
+@dataclass(frozen=True)
+class SweepEnumerationResult:
+    pinned_tip: str
+    selected: tuple[SweepCommit, ...]
+    pending_shas: tuple[str, ...]
+    skipped_count: int
+    coverage_incomplete: bool
+    state_path: Path
+    chronic_zone_names: tuple[str, ...]
 
 
 class AnalyzeBugsError(RuntimeError):
@@ -1929,4 +2071,605 @@ def report_main(argv: list[str]) -> int:
     except AnalyzeBugsError as exc:
         return _fail(str(exc))
     print(report, end="")
+    return 0
+
+
+def _full_sha(value: object, *, label: str) -> str:
+    if not isinstance(value, str) or not FULL_SHA_RE.fullmatch(value):
+        raise AnalyzeBugsError(f"{label} must be a full 40-character lowercase SHA")
+    return value
+
+
+def _sweep_timestamp(value: object, *, label: str) -> str:
+    if not isinstance(value, str) or not SWEEP_TIMESTAMP_RE.fullmatch(value):
+        raise AnalyzeBugsError(f"{label} must be an ISO-8601 UTC timestamp ending in Z")
+    return value
+
+
+def sweep_state_path(ledger_path: Path) -> Path:
+    return ledger_path.expanduser().resolve().parent / SWEEP_STATE_FILENAME
+
+
+def load_sweep_state(path: Path) -> SweepState | None:
+    """Load strict sweep state; absent file means first sweep."""
+    if not path.exists():
+        return None
+    try:
+        raw = _load_json(path)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise AnalyzeBugsError(f"malformed sweep state: {path}: {exc}") from exc
+    required = {"last_sweep_sha", "last_sweep_at", "schema_version", "pending_shas"}
+    if set(raw) != required:
+        raise AnalyzeBugsError(f"malformed sweep state keys: {path}")
+    try:
+        schema_version = int(raw["schema_version"])
+    except (TypeError, ValueError) as exc:
+        raise AnalyzeBugsError(f"malformed sweep state schema_version: {path}") from exc
+    if schema_version != SWEEP_SCHEMA_VERSION:
+        raise AnalyzeBugsError(f"unsupported sweep state schema_version={schema_version}: {path}")
+    pending_raw = raw["pending_shas"]
+    if not isinstance(pending_raw, list):
+        raise AnalyzeBugsError(f"malformed sweep state pending_shas: {path}")
+    if len(pending_raw) > SWEEP_PENDING_CAP:
+        raise AnalyzeBugsError(f"sweep state pending_shas exceeds bound {SWEEP_PENDING_CAP}: {path}")
+    pending: list[str] = []
+    seen: set[str] = set()
+    for item in pending_raw:
+        sha = _full_sha(item, label="pending_shas entry")
+        if sha in seen:
+            raise AnalyzeBugsError(f"duplicate pending SHA in sweep state: {sha}")
+        seen.add(sha)
+        pending.append(sha)
+    return SweepState(
+        last_sweep_sha=_full_sha(raw["last_sweep_sha"], label="last_sweep_sha"),
+        last_sweep_at=_sweep_timestamp(raw["last_sweep_at"], label="last_sweep_at"),
+        schema_version=schema_version,
+        pending_shas=tuple(pending),
+    )
+
+
+def write_sweep_state(path: Path, state: SweepState) -> None:
+    """Atomically write validated sweep state beside the ledger."""
+    if state.schema_version != SWEEP_SCHEMA_VERSION:
+        raise AnalyzeBugsError(f"refusing to write unsupported sweep schema_version={state.schema_version}")
+    _full_sha(state.last_sweep_sha, label="last_sweep_sha")
+    _sweep_timestamp(state.last_sweep_at, label="last_sweep_at")
+    if len(state.pending_shas) > SWEEP_PENDING_CAP:
+        raise AnalyzeBugsError(f"pending_shas exceeds bound {SWEEP_PENDING_CAP}")
+    seen: set[str] = set()
+    pending: list[str] = []
+    for sha in state.pending_shas:
+        normalized = _full_sha(sha, label="pending_shas entry")
+        if normalized in seen:
+            raise AnalyzeBugsError(f"duplicate pending SHA: {normalized}")
+        seen.add(normalized)
+        pending.append(normalized)
+    payload = {
+        "last_sweep_sha": state.last_sweep_sha,
+        "last_sweep_at": state.last_sweep_at,
+        "schema_version": state.schema_version,
+        "pending_shas": pending,
+    }
+    _write_json(path, payload)
+
+
+def _git_required(runner: Runner, argv: Sequence[str], *, desc: str) -> str:
+    result = runner.run(list(argv))
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "").strip()
+        suffix = f": {detail}" if detail else ""
+        raise AnalyzeBugsError(f"{desc} failed{suffix}")
+    return result.stdout
+
+
+def _pin_origin_main(runner: Runner) -> str:
+    fetch = runner.run(["git", "fetch", "origin", "main"])
+    tip = runner.run(["git", "rev-parse", "--verify", "origin/main"])
+    if tip.returncode != 0 or not tip.stdout.strip():
+        detail = (tip.stderr or tip.stdout or fetch.stderr or "").strip()
+        suffix = f": {detail}" if detail else ""
+        raise AnalyzeBugsError(f"could not pin origin/main{suffix}")
+    return _full_sha(tip.stdout.strip(), label="origin/main tip")
+
+
+def _is_ancestor(runner: Runner, *, ancestor: str, descendant: str) -> bool:
+    result = runner.run(["git", "merge-base", "--is-ancestor", ancestor, descendant])
+    return result.returncode == 0
+
+
+def _require_reachable(runner: Runner, *, sha: str, tip: str, label: str) -> None:
+    if not _is_ancestor(runner, ancestor=sha, descendant=tip):
+        raise AnalyzeBugsError(f"{label} {sha} is not reachable from pinned tip {tip}")
+
+
+def _excluded_subject(subject: str) -> bool:
+    return bool(SWEEP_FLUSH_SUBJECT_RE.match(subject) or SWEEP_RELEASE_SUBJECT_RE.match(subject))
+
+
+def _larch_logs_only(paths: Sequence[str]) -> bool:
+    return bool(paths) and all(path == "larch-logs" or path.startswith("larch-logs/") for path in paths)
+
+
+def _extract_changed_symbols(diff_text: str) -> tuple[tuple[str, ...], bool]:
+    symbols: list[str] = []
+    seen: set[str] = set()
+    truncated = False
+    for line in diff_text.splitlines():
+        if not line.startswith("+") or line.startswith("+++"):
+            continue
+        match = SWEEP_PY_DEF_RE.match(line) or SWEEP_PY_CLASS_RE.match(line) or SWEEP_PY_CONST_RE.match(line)
+        if match is None:
+            continue
+        name = match.group(1)
+        if name in seen:
+            continue
+        if len(symbols) >= SWEEP_SYMBOL_CAP:
+            truncated = True
+            break
+        seen.add(name)
+        symbols.append(name)
+    return tuple(symbols), truncated
+
+
+def _first_parent_evidence(runner: Runner, *, merge_sha: str, diff_cap: int) -> tuple[str, tuple[str, ...], int, str, bool, tuple[str, ...], bool]:
+    base = _git_required(runner, ["git", "rev-parse", "--verify", f"{merge_sha}^1"], desc=f"first-parent base for {merge_sha}").strip()
+    base_sha = _full_sha(base, label=f"first-parent base for {merge_sha}")
+    names = _git_required(
+        runner,
+        ["git", "diff", "--name-only", f"{base_sha}..{merge_sha}"],
+        desc=f"touched paths for {merge_sha}",
+    )
+    touched = tuple(line.strip() for line in names.splitlines() if line.strip())
+    full_diff = _git_required(
+        runner,
+        ["git", "diff", "--unified=1", f"{base_sha}..{merge_sha}"],
+        desc=f"first-parent diff for {merge_sha}",
+    )
+    diff_size = len(full_diff)
+    truncated = len(full_diff) > diff_cap
+    capped = _capped(full_diff, diff_cap)
+    symbols, symbols_truncated = _extract_changed_symbols(full_diff)
+    return base_sha, touched, diff_size, capped, truncated, symbols, symbols_truncated
+
+
+def _discover_consumers(runner: Runner, *, symbols: Sequence[str], defining_paths: Sequence[str]) -> tuple[tuple[SweepConsumerHit, ...], bool]:
+    hits: list[SweepConsumerHit] = []
+    truncated = False
+    exclude_args = [f":(exclude){path}" for path in defining_paths]
+    for symbol in symbols:
+        argv = ["git", "grep", "-n", "-F", "-e", symbol, "--", ".", *exclude_args]
+        result = runner.run(argv)
+        if result.returncode not in {0, 1}:
+            detail = (result.stderr or result.stdout or "").strip()
+            suffix = f": {detail}" if detail else ""
+            raise AnalyzeBugsError(f"consumer scan for {symbol} failed{suffix}")
+        for line in result.stdout.splitlines():
+            if not line.strip():
+                continue
+            path_part, sep, rest = line.partition(":")
+            if not sep:
+                continue
+            line_part, sep2, text = rest.partition(":")
+            if not sep2 or not line_part.isdecimal():
+                continue
+            path = path_part.strip()
+            if path in defining_paths:
+                continue
+            if len(hits) >= SWEEP_CONSUMER_CAP:
+                truncated = True
+                return tuple(hits), truncated
+            hits.append(SweepConsumerHit(path=path, line=int(line_part), text=text.strip()))
+    return tuple(hits), truncated
+
+
+def _build_sweep_commit(
+    runner: Runner,
+    *,
+    merge_sha: str,
+    subject: str,
+    commit_time: int,
+    history_order: int,
+    chronic_names: set[str],
+    diff_cap: int,
+) -> SweepCommit:
+    base_sha, touched, diff_size, capped, truncated, symbols, symbols_truncated = _first_parent_evidence(
+        runner, merge_sha=merge_sha, diff_cap=diff_cap
+    )
+    zones = _zones_for_files(touched)
+    chronic_hit = tuple(zone for zone in zones if zone in chronic_names)
+    return SweepCommit(
+        merge_sha=merge_sha,
+        base_sha=base_sha,
+        subject=subject,
+        touched_paths=touched,
+        diff_size=diff_size,
+        capped_diff=capped,
+        diff_truncated=truncated,
+        changed_symbols=symbols,
+        symbols_truncated=symbols_truncated,
+        chronic_zones=chronic_hit,
+        is_chronic=bool(chronic_hit),
+        history_order=history_order,
+        commit_time=commit_time,
+    )
+
+
+def _enumerate_window_rows(runner: Runner, *, tip: str, state: SweepState | None, now: int) -> list[tuple[str, str, int]]:
+    if state is None:
+        since = max(0, now - SWEEP_INITIAL_WINDOW_SECONDS)
+        out = _git_required(
+            runner,
+            ["git", "log", "--first-parent", f"--since={since}", "--format=%H%x00%s%x00%ct", tip],
+            desc="first-run sweep enumeration",
+        )
+    else:
+        out = _git_required(
+            runner,
+            ["git", "log", "--first-parent", "--format=%H%x00%s%x00%ct", tip, "--not", state.last_sweep_sha],
+            desc="watermark sweep enumeration",
+        )
+    rows: list[tuple[str, str, int]] = []
+    for line in out.splitlines():
+        if not line.strip():
+            continue
+        parts = line.split("\0")
+        if len(parts) != SWEEP_LOG_FIELDS:
+            raise AnalyzeBugsError(f"malformed git log sweep row: {line!r}")
+        sha = _full_sha(parts[0], label="enumerated commit")
+        subject = parts[1]
+        try:
+            commit_time = int(parts[2])
+        except ValueError as exc:
+            raise AnalyzeBugsError(f"malformed commit timestamp for {sha}") from exc
+        rows.append((sha, subject, commit_time))
+    # git log is newest-first; history_order should be older-first for deterministic ties.
+    rows.reverse()
+    return rows
+
+
+def _subject_and_time(runner: Runner, *, sha: str) -> tuple[str, int]:
+    out = _git_required(runner, ["git", "show", "-s", "--format=%s%x00%ct", sha], desc=f"commit metadata for {sha}").strip()
+    subject, sep, rest = out.partition("\0")
+    if not sep:
+        raise AnalyzeBugsError(f"malformed commit metadata for {sha}")
+    try:
+        commit_time = int(rest.strip())
+    except ValueError as exc:
+        raise AnalyzeBugsError(f"malformed commit timestamp for {sha}") from exc
+    return subject, commit_time
+
+
+def _chronic_zone_names(*, runner: Runner, repo: str, ledger_path: Path, pinned_tip: str, run_dir: Path) -> tuple[str, ...]:
+    manifest = {
+        "schema_version": "1",
+        "repo": repo,
+        "run_id": "sweep-prepare",
+        "run_dir": str(run_dir),
+        "evidence_ref": pinned_tip,
+        "bugs_requested": 0,
+        "bugs_selected": 0,
+        "generated_at": int(time.time()),
+        "ledger_path": str(ledger_path),
+        "triage_batch_paths": [],
+        "deep_queue_path": "",
+        "issues": [],
+    }
+    analytics = build_analytics_view(manifest=manifest, bundles=[], ledger_path=ledger_path, runner=runner)
+    return tuple(zone.zone for zone in analytics.chronic_zones)
+
+
+def _rank_key(commit: SweepCommit) -> tuple[int, int, int, str]:
+    # Chronic first, then larger diffs, then older history order, then SHA.
+    return (0 if commit.is_chronic else 1, -commit.diff_size, commit.history_order, commit.merge_sha)
+
+
+def sweep_enumeration(
+    *,
+    runner: Runner,
+    ledger_path: Path,
+    run_dir: Path,
+    repo: str,
+    sweep_max: int,
+    diff_cap: int = SWEEP_DIFF_CAP,
+    now: int | None = None,
+    pinned_tip: str | None = None,
+) -> SweepEnumerationResult:
+    if sweep_max <= 0:
+        raise AnalyzeBugsError("--sweep-max must be a positive integer")
+    tip = pinned_tip or _pin_origin_main(runner)
+    tip = _full_sha(tip, label="pinned tip")
+    state_path = sweep_state_path(ledger_path)
+    state = load_sweep_state(state_path)
+    if state is not None:
+        _require_reachable(runner, sha=state.last_sweep_sha, tip=tip, label="last_sweep_sha")
+        for pending in state.pending_shas:
+            _require_reachable(runner, sha=pending, tip=tip, label="pending SHA")
+
+    chronic_names = set(_chronic_zone_names(runner=runner, repo=repo, ledger_path=ledger_path, pinned_tip=tip, run_dir=run_dir))
+    clock = int(time.time()) if now is None else now
+    window_rows = _enumerate_window_rows(runner, tip=tip, state=state, now=clock)
+
+    eligible: dict[str, SweepCommit] = {}
+    history_order = 0
+    for sha, subject, commit_time in window_rows:
+        if _excluded_subject(subject):
+            continue
+        base_sha, touched, diff_size, capped, truncated, symbols, symbols_truncated = _first_parent_evidence(
+            runner, merge_sha=sha, diff_cap=diff_cap
+        )
+        if _larch_logs_only(touched):
+            continue
+        zones = _zones_for_files(touched)
+        chronic_hit = tuple(zone for zone in zones if zone in chronic_names)
+        eligible[sha] = SweepCommit(
+            merge_sha=sha,
+            base_sha=base_sha,
+            subject=subject,
+            touched_paths=touched,
+            diff_size=diff_size,
+            capped_diff=capped,
+            diff_truncated=truncated,
+            changed_symbols=symbols,
+            symbols_truncated=symbols_truncated,
+            chronic_zones=chronic_hit,
+            is_chronic=bool(chronic_hit),
+            history_order=history_order,
+            commit_time=commit_time,
+        )
+        history_order += 1
+
+    if state is not None:
+        for pending in state.pending_shas:
+            if pending in eligible:
+                continue
+            subject, commit_time = _subject_and_time(runner, sha=pending)
+            if _excluded_subject(subject):
+                continue
+            commit = _build_sweep_commit(
+                runner,
+                merge_sha=pending,
+                subject=subject,
+                commit_time=commit_time,
+                history_order=history_order,
+                chronic_names=chronic_names,
+                diff_cap=diff_cap,
+            )
+            if _larch_logs_only(commit.touched_paths):
+                continue
+            eligible[pending] = commit
+            history_order += 1
+
+    ranked = sorted(eligible.values(), key=_rank_key)
+    selected = tuple(ranked[:sweep_max])
+    pending = tuple(commit.merge_sha for commit in ranked[sweep_max:])
+    skipped = len(pending)
+    return SweepEnumerationResult(
+        pinned_tip=tip,
+        selected=selected,
+        pending_shas=pending,
+        skipped_count=skipped,
+        coverage_incomplete=skipped > 0,
+        state_path=state_path,
+        chronic_zone_names=tuple(sorted(chronic_names)),
+    )
+
+
+def _render_sweep_bundle(bundle: SweepBundle) -> str:
+    notices = "\n".join(f"- {item}" for item in bundle.truncation_notices) or "- none"
+    consumers = "\n".join(f"- {hit.path}:{hit.line}: {hit.text}" for hit in bundle.consumers) or "- none"
+    symbols = ", ".join(bundle.changed_symbols) or "none"
+    chronic = ", ".join(bundle.chronic_tags) or "none"
+    touched = "\n".join(f"- {path}" for path in bundle.touched_files) or "- none"
+    return "\n".join(
+        [
+            "# Sweep evidence bundle",
+            "",
+            f"pinned_tip: {bundle.pinned_tip}",
+            f"merge_sha: {bundle.merge_sha}",
+            f"base_sha: {bundle.base_sha}",
+            f"subject: {bundle.subject}",
+            f"chronic_tags: {chronic}",
+            f"changed_symbols: {symbols}",
+            "",
+            "## Touched files",
+            touched,
+            "",
+            "## Truncation notices",
+            notices,
+            "",
+            "## Consumers",
+            consumers,
+            "",
+            "## First-parent diff",
+            "```diff",
+            bundle.capped_diff.rstrip("\n"),
+            "```",
+            "",
+        ]
+    )
+
+
+def build_sweep_bundles(
+    *,
+    runner: Runner,
+    enumeration: SweepEnumerationResult,
+    run_dir: Path,
+    diff_cap: int = SWEEP_DIFF_CAP,
+) -> tuple[SweepBundle, ...]:
+    _private_mkdir(run_dir)
+    bundles: list[SweepBundle] = []
+    for commit in enumeration.selected:
+        consumers, consumers_truncated = _discover_consumers(
+            runner, symbols=commit.changed_symbols, defining_paths=commit.touched_paths
+        )
+        notices: list[str] = []
+        if commit.diff_truncated:
+            notices.append(f"diff truncated to {diff_cap} characters")
+        if commit.symbols_truncated:
+            notices.append(f"changed symbols truncated to {SWEEP_SYMBOL_CAP}")
+        if consumers_truncated:
+            notices.append(f"consumers truncated to {SWEEP_CONSUMER_CAP}")
+        bundle_path = run_dir / f"sweep-{commit.merge_sha}-bundle.md"
+        bundle = SweepBundle(
+            pinned_tip=enumeration.pinned_tip,
+            merge_sha=commit.merge_sha,
+            base_sha=commit.base_sha,
+            subject=commit.subject,
+            touched_files=commit.touched_paths,
+            chronic_tags=commit.chronic_zones,
+            capped_diff=commit.capped_diff,
+            truncation_notices=tuple(notices),
+            changed_symbols=commit.changed_symbols,
+            consumers=consumers,
+            consumers_truncated=consumers_truncated,
+            bundle_path=str(bundle_path),
+        )
+        _atomic_write_text(bundle_path, _render_sweep_bundle(bundle))
+        bundles.append(bundle)
+    return tuple(bundles)
+
+
+def _write_sweep_prepare_artifacts(
+    *,
+    enumeration: SweepEnumerationResult,
+    bundles: Sequence[SweepBundle],
+    run_dir: Path,
+) -> dict[str, object]:
+    selected_path = run_dir / SWEEP_SELECTED_MANIFEST_NAME
+    bundle_manifest_path = run_dir / SWEEP_BUNDLE_MANIFEST_NAME
+    summary_path = run_dir / SWEEP_PREPARE_SUMMARY_NAME
+    selected_payload = {
+        "pinned_tip": enumeration.pinned_tip,
+        "selected_count": len(enumeration.selected),
+        "skipped_count": enumeration.skipped_count,
+        "coverage_incomplete": enumeration.coverage_incomplete,
+        "pending_shas": list(enumeration.pending_shas),
+        "selected": [
+            {
+                "merge_sha": commit.merge_sha,
+                "base_sha": commit.base_sha,
+                "subject": commit.subject,
+                "diff_size": commit.diff_size,
+                "is_chronic": commit.is_chronic,
+                "chronic_zones": list(commit.chronic_zones),
+                "touched_paths": list(commit.touched_paths),
+                "bundle_path": next(bundle.bundle_path for bundle in bundles if bundle.merge_sha == commit.merge_sha),
+            }
+            for commit in enumeration.selected
+        ],
+    }
+    bundle_payload = {
+        "pinned_tip": enumeration.pinned_tip,
+        "bundles": [{"merge_sha": bundle.merge_sha, "path": bundle.bundle_path} for bundle in bundles],
+    }
+    summary_payload = {
+        "pinned_tip": enumeration.pinned_tip,
+        "selected_merge_manifest": str(selected_path),
+        "bundle_path_manifest": str(bundle_manifest_path),
+        "selected_count": len(enumeration.selected),
+        "skipped_count": enumeration.skipped_count,
+        "pending_shas": list(enumeration.pending_shas),
+        "coverage_incomplete": enumeration.coverage_incomplete,
+        "state_path": str(enumeration.state_path),
+        "finder_raw_path": str(run_dir / SWEEP_FINDER_RAW_NAME),
+        "refuter_raw_path": str(run_dir / SWEEP_REFUTER_RAW_NAME),
+        "chronic_zone_names": list(enumeration.chronic_zone_names),
+    }
+    _write_json(selected_path, selected_payload)
+    _write_json(bundle_manifest_path, bundle_payload)
+    _write_json(summary_path, summary_payload)
+    return summary_payload
+
+
+def sweep_prepare(
+    *,
+    runner: Runner,
+    run_dir: Path,
+    ledger_path: Path,
+    repo: str,
+    sweep_max: int,
+    diff_cap: int = SWEEP_DIFF_CAP,
+    now: int | None = None,
+    pinned_tip: str | None = None,
+) -> dict[str, object]:
+    _private_mkdir(run_dir)
+    enumeration = sweep_enumeration(
+        runner=runner,
+        ledger_path=ledger_path,
+        run_dir=run_dir,
+        repo=repo,
+        sweep_max=sweep_max,
+        diff_cap=diff_cap,
+        now=now,
+        pinned_tip=pinned_tip,
+    )
+    bundles = build_sweep_bundles(runner=runner, enumeration=enumeration, run_dir=run_dir, diff_cap=diff_cap)
+    if len(bundles) != len(enumeration.selected):
+        raise AnalyzeBugsError("partial sweep bundle coverage")
+    summary = _write_sweep_prepare_artifacts(enumeration=enumeration, bundles=bundles, run_dir=run_dir)
+    return {
+        "PINNED_TIP": enumeration.pinned_tip,
+        "SELECTED_MERGE_MANIFEST": summary["selected_merge_manifest"],
+        "BUNDLE_PATH_MANIFEST": summary["bundle_path_manifest"],
+        "SELECTED_COUNT": len(enumeration.selected),
+        "SKIPPED_COUNT": enumeration.skipped_count,
+        "PENDING_SHAS": enumeration.pending_shas,
+        "COVERAGE_INCOMPLETE": "true" if enumeration.coverage_incomplete else "false",
+        "STATE_PATH": str(enumeration.state_path),
+        "RUN_DIR": str(run_dir),
+        "SWEEP_FINDER_RAW_PATH": str(run_dir / SWEEP_FINDER_RAW_NAME),
+        "SWEEP_REFUTER_RAW_PATH": str(run_dir / SWEEP_REFUTER_RAW_NAME),
+        "SWEEP_PREPARE_SUMMARY": str(run_dir / SWEEP_PREPARE_SUMMARY_NAME),
+    }
+
+
+def sweep_main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(prog="python/cli.py analyze-bugs sweep")
+    sub = parser.add_subparsers(dest="subphase", required=True)
+    prepare = sub.add_parser("prepare", help="enumerate merges and write sweep evidence bundles")
+    prepare.add_argument("--run-dir", required=True)
+    prepare.add_argument("--ledger-path", required=True)
+    prepare.add_argument("--repo", default="")
+    prepare.add_argument(
+        "--sweep-max",
+        type=lambda value: _positive_int(value, name="--sweep-max"),
+        default=SWEEP_DEFAULT_MAX,
+    )
+    prepare.add_argument(
+        "--diff-cap",
+        type=lambda value: _positive_int(value, name="--diff-cap"),
+        default=SWEEP_DIFF_CAP,
+    )
+    # Follow-up piece registers ingest-finder / ingest-refuter against this dispatcher.
+    args = parser.parse_args(argv)
+    if args.subphase != "prepare":
+        return _fail(f"unknown sweep subphase: {args.subphase}")
+    try:
+        runner = _runner()
+        repo = resolve_repo(runner, args.repo)
+        payload = sweep_prepare(
+            runner=runner,
+            run_dir=Path(args.run_dir),
+            ledger_path=Path(args.ledger_path),
+            repo=repo,
+            sweep_max=args.sweep_max,
+            diff_cap=args.diff_cap,
+        )
+    except AnalyzeBugsError as exc:
+        return _fail(str(exc))
+    _emit_kvs(
+        {
+            "PINNED_TIP": payload["PINNED_TIP"],
+            "SELECTED_MERGE_MANIFEST": payload["SELECTED_MERGE_MANIFEST"],
+            "BUNDLE_PATH_MANIFEST": payload["BUNDLE_PATH_MANIFEST"],
+            "SELECTED_COUNT": payload["SELECTED_COUNT"],
+            "SKIPPED_COUNT": payload["SKIPPED_COUNT"],
+            "PENDING_SHAS": payload["PENDING_SHAS"],
+            "COVERAGE_INCOMPLETE": payload["COVERAGE_INCOMPLETE"],
+            "STATE_PATH": payload["STATE_PATH"],
+            "RUN_DIR": payload["RUN_DIR"],
+            "SWEEP_FINDER_RAW_PATH": payload["SWEEP_FINDER_RAW_PATH"],
+            "SWEEP_REFUTER_RAW_PATH": payload["SWEEP_REFUTER_RAW_PATH"],
+        }
+    )
     return 0

--- a/python/larch/issue/analyze_bugs.py
+++ b/python/larch/issue/analyze_bugs.py
@@ -2578,7 +2578,7 @@ def _write_sweep_prepare_artifacts(
     _write_json(selected_path, selected_payload)
     _write_json(bundle_manifest_path, bundle_payload)
     _write_json(summary_path, summary_payload)
-    return summary_payload
+    return cast("dict[str, object]", summary_payload)
 
 
 def sweep_prepare(

--- a/python/tests/issue/test_analyze_bugs.py
+++ b/python/tests/issue/test_analyze_bugs.py
@@ -4,12 +4,15 @@
 from __future__ import annotations
 
 import json
+import os
+import subprocess
+import time
 from pathlib import Path
 from typing import cast
 
 import pytest
 
-from larch.core.proc import CommandResult
+from larch.core.proc import CommandResult, ProcRunner
 from larch.issue import analyze_bugs
 from test_support import RecordingRunner, run_cli
 
@@ -1148,3 +1151,492 @@ def test_historical_marker_backfill_is_deferred_until_report_success(tmp_path: P
     assert "| #2 | #1 | marker |" in report
     assert rows[-1]["marker_references"] == [1]
     assert rows[-1]["marker_fingerprint"]
+
+
+def _git(repo: Path, *args: str, env: dict[str, str] | None = None) -> str:
+    merged = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "sweep-test",
+        "GIT_AUTHOR_EMAIL": "sweep@example.com",
+        "GIT_COMMITTER_NAME": "sweep-test",
+        "GIT_COMMITTER_EMAIL": "sweep@example.com",
+    }
+    if env:
+        merged.update(env)
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+        env=merged,
+    )
+    return result.stdout.strip()
+
+
+def _init_sweep_repo(root: Path) -> Path:
+    repo = root / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "sweep@example.com")
+    _git(repo, "config", "user.name", "sweep-test")
+    return repo
+
+
+def _commit_file(repo: Path, relative: str, content: str, message: str, *, when: int | None = None) -> str:
+    path = repo / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    _git(repo, "add", "--", relative)
+    env: dict[str, str] = {}
+    if when is not None:
+        stamp = time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime(when)) + " +0000"
+        env["GIT_AUTHOR_DATE"] = stamp
+        env["GIT_COMMITTER_DATE"] = stamp
+    _git(repo, "commit", "-q", "-m", message, env=env or None)
+    return _git(repo, "rev-parse", "HEAD")
+
+
+def _set_origin_main(repo: Path, sha: str | None = None) -> str:
+    tip = sha or _git(repo, "rev-parse", "HEAD")
+    _git(repo, "update-ref", "refs/remotes/origin/main", tip)
+    return tip
+
+
+def _ledger_row(
+    *,
+    issue: int,
+    cache_key: str,
+    files: list[str],
+    fix_time: int,
+    fix_sha: str = "a" * 40,
+    added_lines: int = 10,
+) -> str:
+    zones = sorted({analyze_bugs.zone_for_path(path) for path in files})
+    return json.dumps(
+        {
+            "cache_key": cache_key,
+            "issue": issue,
+            "fix_sha": fix_sha,
+            "later_history_hash": "later",
+            "triage_verdict": "FIXED_CLEAR",
+            "triage_reason": "ok",
+            "triage_missing_items": [],
+            "triage_needs_deep": False,
+            "triage_evidence_verified": True,
+            "deep_verdict": "",
+            "deep_reason": "",
+            "sampled": False,
+            "stages_complete": ["triage"],
+            "updated_at": fix_time,
+            "touched_files": files,
+            "fix_time": fix_time,
+            "added_lines": added_lines,
+            "marker_references": [],
+            "marker_fingerprint": "",
+            "zones": zones,
+            "baseline_extended": False,
+            "metadata_version": analyze_bugs.ANALYTICS_METADATA_VERSION,
+        },
+        sort_keys=True,
+    )
+
+
+def _write_chronic_ledger(path: Path, *, now: int) -> None:
+    # Three bugs in python/larch/issue within the 14-day analytics window.
+    rows = [
+        _ledger_row(issue=11, cache_key="c1", files=["python/larch/issue/shared.py"], fix_time=now - 100, fix_sha="1" * 40),
+        _ledger_row(issue=12, cache_key="c2", files=["python/larch/issue/shared.py"], fix_time=now - 200, fix_sha="2" * 40),
+        _ledger_row(issue=13, cache_key="c3", files=["python/larch/issue/shared.py"], fix_time=now - 300, fix_sha="3" * 40),
+    ]
+    path.write_text("\n".join(rows) + "\n", encoding="utf-8")
+
+
+def test_sweep_state_round_trip_and_absent_default(tmp_path: Path) -> None:
+    path = tmp_path / "sweep-state.json"
+    assert analyze_bugs.load_sweep_state(path) is None
+
+    state = analyze_bugs.SweepState(
+        last_sweep_sha="a" * 40,
+        last_sweep_at="2026-07-13T12:00:00Z",
+        schema_version=analyze_bugs.SWEEP_SCHEMA_VERSION,
+        pending_shas=("b" * 40, "c" * 40),
+    )
+    analyze_bugs.write_sweep_state(path, state)
+    loaded = analyze_bugs.load_sweep_state(path)
+    assert loaded == state
+    assert oct(path.stat().st_mode & 0o777) in {"0o600", "0o400"}
+
+
+def test_sweep_state_rejects_malformed_schema_and_pending(tmp_path: Path) -> None:
+    path = tmp_path / "sweep-state.json"
+    _write_json(
+        path,
+        {
+            "last_sweep_sha": "a" * 40,
+            "last_sweep_at": "2026-07-13T12:00:00Z",
+            "schema_version": 99,
+            "pending_shas": [],
+        },
+    )
+    with pytest.raises(analyze_bugs.AnalyzeBugsError, match="unsupported sweep state schema"):
+        analyze_bugs.load_sweep_state(path)
+
+    _write_json(
+        path,
+        {
+            "last_sweep_sha": "not-a-sha",
+            "last_sweep_at": "2026-07-13T12:00:00Z",
+            "schema_version": 1,
+            "pending_shas": [],
+        },
+    )
+    with pytest.raises(analyze_bugs.AnalyzeBugsError, match="full 40-character"):
+        analyze_bugs.load_sweep_state(path)
+
+    _write_json(
+        path,
+        {
+            "last_sweep_sha": "a" * 40,
+            "last_sweep_at": "2026-07-13T12:00:00Z",
+            "schema_version": 1,
+            "pending_shas": ["b" * 40, "b" * 40],
+        },
+    )
+    with pytest.raises(analyze_bugs.AnalyzeBugsError, match="duplicate pending"):
+        analyze_bugs.load_sweep_state(path)
+
+    _write_json(
+        path,
+        {
+            "last_sweep_sha": "a" * 40,
+            "last_sweep_at": "yesterday",
+            "schema_version": 1,
+            "pending_shas": [],
+        },
+    )
+    with pytest.raises(analyze_bugs.AnalyzeBugsError, match="ISO-8601"):
+        analyze_bugs.load_sweep_state(path)
+
+
+def test_sweep_enumeration_excludes_flush_release_and_logs_only(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = _init_sweep_repo(tmp_path)
+    monkeypatch.chdir(repo)
+    base = _commit_file(repo, "python/larch/issue/a.py", "A = 1\n", "seed", when=1_700_000_000)
+    _set_origin_main(repo, base)
+
+    flush = _commit_file(repo, "larch-logs/run/x.md", "log\n", "chore(larch-logs): flush", when=1_700_000_100)
+    release = _commit_file(repo, "VERSION", "1.0.0\n", "Release v1.0.0", when=1_700_000_200)
+    logs_only = _commit_file(repo, "larch-logs/other.md", "more\n", "docs: logs only", when=1_700_000_300)
+    real_one = _commit_file(repo, "python/larch/issue/a.py", "A = 2\n", "fix: real one", when=1_700_000_400)
+    real_two = _commit_file(repo, "python/larch/core/b.py", "B = 1\n", "fix: real two", when=1_700_000_500)
+    tip = _set_origin_main(repo)
+
+    run_dir = tmp_path / "run"
+    ledger = tmp_path / "ledger.jsonl"
+    ledger.write_text("", encoding="utf-8")
+    analyze_bugs.write_sweep_state(
+        analyze_bugs.sweep_state_path(ledger),
+        analyze_bugs.SweepState(
+            last_sweep_sha=base,
+            last_sweep_at="2026-01-01T00:00:00Z",
+            schema_version=1,
+            pending_shas=(),
+        ),
+    )
+
+    result = analyze_bugs.sweep_enumeration(
+        runner=ProcRunner(),
+        ledger_path=ledger,
+        run_dir=run_dir,
+        repo="o/r",
+        sweep_max=20,
+        pinned_tip=tip,
+    )
+
+    selected = {commit.merge_sha for commit in result.selected}
+    assert selected == {real_one, real_two}
+    assert flush not in selected
+    assert release not in selected
+    assert logs_only not in selected
+    assert result.skipped_count == 0
+
+
+def test_sweep_enumeration_first_run_window_and_empty(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = _init_sweep_repo(tmp_path)
+    monkeypatch.chdir(repo)
+    old = _commit_file(repo, "python/old.py", "X = 1\n", "old commit", when=1_000_000_000)
+    recent = _commit_file(repo, "python/new.py", "Y = 1\n", "recent commit", when=1_800_000_000)
+    tip = _set_origin_main(repo)
+    run_dir = tmp_path / "run"
+    ledger = tmp_path / "ledger.jsonl"
+    ledger.write_text("", encoding="utf-8")
+
+    result = analyze_bugs.sweep_enumeration(
+        runner=ProcRunner(),
+        ledger_path=ledger,
+        run_dir=run_dir,
+        repo="o/r",
+        sweep_max=20,
+        pinned_tip=tip,
+        now=1_800_000_000 + 3_600,
+    )
+    assert [commit.merge_sha for commit in result.selected] == [recent]
+    assert old not in {commit.merge_sha for commit in result.selected}
+
+    # Far enough after the tip that the 48-hour first-run window is empty.
+    empty = analyze_bugs.sweep_enumeration(
+        runner=ProcRunner(),
+        ledger_path=ledger,
+        run_dir=run_dir,
+        repo="o/r",
+        sweep_max=20,
+        pinned_tip=tip,
+        now=1_800_000_000 + analyze_bugs.SWEEP_INITIAL_WINDOW_SECONDS + 10,
+    )
+    assert empty.selected == ()
+    assert empty.pending_shas == ()
+    assert empty.skipped_count == 0
+
+
+def test_sweep_enumeration_reachability_failures(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = _init_sweep_repo(tmp_path)
+    monkeypatch.chdir(repo)
+    tip = _commit_file(repo, "python/a.py", "A = 1\n", "tip", when=1_700_000_000)
+    _set_origin_main(repo, tip)
+    other = tmp_path / "other"
+    other.mkdir()
+    _git(other, "init", "-q", "-b", "main")
+    _git(other, "config", "user.email", "sweep@example.com")
+    _git(other, "config", "user.name", "sweep-test")
+    foreign = _commit_file(other, "x.py", "1\n", "foreign", when=1_700_000_100)
+
+    ledger = tmp_path / "ledger.jsonl"
+    ledger.write_text("", encoding="utf-8")
+    analyze_bugs.write_sweep_state(
+        analyze_bugs.sweep_state_path(ledger),
+        analyze_bugs.SweepState(
+            last_sweep_sha=foreign,
+            last_sweep_at="2026-01-01T00:00:00Z",
+            schema_version=1,
+            pending_shas=(),
+        ),
+    )
+    with pytest.raises(analyze_bugs.AnalyzeBugsError, match=r"last_sweep_sha .* not reachable"):
+        analyze_bugs.sweep_enumeration(
+            runner=ProcRunner(),
+            ledger_path=ledger,
+            run_dir=tmp_path / "run",
+            repo="o/r",
+            sweep_max=20,
+            pinned_tip=tip,
+        )
+
+    analyze_bugs.write_sweep_state(
+        analyze_bugs.sweep_state_path(ledger),
+        analyze_bugs.SweepState(
+            last_sweep_sha=tip,
+            last_sweep_at="2026-01-01T00:00:00Z",
+            schema_version=1,
+            pending_shas=(foreign,),
+        ),
+    )
+    with pytest.raises(analyze_bugs.AnalyzeBugsError, match=r"pending SHA .* not reachable"):
+        analyze_bugs.sweep_enumeration(
+            runner=ProcRunner(),
+            ledger_path=ledger,
+            run_dir=tmp_path / "run",
+            repo="o/r",
+            sweep_max=20,
+            pinned_tip=tip,
+        )
+
+
+def test_sweep_first_parent_merge_evidence_and_symbols(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = _init_sweep_repo(tmp_path)
+    monkeypatch.chdir(repo)
+    _commit_file(repo, "python/larch/issue/mod.py", "VALUE = 1\n\ndef helper():\n    return VALUE\n", "base", when=1_700_000_000)
+    _git(repo, "checkout", "-q", "-b", "feature")
+    _commit_file(
+        repo,
+        "python/larch/issue/mod.py",
+        "VALUE = 2\n\ndef helper():\n    return VALUE\n\ndef planted():\n    return VALUE\n",
+        "feature change",
+        when=1_700_000_100,
+    )
+    _git(repo, "checkout", "-q", "main")
+    mainline = _commit_file(repo, "python/larch/issue/consumer.py", "from python.larch.issue.mod import planted\n", "mainline consumer", when=1_700_000_150)
+    _git(repo, "merge", "--no-ff", "-q", "-m", "Merge feature into main", "feature")
+    merge_sha = _git(repo, "rev-parse", "HEAD")
+    tip = _set_origin_main(repo)
+    ledger = tmp_path / "ledger.jsonl"
+    ledger.write_text("", encoding="utf-8")
+    analyze_bugs.write_sweep_state(
+        analyze_bugs.sweep_state_path(ledger),
+        analyze_bugs.SweepState(last_sweep_sha=mainline, last_sweep_at="2026-01-01T00:00:00Z", schema_version=1, pending_shas=()),
+    )
+
+    result = analyze_bugs.sweep_prepare(
+        runner=ProcRunner(),
+        run_dir=tmp_path / "run",
+        ledger_path=ledger,
+        repo="o/r",
+        sweep_max=20,
+        pinned_tip=tip,
+    )
+    assert result["SELECTED_COUNT"] == 1
+    selected = json.loads(Path(str(result["SELECTED_MERGE_MANIFEST"])).read_text(encoding="utf-8"))
+    row = selected["selected"][0]
+    assert row["merge_sha"] == merge_sha
+    assert row["base_sha"] == mainline
+    assert "python/larch/issue/mod.py" in row["touched_paths"]
+    assert "python/larch/issue/consumer.py" not in row["touched_paths"]
+    bundle_text = Path(row["bundle_path"]).read_text(encoding="utf-8")
+    assert "def planted" in bundle_text
+    assert "planted" in bundle_text
+    assert "changed_symbols: planted" in bundle_text or "planted" in bundle_text
+
+
+def test_sweep_chronic_priority_cap_and_pending_frontier(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = _init_sweep_repo(tmp_path)
+    monkeypatch.chdir(repo)
+    now = int(time.time())
+    base = _commit_file(repo, "README.md", "root\n", "seed", when=now - 1_000)
+    # Non-chronic but large diff.
+    big = "Z = '" + ("x" * 4000) + "'\n"
+    non_chronic = _commit_file(repo, "docs/guide.md", big, "docs: large non-chronic", when=now - 300)
+    # Chronic zone, smaller diff.
+    chronic = _commit_file(repo, "python/larch/issue/shared.py", "SHARED = 1\n", "fix: chronic small", when=now - 200)
+    later = _commit_file(repo, "scripts/tool.sh", "echo hi\n", "scripts: later", when=now - 100)
+    tip = _set_origin_main(repo)
+
+    ledger = tmp_path / "ledger.jsonl"
+    _write_chronic_ledger(ledger, now=now)
+    analyze_bugs.write_sweep_state(
+        analyze_bugs.sweep_state_path(ledger),
+        analyze_bugs.SweepState(last_sweep_sha=base, last_sweep_at="2026-01-01T00:00:00Z", schema_version=1, pending_shas=()),
+    )
+
+    capped = analyze_bugs.sweep_prepare(
+        runner=ProcRunner(),
+        run_dir=tmp_path / "run1",
+        ledger_path=ledger,
+        repo="o/r",
+        sweep_max=1,
+        pinned_tip=tip,
+        now=now,
+    )
+    assert capped["SELECTED_COUNT"] == 1
+    assert capped["SKIPPED_COUNT"] == 2
+    assert capped["COVERAGE_INCOMPLETE"] == "true"
+    assert set(capped["PENDING_SHAS"]) == {non_chronic, later}
+    selected = json.loads(Path(str(capped["SELECTED_MERGE_MANIFEST"])).read_text(encoding="utf-8"))
+    assert selected["selected"][0]["merge_sha"] == chronic
+    assert selected["selected"][0]["is_chronic"] is True
+    # Prepare must not mutate durable sweep state.
+    durable = analyze_bugs.load_sweep_state(analyze_bugs.sweep_state_path(ledger))
+    assert durable is not None
+    assert durable.pending_shas == ()
+    assert durable.last_sweep_sha == base
+
+    # Hand-written state carries pending SHAs; ranking still prefers chronic/pending over new lower-priority work.
+    analyze_bugs.write_sweep_state(
+        analyze_bugs.sweep_state_path(ledger),
+        analyze_bugs.SweepState(
+            last_sweep_sha=tip,
+            last_sweep_at="2026-01-02T00:00:00Z",
+            schema_version=1,
+            pending_shas=(non_chronic, later),
+        ),
+    )
+    _commit_file(repo, "README.md", "root2\n", "chore: tiny readme", when=now + 50)
+    new_tip = _set_origin_main(repo)
+    resumed = analyze_bugs.sweep_enumeration(
+        runner=ProcRunner(),
+        ledger_path=ledger,
+        run_dir=tmp_path / "run2",
+        repo="o/r",
+        sweep_max=1,
+        pinned_tip=new_tip,
+        now=now + 100,
+    )
+    assert resumed.selected[0].merge_sha == non_chronic
+    assert later in resumed.pending_shas
+    assert resumed.skipped_count >= 1
+
+
+def test_sweep_prepare_cli_fence_and_help(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = _init_sweep_repo(tmp_path)
+    monkeypatch.chdir(repo)
+    base = _commit_file(repo, "python/a.py", "A = 1\n", "seed", when=1_700_000_000)
+    _commit_file(repo, "python/a.py", "A = 2\n", "change", when=1_700_000_100)
+    tip = _set_origin_main(repo)
+    ledger = tmp_path / "ledger.jsonl"
+    ledger.write_text("", encoding="utf-8")
+    analyze_bugs.write_sweep_state(
+        analyze_bugs.sweep_state_path(ledger),
+        analyze_bugs.SweepState(last_sweep_sha=base, last_sweep_at="2026-01-01T00:00:00Z", schema_version=1, pending_shas=()),
+    )
+    run_dir = tmp_path / "run"
+    monkeypatch.setattr(analyze_bugs, "_runner", ProcRunner)
+    monkeypatch.setattr(analyze_bugs, "resolve_repo", lambda _runner, explicit="": explicit or "o/r")
+
+    rc = analyze_bugs.sweep_main(
+        ["prepare", "--run-dir", str(run_dir), "--ledger-path", str(ledger), "--repo", "o/r", "--sweep-max", "20"]
+    )
+    assert rc == 0
+    assert (run_dir / analyze_bugs.SWEEP_SELECTED_MANIFEST_NAME).is_file()
+    assert (run_dir / analyze_bugs.SWEEP_BUNDLE_MANIFEST_NAME).is_file()
+    help_result = run_cli("analyze-bugs", "sweep", "--help")
+    assert help_result.returncode == 0
+    assert "prepare" in help_result.stdout
+
+    # Invalid state fails closed.
+    analyze_bugs.write_sweep_state(
+        analyze_bugs.sweep_state_path(ledger),
+        analyze_bugs.SweepState(last_sweep_sha="f" * 40, last_sweep_at="2026-01-01T00:00:00Z", schema_version=1, pending_shas=()),
+    )
+    # Force an unreachable watermark by writing a valid-looking but foreign SHA after replacing tip pin.
+    foreign_repo = tmp_path / "foreign"
+    foreign_repo.mkdir()
+    _git(foreign_repo, "init", "-q", "-b", "main")
+    _git(foreign_repo, "config", "user.email", "sweep@example.com")
+    _git(foreign_repo, "config", "user.name", "sweep-test")
+    foreign = _commit_file(foreign_repo, "z.py", "1\n", "foreign", when=1_700_000_200)
+    bad_state = analyze_bugs.SweepState(last_sweep_sha=foreign, last_sweep_at="2026-01-01T00:00:00Z", schema_version=1, pending_shas=())
+    analyze_bugs.write_sweep_state(analyze_bugs.sweep_state_path(ledger), bad_state)
+    rc_bad = analyze_bugs.sweep_main(
+        ["prepare", "--run-dir", str(tmp_path / "run-bad"), "--ledger-path", str(ledger), "--repo", "o/r"]
+    )
+    assert rc_bad == 1
+    assert tip
+
+
+def test_non_sweep_verbs_do_not_touch_sweep_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    ledger = tmp_path / "ledger.jsonl"
+    state_path = analyze_bugs.sweep_state_path(ledger)
+    assert not state_path.exists()
+    manifest = _single_manifest(run_dir, issue=1, cache_key="k1", mechanical="WONTFIX")
+    manifest["ledger_path"] = str(ledger)
+    _write_json(run_dir / "manifest.json", manifest)
+    _write_bundle(run_dir / "issue-1-bundle.md")
+    monkeypatch.setattr(analyze_bugs, "_runner", lambda: RecordingRunner(default=_result("")))
+
+    summary = analyze_bugs.ledger_compute(
+        run_dir=run_dir,
+        ledger_path=ledger,
+        manifest_path=run_dir / "manifest.json",
+        refresh=False,
+        sample=0,
+        deep_max=0,
+        deep_model="sonnet",
+        batch_size=10,
+    )
+    assert "TRIAGE_BATCH_PATHS" in summary or "DEEP_QUEUE_PATH" in summary or summary
+    assert not state_path.exists()
+
+    report = analyze_bugs.render_report(manifest_path=run_dir / "manifest.json", ledger_path=ledger, run_dir=run_dir)
+    assert "Analyze Bugs Report" in report
+    assert not state_path.exists()

--- a/python/tests/issue/test_analyze_bugs.py
+++ b/python/tests/issue/test_analyze_bugs.py
@@ -1394,8 +1394,8 @@ def test_sweep_enumeration_first_run_window_and_empty(tmp_path: Path, monkeypatc
         pinned_tip=tip,
         now=1_800_000_000 + analyze_bugs.SWEEP_INITIAL_WINDOW_SECONDS + 10,
     )
-    assert empty.selected == ()
-    assert empty.pending_shas == ()
+    assert not empty.selected
+    assert not empty.pending_shas
     assert empty.skipped_count == 0
 
 
@@ -1529,14 +1529,14 @@ def test_sweep_chronic_priority_cap_and_pending_frontier(tmp_path: Path, monkeyp
     assert capped["SELECTED_COUNT"] == 1
     assert capped["SKIPPED_COUNT"] == 2
     assert capped["COVERAGE_INCOMPLETE"] == "true"
-    assert set(capped["PENDING_SHAS"]) == {non_chronic, later}
+    assert set(cast("tuple[str, ...]", capped["PENDING_SHAS"])) == {non_chronic, later}
     selected = json.loads(Path(str(capped["SELECTED_MERGE_MANIFEST"])).read_text(encoding="utf-8"))
     assert selected["selected"][0]["merge_sha"] == chronic
     assert selected["selected"][0]["is_chronic"] is True
     # Prepare must not mutate durable sweep state.
     durable = analyze_bugs.load_sweep_state(analyze_bugs.sweep_state_path(ledger))
     assert durable is not None
-    assert durable.pending_shas == ()
+    assert not durable.pending_shas
     assert durable.last_sweep_sha == base
 
     # Hand-written state carries pending SHAs; ranking still prefers chronic/pending over new lower-priority work.
@@ -1579,7 +1579,7 @@ def test_sweep_prepare_cli_fence_and_help(tmp_path: Path, monkeypatch: pytest.Mo
     )
     run_dir = tmp_path / "run"
     monkeypatch.setattr(analyze_bugs, "_runner", ProcRunner)
-    monkeypatch.setattr(analyze_bugs, "resolve_repo", lambda _runner, explicit="": explicit or "o/r")
+    monkeypatch.setattr(analyze_bugs, "resolve_repo", lambda _runner, explicit="": explicit or "o/r")  # pyright: ignore[reportUnknownLambdaType]  # test stub
 
     rc = analyze_bugs.sweep_main(
         ["prepare", "--run-dir", str(run_dir), "--ledger-path", str(ledger), "--repo", "o/r", "--sweep-max", "20"]


### PR DESCRIPTION
## Summary
- Add strict `sweep-state.json` load/write, first-parent merge enumeration with flush/release/log exclusions, and chronic-zone-first prioritization capped by `--sweep-max`.
- Build per-commit evidence bundles (capped first-parent diff, symbols, consumers) plus selected/bundle manifests under the run directory.
- Register `analyze-bugs sweep prepare` CLI fence; durable state writes and agent ingest remain for later pieces.

Closes #7206

## Test plan
- [x] `python3 -m pytest python/tests/issue/test_analyze_bugs.py -q`
- [x] `make py-lint PY_FILES='python/larch/issue/analyze_bugs.py python/larch/cli.py python/tests/issue/test_analyze_bugs.py'`
- [x] `python3 python/cli.py analyze-bugs sweep --help` (and existing prefetch/ledger/report help)


Made with [Cursor](https://cursor.com)