### PR TITLE
[DONE] Recover /design split-child failures

### DIFF
--- a/python/larch/design/decompose.py
+++ b/python/larch/design/decompose.py
@@ -419,6 +419,7 @@ def prepare_partition_issues(
     feat_path = design_tmpdir / "feature-description.txt"
     feat = feat_path.read_text(encoding="utf-8") if feat_path.is_file() else ""
     feat = _neutralize_markdown_h3_line_starts(feat)
+    feat = issue_wire.neutralize_named_block_markers(text=feat, marker="plan")
     orig = f"#{issue_number}" if issue_number.isdigit() else "(original issue — set ISSUE_NUMBER in session)"
     original_title = _route_state_value(design_tmpdir, "ISSUE_TITLE")
     lines: list[str] = []
@@ -441,13 +442,16 @@ def prepare_partition_issues(
             f"**Acceptance**:\n\n{acceptance_text}\n\n"
             f"**Dependencies (from proposal)**: {dep_lines[i]}\n\n"
             "```\n"
-            + issue_wire.compose_named_block(
-                marker="plan",
-                inner=(
-                    "## Plan\n\n"
-                    "(needs /design — operator runs `/design` on this filed piece "
-                    "and reaches Gate C approval before `[DESIGNED]` or `/implement`.)\n"
+            + issue_wire.neutralize_named_block_markers(
+                text=issue_wire.compose_named_block(
+                    marker="plan",
+                    inner=(
+                        "## Plan\n\n"
+                        "(needs /design — operator runs `/design` on this filed piece "
+                        "and reaches Gate C approval before `[DESIGNED]` or `/implement`.)\n"
+                    ),
                 ),
+                marker="plan",
             )
             + "```\n\n"
             f"**Original feature context (excerpt)**:\n\n{feat[:4000]}\n"

--- a/python/larch/design/design_publish.py
+++ b/python/larch/design/design_publish.py
@@ -17,6 +17,8 @@ from larch.calibration import difficulty
 from larch.core import architectural_guidelines, config, proc
 from larch.report import run_logs
 from larch.design import design_step0_env, plan_grammar
+from larch.design.design_core import capture_contract_stream_to_paths
+from larch.design.design_terminal import stage_terminal_state_core
 from larch.git.repo_roots import consumer_repo_root
 
 
@@ -901,6 +903,92 @@ def _run_log_publish_after_capture(
     return None
 
 
+def _stage_failed_plan_write(
+    *,
+    design_tmpdir: Path,
+    kvs: list[tuple[str, str]],
+) -> None:
+    """Stage the terminal state before failure reporting and run-log publication."""
+    detail_log = design_tmpdir / "design-plan-write.failure.log"
+    if not detail_log.is_file():
+        _ = detail_log.write_text("named-block write failed\n", encoding="utf-8")
+    stdout_log = design_tmpdir / "design-plan-write-stage.stdout.log"
+    stderr_log = design_tmpdir / "design-plan-write-stage.stderr.log"
+    values = dict(kvs)
+    stage_args = [
+        "--design-tmpdir",
+        str(design_tmpdir),
+        "--outcome",
+        "failed-plan-write",
+        "--step",
+        "step5c",
+        "--phase",
+        "plan-write",
+        "--site",
+        "design-publish",
+        "--trigger",
+        "plan-write-failed",
+        "--bail-reason",
+        "plan-write-failed",
+        "--exit-code",
+        "1",
+        "--source-script",
+        "design-publish",
+        "--summary-outcome",
+        "failed-plan-write",
+        "--failure-detail-log",
+        str(detail_log),
+    ]
+    for flag, key in (
+        ("--publish-attempt-id", "PUBLISH_ATTEMPT_ID"),
+        ("--publish-rc-source", "PUBLISH_RC_SOURCE"),
+        ("--latest-phase", "LATEST_PHASE"),
+        ("--plan-write-ok", "PLAN_WRITE_OK"),
+        ("--publish-ok", "PUBLISH_OK"),
+        ("--renamed", "RENAMED"),
+        ("--log-publish-attempted", "LOG_PUBLISH_ATTEMPTED"),
+        ("--log-publish-completed", "LOG_PUBLISH_COMPLETED"),
+        ("--designed-admission-ready", "DESIGNED_ADMISSION_READY"),
+        ("--pr-url", "PR_URL"),
+        ("--recovery-branch", "RECOVERY_BRANCH"),
+    ):
+        if values.get(key, ""):
+            stage_args.extend([flag, values[key]])
+    stage_rc = capture_contract_stream_to_paths(
+        stage_terminal_state_core,
+        stdout_log,
+        stderr_log,
+        stage_args,
+    )
+    staged = "STAGED=true" in stdout_log.read_text(encoding="utf-8", errors="replace") if stdout_log.is_file() else False
+    if stage_rc != 0 or not staged:
+        run_logs.append_execution_issue(
+            log_file=design_tmpdir / "execution-issues.md",
+            category="Warnings",
+            entry="design Step 5c plan-write terminal-state staging failed; failure report may be unavailable.",
+        )
+
+
+def _finalize_failed_plan_write(
+    *,
+    design_tmpdir: Path,
+    transcript_capture: _TranscriptCaptureContext | None,
+    kvs: list[tuple[str, str]],
+    result_env: Path,
+) -> int:
+    _stage_failed_plan_write(design_tmpdir=design_tmpdir, kvs=kvs)
+    if transcript_capture is not None:
+        _ = _run_log_publish_after_capture(
+            ctx=transcript_capture,
+            kvs=kvs,
+            result_env=result_env,
+            outcome="failed-plan-write",
+            write_result_env_on_publish_failure=False,
+        )
+    _emit_rows(kvs)
+    return 1 if _write_result_env(path=result_env, rows=kvs) else 3
+
+
 def publish_core(argv: Sequence[str]) -> int:
     args = list(argv)
     parsed = {
@@ -1161,24 +1249,25 @@ def publish_core(argv: Sequence[str]) -> int:
         check=False,
     )
     if block.returncode != 0:
-        if parsed["--session-id"]:
-            _ = _run_log_publish_after_capture(
-                ctx=_TranscriptCaptureContext(
-                    design_tmpdir=design_tmpdir,
-                    plugin_root=plugin_root,
-                    session_id=parsed["--session-id"],
-                    issue=parsed["--issue"],
-                    repo=parsed["--repo"],
-                    claude_pid=parsed["--claude-pid"],
-                    warning_step_label="5c",
-                ),
-                kvs=kvs,
-                result_env=result_env,
-                outcome="failed-plan-write",
-                write_result_env_on_publish_failure=False,
+        transcript_capture = (
+            _TranscriptCaptureContext(
+                design_tmpdir=design_tmpdir,
+                plugin_root=plugin_root,
+                session_id=parsed["--session-id"],
+                issue=parsed["--issue"],
+                repo=parsed["--repo"],
+                claude_pid=parsed["--claude-pid"],
+                warning_step_label="5c",
             )
-        _emit_rows(kvs)
-        return 1 if _write_result_env(path=result_env, rows=kvs) else 3
+            if parsed["--session-id"]
+            else None
+        )
+        return _finalize_failed_plan_write(
+            design_tmpdir=design_tmpdir,
+            transcript_capture=transcript_capture,
+            kvs=kvs,
+            result_env=result_env,
+        )
     _replace_kv(rows=kvs, key="PLAN_WRITE_OK", value="true")
     _checkpoint_result_env(path=result_env, rows=kvs, phase="plan-write")
     if design_rating is not None:

--- a/python/larch/design/design_summary.py
+++ b/python/larch/design/design_summary.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import cast
 
+from larch import io as larch_io
 from larch.calibration import difficulty
 from larch.core import architectural_guidelines, redact
 from larch.report import exec_issue_detail
@@ -170,6 +171,22 @@ def _build_cost_args(buckets: dict[str, int]) -> list[str]:
         if key in buckets:
             args += [flag, str(buckets[key])]
     return args
+
+
+def _published_run_logs_path(*, design_tmpdir: Path, run_id: str) -> str:
+    """Return a run-log link only after the publisher recorded completion."""
+    if not run_id or run_id == "unknown":
+        return "N/A"
+    result_env = design_tmpdir / ".design-publish-result.env"
+    if not result_env.is_file() or result_env.is_symlink():
+        return "N/A"
+    try:
+        values = larch_io.parse_kv(result_env.read_text(encoding="utf-8", errors="replace"))
+    except (OSError, ValueError):
+        return "N/A"
+    if values.get("LOG_PUBLISH_COMPLETED") != "true":
+        return "N/A"
+    return f"larch-logs/design/{run_id}/"
 
 
 def _duration(design_tmpdir: Path) -> str:
@@ -768,7 +785,7 @@ def render_final_summary_main(argv: Sequence[str]) -> int:
     cost_args = _build_cost_args(buckets)
     duration = _duration(design_tmpdir)
     oos_count, oos_urls = _oos_info(design_tmpdir)
-    run_logs_path = f"larch-logs/design/{run_id}/" if run_id and run_id != "unknown" else "N/A"
+    run_logs_path = _published_run_logs_path(design_tmpdir=design_tmpdir, run_id=run_id)
     out_file = design_tmpdir / "final-summary.md"
     _run_design_failure_report_gate(design_tmpdir=design_tmpdir, phase=phase, outcome=outcome, repo=repo, issue=issue, run_id=run_id)
     load_result = exec_issue_detail.load_issue_detail_groups(design_tmpdir, run_dir=None)

--- a/python/larch/design/design_terminal.py
+++ b/python/larch/design/design_terminal.py
@@ -324,7 +324,7 @@ def stage_terminal_state_core(argv: Sequence[str]) -> tuple[int, list[str]]:
                 ],
             )
             if rc != 0:
-                raise _CoreUsageError(f"{kind} is not a valid token")
+                raise _CoreUsageError(f"{kind} is not a valid token: {value}")
         for kind, value in (("root-cause", ns.root_cause_hint), ("outcome", ns.summary_outcome)):
             if not value:
                 continue
@@ -339,7 +339,7 @@ def stage_terminal_state_core(argv: Sequence[str]) -> tuple[int, list[str]]:
                 ],
             )
             if rc != 0:
-                raise _CoreUsageError(f"{kind} is not a valid token")
+                raise _CoreUsageError(f"{kind} is not a valid token: {value}")
         if ns.exit_code != "unknown" and not ns.exit_code.isdigit():
             raise _CoreUsageError("--exit-code must be an integer or unknown")
         _safe_failure_detail_log(raw=ns.failure_detail_log, design_tmpdir=design_tmpdir)

--- a/python/larch/issue/issue_wire.py
+++ b/python/larch/issue/issue_wire.py
@@ -77,8 +77,17 @@ class _BlockSpan:
 
 
 def _classify_named_block_lines(*, lines: Sequence[str], marker: str) -> _BlockSpan:
-    start_indexes: list[int] = [idx for idx, line in enumerate(lines) if _line_is_marker(line=line, marker=marker, kind="start")]
-    end_indexes: list[int] = [idx for idx, line in enumerate(lines) if _line_is_marker(line=line, marker=marker, kind="end")]
+    fenced_lines = plan_grammar.balanced_fence_line_indices(list(lines))
+    start_indexes: list[int] = [
+        idx
+        for idx, line in enumerate(lines)
+        if idx not in fenced_lines and _line_is_marker(line=line, marker=marker, kind="start")
+    ]
+    end_indexes: list[int] = [
+        idx
+        for idx, line in enumerate(lines)
+        if idx not in fenced_lines and _line_is_marker(line=line, marker=marker, kind="end")
+    ]
     if not start_indexes and not end_indexes:
         return _BlockSpan(None, None, "")
     if len(start_indexes) > 1:
@@ -124,6 +133,18 @@ def compose_named_block(*, marker: str, inner: str) -> str:
     if stripped:
         block += stripped + "\n"
     return block + f"<!-- larch:{marker}:end -->\n"
+
+
+def neutralize_named_block_markers(*, text: str, marker: str) -> str:
+    """Render named-block marker examples inert before embedding them in prose."""
+    if marker not in _ALLOWED_MARKERS:
+        msg = f"unsupported marker: {marker}"
+        raise ValueError(msg)
+    pattern = re.compile(
+        rf"(^[ \t]*)<!--[ \t]+larch:{re.escape(marker)}:(?:start|end)[ \t]+-->[ \t]*$",
+        re.MULTILINE,
+    )
+    return pattern.sub(lambda match: match.group(0).replace("<!--", "<!--\u200b", 1), text)
 
 
 def _single_line_redacted(text: str) -> str:

--- a/python/larch/review/plan_review_normalize.py
+++ b/python/larch/review/plan_review_normalize.py
@@ -621,6 +621,9 @@ def stage_panel_init_failed(*, design_tmpdir: str | Path, trigger: str = "panel-
     sentinel = tmpdir / ".step3-panel-init-terminal-state.recorded"
     if sentinel.exists() or sentinel.is_symlink():
         return 0
+    evidence_ref = "prelaunch-" + re.sub(r"[^A-Za-z0-9_-]+", "-", trigger).strip("-")
+    if evidence_ref == "prelaunch-":
+        evidence_ref = "prelaunch-unknown"
     stdout = tmpdir / "step3-panel-init-terminal-state.stdout.log"
     stderr = tmpdir / "step3-panel-init-terminal-state.stderr.log"
     rc = capture_contract_stream_to_paths(
@@ -639,15 +642,17 @@ def stage_panel_init_failed(*, design_tmpdir: str | Path, trigger: str = "panel-
             "--site",
             "step3-review",
             "--trigger",
-            trigger,
+            "panel-init-failed",
             "--bail-reason",
-            trigger,
+            "panel-init-failed",
             "--exit-code",
             "1",
             "--source-script",
             "design-step3-review",
             "--summary-outcome",
             "failed-judge-panel",
+            "--evidence-ref",
+            evidence_ref,
         ],
     )
     if rc == 0:

--- a/python/tests/design/test_decompose.py
+++ b/python/tests/design/test_decompose.py
@@ -139,10 +139,34 @@ def test_prepare_plan_stub_delegates_to_compose_named_block(
         inner=expected_inner,
     )
     batch = (d / "decompose" / "partition-input.txt").read_text(encoding="utf-8")
-    assert f"```\n{expected_block}```\n" in batch
+    expected_example = issue_wire.neutralize_named_block_markers(text=expected_block, marker="plan")
+    assert f"```\n{expected_example}```\n" in batch
     assert "(needs /design — operator runs `/design` on this filed piece" in batch
     assert expected_block.endswith("<!-- larch:plan:end -->\n")
     assert "\n\n<!-- larch:plan:end -->" not in expected_block
+
+
+def test_prepare_second_generation_child_has_no_live_plan_markers(tmp_path: Path) -> None:
+    d = _design_tmp(tmp_path)
+    parent_plan = issue_wire.compose_named_block(marker="plan", inner="parent plan")
+    (d / "feature-description.txt").write_text(
+        "Child context\n\n```\n" + parent_plan + "```\n",
+        encoding="utf-8",
+    )
+    partition = d / "partition.md"
+    partition.write_text(
+        "## Pieces\n\n"
+        "### Piece 1: Base\n- Scope: base\n- Firm-headings: base/file.py\n"
+        "- Acceptance: verify base\n- Dependencies: none\n\n"
+        "### Piece 2: API\n- Scope: api\n- Firm-headings: api/file.py\n"
+        "- Acceptance: verify api\n- Dependencies: none\n",
+        encoding="utf-8",
+    )
+    status, witness = decompose.prepare_partition_issues(design_tmpdir=d, partition_file=partition, issue_number="123")
+    assert (status, witness) == ("ok", "")
+    batch = (d / "decompose" / "partition-input.txt").read_text(encoding="utf-8")
+    assert issue_wire.parse_named_block(body=batch, marker="plan") == (None, "")
+    assert "<!--\u200b larch:plan:start -->" in batch
 
 
 def test_prepare_rejects_duplicate_declared_dependency(tmp_path: Path) -> None:

--- a/python/tests/design/test_design_lifecycle.py
+++ b/python/tests/design/test_design_lifecycle.py
@@ -3349,6 +3349,19 @@ def _panel_init_stage_args(design: Path, detail_log: Path) -> list[str]:
     ]
 
 
+def test_stage_failed_plan_write_records_terminal_state_before_failure_report(tmp_path: Path) -> None:
+    design = tmp_path / "design"
+    design.mkdir()
+    design_publish._stage_failed_plan_write(  # pyright: ignore[reportPrivateUsage]
+        design_tmpdir=design,
+        kvs=[("PLAN_WRITE_OK", "false"), ("PUBLISH_ATTEMPT_ID", "attempt-1")],
+    )
+    state = (design / "design-failure-terminal-state.env").read_text(encoding="utf-8")
+    assert "FAILURE_OUTCOME=failed-plan-write" in state
+    assert "TRIGGER=plan-write-failed" in state
+    assert "SUMMARY_OUTCOME=failed-plan-write" in state
+
+
 def _stage_terminal_for_report(tmp_path: Path, outcome: str = "failed-clarify") -> None:
     rc, _ = design_lifecycle.stage_terminal_state_core(_stage_args(tmp_path, "--outcome", outcome, "--summary-outcome", outcome))
     assert rc == 0

--- a/python/tests/design/test_design_summary.py
+++ b/python/tests/design/test_design_summary.py
@@ -752,6 +752,15 @@ def test_render_final_summary_empty_identity_argv_does_not_fallback_to_ambient_e
     assert render_args[render_args.index("--run-logs-path") + 1] == "N/A"
 
 
+def test_published_run_logs_path_requires_completed_log_publication(tmp_path: Path) -> None:
+    assert design_summary._published_run_logs_path(design_tmpdir=tmp_path, run_id="run-1") == "N/A"  # pyright: ignore[reportPrivateUsage]
+    result = tmp_path / ".design-publish-result.env"
+    _ = result.write_text("LOG_PUBLISH_COMPLETED=false\n", encoding="utf-8")
+    assert design_summary._published_run_logs_path(design_tmpdir=tmp_path, run_id="run-1") == "N/A"  # pyright: ignore[reportPrivateUsage]
+    _ = result.write_text("LOG_PUBLISH_COMPLETED=true\n", encoding="utf-8")
+    assert design_summary._published_run_logs_path(design_tmpdir=tmp_path, run_id="run-1") == "larch-logs/design/run-1/"  # pyright: ignore[reportPrivateUsage]
+
+
 def test_render_final_summary_redacts_spliced_detail(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/python/tests/issue/test_issue_wire.py
+++ b/python/tests/issue/test_issue_wire.py
@@ -51,6 +51,27 @@ after
     assert issue_wire.parse_named_block(body=body, marker="other") == (None, "")
 
 
+def test_parse_named_block_ignores_marker_examples_inside_fences() -> None:
+    body = (
+        "```\n"
+        "<!-- larch:plan:start -->\n"
+        "example\n"
+        "<!-- larch:plan:end -->\n"
+        "```\n\n"
+        "<!-- larch:plan:start -->\n"
+        "live plan\n"
+        "<!-- larch:plan:end -->\n"
+    )
+    assert issue_wire.parse_named_block(body=body, marker="plan") == ("live plan\n", "")
+
+
+def test_neutralize_named_block_markers_keeps_examples_out_of_wire_parser() -> None:
+    example = issue_wire.compose_named_block(marker="plan", inner="example")
+    neutralized = issue_wire.neutralize_named_block_markers(text=example, marker="plan")
+    assert "<!--\u200b larch:plan:start -->" in neutralized
+    assert issue_wire.parse_named_block(body=neutralized, marker="plan") == (None, "")
+
+
 @pytest.mark.parametrize(
     ("body", "token"),
     [

--- a/python/tests/review/test_plan_review.py
+++ b/python/tests/review/test_plan_review.py
@@ -551,6 +551,25 @@ def test_step3_normalizer_static_contract_pins() -> None:
     assert "_step3_next_action" in body
     assert "file=sys.stderr" in body
 
+
+@pytest.mark.parametrize(
+    ("reason", "evidence_ref"),
+    [
+        ("strip-body-failure", "prelaunch-strip-body-failure"),
+        ("scope-anchor-empty", "prelaunch-scope-anchor-empty"),
+        ("snapshot-pre-review-failure", "prelaunch-snapshot-pre-review-failure"),
+        ("unexpected reason", "prelaunch-unexpected-reason"),
+    ],
+)
+def test_stage_panel_init_failed_records_canonical_tokens_for_prelaunch_reason(
+    tmp_path: Path, reason: str, evidence_ref: str
+) -> None:
+    assert plan_review_normalize.stage_panel_init_failed(design_tmpdir=tmp_path, trigger=reason) == 0
+    state = (tmp_path / "design-failure-terminal-state.env").read_text(encoding="utf-8")
+    assert "TRIGGER=panel-init-failed" in state
+    assert "BAIL_REASON=panel-init-failed" in state
+    assert f"EVIDENCE_REF={evidence_ref}" in state
+
 def test_step3_loop_persist_envelope_merges_and_strips_reason(tmp_path: Path) -> None:
     _ = (tmp_path / ".step3-review-result.env").write_text(
         "TALLY_PLAN_REVIEW_STATUS=ok\nAGGREGATOR_STATUS=ok\nPLAN_REVIEW_CONTINUE_REASON=again\r\n",


### PR DESCRIPTION
Fixes #7337

## Summary

- Keep split-child plan-marker examples inert and ignore fenced examples in the named-block parser.
- Stage canonical Step 3 and failed-plan-write terminal states so the failure reporter can file its report.
- Show a design run-log link only after run-log publication has completed.

## Verification

- `pre-commit run --files` for all changed Python files
- Focused pytest coverage for issue wire handling, decomposition, plan review, design lifecycle, and final-summary rendering
