### PR TITLE
Release v53.1.4

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "53.1.3",
+  "version": "53.1.4",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Added

- Contract-unification: equivalence harness and synthetic golden fixtures ([#7318](https://github.com/character-ai/larch/pull/7318))
- Contract-unification: ban `pylint: skip-file` in runtime modules ([#7319](https://github.com/character-ai/larch/pull/7319))
- Contract-unification: Big-5 mechanical migration, runner adoption, and assertion convention ([#7324](https://github.com/character-ai/larch/pull/7324))

## Changed

- Ship adapter conversion and route-exit reader ([#7308](https://github.com/character-ai/larch/pull/7308))
- Step 7a orchestration parity ([#7311](https://github.com/character-ai/larch/pull/7311))
- OOS disposition-gate parity ([#7321](https://github.com/character-ai/larch/pull/7321))
- Test harnesses now inherit the live session's `IMPLEMENT_TMPDIR` and append fixture noise into the committed run log ([#7322](https://github.com/character-ai/larch/pull/7322))

## Fixed

- Exec Issues falsely reporting a non-issue as an issue ([#7304](https://github.com/character-ai/larch/pull/7304))
- Step 2 run-dispatch foreground fence dying on Bash-tool timeout with no envelope, stranding implementer edits uncommitted with no re-entry contract ([#7325](https://github.com/character-ai/larch/pull/7325))
- Stall-recovery record-escalation rejecting Step 2 vendor-failure tokens and silently dropping the escalation without naming the offending token ([#7326](https://github.com/character-ai/larch/pull/7326))
