### PR TITLE
[DONE] Fix Claude fallback scope relay (#7254)

### DIFF
--- a/python/larch/implement/dispatch_step2.py
+++ b/python/larch/implement/dispatch_step2.py
@@ -552,6 +552,13 @@ def step2_dispatch_main(argv: list[str] | None = None) -> int:  # noqa: C901,PLR
     if not Path(args.feature_file).is_file():
         _err(f"implement step2-dispatch: --feature-file not found: {args.feature_file}")
         return 2
+    repo_result = _run(["git", "rev-parse", "--show-toplevel"])
+    repo_root: Path | None = None
+    if repo_result.returncode == 0 and repo_result.stdout.strip():
+        repo_root = Path(repo_result.stdout.strip()).resolve()
+        larch_io.trusted_atomic_write(
+            tmpdir / "repo-root.txt", str(repo_root) + "\n", root=tmpdir
+        )
     if args.coder == "claude":
         _ensure_step2_baseline(tmpdir)
         _clear_external_scout_state(tmpdir)
@@ -577,14 +584,9 @@ def step2_dispatch_main(argv: list[str] | None = None) -> int:  # noqa: C901,PLR
         return 0
 
     plugin_root = Path(os.environ.get("CLAUDE_PLUGIN_ROOT") or os.environ.get("LARCH_CLAUDE_PLUGIN_ROOT") or _PLUGIN_ROOT).resolve()
-    repo_result = _run(["git", "rev-parse", "--show-toplevel"])
-    if repo_result.returncode != 0 or not repo_result.stdout.strip():
+    if repo_root is None:
         _err("implement step2-dispatch: must be invoked from within a git working tree (git rev-parse --show-toplevel failed)")
         return 2
-    repo_root = Path(repo_result.stdout.strip()).resolve()
-    larch_io.trusted_atomic_write(
-        tmpdir / "repo-root.txt", str(repo_root) + "\n", root=tmpdir
-    )
     st = _dispatch_state(args=args, repo_root=repo_root, tmpdir=tmpdir, plugin_root=plugin_root)
     _append_architectural_knowledge_warnings(st)
     if not (plugin_root / "agents" / f"{st.tool_tag}-implementer.md").is_file():

--- a/python/tests/implement/test_implement_dispatch.py
+++ b/python/tests/implement/test_implement_dispatch.py
@@ -3031,6 +3031,37 @@ def test_step2_dispatch_claude_fallback(tmp_path: Path, capsys: pytest.CaptureFi
     assert "ORCHESTRATOR_EDIT_AUTHORITY=allowed" in out
 
 
+@pytest.mark.parametrize(
+    ("coder", "availability_flag"),
+    [
+        ("claude", None),
+        ("cursor", "--cursor-binary-found"),
+        ("codex", "--codex-binary-found"),
+    ],
+)
+def test_step2_dispatch_fallback_persists_repo_root(
+    repo: Path,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    coder: str,
+    availability_flag: str | None,
+) -> None:
+    tmp = make_implement_tmpdir(tmp_path)
+    args = [
+        "--tmpdir", str(tmp),
+        "--plan-file", str(tmp / "plan.txt"),
+        "--feature-file", str(tmp / "feature-description.txt"),
+        "--coder", coder,
+    ]
+    if availability_flag is not None:
+        args.extend([availability_flag, "false"])
+
+    assert implement_dispatch.step2_dispatch_main(args) == 0
+
+    assert "STATUS=claude_fallback" in capsys.readouterr().out
+    assert (tmp / "repo-root.txt").read_text(encoding="utf-8") == f"{repo}\n"
+
+
 def test_step2_dispatch_claude_fallback_clears_scout_sidecars(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     tmp = make_implement_tmpdir(tmp_path)
     (tmp / "scout-coder-manifest.json").write_text('{"archetypes":[]}\n', encoding="utf-8")


### PR DESCRIPTION
## Summary

- persist `repo-root.txt` before every Step 2 Claude-fallback return
- cover direct Claude, unavailable Cursor, and unavailable Codex fallback routes
- retain the existing optional-manifest behavior from #7256

## Validation

- `python3 -m pytest python/tests/implement/test_implement_dispatch.py -q`
- `cd python && ruff check larch/implement/dispatch_step2.py tests/implement/test_implement_dispatch.py && pyright larch/implement/dispatch_step2.py tests/implement/test_implement_dispatch.py`
- `python3 python/cli.py checks run-relevant --site local --tmpdir /tmp/claude-implement-7254-checks --repo-root /Users/zhupanov/larch2`

Closes #7254
