### PR TITLE
[DONE] Fix execution-issues flush records

### DIFF
--- a/python/larch/agents/_failure_diag.py
+++ b/python/larch/agents/_failure_diag.py
@@ -303,6 +303,9 @@ def _compose_failure_diag(output: Path, *, sink: str = "", history: str = "", ev
         return
     capped = _truncate_utf8_bytes(text="\n".join(sections) + "\n", cap=_vendor_failure_diag_cap())
     if carrier.is_file() and carrier.stat().st_size > 0:
+        existing = carrier.read_text(encoding="utf-8", errors="replace")
+        if capped.rstrip() in existing:
+            return
         _append(path=carrier, text="\n===== additional failure diagnostics =====\n" + capped)
     else:
         _write(path=carrier, text=capped)

--- a/python/larch/core/architectural_guidelines.py
+++ b/python/larch/core/architectural_guidelines.py
@@ -1637,10 +1637,9 @@ def _format_deviation_warning_entry(note: str) -> str:
 
 def _warning_chunk_keys(body: str) -> set[str]:
     from larch.report import exec_issue_detail  # noqa: PLC0415  # lint-layering: ok append helper must match run-log flush warning dedupe.
-    from larch.report.run_log_flush import _execution_issue_chunks as execution_issue_chunks  # noqa: PLC0415  # lint-layering: ok append helper must match run-log flush chunking and dedupe.
+    from larch.issue.execution_issues import _execution_issue_chunks as execution_issue_chunks  # noqa: PLC0415  # lint-layering: ok append helper must match run-log flush chunking and dedupe.
     keys: set[str] = set()
-    for chunk in execution_issue_chunks(body.splitlines()):
-        chunk_body = "\n".join(chunk)
+    for chunk_body in execution_issue_chunks(body):
         for key in exec_issue_detail.structured_body_dedupe_keys(chunk_body, _EXECUTION_WARNINGS_CATEGORY):
             keys.add(f"{_EXECUTION_WARNINGS_CATEGORY}\0{key}")
     return keys
@@ -1648,10 +1647,9 @@ def _warning_chunk_keys(body: str) -> set[str]:
 
 def _warning_chunk_source_shas(body: str) -> set[str]:
     from larch.report.run_log_batch import _normalize_body_for_hash  # noqa: PLC0415  # lint-layering: ok append helper must match run-log flush redaction and append behavior.
-    from larch.report.run_log_flush import _execution_issue_chunks as execution_issue_chunks  # noqa: PLC0415  # lint-layering: ok append helper must match run-log flush chunking and dedupe.
+    from larch.issue.execution_issues import _execution_issue_chunks as execution_issue_chunks  # noqa: PLC0415  # lint-layering: ok append helper must match run-log flush chunking and dedupe.
     shas: set[str] = set()
-    for chunk in execution_issue_chunks(body.splitlines()):
-        chunk_body = "\n".join(chunk)
+    for chunk_body in execution_issue_chunks(body):
         normalized = _normalize_body_for_hash(chunk_body)
         if normalized:
             shas.add(hashlib.sha256(normalized.encode("utf-8")).hexdigest())
@@ -1739,7 +1737,7 @@ def _existing_warning_keys_and_shas_from_ndjson(implement_tmpdir: Path) -> tuple
         batch_text = batch_path.read_text(encoding="utf-8", errors="replace")
     except OSError:
         return set(), set()
-    from larch.report.run_log_flush import _existing_execution_issue_keys as existing_execution_issue_keys  # noqa: PLC0415  # lint-layering: ok append helper must match run-log flush chunking and dedupe.
+    from larch.issue.execution_issues import _existing_execution_issue_keys as existing_execution_issue_keys  # noqa: PLC0415  # lint-layering: ok append helper must match run-log flush chunking and dedupe.
     return existing_execution_issue_keys(batch_text), _existing_warning_source_shas(batch_text)
 
 
@@ -1752,10 +1750,9 @@ def append_deviation_note(implement_tmpdir: Path, note: str) -> str:
     existing_keys = _existing_warning_keys_from_markdown(issue_log)
     ndjson_keys, ndjson_shas = _existing_warning_keys_and_shas_from_ndjson(implement_tmpdir)
     known_keys = existing_keys | ndjson_keys
-    from larch.report.run_log_flush import _execution_issue_chunks as execution_issue_chunks  # noqa: PLC0415  # lint-layering: ok append helper must match run-log flush chunking and dedupe.
+    from larch.issue.execution_issues import _execution_issue_chunks as execution_issue_chunks  # noqa: PLC0415  # lint-layering: ok append helper must match run-log flush chunking and dedupe.
     kept_chunks: list[str] = []
-    for chunk in execution_issue_chunks(redacted_entry.splitlines()):
-        chunk_body = "\n".join(chunk)
+    for chunk_body in execution_issue_chunks(redacted_entry):
         chunk_keys = _warning_chunk_keys(chunk_body)
         chunk_shas = _warning_chunk_source_shas(chunk_body)
         if chunk_keys <= known_keys or (chunk_shas and chunk_shas <= ndjson_shas):

--- a/python/larch/issue/execution_issues.py
+++ b/python/larch/issue/execution_issues.py
@@ -14,13 +14,14 @@ import sys
 import tempfile
 from contextlib import suppress
 from pathlib import Path
+from typing import cast
 from larch import io as larch_io
 from larch.core import config
 from larch.report import exec_issue_detail
 from larch.report.run_log_batch import (
-    _EXECUTION_ISSUE_CATEGORIES,
-    _normalize_body_for_hash,
-    _redact_batch_payload,
+    _EXECUTION_ISSUE_CATEGORIES,  # pyright: ignore[reportPrivateUsage]  # shared writer uses the canonical category set.
+    _normalize_body_for_hash,  # pyright: ignore[reportPrivateUsage]  # shared writer preserves the established hash grammar.
+    _redact_batch_payload,  # pyright: ignore[reportPrivateUsage]  # shared writer uses the existing fail-closed redaction path.
 )
 
 VALIDATION_FAILED_RC = 2
@@ -127,8 +128,9 @@ def _existing_execution_issue_keys(batch_text: str) -> set[str]:
             continue
         if not isinstance(row, dict):
             continue
-        category = row.get("category")
-        body = row.get("body")
+        row_dict = cast("dict[str, object]", row)
+        category = row_dict.get("category")
+        body = row_dict.get("body")
         if isinstance(category, str) and isinstance(body, str):
             keys.update(_execution_issue_body_keys(category=category, body=body))
     return keys

--- a/python/larch/issue/execution_issues.py
+++ b/python/larch/issue/execution_issues.py
@@ -16,8 +16,15 @@ from contextlib import suppress
 from pathlib import Path
 from larch import io as larch_io
 from larch.core import config
+from larch.report import exec_issue_detail
+from larch.report.run_log_batch import (
+    _EXECUTION_ISSUE_CATEGORIES,
+    _normalize_body_for_hash,
+    _redact_batch_payload,
+)
 
 VALIDATION_FAILED_RC = 2
+_WARNINGS_CATEGORY = "Warnings"
 
 
 def emit_kv( *,key: str, value: object) -> None:
@@ -33,33 +40,127 @@ def sha256_file(path: str | Path) -> str:
 
 
 def normalize_body_for_hash(text: str) -> str:
-    lines = text.splitlines()
-    if lines and lines[0].startswith("### "):
-        lines = lines[1:]
-    start = 0
-    while start < len(lines) and not lines[start].strip():
-        start += 1
-    end = len(lines)
-    while end > start and not lines[end - 1].strip():
-        end -= 1
-    return "\n".join(lines[start:end]) + ("\n" if end > start else "")
+    return _normalize_body_for_hash(text)
 
 
-def _sections(text: str) -> list[tuple[str, str]]:
+def _is_fence(line: str) -> bool:
+    candidate = line.lstrip()
+    if candidate.startswith("- "):
+        candidate = candidate[2:].lstrip()
+    return candidate.startswith("```")
+
+
+def execution_issue_sections(text: str) -> list[tuple[str, str]]:
     sections: list[tuple[str, str]] = []
-    current = "Tool Failures"
+    current: str | None = None
     body: list[str] = []
+    in_fence = False
+
+    def append_current() -> None:
+        nonlocal body
+        if current is not None and any(line.strip() for line in body):
+            sections.append((current, "\n".join(body) + "\n"))
+        body = []
+
     for line in text.splitlines():
-        if line.startswith("### "):
-            if body:
-                sections.append((current, "\n".join(body) + "\n"))
-            current = line[4:].strip() or "Tool Failures"
-            body = []
-        else:
-            body.append(line)
-    if body:
-        sections.append((current, "\n".join(body) + "\n"))
-    return [(cat, body) for cat, body in sections if body.strip()]
+        if not in_fence and line.strip() == "---":
+            continue
+        if not in_fence and line.startswith(("### ", "## ")):
+            heading = line.split(" ", 1)[1].strip()
+            if heading in _EXECUTION_ISSUE_CATEGORIES:
+                append_current()
+                current = heading
+                continue
+            append_current()
+            current = _WARNINGS_CATEGORY
+            continue
+        if not in_fence and line.startswith("# ") and line[2:].strip() == "Execution Issues":
+            continue
+        if current is None and line.strip():
+            current = _WARNINGS_CATEGORY
+        body.append(line)
+        if _is_fence(line):
+            in_fence = not in_fence
+    append_current()
+    return sections
+
+
+def _execution_issue_chunks(body: str) -> list[str]:
+    chunks: list[str] = []
+    current: list[str] = []
+    in_fence = False
+    pending_break = False
+    for line in body.splitlines():
+        if not in_fence and not line.strip():
+            pending_break = bool(current)
+            continue
+        is_fence = _is_fence(line)
+        if not in_fence and line.startswith("- ") and current and not is_fence:
+            chunks.append("\n".join(current).strip() + "\n")
+            current = []
+            pending_break = False
+        if pending_break and current:
+            chunks.append("\n".join(current).strip() + "\n")
+            current = []
+        pending_break = False
+        current.append(line)
+        if is_fence:
+            in_fence = not in_fence
+    if current:
+        chunks.append("\n".join(current).strip() + "\n")
+    return chunks
+
+
+def _execution_issue_body_keys(*, category: str, body: str) -> set[str]:
+    return {
+        f"{category}\0{key}"
+        for key in exec_issue_detail.structured_body_dedupe_keys(body, category)
+    }
+
+
+def _existing_execution_issue_keys(batch_text: str) -> set[str]:
+    keys: set[str] = set()
+    for raw in batch_text.splitlines():
+        try:
+            row: object = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(row, dict):
+            continue
+        category = row.get("category")
+        body = row.get("body")
+        if isinstance(category, str) and isinstance(body, str):
+            keys.update(_execution_issue_body_keys(category=category, body=body))
+    return keys
+
+
+def execution_issue_records(
+    *,
+    text: str,
+    existing_batch: str,
+    step_label: str,
+    source_label: str,
+    file_sha: str,
+) -> list[str]:
+    records: list[str] = []
+    seen_keys = _existing_execution_issue_keys(existing_batch)
+    for category, section in execution_issue_sections(text):
+        for chunk in _execution_issue_chunks(section):
+            body = _redact_batch_payload(chunk)
+            body_keys = _execution_issue_body_keys(category=category, body=body)
+            if body_keys <= seen_keys:
+                continue
+            norm_sha = hashlib.sha256(normalize_body_for_hash(body).encode()).hexdigest()
+            records.append(json.dumps({
+                "phase": "implement",
+                "step": step_label,
+                "category": category,
+                "source": source_label,
+                "source_sha256": norm_sha or file_sha,
+                "body": body,
+            }, separators=(",", ":"), sort_keys=True))
+            seen_keys.update(body_keys)
+    return records
 
 
 def execution_issues_batch_contains_all_sections( *,input_file: str | Path, batch_path: str | Path) -> bool:
@@ -69,31 +170,28 @@ def execution_issues_batch_contains_all_sections( *,input_file: str | Path, batc
     text = Path(input_file).read_text(encoding="utf-8", errors="replace")
     batch_text = batch.read_text(encoding="utf-8", errors="replace")
     saw = False
-    for _cat, body in _sections(text):
-        norm_sha = hashlib.sha256(normalize_body_for_hash(body).encode()).hexdigest()
-        if f'"source_sha256":"{norm_sha}"' not in batch_text:
-            return False
-        saw = True
+    existing_keys = _existing_execution_issue_keys(batch_text)
+    for category, section in execution_issue_sections(text):
+        for body in _execution_issue_chunks(section):
+            redacted_body = _redact_batch_payload(body)
+            body_keys = _execution_issue_body_keys(category=category, body=redacted_body)
+            norm_sha = hashlib.sha256(normalize_body_for_hash(redacted_body).encode()).hexdigest()
+            if not body_keys <= existing_keys and f'"source_sha256":"{norm_sha}"' not in batch_text:
+                return False
+            saw = True
     return saw
 
 
 def write_execution_issues_records( *,input_file: str | Path, record_file: str | Path, sha: str, batch_path: str | Path | None = None, step_label: str = "18", source_label: str = "execution-issues.md safety-net") -> int:
     source = Path(input_file)
     batch_text = Path(batch_path).read_text(encoding="utf-8", errors="replace") if batch_path and Path(batch_path).is_file() else ""
-    records: list[str] = []
-    for category, body in _sections(source.read_text(encoding="utf-8", errors="replace")):
-        norm = normalize_body_for_hash(body)
-        norm_sha = hashlib.sha256(norm.encode()).hexdigest() if norm else sha
-        if norm_sha and f'"source_sha256":"{norm_sha}"' in batch_text:
-            continue
-        records.append(json.dumps({
-            "phase": "implement",
-            "step": step_label,
-            "category": category,
-            "source": source_label,
-            "source_sha256": norm_sha or sha,
-            "body": body,
-        }, separators=(",", ":")))
+    records = execution_issue_records(
+        text=source.read_text(encoding="utf-8", errors="replace"),
+        existing_batch=batch_text,
+        step_label=step_label,
+        source_label=source_label,
+        file_sha=sha,
+    )
     Path(record_file).write_text("\n".join(records) + ("\n" if records else ""), encoding="utf-8")
     return len(records)
 

--- a/python/larch/report/run_log_flush.py
+++ b/python/larch/report/run_log_flush.py
@@ -23,7 +23,7 @@ from larch.core.proc import CommandResult, Runner
 from larch.core.run_context import RunContext
 from larch.errors import ShipError
 from larch.git import pr_body
-from larch.report import exec_issue_detail
+from larch.issue import execution_issues
 from larch.report import final_report
 from larch.report import timing
 from larch.report import tokens
@@ -32,9 +32,7 @@ from larch.report.run_log_batch import (
     _REPO_ROOT,
     _append_execution_issue,
     _larch_sessions_scratch_dir,
-    _normalize_body_for_hash,
     _path_is_repo_related,
-    _redact_batch_payload,
     _read_kv_file,
     _read_state_kv,
     _write_batch,
@@ -122,96 +120,6 @@ def _should_flush_execution_issues(
     return batch_path.is_file()
 
 
-def _execution_issue_record(
-    *, body_lines: list[str],
-    category: str,
-    step_label: str,
-    source_label: str,
-    file_sha: str,
-    seen_keys: set[str],
-) -> str | None:
-    body = "\n".join(body_lines)
-    redacted_body = _redact_batch_payload(body)
-    body_keys = _execution_issue_body_keys(category=category, body=redacted_body)
-    if body_keys <= seen_keys:
-        return None
-    norm_sha = hashlib.sha256(
-        _normalize_body_for_hash(redacted_body).encode("utf-8"),
-    ).hexdigest()
-    payload = {
-        "phase": "implement",
-        "step": step_label,
-        "category": category,
-        "source": source_label,
-        "source_sha256": norm_sha or file_sha,
-        "body": redacted_body,
-    }
-    seen_keys.update(body_keys)
-    return json.dumps(payload, sort_keys=True)
-
-
-def _execution_issue_body_keys(*, category: str, body: str) -> set[str]:
-    return {f"{category}\0{key}" for key in exec_issue_detail.structured_body_dedupe_keys(body, category)}
-
-
-def _existing_execution_issue_keys(existing_batch: str) -> set[str]:
-    keys: set[str] = set()
-    for raw in existing_batch.splitlines():
-        try:
-            row: object = json.loads(raw)
-        except json.JSONDecodeError:
-            continue
-        if not isinstance(row, dict):
-            continue
-        row_dict = cast("dict[str, object]", row)
-        category = row_dict.get("category")
-        body = row_dict.get("body")
-        if isinstance(category, str) and isinstance(body, str):
-            keys.update(_execution_issue_body_keys(category=category, body=body))
-    return keys
-
-
-def _execution_issue_chunks(body_lines: list[str]) -> list[list[str]]:
-    chunks: list[list[str]] = []
-    current: list[str] = []
-    in_fence = False
-    for line in body_lines:
-        if line.lstrip().startswith("```"):
-            in_fence = not in_fence
-            current.append(line)
-            continue
-        if not in_fence and line.startswith("- ") and current:
-            if any(item.strip() for item in current):
-                chunks.append(current)
-            current = [line]
-            continue
-        current.append(line)
-    if any(item.strip() for item in current):
-        chunks.append(current)
-    return chunks
-
-
-def _append_execution_issue_records(
-    *,
-    records: list[str],
-    body_lines: list[str],
-    record_context: tuple[str, str, str, str],
-    seen_keys: set[str],
-) -> None:
-    category, step_label, source_label, file_sha = record_context
-    for chunk in _execution_issue_chunks(body_lines):
-        record = _execution_issue_record(
-            body_lines=chunk,
-            category=category,
-            step_label=step_label,
-            source_label=source_label,
-            file_sha=file_sha,
-            seen_keys=seen_keys,
-        )
-        if record is not None:
-            records.append(record)
-
-
 def _render_execution_issues_batch(
     *, ctx: RunContext,
     batch_dir: Path,
@@ -224,30 +132,13 @@ def _render_execution_issues_batch(
         return
     file_sha = hashlib.sha256(issue_log.read_bytes()).hexdigest()
     existing = batch_path.read_text(encoding="utf-8") if batch_path.is_file() else ""
-    seen_keys = _existing_execution_issue_keys(existing)
-    records: list[str] = []
-    current_cat = "Tool Failures"
-    body_lines: list[str] = []
-    for line in issue_log.read_text(encoding="utf-8").splitlines():
-        if line.startswith("### "):
-            if body_lines:
-                _append_execution_issue_records(
-                    records=records,
-                    body_lines=body_lines,
-                    record_context=(current_cat, step_label, source_label, file_sha),
-                    seen_keys=seen_keys,
-                )
-                body_lines = []
-            current_cat = line.removeprefix("### ")
-            continue
-        body_lines.append(line)
-    if body_lines:
-        _append_execution_issue_records(
-            records=records,
-            body_lines=body_lines,
-            record_context=(current_cat, step_label, source_label, file_sha),
-            seen_keys=seen_keys,
-        )
+    records = execution_issues.execution_issue_records(
+        text=issue_log.read_text(encoding="utf-8"),
+        existing_batch=existing,
+        step_label=step_label,
+        source_label=source_label,
+        file_sha=file_sha,
+    )
     if not records:
         return
     batch_path.parent.mkdir(parents=True, exist_ok=True)

--- a/python/larch/report/run_logs.py
+++ b/python/larch/report/run_logs.py
@@ -164,7 +164,6 @@ from larch.report.run_log_flush import (
     _capture_transcript_emit,
     _capture_transcript_redact_stderr,
     _check_preterminal_outcome_label,
-    _execution_issue_record,
     _load_refresh_session_env,
     _parse_preterminal_outcome_label,
     _parse_preterminal_outcome_label_from_run_dir,

--- a/python/tests/agents/test_agents.py
+++ b/python/tests/agents/test_agents.py
@@ -1224,6 +1224,18 @@ def test_compose_failure_diag_orders_failure_carriers(tmp_path: Path) -> None:
     assert carrier.index("===== sink =====") < carrier.index("===== sidecar =====") < carrier.index("===== diag =====")
 
 
+def test_compose_failure_diag_dedupes_identical_additional_diagnostics(tmp_path: Path) -> None:
+    output = tmp_path / "agent.out"
+    _ = output.with_suffix(output.suffix + ".diag").write_text("diag body\n", encoding="utf-8")
+
+    agents._compose_failure_diag(output)  # pylint: disable=protected-access
+    agents._compose_failure_diag(output)  # pylint: disable=protected-access
+
+    carrier = output.with_suffix(output.suffix + ".failure-diag").read_text(encoding="utf-8")
+    assert carrier.count("===== diag =====") == 1
+    assert "===== additional failure diagnostics =====" not in carrier
+
+
 def test_run_external_agent_missing_child_is_post_validation_failure(tmp_path: Path) -> None:
     output = tmp_path / "missing.out"
     result = agents.run_external_agent(

--- a/python/tests/issue/test_execution_issues.py
+++ b/python/tests/issue/test_execution_issues.py
@@ -6,6 +6,8 @@ from pathlib import Path
 import pytest
 
 from larch.issue import execution_issues
+from larch.report import run_log_flush
+from test_support import make_run_context
 
 
 def test_write_execution_issues_records_splits_sections(tmp_path: Path) -> None:
@@ -19,6 +21,45 @@ def test_write_execution_issues_records_splits_sections(tmp_path: Path) -> None:
     text = record_file.read_text(encoding="utf-8")
     assert '"category":"Tool Failures"' in text
     assert '"category":"Warnings"' in text
+
+
+def test_write_execution_issues_records_keeps_fenced_entry_intact(tmp_path: Path) -> None:
+    issue_log = tmp_path / "execution-issues.md"
+    _ = issue_log.write_text(
+        "### Warnings\n\n- **G-Py-11**: bare suppression\n- ```python\n- assert value  # noqa\n- ```\n",
+        encoding="utf-8",
+    )
+    record_file = tmp_path / "records.ndjson"
+
+    count = execution_issues.write_execution_issues_records(
+        input_file=issue_log,
+        record_file=record_file,
+        sha="abc",
+    )
+
+    records = [json.loads(line) for line in record_file.read_text(encoding="utf-8").splitlines()]
+    assert count == 1
+    assert records[0]["body"] == "- **G-Py-11**: bare suppression\n- ```python\n- assert value  # noqa\n- ```\n"
+
+
+def test_write_execution_issues_records_accepts_freeform_warning_heading(tmp_path: Path) -> None:
+    issue_log = tmp_path / "execution-issues.md"
+    _ = issue_log.write_text(
+        "# Execution Issues\n\n## Warnings\n- self-review complete\n\n---\n",
+        encoding="utf-8",
+    )
+    record_file = tmp_path / "records.ndjson"
+
+    count = execution_issues.write_execution_issues_records(
+        input_file=issue_log,
+        record_file=record_file,
+        sha="abc",
+    )
+
+    records = [json.loads(line) for line in record_file.read_text(encoding="utf-8").splitlines()]
+    assert count == 1
+    assert records[0]["category"] == "Warnings"
+    assert records[0]["body"] == "- self-review complete\n"
 
 
 def test_append_execution_issue_idempotent(tmp_path: Path) -> None:
@@ -118,8 +159,8 @@ def test_flush_execution_issues_writes_single_record_with_flush_metadata(
         "step": "7a",
         "category": "Tool Failures",
         "source": "execution-issues.md pre-bump",
-        "source_sha256": hashlib.sha256(b"- tool failed once\n").hexdigest(),
-        "body": "\n- tool failed once\n",
+        "source_sha256": hashlib.sha256(b"- tool failed once").hexdigest(),
+        "body": "- tool failed once\n",
     }
     assert issue_log.read_text(encoding="utf-8") == ""
 
@@ -293,6 +334,39 @@ def test_flush_execution_issues_safety_net_preserves_source_log(tmp_path: Path) 
     assert status in {"ok", "no-records"}
     assert records >= 0
     assert issue_log.read_text(encoding="utf-8") == "### Warnings\n- one\n"
+
+
+def test_safety_net_dedupes_records_written_by_pre_push_flusher(tmp_path: Path) -> None:
+    issue_log = tmp_path / "execution-issues.md"
+    _ = issue_log.write_text("### Warnings\n\n- shared warning\n", encoding="utf-8")
+    log_root = (tmp_path / "larch-logs").resolve()
+    batch_dir = log_root / "implement" / "run-shared"
+    batch_dir.mkdir(parents=True)
+    state = tmp_path / "state.env"
+    _ = state.write_text("RUN_ID=run-shared\n", encoding="utf-8")
+
+    ctx = make_run_context(
+        run_id="run-shared",
+        tmpdir=str(tmp_path),
+        manifest_path=str(tmp_path / "manifest.json"),
+        state_file=str(state),
+    )
+    _ = (tmp_path / ".execution-issues-step7a-reached").write_text("", encoding="utf-8")
+    run_log_flush._render_execution_issues_batch(  # pyright: ignore[reportPrivateUsage]
+        ctx=ctx,
+        batch_dir=batch_dir,
+        step_label="pre-push",
+        source_label="test",
+    )
+
+    rc, status, records, _append_log = execution_issues.flush_execution_issues_safety_net(
+        log_root=log_root,
+        run_id="run-shared",
+        issue_log=issue_log,
+    )
+
+    assert (rc, status, records) == (0, "no-records", 0)
+    assert len((batch_dir / "execution-issues.ndjson").read_text(encoding="utf-8").splitlines()) == 1
 
 
 def test_flush_execution_issues_safety_net_append_failure_preserves_source_log(


### PR DESCRIPTION
## Summary

- Share execution-issue parsing, record construction, and deduplication across every flusher.
- Keep fenced warning entries intact and classify freeform `## Warnings` content correctly.
- Skip duplicate vendor diagnostic payloads.

Closes #7312

## Tests

- `make py-lint`
- `python3 -m pytest python/tests/issue/test_execution_issues.py python/tests/report/test_run_logs.py -q`
- `python3 -m pytest python/tests/core/test_architectural_guidelines.py -k 'append_deviation_note' -q`
- `python3 -m pytest python/tests/report/test_exec_issue_detail.py -q`
- `python3 -m pytest python/tests/agents/test_agents.py::test_compose_failure_diag_orders_failure_carriers python/tests/agents/test_agents.py::test_compose_failure_diag_dedupes_identical_additional_diagnostics -q`
