### PR TITLE
[IMPLEMENTING] contract-unification: review wire factories

### DIFF
--- a/python/test_support.py
+++ b/python/test_support.py
@@ -15,6 +15,7 @@ from larch.core.proc import CommandResult
 from larch.core.run_context import RunContext
 
 from tests.support.repo_contract import ROOT, repo_root
+from tests.support.review_wire import plan_review_slot_line, slot_manifest_ndjson
 
 CLI = ROOT / "python" / "cli.py"
 
@@ -201,11 +202,16 @@ def make_zero_findings_plan_review_fake_cli(
         if argv[:2] == ["plan-review", "panel-dispatch"]:
             paths_file = design / "plan-review-panel-paths.txt"
             _ = (design / "plan-review-slots.ndjson").write_text(
-                '{"slot":"cursor-plan-arch","tool":"cursor","output":"'
-                + str(reviewer_file)
-                + '","prompt_file":"'
-                + str(design / "cursor-plan-arch.prompt")
-                + '"}\n',
+                slot_manifest_ndjson(
+                    [
+                        plan_review_slot_line(
+                            "cursor-plan-arch",
+                            "cursor",
+                            reviewer_file,
+                            prompt_file=design / "cursor-plan-arch.prompt",
+                        )
+                    ]
+                ),
                 encoding="utf-8",
             )
             _ = paths_file.write_text(str(reviewer_file) + "\n", encoding="utf-8")

--- a/python/tests/report/test_review_phase_detail.py
+++ b/python/tests/report/test_review_phase_detail.py
@@ -16,6 +16,7 @@ import pytest  # noqa: TC002
 from larch.review import plan_review
 from larch.report import progress_report
 from larch.report import review_phase_detail
+from tests.support.review_wire import panel_manifest_ndjson, panel_manifest_row
 
 
 def test_invoke_renderer_returns_empty_on_wrapper_empty(
@@ -337,10 +338,7 @@ def test_render_implement_review_detail_omits_rejected_oos_audit(
 def _write_slot_manifest(manifest: Path, outputs: list[Path]) -> None:
     manifest.parent.mkdir(parents=True, exist_ok=True)
     manifest.write_text(
-        "".join(
-            f'{{"slot":"slot-{idx}","tool":"codex","output":"{output}"}}\n'
-            for idx, output in enumerate(outputs, start=1)
-        ),
+        panel_manifest_ndjson([panel_manifest_row(f"slot-{idx}", "codex", output) for idx, output in enumerate(outputs, start=1)]),
         encoding="utf-8",
     )
 

--- a/python/tests/review/test_plan_review.py
+++ b/python/tests/review/test_plan_review.py
@@ -26,6 +26,7 @@ from larch.report import progress_report
 import pytest
 from larch.review import voting
 from test_support import ROOT, make_zero_findings_plan_review_fake_cli, run_cli
+from tests.support.review_wire import make_rejected_block
 
 
 def _read_tsv(path: Path) -> dict[str, dict[str, str]]:
@@ -3877,17 +3878,6 @@ def test_tally_plan_review_neutralized_without_sidecar_fails_closed(tmp_path: Pa
     assert "missing proposer map entry" in proc.stderr
 
 
-def _make_rejected_block(item_id: str, location: str, concern: str, title: str) -> str:
-    """A rejected-findings.md block in the tally's emitted shape (issue #4849 tests)."""
-    return (
-        f"### [Plan Review] {item_id}\n\n"
-        f"### {item_id}: {title}\n"
-        f"- **Location**: {location}\n"
-        f"- **Concern**: {concern}\n"
-        f"- **Severity**: major\n\n"
-    )
-
-
 def _emit_rejected(design: Path, *, report_framing: bool = False) -> subprocess.CompletedProcess[str]:
     args = [
         "plan-review",
@@ -3903,8 +3893,8 @@ def _emit_rejected(design: Path, *, report_framing: bool = False) -> subprocess.
 def test_emit_rejected_excludes_already_applied_findings(tmp_path: Path) -> None:
     design = tmp_path / "design"
     design.mkdir()
-    applied = _make_rejected_block("FINDING_1", "alpha.py:10-20", "Off-by-one in loop bound", "Loop bound")
-    fresh = _make_rejected_block("FINDING_3", "beta.py:5", "Missing nil guard", "Nil guard")
+    applied = make_rejected_block("FINDING_1", "Loop bound", location="alpha.py:10-20", concern="Off-by-one in loop bound")
+    fresh = make_rejected_block("FINDING_3", "Nil guard", location="beta.py:5", concern="Missing nil guard")
     body = applied + fresh
     _ = (design / "rejected-findings.md").write_text(body, encoding="utf-8")
     # Record FINDING_1's dedup key as applied in round 1 (what plan_review_continuation does).
@@ -3924,7 +3914,7 @@ def test_emit_rejected_excludes_already_applied_findings(tmp_path: Path) -> None
 def test_emit_rejected_without_ledger_emits_verbatim(tmp_path: Path) -> None:
     design = tmp_path / "design"
     design.mkdir()
-    body = _make_rejected_block("FINDING_1", "alpha.py:10", "Concern A", "Title A")
+    body = make_rejected_block("FINDING_1", "Title A", location="alpha.py:10", concern="Concern A")
     _ = (design / "rejected-findings.md").write_text(body, encoding="utf-8")
     proc = _emit_rejected(design)
     assert proc.returncode == 0, proc.stderr
@@ -3934,9 +3924,9 @@ def test_emit_rejected_without_ledger_emits_verbatim(tmp_path: Path) -> None:
 def test_emit_rejected_preserves_intervening_oos_block(tmp_path: Path) -> None:
     design = tmp_path / "design"
     design.mkdir()
-    applied = _make_rejected_block("FINDING_1", "alpha.py:10", "Concern A", "Title A")
+    applied = make_rejected_block("FINDING_1", "Title A", location="alpha.py:10", concern="Concern A")
     oos = "### OOS_2: preserve\n- **Concern**: unrelated OOS\n"
-    fresh = _make_rejected_block("FINDING_3", "beta.py:20", "Concern B", "Title B")
+    fresh = make_rejected_block("FINDING_3", "Title B", location="beta.py:20", concern="Concern B")
     body = applied + oos + fresh
     _ = (design / "rejected-findings.md").write_text(body, encoding="utf-8")
     key = plan_review._finding_dedup_key(applied)  # pyright: ignore[reportPrivateUsage]
@@ -3951,7 +3941,7 @@ def test_emit_rejected_preserves_intervening_oos_block(tmp_path: Path) -> None:
 def test_emit_rejected_all_applied_emits_empty(tmp_path: Path) -> None:
     design = tmp_path / "design"
     design.mkdir()
-    block = _make_rejected_block("FINDING_1", "alpha.py:10", "Concern A", "Title A")
+    block = make_rejected_block("FINDING_1", "Title A", location="alpha.py:10", concern="Concern A")
     _ = (design / "rejected-findings.md").write_text(block, encoding="utf-8")
     key = plan_review._finding_dedup_key(block)  # pyright: ignore[reportPrivateUsage]
     _ = (design / ".step3-applied-finding-keys.tsv").write_text(f"2\t{key}\n", encoding="utf-8")
@@ -3963,7 +3953,7 @@ def test_emit_rejected_all_applied_emits_empty(tmp_path: Path) -> None:
 def test_emit_rejected_report_framing_wraps_operator_output(tmp_path: Path) -> None:
     design = tmp_path / "design"
     design.mkdir()
-    body = _make_rejected_block("FINDING_1", "alpha.py:10", "Concern A", "Title A")
+    body = make_rejected_block("FINDING_1", "Title A", location="alpha.py:10", concern="Concern A")
     _ = (design / "rejected-findings.md").write_text(body, encoding="utf-8")
 
     proc = _emit_rejected(design, report_framing=True)
@@ -3979,7 +3969,7 @@ def test_emit_rejected_report_framing_wraps_operator_output(tmp_path: Path) -> N
 def test_emit_rejected_report_framing_all_applied_emits_empty(tmp_path: Path) -> None:
     design = tmp_path / "design"
     design.mkdir()
-    block = _make_rejected_block("FINDING_1", "alpha.py:10", "Concern A", "Title A")
+    block = make_rejected_block("FINDING_1", "Title A", location="alpha.py:10", concern="Concern A")
     _ = (design / "rejected-findings.md").write_text(block, encoding="utf-8")
     key = plan_review._finding_dedup_key(block)  # pyright: ignore[reportPrivateUsage]
     _ = (design / ".step3-applied-finding-keys.tsv").write_text(f"1\t{key}\n", encoding="utf-8")
@@ -3998,23 +3988,13 @@ def test_emit_rejected_missing_file_emits_nothing(tmp_path: Path) -> None:
     assert proc.stdout == ""
 
 
-def _make_finding_only_rejected_block(item_id: str, location: str, concern: str, title: str) -> str:
-    """Rejected block without the ``[Plan Review]`` wrapper (marker drift / hand edit)."""
-    return (
-        f"### {item_id}: {title}\n"
-        f"- **Location**: {location}\n"
-        f"- **Concern**: {concern}\n"
-        f"- **Severity**: major\n\n"
-    )
-
-
 def test_emit_rejected_filters_finding_blocks_without_plan_review_markers(tmp_path: Path) -> None:
     design = tmp_path / "design"
     design.mkdir()
-    applied = _make_finding_only_rejected_block(
-        "FINDING_1", "alpha.py:10-20", "Off-by-one in loop bound", "Loop bound"
+    applied = make_rejected_block(
+        "FINDING_1", "Loop bound", location="alpha.py:10-20", concern="Off-by-one in loop bound", plan_review=False
     )
-    fresh = _make_finding_only_rejected_block("FINDING_3", "beta.py:5", "Missing nil guard", "Nil guard")
+    fresh = make_rejected_block("FINDING_3", "Nil guard", location="beta.py:5", concern="Missing nil guard", plan_review=False)
     body = applied + fresh
     _ = (design / "rejected-findings.md").write_text(body, encoding="utf-8")
     applied_key = plan_review._finding_dedup_key(applied)  # pyright: ignore[reportPrivateUsage]
@@ -4043,10 +4023,10 @@ def test_emit_rejected_ledger_without_recognizable_blocks_emits_empty(tmp_path: 
 def test_emit_rejected_drops_already_addressed_tagged_block(tmp_path: Path) -> None:
     design = tmp_path / "design"
     design.mkdir()
-    tagged = _make_rejected_block(
-        "FINDING_1", "alpha.py:10", "[ALREADY_ADDRESSED] plan already covers this", "Already covered"
+    tagged = make_rejected_block(
+        "FINDING_1", "Already covered", location="alpha.py:10", concern="[ALREADY_ADDRESSED] plan already covers this"
     )
-    fresh = _make_rejected_block("FINDING_2", "beta.py:5", "Missing nil guard", "Nil guard")
+    fresh = make_rejected_block("FINDING_2", "Nil guard", location="beta.py:5", concern="Missing nil guard")
     _ = (design / "rejected-findings.md").write_text(tagged + fresh, encoding="utf-8")
 
     # No ledger present: the [ALREADY_ADDRESSED] tag alone suppresses the block.
@@ -4062,8 +4042,8 @@ def test_emit_rejected_drops_already_addressed_from_ledger(tmp_path: Path) -> No
     design.mkdir()
     # A later round re-raises the same concern WITHOUT the tag; the cross-round
     # ledger (written when an earlier round flagged it) still suppresses it.
-    reraised = _make_rejected_block("FINDING_3", "gamma.py:7", "Concern re-raised untagged", "Reraised")
-    fresh = _make_rejected_block("FINDING_4", "delta.py:2", "Genuinely new concern", "New")
+    reraised = make_rejected_block("FINDING_3", "Reraised", location="gamma.py:7", concern="Concern re-raised untagged")
+    fresh = make_rejected_block("FINDING_4", "New", location="delta.py:2", concern="Genuinely new concern")
     _ = (design / "rejected-findings.md").write_text(reraised + fresh, encoding="utf-8")
     key = plan_review._finding_dedup_key(reraised)  # pyright: ignore[reportPrivateUsage]
     _ = (design / ".step3-already-addressed-finding-keys.tsv").write_text(f"{key}\n", encoding="utf-8")
@@ -4077,15 +4057,15 @@ def test_emit_rejected_drops_already_addressed_from_ledger(tmp_path: Path) -> No
 def test_emit_rejected_already_addressed_ledger_extracts_records_and_dedups(tmp_path: Path) -> None:
     design = tmp_path / "design"
     design.mkdir()
-    tagged = _make_rejected_block(
-        "FINDING_1", "alpha.py:10", "[ALREADY_ADDRESSED] plan covers it", "Covered"
+    tagged = make_rejected_block(
+        "FINDING_1", "Covered", location="alpha.py:10", concern="[ALREADY_ADDRESSED] plan covers it"
     )
-    untagged = _make_rejected_block("FINDING_2", "beta.py:5", "Real concern", "Real")
+    untagged = make_rejected_block("FINDING_2", "Real", location="beta.py:5", concern="Real concern")
     _ = (design / "rejected-findings.md").write_text(tagged + untagged, encoding="utf-8")
 
     # The extracted key is the canonical (tag-stripped) concern key, so it matches
     # an untagged re-raise of the same concern in a later round.
-    untagged_same = _make_rejected_block("FINDING_9", "alpha.py:10", "plan covers it", "Covered")
+    untagged_same = make_rejected_block("FINDING_9", "Covered", location="alpha.py:10", concern="plan covers it")
     canonical_key = plan_review._finding_dedup_key(untagged_same)  # pyright: ignore[reportPrivateUsage]
     keys = plan_review._already_addressed_keys_in_rejected(design)  # pyright: ignore[reportPrivateUsage]
     assert keys == [canonical_key]

--- a/python/tests/review/test_review_tally.py
+++ b/python/tests/review/test_review_tally.py
@@ -15,6 +15,7 @@ from larch.review import review_tally
 from larch.review import review_core_body
 import review_test_support as rts
 from larch.review import voting
+from tests.support.review_wire import ballot_snippet, make_finding_block
 
 ROOT = rts.ROOT
 CLI = rts.CLI
@@ -35,16 +36,22 @@ _CODE_REVIEW_CLASSIFICATION_HEADER = (
 
 def _write_classification_ballot(path: Path) -> None:
     _ = path.write_text(
-        """### FINDING_1: In-scope concern
-- **Reviewer(s)**: cursor-a-output.txt, codex-b-output.txt
-- **Concern**: Real issue.
-- **Suggested revision**: Fix it.
-
-### OOS_1: Future concern
-- **Reviewer**: cursor-oos-output.txt
-- **Concern**: Future issue.
-- **Suggested revision**: File it.
-""",
+        ballot_snippet(
+            make_finding_block(
+                "FINDING_1",
+                "In-scope concern",
+                reviewer=["cursor-a-output.txt", "codex-b-output.txt"],
+                concern="Real issue.",
+                suggested_revision="Fix it.",
+            ),
+            make_finding_block(
+                "OOS_1",
+                "Future concern",
+                reviewer="cursor-oos-output.txt",
+                concern="Future issue.",
+                suggested_revision="File it.",
+            ),
+        ),
         encoding="utf-8",
     )
 
@@ -95,21 +102,11 @@ def _prepare_neutralized_ballot(tmp_path: Path, attributed_text: str) -> tuple[P
 
 def _mk_ballot(path: Path) -> None:
     _ = path.write_text(
-        """### FINDING_1: First in-scope finding
-- **Reviewer**: Codex-Structure
-- **Concern**: Concern 1.
-- **Suggested revision**: Revision 1.
-
-### FINDING_2: Second in-scope finding
-- **Reviewer**: Cursor-Security
-- **Concern**: Concern 2.
-- **Suggested revision**: Revision 2.
-
-### FINDING_3: [OUT_OF_SCOPE] OOS observation
-- **Reviewer**: Codex-Plan-fidelity
-- **Concern**: Pre-existing thing.
-- **Suggested revision**: Revision 3.
-""",
+        ballot_snippet(
+            make_finding_block("FINDING_1", "First in-scope finding", reviewer="Codex-Structure", concern="Concern 1.", suggested_revision="Revision 1."),
+            make_finding_block("FINDING_2", "Second in-scope finding", reviewer="Cursor-Security", concern="Concern 2.", suggested_revision="Revision 2."),
+            make_finding_block("FINDING_3", "[OUT_OF_SCOPE] OOS observation", reviewer="Codex-Plan-fidelity", concern="Pre-existing thing.", suggested_revision="Revision 3."),
+        ),
         encoding="utf-8",
     )
 

--- a/python/tests/review/test_voting.py
+++ b/python/tests/review/test_voting.py
@@ -15,6 +15,7 @@ import pytest
 from larch.review import voting
 from larch.core import config
 from larch.review.review_types import JudgeSeverity, ReviewVote
+from tests.support.review_wire import vote_lines
 
 CLI = Path(__file__).resolve().parents[2] / "cli.py"
 
@@ -51,9 +52,7 @@ def test_normalize_reviewer_basename_strips_path_and_waterfall_suffixes() -> Non
 def test_vote_for_id_last_match_and_exonerate(tmp_path: Path) -> None:
     voter = tmp_path / "voter.txt"
     voter.write_text(
-        "FINDING_1: YES\n"
-        "FINDING_10: YES\n"
-        "finding_1: exonerate -- old token\n",
+        vote_lines({"FINDING_1": "YES", "FINDING_10": "YES"}) + "finding_1: exonerate -- old token\n",
         encoding="utf-8",
     )
     result = run_cli("voting", "vote-for-id", "FINDING_1", str(voter))

--- a/python/tests/support/review_wire.py
+++ b/python/tests/support/review_wire.py
@@ -1,0 +1,120 @@
+"""Canonical wire-format builders for review and plan-review tests.
+
+The builders deliberately serialize only valid, ordinary fixture shapes. Tests
+that exercise malformed or legacy wire data should keep their literals inline.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import TypeAlias
+
+WireValue: TypeAlias = str | int | float | bool | None | Path
+WireRow: TypeAlias = Mapping[str, WireValue]
+
+
+def make_finding_block(  # noqa: PLR0913 - canonical Markdown fields map directly to the wire format.
+    item_id: str,
+    title: str,
+    *,
+    reviewer: str | Sequence[str] | None = None,
+    location: str | None = None,
+    severity: str | None = None,
+    concern: str | None = None,
+    suggested_revision: str | None = None,
+) -> str:
+    """Build one ordinary finding or OOS Markdown block with terminal spacing."""
+    lines: list[str] = [f"### {item_id}: {title}"]
+    if reviewer is not None:
+        reviewers: str = ", ".join(reviewer) if not isinstance(reviewer, str) else reviewer
+        label: str = "Reviewer" if isinstance(reviewer, str) else "Reviewer(s)"
+        lines.append(f"- **{label}**: {reviewers}")
+    if location is not None:
+        lines.append(f"- **Location**: {location}")
+    if severity is not None:
+        lines.append(f"- **Severity**: {severity}")
+    if concern is not None:
+        lines.append(f"- **Concern**: {concern}")
+    if suggested_revision is not None:
+        lines.append(f"- **Suggested revision**: {suggested_revision}")
+    return "\n".join(lines) + "\n\n"
+
+
+def make_rejected_block(  # noqa: PLR0913 - rejected tally fields map directly to the wire format.
+    item_id: str,
+    title: str,
+    *,
+    location: str,
+    concern: str,
+    severity: str = "major",
+    plan_review: bool = True,
+) -> str:
+    """Build a rejected-finding block in the plan-review tally's normal shape."""
+    prefix: str = f"### [Plan Review] {item_id}\n\n" if plan_review else ""
+    return (
+        prefix
+        + f"### {item_id}: {title}\n"
+        + f"- **Location**: {location}\n"
+        + f"- **Concern**: {concern}\n"
+        + f"- **Severity**: {severity}\n\n"
+    )
+
+
+def vote_lines(votes: Mapping[str, str]) -> str:
+    """Serialize canonical per-item judge vote lines in caller-supplied order."""
+    return "".join(f"{item_id}: {vote}\n" for item_id, vote in votes.items())
+
+
+def ballot_snippet(*blocks: str) -> str:
+    """Compose complete Markdown blocks with exactly one blank line between them."""
+    if not blocks:
+        return ""
+    return "\n\n".join(block.rstrip("\n") for block in blocks) + "\n"
+
+
+def plan_review_slot_line(  # noqa: PLR0913 - manifest fields are intentionally named at fixture call sites.
+    slot: str,
+    tool: str,
+    output: str | Path,
+    *,
+    prompt_file: str | Path | None = None,
+    vendor: str | None = None,
+    resolved_model: str | None = None,
+    **optional_fields: WireValue,
+) -> dict[str, WireValue]:
+    """Build one valid plan-review slot-manifest row without reordering fields."""
+    row: dict[str, WireValue] = {"slot": slot, "tool": tool, "output": output}
+    if prompt_file is not None:
+        row["prompt_file"] = prompt_file
+    if vendor is not None:
+        row["vendor"] = vendor
+    if resolved_model is not None:
+        row["resolved_model"] = resolved_model
+    row.update(optional_fields)
+    return row
+
+
+def panel_manifest_row(
+    slot: str,
+    tool: str,
+    output: str | Path,
+    **optional_fields: WireValue,
+) -> dict[str, WireValue]:
+    """Build one valid shared panel-manifest row."""
+    row: dict[str, WireValue] = {"slot": slot, "tool": tool, "output": output}
+    row.update(optional_fields)
+    return row
+
+
+def slot_manifest_ndjson(rows: Sequence[WireRow]) -> str:
+    """Serialize rows as compact NDJSON, preserving order and ending in one newline."""
+    if not rows:
+        return ""
+    return "".join(json.dumps(dict(row), default=str, ensure_ascii=False, separators=(",", ":")) + "\n" for row in rows)
+
+
+def panel_manifest_ndjson(rows: Sequence[WireRow]) -> str:
+    """Serialize shared panel-manifest rows using the canonical NDJSON contract."""
+    return slot_manifest_ndjson(rows)

--- a/python/tests/support/test_foundation.py
+++ b/python/tests/support/test_foundation.py
@@ -26,6 +26,79 @@ from test_support import (
     write_session_env,
 )
 from tests.support import repo_contract, session
+from tests.support.review_wire import (
+    ballot_snippet,
+    make_finding_block,
+    make_rejected_block,
+    panel_manifest_ndjson,
+    panel_manifest_row,
+    plan_review_slot_line,
+    slot_manifest_ndjson,
+    vote_lines,
+)
+
+
+def test_review_wire_builders_preserve_canonical_fixture_shapes(tmp_path: Path) -> None:
+    finding = make_finding_block(
+        "FINDING_1",
+        "Concern",
+        reviewer=["codex-a", "cursor-b"],
+        concern="The concern.",
+        suggested_revision="Fix it.",
+    )
+
+    assert ballot_snippet(finding, make_finding_block("OOS_1", "Future", reviewer="cursor-c")) == (
+        "### FINDING_1: Concern\n"
+        "- **Reviewer(s)**: codex-a, cursor-b\n"
+        "- **Concern**: The concern.\n"
+        "- **Suggested revision**: Fix it.\n\n"
+        "### OOS_1: Future\n"
+        "- **Reviewer**: cursor-c\n"
+    )
+    assert make_rejected_block("FINDING_2", "Title", location="a.py:2", concern="Fix it.") == (
+        "### [Plan Review] FINDING_2\n\n"
+        "### FINDING_2: Title\n"
+        "- **Location**: a.py:2\n"
+        "- **Concern**: Fix it.\n"
+        "- **Severity**: major\n\n"
+    )
+    assert vote_lines({"FINDING_1": "YES", "OOS_1": "NO"}) == "FINDING_1: YES\nOOS_1: NO\n"
+
+    output = tmp_path / "output with spaces.txt"
+    row = plan_review_slot_line(
+        "codex-arch",
+        "codex",
+        output,
+        prompt_file=tmp_path / "prompt.txt",
+        vendor="codex",
+        resolved_model="model",
+    )
+    expected = (
+        '{"slot":"codex-arch","tool":"codex","output":"'
+        + str(output)
+        + '","prompt_file":"'
+        + str(tmp_path / "prompt.txt")
+        + '","vendor":"codex","resolved_model":"model"}\n'
+    )
+    assert slot_manifest_ndjson([row]) == expected
+    assert panel_manifest_ndjson([panel_manifest_row("codex-arch", "codex", output)]) == (
+        '{"slot":"codex-arch","tool":"codex","output":"' + str(output) + '"}\n'
+    )
+    unusual_row = plan_review_slot_line(
+        "codex-β",
+        "codex",
+        tmp_path / 'output "quoted"\\path.txt',
+        vendor='vendor "β"\\path',
+    )
+    unusual_manifest = slot_manifest_ndjson([unusual_row])
+    assert "\\u03b2" not in unusual_manifest
+    assert json.loads(unusual_manifest) == {
+        "slot": "codex-β",
+        "tool": "codex",
+        "output": str(tmp_path / 'output "quoted"\\path.txt'),
+        "vendor": 'vendor "β"\\path',
+    }
+    assert slot_manifest_ndjson([]) == ""
 
 
 def test_ok_normalizes_arguments_and_preserves_stdout() -> None:


### PR DESCRIPTION
Fixes #7025

## Summary
- add canonical review and plan-review wire fixture builders
- migrate ordinary ballot, vote, rejected-finding, and manifest fixtures
- retain malformed and legacy parser fixtures inline

## Verification
- `python3 -m pytest -q python/tests/review` (916 passed)
- focused migrated suites (422 passed)
- Ruff and Pyright on changed files