### PR TITLE
Fixes #7260: Guard Step 5 on Gate C assessments

### DIFF
--- a/python/larch/design/design_step5b.py
+++ b/python/larch/design/design_step5b.py
@@ -10,7 +10,9 @@ import sys
 from pathlib import Path
 from collections.abc import Mapping, Sequence
 
+from larch.core import architectural_guidelines
 from larch.design import design_oos
+from larch.git.repo_roots import consumer_repo_root
 
 from larch.design.design_core import _append_failure
 from larch.design.design_router import _parse_stdout_kv
@@ -63,6 +65,41 @@ def _step5b_annotate_sequencing_error(oos_issue_stdout: Path) -> bool:
         return not oos_issue_stdout.read_text(encoding="utf-8", errors="replace").strip()
     except OSError:
         return True
+
+
+def _step5b_missing_gatec_assessments(*, design_tmpdir: Path, repo_root: Path) -> list[str]:
+    """Return required Gate C assessment artifacts that are not regular files."""
+    invariant_result = architectural_guidelines.read_invariants(repo_root=repo_root)
+    guideline_result = architectural_guidelines.read_guidelines(repo_root=repo_root)
+    required_artifacts: list[str] = []
+    if invariant_result.status == "present" and invariant_result.content.strip():
+        required_artifacts.append(architectural_guidelines.INVARIANT_DESIGN_ASSESSMENT)
+    if guideline_result.status == "present":
+        required_artifacts.append(architectural_guidelines.DESIGN_ASSESSMENT)
+    return [
+        artifact
+        for artifact in required_artifacts
+        if not (design_tmpdir / artifact).is_file() or (design_tmpdir / artifact).is_symlink()
+    ]
+
+
+def _step5b_gatec_assessment_precheck(*, design_tmpdir: Path, repo_root: Path) -> int:
+    missing = _step5b_missing_gatec_assessments(design_tmpdir=design_tmpdir, repo_root=repo_root)
+    if not missing:
+        return 0
+    artifacts = " and ".join(missing)
+    print(
+        f"**⚠ 5b: finalize refused: missing {artifacts}; return to Gate C to persist required assessment artifacts before Step 5.**",
+        flush=True,
+    )
+    return 4
+
+
+def _step5b_prepare_prelude(*, env: Mapping[str, str], design_tmpdir: Path, plugin_root: Path) -> int:
+    if (design_tmpdir / ".pause-requested").is_file():
+        return _call_pause_save(design_tmpdir=design_tmpdir)
+    repo_root = Path(env["REPO_ROOT"]) if env.get("REPO_ROOT") else consumer_repo_root() or plugin_root
+    return _step5b_gatec_assessment_precheck(design_tmpdir=design_tmpdir, repo_root=repo_root)
 
 
 _STEP5B_SKIP_BREADCRUMBS = {
@@ -143,11 +180,12 @@ def step5b_prepare_main(argv: Sequence[str]) -> int:
         return req
     plugin_root = Path(os.environ["CLAUDE_PLUGIN_ROOT"])
     design_tmpdir = _require_design_tmpdir_nonempty(env=env, site="prepare")
+    prelude_rc = _step5b_prepare_prelude(env=env, design_tmpdir=design_tmpdir, plugin_root=plugin_root)
+    if prelude_rc != 0:
+        return prelude_rc
     completed = design_tmpdir / ".completed"
     completed.mkdir(parents=True, exist_ok=True)
     (completed / "step-4b").touch()
-    if (design_tmpdir / ".pause-requested").is_file():
-        return _call_pause_save(design_tmpdir=design_tmpdir)
     _maybe_timing_mark(label="design Step 5 — finalize")
 
     stderr_path = design_tmpdir / "oos-filing-prepare.stderr.log"

--- a/python/larch/state/session_env.py
+++ b/python/larch/state/session_env.py
@@ -140,6 +140,7 @@ COMMON_DESIGN_ENV_DEFAULTS: dict[str, str] = {
     "ISSUE_TITLE": "",
     "HAS_CLARIFY_LABEL": "false",
     "REPO": "",
+    "REPO_ROOT": "",
     "CLAUDE_BINARY_FOUND": "",
     "CODEX_BINARY_FOUND": "",
     "CURSOR_BINARY_FOUND": "",

--- a/python/tests/design/test_design_oos.py
+++ b/python/tests/design/test_design_oos.py
@@ -340,6 +340,76 @@ def _step5b_argv() -> list[str]:
     return ["--plugin-root", _plugin_root()]
 
 
+@pytest.fixture(autouse=True)
+def _isolate_step5b_architectural_sources(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:  # pyright: ignore[reportUnusedFunction]
+    """Keep Step 5b orchestration tests independent of this checkout's policy files."""
+    monkeypatch.setenv("REPO_ROOT", str(tmp_path))
+
+
+def test_step5b_prepare_refuses_before_oos_when_gatec_assessments_are_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _ = (repo / "ARCHITECTURAL_INVARIANTS.md").write_text("### I-Test-1: Gate C assessment required\n", encoding="utf-8")
+    _ = (repo / "ARCHITECTURAL_GUIDELINES.md").write_text("# Guidelines\n", encoding="utf-8")
+    design = tmp_path / "design"
+    design.mkdir()
+    source_env = tmp_path / "source-env.sh"
+    _ = source_env.write_text(f"export DESIGN_TMPDIR={design}\nexport REPO_ROOT={repo}\n", encoding="utf-8")
+
+    def unexpected_prepare(_argv: Sequence[str]) -> int:
+        raise AssertionError("OOS prepare must not run without required Gate C assessments")
+
+    monkeypatch.setattr(design_step5b.design_oos, "file_oos_prepare_main", unexpected_prepare)
+
+    rc = design_lifecycle.step5b_prepare_main([*_step5b_argv(), "--session-env-path", str(source_env)])
+    out = capsys.readouterr().out
+
+    assert rc == 4
+    assert "architectural-invariant-assessment.md" in out
+    assert "architectural-guideline-assessment.md" in out
+    assert "return to Gate C" in out
+    assert not (design / ".completed" / "step-4b").exists()
+    assert not (design / "oos-filing-prepare.env").exists()
+
+
+def test_step5b_prepare_allows_regular_gatec_assessments(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _ = (repo / "ARCHITECTURAL_INVARIANTS.md").write_text("### I-Test-1: Gate C assessment required\n", encoding="utf-8")
+    _ = (repo / "ARCHITECTURAL_GUIDELINES.md").write_text("# Guidelines\n", encoding="utf-8")
+    design = tmp_path / "design"
+    design.mkdir()
+    _ = (design / "architectural-invariant-assessment.md").write_text("clean\n", encoding="utf-8")
+    _ = (design / "architectural-guideline-assessment.md").write_text("clean\n", encoding="utf-8")
+    source_env = tmp_path / "source-env.sh"
+    _ = source_env.write_text(f"export DESIGN_TMPDIR={design}\nexport REPO_ROOT={repo}\n", encoding="utf-8")
+    called = False
+
+    def fake_prepare(_argv: Sequence[str]) -> int:
+        nonlocal called
+        called = True
+        print("FILE_DESIGN_OOS_STATUS=skip-no-items")
+        return 0
+
+    monkeypatch.setattr(design_step5b.design_oos, "file_oos_prepare_main", fake_prepare)
+
+    rc = design_lifecycle.step5b_prepare_main([*_step5b_argv(), "--session-env-path", str(source_env)])
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert called
+    assert "STEP5B_STATUS=skip-no-items" in out
+    assert (design / ".completed" / "step-4b").is_file()
+
+
 def test_step5b_prepare_ready_orchestration(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
     monkeypatch.setenv("DESIGN_TMPDIR", str(tmp_path))
     monkeypatch.setattr(design_step5b, "_maybe_timing_mark", _noop_timing_mark)

--- a/skills/design/scripts/design-step5b-prepare.md
+++ b/skills/design/scripts/design-step5b-prepare.md
@@ -16,6 +16,7 @@ Thin launcher-compat wrapper for the `/design` Step 5b prepare block.
 - The `DESIGN_TMPDIR` guard rejects only an empty value, matching the retired Bash prelude.
 - The prepare entrypoint creates `$DESIGN_TMPDIR/.completed` before writing `.completed/step-4b`.
 - The prepare entrypoint returns immediately through pause-save when `.pause-requested` exists.
+- Before it writes `.completed/step-4b` or starts OOS filing, the prepare entrypoint refuses Step 5 when a present, non-empty architectural source lacks its required regular Gate C assessment artifact. It reports invariants before guidelines and uses the persisted `REPO_ROOT` when available; wrapper rehydration retains that key.
 - It marks `design Step 5 — finalize` timing after the pause check.
 - It captures OOS prepare stdout to `oos-filing-prepare.env` and stderr to `oos-filing-prepare.stderr.log`.
 - It emits `NEXT_ACTION=skip-pipeline|file-issues|label-only` on stdout for deterministic Step 5b routing. Every skip status (`skip-sentinel`, `skip-already-filed-sentinel`, `skip-no-items`, `skip-all-security`) emits `NEXT_ACTION=skip-pipeline`. `ready` emits `NEXT_ACTION=file-issues`. `label-only-retry` emits `NEXT_ACTION=label-only`.


### PR DESCRIPTION
Fixes #7260.

Adds a fail-closed Step 5b precheck for required Gate C architectural assessment artifacts before OOS filing, diagram work, or publish.