### PR TITLE
Release v52.11.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.10.0",
+  "version": "52.11.0",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Added

- Add `/f` alias and Claude subagents for `--self-implement` and `--self-review` (#7239).

## Changed

- Add sweep state tracking, merge enumeration, prioritization, and evidence bundle support to the sweep prepare phase (#7234).
- Add sweep finder and refuter agent contract with strict JSONL ingest verbs (#7241).
- Adopt the shared tally engine in plan review and remove the policy loop (#7238).

## Fixed

- Pin the Cursor MODERATE implement lane to a valid model ID (#7240).
