### PR TITLE
test: migrate execution issues flush harness

### DIFF
--- a/python/tests/issue/test_execution_issues.py
+++ b/python/tests/issue/test_execution_issues.py
@@ -1,4 +1,5 @@
 import hashlib
+import json
 import subprocess
 from pathlib import Path
 
@@ -70,6 +71,81 @@ def test_flush_execution_issues_writes_sentinel_and_clears_log(tmp_path: Path) -
     assert (tmp_path / ".execution-issues-flushed.sha").is_file()
 
 
+def test_flush_execution_issues_skips_missing_log_and_writes_checkpoint(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    rc = execution_issues.flush_execution_issues_main(
+        [
+            "--log-root",
+            str((tmp_path / "larch-logs").resolve()),
+            "--run-id",
+            "run-empty",
+            "--issue-log",
+            str(tmp_path / "missing.md"),
+        ]
+    )
+
+    assert rc == 0
+    assert capsys.readouterr().out == "FLUSH_STATUS=skip\nRECORDS=0\n"
+    assert (tmp_path / ".execution-issues-step7a-reached").is_file()
+
+
+def test_flush_execution_issues_writes_single_record_with_flush_metadata(
+    tmp_path: Path,
+) -> None:
+    issue_log = tmp_path / "execution-issues.md"
+    _ = issue_log.write_text(
+        "### Tool Failures\n\n- tool failed once\n", encoding="utf-8"
+    )
+    log_root = (tmp_path / "larch-logs").resolve()
+
+    rc, status, records, append_log = execution_issues.flush_execution_issues(
+        log_root=log_root,
+        run_id="run-single",
+        issue_log=issue_log,
+    )
+
+    record = json.loads(
+        (log_root / "implement" / "run-single" / "execution-issues.ndjson").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert (rc, status, records) == (0, "ok", 1)
+    assert Path(append_log).is_file()
+    assert record == {
+        "phase": "implement",
+        "step": "7a",
+        "category": "Tool Failures",
+        "source": "execution-issues.md pre-bump",
+        "source_sha256": hashlib.sha256(b"- tool failed once\n").hexdigest(),
+        "body": "\n- tool failed once\n",
+    }
+    assert issue_log.read_text(encoding="utf-8") == ""
+
+
+def test_flush_execution_issues_writes_one_record_per_section(tmp_path: Path) -> None:
+    issue_log = tmp_path / "execution-issues.md"
+    _ = issue_log.write_text(
+        "### Tool Failures\n\n- first failure\n\n### Warnings\n\n- warning entry\n",
+        encoding="utf-8",
+    )
+    log_root = (tmp_path / "larch-logs").resolve()
+
+    rc, status, records, _append_log = execution_issues.flush_execution_issues(
+        log_root=log_root,
+        run_id="run-multi",
+        issue_log=issue_log,
+    )
+
+    batch = log_root / "implement" / "run-multi" / "execution-issues.ndjson"
+    written = [
+        json.loads(line) for line in batch.read_text(encoding="utf-8").splitlines()
+    ]
+    assert (rc, status, records) == (0, "ok", 2)
+    assert [record["category"] for record in written] == ["Tool Failures", "Warnings"]
+
+
 def test_flush_execution_issues_idempotent_when_sentinel_matches(tmp_path: Path) -> None:
     issue_log = tmp_path / "execution-issues.md"
     _ = issue_log.write_text("### Warnings\n- one\n", encoding="utf-8")
@@ -83,6 +159,8 @@ def test_flush_execution_issues_idempotent_when_sentinel_matches(tmp_path: Path)
     assert second[0] == 0
     assert second[1] == "already-flushed"
     assert issue_log.read_text(encoding="utf-8") == ""
+    batch = log_root / "implement" / run_id / "execution-issues.ndjson"
+    assert len(batch.read_text(encoding="utf-8").splitlines()) == 1
 
 
 def test_flush_execution_issues_already_flushed_when_batch_contains_normalized_sections(tmp_path: Path) -> None:
@@ -108,6 +186,39 @@ def test_flush_execution_issues_already_flushed_when_batch_contains_normalized_s
     assert records_count == 0
     assert (tmp_path / ".execution-issues-flushed.sha").is_file()
     assert issue_log.read_text(encoding="utf-8") == ""
+
+
+def test_flush_execution_issues_append_failure_preserves_source_log_and_diagnostics(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    issue_log = tmp_path / "execution-issues.md"
+    _ = issue_log.write_text(
+        "### Tool Failures\n\n- original failure\n", encoding="utf-8"
+    )
+
+    def fake_run(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            ["run-log"], 9, "out\n", "simulated larch-log failure\n"
+        )
+
+    monkeypatch.setattr(execution_issues.subprocess, "run", fake_run)
+
+    rc, status, records, append_log = execution_issues.flush_execution_issues(
+        log_root=(tmp_path / "larch-logs").resolve(),
+        run_id="run-fail",
+        issue_log=issue_log,
+    )
+
+    text = issue_log.read_text(encoding="utf-8")
+    assert (rc, status, records) == (1, "failed", 0)
+    assert "- original failure" in text
+    assert "flush-execution-issues" in text
+    assert "run-log exited 9" in text
+    assert (
+        Path(append_log).read_text(encoding="utf-8")
+        == "out\nsimulated larch-log failure\n"
+    )
 
 
 def test_refresh_execution_issues_skips_when_issue_not_set(
@@ -209,6 +320,7 @@ def test_flush_execution_issues_safety_net_append_failure_preserves_source_log(
     assert "- one" in text
     assert "flush-execution-issues-safety-net" in text
     assert "run-log exited 9" in text
+    assert Path(_append_log).read_text(encoding="utf-8") == "out\nerr\n"
 
 
 def test_flush_execution_issues_safety_net_main_emits_kv_contract(

--- a/skills/implement/scripts/test-flush-execution-issues.md
+++ b/skills/implement/scripts/test-flush-execution-issues.md
@@ -1,9 +1,8 @@
 # test-flush-execution-issues.sh
 
-Offline harness for `skills/implement/scripts/flush-execution-issues.sh`.
+Delegation smoke for `skills/implement/scripts/flush-execution-issues.sh`.
 
-It runs the helper in a temporary plugin/repo sandbox with stubbed
-`run-log` and `run-log append-failure`, then verifies empty-input skip,
-single-section and multi-section NDJSON composition, idempotent rerun behavior,
-and the append-failure path that records `run-log` output back into
-`execution-issues.md`.
+It verifies both `CLAUDE_PLUGIN_ROOT` override and script-relative fallback.
+Each case checks exact CLI routing, argument forwarding, exit-status forwarding,
+and stdout and stderr passthrough. Behavioral coverage lives in
+`python/tests/issue/test_execution_issues.py`.

--- a/skills/implement/scripts/test-flush-execution-issues.sh
+++ b/skills/implement/scripts/test-flush-execution-issues.sh
@@ -1,258 +1,54 @@
 #!/usr/bin/env bash
-# test-flush-execution-issues.sh — offline harness for flush-execution-issues.sh.
-
+# Delegation smoke for flush-execution-issues.sh.
+# Behavioral coverage lives in python/tests/issue/test_execution_issues.py.
 set -euo pipefail
-
-export LARCH_QUIET_DISABLE=1
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 HELPER="$SCRIPT_DIR/flush-execution-issues.sh"
-REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd -P)"
-
-PASS=0
-FAIL=0
 TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/test-flush-execution-issues.XXXXXX")"
 trap 'rm -rf "$TMP_ROOT"' EXIT
 
-pass() {
-    PASS=$((PASS + 1))
-    printf 'PASS: %s\n' "$1"
-}
-
-fail() {
-    FAIL=$((FAIL + 1))
-    printf 'FAIL: %s\n' "$1" >&2
-}
-
-assert_contains() {
-    local needle=$1 haystack=$2 label=$3
-    if printf '%s' "$haystack" | grep -Fq -- "$needle"; then
-        pass "$label"
-    else
-        fail "$label (missing: $needle)"
-    fi
-}
-
-assert_file_contains() {
-    local needle=$1 path=$2 label=$3
-    assert_contains "$needle" "$(cat "$path" 2>/dev/null || true)" "$label"
-}
-
-assert_equals() {
-    local expected=$1 actual=$2 label=$3
-    if [ "$expected" = "$actual" ]; then
-        pass "$label"
-    else
-        fail "$label (expected $expected got $actual)"
-    fi
-}
-
-kv_value() {
-    local key=$1 body=$2
-    printf '%s\n' "$body" | awk -F= -v key="$key" '$1==key{print substr($0, index($0, "=") + 1); exit}'
-}
-
-setup_plugin() {
+write_cli() {
     local root=$1
-    mkdir -p "$root/scripts" "$root/python"
-    cat > "$root/python/cli.py" <<'STUB'
+    mkdir -p "$root/python"
+    cat >"$root/python/cli.py" <<'PY'
+import json
 import os
 import sys
 from pathlib import Path
 
-def _parse(args):
-    d = {}
-    i = 0
-    while i < len(args):
-        if args[i] == "--redact":
-            i += 1
-            continue
-        if args[i].startswith("--") and i + 1 < len(args):
-            d[args[i][2:]] = args[i + 1]
-            i += 2
-        else:
-            print(f"unknown option: {args[i]}", file=sys.stderr)
-            raise SystemExit(2)
-    return d
-
-def main():
-    if sys.argv[1:3] == ["execution-issues", "flush"]:
-        sys.path.insert(0, os.environ["LARCH_TEST_REPO_ROOT"] + "/python")
-        from execution_issues import flush_execution_issues_main
-        raise SystemExit(flush_execution_issues_main(sys.argv[3:]))
-    if len(sys.argv) < 3 or sys.argv[1] != "run-log":
-        print(f"unsupported command: {sys.argv[1:]}", file=sys.stderr)
-        raise SystemExit(2)
-    verb = sys.argv[2]
-    if verb == "append":
-        if os.environ.get("LARCH_LOG_FAIL", "") == "1":
-            print("simulated larch-log failure", file=sys.stderr)
-            raise SystemExit(1)
-        d = _parse(sys.argv[3:])
-        path = Path(d["log-root"]) / d["skill"] / d["run-id"] / f"{d['batch']}.ndjson"
-        path.parent.mkdir(parents=True, exist_ok=True)
-        with path.open("a", encoding="utf-8") as handle:
-            handle.write(Path(d["record-file"]).read_text(encoding="utf-8"))
-        print("LOG_WRITTEN=true")
-        print(f"LOG_PATH={path}")
-        raise SystemExit(0)
-    if verb == "append-failure":
-        d = _parse(sys.argv[3:])
-        log = d.get("log", "")
-        body = Path(d["output-file"]).read_text(encoding="utf-8") if d.get("output-file") else ""
-        with open(log, "a", encoding="utf-8") as handle:
-            handle.write(f"\n### {d.get('category', 'Tool Failures')}\n\n")
-            handle.write(f"- **Step {d.get('site', '')} — {d.get('tool', '')} failed (exit {d.get('exit-code', '')})**:\n")
-            handle.write(body)
-            handle.write("\n")
-        raise SystemExit(0)
-    print(f"unsupported command: {verb}", file=sys.stderr)
-    raise SystemExit(2)
-
-if __name__ == "__main__":
-    main()
-STUB
+Path(os.environ["FLUSH_CAPTURE"]).write_text(json.dumps({"program": sys.argv[0], "argv": sys.argv[1:]}), encoding="utf-8")
+sys.stdout.write("wrapper stdout\n")
+sys.stderr.write("wrapper stderr\n")
+raise SystemExit(23)
+PY
 }
 
-run_helper() {
-    local plugin=$1 tmpdir=$2 log_root=$3 run_id=$4 issue_log=$5
+assert_case() {
+    local helper=$1 root=$2 capture=$3 stdout=$4 stderr=$5 plugin_root=$2 rc
+    if [ "$helper" = "$fallback/skills/implement/scripts/flush-execution-issues.sh" ]; then plugin_root=""; fi
     set +e
-    CLAUDE_PLUGIN_ROOT="$plugin" IMPLEMENT_TMPDIR="$tmpdir" LARCH_TEST_REPO_ROOT="$REPO_ROOT" \
-        "$HELPER" --log-root "$log_root" --run-id "$run_id" --issue-log "$issue_log"
-    local rc=$?
+    CLAUDE_PLUGIN_ROOT="$plugin_root" FLUSH_CAPTURE="$capture" "$helper" --run-id run-7 --issue-log 'two words' >"$stdout" 2>"$stderr"
+    rc=$?
     set -e
-    return "$rc"
+    [ "$rc" -eq 23 ] && [ "$(cat "$stdout")" = 'wrapper stdout' ] && [ "$(cat "$stderr")" = 'wrapper stderr' ]
+    python3 - "$capture" "$root" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+record = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+if Path(record["program"]).resolve() != (Path(sys.argv[2]) / "python" / "cli.py").resolve() or record["argv"] != ["execution-issues", "flush", "--run-id", "run-7", "--issue-log", "two words"]:
+    raise SystemExit(f"unexpected delegation: {record!r}")
+PY
 }
 
-line_count() {
-    wc -l < "$1" | tr -d '[:space:]'
-}
+fallback="$TMP_ROOT/fallback"; mkdir -p "$fallback/skills/implement/scripts"
+cp "$HELPER" "$fallback/skills/implement/scripts/flush-execution-issues.sh"
+chmod +x "$fallback/skills/implement/scripts/flush-execution-issues.sh"
+write_cli "$fallback"
+assert_case "$fallback/skills/implement/scripts/flush-execution-issues.sh" "$fallback" "$TMP_ROOT/fallback.json" "$TMP_ROOT/fallback.out" "$TMP_ROOT/fallback.err"
 
-echo "=== test-flush-execution-issues ==="
-
-PLUGIN="$TMP_ROOT/plugin"
-setup_plugin "$PLUGIN"
-
-case_dir="$TMP_ROOT/empty"
-mkdir -p "$case_dir"
-out=$(run_helper "$PLUGIN" "$case_dir" "$case_dir/larch-logs" "run-empty" "$case_dir/missing.md")
-rc=$?
-assert_equals 0 "$rc" "empty input exits 0"
-assert_contains "FLUSH_STATUS=skip" "$out" "empty input emits skip"
-assert_contains "RECORDS=0" "$out" "empty input emits zero records"
-if [ -f "$case_dir/.execution-issues-step7a-reached" ]; then pass "empty input writes Step 7a checkpoint"; else fail "empty input writes Step 7a checkpoint"; fi
-
-case_dir="$TMP_ROOT/single"
-mkdir -p "$case_dir"
-cat > "$case_dir/execution-issues.md" <<'ISSUES'
-### Tool Failures
-
-- tool failed once
-ISSUES
-out=$(run_helper "$PLUGIN" "$case_dir" "$case_dir/larch-logs" "run-single" "$case_dir/execution-issues.md")
-rc=$?
-batch="$case_dir/larch-logs/implement/run-single/execution-issues.ndjson"
-assert_equals 0 "$rc" "single-section exits 0"
-assert_contains "FLUSH_STATUS=ok" "$out" "single-section emits ok"
-assert_contains "RECORDS=1" "$out" "single-section emits one record"
-append_log=$(kv_value APPEND_LOG_FILE "$out")
-if [ -n "$append_log" ] && [ -r "$append_log" ]; then pass "single-section preserves append log file"; else fail "single-section preserves append log file"; fi
-assert_file_contains '"step":"7a"' "$batch" "single-section records step 7a"
-assert_file_contains '"source":"execution-issues.md pre-bump"' "$batch" "single-section records pre-bump source"
-if [ -s "$case_dir/.execution-issues-flushed.sha" ]; then pass "single-section writes sentinel"; else fail "single-section writes sentinel"; fi
-if [ ! -s "$case_dir/execution-issues.md" ]; then pass "single-section clears flushed issue log"; else fail "single-section clears flushed issue log"; fi
-
-case_dir="$TMP_ROOT/multi"
-mkdir -p "$case_dir"
-cat > "$case_dir/execution-issues.md" <<'ISSUES'
-### Tool Failures
-
-- first failure
-
-### Warnings
-
-- warning entry
-ISSUES
-out=$(run_helper "$PLUGIN" "$case_dir" "$case_dir/larch-logs" "run-multi" "$case_dir/execution-issues.md")
-rc=$?
-batch="$case_dir/larch-logs/implement/run-multi/execution-issues.ndjson"
-assert_equals 0 "$rc" "multi-section exits 0"
-assert_contains "FLUSH_STATUS=ok" "$out" "multi-section emits ok"
-assert_contains "RECORDS=2" "$out" "multi-section emits two records"
-assert_equals 2 "$(line_count "$batch")" "multi-section appends two lines"
-assert_file_contains '"category":"Tool Failures"' "$batch" "multi-section includes Tool Failures"
-assert_file_contains '"category":"Warnings"' "$batch" "multi-section includes Warnings"
-
-case_dir="$TMP_ROOT/idempotent"
-mkdir -p "$case_dir"
-cat > "$case_dir/execution-issues.md" <<'ISSUES'
-### Warnings
-
-- one warning
-ISSUES
-out=$(run_helper "$PLUGIN" "$case_dir" "$case_dir/larch-logs" "run-idem" "$case_dir/execution-issues.md")
-rc=$?
-batch="$case_dir/larch-logs/implement/run-idem/execution-issues.ndjson"
-before=$(line_count "$batch")
-cat > "$case_dir/execution-issues.md" <<'ISSUES'
-### Warnings
-
-- one warning
-ISSUES
-out=$(run_helper "$PLUGIN" "$case_dir" "$case_dir/larch-logs" "run-idem" "$case_dir/execution-issues.md")
-rc=$?
-after=$(line_count "$batch")
-assert_equals 0 "$rc" "idempotent rerun exits 0"
-assert_contains "FLUSH_STATUS=already-flushed" "$out" "idempotent rerun emits already-flushed"
-assert_contains "RECORDS=0" "$out" "idempotent rerun emits zero records"
-assert_equals "$before" "$after" "idempotent rerun appends no duplicate"
-
-case_dir="$TMP_ROOT/per-section-probe"
-mkdir -p "$case_dir"
-cat > "$case_dir/execution-issues.md" <<'ISSUES'
-### Warnings
-
-- already flushed section
-ISSUES
-out=$(run_helper "$PLUGIN" "$case_dir" "$case_dir/larch-logs" "run-section-probe" "$case_dir/execution-issues.md")
-rc=$?
-batch="$case_dir/larch-logs/implement/run-section-probe/execution-issues.ndjson"
-assert_equals 0 "$rc" "per-section probe seed exits 0"
-assert_contains "FLUSH_STATUS=ok" "$out" "per-section probe seed emits ok"
-rm -f "$case_dir/.execution-issues-flushed.sha"
-cat > "$case_dir/execution-issues.md" <<'ISSUES'
-### Warnings
-
-- already flushed section
-ISSUES
-before=$(line_count "$batch")
-out=$(run_helper "$PLUGIN" "$case_dir" "$case_dir/larch-logs" "run-section-probe" "$case_dir/execution-issues.md")
-rc=$?
-after=$(line_count "$batch")
-assert_equals 0 "$rc" "per-section probe rerun exits 0"
-assert_contains "FLUSH_STATUS=already-flushed" "$out" "per-section probe rerun emits already-flushed"
-assert_contains "RECORDS=0" "$out" "per-section probe rerun emits zero records"
-assert_equals "$before" "$after" "per-section probe rerun appends no duplicate"
-if [ ! -s "$case_dir/execution-issues.md" ]; then pass "per-section probe rerun clears flushed issue log"; else fail "per-section probe rerun clears flushed issue log"; fi
-
-case_dir="$TMP_ROOT/failure"
-mkdir -p "$case_dir"
-cat > "$case_dir/execution-issues.md" <<'ISSUES'
-### Tool Failures
-
-- original failure
-ISSUES
-set +e
-out=$(CLAUDE_PLUGIN_ROOT="$PLUGIN" IMPLEMENT_TMPDIR="$case_dir" LARCH_LOG_FAIL=1 \
-    "$HELPER" --log-root "$case_dir/larch-logs" --run-id "run-fail" --issue-log "$case_dir/execution-issues.md")
-rc=$?
-set -e
-assert_equals 1 "$rc" "larch-log failure exits 1"
-assert_contains "FLUSH_STATUS=failed" "$out" "larch-log failure emits failed"
-append_log=$(kv_value APPEND_LOG_FILE "$out")
-if [ -n "$append_log" ] && [ -r "$append_log" ]; then pass "failure preserves append log file"; else fail "failure preserves append log file"; fi
-assert_file_contains "run-log failed" "$case_dir/execution-issues.md" "larch-log failure is appended to execution issues"
-assert_file_contains "simulated larch-log failure" "$case_dir/execution-issues.md" "larch-log failure output is captured"
-
-echo "=== test-flush-execution-issues: $PASS passed, $FAIL failed ==="
-[ "$FAIL" -eq 0 ]
+override="$TMP_ROOT/override"; write_cli "$override"
+assert_case "$HELPER" "$override" "$TMP_ROOT/override.json" "$TMP_ROOT/override.out" "$TMP_ROOT/override.err"
+printf 'PASS: flush-execution-issues wrapper delegation\n'


### PR DESCRIPTION
Closes #7266.

## Summary
- Move flush behavior coverage into pytest.
- Reduce the Bash harness to a wrapper delegation smoke.
- Document the reduced smoke contract.

## Validation
- make test-flush-execution-issues
- bash skills/implement/scripts/test-flush-execution-issues.sh
- make lint-bash32
- pre-commit run shellcheck --files skills/implement/scripts/test-flush-execution-issues.sh
- python3 -m pytest python/tests/issue/test_execution_issues.py -q
- ruff check python/tests/issue/test_execution_issues.py
- pyright python/tests/issue/test_execution_issues.py