### PR TITLE
Release v53.1.3

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "53.1.2",
+  "version": "53.1.3",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Added

- Add optional ship result-env direct-write sink (#7287).
- Add design/plan wire and result-env KV writers as part of contract unification (#7293).
- Add `gh issue-list` wrapper with raw-argv funnel as part of contract unification (#7294).
- Migrate real-script implement helper as part of contract unification (#7299).
- Add `/design` Gate C adverse-outcome fix ladder: reviser tier, main-agent tier, and guideline exception block (#7301).

## Changed

- Extend schema and run baseline migration (#7295).

## Fixed

- Fix `/implement` Step 3 lint-fix contract failure on pyright `UnnecessaryIsInstance` (#7288).
- Fix `/design` and `/implement` to assign a common prefix when splitting a feature into components (#7300).
