### PR TITLE
Fixes #7306: Implement report typed APIs

### DIFF
--- a/python/larch/report/final_report.py
+++ b/python/larch/report/final_report.py
@@ -425,7 +425,7 @@ def _issue_load_result_for_run(
     return run_dir, load_result, exec_count, warn_count
 
 
-def _merge_line_count_state(*, ship: Path, pr_number: str, lines: Mapping[str, object]) -> None:
+def _merge_line_count_state(*, ship: Path, pr_number: str, lines: tokens.PrLineCountResult) -> None:
     if not ship.is_file() or ship.is_symlink() or not os.access(ship, os.W_OK):
         return
     preserved: list[str] = []
@@ -437,7 +437,7 @@ def _merge_line_count_state(*, ship: Path, pr_number: str, lines: Mapping[str, o
     tmp.write_text(
         "".join(f"{line}\n" for line in preserved)
         + f"LINES_PR_NUMBER={pr_number or '0'}\n"
-        + "".join(f"{key}={lines[key]}\n" for key in ("LINES_STATUS", "CODE_ADDED", "CODE_DELETED", "LOGS_ADDED", "LOGS_DELETED") if key in lines),
+        + "".join(f"{key}={value}\n" for key, value in lines.kv_items() if key != "REASON"),
         encoding="utf-8",
     )
     tmp.replace(ship)
@@ -452,14 +452,14 @@ def _derive_pr_line_counts(*, repo: str, repo_unavailable: bool, pr_number: str,
         if all(value.isdigit() for value in (ca, cd, la, ld)):
             return ca, cd, la, ld
     result = tokens.compute_pr_line_counts(pr_number=int(pr_number), repo=repo or None)
-    if result.get("LINES_STATUS") == "ok":
+    if result.status == "ok":
         with contextlib.suppress(OSError):
             _merge_line_count_state(ship=ship, pr_number=pr_number, lines=result)
         return (
-            str(result.get("CODE_ADDED", "")),
-            str(result.get("CODE_DELETED", "")),
-            str(result.get("LOGS_ADDED", "")),
-            str(result.get("LOGS_DELETED", "")),
+            str(result.code_added),
+            str(result.code_deleted),
+            str(result.logs_added),
+            str(result.logs_deleted),
         )
     return "", "", "", ""
 

--- a/python/larch/report/progress_file.py
+++ b/python/larch/report/progress_file.py
@@ -13,6 +13,7 @@ import stat
 import sys
 import time
 import uuid
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Final
 
@@ -33,6 +34,14 @@ _C1_CONTROL_MIN = 0x80
 _C1_CONTROL_MAX = 0x9F
 _RUN_ID_PATTERN: Final[re.Pattern[str]] = re.compile(r"[A-Za-z0-9._-]{1,128}")
 _CLONE_HASH_PATTERN: Final[re.Pattern[str]] = re.compile(r"[0-9a-f]{16}")
+
+
+@dataclass(frozen=True)
+class PersistedRunResult:
+    """Session-owned run identity recovered from persisted environment files."""
+
+    run_id: str | None
+    repo_root: Path | None
 
 
 def _cache_home() -> Path:
@@ -129,6 +138,14 @@ def resolve_persisted_repo_root(*, tmpdir: str | Path) -> Path | None:
                         with contextlib.suppress(OSError):
                             return candidate.resolve()
     return None
+
+
+def resolve_persisted_run(*, tmpdir: str | Path, env: dict[str, str] | None = None) -> PersistedRunResult:
+    """Resolve the persisted run ID and consumer root without using an active pointer."""
+    return PersistedRunResult(
+        run_id=resolve_owned_run_id(tmpdir=tmpdir, env=env),
+        repo_root=resolve_persisted_repo_root(tmpdir=tmpdir),
+    )
 
 
 def progress_clone_dir(repo_root: str | Path) -> Path:

--- a/python/larch/report/statusline_install.py
+++ b/python/larch/report/statusline_install.py
@@ -7,6 +7,7 @@ import json
 import os
 import shlex
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
 
@@ -16,6 +17,17 @@ from larch.git.repo_roots import consumer_repo_root
 ENV_CLAUDE_PLUGIN_ROOT = "CLAUDE_PLUGIN_ROOT"
 LOCAL_SETTINGS = Path(".claude") / "settings.local.json"
 LARCH_COMMAND_MARKER = ".cache/larch/statusline.sh"
+
+
+@dataclass(frozen=True)
+class StatuslineInstallResult:
+    """Outcome of an attempted statusline installation."""
+
+    installed: bool
+    reason: str = ""
+
+    def __bool__(self) -> bool:
+        return self.installed
 
 
 def _launcher_path() -> Path:
@@ -118,9 +130,9 @@ def _safe_existing_file(path: Path) -> bool:
     return not path.exists() or (path.is_file() and not path.is_symlink())
 
 
-def install_statusline(*, repo_root: Path, plugin_root: Path, notice: bool = False) -> bool:
+def install_statusline(*, repo_root: Path, plugin_root: Path, notice: bool = False) -> StatuslineInstallResult:
     if os.environ.get("LARCH_STATUSLINE_DISABLE") == "1":
-        return False
+        return StatuslineInstallResult(installed=False, reason="disabled")
     try:
         repo = consumer_repo_root(repo_root.expanduser()) or repo_root.expanduser().resolve()
         plugin = plugin_root.expanduser().resolve()
@@ -130,7 +142,7 @@ def install_statusline(*, repo_root: Path, plugin_root: Path, notice: bool = Fal
         notice_sentinel = _notice_sentinel()
         larch_io.assert_no_symlink_path_or_ancestors(launcher)
         if not _safe_existing_file(settings_path) or not _safe_existing_file(launcher):
-            return False
+            return StatuslineInstallResult(installed=False, reason="unsafe-path")
         user_command = _read_user_statusline()
         larch_io.atomic_write(
             path=launcher,
@@ -140,10 +152,10 @@ def install_statusline(*, repo_root: Path, plugin_root: Path, notice: bool = Fal
         )
         settings = _read_json_object(settings_path)
         if settings is None:
-            return False
+            return StatuslineInstallResult(installed=False, reason="invalid-settings")
         current = _statusline_command(settings)
         if current and LARCH_COMMAND_MARKER not in current and "progress statusline" not in current:
-            return False
+            return StatuslineInstallResult(installed=False, reason="custom-statusline")
         first_install = not current
         settings["statusLine"] = {"type": "command", "command": str(launcher), "refreshInterval": 2}
         rendered = json.dumps(settings, indent=2, sort_keys=True) + "\n"
@@ -151,9 +163,9 @@ def install_statusline(*, repo_root: Path, plugin_root: Path, notice: bool = Fal
         if notice and first_install and not notice_sentinel.exists():
             larch_io.atomic_write(path=notice_sentinel, text="installed\n", nofollow=True, mode=0o600)
             print("larch: installed progress statusline (set LARCH_STATUSLINE_DISABLE=1 to opt out)")
-        return True
+        return StatuslineInstallResult(installed=True)
     except (OSError, TypeError, ValueError):
-        return False
+        return StatuslineInstallResult(installed=False, reason="write-failed")
 
 
 def install_statusline_main(argv: list[str] | None = None) -> int:

--- a/python/larch/report/timing.py
+++ b/python/larch/report/timing.py
@@ -12,7 +12,7 @@ import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, Literal, cast
 from collections.abc import Mapping
 
 from larch.core import config as _larch_config
@@ -49,6 +49,67 @@ TIMING_VENDOR_MIN_COLS = 13
 TIMING_LOCK_TIMEOUT_S = 5.0
 TIMING_VENDORS_ALLOWED: frozenset[str] = frozenset({"codex", "cursor", "claude"})
 _TASK_KIND_RE = re.compile(r"^[a-z][a-z0-9-]{0,63}$")
+
+
+@dataclass(frozen=True)
+class TimingMarkResult:
+    """Outcome of a timing step mark."""
+
+    ledger_path: Path | None
+    marked: bool
+
+
+@dataclass(frozen=True)
+class VendorTaskRequest:
+    """Inputs for recording one vendor task in a timing ledger."""
+
+    vendor: str
+    task_kind: str
+    start_s: float
+    end_s: float
+    output: str
+    exit_code: int = 0
+    status: str = "complete"
+    skill: str = "implement"
+
+
+@dataclass(frozen=True)
+class VendorTaskResult:
+    """Outcome of writing a vendor-task timing row."""
+
+    ledger_path: Path | None
+    recorded: bool
+
+
+@dataclass(frozen=True)
+class RoundRequest:
+    """Inputs for recording one timing review round."""
+
+    skill: str
+    step: str
+    round_n: int
+    start_s: float
+    end_s: float
+    accepted: int
+    rejected: int
+    oos: int | None = None
+
+
+@dataclass(frozen=True)
+class RoundResult:
+    """Outcome of writing a timing round row."""
+
+    ledger_path: Path | None
+    recorded: bool
+
+
+@dataclass(frozen=True)
+class TimingReportResult:
+    """Rendered timing report and its ledger availability."""
+
+    ledger_path: Path | None
+    rendered: str | None
+    status: Literal["rendered", "unavailable"]
 
 
 @dataclass(frozen=True)
@@ -367,6 +428,88 @@ def resolve_timing_ledger_path(*, ledger: str | None = None, env: Mapping[str, s
     return None
 
 
+def mark(
+    *,
+    label: str,
+    ledger: str | None = None,
+    skill: str = "implement",
+    if_latest_differs: bool = False,
+    env: Mapping[str, str] | None = None,
+) -> TimingMarkResult:
+    """Record a timing mark, optionally suppressing a duplicate latest label."""
+    path = resolve_timing_ledger_path(ledger=ledger, env=env)
+    if path is None:
+        return TimingMarkResult(ledger_path=None, marked=False)
+    if if_latest_differs:
+        skill_marks = [item for item in _parse_rows(path)[0] if item.skill == skill]
+        if skill_marks and skill_marks[-1].step == label:
+            return TimingMarkResult(ledger_path=path, marked=False)
+    TimingLedger(path, skill=skill).mark(label)
+    return TimingMarkResult(ledger_path=path, marked=True)
+
+
+def record_vendor_task(
+    *,
+    request: VendorTaskRequest,
+    ledger: str | None = None,
+    env: Mapping[str, str] | None = None,
+) -> VendorTaskResult:
+    """Record one vendor task, or return a typed skipped-ledger outcome."""
+    path = resolve_timing_ledger_path(ledger=ledger, env=env)
+    if path is None:
+        return VendorTaskResult(ledger_path=None, recorded=False)
+    TimingLedger(path, skill=request.skill).record_vendor_task(
+        vendor=request.vendor,
+        task_kind=request.task_kind,
+        start_s=request.start_s,
+        end_s=request.end_s,
+        output=request.output,
+        exit_code=request.exit_code,
+        status=request.status,
+    )
+    return VendorTaskResult(ledger_path=path, recorded=True)
+
+
+def record_round(
+    *,
+    request: RoundRequest,
+    ledger: str | None = None,
+    env: Mapping[str, str] | None = None,
+) -> RoundResult:
+    """Record one round, or return a typed skipped-ledger outcome."""
+    path = resolve_timing_ledger_path(ledger=ledger, env=env)
+    if path is None:
+        return RoundResult(ledger_path=None, recorded=False)
+    TimingLedger(path).record_round(
+        skill=request.skill,
+        step=request.step,
+        round_n=request.round_n,
+        start_s=request.start_s,
+        end_s=request.end_s,
+        accepted=request.accepted,
+        rejected=request.rejected,
+        oos=request.oos,
+    )
+    return RoundResult(ledger_path=path, recorded=True)
+
+
+def render_report(
+    *,
+    mode: str,
+    fmt: str = "markdown",
+    ledger: str | None = None,
+    append_timing_section: Path | None = None,
+    env: Mapping[str, str] | None = None,
+) -> TimingReportResult:
+    """Render a report from a resolved ledger without CLI argument handling."""
+    path = resolve_timing_ledger_path(ledger=ledger, env=env)
+    if path is None:
+        return TimingReportResult(ledger_path=None, rendered=None, status="unavailable")
+    rendered = TimingReport(path).render(mode=mode, fmt=fmt, append_timing_section=append_timing_section, env=env)
+    status: Literal["rendered", "unavailable"] = "unavailable" if rendered.startswith("Timing report unavailable:") else "rendered"
+    return TimingReportResult(ledger_path=path, rendered=rendered, status=status)
+
+
 def harness_mark(*, label: str, argv: list[str]) -> int:
     start = time.time()
     rc = 127
@@ -400,7 +543,7 @@ def step_telemetry_mark(*, implement_tmpdir: Path, label: str) -> int:
     try:
         ledger = tokens.resolve_token_ledger_path(env=env)
         if ledger is not None:
-            tokens.TokenLedger(ledger).mark(label)
+            _ = tokens.TokenLedger(ledger).mark(label)
     except Exception as exc:
         print(f"timing telemetry-mark: token mark skipped: {exc}", file=sys.stderr)
     try:
@@ -713,28 +856,17 @@ def timing_mark_main(argv: list[str] | None = None) -> int:
     if not args:
         print("timing mark requires <step>", file=sys.stderr)
         return 1
-    try:
-        ledger = resolve_timing_ledger_path(ledger=raw_ledger)
-    except ValueError as exc:
-        print(f"timing mark: {exc}", file=sys.stderr)
-        return 1
-    if ledger is None:
-        return 0
-    if if_latest_differs:
-        skill = os.environ.get("LARCH_TIMING_SKILL", "implement")
-        skill_marks = [m for m in _parse_rows(ledger)[0] if m.skill == skill]
-        if skill_marks and skill_marks[-1].step == args[0]:
-            return 0
     skill = os.environ.get("LARCH_TIMING_SKILL", "implement")
     try:
-        TimingLedger(ledger, skill=skill).mark(args[0])
+        result = mark(label=args[0], ledger=raw_ledger, skill=skill, if_latest_differs=if_latest_differs)
     except ValueError as exc:
         print(f"timing mark: {exc}", file=sys.stderr)
         return 1
     except OSError as exc:
         print(f"timing mark: WARNING: ledger write skipped: {exc}", file=sys.stderr)
         return 0
-    _append_progress_mark(skill=skill, label=args[0])
+    if result.marked:
+        _append_progress_mark(skill=skill, label=args[0])
     return 0
 
 
@@ -742,21 +874,18 @@ def timing_record_vendor_task_main(argv: list[str] | None = None) -> int:
     args, raw_ledger = _ledger_from_args(list(argv if argv is not None else sys.argv[1:]))
     opts = _flag_map(args)
     try:
-        ledger = resolve_timing_ledger_path(ledger=raw_ledger)
-    except ValueError as exc:
-        print(f"timing record-vendor-task: {exc}", file=sys.stderr)
-        return 1
-    if ledger is None:
-        return 0
-    try:
-        TimingLedger(ledger, skill=os.environ.get("LARCH_TIMING_SKILL", "implement")).record_vendor_task(
-            vendor=opts["--vendor"],
-            task_kind=opts["--task-kind"],
-            start_s=float(opts["--start-s"]),
-            end_s=float(opts["--end-s"]),
-            output=opts["--output"],
-            exit_code=int(opts.get("--exit-code", "0") or "0"),
-            status=opts.get("--status", "complete") or "complete",
+        _ = record_vendor_task(
+            request=VendorTaskRequest(
+                vendor=opts["--vendor"],
+                task_kind=opts["--task-kind"],
+                start_s=float(opts["--start-s"]),
+                end_s=float(opts["--end-s"]),
+                output=opts["--output"],
+                exit_code=int(opts.get("--exit-code", "0") or "0"),
+                status=opts.get("--status", "complete") or "complete",
+                skill=os.environ.get("LARCH_TIMING_SKILL", "implement"),
+            ),
+            ledger=raw_ledger,
         )
     except (KeyError, ValueError) as exc:
         print(f"timing record-vendor-task: {exc}", file=sys.stderr)
@@ -771,17 +900,13 @@ def timing_record_round_main(argv: list[str] | None = None) -> int:
     args, raw_ledger = _ledger_from_args(list(argv if argv is not None else sys.argv[1:]))
     opts = _flag_map(args)
     try:
-        ledger = resolve_timing_ledger_path(ledger=raw_ledger)
-    except ValueError as exc:
-        print(f"timing record-round: {exc}", file=sys.stderr)
-        return 1
-    if ledger is None:
-        return 0
-    try:
-        TimingLedger(ledger).record_round(
-            skill=opts["--skill"], step=opts["--step"], round_n=int(opts["--round"]),
-            start_s=float(opts["--start-s"]), end_s=float(opts["--end-s"]),
-            accepted=int(opts["--accepted"]), rejected=int(opts["--rejected"]), oos=int(opts.get("--oos", "0") or "0"),
+        _ = record_round(
+            request=RoundRequest(
+                skill=opts["--skill"], step=opts["--step"], round_n=int(opts["--round"]),
+                start_s=float(opts["--start-s"]), end_s=float(opts["--end-s"]),
+                accepted=int(opts["--accepted"]), rejected=int(opts["--rejected"]), oos=int(opts.get("--oos", "0") or "0"),
+            ),
+            ledger=raw_ledger,
         )
     except (KeyError, ValueError) as exc:
         print(f"timing record-round: {exc}", file=sys.stderr)
@@ -840,10 +965,10 @@ def timing_report_main(argv: list[str] | None = None) -> int:
             raise ValueError("missing report mode")
         if fmt not in {"json", "markdown"}:
             raise ValueError(f"unknown format: {fmt}")
-        ledger = resolve_timing_ledger_path(ledger=raw_ledger)
-        if ledger is None:
+        result = render_report(mode=mode, fmt=fmt, ledger=raw_ledger, append_timing_section=append)
+        if result.rendered is None:
             raise ValueError("ledger path unavailable")
-        rendered = TimingReport(ledger).render(mode=mode, fmt=fmt, append_timing_section=append)
+        rendered = result.rendered
         text = rendered + "\n"
         if mode == "full" and output is not None:
             tmp = output.with_name(output.name + ".tmp")

--- a/python/larch/report/tokens.py
+++ b/python/larch/report/tokens.py
@@ -77,6 +77,63 @@ class TimingRecord:
     duration_ms: int
 
 
+@dataclass(frozen=True)
+class TokenMarkResult:
+    """Outcome of recording a token-ledger step mark."""
+
+    ledger_path: Path | None
+    marked: bool
+
+
+@dataclass(frozen=True)
+class BudgetCheckResult:
+    """Current token usage since the last mark and its configured cap."""
+
+    status: Literal["cap_hit", "under_cap"]
+    total: int
+    cap: int
+    step: str
+
+
+@dataclass(frozen=True)
+class ClaudeSourceResult:
+    """Validated Claude transcript source, or its unavailable reason."""
+
+    transcript_path: Path | None
+    session_dir: Path | None
+    session_uuid: str
+    reason: str = ""
+
+    @property
+    def available(self) -> bool:
+        return self.transcript_path is not None
+
+
+@dataclass(frozen=True)
+class PrLineCountResult:
+    """PR file-line totals, split between code and committed run logs."""
+
+    status: Literal["ok", "skipped", "unavailable"]
+    code_added: int | None = None
+    code_deleted: int | None = None
+    logs_added: int | None = None
+    logs_deleted: int | None = None
+    reason: str = ""
+
+    def kv_items(self) -> tuple[tuple[str, str], ...]:
+        items: list[tuple[str, str]] = [("LINES_STATUS", self.status)]
+        if self.status == "ok":
+            items.extend((
+                ("CODE_ADDED", str(self.code_added)),
+                ("CODE_DELETED", str(self.code_deleted)),
+                ("LOGS_ADDED", str(self.logs_added)),
+                ("LOGS_DELETED", str(self.logs_deleted)),
+            ))
+        else:
+            items.append(("REASON", self.reason))
+        return tuple(items)
+
+
 PANEL_PROMPT_SIZE_BASENAME = "panel-prompt-sizes.tsv"
 _PANEL_PROMPT_SIZE_FIELDS = (
     "site",
@@ -196,11 +253,13 @@ class TokenLedger:
     path: Path
     session_id: str | None = None
 
-    def mark(self, step: str) -> None:
+    def mark(self, step: str) -> bool:
         try:
             self._append({"type": "mark", "step": step, "ts": _timestamp_utc()})
         except OSError as exc:
             print(f"token mark: write skipped: {exc}", file=sys.stderr)
+            return False
+        return True
 
     def record_vendor(
         self,
@@ -1340,11 +1399,11 @@ def _transcript_sources(
 ) -> list[Path]:
     if transcript_path is None:
         source = token_claude_source(env=env)
-        if not source.get("TRANSCRIPT_PATH"):
-            msg = str(source.get("REASON") or "Claude transcript source unavailable")
+        if source.transcript_path is None:
+            msg = source.reason or "Claude transcript source unavailable"
             raise ValueError(msg)
-        transcript_path = Path(str(source["TRANSCRIPT_PATH"]))
-        session_dir = Path(str(source.get("SESSION_DIR") or "")) if source.get("SESSION_DIR") else None
+        transcript_path = source.transcript_path
+        session_dir = source.session_dir
     if not transcript_path.is_file():
         msg = "transcript not found"
         raise ValueError(msg)
@@ -1414,7 +1473,7 @@ def token_report(
     return rendered
 
 
-def check_step_token_budget(*, cap: int, step: str = "unknown", env: Mapping[str, str] | None = None) -> dict[str, object]:
+def check_step_token_budget(*, cap: int, step: str = "unknown", env: Mapping[str, str] | None = None) -> BudgetCheckResult:
     total = 0
     try:
         ledger = resolve_token_ledger_path(env=env)
@@ -1425,7 +1484,7 @@ def check_step_token_budget(*, cap: int, step: str = "unknown", env: Mapping[str
                 total += _int_field(data=row, key="total")
     except (OSError, ValueError):
         total = 0
-    return {"status": "cap_hit" if total >= cap else "under_cap", "total": total, "cap": cap, "step": step}
+    return BudgetCheckResult(status="cap_hit" if total >= cap else "under_cap", total=total, cap=cap, step=step)
 
 
 def _cached_claude_source_replay(
@@ -1491,12 +1550,18 @@ def token_claude_source(
     *,
     claude_source_file: Path | None = None,
     env: Mapping[str, str] | None = None,
-) -> dict[str, str]:
+) -> ClaudeSourceResult:
     env_map = os.environ if env is None else env
     replay = _cached_claude_source_replay(claude_source_file=claude_source_file, env_map=env_map)
-    if replay is not None:
-        return replay
-    return _resolve_claude_source_from_project(env_map)
+    data = replay if replay is not None else _resolve_claude_source_from_project(env_map)
+    transcript = data.get("TRANSCRIPT_PATH", "")
+    if transcript:
+        return ClaudeSourceResult(
+            transcript_path=Path(transcript),
+            session_dir=Path(data["SESSION_DIR"]) if data.get("SESSION_DIR") else None,
+            session_uuid=data.get("SESSION_UUID", ""),
+        )
+    return ClaudeSourceResult(transcript_path=None, session_dir=None, session_uuid="", reason=data.get("REASON", ""))
 
 
 def _assistant_model_from_line(raw: str) -> str:
@@ -1531,10 +1596,9 @@ def read_main_model(
     is the orchestrator session rather than a spawned reviewer/voter.
     """
     source = token_claude_source(claude_source_file=claude_source_file, env=env)
-    transcript = source.get("TRANSCRIPT_PATH", "")
-    if not transcript:
+    if source.transcript_path is None:
         return ""
-    path = Path(transcript)
+    path = source.transcript_path
     if not path.is_file():
         return ""
     try:
@@ -1768,11 +1832,11 @@ def validate_research_dir(path: Path) -> None:
         raise ValueError(msg)
 
 
-def compute_pr_line_counts(*, pr_number: int, repo: str | None = None) -> dict[str, int | str]:
+def compute_pr_line_counts(*, pr_number: int, repo: str | None = None) -> PrLineCountResult:
     if pr_number < 1:
-        return {"LINES_STATUS": "skipped", "REASON": "no-pr"}
+        return PrLineCountResult(status="skipped", reason="no-pr")
     if repo is not None and not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repo):
-        return {"LINES_STATUS": "skipped", "REASON": "invalid-repo"}
+        return PrLineCountResult(status="skipped", reason="invalid-repo")
     endpoint = f"repos/{repo}/pulls/{pr_number}/files" if repo else f"repos/{{owner}}/{{repo}}/pulls/{pr_number}/files"
     try:
         result = gh.command(
@@ -1784,7 +1848,7 @@ def compute_pr_line_counts(*, pr_number: int, repo: str | None = None) -> dict[s
             )
         out = result.stdout
     except (OSError, subprocess.CalledProcessError):
-        return {"LINES_STATUS": "unavailable", "REASON": "gh-failed"}
+        return PrLineCountResult(status="unavailable", reason="gh-failed")
     code_added = code_deleted = logs_added = logs_deleted = 0
     for line in out.splitlines():
         parts = line.split("\t")
@@ -1798,7 +1862,13 @@ def compute_pr_line_counts(*, pr_number: int, repo: str | None = None) -> dict[s
         else:
             code_added += added
             code_deleted += deleted
-    return {"LINES_STATUS": "ok", "CODE_ADDED": code_added, "CODE_DELETED": code_deleted, "LOGS_ADDED": logs_added, "LOGS_DELETED": logs_deleted}
+    return PrLineCountResult(
+        status="ok",
+        code_added=code_added,
+        code_deleted=code_deleted,
+        logs_added=logs_added,
+        logs_deleted=logs_deleted,
+    )
 
 
 def _repo_root() -> Path:
@@ -2788,20 +2858,27 @@ def _pop_ledger(argv: list[str]) -> tuple[list[str], str | None]:
     return out, ledger
 
 
+def token_mark(
+    *,
+    step: str,
+    ledger: str | None = None,
+    env: Mapping[str, str] | None = None,
+) -> TokenMarkResult:
+    """Record one token mark, returning a typed skipped or recorded outcome."""
+    path = resolve_token_ledger_path(ledger=ledger, env=env)
+    if path is None:
+        return TokenMarkResult(ledger_path=None, marked=False)
+    marked = TokenLedger(path).mark(step)
+    return TokenMarkResult(ledger_path=path, marked=marked)
+
+
 def token_mark_main(argv: list[str] | None = None) -> int:
     args, ledger_override = _pop_ledger(list(argv if argv is not None else sys.argv[1:]))
     if not args:
         print("token mark requires <step>", file=sys.stderr)
         return 1
     try:
-        ledger = resolve_token_ledger_path(ledger=ledger_override)
-    except ValueError as exc:
-        print(f"token mark: {exc}", file=sys.stderr)
-        return 1
-    if ledger is None:
-        return 0
-    try:
-        TokenLedger(ledger).mark(args[0])
+        _ = token_mark(step=args[0], ledger=ledger_override)
     except (OSError, ValueError) as exc:
         if isinstance(exc, ValueError):
             print(f"token mark: {exc}", file=sys.stderr)
@@ -2952,7 +3029,7 @@ def token_check_budget_main(argv: list[str] | None = None) -> int:
         print("token check-budget: --cap must be >= 1", file=sys.stderr)
         return 1
     result = check_step_token_budget(cap=cap, step=step)
-    print(f"STATUS={result['status']} TOTAL={result['total']} CAP={result['cap']} STEP={result['step']}")
+    print(f"STATUS={result.status} TOTAL={result.total} CAP={result.cap} STEP={result.step}")
     return 0
 
 
@@ -2960,10 +3037,16 @@ def token_claude_source_main(argv: list[str] | None = None) -> int:
     args = list(argv if argv is not None else sys.argv[1:])
     snap = Path(args[0]) if args else None
     result = token_claude_source(claude_source_file=snap)
-    for key in ("TRANSCRIPT_PATH", "SESSION_DIR", "SESSION_UUID", "STATUS", "REASON"):
-        if key in result:
-            print(f"{key}={result[key]}")
-    return 0 if "TRANSCRIPT_PATH" in result else 1
+    if result.available:
+        print(f"TRANSCRIPT_PATH={result.transcript_path}")
+        if result.session_dir is not None:
+            print(f"SESSION_DIR={result.session_dir}")
+        if result.session_uuid:
+            print(f"SESSION_UUID={result.session_uuid}")
+        return 0
+    print("STATUS=unavailable")
+    print(f"REASON={result.reason}")
+    return 1
 
 
 def token_lane_write_main(argv: list[str] | None = None) -> int:
@@ -3038,7 +3121,7 @@ def compute_pr_line_counts_main(argv: list[str] | None = None) -> int:
         print("LINES_STATUS=skipped\nREASON=no-pr")
         return 0
     result = compute_pr_line_counts(pr_number=int(pr_raw), repo=opts.get("--repo") or None)
-    for key, value in result.items():
+    for key, value in result.kv_items():
         print(f"{key}={value}")
     return 0
 

--- a/python/tests/report/test_final_report.py
+++ b/python/tests/report/test_final_report.py
@@ -16,9 +16,26 @@ import pytest
 from larch.core import config
 from larch.errors import ShipError
 from larch.implement import scope_disposition
-from larch.report import final_report, progress_report
+from larch.report import final_report, progress_report, tokens
 
 from test_support import IMPLEMENT_BASELINE_KEYS, write_session_env
+
+
+def test_derive_pr_line_counts_consumes_typed_result(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    ship = tmp_path / "ship-pr-state.sh"
+    _ = ship.write_text("PR_URL=https://example.test/pr/42\n", encoding="utf-8")
+    monkeypatch.setattr(
+        final_report.tokens,
+        "compute_pr_line_counts",
+        lambda **_kwargs: tokens.PrLineCountResult(
+            status="ok", code_added=10, code_deleted=2, logs_added=3, logs_deleted=1,
+        ),
+    )
+
+    values = final_report._derive_pr_line_counts(repo="owner/repo", repo_unavailable=False, pr_number="42", ship=ship)
+
+    assert values == ("10", "2", "3", "1")
+    assert "LINES_STATUS=ok" in ship.read_text(encoding="utf-8")
 
 
 def _write_minimal_state(tmp_path: Path) -> None:

--- a/python/tests/report/test_progress_statusline.py
+++ b/python/tests/report/test_progress_statusline.py
@@ -6,6 +6,7 @@ import os
 import re
 import subprocess
 import time
+from dataclasses import FrozenInstanceError
 from pathlib import Path
 
 import pytest
@@ -15,6 +16,20 @@ from larch.report import statusline
 from larch.report import statusline_install
 from larch.report import timing
 from larch import cli
+
+
+def test_resolve_persisted_run_returns_frozen_named_fields(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _ = (tmp_path / "session-env.sh").write_text("LARCH_RUN_ID=design-20260714.1\n", encoding="utf-8")
+    _ = (tmp_path / "source-env.sh").write_text(f"REPO_ROOT={repo}\n", encoding="utf-8")
+
+    result = progress_file.resolve_persisted_run(tmpdir=tmp_path, env={})
+
+    assert result.run_id == "design-20260714.1"
+    assert result.repo_root == repo.resolve()
+    with pytest.raises(FrozenInstanceError):
+        result.run_id = "other"  # type: ignore[misc]
 
 
 def test_progress_path_uses_repo_realpath_and_short_hash(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1004,7 +1019,9 @@ def test_install_statusline_creates_settings_and_launcher(tmp_path: Path, monkey
     _ = (plugin / "python" / "cli.py").write_text("", encoding="utf-8")
     monkeypatch.setenv("HOME", str(home))
 
-    assert statusline_install.install_statusline(repo_root=repo, plugin_root=plugin)
+    result = statusline_install.install_statusline(repo_root=repo, plugin_root=plugin)
+    assert result.installed
+    assert result.reason == ""
 
     settings = json.loads((repo / ".claude" / "settings.local.json").read_text(encoding="utf-8"))
     assert settings["statusLine"]["refreshInterval"] == 2
@@ -1025,7 +1042,9 @@ def test_install_statusline_preserves_local_non_larch_entry(tmp_path: Path, monk
     _ = settings_path.write_text(original, encoding="utf-8")
     monkeypatch.setenv("HOME", str(home))
 
-    assert not statusline_install.install_statusline(repo_root=repo, plugin_root=plugin)
+    result = statusline_install.install_statusline(repo_root=repo, plugin_root=plugin)
+    assert not result.installed
+    assert result.reason == "custom-statusline"
     assert settings_path.read_text(encoding="utf-8") == original
 
 

--- a/python/tests/report/test_timing.py
+++ b/python/tests/report/test_timing.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import fcntl as fcntl_mod
 import os
 import stat
+from dataclasses import FrozenInstanceError
 from pathlib import Path
 
 from larch.report import progress_file
@@ -12,6 +13,36 @@ from larch.report import progress_file
 import pytest
 
 from larch.report import timing
+
+
+def test_typed_timing_entry_points_return_frozen_results(tmp_path: Path) -> None:
+    ledger = tmp_path / "timing-ledger.tsv"
+    env = {"TMPDIR": str(tmp_path)}
+
+    marked = timing.mark(label="Step 1", ledger=str(ledger), env=env)
+    vendor = timing.record_vendor_task(
+        request=timing.VendorTaskRequest(
+            vendor="codex", task_kind="codex-review", start_s=1, end_s=2, output="out.txt",
+        ),
+        ledger=str(ledger),
+        env=env,
+    )
+    round_result = timing.record_round(
+        request=timing.RoundRequest(
+            skill="implement", step="Step 1", round_n=1, start_s=1, end_s=2, accepted=1, rejected=0,
+        ),
+        ledger=str(ledger),
+        env=env,
+    )
+    report = timing.render_report(mode="full", ledger=str(ledger), env=env)
+
+    assert marked.marked
+    assert vendor.recorded
+    assert round_result.recorded
+    assert report.status == "rendered"
+    assert report.rendered is not None
+    with pytest.raises(FrozenInstanceError):
+        marked.marked = False  # type: ignore[misc]
 
 
 def test_timing_vendor_task_accepts_claude_and_basename(tmp_path: Path) -> None:

--- a/python/tests/report/test_tokens.py
+++ b/python/tests/report/test_tokens.py
@@ -6,6 +6,7 @@ import json
 import os
 import subprocess
 import sys
+from dataclasses import FrozenInstanceError
 from pathlib import Path
 from collections.abc import Mapping, Sequence
 from types import SimpleNamespace
@@ -133,7 +134,8 @@ def test_token_claude_source_requires_complete_snapshot(tmp_path: Path) -> None:
     snap = tmp_path / "source.env"
     _ = snap.write_text(f"TRANSCRIPT_PATH={transcript}\n", encoding="utf-8")
     out = tokens.token_claude_source(claude_source_file=snap, env={"HOME": str(tmp_path)})
-    assert out.get("STATUS") == "unavailable"
+    assert not out.available
+    assert out.reason
 
 
 def test_token_cost_helpers_exported_from_tokens_module() -> None:
@@ -153,7 +155,8 @@ def test_token_claude_source_rejects_transcript_outside_session_dir(tmp_path: Pa
         encoding="utf-8",
     )
     out = tokens.token_claude_source(claude_source_file=snap, env={"HOME": str(tmp_path)})
-    assert out.get("STATUS") == "unavailable"
+    assert not out.available
+    assert out.reason
 
 
 def test_token_claude_source_accepts_complete_snapshot(tmp_path: Path) -> None:
@@ -167,9 +170,12 @@ def test_token_claude_source_accepts_complete_snapshot(tmp_path: Path) -> None:
         encoding="utf-8",
     )
     out = tokens.token_claude_source(claude_source_file=snap)
-    assert out["TRANSCRIPT_PATH"] == str(transcript.resolve())
-    assert out["SESSION_DIR"] == str(session_dir)
-    assert out["SESSION_UUID"] == "session-uuid"
+    assert out.available
+    assert out.transcript_path == transcript.resolve()
+    assert out.session_dir == session_dir
+    assert out.session_uuid == "session-uuid"
+    with pytest.raises(FrozenInstanceError):
+        out.reason = "changed"  # type: ignore[misc]
 
 
 def test_find_latest_claude_transcript_uses_ambient_claude_sid(tmp_path: Path) -> None:
@@ -253,9 +259,11 @@ def test_check_step_token_budget_resets_at_mark(tmp_path: Path, monkeypatch: pyt
     monkeypatch.setenv("LARCH_TOKEN_LEDGER", str(ledger))
     under = tokens.check_step_token_budget(cap=100, step="Step 1")
     over = tokens.check_step_token_budget(cap=40, step="Step 1")
-    assert under["status"] == "under_cap"
-    assert over["status"] == "cap_hit"
-    assert over["total"] == 50
+    assert under.status == "under_cap"
+    assert over.status == "cap_hit"
+    assert over.total == 50
+    with pytest.raises(FrozenInstanceError):
+        over.total = 0  # type: ignore[misc]
 
 
 def _token_report_fixtures(tmp_path: Path) -> tuple[Path, Path]:
@@ -669,11 +677,30 @@ def test_compute_pr_line_counts_buckets(monkeypatch: pytest.MonkeyPatch) -> None
 
     monkeypatch.setattr(tokens.proc, "run", fake_run)
     result = tokens.compute_pr_line_counts(pr_number=42, repo="owner/repo")
-    assert result["LINES_STATUS"] == "ok"
-    assert result["CODE_ADDED"] == 10
-    assert result["CODE_DELETED"] == 2
-    assert result["LOGS_ADDED"] == 5
-    assert result["LOGS_DELETED"] == 1
+    assert result.status == "ok"
+    assert result.code_added == 10
+    assert result.code_deleted == 2
+    assert result.logs_added == 5
+    assert result.logs_deleted == 1
+    assert result.kv_items() == (
+        ("LINES_STATUS", "ok"),
+        ("CODE_ADDED", "10"),
+        ("CODE_DELETED", "2"),
+        ("LOGS_ADDED", "5"),
+        ("LOGS_DELETED", "1"),
+    )
+
+
+def test_token_mark_returns_typed_recorded_and_skipped_results(tmp_path: Path) -> None:
+    recorded = tokens.token_mark(step="Step 1", env={"IMPLEMENT_TMPDIR": str(tmp_path)})
+    skipped = tokens.token_mark(step="Step 1", env={})
+
+    assert recorded.marked
+    assert recorded.ledger_path is not None
+    assert not skipped.marked
+    assert skipped.ledger_path is None
+    with pytest.raises(FrozenInstanceError):
+        recorded.marked = False  # type: ignore[misc]
 
 
 def test_classify_md_tier_and_claude_imports() -> None:
@@ -848,8 +875,8 @@ def test_read_main_model_returns_first_assistant_model(monkeypatch: pytest.Monke
         encoding="utf-8",
     )
 
-    def fake_source(**_: object) -> dict[str, str]:
-        return {"TRANSCRIPT_PATH": str(transcript)}
+    def fake_source(**_: object) -> tokens.ClaudeSourceResult:
+        return tokens.ClaudeSourceResult(transcript_path=transcript, session_dir=None, session_uuid="")
 
     monkeypatch.setattr(tokens, "token_claude_source", fake_source)
     assert tokens.read_main_model() == "claude-opus-4-8"
@@ -859,16 +886,16 @@ def test_read_main_model_blank_when_no_assistant_model(monkeypatch: pytest.Monke
     transcript = tmp_path / "session.jsonl"
     _ = transcript.write_text(json.dumps({"type": "user", "message": {"content": "hi"}}), encoding="utf-8")
 
-    def fake_source(**_: object) -> dict[str, str]:
-        return {"TRANSCRIPT_PATH": str(transcript)}
+    def fake_source(**_: object) -> tokens.ClaudeSourceResult:
+        return tokens.ClaudeSourceResult(transcript_path=transcript, session_dir=None, session_uuid="")
 
     monkeypatch.setattr(tokens, "token_claude_source", fake_source)
     assert tokens.read_main_model() == ""
 
 
 def test_read_main_model_blank_when_transcript_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
-    def fake_source(**_: object) -> dict[str, str]:
-        return {"STATUS": "unavailable"}
+    def fake_source(**_: object) -> tokens.ClaudeSourceResult:
+        return tokens.ClaudeSourceResult(transcript_path=None, session_dir=None, session_uuid="", reason="unavailable")
 
     monkeypatch.setattr(tokens, "token_claude_source", fake_source)
     assert tokens.read_main_model() == ""


### PR DESCRIPTION
## Summary
- add frozen typed report-boundary results and callable entry points
- preserve CLI KV output and update typed consumers
- add compatibility and immutability coverage

Fixes #7306

## Verification
- make py-lint
- make py-test