### PR TITLE
Fix #7060: add shared shell test fixtures

### DIFF
--- a/python/conftest.py
+++ b/python/conftest.py
@@ -4,12 +4,15 @@ from __future__ import annotations
 
 import os
 import time
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
+from pathlib import Path
 
 import pytest
 from larch.core import config
 from larch.core import logging_util
 import pytest_sharding
+
+from tests.support import shell_fixtures as _shell_fixtures
 
 
 @pytest.fixture(autouse=True)
@@ -105,6 +108,38 @@ def _no_real_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
         pass
 
     monkeypatch.setattr(time, "sleep", noop)
+
+
+@pytest.fixture
+def fake_bin_dir(tmp_path: Path) -> _shell_fixtures.FakeBinDirFactory:
+    """Return a function-scoped factory for fail-closed external-command fakes."""
+    count = 0
+
+    def make() -> _shell_fixtures.FakeBinDir:
+        nonlocal count
+        count += 1
+        return _shell_fixtures.make_fake_bin_dir(tmp_path / f"fake-bin-{count}")
+
+    return make
+
+
+@pytest.fixture
+def subprocess_env() -> _shell_fixtures.SubprocessEnvFactory:
+    """Return a function-scoped factory for controlled subprocess environments."""
+    return _shell_fixtures.make_subprocess_env
+
+
+@pytest.fixture
+def fake_plugin_tree(tmp_path: Path) -> _shell_fixtures.PluginTreeFactory:
+    """Return a function-scoped factory for minimal symlinked plugin trees."""
+    count = 0
+
+    def make(sources: Sequence[_shell_fixtures.PluginSource]) -> Path:
+        nonlocal count
+        count += 1
+        return _shell_fixtures.make_fake_plugin_tree(tmp_path / f"plugin-{count}", sources)
+
+    return make
 
 
 def pytest_configure(config: pytest.Config) -> None:

--- a/python/tests/support/shell_fixtures.py
+++ b/python/tests/support/shell_fixtures.py
@@ -1,0 +1,195 @@
+"""Hermetic fixtures for tests that invoke supported external shell tools."""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import sys
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, cast
+
+from tests.support.repo_contract import repo_root
+
+ExternalTool = Literal["gh", "codex", "cursor", "claude"]
+PluginSource = str | Path
+
+_SUPPORTED_TOOL_NAMES: tuple[ExternalTool, ...] = ("gh", "codex", "cursor", "claude")
+_SUPPORTED_TOOLS: frozenset[str] = frozenset(_SUPPORTED_TOOL_NAMES)
+_DEFAULT_FAILURE_CODE = 127
+
+
+@dataclass(frozen=True)
+class FakeCommand:
+    """Configured response returned by a fake external command."""
+
+    stdout: str = ""
+    stderr: str = ""
+    returncode: int = 0
+
+
+@dataclass(frozen=True)
+class Invocation:
+    """One exact argv vector received by a fake external command."""
+
+    tool: ExternalTool
+    argv: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class FakeBinDir:
+    """A directory of fail-closed external command fakes and their invocation log."""
+
+    path: Path
+    _config_dir: Path
+    _log_path: Path
+
+    def configure(self, tool: ExternalTool, response: FakeCommand | None = None) -> None:
+        """Configure *tool* to return *response* on later invocations."""
+        _validate_tool(tool)
+        command = response or FakeCommand()
+        payload: dict[str, str | int] = {
+            "stdout": command.stdout,
+            "stderr": command.stderr,
+            "returncode": command.returncode,
+        }
+        config_path = self._config_dir / f"{tool}.json"
+        _ = config_path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+
+    def invocations(self) -> list[Invocation]:
+        """Return the exact ordered external command invocations."""
+        if not self._log_path.exists():
+            return []
+        records: list[Invocation] = []
+        for line in self._log_path.read_text(encoding="utf-8").splitlines():
+            raw: object = json.loads(line)
+            if not isinstance(raw, dict):
+                msg = "invalid fake-command invocation record"
+                raise TypeError(msg)
+            record = cast("Mapping[str, object]", raw)
+            tool = _parse_tool(record.get("tool"))
+            argv_value = record.get("argv")
+            if not isinstance(argv_value, list):
+                msg = "invalid fake-command argv in invocation record"
+                raise TypeError(msg)
+            argv: list[str] = []
+            argv_values = cast("list[object]", argv_value)
+            for argument in argv_values:
+                if not isinstance(argument, str):
+                    msg = "invalid fake-command argv in invocation record"
+                    raise TypeError(msg)
+                argv.append(argument)
+            records.append(Invocation(tool=tool, argv=tuple(argv)))
+        return records
+
+
+FakeBinDirFactory = Callable[[], FakeBinDir]
+PluginTreeFactory = Callable[[Sequence[PluginSource]], Path]
+SubprocessEnvFactory = Callable[[FakeBinDir, Mapping[str, str] | None], dict[str, str]]
+
+
+def _validate_tool(tool: str) -> None:
+    if tool not in _SUPPORTED_TOOLS:
+        msg = f"unsupported fake executable: {tool!r}"
+        raise ValueError(msg)
+
+
+def _parse_tool(value: object) -> ExternalTool:
+    if not isinstance(value, str) or value not in _SUPPORTED_TOOLS:
+        msg = "invalid fake-command tool in invocation record"
+        raise ValueError(msg)
+    return cast("ExternalTool", value)
+
+
+def _default_response(tool: ExternalTool) -> FakeCommand:
+    return FakeCommand(
+        stderr=f"fake {tool} is not configured; refusing to run a live executable\\n",
+        returncode=_DEFAULT_FAILURE_CODE,
+    )
+
+
+def _fake_script(tool: ExternalTool, config_path: Path, log_path: Path) -> str:
+    config_literal = json.dumps(str(config_path))
+    log_literal = json.dumps(str(log_path))
+    tool_literal = json.dumps(tool)
+    return f"""#!{sys.executable}
+import json
+import sys
+from pathlib import Path
+
+config = json.loads(Path({config_literal}).read_text(encoding=\"utf-8\"))
+record = {{\"tool\": {tool_literal}, \"argv\": sys.argv[1:]}}
+with Path({log_literal}).open(\"a\", encoding=\"utf-8\") as stream:
+    stream.write(json.dumps(record, ensure_ascii=False) + \"\\n\")
+sys.stdout.write(config[\"stdout\"])
+sys.stderr.write(config[\"stderr\"])
+raise SystemExit(config[\"returncode\"])
+"""
+
+
+def make_fake_bin_dir(tmp_path: Path) -> FakeBinDir:
+    """Create fakes for every supported external tool under *tmp_path*.
+
+    All tools fail closed until configured. The generated scripts use structured
+    JSONL records so argument boundaries survive spaces, empty arguments, and
+    embedded newlines.
+    """
+    bin_dir = tmp_path / "fake-bin"
+    config_dir = bin_dir / "config"
+    config_dir.mkdir(parents=True)
+    log_path = bin_dir / "invocations.jsonl"
+    fake_bin = FakeBinDir(path=bin_dir, _config_dir=config_dir, _log_path=log_path)
+    for tool in _SUPPORTED_TOOL_NAMES:
+        fake_bin.configure(tool, _default_response(tool))
+        script_path = bin_dir / tool
+        _ = script_path.write_text(_fake_script(tool, config_dir / f"{tool}.json", log_path), encoding="utf-8")
+        script_path.chmod(script_path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return fake_bin
+
+
+def make_subprocess_env(
+    fake_bin: FakeBinDir,
+    overrides: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    """Build a fresh subprocess environment with *fake_bin* first on ``PATH``."""
+    environment = dict(os.environ)
+    system_path = environment.get("PATH", "")
+    requested_path = ""
+    if overrides is not None:
+        environment.update(overrides)
+        requested_path = overrides.get("PATH", "")
+    path_parts = [str(fake_bin.path), requested_path, system_path]
+    environment["PATH"] = os.pathsep.join(part for part in path_parts if part)
+    return environment
+
+
+def _checkout_source(source: PluginSource) -> tuple[Path, Path]:
+    relative = Path(source)
+    if relative.is_absolute() or ".." in relative.parts:
+        msg = f"plugin source must be a checkout-relative path: {source!r}"
+        raise ValueError(msg)
+    checkout_root = repo_root()
+    resolved = (checkout_root / relative).resolve()
+    try:
+        _ = resolved.relative_to(checkout_root)
+    except ValueError as exc:
+        msg = f"plugin source escapes checkout root: {source!r}"
+        raise ValueError(msg) from exc
+    if not resolved.exists():
+        msg = f"checkout source does not exist: {source!r}"
+        raise FileNotFoundError(msg)
+    return relative, resolved
+
+
+def make_fake_plugin_tree(tmp_path: Path, sources: Sequence[PluginSource]) -> Path:
+    """Build a minimal plugin tree that symlinks the requested checkout sources."""
+    plugin_root = tmp_path / "plugin"
+    _ = plugin_root.mkdir(parents=True)
+    for source in sources:
+        relative, resolved = _checkout_source(source)
+        destination = plugin_root / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        _ = destination.symlink_to(resolved, target_is_directory=resolved.is_dir())
+    return plugin_root

--- a/python/tests/support/test_shell_fixtures.py
+++ b/python/tests/support/test_shell_fixtures.py
@@ -1,0 +1,168 @@
+"""Focused self-tests for shared shell-subprocess fixtures."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from collections.abc import Mapping
+from pathlib import Path
+
+import pytest
+
+from tests.support import shell_fixtures
+
+
+def _run(tool: str, *argv: str, env: Mapping[str, str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run([tool, *argv], env=env, text=True, capture_output=True, check=False)
+
+
+@pytest.mark.parametrize("tool", ["gh", "codex", "cursor", "claude"])
+def test_all_supported_tools_are_configurable_and_recorded(tmp_path: Path, tool: str) -> None:
+    fake_bin = shell_fixtures.make_fake_bin_dir(tmp_path)
+    fake_bin.configure(tool, shell_fixtures.FakeCommand(stdout=f"{tool} ok\\n"))  # pyright: ignore[reportArgumentType] - parametrized literals exercise the public runtime check.
+
+    result = _run(tool, "status", env=shell_fixtures.make_subprocess_env(fake_bin))
+
+    assert result.returncode == 0
+    assert result.stdout == f"{tool} ok\\n"
+    assert fake_bin.invocations() == [shell_fixtures.Invocation(tool=tool, argv=("status",))]  # pyright: ignore[reportArgumentType] - parametrized literals exercise the public runtime check.
+
+
+def test_fake_commands_preserve_exact_argv_and_configured_result(tmp_path: Path) -> None:
+    fake_bin = shell_fixtures.make_fake_bin_dir(tmp_path)
+    fake_bin.configure(
+        "gh",
+        shell_fixtures.FakeCommand(stdout="café\\n", stderr="problem\\n", returncode=17),
+    )
+    argv = ("arg with spaces", "", "line one\\nline two", "☃")
+
+    result = _run("gh", *argv, env=shell_fixtures.make_subprocess_env(fake_bin))
+
+    assert result.returncode == 17
+    assert result.stdout == "café\\n"
+    assert result.stderr == "problem\\n"
+    assert fake_bin.invocations() == [shell_fixtures.Invocation(tool="gh", argv=argv)]
+
+
+def test_fake_commands_log_ordered_repeated_invocations(tmp_path: Path) -> None:
+    fake_bin = shell_fixtures.make_fake_bin_dir(tmp_path)
+    fake_bin.configure("gh")
+    env = shell_fixtures.make_subprocess_env(fake_bin)
+
+    _ = _run("gh", "issue", "view", env=env)
+    _ = _run("gh", "pr", "view", env=env)
+
+    assert fake_bin.invocations() == [
+        shell_fixtures.Invocation(tool="gh", argv=("issue", "view")),
+        shell_fixtures.Invocation(tool="gh", argv=("pr", "view")),
+    ]
+
+
+def test_fake_bin_dirs_keep_multiple_configured_tools_and_logs_isolated(tmp_path: Path) -> None:
+    first = shell_fixtures.make_fake_bin_dir(tmp_path / "first")
+    second = shell_fixtures.make_fake_bin_dir(tmp_path / "second")
+    first.configure("gh")
+    first.configure("codex")
+    second.configure("cursor")
+
+    first_env = shell_fixtures.make_subprocess_env(first)
+    _ = _run("gh", "issue", env=first_env)
+    _ = _run("codex", "review", env=first_env)
+    _ = _run("cursor", "agent", env=shell_fixtures.make_subprocess_env(second))
+
+    assert first.invocations() == [
+        shell_fixtures.Invocation(tool="gh", argv=("issue",)),
+        shell_fixtures.Invocation(tool="codex", argv=("review",)),
+    ]
+    assert second.invocations() == [shell_fixtures.Invocation(tool="cursor", argv=("agent",))]
+
+
+@pytest.mark.parametrize("tool", ["gh", "codex", "cursor", "claude"])
+def test_unconfigured_tools_fail_closed_before_ambient_path(tmp_path: Path, tool: str) -> None:
+    ambient_bin = tmp_path / "ambient-bin"
+    ambient_bin.mkdir()
+    ambient_tool = ambient_bin / tool
+    _ = ambient_tool.write_text("#!/usr/bin/env sh\nprintf live\\n\n", encoding="utf-8")
+    ambient_tool.chmod(0o755)
+    fake_bin = shell_fixtures.make_fake_bin_dir(tmp_path / "fixtures")
+    env = shell_fixtures.make_subprocess_env(fake_bin, {"PATH": str(ambient_bin)})
+
+    result = _run(tool, "version", env=env)
+
+    assert result.returncode == 127
+    assert result.stdout == ""
+    assert "not configured" in result.stderr
+    assert fake_bin.invocations() == [
+        shell_fixtures.Invocation(tool=tool, argv=("version",))  # pyright: ignore[reportArgumentType] - parametrized literals exercise the public runtime check.
+    ]
+
+
+def test_subprocess_environment_is_fresh_and_does_not_mutate_parent(tmp_path: Path) -> None:
+    fake_bin = shell_fixtures.make_fake_bin_dir(tmp_path)
+    before = os.environ.copy()
+
+    first = shell_fixtures.make_subprocess_env(fake_bin, {"FIXTURE_ONLY": "first"})
+    second = shell_fixtures.make_subprocess_env(fake_bin, {"FIXTURE_ONLY": "second"})
+    first["FIXTURE_ONLY"] = "changed"
+
+    assert os.environ == before
+    assert first["PATH"].split(os.pathsep)[0] == str(fake_bin.path)
+    assert second["PATH"].split(os.pathsep)[0] == str(fake_bin.path)
+    assert second["FIXTURE_ONLY"] == "second"
+
+
+def test_subprocess_environment_keeps_system_commands_after_path_override(tmp_path: Path) -> None:
+    fake_bin = shell_fixtures.make_fake_bin_dir(tmp_path)
+    requested_path = str(tmp_path / "requested-bin")
+
+    environment = shell_fixtures.make_subprocess_env(fake_bin, {"PATH": requested_path})
+
+    assert environment["PATH"].split(os.pathsep)[0:2] == [str(fake_bin.path), requested_path]
+    if before_path := os.environ.get("PATH"):
+        assert environment["PATH"].endswith(before_path)
+
+
+def test_fake_plugin_tree_is_checkout_anchored_and_uses_symlinks(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    unrelated = tmp_path / "unrelated"
+    unrelated.mkdir()
+    monkeypatch.chdir(unrelated)
+
+    plugin_root = shell_fixtures.make_fake_plugin_tree(tmp_path, ["scripts/sleep-seconds.sh", "python"])
+
+    script_link = plugin_root / "scripts" / "sleep-seconds.sh"
+    python_link = plugin_root / "python"
+    assert script_link.is_symlink()
+    assert python_link.is_symlink()
+    assert script_link.samefile(shell_fixtures.repo_root() / "scripts" / "sleep-seconds.sh")
+    assert python_link.samefile(shell_fixtures.repo_root() / "python")
+    assert not (plugin_root / "skills").exists()
+    result = subprocess.run([str(script_link), "0"], text=True, capture_output=True, check=False)
+    assert result.returncode == 0
+
+
+@pytest.mark.parametrize("source", ["../outside", "/absolute/path"])
+def test_fake_plugin_tree_rejects_unsafe_checkout_sources(tmp_path: Path, source: str) -> None:
+    with pytest.raises(ValueError, match="checkout-relative"):
+        _ = shell_fixtures.make_fake_plugin_tree(tmp_path, [source])
+
+
+def test_fake_plugin_tree_rejects_missing_checkout_source(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError, match="does not exist"):
+        _ = shell_fixtures.make_fake_plugin_tree(tmp_path, ["scripts/not-present.sh"])
+
+
+def test_conftest_factories_are_opt_in_and_function_scoped(
+    fake_bin_dir: shell_fixtures.FakeBinDirFactory,
+    fake_plugin_tree: shell_fixtures.PluginTreeFactory,
+    subprocess_env: shell_fixtures.SubprocessEnvFactory,
+) -> None:
+    fake_bin = fake_bin_dir()
+    fake_bin.configure("claude", shell_fixtures.FakeCommand(stdout="ok\\n"))
+    env = subprocess_env(fake_bin, {"FIXTURE_NAME": "shell"})
+    plugin_root = fake_plugin_tree(["scripts/sleep-seconds.sh"])
+
+    result = _run("claude", "--version", env=env)
+
+    assert result.stdout == "ok\\n"
+    assert env["FIXTURE_NAME"] == "shell"
+    assert (plugin_root / "scripts" / "sleep-seconds.sh").is_symlink()

--- a/python/tests/test_conftest_session_isolation.py
+++ b/python/tests/test_conftest_session_isolation.py
@@ -34,6 +34,8 @@ _SESSION_ROUTING_VARS = (
     "REVIEW_TMPDIR",
     "SESSION_ENV_PATH",
     "LARCH_EXECUTION_ISSUES_LOG",
+    "CLAUDE_PLUGIN_ROOT",
+    "LARCH_CLAUDE_PLUGIN_ROOT",
 )
 
 
@@ -56,6 +58,8 @@ def _ambient_live_session(
     os.environ["REVIEW_TMPDIR"] = str(session_dir)
     os.environ["SESSION_ENV_PATH"] = str(session_dir / "session-env.sh")
     os.environ["LARCH_EXECUTION_ISSUES_LOG"] = str(session_dir / "execution-issues.md")
+    os.environ["CLAUDE_PLUGIN_ROOT"] = str(session_dir / "plugin-root")
+    os.environ["LARCH_CLAUDE_PLUGIN_ROOT"] = str(session_dir / "larch-plugin-root")
     try:
         yield session_dir
     finally:


### PR DESCRIPTION
## Summary

- Add typed, fail-closed shell-test fixtures for `gh`, `codex`, `cursor`, and `claude`.
- Expose isolated fake-bin, subprocess-environment, and symlinked plugin-tree factories to pytest.
- Cover argv preservation, configured results, PATH safety, checkout-root anchoring, and session-env isolation.

Fixes #7060

## Testing

- `python3 -m pytest python/tests/support/test_shell_fixtures.py python/tests/support/test_foundation.py python/tests/test_conftest_session_isolation.py -q`
- `ruff check --config python/ruff.toml python/conftest.py python/tests/support/shell_fixtures.py python/tests/support/test_shell_fixtures.py python/tests/test_conftest_session_isolation.py`
- `pylint --rcfile=python/.pylintrc python/conftest.py python/tests/support/shell_fixtures.py python/tests/support/test_shell_fixtures.py python/tests/test_conftest_session_isolation.py`
- `pyright --project python/pyrightconfig.json python/conftest.py python/tests/support/shell_fixtures.py python/tests/support/test_shell_fixtures.py python/tests/test_conftest_session_isolation.py`
