### PR TITLE
Fixes #7289: preserve lint-fix escalation evidence

### DIFF
--- a/python/larch/implement/checks_lint_fix.py
+++ b/python/larch/implement/checks_lint_fix.py
@@ -827,9 +827,10 @@ def _exhausted_outcome(
     *, site: str, reason: str, ledger_path: Path,
     stderr_tail_path: str = "", failure_detail_log: str = ""
 ) -> FixOutcome:
-    # Pre-ship sites and ship-pr-ci-initial stall without escalation; carry
-    # ledger metadata for diagnostics but do NOT set ledger_ready so the
-    # repair-loop consumer routes to stall, not stall-recovery record-escalation.
+    # Preserve the redacted failure log for the repair loop to validate before it
+    # decides whether this terminal outcome can escalate. Pre-ship outcomes do
+    # not set ledger_ready here: _repair_loop_action owns that decision after
+    # containment-checking the log it will hand to the ci-fixer.
     if _is_pre_ship_site(site) or site == "ship-pr-ci-initial":
         return FixOutcome(
             status="failed", delta_paths=(), failure_reason=reason, commit_sha=None,
@@ -1965,6 +1966,11 @@ def _handle_fix_outcome(
         loop.coder_log_path = fix.coder_log_path
         return False
     if fix.status == "failed":
+        # A delegated waterfall can fail before re-running checks, so there is
+        # no later capture to populate final_redacted_checks_log. Keep its
+        # redacted input as the candidate; _repair_loop_action validates it
+        # against the session root before using it for an escalation.
+        loop.final_redacted_checks_log = fix.ledger_failure_detail_log
         if fix.failure_reason in _PRE_SHIP_NON_STRUCTURAL_REASONS:
             loop.status = "exhausted"
         elif fix.failure_reason == "head-changed-after-dispatch":

--- a/python/tests/implement/test_checks.py
+++ b/python/tests/implement/test_checks.py
@@ -4703,17 +4703,20 @@ def test_checks_repair_loop_main_all_tiers_no_delta_escalates_to_main_agent(
     session = _checks_session(tmp_path, monkeypatch)
     checks_log = session / "initial.redacted.log"
     checks_log.write_text("initial failure\n", encoding="utf-8")
-    final_failure_log = session / "final.redacted.log"
-    final_failure_log.write_text("pyright failure\n", encoding="utf-8")
 
-    def fake_run_check_fix_loop(**_kwargs: object) -> checks.LoopResult:
-        return checks.LoopResult(
-            status="exhausted",
+    def fake_run_lint_fix(_runner: object, **_kwargs: object) -> checks.FixOutcome:
+        return checks.FixOutcome(
+            status="failed",
+            delta_paths=(),
             failure_reason="lint-fix-all-tiers-no-useful-delta",
-            final_redacted_checks_log=str(final_failure_log),
+            commit_sha=None,
+            head_changed=False,
+            coder_tool=None,
+            tier_ledger_path=str(session / "lint-fix-tier-ledger.tsv"),
+            ledger_failure_detail_log=str(checks_log),
         )
 
-    monkeypatch.setattr(_clf, "run_check_fix_loop", fake_run_check_fix_loop)
+    monkeypatch.setattr(_clf, "run_lint_fix", fake_run_lint_fix)
     rc = checks.checks_repair_loop_main([
         "--tmpdir",
         str(session),
@@ -4737,7 +4740,7 @@ def test_checks_repair_loop_main_all_tiers_no_delta_escalates_to_main_agent(
     assert f"LINT_FIX_LEDGER_PHASE={phase}" in out
     assert "LINT_FIX_LEDGER_DISPATCHER=lint-fix-loop" in out
     assert "LINT_FIX_LEDGER_EXIT_CODE=1" in out
-    assert f"LINT_FIX_LEDGER_FAILURE_DETAIL_LOG={final_failure_log.resolve()}" in out
+    assert f"LINT_FIX_LEDGER_FAILURE_DETAIL_LOG={checks_log.resolve()}" in out
 
 
 @pytest.mark.parametrize("final_log", ["", "outside.redacted.log"])
@@ -5280,7 +5283,7 @@ def test_run_lint_fix_claude_only_host_dispatches_claude(
     assert outcome.coder_tool == "claude"
 
 
-def test_run_lint_fix_all_three_tiers_fail_main_agent_required(
+def test_run_lint_fix_all_three_tiers_report_exhaustion_for_repair_loop(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Fixes #7289

Preserves the redacted failure log from a delegated lint-fix waterfall so the repair loop can validate it and route all-tier no-useful-delta exhaustion to the ci-fixer handoff. The regression now exercises the live repair-loop path instead of injecting a final log.

Verified locally:
- `python3 -m pytest python/tests/implement/test_checks.py -q`
- `ruff check larch/implement/checks_lint_fix.py tests/implement/test_checks.py`
- `pyright larch/implement/checks_lint_fix.py tests/implement/test_checks.py`