### PR TITLE
Fixes #7302: omit successful self-review execution issue

### DIFF
--- a/python/skill-closure-baseline.json
+++ b/python/skill-closure-baseline.json
@@ -38,9 +38,9 @@
     "skill_md_lines": 694
   },
   {
-    "closure_content_estimated_tokens": 48061,
-    "closure_estimated_tokens": 48183,
-    "closure_lines": 1362,
+    "closure_content_estimated_tokens": 48082,
+    "closure_estimated_tokens": 48203,
+    "closure_lines": 1364,
     "conditional_content_estimated_tokens": 17914,
     "conditional_estimated_tokens": 17959,
     "conditional_files": [

--- a/python/tests/skills/_structure_implement_specialized.py
+++ b/python/tests/skills/_structure_implement_specialized.py
@@ -1021,7 +1021,7 @@ def run(repo_root: Path) -> list[str]:
             "Checks Failure Entry Macro",
             "--site step5-self-review",
             "SELF_REVIEW_RESULT=complete",
-            "Claude subagent review complete",
+            "Do not record a successful self-review",
         ]:
             if needle not in self_review_text:
                 checks.append(f"self-review.md missing relocated authority {needle!r}")

--- a/skills/implement/references/self-review.md
+++ b/skills/implement/references/self-review.md
@@ -38,7 +38,9 @@ Wait with the shared bgjob contract. Repeat this exact fence on `BGJOB_STATUS=WA
 
 After the self-review composite bgjob returns `DONE` with `BGJOB_RC=0`, parse exactly one line-anchored composite `NEXT_ACTION=` record from the final `DONE` stdout and/or bgjob result env. Continue only on `NEXT_ACTION=continue`. On `NEXT_ACTION=main-agent-edit`, follow the reference's in-step Edit/Write and re-entry contract (orchestrator repair only for structural composite failures), then re-run this same composite launcher with identical argv. On missing, duplicated, malformed, seed-failed, non-zero `BGJOB_RC`, or non-zero-without-`NEXT_ACTION` output, treat it as an invalid composite envelope: log to `Warnings`, set prompt-side `STALL_TRACKING=true` and `STALL_STEP=5` when durable seed is absent, and skip to Step 18. Do not proceed to the next self-review step or Step 6.
 
-4. Log `Step 5: self-review mode: Claude subagent review complete` to `Warnings` in `$IMPLEMENT_TMPDIR/execution-issues.md`.
+4. Do not record a successful self-review in `$IMPLEMENT_TMPDIR/execution-issues.md`.
+That log is for warnings and failures that need operator attention.
+Normal review artifacts record successful completion.
 
 5. Emit self-review Step 5 run-log artifacts so final report and `audit_runs` Step 5 detection treat a clean self-review as review ran. The CLI reconciles accepted and rejected counts from durable self-review artifacts under `$IMPLEMENT_TMPDIR`. This verb is best effort: writer failure records a Warnings entry in `$IMPLEMENT_TMPDIR/execution-issues.md` and returns `0`, so it never blocks Step 6.
 


### PR DESCRIPTION
Closes #7302

Removes the clean self-review completion entry from the execution-issues ledger and adds a structure regression to preserve the distinction between successful completion and actionable warnings.