### PR TITLE
Release v53.1.5

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "53.1.4",
+  "version": "53.1.5",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Added

- `/analyze-bugs`: wire sweep stages, merge reports, and commit fail-closed state (#7338)

## Changed

- Migrate drafter and negotiation launchers (#7327)
- Pre-ship lint-fix waterfall exhaustion escalates to main-agent handoff (#7329)
- Add complexity debt gate, writer, report, tests, and docs (#7333)
- Migrate execution-issues flush test harness (#7331)

## Fixed

- Guideline-debt sweep: fence-scanner reuse, RECONCILE_STATUS constants, codex-gate signal typing, and issue-close read-back (#7330)
- Execution-issues flush records (#7334)
