### PR TITLE
Release v53.1.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "53.1.0",
+  "version": "53.1.1",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## What's Changed

### Added
- Added shared shell test fixtures (#7263).
- Added shared review wire fixtures for review contract unification (#7264).
- Added optional Gate C assessment-artifact precheck before `/implement` Step 5 (#7271).

### Fixed
- Fixed Claude fallback scope relay (#7259).
- Fixed `/design --skip-approve` skipping Gate C architectural-invariant assessment note authoring (#7262).
- Fixed Cursor grok token pricing in `/design` and per-round cost reporting (#7270).
