### PR TITLE
Release v52.10.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.9.0",
+  "version": "52.10.0",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Added

- Replaced the delegated CI-fixer lane with an in-session CI-fixer subagent; ship-pr now bails on CI failure with a structured error file for the subagent to repair (#7199)
- Architectural assessments are now authored by a subagent; the vendor waterfall is retired (#7200)
- Introduced inactive vendor descriptor, argv builder, and model-extraction foundations for the contract-unification effort (#7227)
- Added run_vendor_launch lifecycle support — caps, config contexts, envelopes, and retries — as an inactive contract-unification layer (#7230)
- Introduced `tally_engine.py`, a shared tally adjudication engine, and adopted it in the code-review tally path (#7231)
- Parser-backed ballot-heading unification in `voting.py` replaces fragile string matching (#7228)

## Fixed

- Cleared stale CI-fixer lane references from `SECURITY.md` and configuration docs left over from the subagent overhaul (#7220)
- Closed merge-gate fail-open remnants introduced during the subagent overhaul (#7224)
- Removed dead code, repaired contract drift, and pinned missing test fixtures from the subagent overhaul (#7226)
- Release prepare no longer misreads an issue number embedded in a commit subject as a PR number; unresolved suffixes now fall through to the commits-to-pulls fallback (#7232)
- Re-pointed the invariant-primary CI-fix to the correct Step 8 fix ladder (#7221)
