### PR TITLE
[DONE] Skip external health validation for self-subagents

### DIFF
--- a/python/complexity-baseline.json
+++ b/python/complexity-baseline.json
@@ -6237,7 +6237,7 @@
     "file": "larch/state/bootstrap.py",
     "code": "C901",
     "qualified_symbol": "_run_absorbed_continue_tail",
-    "metric": 24
+    "metric": 26
   },
   {
     "file": "larch/state/bootstrap.py",
@@ -6261,7 +6261,7 @@
     "file": "larch/state/bootstrap.py",
     "code": "PLR0911",
     "qualified_symbol": "_run_absorbed_continue_tail",
-    "metric": 9
+    "metric": 10
   },
   {
     "file": "larch/state/bootstrap.py",
@@ -6309,7 +6309,7 @@
     "file": "larch/state/bootstrap.py",
     "code": "PLR0912",
     "qualified_symbol": "_run_absorbed_continue_tail",
-    "metric": 24
+    "metric": 26
   },
   {
     "file": "larch/state/bootstrap.py",
@@ -6345,7 +6345,7 @@
     "file": "larch/state/bootstrap.py",
     "code": "PLR0915",
     "qualified_symbol": "_run_absorbed_continue_tail",
-    "metric": 63
+    "metric": 69
   },
   {
     "file": "larch/state/bootstrap.py",

--- a/python/larch/state/bootstrap.py
+++ b/python/larch/state/bootstrap.py
@@ -452,6 +452,28 @@ def _restore_resume_progress(st: BootstrapState) -> None:
         _cli("progress", "activate", "--repo-root", str(Path.cwd()), "--run-id", st.run_id)
 
 
+def _self_subagents_only(opts: BootstrapOptions) -> bool:
+    return opts.self_review_requested == "true" and opts.self_implement_requested == "true"
+
+
+def _refresh_reviewer_state(st: BootstrapState) -> None:
+    if _self_subagents_only(st.opts):
+        return
+    reviewer_args = ["agent", "check-reviewers"]
+    if st.opts.skip_codex_probe:
+        reviewer_args.append("--skip-codex-probe")
+    if st.opts.skip_cursor_probe:
+        reviewer_args.append("--skip-cursor-probe")
+    reviewer = _cli(*reviewer_args)
+    reviewer_kv = _parse_kv(reviewer.stdout)
+    if reviewer.returncode == 0:
+        st.codex_present = reviewer_kv.get("CODEX_PRESENT", st.codex_present)
+        st.cursor_present = reviewer_kv.get("CURSOR_PRESENT", st.cursor_present)
+        st.codex_binary_found = reviewer_kv.get("CODEX_BINARY_FOUND", st.codex_binary_found)
+        st.cursor_binary_found = reviewer_kv.get("CURSOR_BINARY_FOUND", st.cursor_binary_found)
+        _write_base_session_env(st)
+
+
 def _phase_infra(st: BootstrapState) -> None:
     _cli("progress", "clear", "--repo-root", str(Path.cwd()))
     branch = _cli("pr", "create-branch", "--check")
@@ -497,11 +519,12 @@ def _phase_infra(st: BootstrapState) -> None:
         _ensure_plugin_root_env(st)
     else:
         setup_args = ["session", "setup", "--prefix", "claude-implement"]
+        skip_external_tool_probes = _self_subagents_only(st.opts)
         if st.skip_branch_check == "true":
             setup_args.append("--skip-branch-check")
-        if st.opts.skip_codex_probe:
+        if st.opts.skip_codex_probe or skip_external_tool_probes:
             setup_args.append("--skip-codex-probe")
-        if st.opts.skip_cursor_probe:
+        if st.opts.skip_cursor_probe or skip_external_tool_probes:
             setup_args.append("--skip-cursor-probe")
         if st.opts.caller_env:
             setup_args.extend(["--caller-env", st.opts.caller_env])
@@ -532,19 +555,7 @@ def _phase_infra(st: BootstrapState) -> None:
         _cli("token", "mark", "Step 0 — preflight")
         env = {**os.environ, "LARCH_TIMING_SKILL": "implement"}
         _cli("timing", "mark", "Step 0 — preflight", env=env)
-        reviewer_args = ["agent", "check-reviewers"]
-        if st.opts.skip_codex_probe:
-            reviewer_args.append("--skip-codex-probe")
-        if st.opts.skip_cursor_probe:
-            reviewer_args.append("--skip-cursor-probe")
-        reviewer = _cli(*reviewer_args)
-        reviewer_kv = _parse_kv(reviewer.stdout)
-        if reviewer.returncode == 0:
-            st.codex_present = reviewer_kv.get("CODEX_PRESENT", st.codex_present)
-            st.cursor_present = reviewer_kv.get("CURSOR_PRESENT", st.cursor_present)
-            st.codex_binary_found = reviewer_kv.get("CODEX_BINARY_FOUND", st.codex_binary_found)
-            st.cursor_binary_found = reviewer_kv.get("CURSOR_BINARY_FOUND", st.cursor_binary_found)
-            _write_base_session_env(st)
+        _refresh_reviewer_state(st)
     _install_statusline_best_effort()
     if st.implement_tmpdir and not _write_larch_run_sh(st.implement_tmpdir):
         st.emit_step_failed("larch-run")
@@ -1720,6 +1731,17 @@ def _run_absorbed_continue_tail(
     st.cursor_present = data.get("CURSOR_PRESENT", st.cursor_present)
     st.codex_binary_found = data.get("CODEX_BINARY_FOUND", st.codex_binary_found)
     st.cursor_binary_found = data.get("CURSOR_BINARY_FOUND", st.cursor_binary_found)
+    if _self_subagents_only(opts):
+        probe_routing, advisory, _probe_rc = _run_1r_probe(st, forked_target=opts.forked_target)
+        routing = {
+            "DEGRADED": "false",
+            "BOTH_DOWN": "false",
+            "DEGRADED_PROMPT_REQUIRED": "false",
+        }
+        routing.update({key: value for key, value in probe_routing.items() if value})
+        if _step2_blockers({**data, **routing}):
+            routing.pop("ROUTE", None)
+        return ContinueTailResult(routing=routing, advisory_lines=advisory)
     probe_failed = _refresh_gate_probe(st)
     if probe_failed:
         return ContinueTailResult(contract_failure=True, step_failed=probe_failed)

--- a/python/tests/state/test_bootstrap.py
+++ b/python/tests/state/test_bootstrap.py
@@ -1692,7 +1692,7 @@ def test_self_review_and_self_implement_skip_external_tool_health_validation(tmp
         non_interactive=True,
     )
 
-    assert calls == []
+    assert not calls
     assert tail.contract_failure is False
     assert tail.routing["DEGRADED"] == "false"
     assert tail.routing["DEGRADED_PROMPT_REQUIRED"] == "false"

--- a/python/tests/state/test_bootstrap.py
+++ b/python/tests/state/test_bootstrap.py
@@ -1355,6 +1355,8 @@ def _run_phase_infra_for_progress(
     opts_run_id: str = "",
     setup_session_id: str = "setup-run-id",
     activate_returncode: int = 0,
+    self_review_requested: str = "false",
+    self_implement_requested: str = "false",
 ) -> tuple[bootstrap.BootstrapState, list[tuple[str, ...]]]:
     calls: list[tuple[str, ...]] = []
     monkeypatch.setenv("LARCH_CLAUDE_PID", "12345")
@@ -1374,7 +1376,14 @@ def _run_phase_infra_for_progress(
         return subprocess.CompletedProcess(["cli", *args], 0, "", "")
 
     monkeypatch.setattr(bootstrap, "_cli", fake_cli)
-    st = bootstrap.BootstrapState(bootstrap.BootstrapOptions(up_to_phase="infra", run_id=opts_run_id))
+    st = bootstrap.BootstrapState(
+        bootstrap.BootstrapOptions(
+            up_to_phase="infra",
+            run_id=opts_run_id,
+            self_review_requested=self_review_requested,
+            self_implement_requested=self_implement_requested,
+        )
+    )
     bootstrap._phase_infra(st)  # pyright: ignore[reportPrivateUsage]
     return st, calls
 
@@ -1433,6 +1442,25 @@ def test_phase_infra_progress_activate_failure_is_best_effort(
     assert any(call[:2] == ("progress", "activate") for call in calls)
     assert any(call[:2] == ("session", "write-implement-env") for call in calls)
     assert "STEP_FAILED=" not in captured.out
+
+
+def test_phase_infra_self_subagents_skip_external_tool_health_validation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _st, calls = _run_phase_infra_for_progress(
+        tmp_path,
+        monkeypatch,
+        opts_run_id="self-subagent-run",
+        setup_session_id="setup-run-id",
+        self_review_requested="true",
+        self_implement_requested="true",
+    )
+
+    setup_call = next(call for call in calls if call[:2] == ("session", "setup"))
+    assert "--skip-codex-probe" in setup_call
+    assert "--skip-cursor-probe" in setup_call
+    assert not any(call[:2] == ("agent", "check-reviewers") for call in calls)
 
 
 @pytest.mark.parametrize("reserved_run_id", ["current", ".", ".."])
@@ -1642,6 +1670,33 @@ def test_invoke_absorbed_degraded_gate_healthy_tools_do_not_prompt(tmp_path: Pat
     assert tail.routing.get("DEGRADED_PROMPT_REQUIRED") == "false"
     assert tail.routing.get("ROUTE") == "continue"
     assert tail.routing.get("CHECKPOINT_NEXT") == "continue"
+
+
+def test_self_review_and_self_implement_skip_external_tool_health_validation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[str, ...]] = []
+
+    def fake_cli(*args: str, **_kwargs):
+        calls.append(args)
+        raise AssertionError("combined self-subagent mode must not validate external tools")
+
+    monkeypatch.setattr(bootstrap, "_cli", fake_cli)
+    monkeypatch.setattr(bootstrap, "_run", lambda argv, **_: subprocess.CompletedProcess(argv, 0, _probe_stdout(), ""))
+
+    tail = bootstrap._run_absorbed_continue_tail(  # pyright: ignore[reportPrivateUsage]
+        _continue_data(tmp_path, CODEX_PRESENT="false", CURSOR_PRESENT="false"),
+        opts=bootstrap.BootstrapOptions(
+            up_to_phase="coder",
+            self_review_requested="true",
+            self_implement_requested="true",
+        ),
+        non_interactive=True,
+    )
+
+    assert calls == []
+    assert tail.contract_failure is False
+    assert tail.routing["DEGRADED"] == "false"
+    assert tail.routing["DEGRADED_PROMPT_REQUIRED"] == "false"
+    assert tail.routing["ROUTE"] == "continue"
 
 
 def test_invoke_absorbed_degraded_gate_one_down_interactive_requires_prompt(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Fixes #7244.

Skips Codex/Cursor health validation only when `/implement` uses both `--self-review` and `--self-implement`, while retaining the checkpoint probe and existing behavior for all other modes.