### PR TITLE
Add optional ship result-env direct-write sink

### DIFF
--- a/python/larch/implement/ship.py
+++ b/python/larch/implement/ship.py
@@ -99,6 +99,7 @@ from larch.implement.ship_result import (
     _step_result_to_ship,
     _write_terminal_finalize_if_terminal,
     emit_result,
+    validate_ship_result_env_path,
 )
 from larch.implement.ship_guidelines import (
     GuidelinesGateResult,
@@ -1995,6 +1996,7 @@ def build_parser() -> argparse.ArgumentParser:
     _ = parser.add_argument("--no-logs-commit", nargs="?", const="true", default=None)
     _ = parser.add_argument("--expected-session-id")
     _ = parser.add_argument("--expected-tmpdir-basename-prefix")
+    _ = parser.add_argument("--result-env-path")
     return parser
 
 
@@ -2142,6 +2144,7 @@ def _distill_ci_errors_for_result(*, ctx: RunContext, result: ShipResult) -> tup
 def main(argv: list[str] | None = None) -> int:
     ctx = RunContext.from_env(env={})
     result: ShipResult
+    result_env_path: Path | None = None
     parser = build_parser()
     try:
         args = parser.parse_args(argv)
@@ -2155,24 +2158,42 @@ def main(argv: list[str] | None = None) -> int:
         return config.OUTCOME_EXIT_MAP[Outcome.INTERNAL_ERROR]
     try:
         ctx = _ctx_from_args(args)
+        # Prevalidate a supplied result-env sink before logging setup, run_ship,
+        # stall persistence, or CI distillation so invalid config fails closed.
+        raw_result_env = getattr(args, "result_env_path", None)
+        if raw_result_env not in (None, ""):
+            result_env_path = validate_ship_result_env_path(
+                tmpdir=ctx.tmpdir,
+                path=str(raw_result_env),
+            )
         if _tmpdir_under_allowed_root(ctx.tmpdir):
             os.environ[config.ENV_IMPLEMENT_TMPDIR] = ctx.tmpdir
             logging_util.quiet_init(argv0="ship.py")
         result = run_ship(ctx, runner=proc, cwd=str(Path.cwd()))
     except Exception as exc:  # top-level contract envelope
+        # Prevalidation raises before assigning result_env_path, so the sink stays
+        # None and no result-env write is attempted. A later failure keeps a
+        # previously validated path for exception result emission.
         logging_util.BreadcrumbWriter().emit(
             f"ship.py: internal error\n{traceback.format_exc()}",
         )
         result = ShipResult(Outcome.INTERNAL_ERROR, detail=f"{type(exc).__name__}: {exc}")
     _persist_stall_metadata_if_needed(ctx=ctx, result=result, tmpdir=Path(ctx.tmpdir))
     ci_errors_file, ci_errors_distill_class, failed_jobs_count = _distill_ci_errors_for_result(ctx=ctx, result=result)
-    emit_result(
-        ctx=ctx,
-        result=result,
-        ci_errors_file=ci_errors_file,
-        ci_errors_distill_class=ci_errors_distill_class,
-        failed_jobs_count=failed_jobs_count,
-    )
+    try:
+        emit_result(
+            ctx=ctx,
+            result=result,
+            ci_errors_file=ci_errors_file,
+            ci_errors_distill_class=ci_errors_distill_class,
+            failed_jobs_count=failed_jobs_count,
+            result_env_path=result_env_path,
+        )
+    except Exception:  # required result-env write must not publish JSON then succeed
+        logging_util.BreadcrumbWriter().emit(
+            f"ship.py: result-env emit failed\n{traceback.format_exc()}",
+        )
+        return config.OUTCOME_EXIT_MAP[Outcome.INTERNAL_ERROR]
     return config.OUTCOME_EXIT_MAP[result.outcome]
 
 

--- a/python/larch/implement/ship_result.py
+++ b/python/larch/implement/ship_result.py
@@ -10,14 +10,45 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, TextIO
 
+from larch.bgjob import model as bgjob_model
 from larch.core import config
 from larch.core import logging_util
 from larch.core import redact
 from larch.core.run_context import RunContext
 from larch.errors import NeedsUserInput, ShipError, Stalled, TransientNetworkError
+from larch import io as larch_io
 from larch.outcomes import Outcome, StepResult
 from larch.state import finalize
 from larch.implement.ship_state import _tmpdir_under_allowed_root, _terminal_overlay_fields, _breadcrumb
+
+# Explicit wire-key map aligned with dispatch_ship handoff vocabulary (not blanket uppercasing).
+_RESULT_ENV_WIRE_KEYS: tuple[tuple[str, str], ...] = (
+    ("outcome", "outcome"),
+    ("needs_user_reason", "NEEDS_USER_REASON"),
+    ("failed_run_id", "FAILED_RUN_ID"),
+    ("pr_number", "PR_NUMBER"),
+    ("pr_url", "PR_URL"),
+    ("merge_result", "MERGE_RESULT"),
+    ("detail", "DETAIL"),
+    ("ledger_ready", "ledger_ready"),
+    ("ledger_site", "ledger_site"),
+    ("ledger_trigger", "ledger_trigger"),
+    ("ledger_step", "ledger_step"),
+    ("ledger_phase", "ledger_phase"),
+    ("ledger_dispatcher", "ledger_dispatcher"),
+    ("ledger_exit_code", "ledger_exit_code"),
+    ("ledger_failure_detail_log", "ledger_failure_detail_log"),
+    ("main_health_head_sha", "MAIN_HEALTH_HEAD_SHA"),
+    ("main_health_repair_committed", "MAIN_HEALTH_REPAIR_COMMITTED"),
+    ("main_health_repair_failed_run_id", "MAIN_HEALTH_REPAIR_FAILED_RUN_ID"),
+    ("main_health_repair_base_sha", "MAIN_HEALTH_REPAIR_BASE_SHA"),
+    ("main_health_repair_head", "MAIN_HEALTH_REPAIR_HEAD"),
+    ("emergency_repair_branch", "EMERGENCY_REPAIR_BRANCH"),
+    ("original_branch_forbidden", "ORIGINAL_BRANCH_FORBIDDEN"),
+    ("main_repair_run_id", "MAIN_REPAIR_RUN_ID"),
+    ("main_repair_head", "MAIN_REPAIR_HEAD"),
+    ("emergency_repair_pr_number", "EMERGENCY_REPAIR_PR_NUMBER"),
+)
 
 
 @dataclass(frozen=True)
@@ -242,6 +273,74 @@ def _close_contract_stream(stream: TextIO) -> None:
             stream.close()
 
 
+def validate_ship_result_env_path(*, tmpdir: str, path: str | Path) -> Path:
+    """Prevalidate a caller-supplied result-env sink under the owned session tmpdir."""
+    if not _tmpdir_under_allowed_root(tmpdir):
+        msg = "result-env requires tmpdir under an allowed root"
+        raise ValueError(msg)
+    candidate = Path(path)
+    if ".." in candidate.parts:
+        msg = f"result-env path must not contain '..': {candidate}"
+        raise ValueError(msg)
+    return bgjob_model.validate_merge_result_env(path=candidate, tmpdir=Path(tmpdir))
+
+
+def _result_env_scalar(value: object) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if value is None:
+        return ""
+    if isinstance(value, int) and not isinstance(value, bool):
+        return str(value)
+    text = value if isinstance(value, str) else str(value)
+    return text.replace("\r", " ").replace("\n", " ")
+
+
+def _result_env_rows(
+    *,
+    payload: dict[str, Any],
+    ci_errors_file: str,
+    ci_errors_distill_class: str,
+    failed_jobs_count: int,
+) -> tuple[tuple[str, str], ...]:
+    rows: list[tuple[str, str]] = [
+        (wire_key, _result_env_scalar(payload.get(source_key)))
+        for source_key, wire_key in _RESULT_ENV_WIRE_KEYS
+    ]
+    # CI pairing mirrors dispatch_ship._write_ship_route_handoff: always emit
+    # CI_ERRORS_FILE and FAILED_JOBS_COUNT; CI_ERRORS_DISTILL_CLASS only when
+    # the digest path is empty. Built from raw emit_result args, not the sparse
+    # JSON-bound payload.
+    file_value = _result_env_scalar(ci_errors_file)
+    rows.append(("CI_ERRORS_FILE", file_value))
+    count = max(failed_jobs_count, 0)
+    rows.append(("FAILED_JOBS_COUNT", str(count)))
+    if not file_value:
+        rows.append(("CI_ERRORS_DISTILL_CLASS", _result_env_scalar(ci_errors_distill_class)))
+    return tuple(rows)
+
+
+def _write_result_env(
+    *,
+    ctx: RunContext,
+    path: Path,
+    payload: dict[str, Any],
+    ci_errors_file: str,
+    ci_errors_distill_class: str,
+    failed_jobs_count: int,
+) -> None:
+    validated = validate_ship_result_env_path(tmpdir=ctx.tmpdir, path=path)
+    text = larch_io.format_kvs(
+        _result_env_rows(
+            payload=payload,
+            ci_errors_file=ci_errors_file,
+            ci_errors_distill_class=ci_errors_distill_class,
+            failed_jobs_count=failed_jobs_count,
+        ),
+    )
+    larch_io.trusted_atomic_write(validated, text, root=ctx.tmpdir, mode=0o600)
+
+
 def emit_result(
     *,
     ctx: RunContext,
@@ -249,6 +348,7 @@ def emit_result(
     ci_errors_file: str = "",
     ci_errors_distill_class: str = "",
     failed_jobs_count: int = 0,
+    result_env_path: Path | None = None,
 ) -> None:
     payload = _redacted_result_payload(result)
     # CI-failure digest path injected raw (not redacted): route-exit reads these
@@ -263,6 +363,17 @@ def emit_result(
     # FAILED_JOBS_COUNT=0 on the ci-fix route.
     if failed_jobs_count:
         payload["failed_jobs_count"] = failed_jobs_count
+    if result_env_path is not None:
+        # Required sink: write before JSON; validation/write failures must not
+        # publish a successful JSON contract.
+        _write_result_env(
+            ctx=ctx,
+            path=result_env_path,
+            payload=payload,
+            ci_errors_file=ci_errors_file,
+            ci_errors_distill_class=ci_errors_distill_class,
+            failed_jobs_count=failed_jobs_count,
+        )
     stream = logging_util.contract_stream()
     try:
         print(json.dumps(payload, sort_keys=True), file=stream)

--- a/python/larch/implement/ship_result.py
+++ b/python/larch/implement/ship_result.py
@@ -331,7 +331,7 @@ def _write_result_env(
     larch_io.trusted_atomic_write(validated, text, root=ctx.tmpdir, mode=0o600)
 
 
-def emit_result(  # noqa: PLR0913 - result-env sink is an optional peer to the CI digest kwargs
+def emit_result(  # noqa: PLR0913,RUF100 - result-env sink is an optional peer to the CI digest kwargs
     *,
     ctx: RunContext,
     result: ShipResult,

--- a/python/larch/implement/ship_result.py
+++ b/python/larch/implement/ship_result.py
@@ -324,24 +324,14 @@ def _write_result_env(
     *,
     ctx: RunContext,
     path: Path,
-    payload: dict[str, Any],
-    ci_errors_file: str,
-    ci_errors_distill_class: str,
-    failed_jobs_count: int,
+    rows: tuple[tuple[str, str], ...],
 ) -> None:
     validated = validate_ship_result_env_path(tmpdir=ctx.tmpdir, path=path)
-    text = larch_io.format_kvs(
-        _result_env_rows(
-            payload=payload,
-            ci_errors_file=ci_errors_file,
-            ci_errors_distill_class=ci_errors_distill_class,
-            failed_jobs_count=failed_jobs_count,
-        ),
-    )
+    text = larch_io.format_kvs(rows)
     larch_io.trusted_atomic_write(validated, text, root=ctx.tmpdir, mode=0o600)
 
 
-def emit_result(
+def emit_result(  # noqa: PLR0913 - result-env sink is an optional peer to the CI digest kwargs
     *,
     ctx: RunContext,
     result: ShipResult,
@@ -369,10 +359,12 @@ def emit_result(
         _write_result_env(
             ctx=ctx,
             path=result_env_path,
-            payload=payload,
-            ci_errors_file=ci_errors_file,
-            ci_errors_distill_class=ci_errors_distill_class,
-            failed_jobs_count=failed_jobs_count,
+            rows=_result_env_rows(
+                payload=payload,
+                ci_errors_file=ci_errors_file,
+                ci_errors_distill_class=ci_errors_distill_class,
+                failed_jobs_count=failed_jobs_count,
+            ),
         )
     stream = logging_util.contract_stream()
     try:

--- a/python/tests/implement/test_ship.py
+++ b/python/tests/implement/test_ship.py
@@ -5810,7 +5810,7 @@ def test_main_result_env_preflight_rejects_unsafe_paths(
             str(raw_path),
         ],
     )
-    assert called == []
+    assert not called
     assert rc == config.EXIT_INTERNAL_ERROR
     captured = capsys.readouterr()
     assert json.loads(captured.out)["outcome"] == "INTERNAL_ERROR"
@@ -5845,7 +5845,7 @@ def test_main_result_env_preflight_rejects_symlink_destination(
             str(link),
         ],
     )
-    assert called == []
+    assert not called
     assert rc == config.EXIT_INTERNAL_ERROR
     assert json.loads(capsys.readouterr().out)["outcome"] == "INTERNAL_ERROR"
 
@@ -5879,7 +5879,7 @@ def test_main_result_env_preflight_rejects_symlink_parent(
             str(sink),
         ],
     )
-    assert called == []
+    assert not called
     assert rc == config.EXIT_INTERNAL_ERROR
     assert json.loads(capsys.readouterr().out)["outcome"] == "INTERNAL_ERROR"
 

--- a/python/tests/implement/test_ship.py
+++ b/python/tests/implement/test_ship.py
@@ -20,6 +20,7 @@ from larch.implement import ship
 from larch.implement import ship_guidelines
 from larch.implement import ship_pr
 from larch.implement import ship_resume
+from larch.implement import ship_result
 from larch.errors import PrePushConflictHandoff, ShipError, Stalled
 from larch.outcomes import Outcome, StepResult
 from larch.core.proc import CommandResult, ProcRunner
@@ -5605,6 +5606,345 @@ def test_emit_result_skips_journal_on_invalid_tmpdir(tmp_path: Path, capsys: pyt
     ship.emit_result(ctx=ctx, result=ship.ShipResult(Outcome.STALLED, detail="invalid tmpdir"))
     assert json.loads(capsys.readouterr().out)["outcome"] == "STALLED"
     assert not Path("/not/allowed/larch").exists()
+
+
+def _parse_result_env(path: Path) -> dict[str, str]:
+    data: dict[str, str] = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        key, sep, value = line.partition("=")
+        if sep:
+            data[key] = value
+    return data
+
+
+def test_emit_result_writes_mixed_case_result_env(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    sink = tmp_path / "ship.result.env"
+    ctx = _ctx(tmp_path)
+    ship.emit_result(
+        ctx=ctx,
+        result=ship.ShipResult(
+            Outcome.NEEDS_USER_INPUT,
+            needs_user_reason="main-ci-fail",
+            failed_run_id="99",
+            pr_number=7,
+            pr_url="https://example.test/pr/7",
+            merge_result="merged",
+            detail="line one\nline two",
+            ledger_ready=True,
+            ledger_site="ship-pr",
+            ledger_trigger="main-ci-fail",
+            ledger_step="8",
+            ledger_phase="ci-merge",
+            ledger_dispatcher="ship-pr",
+            ledger_exit_code=3,
+            ledger_failure_detail_log="/tmp/detail.log",
+            main_health_head_sha="abc123",
+            main_health_repair_committed="false",
+            original_branch_forbidden="true",
+            main_repair_run_id="99",
+            main_repair_head="abc123",
+        ),
+        ci_errors_file="",
+        ci_errors_distill_class="github-log-failure",
+        failed_jobs_count=0,
+        result_env_path=sink,
+    )
+    env = _parse_result_env(sink)
+    assert env["outcome"] == "NEEDS_USER_INPUT"
+    assert env["ledger_ready"] == "true"
+    assert env["ledger_site"] == "ship-pr"
+    assert env["ledger_exit_code"] == "3"
+    assert env["NEEDS_USER_REASON"] == "main-ci-fail"
+    assert env["FAILED_RUN_ID"] == "99"
+    assert env["PR_NUMBER"] == "7"
+    assert env["PR_URL"] == "https://example.test/pr/7"
+    assert env["MERGE_RESULT"] == "merged"
+    assert env["DETAIL"] == "line one line two"
+    assert env["MAIN_HEALTH_HEAD_SHA"] == "abc123"
+    assert env["ORIGINAL_BRANCH_FORBIDDEN"] == "true"
+    assert env["MAIN_REPAIR_RUN_ID"] == "99"
+    assert env["CI_ERRORS_FILE"] == ""
+    assert env["FAILED_JOBS_COUNT"] == "0"
+    assert env["CI_ERRORS_DISTILL_CLASS"] == "github-log-failure"
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["outcome"] == "NEEDS_USER_INPUT"
+    assert "ci_errors_file" not in payload
+    assert "failed_jobs_count" not in payload
+
+
+def test_emit_result_ci_digest_omits_distill_class(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    sink = tmp_path / "ship.result.env"
+    digest = tmp_path / "ci-errors-1.md"
+    _ = digest.write_text("digest", encoding="utf-8")
+    ship.emit_result(
+        ctx=_ctx(tmp_path),
+        result=ship.ShipResult(Outcome.NEEDS_USER_INPUT, needs_user_reason="first-fixer-non-health"),
+        ci_errors_file=str(digest),
+        ci_errors_distill_class="should-not-appear",
+        failed_jobs_count=4,
+        result_env_path=sink,
+    )
+    env = _parse_result_env(sink)
+    assert env["CI_ERRORS_FILE"] == str(digest)
+    assert env["FAILED_JOBS_COUNT"] == "4"
+    assert "CI_ERRORS_DISTILL_CLASS" not in env
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ci_errors_file"] == str(digest)
+    assert payload["failed_jobs_count"] == 4
+    # JSON injection stays truthy-sparse and unchanged: a supplied class still lands
+    # in the JSON payload even when result-env pairing omits it.
+    assert payload["ci_errors_distill_class"] == "should-not-appear"
+
+
+def test_emit_result_omitting_flag_creates_no_result_env_artifact(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    ctx = _ctx(tmp_path)
+    before = {p.name for p in tmp_path.iterdir()}
+    ship.emit_result(ctx=ctx, result=ship.ShipResult(Outcome.OK, pr_number=1, pr_url="u"))
+    after = {p.name for p in tmp_path.iterdir()}
+    assert not any(name.endswith(".result.env") for name in after - before)
+    assert json.loads(capsys.readouterr().out)["outcome"] == "OK"
+
+
+def test_emit_result_none_and_bool_scalar_rendering(tmp_path: Path) -> None:
+    sink = tmp_path / "ship.result.env"
+    ship.emit_result(
+        ctx=_ctx(tmp_path),
+        result=ship.ShipResult(Outcome.OK, pr_number=None, ledger_ready=False, ledger_exit_code=None),
+        result_env_path=sink,
+    )
+    env = _parse_result_env(sink)
+    assert env["PR_NUMBER"] == ""
+    assert env["ledger_ready"] == "false"
+    assert env["ledger_exit_code"] == ""
+    assert env["CI_ERRORS_FILE"] == ""
+    assert env["FAILED_JOBS_COUNT"] == "0"
+    assert env["CI_ERRORS_DISTILL_CLASS"] == ""
+
+
+def test_main_result_env_flag_plumbing(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    sink = tmp_path / "bgjob" / "ship.result.env"
+    sink.parent.mkdir()
+
+    def fake_run_ship(*_a: object, **_k: object) -> ship.ShipResult:
+        return ship.ShipResult(
+            Outcome.OK,
+            pr_number=12,
+            pr_url="https://example.test/pr/12",
+            ledger_ready=False,
+        )
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(ship, "run_ship", fake_run_ship)
+    monkeypatch.setattr(ship.logging_util, "quiet_init", lambda **_: None)
+    rc = ship.main(
+        [
+            "--tmpdir",
+            str(tmp_path),
+            "--manifest-path",
+            str(tmp_path / "manifest.json"),
+            "--result-env-path",
+            str(sink),
+        ],
+    )
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["outcome"] == "OK"
+    env = _parse_result_env(sink)
+    assert env["outcome"] == "OK"
+    assert env["PR_NUMBER"] == "12"
+    assert env["CI_ERRORS_FILE"] == ""
+    assert env["FAILED_JOBS_COUNT"] == "0"
+
+
+@pytest.mark.parametrize(
+    ("path_factory", "tmpdir_override"),
+    [
+        (lambda tmp: str(tmp / "outside" / "ship.result.env"), "/not/allowed/larch"),
+        (lambda _tmp: str(Path("/tmp") / "larch-result-env-escape.env"), None),
+        (lambda _tmp: "relative/ship.result.env", None),
+        (lambda tmp: str(tmp / "nested" / ".." / "ship.result.env"), None),
+        (lambda tmp: str(tmp / "not-a-file"), None),
+    ],
+)
+def test_main_result_env_preflight_rejects_unsafe_paths(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+    path_factory: object,
+    tmpdir_override: str | None,
+) -> None:
+    called: list[bool] = []
+
+    def fake_run_ship(*_a: object, **_k: object) -> ship.ShipResult:
+        called.append(True)
+        return ship.ShipResult(Outcome.OK)
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(ship, "run_ship", fake_run_ship)
+    monkeypatch.setattr(ship.logging_util, "quiet_init", lambda **_: None)
+    assert callable(path_factory)
+    raw_path = path_factory(tmp_path)
+    if str(raw_path).endswith("not-a-file"):
+        (tmp_path / "not-a-file").mkdir()
+    tmpdir = tmpdir_override or str(tmp_path)
+    rc = ship.main(
+        [
+            "--tmpdir",
+            tmpdir,
+            "--manifest-path",
+            str(tmp_path / "manifest.json"),
+            "--result-env-path",
+            str(raw_path),
+        ],
+    )
+    assert called == []
+    assert rc == config.EXIT_INTERNAL_ERROR
+    captured = capsys.readouterr()
+    assert json.loads(captured.out)["outcome"] == "INTERNAL_ERROR"
+    assert not any(tmp_path.rglob("*.result.env"))
+
+
+def test_main_result_env_preflight_rejects_symlink_destination(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "real.env"
+    _ = target.write_text("x=1\n", encoding="utf-8")
+    link = tmp_path / "ship.result.env"
+    link.symlink_to(target)
+    called: list[bool] = []
+
+    def fake_run_ship(*_a: object, **_k: object) -> ship.ShipResult:
+        called.append(True)
+        return ship.ShipResult(Outcome.OK)
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(ship, "run_ship", fake_run_ship)
+    monkeypatch.setattr(ship.logging_util, "quiet_init", lambda **_: None)
+    rc = ship.main(
+        [
+            "--tmpdir",
+            str(tmp_path),
+            "--manifest-path",
+            str(tmp_path / "manifest.json"),
+            "--result-env-path",
+            str(link),
+        ],
+    )
+    assert called == []
+    assert rc == config.EXIT_INTERNAL_ERROR
+    assert json.loads(capsys.readouterr().out)["outcome"] == "INTERNAL_ERROR"
+
+
+def test_main_result_env_preflight_rejects_symlink_parent(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    real_dir = tmp_path / "real"
+    real_dir.mkdir()
+    link_dir = tmp_path / "linked"
+    link_dir.symlink_to(real_dir)
+    sink = link_dir / "ship.result.env"
+    called: list[bool] = []
+
+    def fake_run_ship(*_a: object, **_k: object) -> ship.ShipResult:
+        called.append(True)
+        return ship.ShipResult(Outcome.OK)
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(ship, "run_ship", fake_run_ship)
+    monkeypatch.setattr(ship.logging_util, "quiet_init", lambda **_: None)
+    rc = ship.main(
+        [
+            "--tmpdir",
+            str(tmp_path),
+            "--manifest-path",
+            str(tmp_path / "manifest.json"),
+            "--result-env-path",
+            str(sink),
+        ],
+    )
+    assert called == []
+    assert rc == config.EXIT_INTERNAL_ERROR
+    assert json.loads(capsys.readouterr().out)["outcome"] == "INTERNAL_ERROR"
+
+
+def test_emit_result_trusted_write_failure_skips_json(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    sink = tmp_path / "ship.result.env"
+    missing_parent = tmp_path / "missing-parent" / "ship.result.env"
+
+    def boom(*_a: object, **_k: object) -> None:
+        raise OSError("trusted write blocked")
+
+    monkeypatch.setattr(ship_result.larch_io, "trusted_atomic_write", boom)
+    with pytest.raises(OSError, match="trusted write blocked"):
+        ship.emit_result(
+            ctx=_ctx(tmp_path),
+            result=ship.ShipResult(Outcome.OK, pr_number=1),
+            result_env_path=sink,
+        )
+    assert capsys.readouterr().out == ""
+    assert not sink.exists()
+
+    with pytest.raises((OSError, ValueError)):
+        ship.emit_result(
+            ctx=_ctx(tmp_path),
+            result=ship.ShipResult(Outcome.OK, pr_number=1),
+            result_env_path=missing_parent,
+        )
+    assert not (tmp_path / "missing-parent").exists()
+    assert capsys.readouterr().out == ""
+
+
+def test_main_result_env_write_failure_returns_internal_error(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    sink = tmp_path / "ship.result.env"
+
+    def fake_run_ship(*_a: object, **_k: object) -> ship.ShipResult:
+        return ship.ShipResult(Outcome.OK, pr_number=1)
+
+    def boom(*_a: object, **_k: object) -> None:
+        raise OSError("trusted write blocked")
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(ship, "run_ship", fake_run_ship)
+    monkeypatch.setattr(ship.logging_util, "quiet_init", lambda **_: None)
+    monkeypatch.setattr(ship_result.larch_io, "trusted_atomic_write", boom)
+    rc = ship.main(
+        [
+            "--tmpdir",
+            str(tmp_path),
+            "--manifest-path",
+            str(tmp_path / "manifest.json"),
+            "--result-env-path",
+            str(sink),
+        ],
+    )
+    assert rc == config.EXIT_INTERNAL_ERROR
+    assert capsys.readouterr().out == ""
+    assert not sink.exists()
 
 
 def test_persist_stall_metadata_gap_fill_preserves_custom_key(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Add `--result-env-path` to `ship pr` for a trusted atomic result-env sink under the session tmpdir
- Emit mixed-case outcome KVs aligned with `dispatch_ship` handoff vocabulary; keep JSON stdout byte-compatible when the flag is omitted
- Fail closed on invalid paths (lexical `..`, outside-root, symlink) before `run_ship`, and on required result-env write failures

Fixes #7137.

## Test plan
- [x] `python3 -m pytest python/tests/implement/test_ship.py` (276 passed)
- [x] `pyright --project python/pyrightconfig.json` on changed files
- [x] `ruff check` on changed files
- [ ] CI green on the PR

Made with [Cursor](https://cursor.com)