### PR TITLE
Fixes #7307: Type PR body results

### DIFF
--- a/python/larch/git/pr_body.py
+++ b/python/larch/git/pr_body.py
@@ -42,6 +42,35 @@ class MermaidResult:
     fence_count: int
 
 
+@dataclass(frozen=True)
+class FinalReportResult:
+    exit_code: int
+    comment_url: str
+    error: str
+
+
+@dataclass(frozen=True)
+class TrackingIssuePostResult:
+    exit_code: int
+    posted: bool
+    comment_url: str
+    error: str
+
+
+@dataclass(frozen=True)
+class SlackIssueAnnouncementResult:
+    exit_code: int
+    status: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class CodeFlowDiagramResult:
+    exit_code: int
+    status: str
+    diagram_file: str
+    reason: str
+
 _FENCE_RE = re.compile(r"^(\s{0,3})(`{3,})([^`]*)$")
 _FLOWCHART_START = re.compile(r"^(flowchart|graph)(\s|$)")
 _OPEN_BRACKET = frozenset("[{(")
@@ -926,13 +955,18 @@ def write_final_report(
     comment_only: bool = False,
     print_stdout: bool = False,
     skip_tracking_upsert: bool = False,
-) -> tuple[int, str, str]:
-    return _final_report_module().write_final_report(  # type: ignore[attr-defined]
-        implement_tmpdir,
-        comment_only=comment_only,
-        print_stdout=print_stdout,
-        skip_tracking_upsert=skip_tracking_upsert,
+) -> FinalReportResult:
+    delegated = cast(
+        "tuple[int, str, str]",
+        _final_report_module().write_final_report(  # type: ignore[attr-defined]
+            implement_tmpdir,
+            comment_only=comment_only,
+            print_stdout=print_stdout,
+            skip_tracking_upsert=skip_tracking_upsert,
+        ),
     )
+    exit_code, comment_url, error = delegated
+    return FinalReportResult(exit_code, comment_url, error)
 
 
 def write_final_report_main(argv: list[str] | None = None) -> int:
@@ -953,11 +987,28 @@ def step18b_final_report(
 def step18b_final_report_main(argv: list[str] | None = None) -> int:
     return _final_report_module().step18b_final_report_main(argv)  # type: ignore[attr-defined]
 
-def post_tracking_issue(implement_tmpdir: Path, *, issue_number: str = "", run_id: str = "", adopted: str = "true", force_requested: str = "false") -> tuple[int, bool, str, str]:
+def post_tracking_issue(
+    implement_tmpdir: Path,
+    *,
+    issue_number: str = "",
+    run_id: str = "",
+    adopted: str = "true",
+    force_requested: str = "false",
+) -> TrackingIssuePostResult:
     if adopted not in {"true", "false"}:
-        return 2, False, "", "--adopted must be true or false"
+        return TrackingIssuePostResult(
+            exit_code=2,
+            posted=False,
+            comment_url="",
+            error="--adopted must be true or false",
+        )
     if force_requested not in {"true", "false"}:
-        return 2, False, "", "--force-requested must be true or false"
+        return TrackingIssuePostResult(
+            exit_code=2,
+            posted=False,
+            comment_url="",
+            error="--force-requested must be true or false",
+        )
     parent = implement_tmpdir / "parent-issue.md"
     session = implement_tmpdir / "session-env.sh"
     flags = implement_tmpdir / "run-flags.sh"
@@ -966,11 +1017,26 @@ def post_tracking_issue(implement_tmpdir: Path, *, issue_number: str = "", run_i
     if force_requested == "false" and _read_kv(path=flags, key="FORCE_REQUESTED") == "true":
         force_requested = "true"
     if not issue:
-        return 1, False, "", "ISSUE_NUMBER not found in parent-issue.md"
+        return TrackingIssuePostResult(
+            exit_code=1,
+            posted=False,
+            comment_url="",
+            error="ISSUE_NUMBER not found in parent-issue.md",
+        )
     if not issue.isdigit():
-        return 1, False, "", "ISSUE_NUMBER must be numeric"
+        return TrackingIssuePostResult(
+            exit_code=1,
+            posted=False,
+            comment_url="",
+            error="ISSUE_NUMBER must be numeric",
+        )
     if not re.fullmatch(r"[A-Za-z0-9._-]+", run or ""):
-        return 1, False, "", "RUN_ID must match ^[A-Za-z0-9._-]+$"
+        return TrackingIssuePostResult(
+            exit_code=1,
+            posted=False,
+            comment_url="",
+            error="RUN_ID must match ^[A-Za-z0-9._-]+$",
+        )
     version = "unknown"
     try:
         completed = subprocess.run([sys.executable, str(_PY_CLI), "plugin", "read-version"], text=True, capture_output=True, check=False)
@@ -992,10 +1058,20 @@ def post_tracking_issue(implement_tmpdir: Path, *, issue_number: str = "", run_i
         if issue_number:
             parent.write_text(f"ISSUE_NUMBER={issue}\nRUN_ID={run}\nADOPTED={adopted}\n", encoding="utf-8")
         m: re.Match[str] | None = re.search(r"^COMMENT_URL=(.*)$", completed.stdout, re.MULTILINE)
-        return 0, True, m.group(1) if m else "", ""
+        return TrackingIssuePostResult(
+            exit_code=0,
+            posted=True,
+            comment_url=m.group(1) if m else "",
+            error="",
+        )
     err = " ".join(completed.stderr.split())[:500]
     _warn(f"tracking-issue upsert-summary failed rc={completed.returncode} stderr={err}")
-    return 1, False, "", err
+    return TrackingIssuePostResult(
+        exit_code=1,
+        posted=False,
+        comment_url="",
+        error=err,
+    )
 
 
 def post_tracking_issue_main(argv: list[str] | None = None) -> int:
@@ -1006,27 +1082,41 @@ def post_tracking_issue_main(argv: list[str] | None = None) -> int:
     parser.add_argument("--adopted", default="true")
     parser.add_argument("--force-requested", default="false")
     args = parser.parse_args(argv)
-    rc, posted, url, err = post_tracking_issue(Path(args.implement_tmpdir), issue_number=args.issue_number, run_id=args.run_id, adopted=args.adopted, force_requested=args.force_requested)
-    _emit_kv(key="POSTED", value=str(posted).lower())
-    _emit_kv(key="COMMENT_URL", value=url)
-    if err:
-        _emit_kv(key="ERROR", value=err)
-    return rc
+    result = post_tracking_issue(
+        Path(args.implement_tmpdir),
+        issue_number=args.issue_number,
+        run_id=args.run_id,
+        adopted=args.adopted,
+        force_requested=args.force_requested,
+    )
+    _emit_kv(key="POSTED", value=str(result.posted).lower())
+    _emit_kv(key="COMMENT_URL", value=result.comment_url)
+    if result.error:
+        _emit_kv(key="ERROR", value=result.error)
+    return result.exit_code
 
 
-def slack_issue_announce(implement_tmpdir: Path, *, best_effort: bool = False) -> tuple[int, str, str]:
+def slack_issue_announce(
+    implement_tmpdir: Path, *, best_effort: bool = False
+) -> SlackIssueAnnouncementResult:
     parent = implement_tmpdir / "parent-issue.md"
     ship = implement_tmpdir / "ship-pr-state.sh"
     issue = _read_kv(path=parent, key="ISSUE_NUMBER", default="0") or "0"
     if not issue.isdigit():
-        return (0 if best_effort else 1), "failed", "ISSUE_NUMBER must be numeric"
+        return SlackIssueAnnouncementResult(
+            0 if best_effort else 1, "failed", "ISSUE_NUMBER must be numeric"
+        )
     if issue == "0":
-        return 0, "skipped", "issue-not-set"
+        return SlackIssueAnnouncementResult(0, "skipped", "issue-not-set")
     webhook = os.environ.get("LARCH_SLACK_WEBHOOK_URL", "")
     if not webhook:
-        return 0, "skipped", "webhook-not-set"
+        return SlackIssueAnnouncementResult(0, "skipped", "webhook-not-set")
     if urllib.parse.urlparse(webhook).scheme not in {"http", "https"}:
-        return (0 if best_effort else 1), "failed", "webhook scheme must be http or https"
+        return SlackIssueAnnouncementResult(
+            0 if best_effort else 1,
+            "failed",
+            "webhook scheme must be http or https",
+        )
     run_id = _read_kv(path=parent, key="RUN_ID") or ((implement_tmpdir / "session-id").read_text(encoding="utf-8").strip() if (implement_tmpdir / "session-id").is_file() else "")
     text = f"Implement run {run_id} opened PR {_read_kv(path=ship, key='PR_URL', default='N/A')} for tracking issue #{issue}"
     if _read_kv(path=ship, key="PR_TITLE"):
@@ -1037,8 +1127,12 @@ def slack_issue_announce(implement_tmpdir: Path, *, best_effort: bool = False) -
         with urllib.request.urlopen(req, timeout=10):  # noqa: S310
             pass
     except Exception as exc:
-        return (0 if best_effort else 1), "failed", " ".join(str(exc).split())[:500]
-    return 0, "posted", ""
+        return SlackIssueAnnouncementResult(
+            0 if best_effort else 1,
+            "failed",
+            " ".join(str(exc).split())[:500],
+        )
+    return SlackIssueAnnouncementResult(0, "posted", "")
 
 
 def slack_issue_announce_main(argv: list[str] | None = None) -> int:
@@ -1054,11 +1148,16 @@ def slack_issue_announce_main(argv: list[str] | None = None) -> int:
         _emit_kv(key="STATUS", value="failed")
         _emit_kv(key="ERROR", value="--implement-tmpdir not found")
         return 2
-    rc, status, reason = slack_issue_announce(Path(args.implement_tmpdir), best_effort=args.best_effort)
-    _emit_kv(key="STATUS", value=status)
-    if reason:
-        _emit_kv(key="REASON" if status == "skipped" else "ERROR", value=reason)
-    return rc
+    result = slack_issue_announce(
+        Path(args.implement_tmpdir), best_effort=args.best_effort
+    )
+    _emit_kv(key="STATUS", value=result.status)
+    if result.reason:
+        _emit_kv(
+            key="REASON" if result.status == "skipped" else "ERROR",
+            value=result.reason,
+        )
+    return result.exit_code
 
 
 def _diagram_failure_capture(*, returncode: int, stderr: str) -> tuple[str, str]:
@@ -1122,7 +1221,13 @@ def _diagram_stderr_from_sidecar(raw: Path, fallback: str) -> str:
     return _sidecar_text or fallback
 
 
-def generate_code_flow_diagram(implement_tmpdir: Path, *, model: str = "claude-sonnet-4-6", base_remote: str = "origin", base_ref: str = "main") -> tuple[int, str, str, str]:
+def generate_code_flow_diagram(
+    implement_tmpdir: Path,
+    *,
+    model: str = "claude-sonnet-4-6",
+    base_remote: str = "origin",
+    base_ref: str = "main",
+) -> CodeFlowDiagramResult:
     implement_tmpdir.mkdir(parents=True, exist_ok=True)
     raw = implement_tmpdir / "code-flow-diagram.raw.md"
     candidate = implement_tmpdir / "code-flow-diagram.candidate.md"
@@ -1196,9 +1301,9 @@ def generate_code_flow_diagram(implement_tmpdir: Path, *, model: str = "claude-s
                 failure_log.write_text(diagnostic, encoding="utf-8")
         except OSError:
             reason = f"{reason} log-write-failed"
-        return 1, "failed", "", reason
+        return CodeFlowDiagramResult(1, "failed", "", reason)
     if not raw.is_file() or raw.stat().st_size == 0:
-        return 1, "failed", "", "empty-generation"
+        return CodeFlowDiagramResult(1, "failed", "", "empty-generation")
     candidate.write_bytes(raw.read_bytes())
     result = sanitize_fragment(candidate.read_text(encoding="utf-8"), from_md=True)
     if result.status == "ok":
@@ -1206,9 +1311,14 @@ def generate_code_flow_diagram(implement_tmpdir: Path, *, model: str = "claude-s
         with contextlib.suppress(OSError):
             failure_log.unlink()
             _ = (implement_tmpdir / "code-flow-diagram.raw-failure.log").unlink(missing_ok=True)
-        return 0, "ok", str(diagram), ""
+        return CodeFlowDiagramResult(0, "ok", str(diagram), "")
     candidate.unlink(missing_ok=True)
-    return 0, "skipped", "", result.reason_tokens[0] if result.reason_tokens else "sanitizer-rejected"
+    return CodeFlowDiagramResult(
+        0,
+        "skipped",
+        "",
+        result.reason_tokens[0] if result.reason_tokens else "sanitizer-rejected",
+    )
 
 
 def generate_code_flow_diagram_main(argv: list[str] | None = None) -> int:
@@ -1218,8 +1328,13 @@ def generate_code_flow_diagram_main(argv: list[str] | None = None) -> int:
     parser.add_argument("--base-remote", default="origin")
     parser.add_argument("--base-ref", default="main")
     args = parser.parse_args(argv)
-    rc, status, diagram, reason = generate_code_flow_diagram(Path(args.implement_tmpdir), model=args.model, base_remote=args.base_remote, base_ref=args.base_ref)
-    _emit_kv(key="STATUS", value=status)
-    _emit_kv(key="DIAGRAM_FILE", value=diagram)
-    _emit_kv(key="SKIP_REASON", value=reason)
-    return rc
+    result = generate_code_flow_diagram(
+        Path(args.implement_tmpdir),
+        model=args.model,
+        base_remote=args.base_remote,
+        base_ref=args.base_ref,
+    )
+    _emit_kv(key="STATUS", value=result.status)
+    _emit_kv(key="DIAGRAM_FILE", value=result.diagram_file)
+    _emit_kv(key="SKIP_REASON", value=result.reason)
+    return result.exit_code

--- a/python/larch/implement/step_7a.py
+++ b/python/larch/implement/step_7a.py
@@ -268,6 +268,52 @@ def _run_log_flush(
     return log_flush_status
 
 
+def _generate_code_flow_diagram(
+    implement_tmpdir: Path,
+    *,
+    base_remote: str,
+    base_ref: str,
+) -> pr_body.CodeFlowDiagramResult:
+    result = pr_body.generate_code_flow_diagram(
+        implement_tmpdir,
+        base_remote=base_remote,
+        base_ref=base_ref,
+    )
+    retry_sidecar = implement_tmpdir / "code-flow-diagram.retried"
+    if retry_sidecar.is_file():
+        first_rc = ""
+        with contextlib.suppress(OSError, ValueError):
+            for line in retry_sidecar.read_text(encoding="utf-8").splitlines():
+                if line.startswith("FIRST_RC="):
+                    first_rc = line.split("=", 1)[1].strip()
+        retry_msg = f"code-flow subprocess transient (rc={first_rc}); retried once"
+        run_logs.append_execution_issue(
+            log_file=implement_tmpdir / "execution-issues.md",
+            category="Warnings",
+            entry=f"- **Step 7a — code flow diagram**: {retry_msg}",
+        )
+        with contextlib.suppress(OSError):
+            retry_sidecar.unlink()
+    if result.status == "ok" and result.diagram_file:
+        section = implement_tmpdir / "code-flow-section.md"
+        section.write_text(
+            (implement_tmpdir / "code-flow-diagram.md").read_text(encoding="utf-8"),
+            encoding="utf-8",
+        )
+        return result
+    _cleanup_diagram_artifacts(implement_tmpdir, keep_diagram=False)
+    if result.exit_code == 0 and result.status != "failed":
+        return result
+    reason = result.reason or "generation failed"
+    _append_diagram_warning(implement_tmpdir=implement_tmpdir, message=reason)
+    return pr_body.CodeFlowDiagramResult(
+        exit_code=result.exit_code,
+        status="failed",
+        diagram_file="",
+        reason=reason,
+    )
+
+
 def run_step7a(
     implement_tmpdir: Path,
     *,
@@ -341,37 +387,14 @@ def _run_step7a_inner(
         _cleanup_diagram_artifacts(implement_tmpdir, keep_diagram=False)
         print("⏩ 7a: pre-ship status=skip reason=small-non-runtime-change elapsed=0s")
     else:
-        diagram_rc, diagram_status, diagram_path, reason = pr_body.generate_code_flow_diagram(
+        diagram_result = _generate_code_flow_diagram(
             implement_tmpdir,
             base_remote=base_remote,
             base_ref=base_ref,
         )
-        retry_sidecar = implement_tmpdir / "code-flow-diagram.retried"
-        if retry_sidecar.is_file():
-            first_rc = ""
-            with contextlib.suppress(OSError, ValueError):
-                for line in retry_sidecar.read_text(encoding="utf-8").splitlines():
-                    if line.startswith("FIRST_RC="):
-                        first_rc = line.split("=", 1)[1].strip()
-            retry_msg = f"code-flow subprocess transient (rc={first_rc}); retried once"
-            run_logs.append_execution_issue(
-                log_file=implement_tmpdir / "execution-issues.md",
-                category="Warnings",
-                entry=f"- **Step 7a — code flow diagram**: {retry_msg}",
-            )
-            with contextlib.suppress(OSError):
-                retry_sidecar.unlink()
-        keep_diagram = diagram_status == "ok" and bool(diagram_path)
-        if keep_diagram:
-            section = implement_tmpdir / "code-flow-section.md"
-            section.write_text((implement_tmpdir / "code-flow-diagram.md").read_text(encoding="utf-8"), encoding="utf-8")
-        else:
-            _cleanup_diagram_artifacts(implement_tmpdir, keep_diagram=False)
-        if diagram_rc != 0 or diagram_status == "failed":
-            diagram_status = "failed"
-            diagram_reason = reason or "generation failed"
-            diagram_path = ""
-            _append_diagram_warning(implement_tmpdir=implement_tmpdir, message=diagram_reason)
+        diagram_status = diagram_result.status
+        diagram_path = diagram_result.diagram_file
+        diagram_reason = diagram_result.reason if diagram_status == "failed" else ""
 
     if issue_number and (implement_tmpdir / "code-flow-section.md").is_file() and (implement_tmpdir / "code-flow-section.md").stat().st_size > 0:
         upsert_args = ["diagrams", "upsert", "--issue", issue_number, "--code-flow-file", str(implement_tmpdir / "code-flow-section.md")]

--- a/python/larch/report/run_log_flush.py
+++ b/python/larch/report/run_log_flush.py
@@ -193,20 +193,20 @@ def _write_final_report(
     skip_tracking_upsert: bool = False,
 ) -> None:
     _ = runner
-    rc, _comment_url, error = pr_body.write_final_report(
+    result = pr_body.write_final_report(
         Path(ctx.tmpdir),
         skip_tracking_upsert=skip_tracking_upsert,
     )
-    if rc != 0:
-        msg = error or "final report write failed"
+    if result.exit_code != 0:
+        msg = result.error or "final report write failed"
         raise ShipError(msg)
 
 
 def write_final_report_comment(*, runner: Runner, ctx: RunContext) -> None:
     _ = runner
-    rc, _comment_url, error = pr_body.write_final_report(Path(ctx.tmpdir), comment_only=True)
-    if rc != 0:
-        msg = error or "final report comment write failed"
+    result = pr_body.write_final_report(Path(ctx.tmpdir), comment_only=True)
+    if result.exit_code != 0:
+        msg = result.error or "final report comment write failed"
         raise ShipError(msg)
 
 

--- a/python/tests/agents/test_agents.py
+++ b/python/tests/agents/test_agents.py
@@ -29,6 +29,7 @@ from larch.agents import _ci_launcher
 from larch.agents import _review_launcher
 from larch.agents import _drafter
 from larch.agents import _claude_runner
+from larch.agents import _failure_diag
 from larch.agents import _launch_failure
 from larch.agents import _types
 from larch.design import plan_grammar
@@ -6387,3 +6388,21 @@ def test_parse_drafter_output_dialectic_inside_plan_is_fatal(tmp_path: Path) -> 
     )
     with pytest.raises(ValueError, match="dialectic block may not appear inside plan"):
         agents.parse_drafter_output(raw_file=raw, plan_tmp=tmp_path / "plan.tmp", summary_tmp=tmp_path / "summary.tmp")
+
+
+@pytest.mark.parametrize(
+    ("name", "module"),
+    [
+        ("TierAttempt", _types),
+        ("classify_launch_failure", _launch_failure),
+        ("parse_codex_usage_file", _failure_diag),
+        ("run_external_agent", _run_external),
+        ("check_reviewers", _auth),
+        ("launch_codex_drafter", _drafter),
+        ("launch_codex_ci_main", _ci_launcher),
+        ("launch_review_main", _review_launcher),
+        ("launch_claude_subprocess_main", _claude_runner),
+    ],
+)
+def test_agents_reexports_split_public_contract(name: str, module: object) -> None:
+    assert getattr(agents, name) is getattr(module, name)

--- a/python/tests/calibration/test_difficulty.py
+++ b/python/tests/calibration/test_difficulty.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+from dataclasses import FrozenInstanceError, is_dataclass
 from pathlib import Path
 
 import pytest
@@ -19,6 +20,14 @@ def test_validate_rating_low_confidence_bumps_and_sanitizes() -> None:
     assert rating.predicted_tier == difficulty.TRIVIAL
     assert rating.adjusted_tier == difficulty.MODERATE
     assert rating.rationale == "line with controls"
+
+
+def test_public_difficulty_results_are_frozen() -> None:
+    result = difficulty.FloorResult(tier=difficulty.TRIVIAL, matches=())
+
+    assert is_dataclass(result)
+    with pytest.raises(FrozenInstanceError):
+        result.tier = difficulty.HARD  # type: ignore[misc]
 
 
 @pytest.mark.parametrize("tier", ["", "EASY", "harder"])

--- a/python/tests/git/test_pr.py
+++ b/python/tests/git/test_pr.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import FrozenInstanceError, is_dataclass
 from pathlib import Path
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
@@ -48,6 +49,19 @@ def test_ensure_pr_invalid_issue_raises() -> None:
         _ = pr_module.ensure_pr(
             runner=runner, ctx=_ctx(issue=""), body="body", title="t"
         )
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        pr_module.PrResult(number=1, url="https://example.test/pr/1", status="created"),
+        pr_module.CreateBranchResult(status="created", branch_name="dev/feature"),
+    ],
+)
+def test_public_pr_results_are_frozen(result: object) -> None:
+    assert is_dataclass(result)
+    with pytest.raises(FrozenInstanceError):
+        result.exit_code = 1  # type: ignore[attr-defined]
 
 
 def test_ensure_pr_repo_unavailable() -> None:

--- a/python/tests/git/test_pr_body.py
+++ b/python/tests/git/test_pr_body.py
@@ -13,7 +13,7 @@ from typing import Self
 import pytest
 
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass, field
+from dataclasses import FrozenInstanceError, dataclass, field, is_dataclass
 
 from larch.core import config
 from larch.report import final_report
@@ -38,6 +38,60 @@ def test_py_cli_resolves_to_repo_python_cli() -> None:
     expected = Path(__file__).resolve().parents[2] / "cli.py"
     assert expected == pr_body._PY_CLI
     assert pr_body._PY_CLI.is_file()
+
+
+def test_write_final_report_returns_typed_result(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FinalReportModule:
+        def write_final_report(
+            self,
+            implement_tmpdir: Path,
+            *,
+            comment_only: bool,
+            print_stdout: bool,
+            skip_tracking_upsert: bool,
+        ) -> tuple[int, str, str]:
+            assert implement_tmpdir == Path("/tmp/implementation")
+            assert comment_only is True
+            assert print_stdout is False
+            assert skip_tracking_upsert is True
+            return 0, "https://example.test/comment/1", ""
+
+    def fake_final_report_module() -> FinalReportModule:
+        return FinalReportModule()
+
+    monkeypatch.setattr(pr_body, "_final_report_module", fake_final_report_module)
+
+    result = pr_body.write_final_report(
+        Path("/tmp/implementation"),
+        comment_only=True,
+        skip_tracking_upsert=True,
+    )
+
+    assert result == pr_body.FinalReportResult(
+        exit_code=0,
+        comment_url="https://example.test/comment/1",
+        error="",
+    )
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        pr_body.FinalReportResult(0, "", ""),
+        pr_body.TrackingIssuePostResult(
+            exit_code=0,
+            posted=True,
+            comment_url="",
+            error="",
+        ),
+        pr_body.SlackIssueAnnouncementResult(0, "posted", ""),
+        pr_body.CodeFlowDiagramResult(0, "ok", "diagram.md", ""),
+    ],
+)
+def test_public_result_types_are_frozen(result: object) -> None:
+    assert is_dataclass(result)
+    with pytest.raises(FrozenInstanceError):
+        result.exit_code = 1  # type: ignore[attr-defined]
 
 
 
@@ -1050,7 +1104,10 @@ def test_slack_issue_announce_webhook_unset_skips(
     _write_slack_issue_state(tmp_path)
     monkeypatch.delenv("LARCH_SLACK_WEBHOOK_URL", raising=False)
 
-    assert pr_body.slack_issue_announce(tmp_path) == (0, "skipped", "webhook-not-set")
+    result = pr_body.slack_issue_announce(tmp_path)
+    assert result.exit_code == 0
+    assert result.status == "skipped"
+    assert result.reason == "webhook-not-set"
 
 
 @pytest.mark.parametrize("issue_number", ["", "0"])
@@ -1058,27 +1115,30 @@ def test_slack_issue_announce_issue_unset_skips(tmp_path: Path, issue_number: st
     if issue_number:
         _write_slack_issue_state(tmp_path, issue_number=issue_number)
 
-    assert pr_body.slack_issue_announce(tmp_path) == (0, "skipped", "issue-not-set")
+    result = pr_body.slack_issue_announce(tmp_path)
+    assert result.exit_code == 0
+    assert result.status == "skipped"
+    assert result.reason == "issue-not-set"
 
 
 def test_slack_issue_announce_nonnumeric_issue_fails(tmp_path: Path) -> None:
     _write_slack_issue_state(tmp_path, issue_number="abc")
 
-    rc, status, reason = pr_body.slack_issue_announce(tmp_path)
+    result = pr_body.slack_issue_announce(tmp_path)
 
-    assert rc != 0
-    assert status == "failed"
-    assert reason == "ISSUE_NUMBER must be numeric"
+    assert result.exit_code != 0
+    assert result.status == "failed"
+    assert result.reason == "ISSUE_NUMBER must be numeric"
 
 
 def test_slack_issue_announce_nonnumeric_issue_best_effort_exits_zero(tmp_path: Path) -> None:
     _write_slack_issue_state(tmp_path, issue_number="abc")
 
-    rc, status, reason = pr_body.slack_issue_announce(tmp_path, best_effort=True)
+    result = pr_body.slack_issue_announce(tmp_path, best_effort=True)
 
-    assert rc == 0
-    assert status == "failed"
-    assert reason == "ISSUE_NUMBER must be numeric"
+    assert result.exit_code == 0
+    assert result.status == "failed"
+    assert result.reason == "ISSUE_NUMBER must be numeric"
 
 
 def test_slack_issue_announce_posts_json(
@@ -1097,7 +1157,10 @@ def test_slack_issue_announce_posts_json(
 
     monkeypatch.setattr(pr_body.urllib.request, "urlopen", fake_urlopen)
 
-    assert pr_body.slack_issue_announce(tmp_path) == (0, "posted", "")
+    result = pr_body.slack_issue_announce(tmp_path)
+    assert result.exit_code == 0
+    assert result.status == "posted"
+    assert result.reason == ""
 
     assert len(requests) == 1
     request = requests[0]
@@ -1125,11 +1188,11 @@ def test_slack_issue_announce_urlopen_failure_fails(
 
     monkeypatch.setattr(pr_body.urllib.request, "urlopen", fake_urlopen)
 
-    rc, status, reason = pr_body.slack_issue_announce(tmp_path)
+    result = pr_body.slack_issue_announce(tmp_path)
 
-    assert rc != 0
-    assert status == "failed"
-    assert reason == "network down"
+    assert result.exit_code != 0
+    assert result.status == "failed"
+    assert result.reason == "network down"
 
 
 def test_slack_issue_announce_urlopen_failure_best_effort_exits_zero(
@@ -1145,11 +1208,11 @@ def test_slack_issue_announce_urlopen_failure_best_effort_exits_zero(
 
     monkeypatch.setattr(pr_body.urllib.request, "urlopen", fake_urlopen)
 
-    rc, status, reason = pr_body.slack_issue_announce(tmp_path, best_effort=True)
+    result = pr_body.slack_issue_announce(tmp_path, best_effort=True)
 
-    assert rc == 0
-    assert status == "failed"
-    assert reason == "network down"
+    assert result.exit_code == 0
+    assert result.status == "failed"
+    assert result.reason == "network down"
 
 
 def test_slack_issue_announce_invalid_webhook_scheme_does_not_call_urlopen(
@@ -1165,11 +1228,11 @@ def test_slack_issue_announce_invalid_webhook_scheme_does_not_call_urlopen(
 
     monkeypatch.setattr(pr_body.urllib.request, "urlopen", fake_urlopen)
 
-    rc, status, reason = pr_body.slack_issue_announce(tmp_path)
+    result = pr_body.slack_issue_announce(tmp_path)
 
-    assert rc != 0
-    assert status == "failed"
-    assert reason == "webhook scheme must be http or https"
+    assert result.exit_code != 0
+    assert result.status == "failed"
+    assert result.reason == "webhook scheme must be http or https"
 
 
 def test_slack_issue_announce_main_posted_envelope(
@@ -1294,12 +1357,12 @@ def test_post_tracking_issue_writes_metadata(tmp_path: Path, monkeypatch: pytest
         return Result()
 
     monkeypatch.setattr(pr_body.subprocess, "run", fake_run)
-    rc, posted, url, err = pr_body.post_tracking_issue(tmp_path)
-    assert rc == 0
-    assert posted is True
-    assert "issues/42" in url
+    result = pr_body.post_tracking_issue(tmp_path)
+    assert result.exit_code == 0
+    assert result.posted is True
+    assert "issues/42" in result.comment_url
     assert (tmp_path / "summary-metadata.md").is_file()
-    assert err == ""
+    assert result.error == ""
     assert [cmd[1] for cmd in calls] == [str(pr_body._PY_CLI), str(pr_body._PY_CLI)]
 
 
@@ -1322,12 +1385,12 @@ def test_post_tracking_issue_warns_plugin_read_version_nonzero_on_stderr(
         return Result()
 
     monkeypatch.setattr(pr_body.subprocess, "run", fake_run)
-    rc, posted, _url, err = pr_body.post_tracking_issue(tmp_path)
+    result = pr_body.post_tracking_issue(tmp_path)
     captured = capsys.readouterr()
 
-    assert rc == 0
-    assert posted is True
-    assert err == ""
+    assert result.exit_code == 0
+    assert result.posted is True
+    assert result.error == ""
     assert "pr_body: plugin read-version failed rc=7" in captured.err
     assert "pr_body: plugin read-version" not in captured.out
 
@@ -1353,14 +1416,14 @@ def test_generate_code_flow_diagram_uses_launcher_not_stub(tmp_path: Path, monke
         return type("R", (), {"returncode": 1, "stdout": "stdout diagnostic\n## Code Flow Diagram\n```mermaid\ngraph TD\nA-->B\n```", "stderr": raw_stderr})()
 
     monkeypatch.setattr(pr_body.subprocess, "run", fake_run)
-    rc, status, _diagram, reason = pr_body.generate_code_flow_diagram(tmp_path)
-    assert rc == 1
-    assert status == "failed"
-    assert reason != "generation-failed"
-    assert "generation-failed rc=1" in reason
-    assert "tail=" in reason
-    assert "timeout after 600s" in reason
-    assert raw_secret not in reason
+    result = pr_body.generate_code_flow_diagram(tmp_path)
+    assert result.exit_code == 1
+    assert result.status == "failed"
+    assert result.reason != "generation-failed"
+    assert "generation-failed rc=1" in result.reason
+    assert "tail=" in result.reason
+    assert "timeout after 600s" in result.reason
+    assert raw_secret not in result.reason
     failure_log = tmp_path / "code-flow-diagram.failure.log"
     assert failure_log.is_file()
     log_text = failure_log.read_text(encoding="utf-8")
@@ -1394,12 +1457,12 @@ def test_generate_code_flow_diagram_labels_launcher_failure_class(
         )
 
     monkeypatch.setattr(pr_body.subprocess, "run", fake_run)
-    rc, status, _diagram, reason = pr_body.generate_code_flow_diagram(tmp_path)
+    result = pr_body.generate_code_flow_diagram(tmp_path)
 
-    assert rc == 1
-    assert status == "failed"
-    assert "generation-failed health/auth rc=124" in reason
-    assert "tail=" in reason
+    assert result.exit_code == 1
+    assert result.status == "failed"
+    assert "generation-failed health/auth rc=124" in result.reason
+    assert "tail=" in result.reason
 
 
 def test_generate_code_flow_diagram_uses_py_cli_launcher(
@@ -1426,12 +1489,12 @@ def test_generate_code_flow_diagram_uses_py_cli_launcher(
         return subprocess.CompletedProcess(argv, 1, stdout="", stderr="unexpected argv")
 
     monkeypatch.setattr(pr_body.subprocess, "run", fake_run)
-    rc, status, diagram, reason = pr_body.generate_code_flow_diagram(tmp_path)
+    result = pr_body.generate_code_flow_diagram(tmp_path)
 
-    assert rc == 0
-    assert status == "ok"
-    assert diagram
-    assert reason == ""
+    assert result.exit_code == 0
+    assert result.status == "ok"
+    assert result.diagram_file
+    assert result.reason == ""
     assert launch_argv[1] == str(pr_body._PY_CLI)
     assert launch_argv[2:4] == ["agent", "launch-claude-subprocess"]
     timeout_idx = launch_argv.index("--timeout")
@@ -1470,13 +1533,13 @@ def test_generate_code_flow_diagram_retries_on_timeout(
         return subprocess.CompletedProcess(argv, 1, stdout="", stderr="unexpected")
 
     monkeypatch.setattr(pr_body.subprocess, "run", fake_run)  # type: ignore[arg-type]
-    rc, status, diagram, reason = pr_body.generate_code_flow_diagram(tmp_path)
+    result = pr_body.generate_code_flow_diagram(tmp_path)
 
     assert call_count == 2, "should succeed on first retry"
-    assert rc == 0
-    assert status == "ok"
-    assert diagram
-    assert reason == ""
+    assert result.exit_code == 0
+    assert result.status == "ok"
+    assert result.diagram_file
+    assert result.reason == ""
     assert (tmp_path / "code-flow-diagram.retried").is_file()
     retried_text = (tmp_path / "code-flow-diagram.retried").read_text(encoding="utf-8")
     assert f"FIRST_RC={config.EXIT_TIMEOUT}" in retried_text
@@ -1515,12 +1578,12 @@ def test_generate_code_flow_diagram_retries_on_empty_output(
         return subprocess.CompletedProcess(argv, 1, stdout="", stderr="unexpected")
 
     monkeypatch.setattr(pr_body.subprocess, "run", fake_run)  # type: ignore[arg-type]
-    rc, status, _diagram, reason = pr_body.generate_code_flow_diagram(tmp_path)
+    result = pr_body.generate_code_flow_diagram(tmp_path)
 
     assert call_count == 2, "should succeed on first retry"
-    assert rc == 0
-    assert status == "ok"
-    assert reason == ""
+    assert result.exit_code == 0
+    assert result.status == "ok"
+    assert result.reason == ""
     assert (tmp_path / "code-flow-diagram.retried").is_file()
 
 
@@ -1545,11 +1608,11 @@ def test_generate_code_flow_diagram_no_retry_on_hard_failure(
         return subprocess.CompletedProcess(argv, 1, stdout="", stderr="unexpected")
 
     monkeypatch.setattr(pr_body.subprocess, "run", fake_run)  # type: ignore[arg-type]
-    rc, status, _diagram, _reason = pr_body.generate_code_flow_diagram(tmp_path)
+    result = pr_body.generate_code_flow_diagram(tmp_path)
 
     assert call_count == 1, "should NOT retry when output file is absent"
-    assert rc == 1
-    assert status == "failed"
+    assert result.exit_code == 1
+    assert result.status == "failed"
     assert not (tmp_path / "code-flow-diagram.retried").is_file()
 
 
@@ -1577,12 +1640,12 @@ def test_generate_code_flow_diagram_retries_up_to_max_on_persistent_failure(
         return subprocess.CompletedProcess(argv, 1, stdout="", stderr="unexpected")
 
     monkeypatch.setattr(pr_body.subprocess, "run", fake_run)  # type: ignore[arg-type]
-    rc, status, _diagram, _reason = pr_body.generate_code_flow_diagram(tmp_path)
+    result = pr_body.generate_code_flow_diagram(tmp_path)
 
     expected_calls = 1 + pr_body._MAX_DIAGRAM_RETRIES
     assert call_count == expected_calls, f"should attempt {expected_calls} times total"
-    assert rc == 1
-    assert status == "failed"
+    assert result.exit_code == 1
+    assert result.status == "failed"
     assert (tmp_path / "code-flow-diagram.retried").is_file()
     retried_text = (tmp_path / "code-flow-diagram.retried").read_text(encoding="utf-8")
     assert f"FIRST_RC={config.EXIT_TIMEOUT}" in retried_text
@@ -1611,13 +1674,13 @@ def test_generate_code_flow_diagram_reads_stderr_sidecar(
         return subprocess.CompletedProcess(argv, 1, stdout="", stderr="unexpected")
 
     monkeypatch.setattr(pr_body.subprocess, "run", fake_run)  # type: ignore[arg-type]
-    rc, status, _diagram, reason = pr_body.generate_code_flow_diagram(tmp_path)
+    result = pr_body.generate_code_flow_diagram(tmp_path)
 
-    assert rc == 1
-    assert status == "failed"
+    assert result.exit_code == 1
+    assert result.status == "failed"
     # Sidecar content must appear in the reason; completed.stderr was empty so
     # without Fix 1 the tail would be "no-output" instead.
-    assert "claude.ai login" in reason
+    assert "claude.ai login" in result.reason
 
 
 def test_derive_oos_fields_reads_json_body_filed_url(tmp_path: Path) -> None:

--- a/python/tests/implement/test_step_7a.py
+++ b/python/tests/implement/test_step_7a.py
@@ -113,11 +113,13 @@ def test_step7a_bgjob_launch_rejects_symlinked_tmpdir_before_merge_env_setup(
 def test_step7a_emits_terminal_kvs(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     _ = (tmp_path / "session-id").write_text("run-1\n", encoding="utf-8")
 
-    def fake_generate_code_flow_diagram(implement_tmpdir: Path, *, base_remote: str, base_ref: str) -> tuple[int, str, str, str]:
+    def fake_generate_code_flow_diagram(
+        implement_tmpdir: Path, *, base_remote: str, base_ref: str
+    ) -> step_7a.pr_body.CodeFlowDiagramResult:
         _ = (base_remote, base_ref)
         diagram = implement_tmpdir / "code-flow-diagram.md"
         _ = diagram.write_text("## Code Flow Diagram\n\n```mermaid\ngraph TD\nA-->B\n```\n", encoding="utf-8")
-        return 0, "ok", str(diagram), ""
+        return step_7a.pr_body.CodeFlowDiagramResult(0, "ok", str(diagram), "")
 
     with patch.object(step_7a, "_is_small_non_runtime_change", return_value=False), patch.object(
         step_7a.pr_body,
@@ -290,10 +292,12 @@ def test_step7a_diagram_failure_exits_zero_and_clears_stale_artifacts(tmp_path: 
     _ = (tmp_path / "code-flow-diagram.md").write_text("stale\n", encoding="utf-8")
     reason = "generation-failed rc=7 tail=timeout after 600s"
 
-    def fake_generate_code_flow_diagram(implement_tmpdir: Path, *, base_remote: str, base_ref: str) -> tuple[int, str, str, str]:
+    def fake_generate_code_flow_diagram(
+        implement_tmpdir: Path, *, base_remote: str, base_ref: str
+    ) -> step_7a.pr_body.CodeFlowDiagramResult:
         _ = (base_remote, base_ref)
         _ = (implement_tmpdir / "code-flow-diagram.failure.log").write_text("returncode: 7\nstderr: timeout after 600s\n", encoding="utf-8")
-        return 1, "failed", "", reason
+        return step_7a.pr_body.CodeFlowDiagramResult(1, "failed", "", reason)
 
     with patch.object(step_7a, "_is_small_non_runtime_change", return_value=False), patch.object(
         step_7a.pr_body,
@@ -324,7 +328,7 @@ def test_step7a_diagram_failure_emits_diagram_reason_on_rebase_failure(tmp_path:
     with patch.object(step_7a, "_is_small_non_runtime_change", return_value=False), patch.object(
         step_7a.pr_body,
         "generate_code_flow_diagram",
-        return_value=(1, "failed", "", reason),
+        return_value=step_7a.pr_body.CodeFlowDiagramResult(1, "failed", "", reason),
     ), patch.object(step_7a, "_run_log_flush", return_value="ok") as mock_flush, patch.object(step_7a, "subprocess") as mock_subprocess:
         mock_subprocess.run.return_value.returncode = 1
         mock_subprocess.run.return_value.stdout = "REBASE_OUTCOME=conflict\n"
@@ -446,12 +450,14 @@ def test_step7a_orchestrates_generation_upsert_and_checkpoint_in_order(
     calls: list[tuple[str, ...]] = []
     events: list[str] = []
 
-    def fake_generate(implement_tmpdir: Path, *, base_remote: str, base_ref: str) -> tuple[int, str, str, str]:
+    def fake_generate(
+        implement_tmpdir: Path, *, base_remote: str, base_ref: str
+    ) -> step_7a.pr_body.CodeFlowDiagramResult:
         assert (base_remote, base_ref) == ("origin", "main")
         events.append("generate")
         diagram = implement_tmpdir / "code-flow-diagram.md"
         _ = diagram.write_text("## Code Flow Diagram\n\n```mermaid\ngraph TD\nA-->B\n```\n", encoding="utf-8")
-        return 0, "ok", str(diagram), ""
+        return step_7a.pr_body.CodeFlowDiagramResult(0, "ok", str(diagram), "")
 
     def fake_run_cli(*args: str) -> subprocess.CompletedProcess[str]:
         calls.append(args)
@@ -504,11 +510,13 @@ def test_step7a_rehydrates_fork_target_for_generation_and_checkpoint(
     calls: list[tuple[str, ...]] = []
     generation_target: list[tuple[str, str]] = []
 
-    def fake_generate(implement_tmpdir: Path, *, base_remote: str, base_ref: str) -> tuple[int, str, str, str]:
+    def fake_generate(
+        implement_tmpdir: Path, *, base_remote: str, base_ref: str
+    ) -> step_7a.pr_body.CodeFlowDiagramResult:
         generation_target.append((base_remote, base_ref))
         diagram = implement_tmpdir / "code-flow-diagram.md"
         _ = diagram.write_text("## Code Flow Diagram\n", encoding="utf-8")
-        return 0, "ok", str(diagram), ""
+        return step_7a.pr_body.CodeFlowDiagramResult(0, "ok", str(diagram), "")
 
     def fake_run_cli(*args: str) -> subprocess.CompletedProcess[str]:
         calls.append(args)
@@ -548,8 +556,10 @@ def test_step7a_sanitizer_skip_clears_stale_artifacts_and_omits_upsert(
             return subprocess.CompletedProcess(args, 0, "REBASE_OUTCOME=ok\n", "")
         return subprocess.CompletedProcess(args, 0, "", "")
 
-    def fake_generate(*_args: object, **_kwargs: object) -> tuple[int, str, str, str]:
-        return 0, status, "", reason
+    def fake_generate(
+        *_args: object, **_kwargs: object
+    ) -> step_7a.pr_body.CodeFlowDiagramResult:
+        return step_7a.pr_body.CodeFlowDiagramResult(0, status, "", reason)
 
     monkeypatch.setattr(step_7a, "_is_small_non_runtime_change", _no_small_non_runtime_change)
     monkeypatch.setattr(step_7a.pr_body, "generate_code_flow_diagram", fake_generate)
@@ -572,10 +582,12 @@ def test_step7a_upsert_failure_keeps_checkpoint_and_exit_success(
     _ = (tmp_path / "session-id").write_text("run-1\n", encoding="utf-8")
     calls: list[tuple[str, ...]] = []
 
-    def fake_generate(implement_tmpdir: Path, **_kwargs: str) -> tuple[int, str, str, str]:
+    def fake_generate(
+        implement_tmpdir: Path, **_kwargs: str
+    ) -> step_7a.pr_body.CodeFlowDiagramResult:
         diagram = implement_tmpdir / "code-flow-diagram.md"
         _ = diagram.write_text("## Code Flow Diagram\n", encoding="utf-8")
-        return 0, "ok", str(diagram), ""
+        return step_7a.pr_body.CodeFlowDiagramResult(0, "ok", str(diagram), "")
 
     def fake_run_cli(*args: str) -> subprocess.CompletedProcess[str]:
         calls.append(args)
@@ -603,10 +615,12 @@ def test_step7a_empty_issue_number_skips_upsert_but_runs_checkpoint(
     _ = (tmp_path / "session-id").write_text("run-1\n", encoding="utf-8")
     calls: list[tuple[str, ...]] = []
 
-    def fake_generate(implement_tmpdir: Path, **_kwargs: str) -> tuple[int, str, str, str]:
+    def fake_generate(
+        implement_tmpdir: Path, **_kwargs: str
+    ) -> step_7a.pr_body.CodeFlowDiagramResult:
         diagram = implement_tmpdir / "code-flow-diagram.md"
         _ = diagram.write_text("## Code Flow Diagram\n", encoding="utf-8")
-        return 0, "ok", str(diagram), ""
+        return step_7a.pr_body.CodeFlowDiagramResult(0, "ok", str(diagram), "")
 
     def fake_run_cli(*args: str) -> subprocess.CompletedProcess[str]:
         calls.append(args)


### PR DESCRIPTION
Closes #7307

Replaces the public PR-body tuple results with frozen dataclasses, updates internal consumers, and preserves the existing CLI KV envelopes.

Validation: focused Ruff, Pyright, Pylint, and 527 focused tests.