### PR TITLE
Release v53.0.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "52.11.0",
+  "version": "53.0.0",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Added

- **Claude fallback for Step 2.4** via the `claude-implementer` subagent. Full-plan implementation now routes through a dedicated subagent when other implementers are unavailable. (#7243)
- **Conflict-fix resolution** via the `ci-fixer` subagent. Merge conflicts from CI runs are now resolved through the same fixer path as other CI failures. (#7252)
- **`/design` Gate C assessment authoring** via the `arch-assessor` subagent. Architectural invariant and guideline assessment notes are now authored in a read-only subagent at Gate C, matching the `/implement` Step 8 pattern. Added inline-only carve-out documentation. (#7253)

## Changed

- **Route check fixes through `ci-fixer`**. CI check failures are now dispatched through the `ci-fixer` subagent rather than handled inline. (#7246)
- **Skip external health validation for self-subagents**. Subagents that call themselves no longer perform external health checks, reducing unnecessary validation overhead. (#7249)
- **Config, runtime, agent deletion, and tests**. Updates to configuration handling, runtime behavior, agent lifecycle, and test coverage. (#7251)
