### PR TITLE
Fixes #7257: price Cursor grok tokens at grok rates in /design and per-round cost

### DIFF
--- a/python/larch/design/design_summary.py
+++ b/python/larch/design/design_summary.py
@@ -54,6 +54,36 @@ def _run_cli(*args: str) -> subprocess.CompletedProcess[str]:
     )
 
 
+def _cursor_buckets_by_model(data: dict[str, object]) -> dict[str, int]:
+    """Split Cursor per-model token buckets into composer and grok lanes.
+
+    Grok-class models (CURSOR_GROK_MODELS) price at grok rates, so they route to
+    U_GROK_* keys and every other model (composer-2.5, unknown, legacy) folds into
+    U_* (composer rates). Mirrors the codex split and /implement's final report,
+    reusing the shared pricer's grok bucketing constant so /design stays in sync
+    (issue #7257). Returns an empty mapping when BUCKETS_cursor_by_model is absent,
+    so the caller keeps the aggregate composer-rate fallback.
+    """
+    cursor_by_model = data.get("BUCKETS_cursor_by_model")
+    if not isinstance(cursor_by_model, dict):
+        return {}
+    cbm: dict[str, object] = cursor_by_model  # type: ignore[assignment]  # isinstance guard yields dict[Unknown]; used as dict[str, object]
+    composer = {"in": 0, "cr": 0, "out": 0}
+    grok = {"in": 0, "cr": 0, "out": 0}
+    for model, raw_cb in cbm.items():
+        if not isinstance(raw_cb, dict):
+            continue
+        cb: dict[str, object] = raw_cb  # type: ignore[assignment]  # isinstance guard yields dict[Unknown]; used as dict[str, object]
+        target = grok if model in CURSOR_GROK_MODELS else composer
+        target["in"] += int(cb.get("input", 0) or 0)  # type: ignore[arg-type]  # dict[str, object].get returns object; int() coerces the bucket count
+        target["cr"] += int(cb.get("cache_read", 0) or 0)  # type: ignore[arg-type]  # dict[str, object].get returns object; int() coerces the bucket count
+        target["out"] += int(cb.get("output", 0) or 0)  # type: ignore[arg-type]  # dict[str, object].get returns object; int() coerces the bucket count
+    return {
+        "U_IN": composer["in"], "U_CR": composer["cr"], "U_OUT": composer["out"],
+        "U_GROK_IN": grok["in"], "U_GROK_CR": grok["cr"], "U_GROK_OUT": grok["out"],
+    }
+
+
 def _read_token_report(design_tmpdir: Path) -> dict[str, int]:
     tok_json = design_tmpdir / "token-report-final.json"
     if not tok_json.is_file():
@@ -94,26 +124,9 @@ def _read_token_report(design_tmpdir: Path) -> dict[str, int]:
             target["out"] += int(mb.get("output", 0) or 0)  # type: ignore[arg-type]
         buckets["D_IN"], buckets["D_CR"], buckets["D_OUT"] = main["in"], main["cr"], main["out"]
         buckets["D_MINI_IN"], buckets["D_MINI_CR"], buckets["D_MINI_OUT"] = mini["in"], mini["cr"], mini["out"]
-    # Split cursor by model so the cost line prices grok-class models at grok rates,
-    # not composer. Grok-class models (CURSOR_GROK_MODELS) route to U_GROK_*; every
-    # other model (composer-2.5, unknown, legacy) folds into U_* (composer rates).
-    # Mirrors the codex split above and /implement's final report, reusing the shared
-    # pricer's grok bucketing constant so /design stays in sync (issue #7257).
-    cursor_by_model = data.get("BUCKETS_cursor_by_model")
-    if isinstance(cursor_by_model, dict):
-        cbm: dict[str, object] = cursor_by_model  # type: ignore[assignment]  # isinstance guard yields dict[Unknown]; used as dict[str, object]
-        composer = {"in": 0, "cr": 0, "out": 0}
-        grok = {"in": 0, "cr": 0, "out": 0}
-        for model, raw_cb in cbm.items():
-            if not isinstance(raw_cb, dict):
-                continue
-            cb: dict[str, object] = raw_cb  # type: ignore[assignment]  # isinstance guard yields dict[Unknown]; used as dict[str, object]
-            target = grok if model in CURSOR_GROK_MODELS else composer
-            target["in"] += int(cb.get("input", 0) or 0)  # type: ignore[arg-type]  # dict[str, object].get returns object; int() coerces the bucket count
-            target["cr"] += int(cb.get("cache_read", 0) or 0)  # type: ignore[arg-type]  # dict[str, object].get returns object; int() coerces the bucket count
-            target["out"] += int(cb.get("output", 0) or 0)  # type: ignore[arg-type]  # dict[str, object].get returns object; int() coerces the bucket count
-        buckets["U_IN"], buckets["U_CR"], buckets["U_OUT"] = composer["in"], composer["cr"], composer["out"]
-        buckets["U_GROK_IN"], buckets["U_GROK_CR"], buckets["U_GROK_OUT"] = grok["in"], grok["cr"], grok["out"]
+    # Split cursor by model so grok-class models price at grok rates, not composer
+    # (issue #7257); see _cursor_buckets_by_model.
+    buckets.update(_cursor_buckets_by_model(data))
     return buckets
 
 

--- a/python/larch/design/design_summary.py
+++ b/python/larch/design/design_summary.py
@@ -18,7 +18,7 @@ from larch.report import exec_issue_detail
 from larch.report import review_phase_detail
 from larch.design.design_publish import review_provenance
 from larch.git.pr_body import _map_outcome_display  # pyright: ignore[reportPrivateUsage]
-from larch.report.report_tokens_cost import CODEX_MINI_MODELS
+from larch.report.report_tokens_cost import CODEX_MINI_MODELS, CURSOR_GROK_MODELS
 
 
 _VALID_OUTCOMES = frozenset({
@@ -94,6 +94,26 @@ def _read_token_report(design_tmpdir: Path) -> dict[str, int]:
             target["out"] += int(mb.get("output", 0) or 0)  # type: ignore[arg-type]
         buckets["D_IN"], buckets["D_CR"], buckets["D_OUT"] = main["in"], main["cr"], main["out"]
         buckets["D_MINI_IN"], buckets["D_MINI_CR"], buckets["D_MINI_OUT"] = mini["in"], mini["cr"], mini["out"]
+    # Split cursor by model so the cost line prices grok-class models at grok rates,
+    # not composer. Grok-class models (CURSOR_GROK_MODELS) route to U_GROK_*; every
+    # other model (composer-2.5, unknown, legacy) folds into U_* (composer rates).
+    # Mirrors the codex split above and /implement's final report, reusing the shared
+    # pricer's grok bucketing constant so /design stays in sync (issue #7257).
+    cursor_by_model = data.get("BUCKETS_cursor_by_model")
+    if isinstance(cursor_by_model, dict):
+        cbm: dict[str, object] = cursor_by_model  # type: ignore[assignment]  # isinstance guard yields dict[Unknown]; used as dict[str, object]
+        composer = {"in": 0, "cr": 0, "out": 0}
+        grok = {"in": 0, "cr": 0, "out": 0}
+        for model, raw_cb in cbm.items():
+            if not isinstance(raw_cb, dict):
+                continue
+            cb: dict[str, object] = raw_cb  # type: ignore[assignment]  # isinstance guard yields dict[Unknown]; used as dict[str, object]
+            target = grok if model in CURSOR_GROK_MODELS else composer
+            target["in"] += int(cb.get("input", 0) or 0)  # type: ignore[arg-type]  # dict[str, object].get returns object; int() coerces the bucket count
+            target["cr"] += int(cb.get("cache_read", 0) or 0)  # type: ignore[arg-type]  # dict[str, object].get returns object; int() coerces the bucket count
+            target["out"] += int(cb.get("output", 0) or 0)  # type: ignore[arg-type]  # dict[str, object].get returns object; int() coerces the bucket count
+        buckets["U_IN"], buckets["U_CR"], buckets["U_OUT"] = composer["in"], composer["cr"], composer["out"]
+        buckets["U_GROK_IN"], buckets["U_GROK_CR"], buckets["U_GROK_OUT"] = grok["in"], grok["cr"], grok["out"]
     return buckets
 
 
@@ -121,6 +141,9 @@ def _build_cost_args(buckets: dict[str, int]) -> list[str]:
         ("U_IN", "--cursor-input-tokens"),
         ("U_CR", "--cursor-cache-read-tokens"),
         ("U_OUT", "--cursor-output-tokens"),
+        ("U_GROK_IN", "--cursor-grok-input-tokens"),
+        ("U_GROK_CR", "--cursor-grok-cache-read-tokens"),
+        ("U_GROK_OUT", "--cursor-grok-output-tokens"),
         ("CS_IN", "--claude-sub-input-tokens"),
         ("CS_CR", "--claude-sub-cache-read-tokens"),
         ("CS_CW5", "--claude-sub-cache-write-5m-tokens"),

--- a/python/larch/report/progress_report.py
+++ b/python/larch/report/progress_report.py
@@ -114,7 +114,11 @@ def _add_round_vendor_cost_row(
         bucket["cache_create_5m"] += _as_int(data.get("cache_create"))
         bucket["output"] += _as_int(data.get("output"))
         return
-    bucket_key = "codex_mini" if vendor == "codex" and model in report_tokens_cost.CODEX_MINI_MODELS else vendor
+    bucket_key = vendor
+    if vendor == "codex" and model in report_tokens_cost.CODEX_MINI_MODELS:
+        bucket_key = "codex_mini"
+    elif vendor == "cursor" and model in report_tokens_cost.CURSOR_GROK_MODELS:
+        bucket_key = "cursor_grok"
     bucket = sums.setdefault(bucket_key, {"input": 0, "cache_read": 0, "cache_create": 0, "output": 0})
     bucket["input"] += _as_int(data.get("input"))
     bucket["cache_read"] += _as_int(data.get("cache_read"))
@@ -135,6 +139,8 @@ def _round_vendor_cost_argv(
             argv.extend(["--codex-mini-input-tokens", str(bucket["input"]), "--codex-mini-cached-input-tokens", str(bucket["cache_read"]), "--codex-mini-output-tokens", str(bucket["output"])])
         elif vendor == "cursor":
             argv.extend(["--cursor-input-tokens", str(bucket["input"]), "--cursor-cache-read-tokens", str(bucket["cache_read"]), "--cursor-output-tokens", str(bucket["output"])])
+        elif vendor == "cursor_grok":
+            argv.extend(["--cursor-grok-input-tokens", str(bucket["input"]), "--cursor-grok-cache-read-tokens", str(bucket["cache_read"]), "--cursor-grok-output-tokens", str(bucket["output"])])
     if claude_sub_by_model:
         argv.extend(report_tokens_cost.claude_sub_argv_from_buckets(by_model=claude_sub_by_model, bucket={}))
     return argv

--- a/python/tests/design/test_design_summary.py
+++ b/python/tests/design/test_design_summary.py
@@ -4,14 +4,17 @@
 
 from __future__ import annotations
 
+import json
 import subprocess
 from pathlib import Path
 
 import pytest  # noqa: TC002
 
+from larch.core import config
 from larch.design import design_summary
 from larch.design import design_lifecycle
 from larch.report import progress_report
+from larch.report import report_tokens_cost
 from test_design_cli_ports import test_design_port_registry_entries_are_machine_stdout  # noqa: F401  # pylint: disable=unused-import,import-error  # pyright: ignore[reportUnusedImport]
 
 
@@ -824,6 +827,34 @@ def test_difficulty_summary_line_prefers_record(tmp_path: Path) -> None:
     line = design_summary._difficulty_summary_line(tmp_path)  # pyright: ignore[reportPrivateUsage]
 
     assert line == "predicted MODERATE; applied HARD; floor raised"
+
+
+def test_read_token_report_splits_cursor_grok_from_composer(tmp_path: Path) -> None:
+    """/design prices cursor grok tokens at grok rates, not composer (issue #7257)."""
+    report = {
+        "cursor": {"totals": {"total": 6180000}},
+        "BUCKETS_cursor": {"input": 150000, "cache_read": 6000000, "output": 30000, "total": 6180000},
+        "BUCKETS_cursor_by_model": {
+            config.CURSOR_DEFAULT_MODEL: {"input": 100000, "cache_read": 4000000, "output": 20000, "total": 4120000},
+            config.CURSOR_GROK_4_5_HIGH_MODEL: {"input": 50000, "cache_read": 2000000, "output": 10000, "total": 2060000},
+        },
+    }
+    _ = (tmp_path / "token-report-final.json").write_text(json.dumps(report), encoding="utf-8")
+
+    buckets = design_summary._read_token_report(tmp_path)  # pyright: ignore[reportPrivateUsage]
+
+    # Composer lane keeps only the composer-2.5 counts; grok routes to its own lane.
+    assert (buckets["U_IN"], buckets["U_CR"], buckets["U_OUT"]) == (100000, 4000000, 20000)
+    assert (buckets["U_GROK_IN"], buckets["U_GROK_CR"], buckets["U_GROK_OUT"]) == (50000, 2000000, 10000)
+
+    cost_args = design_summary._build_cost_args(buckets)  # pyright: ignore[reportPrivateUsage]
+    assert "--cursor-grok-cache-read-tokens" in cost_args
+    assert cost_args[cost_args.index("--cursor-grok-cache-read-tokens") + 1] == "2000000"
+
+    # Grok cache read prices at $0.50/M (grok), not $0.45/M (composer): 2M -> $1.00,
+    # plus 50k input * $2.00/M + 10k output * $6.00/M = $1.16.
+    cost_kv = report_tokens_cost.token_cost_from_args(cost_args)
+    assert "CURSOR_GROK_COST=1.16" in cost_kv.splitlines()
 
 
 def test_render_final_summary_persists_difficulty_record_before_render(

--- a/python/tests/report/test_review_phase_detail.py
+++ b/python/tests/report/test_review_phase_detail.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 import pytest  # noqa: TC002
 
+from larch.core import config
 from larch.review import plan_review
 from larch.report import progress_report
 from larch.report import review_phase_detail
@@ -439,6 +440,19 @@ def test_round_vendor_cost_uses_claude_sub_raw_fallback(tmp_path: Path) -> None:
     ledger.write_text("\n".join(json.dumps(row) for row in rows) + "\n", encoding="utf-8")
 
     assert progress_report._round_vendor_cost(token_ledger=ledger, start_s=1782345600, end_s=1782345610) == "$6.00"
+
+
+def test_round_vendor_cost_prices_cursor_grok_by_model(tmp_path: Path) -> None:
+    """Per-round cost prices cursor grok at grok rates, not composer (issue #7257)."""
+    ledger = tmp_path / "larch-tokens.jsonl"
+    rows = [
+        {"type": "vendor", "vendor": "cursor", "input": 1_000_000, "model": config.CURSOR_GROK_4_5_HIGH_MODEL, "ts": "2026-06-25T00:00:05Z"},
+        {"type": "vendor", "vendor": "cursor", "input": 1_000_000, "model": config.CURSOR_DEFAULT_MODEL, "ts": "2026-06-25T00:00:06Z"},
+    ]
+    ledger.write_text("\n".join(json.dumps(row) for row in rows) + "\n", encoding="utf-8")
+
+    # Grok input prices at $2.00/M (not composer $0.75/M): grok $2.00 + composer $0.75 = $2.75.
+    assert progress_report._round_vendor_cost(token_ledger=ledger, start_s=1782345600, end_s=1782345610) == "$2.75"
 
 
 def test_fallback_label_remap_annotates_executing_tool(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

When a run used `cursor-grok-4.5-high` (the MODERATE `/implement` Step 2 coder, or any lane pinned via `LARCH_CURSOR_MODEL`), the calculated cost at the end was bogus. Two cost consumers folded every Cursor token into the composer lane, so grok tokens were priced at composer rates instead of grok rates.

## Root cause

PR #7237 added Cursor grok pricing to the shared pricer (`report_tokens_cost`), but two downstream consumers were never swept when the grok lane landed:

- `python/larch/design/design_summary.py` `_read_token_report` (the `/design` final-summary cost). It split `BUCKETS_codex_by_model` but never `BUCKETS_cursor_by_model`.
- `python/larch/report/progress_report.py` `_add_round_vendor_cost_row` (the per-round review Cost column). It split `codex_mini` by model but not `cursor_grok`.

The shared pricer (`report_tokens_cost.cursor_argv_from_buckets`), the `render run-summary` renderer, and `/implement`'s `final_report.py` already split Cursor by model and were correct.

## Fix

Both consumers now route grok-class models to the `--cursor-grok-*` flags and every other model to the composer flags, mirroring the existing Codex-mini split. Both reuse the shared `report_tokens_cost.CURSOR_GROK_MODELS` constant so the writer and its selectors stay in sync. When `BUCKETS_cursor_by_model` is absent, the composer fallback is preserved for backward compatibility.

## Tests

Regression tests that fail before the fix and pass after:

- `python/tests/design/test_design_summary.py::test_read_token_report_splits_cursor_grok_from_composer`
- `python/tests/report/test_review_phase_detail.py::test_round_vendor_cost_prices_cursor_grok_by_model`

ruff and pyright are clean on all four changed files.

Fixes #7257.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
