### PR TITLE
Fixes #7347: Complete deferred KEY=value codec and emit_kv migrations

### DIFF
--- a/python/kv-codec-baseline.json
+++ b/python/kv-codec-baseline.json
@@ -273,7 +273,7 @@
   },
   {
     "anchor": "split=0b405025401f6ee54b9cfde500932675848b8814a014d0e62666ddb9e3753bcb",
-    "line": 290,
+    "line": 292,
     "message": "ad-hoc KEY=value split loop; use larch.io codec",
     "path": "python/larch/implement/dispatch_manifest.py",
     "reason": "pre-existing KEY=value reader pending shared codec migration",
@@ -289,7 +289,7 @@
   },
   {
     "anchor": "split=0b405025401f6ee54b9cfde500932675848b8814a014d0e62666ddb9e3753bcb",
-    "line": 355,
+    "line": 288,
     "message": "ad-hoc KEY=value split loop; use larch.io codec",
     "path": "python/larch/implement/step_7a.py",
     "reason": "pre-existing KEY=value reader pending shared codec migration",
@@ -313,7 +313,7 @@
   },
   {
     "anchor": "split=0b405025401f6ee54b9cfde500932675848b8814a014d0e62666ddb9e3753bcb",
-    "line": 433,
+    "line": 430,
     "message": "ad-hoc KEY=value split loop; use larch.io codec",
     "path": "python/larch/report/final_report.py",
     "reason": "pre-existing KEY=value reader pending shared codec migration",

--- a/python/kv-codec-baseline.json
+++ b/python/kv-codec-baseline.json
@@ -1,77 +1,5 @@
 [
   {
-    "anchor": "split=080a782305839e2c76098f8374e5af8c153aa09bbdee7165c531bf698ccc131d",
-    "line": 717,
-    "message": "ad-hoc KEY=value split loop; use larch.io codec",
-    "path": "python/larch/agents/_ci_launcher.py",
-    "reason": "pre-existing KEY=value reader pending shared codec migration",
-    "rule_id": "kv-codec"
-  },
-  {
-    "anchor": "split=23a21f5bc74c529e98087b24807f53cb78eef8fdc9e139b64373a7d4c838ffd4",
-    "line": 715,
-    "message": "ad-hoc KEY=value split loop; use larch.io codec",
-    "path": "python/larch/agents/_ci_launcher.py",
-    "reason": "pre-existing KEY=value reader pending shared codec migration",
-    "rule_id": "kv-codec"
-  },
-  {
-    "anchor": "split=0b405025401f6ee54b9cfde500932675848b8814a014d0e62666ddb9e3753bcb",
-    "line": 696,
-    "message": "ad-hoc KEY=value split loop; use larch.io codec",
-    "path": "python/larch/agents/_claude_runner.py",
-    "reason": "pre-existing KEY=value reader pending shared codec migration",
-    "rule_id": "kv-codec"
-  },
-  {
-    "anchor": "split=0b405025401f6ee54b9cfde500932675848b8814a014d0e62666ddb9e3753bcb",
-    "line": 116,
-    "message": "ad-hoc KEY=value split loop; use larch.io codec",
-    "path": "python/larch/agents/_launch_failure.py",
-    "reason": "pre-existing KEY=value reader pending shared codec migration",
-    "rule_id": "kv-codec"
-  },
-  {
-    "anchor": "split=602272923aa5c1c3e8372b58e179181cc7c5487180d8a5034e933f9ff80b283e",
-    "line": 339,
-    "message": "ad-hoc KEY=value split loop; use larch.io codec",
-    "path": "python/larch/agents/_launch_failure.py",
-    "reason": "pre-existing KEY=value reader pending shared codec migration",
-    "rule_id": "kv-codec"
-  },
-  {
-    "anchor": "split=ccb82c555b56cfb985a07d1efe10199322a9a0a5ea06e7db3648f5a44032ed9c",
-    "line": 173,
-    "message": "ad-hoc KEY=value split loop; use larch.io codec",
-    "path": "python/larch/agents/_launch_failure.py",
-    "reason": "pre-existing KEY=value reader pending shared codec migration",
-    "rule_id": "kv-codec"
-  },
-  {
-    "anchor": "split=080a782305839e2c76098f8374e5af8c153aa09bbdee7165c531bf698ccc131d",
-    "line": 496,
-    "message": "ad-hoc KEY=value split loop; use larch.io codec",
-    "path": "python/larch/agents/_review_launcher.py",
-    "reason": "pre-existing KEY=value reader pending shared codec migration",
-    "rule_id": "kv-codec"
-  },
-  {
-    "anchor": "split=0b405025401f6ee54b9cfde500932675848b8814a014d0e62666ddb9e3753bcb",
-    "line": 346,
-    "message": "ad-hoc KEY=value split loop; use larch.io codec",
-    "path": "python/larch/agents/_review_launcher.py",
-    "reason": "pre-existing KEY=value reader pending shared codec migration",
-    "rule_id": "kv-codec"
-  },
-  {
-    "anchor": "split=9f2602228dbd558d72a463fdac1471483f4177f6f0db977c88ca7e64addb47b6",
-    "line": 1043,
-    "message": "ad-hoc KEY=value split loop; use larch.io codec",
-    "path": "python/larch/agents/_run_external.py",
-    "reason": "pre-existing KEY=value reader pending shared codec migration",
-    "rule_id": "kv-codec"
-  },
-  {
     "anchor": "split=23a21f5bc74c529e98087b24807f53cb78eef8fdc9e139b64373a7d4c838ffd4",
     "line": 454,
     "message": "ad-hoc KEY=value split loop; use larch.io codec",
@@ -124,46 +52,6 @@
     "line": 324,
     "message": "ad-hoc KEY=value split loop; use larch.io codec",
     "path": "python/larch/design/design_log_publish_flow.py",
-    "reason": "pre-existing KEY=value reader pending shared codec migration",
-    "rule_id": "kv-codec"
-  },
-  {
-    "anchor": "split=45c7cccadcb9ab919888b7499410eaa22fd8a9f22a42c425693df8f894d7c3cf",
-    "line": 432,
-    "message": "ad-hoc KEY=value split loop; use larch.io codec",
-    "path": "python/larch/design/design_oos.py",
-    "reason": "pre-existing KEY=value reader pending shared codec migration",
-    "rule_id": "kv-codec"
-  },
-  {
-    "anchor": "split=602272923aa5c1c3e8372b58e179181cc7c5487180d8a5034e933f9ff80b283e",
-    "line": 429,
-    "message": "ad-hoc KEY=value split loop; use larch.io codec",
-    "path": "python/larch/design/design_oos.py",
-    "reason": "pre-existing KEY=value reader pending shared codec migration",
-    "rule_id": "kv-codec"
-  },
-  {
-    "anchor": "split=73879ff6b80412c58c97f623bd0ba49c10ef6095c7b3b37ab80ca73050b805f5",
-    "line": 383,
-    "message": "ad-hoc KEY=value split loop; use larch.io codec",
-    "path": "python/larch/design/design_oos.py",
-    "reason": "pre-existing KEY=value reader pending shared codec migration",
-    "rule_id": "kv-codec"
-  },
-  {
-    "anchor": "split=a46fca1b9fdf9739c559937a6424b15fb06487f0549a53686871feefd9215c98",
-    "line": 644,
-    "message": "ad-hoc KEY=value split loop; use larch.io codec",
-    "path": "python/larch/design/design_oos.py",
-    "reason": "pre-existing KEY=value reader pending shared codec migration",
-    "rule_id": "kv-codec"
-  },
-  {
-    "anchor": "split=ccb82c555b56cfb985a07d1efe10199322a9a0a5ea06e7db3648f5a44032ed9c",
-    "line": 426,
-    "message": "ad-hoc KEY=value split loop; use larch.io codec",
-    "path": "python/larch/design/design_oos.py",
     "reason": "pre-existing KEY=value reader pending shared codec migration",
     "rule_id": "kv-codec"
   },
@@ -268,14 +156,6 @@
     "line": 500,
     "message": "ad-hoc KEY=value split loop; use larch.io codec",
     "path": "python/larch/design/design_step5c.py",
-    "reason": "pre-existing KEY=value reader pending shared codec migration",
-    "rule_id": "kv-codec"
-  },
-  {
-    "anchor": "split=0b405025401f6ee54b9cfde500932675848b8814a014d0e62666ddb9e3753bcb",
-    "line": 337,
-    "message": "ad-hoc KEY=value split loop; use larch.io codec",
-    "path": "python/larch/design/design_summary.py",
     "reason": "pre-existing KEY=value reader pending shared codec migration",
     "rule_id": "kv-codec"
   },
@@ -393,7 +273,7 @@
   },
   {
     "anchor": "split=0b405025401f6ee54b9cfde500932675848b8814a014d0e62666ddb9e3753bcb",
-    "line": 292,
+    "line": 290,
     "message": "ad-hoc KEY=value split loop; use larch.io codec",
     "path": "python/larch/implement/dispatch_manifest.py",
     "reason": "pre-existing KEY=value reader pending shared codec migration",
@@ -521,38 +401,6 @@
   },
   {
     "anchor": "split=0b405025401f6ee54b9cfde500932675848b8814a014d0e62666ddb9e3753bcb",
-    "line": 93,
-    "message": "ad-hoc KEY=value split loop; use larch.io codec",
-    "path": "python/larch/state/admission.py",
-    "reason": "pre-existing KEY=value reader pending shared codec migration",
-    "rule_id": "kv-codec"
-  },
-  {
-    "anchor": "split=45c7cccadcb9ab919888b7499410eaa22fd8a9f22a42c425693df8f894d7c3cf",
-    "line": 269,
-    "message": "ad-hoc KEY=value split loop; use larch.io codec",
-    "path": "python/larch/state/admission.py",
-    "reason": "pre-existing KEY=value reader pending shared codec migration",
-    "rule_id": "kv-codec"
-  },
-  {
-    "anchor": "split=602272923aa5c1c3e8372b58e179181cc7c5487180d8a5034e933f9ff80b283e",
-    "line": 113,
-    "message": "ad-hoc KEY=value split loop; use larch.io codec",
-    "path": "python/larch/state/admission.py",
-    "reason": "pre-existing KEY=value reader pending shared codec migration",
-    "rule_id": "kv-codec"
-  },
-  {
-    "anchor": "split=ccb82c555b56cfb985a07d1efe10199322a9a0a5ea06e7db3648f5a44032ed9c",
-    "line": 209,
-    "message": "ad-hoc KEY=value split loop; use larch.io codec",
-    "path": "python/larch/state/admission.py",
-    "reason": "pre-existing KEY=value reader pending shared codec migration",
-    "rule_id": "kv-codec"
-  },
-  {
-    "anchor": "split=0b405025401f6ee54b9cfde500932675848b8814a014d0e62666ddb9e3753bcb",
     "line": 1304,
     "message": "ad-hoc KEY=value split loop; use larch.io codec",
     "path": "python/larch/state/bootstrap.py",
@@ -617,58 +465,18 @@
   },
   {
     "anchor": "split=0b405025401f6ee54b9cfde500932675848b8814a014d0e62666ddb9e3753bcb",
-    "line": 568,
+    "line": 565,
     "message": "ad-hoc KEY=value split loop; use larch.io codec",
     "path": "python/larch/state/session_env.py",
     "reason": "pre-existing KEY=value reader pending shared codec migration",
     "rule_id": "kv-codec"
   },
   {
-    "anchor": "split=602272923aa5c1c3e8372b58e179181cc7c5487180d8a5034e933f9ff80b283e",
-    "line": 795,
+    "anchor": "split=2ce4610c86cedf4a5a9b299086d5f06f92855bb33caee200eb9b4de1366dc7e9",
+    "line": 1547,
     "message": "ad-hoc KEY=value split loop; use larch.io codec",
     "path": "python/larch/state/session_env.py",
     "reason": "pre-existing KEY=value reader pending shared codec migration",
-    "rule_id": "kv-codec"
-  },
-  {
-    "anchor": "split=ccb82c555b56cfb985a07d1efe10199322a9a0a5ea06e7db3648f5a44032ed9c",
-    "line": 604,
-    "message": "ad-hoc KEY=value split loop; use larch.io codec",
-    "path": "python/larch/state/session_env.py",
-    "reason": "pre-existing KEY=value reader pending shared codec migration",
-    "rule_id": "kv-codec"
-  },
-  {
-    "anchor": "split=d80873a849f52f7146e9e9d69178c7813893feb94e19d74dd1ef24c40aa3dbdd",
-    "line": 1554,
-    "message": "ad-hoc KEY=value split loop; use larch.io codec",
-    "path": "python/larch/state/session_env.py",
-    "reason": "pre-existing KEY=value reader pending shared codec migration",
-    "rule_id": "kv-codec"
-  },
-  {
-    "anchor": "shell=0428f347225f40408c743827f948f175bbf8878ac34711b7f1e5701359f18d8d",
-    "line": 300,
-    "message": "ad-hoc shell KEY=value reader; use cli.py kv get",
-    "path": "skills/design/scripts/design-step3-mav.sh",
-    "reason": "legacy or bootstrap reader pending migration to shared codec",
-    "rule_id": "kv-codec"
-  },
-  {
-    "anchor": "shell=c158ceeb60de26eac2ecfb40d5b6e3f907f2fee182ee0385cf2128e2bd67b731",
-    "line": 125,
-    "message": "ad-hoc shell KEY=value reader; use cli.py kv get",
-    "path": "skills/implement/scripts/post-tracking-issue.sh",
-    "reason": "legacy or bootstrap reader pending migration to shared codec",
-    "rule_id": "kv-codec"
-  },
-  {
-    "anchor": "shell=49d840ea52ce28e9feb0515900059c130c47e78b0a0cd1e07431c7dfd4b49294",
-    "line": 115,
-    "message": "ad-hoc shell KEY=value reader; use cli.py kv get",
-    "path": "skills/implement/scripts/step-18.sh",
-    "reason": "legacy or bootstrap reader pending migration to shared codec",
     "rule_id": "kv-codec"
   }
 ]

--- a/python/larch/agents/_auth.py
+++ b/python/larch/agents/_auth.py
@@ -41,7 +41,6 @@ from larch.agents._types import (
     DegradedToolsResult,
     _err,
     _emit,
-    _emit_kv,
     _write,
     _append,
     _plugin_root,
@@ -796,8 +795,8 @@ def external_tool_registry_main(argv: list[str] | None = None) -> int:
         for tool in EXTERNAL_TOOL_NAMES:
             _emit(tool)
     else:
-        _emit_kv(key="EXTERNAL_TOOLS", value=",".join(EXTERNAL_TOOL_NAMES))
-        _emit_kv(key="IMPLEMENTER_CODERS", value="claude,codex,cursor")
+        logging_util.emit_kv(key="EXTERNAL_TOOLS", value=",".join(EXTERNAL_TOOL_NAMES))
+        logging_util.emit_kv(key="IMPLEMENTER_CODERS", value="claude,codex,cursor")
     return 0
 
 
@@ -906,14 +905,14 @@ def degraded_tools_gate_main(argv: list[str] | None = None) -> int:
         cursor_present=ctx.cursor_present,
         skill=ctx.str_value(key="skill", default="this"),
     )
-    _emit_kv(key="DEGRADED", value=str(result.degraded).lower())
-    _emit_kv(key="CODEX_STATE", value=result.codex_state)
-    _emit_kv(key="CURSOR_STATE", value=result.cursor_state)
-    _emit_kv(key="BOTH_DOWN", value=str(result.both_down).lower())
+    logging_util.emit_kv(key="DEGRADED", value=str(result.degraded).lower())
+    logging_util.emit_kv(key="CODEX_STATE", value=result.codex_state)
+    logging_util.emit_kv(key="CURSOR_STATE", value=result.cursor_state)
+    logging_util.emit_kv(key="BOTH_DOWN", value=str(result.both_down).lower())
     if result.both_down:
-        _emit_kv(key="DEGRADED_HARD_FAIL", value="true")
+        logging_util.emit_kv(key="DEGRADED_HARD_FAIL", value="true")
     if result.presence_input_empty:
-        _emit_kv(key="PRESENCE_INPUT_EMPTY", value="true")
+        logging_util.emit_kv(key="PRESENCE_INPUT_EMPTY", value="true")
     if result.degraded:
         _emit("DEGRADED_EXPLANATION_BEGIN")
         for line in result.explanation:
@@ -965,16 +964,16 @@ def status_check_main(argv: list[str] | None = None) -> int:
         cursor_present=cursor_present,
         skill="status",
     )
-    _emit_kv(key="LARCH_PLUGIN_VERSION", value=version)
-    _emit_kv(key="CODEX_BINARY_FOUND", value=codex_binary_found)
-    _emit_kv(key="CURSOR_BINARY_FOUND", value=cursor_binary_found)
-    _emit_kv(key="CODEX_PRESENT", value=codex_present)
-    _emit_kv(key="CURSOR_PRESENT", value=cursor_present)
-    _emit_kv(key="CODEX_STATE", value=degraded.codex_state)
-    _emit_kv(key="CURSOR_STATE", value=degraded.cursor_state)
-    _emit_kv(key="DEGRADED", value=str(degraded.degraded).lower())
+    logging_util.emit_kv(key="LARCH_PLUGIN_VERSION", value=version)
+    logging_util.emit_kv(key="CODEX_BINARY_FOUND", value=codex_binary_found)
+    logging_util.emit_kv(key="CURSOR_BINARY_FOUND", value=cursor_binary_found)
+    logging_util.emit_kv(key="CODEX_PRESENT", value=codex_present)
+    logging_util.emit_kv(key="CURSOR_PRESENT", value=cursor_present)
+    logging_util.emit_kv(key="CODEX_STATE", value=degraded.codex_state)
+    logging_util.emit_kv(key="CURSOR_STATE", value=degraded.cursor_state)
+    logging_util.emit_kv(key="DEGRADED", value=str(degraded.degraded).lower())
     if degraded.codex_state == "probe-failed":
         gate_detail = reviewer_result.codex_gate_detail or _current_codex_gate_detail()
         if gate_detail is not None:
-            _emit_kv(key="CODEX_PROBE_DETAIL", value=gate_detail.message)
+            logging_util.emit_kv(key="CODEX_PROBE_DETAIL", value=gate_detail.message)
     return 0

--- a/python/larch/agents/_ci_launcher.py
+++ b/python/larch/agents/_ci_launcher.py
@@ -32,7 +32,6 @@ from larch.agents._types import (
     CURSOR_PREREAD_FAIL_MSG,
     LauncherPaths,
     _err,
-    _emit_kv,
     _read_text,
     _write,
     _append,
@@ -231,10 +230,10 @@ def _emit_ci_launcher_result(*, output: Path, launcher_exit: int, tool: str, bin
         tool=tool,
         output_file=output,
     )
-    _emit_kv(key="LAUNCHER_EXIT", value=launcher_exit)
-    _emit_kv(key="LAUNCHER_FAILURE_CLASS", value=failure.failure_class)
-    _emit_kv(key="LAUNCHER_FAILURE_REASON", value=failure.reason)
-    _emit_kv(key="OUTPUT", value=str(output))
+    logging_util.emit_kv(key="LAUNCHER_EXIT", value=launcher_exit)
+    logging_util.emit_kv(key="LAUNCHER_FAILURE_CLASS", value=failure.failure_class)
+    logging_util.emit_kv(key="LAUNCHER_FAILURE_REASON", value=failure.reason)
+    logging_util.emit_kv(key="OUTPUT", value=str(output))
 
 
 def launch_codex_ci_main(argv: list[str] | None = None) -> int:
@@ -694,27 +693,23 @@ def _implement_prompt(*, tool: str, args: argparse.Namespace, codex_session: Pat
 
 
 def _emit_implement_launcher_envelope(*, args: argparse.Namespace, launcher_exit: int, status: str = "") -> None:
-    _emit_kv(key="LAUNCHER_EXIT", value=launcher_exit)
-    _emit_kv(key="MANIFEST_WRITTEN", value=str(Path(args.manifest_path).is_file() and Path(args.manifest_path).stat().st_size > 0).lower())
-    _emit_kv(key="QA_PENDING_WRITTEN", value=str(Path(args.qa_pending_path).is_file() and Path(args.qa_pending_path).stat().st_size > 0).lower())
-    _emit_kv(key="SCOUT_MANIFEST_WRITTEN", value=str(Path(args.scout_manifest_path).is_file() and Path(args.scout_manifest_path).stat().st_size > 0).lower())
+    logging_util.emit_kv(key="LAUNCHER_EXIT", value=launcher_exit)
+    logging_util.emit_kv(key="MANIFEST_WRITTEN", value=str(Path(args.manifest_path).is_file() and Path(args.manifest_path).stat().st_size > 0).lower())
+    logging_util.emit_kv(key="QA_PENDING_WRITTEN", value=str(Path(args.qa_pending_path).is_file() and Path(args.qa_pending_path).stat().st_size > 0).lower())
+    logging_util.emit_kv(key="SCOUT_MANIFEST_WRITTEN", value=str(Path(args.scout_manifest_path).is_file() and Path(args.scout_manifest_path).stat().st_size > 0).lower())
     if status:
-        _emit_kv(key="STATUS", value=status)
-    _emit_kv(key="TRANSCRIPT", value=args.transcript_path)
-    _emit_kv(key="SIDECAR_LOG", value=args.sidecar_log)
+        logging_util.emit_kv(key="STATUS", value=status)
+    logging_util.emit_kv(key="TRANSCRIPT", value=args.transcript_path)
+    logging_util.emit_kv(key="SIDECAR_LOG", value=args.sidecar_log)
 
 
 def _implement_token_budget_hit(*, args: argparse.Namespace, tool: str, default_kind: str) -> bool:
     cap = args.token_budget_cap or os.environ.get("LARCH_TOKEN_BUDGET_CAP_IMPLEMENT", "")
     if cap and _is_positive_int(cap):
         result = proc.run([sys.executable, str(_PY_CLI), "token", "check-budget", "--cap", cap, "--step", args.timing_task_kind or default_kind], check=False)
-        status = ""
-        total = ""
-        for token in result.stdout.split():
-            if token.startswith("STATUS="):
-                status = token.split("=", 1)[1]
-            elif token.startswith("TOTAL="):
-                total = token.split("=", 1)[1]
+        budget_kv = larch_io.parse_kv("\n".join(result.stdout.split()), duplicate_policy="last")
+        status = budget_kv.get("STATUS", "")
+        total = budget_kv.get("TOTAL", "")
         if status == "cap_hit":
             _err(f"⚠ agent launch-{tool}-implement: step token budget cap of {cap} tokens exceeded ({total} combined vendor tokens); external implementer fan-out skipped")
             _write(path=args.transcript_path, text="STATUS=cap_hit\n")

--- a/python/larch/agents/_claude_runner.py
+++ b/python/larch/agents/_claude_runner.py
@@ -18,6 +18,7 @@ from pathlib import Path
 
 from larch.core import config
 from larch.git import git
+from larch import io as larch_io
 from larch.core import logging_util
 from larch.core import proc
 from larch.core import redact
@@ -36,7 +37,6 @@ from larch.agents._types import (
     WaterfallResult,
     TierAttempt,
     _err,
-    _emit_kv,
     _read_text,
     _write,
     _append,
@@ -450,9 +450,9 @@ def launch_claude_subprocess_main(argv: list[str] | None = None) -> int:
     )
     # Emit STATUS based on exit_code (tracks whether JSON promotion succeeded),
     # but return the subprocess's own returncode so callers that check the
-    _emit_kv(key="STATUS", value="OK" if exit_code == 0 else ("TIMEOUT" if exit_code == config.EXIT_TIMEOUT else "ERROR"))
-    _emit_kv(key="OUTPUT_FILE", value=str(output))
-    _emit_kv(key="ELAPSED", value=elapsed)
+    logging_util.emit_kv(key="STATUS", value="OK" if exit_code == 0 else ("TIMEOUT" if exit_code == config.EXIT_TIMEOUT else "ERROR"))
+    logging_util.emit_kv(key="OUTPUT_FILE", value=str(output))
+    logging_util.emit_kv(key="ELAPSED", value=elapsed)
     _emit_claude_subprocess_failure_fields(output=output, launcher_exit=exit_code)
     return exit_code
 
@@ -690,11 +690,8 @@ def ingest_launcher_token_sidecar(
     then calls ``token record-vendor-sidecar`` on every invocation so that
     partial-failure retries still record vendor usage.
     """
-    token_record: str | None = None
-    for line in launcher_stdout.splitlines():
-        if line.startswith("TOKEN_RECORD="):
-            token_record = line.split("=", 1)[1].strip()
-            break
+    token_record_raw = larch_io.kv_value(text=launcher_stdout, key="TOKEN_RECORD", duplicate_policy="first").strip()
+    token_record: str | None = token_record_raw or None
     if not token_record:
         if allow_output_fallback and output is not None:
             fallback = Path(f"{output}.token-record")

--- a/python/larch/agents/_drafter.py
+++ b/python/larch/agents/_drafter.py
@@ -31,7 +31,6 @@ from larch.agents._types import (
     LauncherPaths,
     DrafterParseResult,
     _err,
-    _emit_kv,
     _write,
     _append,
     _is_positive_int,
@@ -94,7 +93,7 @@ def _negotiation_base(output: Path) -> Path:
 
 
 def _emit_response_file(*, output_path: Path, **_kwargs: object) -> None:
-    _emit_kv(key="RESPONSE_FILE", value=str(output_path))
+    logging_util.emit_kv(key="RESPONSE_FILE", value=str(output_path))
 
 
 def _negotiation_codex_preflight(*, prep_rc: int, prep_msg: str, sidecar: Path, **_kwargs: object) -> bool:
@@ -406,7 +405,7 @@ def run_negotiation_round(*, tool: str, prompt_file: str | Path, output: str | P
                 use_config_context=False,
             )
             if outcome.status == "preflight_refused":
-                _emit_kv(key="RESPONSE_FILE", value=str(output_path))
+                logging_util.emit_kv(key="RESPONSE_FILE", value=str(output_path))
                 return 2
             if outcome.process_result is not None and outcome.process_result.exit_code != 0:
                 return 2
@@ -441,7 +440,7 @@ def run_negotiation_round(*, tool: str, prompt_file: str | Path, output: str | P
         use_config_context=False,
     )
     if cursor_outcome.status == "preflight_refused":
-        _emit_kv(key="RESPONSE_FILE", value=str(output_path))
+        logging_util.emit_kv(key="RESPONSE_FILE", value=str(output_path))
         return 3
     if cursor_outcome.process_result is not None and cursor_outcome.process_result.exit_code != 0:
         return 2
@@ -533,8 +532,8 @@ def launch_codex_exec_main(argv: list[str] | None = None) -> int:
             use_config_context=False,
         )
         launcher_exit = outcome.process_result.exit_code if outcome.process_result is not None else 0
-    _emit_kv(key="LAUNCHER_EXIT", value=launcher_exit)
-    _emit_kv(key="OUTPUT", value=str(output))
+    logging_util.emit_kv(key="LAUNCHER_EXIT", value=launcher_exit)
+    logging_util.emit_kv(key="OUTPUT", value=str(output))
     return 0
 
 
@@ -969,16 +968,16 @@ def launch_codex_drafter(
             if source.is_file() and source.stat().st_size > 0:
                 write_failed_agent_stderr_tail(source=source, output=output)
             _write(path=paths.done, text=f"{launcher_exit}\n")
-            _emit_kv(key="STATUS", value="ERROR")
-            _emit_kv(key="OUTPUT_FILE", value=str(output))
-            _emit_kv(key="TOKEN_RECORD", value=str(paths.token_record) if paths.token_record.is_file() else "")
+            logging_util.emit_kv(key="STATUS", value="ERROR")
+            logging_util.emit_kv(key="OUTPUT_FILE", value=str(output))
+            logging_util.emit_kv(key="TOKEN_RECORD", value=str(paths.token_record) if paths.token_record.is_file() else "")
             return launcher_exit
         if not raw.is_file() or raw.stat().st_size == 0:
             _write(path=paths.failure_diag, text="CODEX_EMPTY_OUTPUT\n")
             _write_drafter_status_file(output=output, status="ERROR", plan_written=False, plan_lines=0, diff_lines=0, summary_written=False, launched=True, reason="CODEX_EMPTY_OUTPUT")
             _write(path=paths.done, text="1\n")
-            _emit_kv(key="STATUS", value="ERROR")
-            _emit_kv(key="OUTPUT_FILE", value=str(output))
+            logging_util.emit_kv(key="STATUS", value="ERROR")
+            logging_util.emit_kv(key="OUTPUT_FILE", value=str(output))
             return 1
         try:
             parsed = parse_drafter_output(raw_file=raw, plan_tmp=plan_tmp, summary_tmp=summary_tmp, scout_tmp=scout_candidate)
@@ -986,8 +985,8 @@ def launch_codex_drafter(
             _write(path=paths.failure_diag, text=f"DELIMITER_EXTRACTION_INVALID\n{exc}\n")
             _write_drafter_status_file(output=output, status="ERROR", plan_written=False, plan_lines=0, diff_lines=0, summary_written=False, launched=True, reason="DELIMITER_EXTRACTION_INVALID")
             _write(path=paths.done, text="99\n")
-            _emit_kv(key="STATUS", value="ERROR")
-            _emit_kv(key="OUTPUT_FILE", value=str(output))
+            logging_util.emit_kv(key="STATUS", value="ERROR")
+            logging_util.emit_kv(key="OUTPUT_FILE", value=str(output))
             return 99
         scout_written = False
         scout_reason = parsed.scout_fail_reason
@@ -1005,19 +1004,19 @@ def launch_codex_drafter(
                 stale.unlink()
         _write_drafter_status_file(output=output, status="OK", plan_written=True, plan_lines=parsed.plan_lines, diff_lines=parsed.diff_lines, summary_written=parsed.summary_written, scout_written=scout_written, scout_fail_reason=scout_reason if not scout_written else "", dialectic_parsed=parsed.dialectic_parsed, dialectic_raw_pending_written=dialectic_pending_written, dialectic_fail_reason=parsed.dialectic_fail_reason if not parsed.dialectic_parsed else "", launched=True)
         _write(path=paths.done, text="0\n")
-        _emit_kv(key="STATUS", value="OK")
-        _emit_kv(key="OUTPUT_FILE", value=str(output))
+        logging_util.emit_kv(key="STATUS", value="OK")
+        logging_util.emit_kv(key="OUTPUT_FILE", value=str(output))
         if paths.token_record.is_file():
-            _emit_kv(key="TOKEN_RECORD", value=str(paths.token_record))
+            logging_util.emit_kv(key="TOKEN_RECORD", value=str(paths.token_record))
         else:
-            _emit_kv(key="TOKEN_RECORD_MISSING", value="true")
-        _emit_kv(key="SCOUT_WRITTEN", value=str(scout_written).lower())
-        _emit_kv(key="DIALECTIC_CANDIDATES_PARSED", value=str(parsed.dialectic_parsed).lower())
-        _emit_kv(key="DIALECTIC_RAW_PENDING_WRITTEN", value=str(dialectic_pending_written).lower())
+            logging_util.emit_kv(key="TOKEN_RECORD_MISSING", value="true")
+        logging_util.emit_kv(key="SCOUT_WRITTEN", value=str(scout_written).lower())
+        logging_util.emit_kv(key="DIALECTIC_CANDIDATES_PARSED", value=str(parsed.dialectic_parsed).lower())
+        logging_util.emit_kv(key="DIALECTIC_RAW_PENDING_WRITTEN", value=str(dialectic_pending_written).lower())
         if parsed.dialectic_fail_reason and not parsed.dialectic_parsed:
-            _emit_kv(key="DIALECTIC_CANDIDATES_FAIL_REASON", value=parsed.dialectic_fail_reason)
+            logging_util.emit_kv(key="DIALECTIC_CANDIDATES_FAIL_REASON", value=parsed.dialectic_fail_reason)
         if scout_reason and not scout_written:
-            _emit_kv(key="SCOUT_FAIL_REASON", value=scout_reason)
+            logging_util.emit_kv(key="SCOUT_FAIL_REASON", value=scout_reason)
         return 0
     finally:
         _write_drafter_dirty_tree_sidecar(output, repo_root=repo, baseline=baseline, launched=launched, tool="codex")
@@ -1189,15 +1188,15 @@ def launch_claude_drafter(
         end = time.time()
         _write_drafter_dirty_tree_sidecar(output, repo_root=repo, baseline=baseline, launched=launched, tool="claude")
         proc.run([sys.executable, str(_PY_CLI), "timing", "record-vendor-task", "--vendor", "claude", "--task-kind", timing_task_kind, "--start-s", str(int(start)), "--end-s", str(int(end)), "--output", str(output), "--exit-code", str(exit_code), "--status", status], check=False)
-        _emit_kv(key="STATUS", value=status)
-        _emit_kv(key="OUTPUT_FILE", value=str(output))
-        _emit_kv(key="ELAPSED", value=int(end - start))
+        logging_util.emit_kv(key="STATUS", value=status)
+        logging_util.emit_kv(key="OUTPUT_FILE", value=str(output))
+        logging_util.emit_kv(key="ELAPSED", value=int(end - start))
         status_text = output.read_text(encoding="utf-8", errors="replace") if output.is_file() else ""
         scout_written = "SCOUT_WRITTEN=true" in status_text
-        _emit_kv(key="SCOUT_WRITTEN", value=str(scout_written).lower())
+        logging_util.emit_kv(key="SCOUT_WRITTEN", value=str(scout_written).lower())
         status_text_for_dialectic = output.read_text(encoding="utf-8", errors="replace") if output.is_file() else ""
-        _emit_kv(key="DIALECTIC_CANDIDATES_PARSED", value=str("DIALECTIC_CANDIDATES_PARSED=true" in status_text_for_dialectic).lower())
-        _emit_kv(key="DIALECTIC_RAW_PENDING_WRITTEN", value=str("DIALECTIC_RAW_PENDING_WRITTEN=true" in status_text_for_dialectic).lower())
+        logging_util.emit_kv(key="DIALECTIC_CANDIDATES_PARSED", value=str("DIALECTIC_CANDIDATES_PARSED=true" in status_text_for_dialectic).lower())
+        logging_util.emit_kv(key="DIALECTIC_RAW_PENDING_WRITTEN", value=str("DIALECTIC_RAW_PENDING_WRITTEN=true" in status_text_for_dialectic).lower())
         for pattern in (f"{output.name}.json.*", f"{output.name}.extract.*", "plan.txt.tmp.*", "plan-summary.md.tmp.*", "scout-plan-manifest.json.candidate.*", "scout-plan-manifest.json.filtered.*"):
             for path in (output.parent if pattern.startswith(output.name) else design).glob(pattern):
                 with contextlib.suppress(FileNotFoundError):

--- a/python/larch/agents/_failure_diag.py
+++ b/python/larch/agents/_failure_diag.py
@@ -15,7 +15,6 @@ from larch.core import redact
 
 from larch.agents._types import (
     _err,
-    _emit_kv,
     _write,
     _append,
     _parse_positive_or_zero_int,
@@ -163,10 +162,10 @@ def parse_codex_usage_main(argv: list[str] | None = None) -> int:
         else:
             _err("agent parse-codex-usage: no usage events")
         return 1
-    _emit_kv(key="INPUT", value=totals.uncached_input_tokens)
-    _emit_kv(key="CACHED_INPUT", value=totals.cached_input_tokens)
-    _emit_kv(key="OUTPUT", value=totals.output_tokens)
-    _emit_kv(key="TOTAL", value=totals.total_tokens)
+    logging_util.emit_kv(key="INPUT", value=totals.uncached_input_tokens)
+    logging_util.emit_kv(key="CACHED_INPUT", value=totals.cached_input_tokens)
+    logging_util.emit_kv(key="OUTPUT", value=totals.output_tokens)
+    logging_util.emit_kv(key="TOTAL", value=totals.total_tokens)
     return 0
 
 

--- a/python/larch/agents/_launch_failure.py
+++ b/python/larch/agents/_launch_failure.py
@@ -13,6 +13,7 @@ from typing import Literal
 
 from larch.core import config
 from larch.core.ctx import Ctx
+from larch import io as larch_io
 from larch.core import logging_util
 from larch.core import proc
 
@@ -29,7 +30,6 @@ from larch.agents._types import (
     ModelArgResult,
     _err,
     _emit,
-    _emit_kv,
     _read_text,
 )
 
@@ -111,14 +111,13 @@ def _fallback_launcher_exit(process_rc: int) -> int:
 
 
 def _parse_launcher_exit_value(text: str) -> int | None:
-    for line in text.splitlines():
-        if line.startswith("LAUNCHER_EXIT="):
-            raw = line.split("=", 1)[1].strip().strip("\r")
-            try:
-                return int(raw)
-            except ValueError:
-                return None
-    return None
+    raw = larch_io.kv_value(text=text, key="LAUNCHER_EXIT", duplicate_policy="first", cr_strip="strip").strip()
+    if not raw:
+        return None
+    try:
+        return int(raw)
+    except ValueError:
+        return None
 
 
 def parse_launcher_exit_text(*, text: str, process_rc: int = 0) -> int:
@@ -167,10 +166,12 @@ def read_launcher_exit(*, output_file: str | Path, process_rc: int = 0) -> int:
 
 
 def _launcher_failure_class_from_text(text: str) -> str | None:
-    last = ""
-    for line in text.splitlines():
-        if line.startswith("LAUNCHER_FAILURE_CLASS="):
-            last = line.split("=", 1)[1].strip().strip("\r")
+    last = larch_io.kv_value(
+        text=text,
+        key="LAUNCHER_FAILURE_CLASS",
+        duplicate_policy="last",
+        cr_strip="strip",
+    ).strip()
     if last in ("none", "health", "other"):
         return last
     return None
@@ -333,11 +334,7 @@ def model_args_main(argv: list[str] | None = None) -> int:
 
 def read_claude_model() -> str:
     source = proc.run([sys.executable, str(_PY_CLI), "token", "claude-source"])
-    transcript = ""
-    for line in source.stdout.splitlines():
-        if line.startswith("TRANSCRIPT_PATH="):
-            transcript = line.split("=", 1)[1]
-            break
+    transcript = larch_io.kv_value(text=source.stdout, key="TRANSCRIPT_PATH", duplicate_policy="first")
     if not transcript:
         return "unknown"
     path = Path(transcript)
@@ -357,5 +354,5 @@ def read_claude_model() -> str:
 def read_claude_model_main(argv: list[str] | None = None) -> int:
     _ = argv
     logging_util.quiet_init(argv0="cli.py")
-    _emit_kv(key="CLAUDE_MODEL", value=read_claude_model())
+    logging_util.emit_kv(key="CLAUDE_MODEL", value=read_claude_model())
     return 0

--- a/python/larch/agents/_review_launcher.py
+++ b/python/larch/agents/_review_launcher.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from larch.state import dirty_tree
 from larch.review import findings_ledger
 from larch.git import git
+from larch import io as larch_io
 from larch.core import config
 from larch.core import logging_util
 from larch.core import proc
@@ -44,7 +45,6 @@ from larch.agents._types import (
     LauncherPaths,
     RunExternalAgentResult,
     _err,
-    _emit_kv,
     _write,
     _append,
     _is_positive_int,
@@ -339,12 +339,7 @@ def _review_read_codex_prompt_sentinel(path: str) -> tuple[int, str] | None:
     lines = text[sentinel_idx:].splitlines()
     if not lines or lines[0] != "LARCH_PROMPT_SENTINEL=1":
         return None
-    values: dict[str, str] = {}
-    for line in lines[1:]:
-        if "=" not in line:
-            continue
-        key, value = line.split("=", 1)
-        values[key] = value
+    values = larch_io.parse_kv("\n".join(lines[1:]), duplicate_policy="last")
     if (
         values.get("KIND") != "specialist"
         or not values.get("AGENT_FILE")
@@ -906,10 +901,10 @@ def _review_emit_launcher_result(
         tool=tool,
         output_file=output,
     )
-    _emit_kv(key="LAUNCHER_EXIT", value=launcher_exit)
-    _emit_kv(key="LAUNCHER_FAILURE_CLASS", value=failure.failure_class)
-    _emit_kv(key="LAUNCHER_FAILURE_REASON", value=failure.reason)
-    _emit_kv(key="OUTPUT", value=str(output))
+    logging_util.emit_kv(key="LAUNCHER_EXIT", value=launcher_exit)
+    logging_util.emit_kv(key="LAUNCHER_FAILURE_CLASS", value=failure.failure_class)
+    logging_util.emit_kv(key="LAUNCHER_FAILURE_REASON", value=failure.reason)
+    logging_util.emit_kv(key="OUTPUT", value=str(output))
 
 
 def _review_write_preflight_bundle(

--- a/python/larch/agents/_review_launcher.py
+++ b/python/larch/agents/_review_launcher.py
@@ -485,11 +485,7 @@ def _review_effective_token_cap(args: argparse.Namespace) -> int | None:
 
 
 def _review_write_cap_hit_artifacts(*, output: Path, cap: int, stdout: str) -> None:
-    total = ""
-    for token in stdout.split():
-        if token.startswith("TOTAL="):
-            total = token.split("=", 1)[1]
-            break
+    total = larch_io.parse_kv("\n".join(stdout.split()), duplicate_policy="last").get("TOTAL", "")
     _err(
         f"⚠ agent launch-review: step token budget cap of {cap} tokens exceeded ({total} combined vendor tokens); external reviewer fan-out skipped"
     )

--- a/python/larch/agents/_run_external.py
+++ b/python/larch/agents/_run_external.py
@@ -9,7 +9,6 @@ import os
 import platform
 import re
 import shutil
-import shlex
 import signal
 import subprocess
 import sys
@@ -22,6 +21,7 @@ from larch import io as larch_io
 from larch.core import config
 from larch.core.ctx import Ctx
 from larch.core import logging_util
+from larch.core.env_file import read_env_file
 from larch.core import proc
 from larch.core import redact
 from larch.core.proc import CommandResult
@@ -37,7 +37,6 @@ from larch.agents._types import (
     TailReadResult,
     StartupLockState,
     _err,
-    _emit_kv,
     _read_text,
     _write,
     _append,
@@ -609,8 +608,8 @@ def _emit_claude_subprocess_failure_fields(*, output: Path, launcher_exit: int) 
         tool="claude",
         output_file=output,
     )
-    _emit_kv(key="LAUNCHER_FAILURE_CLASS", value=failure.failure_class)
-    _emit_kv(key="LAUNCHER_FAILURE_REASON", value=failure.reason)
+    logging_util.emit_kv(key="LAUNCHER_FAILURE_CLASS", value=failure.failure_class)
+    logging_util.emit_kv(key="LAUNCHER_FAILURE_REASON", value=failure.reason)
 
 
 def _record_usage_from_events(*, events: Path, sidecar: Path, label: str, token_record: Path | None = None, model: str = "") -> None:
@@ -993,7 +992,7 @@ def _write_preflight_bundle(
         text=f"TOOL={tool}\nTIMEOUT={timeout}\nCAPTURE_STDOUT=false\nOUTPUT_FILE={output}\nCMD_JSON=[]\n"
     )
     _write(path=output.with_suffix(output.suffix + ".done"), text=f"{launcher_exit}\n")
-    _emit_kv(key="LAUNCHER_EXIT", value=launcher_exit)
+    logging_util.emit_kv(key="LAUNCHER_EXIT", value=launcher_exit)
     failure = classify_launch_failure(
         launcher_exit=launcher_exit,
         sidecar=output.with_suffix(output.suffix + ".diag"),
@@ -1001,9 +1000,9 @@ def _write_preflight_bundle(
         tool=tool,
         output_file=output,
     )
-    _emit_kv(key="LAUNCHER_FAILURE_CLASS", value=failure.failure_class)
-    _emit_kv(key="LAUNCHER_FAILURE_REASON", value=failure.reason or failure_reason)
-    _emit_kv(key="OUTPUT", value=str(output))
+    logging_util.emit_kv(key="LAUNCHER_FAILURE_CLASS", value=failure.failure_class)
+    logging_util.emit_kv(key="LAUNCHER_FAILURE_REASON", value=failure.reason or failure_reason)
+    logging_util.emit_kv(key="OUTPUT", value=str(output))
 
 
 def _trust_config_arg(workdir: str) -> str:
@@ -1030,29 +1029,8 @@ def _git_toplevel(path: str) -> str | None:
 
 
 def _read_keepalive_clone_path(keepalive: Path) -> str | None:
-    try:
-        text = keepalive.read_text(encoding="utf-8", errors="replace")
-    except OSError:
-        return None
-    for line in text.splitlines():
-        stripped = line.strip()
-        if not stripped or stripped.startswith("#") or "=" not in stripped:
-            continue
-        if stripped.startswith("export "):
-            stripped = stripped[len("export ") :].strip()
-        key, value = stripped.split("=", 1)
-        if not re.fullmatch(r"[A-Z_][A-Z0-9_]*", key):
-            continue
-        if key != "CLONE_PATH":
-            continue
-        try:
-            parsed = shlex.split(value, posix=True)
-        except ValueError:
-            parsed = [value]
-        clone_path = parsed[0] if len(parsed) == 1 else value
-        if clone_path.strip():
-            return clone_path.strip()
-    return None
+    clone_path = read_env_file(keepalive).get("CLONE_PATH", "").strip()
+    return clone_path or None
 
 
 def _clone_path_from_session_tmpdir() -> str | None:
@@ -1157,7 +1135,7 @@ def _post_codex_events(*, events: Path, sidecar: Path) -> None:
 
 def _emit_token_record_if_present(token_record: Path) -> None:
     if token_record.is_file():
-        _emit_kv(key="TOKEN_RECORD", value=str(token_record))
+        logging_util.emit_kv(key="TOKEN_RECORD", value=str(token_record))
 
 
 def _record_usage_from_events_and_emit_token(*, events: Path, sidecar: Path, label: str, token_record: Path, model: str = "") -> None:

--- a/python/larch/agents/_types.py
+++ b/python/larch/agents/_types.py
@@ -311,10 +311,6 @@ def _emit(text: str) -> None:
     logging_util.emit(text)
 
 
-def _emit_kv(*, key: str, value: str | int) -> None:
-    logging_util.emit_kv(key=key, value=str(value))
-
-
 def _read_text(path: str | Path | None) -> str:
     if not path:
         return ""

--- a/python/larch/agents/agents.py
+++ b/python/larch/agents/agents.py
@@ -54,7 +54,6 @@ from larch.agents._types import (  # noqa: F401
     _CURSOR_NO_WORK_INPUT_TOKEN_FLOOR,
     _err,
     _emit,
-    _emit_kv,
     _read_text,
     _write,
     _append,

--- a/python/larch/design/design_oos.py
+++ b/python/larch/design/design_oos.py
@@ -11,7 +11,9 @@ import sys
 from pathlib import Path
 from collections.abc import Sequence
 
+from larch import io as larch_io
 from larch.core import config
+from larch.core import logging_util
 from larch.core import proc
 from larch.git import gh
 from larch.issue import file_oos
@@ -32,9 +34,6 @@ _ISSUE_FAILED_KV_RE = re.compile(r"^ISSUE_(\d+)_FAILED=true$")
 _PRIORITY_PENDING = ".oos-priority-label-pending"
 _OOS_FILE_MAP_FIELD_COUNT = 3
 
-
-def _emit_kv(*, key: str, value: str) -> None:
-    print(f"{key}={value}")
 
 
 def _plugin_root() -> Path:
@@ -170,9 +169,9 @@ def _accepted_unfiled_text(accepted: Path) -> str:
 
 
 def _emit_empty_stdout_retry(issue_stdout_file: str) -> int:
-    _emit_kv(key="FILE_DESIGN_OOS_STATUS", value="annotate-failed-empty-stdout")
-    _emit_kv(key="NEXT_ACTION", value="retry-file-and-annotate")
-    _emit_kv(
+    logging_util.emit_kv(key="FILE_DESIGN_OOS_STATUS", value="annotate-failed-empty-stdout")
+    logging_util.emit_kv(key="NEXT_ACTION", value="retry-file-and-annotate")
+    logging_util.emit_kv(
         key="WARN",
         value=f"file-design-oos annotate: issue-stdout-file empty or missing ({issue_stdout_file}); oos-issues-created.md not written",
     )
@@ -190,14 +189,14 @@ def _prepare_sentinel_handled(
 ) -> bool:
     if sentinel.is_file() and sentinel.stat().st_size > 0:
         if not _accepted_unfiled_text(accepted).strip():
-            _emit_kv(key="FILE_DESIGN_OOS_STATUS", value="skip-sentinel")
+            logging_util.emit_kv(key="FILE_DESIGN_OOS_STATUS", value="skip-sentinel")
             return True
         sentinel.unlink(missing_ok=True)
     created, failed, deduped = _load_issue_sentinel_status(design_tmpdir)
     if failed == 0 and (created + deduped) > 0:
         if not _accepted_unfiled_text(accepted).strip():
-            _emit_kv(key="FILE_DESIGN_OOS_STATUS", value="skip-already-filed-sentinel")
-            _emit_kv(
+            logging_util.emit_kv(key="FILE_DESIGN_OOS_STATUS", value="skip-already-filed-sentinel")
+            logging_util.emit_kv(
                 key="WARN",
                 value="file-design-oos prepare: oos-issue-sentinel present "
                 f"(ISSUES_CREATED={created} ISSUES_DEDUPLICATED={deduped}) but "
@@ -230,7 +229,7 @@ def _prepare_sentinel_handled(
             if ok:
                 _ = accepted.write_text(recovered, encoding="utf-8")
                 if not _extract_unfiled_blocks(recovered).strip():
-                    _emit_kv(key="FILE_DESIGN_OOS_STATUS", value="skip-sentinel")
+                    logging_util.emit_kv(key="FILE_DESIGN_OOS_STATUS", value="skip-sentinel")
                     return True
             sentinel.unlink(missing_ok=True)
             _append_warning_log(
@@ -372,16 +371,17 @@ def _clear_label_retry_pending(*, design_tmpdir: Path, issue_number: str) -> Non
 
 
 def _read_simple_env_value(path: Path, key: str) -> str:
-    if not path.is_file():
-        return ""
-    try:
-        text = path.read_text(encoding="utf-8", errors="replace")
-    except OSError:
-        return ""
-    for raw in text.splitlines():
-        if raw.startswith(f"{key}="):
-            return raw.split("=", 1)[1].strip().strip("'\"")
-    return ""
+    return (
+        larch_io.read_kv(
+            path=path,
+            key=key,
+            default="",
+            duplicate_policy="first",
+            on_error_default=True,
+        )
+        .strip()
+        .strip("'\"")
+    )
 
 
 def _resolve_filing_repo(*, design_tmpdir: Path, issue_number: str | None) -> str:
@@ -418,19 +418,20 @@ def _load_issue_sentinel_status(design_tmpdir: Path) -> tuple[int, int, int]:
     sentinel = design_tmpdir / "oos-issue-sentinel"
     if not sentinel.is_file():
         return 0, 0, 0
-    created = 0
-    failed = 0
-    deduped = 0
-    for line in sentinel.read_text(encoding="utf-8", errors="replace").splitlines():
-        if line.startswith("ISSUES_CREATED="):
-            value = line.split("=", 1)[1].strip()
-            created = int(value) if value.isdigit() else 0
-        elif line.startswith("ISSUES_FAILED="):
-            value = line.split("=", 1)[1].strip()
-            failed = int(value) if value.isdigit() else 0
-        elif line.startswith("ISSUES_DEDUPLICATED="):
-            value = line.split("=", 1)[1].strip()
-            deduped = int(value) if value.isdigit() else 0
+    try:
+        values = larch_io.parse_kv(
+            sentinel.read_text(encoding="utf-8", errors="replace"),
+            duplicate_policy="last",
+            strip_value=True,
+        )
+    except OSError:
+        return 0, 0, 0
+    created_raw = values.get("ISSUES_CREATED", "")
+    failed_raw = values.get("ISSUES_FAILED", "")
+    deduped_raw = values.get("ISSUES_DEDUPLICATED", "")
+    created = int(created_raw) if created_raw.isdigit() else 0
+    failed = int(failed_raw) if failed_raw.isdigit() else 0
+    deduped = int(deduped_raw) if deduped_raw.isdigit() else 0
     return created, failed, deduped
 
 
@@ -534,11 +535,11 @@ def file_oos_prepare_main(argv: Sequence[str]) -> int:
                     path.unlink(missing_ok=True)
     if _label_retry_pending(design_tmpdir=design_tmpdir, issue_number=issue_number):
         _ = _restore_label_retry_sidecars(design_tmpdir=design_tmpdir, issue_number=issue_number)
-        _emit_kv(key="FILE_DESIGN_OOS_STATUS", value="label-only-retry")
-        _emit_kv(key="NEXT_ACTION", value="label-only")
-        _emit_kv(key="STEP5B_NEEDS_ANNOTATE", value="true")
+        logging_util.emit_kv(key="FILE_DESIGN_OOS_STATUS", value="label-only-retry")
+        logging_util.emit_kv(key="NEXT_ACTION", value="label-only")
+        logging_util.emit_kv(key="STEP5B_NEEDS_ANNOTATE", value="true")
         if args.repo:
-            _emit_kv(key="REPO", value=args.repo)
+            logging_util.emit_kv(key="REPO", value=args.repo)
         return 0
     _promote_aggregate_oos_pool(accepted_path=accepted, pool_path=design_tmpdir / OOS_AGGREGATE_POOL_FILE)
     if _prepare_sentinel_handled(
@@ -550,13 +551,13 @@ def file_oos_prepare_main(argv: Sequence[str]) -> int:
     ):
         return 0
     if not accepted.is_file() or accepted.stat().st_size == 0:
-        _emit_kv(key="FILE_DESIGN_OOS_STATUS", value="skip-no-items")
+        logging_util.emit_kv(key="FILE_DESIGN_OOS_STATUS", value="skip-no-items")
         return 0
     for path in (combined, deps_tsv, order_file):
         path.unlink(missing_ok=True)
     unfiled = _extract_unfiled_blocks(accepted.read_text(encoding="utf-8"))
     if not unfiled.strip():
-        _emit_kv(key="FILE_DESIGN_OOS_STATUS", value="skip-no-items")
+        logging_util.emit_kv(key="FILE_DESIGN_OOS_STATUS", value="skip-no-items")
         return 0
     _ = combined.write_text(unfiled, encoding="utf-8")
     headers = [
@@ -566,11 +567,11 @@ def file_oos_prepare_main(argv: Sequence[str]) -> int:
     ]
     if not headers:
         combined.unlink(missing_ok=True)
-        _emit_kv(key="FILE_DESIGN_OOS_STATUS", value="skip-no-items")
+        logging_util.emit_kv(key="FILE_DESIGN_OOS_STATUS", value="skip-no-items")
         return 0
     if _count_non_security_blocks(unfiled) == 0:
         combined.unlink(missing_ok=True)
-        _emit_kv(key="FILE_DESIGN_OOS_STATUS", value="skip-all-security")
+        logging_util.emit_kv(key="FILE_DESIGN_OOS_STATUS", value="skip-all-security")
         return 0
     _ = order_file.write_text("\n".join(headers) + "\n", encoding="utf-8")
     capped = combined.with_suffix(".md.capped.tmp")
@@ -606,13 +607,13 @@ def file_oos_prepare_main(argv: Sequence[str]) -> int:
             f"file-design-oos: python/cli.py oos file-conflict-deps exit {deps_result.returncode}: graceful-degrade (no caller TSV)",
             file=sys.stderr,
         )
-    _emit_kv(key="FILE_DESIGN_OOS_DEPS_AVAILABLE", value="true" if deps_available else "false")
-    _emit_kv(key="FILE_DESIGN_OOS_STATUS", value="ready")
-    _emit_kv(key="FILE_DESIGN_OOS_COMBINED", value=str(combined))
-    _emit_kv(key="FILE_DESIGN_OOS_DEPS_TSV", value=str(deps_tsv))
-    _emit_kv(key="FILE_DESIGN_OOS_ORDER", value=str(order_file))
+    logging_util.emit_kv(key="FILE_DESIGN_OOS_DEPS_AVAILABLE", value="true" if deps_available else "false")
+    logging_util.emit_kv(key="FILE_DESIGN_OOS_STATUS", value="ready")
+    logging_util.emit_kv(key="FILE_DESIGN_OOS_COMBINED", value=str(combined))
+    logging_util.emit_kv(key="FILE_DESIGN_OOS_DEPS_TSV", value=str(deps_tsv))
+    logging_util.emit_kv(key="FILE_DESIGN_OOS_ORDER", value=str(order_file))
     if args.repo:
-        _emit_kv(key="REPO", value=args.repo)
+        logging_util.emit_kv(key="REPO", value=args.repo)
     return 0
 
 
@@ -624,7 +625,12 @@ def _parse_issue_stdout(stdout_text: str) -> tuple[dict[str, str], dict[str, str
     url_by_idx: dict[str, str] = {}
     dup_by_idx: dict[str, str] = {}
     failed: set[str] = set()
-    issues_failed_count = 0
+    issues_failed_raw = larch_io.kv_value(
+        text=stdout_text,
+        key="ISSUES_FAILED",
+        duplicate_policy="last",
+    ).strip()
+    issues_failed_count = int(issues_failed_raw) if issues_failed_raw.isdigit() else 0
     for line in stdout_text.splitlines():
         kv = _ISSUE_URL_KV_RE.match(line)
         if kv:
@@ -640,10 +646,6 @@ def _parse_issue_stdout(stdout_text: str) -> tuple[dict[str, str], dict[str, str
         if fail:
             failed.add(fail.group(1))
             continue
-        if line.startswith("ISSUES_FAILED="):
-            value = line.split("=", 1)[1].strip()
-            if value.isdigit():
-                issues_failed_count = int(value)
     return url_by_idx, dup_by_idx, failed, issues_failed_count
 
 
@@ -947,7 +949,7 @@ def file_oos_annotate_main(argv: Sequence[str]) -> int:
         combined = design_tmpdir / "oos-combined.md"
         order_file = design_tmpdir / "oos-design-filing-order.txt"
         if not sentinel.is_file() or not combined.is_file():
-            _emit_kv(key="FILE_DESIGN_OOS_STATUS", value="annotate-label-failed")
+            logging_util.emit_kv(key="FILE_DESIGN_OOS_STATUS", value="annotate-label-failed")
             print("design file-oos-annotate: label-only retry missing sentinel or combined OOS file", file=sys.stderr)
             return 1
         rc = _apply_priority_labels_only(
@@ -959,7 +961,7 @@ def file_oos_annotate_main(argv: Sequence[str]) -> int:
             issue_stdout_path=stdout_path if stdout_path.is_file() else None,
             issue_number=issue_number,
         )
-        _emit_kv(key="FILE_DESIGN_OOS_STATUS", value="annotate-label-complete" if rc == 0 else "annotate-label-failed")
+        logging_util.emit_kv(key="FILE_DESIGN_OOS_STATUS", value="annotate-label-complete" if rc == 0 else "annotate-label-failed")
         return rc
     if not stdout_path.is_file() or stdout_path.stat().st_size == 0:
         return _emit_empty_stdout_retry(issue_stdout_file)
@@ -1009,14 +1011,14 @@ def file_oos_annotate_main(argv: Sequence[str]) -> int:
         issue_number=issue_number,
     )
     if label_rc != 0:
-        _emit_kv(key="FILE_DESIGN_OOS_STATUS", value="annotate-label-failed")
+        logging_util.emit_kv(key="FILE_DESIGN_OOS_STATUS", value="annotate-label-failed")
         return 1
     if issues_failed_count > 0:
         _ = (design_tmpdir / "oos-issues-created.partial.md").write_text(sentinel_body, encoding="utf-8")
         (design_tmpdir / "oos-issues-created.md").unlink(missing_ok=True)
-        _emit_kv(key="FILE_DESIGN_OOS_STATUS", value="annotate-partial-failed")
+        logging_util.emit_kv(key="FILE_DESIGN_OOS_STATUS", value="annotate-partial-failed")
         return 1
     (design_tmpdir / "oos-issues-created.partial.md").unlink(missing_ok=True)
     _sync_cross_session_cache(design_tmpdir=design_tmpdir, sentinel=complete_sentinel, issue_number=issue_number)
-    _emit_kv(key="FILE_DESIGN_OOS_STATUS", value="annotate-complete")
+    logging_util.emit_kv(key="FILE_DESIGN_OOS_STATUS", value="annotate-complete")
     return 0

--- a/python/larch/design/design_step_log.py
+++ b/python/larch/design/design_step_log.py
@@ -11,6 +11,8 @@ import tempfile
 from pathlib import Path
 from collections.abc import Sequence
 
+from larch import io as larch_io
+
 
 def _fail(msg: str) -> int:
     print(f"run-step1-plan-log.sh: {msg}", file=sys.stderr)
@@ -18,20 +20,14 @@ def _fail(msg: str) -> int:
 
 
 def _session_get(*, path: Path, key: str, default: str = "") -> str:
-    if not path.is_file():
-        return default
-    # Read inside the try, scan outside it: narrows the OSError scope and keeps
-    # this helper structurally distinct from design_lifecycle._read_env_value
-    # (avoids pylint R0801 duplicate-code across the two modules).
-    try:
-        text = path.read_text(encoding="utf-8", errors="replace")
-    except OSError:
-        return default
-    prefix = f"{key}="
-    for raw in text.splitlines():
-        if raw.startswith(prefix):
-            return raw[len(prefix):] or default
-    return default
+    return larch_io.read_kv(
+        path=path,
+        key=key,
+        default=default,
+        duplicate_policy="first",
+        empty_value_means_default=True,
+        on_error_default=True,
+    )
 
 
 def _resolve_run_id(*, session_env_path: Path, implement_tmpdir: Path, session_id_file: Path) -> str:

--- a/python/larch/design/design_summary.py
+++ b/python/larch/design/design_summary.py
@@ -330,12 +330,10 @@ def _dynamic_archetypes_line(design_tmpdir: Path) -> str:
     status_file = design_tmpdir / "step2b-drafter-status.txt"
     if not status_file.is_file():
         return "static-only, drafter absent"
-    text = status_file.read_text(encoding="utf-8", errors="replace")
-    values: dict[str, str] = {}
-    for line in text.splitlines():
-        if "=" in line:
-            key, value = line.split("=", 1)
-            values[key] = value
+    values = larch_io.parse_kv(
+        status_file.read_text(encoding="utf-8", errors="replace"),
+        duplicate_policy="last",
+    )
     if values.get("SCOUT_WRITTEN") != "true":
         return f"static-only, drafter {values.get('SCOUT_FAIL_REASON') or 'absent'}"
     try:

--- a/python/larch/git/git.py
+++ b/python/larch/git/git.py
@@ -1361,9 +1361,6 @@ def remote_branch_state(
 
 
 # CLI entrypoints migrated from git_cli.py.
-def _emit_kv(*, key: str, value: object) -> None:
-    logging_util.emit_kv(key=key, value=str(value))
-
 
 def _parse(*, parser: argparse.ArgumentParser, argv: list[str]) -> argparse.Namespace | None:
     try:
@@ -1447,7 +1444,7 @@ def current_branch_main(argv: list[str]) -> int:
     if not branch:
         print("git-current-branch.sh: not on a named branch (detached HEAD or not a git repo)", file=sys.stderr)
         return 1
-    _emit_kv(key="BRANCH", value=branch)
+    logging_util.emit_kv(key="BRANCH", value=branch)
     return 0
 
 
@@ -1458,8 +1455,8 @@ def branch_info_main(argv: list[str]) -> int:
     info = branch_info(proc)
     if info is None:
         return 1
-    _emit_kv(key="HEAD_SHA", value=info.head_sha)
-    _emit_kv(key="CURRENT_BRANCH", value=info.current_branch)
+    logging_util.emit_kv(key="HEAD_SHA", value=info.head_sha)
+    logging_util.emit_kv(key="CURRENT_BRANCH", value=info.current_branch)
     return 0
 
 
@@ -1472,10 +1469,10 @@ def conflict_files_main(argv: list[str]) -> int:
         sys.stderr.write(result.stderr)
         return result.returncode
     for item in _parse_conflict_file_rows(result.stdout):
-        _emit_kv(key="FILE", value=item.path)
-        _emit_kv(key="STAGE_1", value=str(item.stage_1).lower())
-        _emit_kv(key="STAGE_2", value=str(item.stage_2).lower())
-        _emit_kv(key="STAGE_3", value=str(item.stage_3).lower())
+        logging_util.emit_kv(key="FILE", value=item.path)
+        logging_util.emit_kv(key="STAGE_1", value=str(item.stage_1).lower())
+        logging_util.emit_kv(key="STAGE_2", value=str(item.stage_2).lower())
+        logging_util.emit_kv(key="STAGE_3", value=str(item.stage_3).lower())
         print()
     return 0
 
@@ -1552,7 +1549,7 @@ def sync_local_main_main(argv: list[str]) -> int:
         return 1
     result, rc = sync_local_main(proc, base_remote=args.base_remote, base_ref=args.base_ref)
     if rc == 0:
-        _emit_kv(key="RESULT", value=result)
+        logging_util.emit_kv(key="RESULT", value=result)
     else:
         print(f"cli.py git sync-local-main: {result}", file=sys.stderr)
     return rc
@@ -1565,11 +1562,11 @@ def clean_tree_main(argv: list[str]) -> int:
     if args is None:
         return 2
     result = clean_tree(proc, fail_closed=args.fail_closed)
-    _emit_kv(key="CLEAN", value=result.clean)
+    logging_util.emit_kv(key="CLEAN", value=result.clean)
     if result.dirty_out:
-        _emit_kv(key="DIRTY_OUT", value=result.dirty_out)
+        logging_util.emit_kv(key="DIRTY_OUT", value=result.dirty_out)
     if result.probe_error:
-        _emit_kv(key="PROBE_ERROR", value=result.probe_error)
+        logging_util.emit_kv(key="PROBE_ERROR", value=result.probe_error)
     return result.exit_code
 
 
@@ -1621,11 +1618,11 @@ def check_main_sync_main(argv: list[str]) -> int:
         print(f"check-main-sync.sh: unknown flag: {argv[0]}", file=sys.stderr)
         return 2
     result = check_main_sync(proc)
-    _emit_kv(key="SYNC_STATUS", value=result.status)
+    logging_util.emit_kv(key="SYNC_STATUS", value=result.status)
     if result.ahead_count is not None:
-        _emit_kv(key="AHEAD_COUNT", value=result.ahead_count)
+        logging_util.emit_kv(key="AHEAD_COUNT", value=result.ahead_count)
     if result.error:
-        _emit_kv(key="ERROR", value=result.error)
+        logging_util.emit_kv(key="ERROR", value=result.error)
     return result.exit_code
 
 
@@ -1643,30 +1640,30 @@ def check_remote_branch_main(argv: list[str]) -> int:
             remote = argv[index + 1] if index + 1 < len(argv) else ""
             index += 2
             continue
-        _emit_kv(key="STATE", value="error")
-        _emit_kv(key="RC", value=1)
-        _emit_kv(key="ERROR", value=f"unknown flag: {arg}")
+        logging_util.emit_kv(key="STATE", value="error")
+        logging_util.emit_kv(key="RC", value=1)
+        logging_util.emit_kv(key="ERROR", value=f"unknown flag: {arg}")
         return 0
     if not branch:
-        _emit_kv(key="STATE", value="error")
-        _emit_kv(key="RC", value=1)
-        _emit_kv(key="ERROR", value="--branch is required")
+        logging_util.emit_kv(key="STATE", value="error")
+        logging_util.emit_kv(key="RC", value=1)
+        logging_util.emit_kv(key="ERROR", value="--branch is required")
         return 0
     result = remote_branch_state(proc, branch, remote=remote)
-    _emit_kv(key="STATE", value=result.state)
-    _emit_kv(key="RC", value=result.rc)
+    logging_util.emit_kv(key="STATE", value=result.state)
+    logging_util.emit_kv(key="RC", value=result.rc)
     if result.error:
-        _emit_kv(key="ERROR", value=result.error)
+        logging_util.emit_kv(key="ERROR", value=result.error)
     return 0
 
 
 def _emit_phantom_dirty_result(result: phantom.PhantomDirtyResult) -> None:
-    _emit_kv(key="STATUS", value=result.status)
+    logging_util.emit_kv(key="STATUS", value=result.status)
     if result.reason:
-        _emit_kv(key="REASON", value=result.reason)
+        logging_util.emit_kv(key="REASON", value=result.reason)
     if result.status == "phantom":
-        _emit_kv(key="PHANTOM_COUNT", value=result.count)
-        _emit_kv(key="PHANTOM_PATHS_FILE", value=result.paths_file)
+        logging_util.emit_kv(key="PHANTOM_COUNT", value=result.count)
+        logging_util.emit_kv(key="PHANTOM_PATHS_FILE", value=result.paths_file)
 
 
 def check_phantom_dirty_main(argv: list[str]) -> int:
@@ -1710,13 +1707,13 @@ def check_phantom_dirty_main(argv: list[str]) -> int:
             parse_error = "phantom-paths-dir-required"
 
     if parse_error:
-        _emit_kv(key="STATUS", value="unknown")
-        _emit_kv(key="REASON", value=parse_error)
+        logging_util.emit_kv(key="STATUS", value="unknown")
+        logging_util.emit_kv(key="REASON", value=parse_error)
         return 0
 
     if not re.fullmatch(r"^[A-Za-z0-9_.-]+$", step):
-        _emit_kv(key="STATUS", value="unknown")
-        _emit_kv(key="REASON", value="bad-step")
+        logging_util.emit_kv(key="STATUS", value="unknown")
+        logging_util.emit_kv(key="REASON", value="bad-step")
         return 0
 
     result = phantom.check_phantom_dirty(
@@ -1742,12 +1739,12 @@ def phantom_probe_main(argv: list[str]) -> int:
         step=args.step,
         baseline_file=args.baseline_file,
     )
-    _emit_kv(key="PHANTOM_STATUS", value=result.dirty.status)
+    logging_util.emit_kv(key="PHANTOM_STATUS", value=result.dirty.status)
     if result.dirty.reason:
-        _emit_kv(key="PHANTOM_REASON", value=result.dirty.reason)
+        logging_util.emit_kv(key="PHANTOM_REASON", value=result.dirty.reason)
     if result.dirty.status == "phantom":
-        _emit_kv(key="PHANTOM_COUNT", value=result.dirty.count)
-        _emit_kv(key="PHANTOM_PATHS_FILE", value=result.dirty.paths_file)
+        logging_util.emit_kv(key="PHANTOM_COUNT", value=result.dirty.count)
+        logging_util.emit_kv(key="PHANTOM_PATHS_FILE", value=result.dirty.paths_file)
     if result.append_warn_error:
-        _emit_kv(key="PHANTOM_APPEND_WARN_ERROR", value=result.append_warn_error)
+        logging_util.emit_kv(key="PHANTOM_APPEND_WARN_ERROR", value=result.append_warn_error)
     return 0

--- a/python/larch/git/merge.py
+++ b/python/larch/git/merge.py
@@ -582,9 +582,6 @@ def _attempt_merge(
 
 
 # CLI entrypoint migrated from merge_cli.py.
-def _emit_kv(*, key: str, value: object) -> None:
-    logging_util.emit_kv(key=key, value=str(value))
-
 
 def pr_main(argv: list[str]) -> int:
     parser = argparse.ArgumentParser(prog="cli.py merge pr")
@@ -612,6 +609,6 @@ def pr_main(argv: list[str]) -> int:
         no_logs_commit=True,
     )
     result = merge_pr(runner=proc, ctx=ctx, post_flush=False)
-    _emit_kv(key="MERGE_RESULT", value=result.result)
-    _emit_kv(key="ERROR", value=result.error)
+    logging_util.emit_kv(key="MERGE_RESULT", value=result.result)
+    logging_util.emit_kv(key="ERROR", value=result.error)
     return 0

--- a/python/larch/git/pr.py
+++ b/python/larch/git/pr.py
@@ -385,9 +385,6 @@ def create_pr_parity(
 
 
 # CLI entrypoints migrated from pr_cli.py.
-def _emit_kv(*, key: str, value: object) -> None:
-    logging_util.emit_kv(key=key, value=str(value))
-
 
 def _parse(
     *, parser: argparse.ArgumentParser, argv: list[str]
@@ -409,10 +406,10 @@ def create_branch_main(argv: list[str]) -> int:
         return 2
     if args.check:
         result = check_branch_state(proc)
-        _emit_kv(key="CURRENT_BRANCH", value=result.current_branch)
-        _emit_kv(key="IS_MAIN", value=str(result.is_main).lower())
-        _emit_kv(key="IS_USER_BRANCH", value=str(result.is_user_branch).lower())
-        _emit_kv(key="USER_PREFIX", value=result.user_prefix)
+        logging_util.emit_kv(key="CURRENT_BRANCH", value=result.current_branch)
+        logging_util.emit_kv(key="IS_MAIN", value=str(result.is_main).lower())
+        logging_util.emit_kv(key="IS_USER_BRANCH", value=str(result.is_user_branch).lower())
+        logging_util.emit_kv(key="USER_PREFIX", value=result.user_prefix)
         return result.exit_code
     if not args.branch:
         print("create-branch.sh: --branch is required", file=sys.stderr)
@@ -424,8 +421,8 @@ def create_branch_main(argv: list[str]) -> int:
         base_ref=args.base_ref,
     )
     if result.exit_code == 0:
-        _emit_kv(key="BRANCH_NAME", value=result.branch_name)
-        _emit_kv(key="ACTION", value=result.action)
+        logging_util.emit_kv(key="BRANCH_NAME", value=result.branch_name)
+        logging_util.emit_kv(key="ACTION", value=result.action)
     else:
         print(f"create-branch.sh: {result.status}: {result.branch}", file=sys.stderr)
     return result.exit_code
@@ -489,19 +486,19 @@ def create_main(argv: list[str]) -> int:
             exit_code=config.EXIT_NEEDS_USER_INPUT,
         )
     except Exception as exc:  # pylint: disable=broad-except
-        _emit_kv(key="PR_STATUS", value="error")
-        _emit_kv(key="PR_NUMBER", value=0)
-        _emit_kv(key="PR_URL", value="")
-        _emit_kv(key="PR_TITLE", value=args.title)
+        logging_util.emit_kv(key="PR_STATUS", value="error")
+        logging_util.emit_kv(key="PR_NUMBER", value=0)
+        logging_util.emit_kv(key="PR_URL", value="")
+        logging_util.emit_kv(key="PR_TITLE", value=args.title)
         print(str(exc), file=sys.stderr)
         return 2
-    _emit_kv(key="PR_NUMBER", value=result.number)
-    _emit_kv(key="PR_URL", value=result.url)
-    _emit_kv(key="PR_TITLE", value=result.title)
-    _emit_kv(key="PR_STATUS", value=result.status)
+    logging_util.emit_kv(key="PR_NUMBER", value=result.number)
+    logging_util.emit_kv(key="PR_URL", value=result.url)
+    logging_util.emit_kv(key="PR_TITLE", value=result.title)
+    logging_util.emit_kv(key="PR_STATUS", value=result.status)
     if needs_scope_disposition:
-        _emit_kv(key="needs_user_reason", value=config.NEEDS_USER_SCOPE_DISPOSITION)
-        _emit_kv(
+        logging_util.emit_kv(key="needs_user_reason", value=config.NEEDS_USER_SCOPE_DISPOSITION)
+        logging_util.emit_kv(
             key="NEXT_ACTION", value=config.SHIP_ROUTE_ACTION_HALT_SCOPE_DISPOSITION
         )
     return result.exit_code
@@ -520,11 +517,11 @@ def body_update_main(argv: list[str]) -> int:
         if repo_err is not None:
             return repo_err
     result = gh.pr_edit_body_file(proc, args.pr, args.body_file, repo=args.repo)
-    _emit_kv(key="UPDATED", value=str(result.updated).lower())
-    _emit_kv(key="ERROR", value=result.error)
+    logging_util.emit_kv(key="UPDATED", value=str(result.updated).lower())
+    logging_util.emit_kv(key="ERROR", value=result.error)
     if result.exit_code == config.EXIT_NEEDS_USER_INPUT:
-        _emit_kv(key="needs_user_reason", value=config.NEEDS_USER_SCOPE_DISPOSITION)
-        _emit_kv(
+        logging_util.emit_kv(key="needs_user_reason", value=config.NEEDS_USER_SCOPE_DISPOSITION)
+        logging_util.emit_kv(
             key="NEXT_ACTION", value=config.SHIP_ROUTE_ACTION_HALT_SCOPE_DISPOSITION
         )
     return result.exit_code

--- a/python/larch/git/pr_body.py
+++ b/python/larch/git/pr_body.py
@@ -22,6 +22,7 @@ from typing import Any, cast
 
 from larch import io as larch_io
 from larch.core import config
+from larch.core import logging_util
 from larch.report import design_diagram_log
 from larch.git import gh
 from larch.git import git
@@ -520,8 +521,9 @@ def update_pr_body(
 # ---------------------------------------------------------------------------
 
 
+
 def _emit_kv(*, key: str, value: object) -> None:
-    print(f"{key}={value}")
+    logging_util.emit_kv(key=key, value=str(value))
 
 
 def _read_kv(*, path: Path, key: str, default: str = "") -> str:
@@ -1141,12 +1143,12 @@ def slack_issue_announce_main(argv: list[str] | None = None) -> int:
     parser.add_argument("--best-effort", action="store_true")
     args = parser.parse_args(argv)
     if not args.implement_tmpdir:
-        _emit_kv(key="STATUS", value="failed")
-        _emit_kv(key="ERROR", value="--implement-tmpdir is required")
+        logging_util.emit_kv(key="STATUS", value="failed")
+        logging_util.emit_kv(key="ERROR", value="--implement-tmpdir is required")
         return 2
     if not Path(args.implement_tmpdir).is_dir():
-        _emit_kv(key="STATUS", value="failed")
-        _emit_kv(key="ERROR", value="--implement-tmpdir not found")
+        logging_util.emit_kv(key="STATUS", value="failed")
+        logging_util.emit_kv(key="ERROR", value="--implement-tmpdir not found")
         return 2
     result = slack_issue_announce(
         Path(args.implement_tmpdir), best_effort=args.best_effort

--- a/python/larch/git/push.py
+++ b/python/larch/git/push.py
@@ -154,9 +154,6 @@ _REBASE_FAILED_EXIT = 3
 _CHECKPOINT_LOAD_ROUTING = "load-routing"
 
 
-def _emit_kv(*, key: str, value: object) -> None:
-    logging_util.emit_kv(key=key, value=str(value))
-
 
 def _checkpoint_next_for_exit(exit_code: int) -> str:
     if exit_code == 0:
@@ -186,39 +183,39 @@ def _conflict_files_csv(result: rebase.RebasePushResult) -> str:
 
 def _emit_rebase_checkpoint_keys(result: rebase.RebasePushResult) -> int:
     if result.skipped_already_pushed:
-        _emit_kv(key="SKIPPED_ALREADY_PUSHED", value="true")
+        logging_util.emit_kv(key="SKIPPED_ALREADY_PUSHED", value="true")
     if result.skipped_already_fresh:
-        _emit_kv(key="SKIPPED_ALREADY_FRESH", value="true")
+        logging_util.emit_kv(key="SKIPPED_ALREADY_FRESH", value="true")
     if result.conflict_files:
-        _emit_kv(key="CONFLICT_FILES", value=result.conflict_files)
+        logging_util.emit_kv(key="CONFLICT_FILES", value=result.conflict_files)
     if result.rebase_error and result.exit_code != _REBASE_FAILED_EXIT:
-        _emit_kv(key="REBASE_ERROR", value=_rebase_sanitize(result.rebase_error))
+        logging_util.emit_kv(key="REBASE_ERROR", value=_rebase_sanitize(result.rebase_error))
 
     if result.exit_code == 0:
         if result.skipped_already_pushed or result.skipped_already_fresh:
-            _emit_kv(key="REBASE_OUTCOME", value="skipped")
+            logging_util.emit_kv(key="REBASE_OUTCOME", value="skipped")
         else:
-            _emit_kv(key="REBASE_OUTCOME", value="ok")
-        _emit_kv(key="ROUTE", value="continue")
-        _emit_kv(key="CHECKPOINT_NEXT", value=_checkpoint_next_for_exit(result.exit_code))
+            logging_util.emit_kv(key="REBASE_OUTCOME", value="ok")
+        logging_util.emit_kv(key="ROUTE", value="continue")
+        logging_util.emit_kv(key="CHECKPOINT_NEXT", value=_checkpoint_next_for_exit(result.exit_code))
         return 0
     if result.exit_code == 1:
-        _emit_kv(key="REBASE_OUTCOME", value="conflict")
-        _emit_kv(key="CONFLICT_FILES", value=_conflict_files_csv(result))
-        _emit_kv(key="ROUTE", value="conflict")
-        _emit_kv(key="CHECKPOINT_NEXT", value=_checkpoint_next_for_exit(result.exit_code))
+        logging_util.emit_kv(key="REBASE_OUTCOME", value="conflict")
+        logging_util.emit_kv(key="CONFLICT_FILES", value=_conflict_files_csv(result))
+        logging_util.emit_kv(key="ROUTE", value="conflict")
+        logging_util.emit_kv(key="CHECKPOINT_NEXT", value=_checkpoint_next_for_exit(result.exit_code))
         return 1
     if result.exit_code == _REBASE_FAILED_EXIT:
-        _emit_kv(key="REBASE_OUTCOME", value="failed")
+        logging_util.emit_kv(key="REBASE_OUTCOME", value="failed")
         err = result.rebase_error or "rebase-failed"
-        _emit_kv(key="REBASE_ERROR", value=_rebase_sanitize(err))
-        _emit_kv(key="ROUTE", value="bail")
-        _emit_kv(key="CHECKPOINT_NEXT", value=_checkpoint_next_for_exit(result.exit_code))
+        logging_util.emit_kv(key="REBASE_ERROR", value=_rebase_sanitize(err))
+        logging_util.emit_kv(key="ROUTE", value="bail")
+        logging_util.emit_kv(key="CHECKPOINT_NEXT", value=_checkpoint_next_for_exit(result.exit_code))
         return 3
-    _emit_kv(key="REBASE_OUTCOME", value="failed")
-    _emit_kv(key="REBASE_ERROR", value=f"unexpected-rc-{result.exit_code}")
-    _emit_kv(key="ROUTE", value="bail")
-    _emit_kv(key="CHECKPOINT_NEXT", value=_checkpoint_next_for_exit(result.exit_code))
+    logging_util.emit_kv(key="REBASE_OUTCOME", value="failed")
+    logging_util.emit_kv(key="REBASE_ERROR", value=f"unexpected-rc-{result.exit_code}")
+    logging_util.emit_kv(key="ROUTE", value="bail")
+    logging_util.emit_kv(key="CHECKPOINT_NEXT", value=_checkpoint_next_for_exit(result.exit_code))
     return result.exit_code
 
 
@@ -357,7 +354,7 @@ def branch_main(argv: list[str]) -> int:
         return 1
     result = push_current_branch(proc)
     if result.branch:
-        _emit_kv(key="BRANCH", value=result.branch)
+        logging_util.emit_kv(key="BRANCH", value=result.branch)
     if result.stderr:
         sys.stderr.write(result.stderr)
     return result.exit_code
@@ -374,11 +371,11 @@ def force_main(argv: list[str]) -> int:
         expected_remote_oid=args.expected_remote_oid,
     )
     if result.branch:
-        _emit_kv(key="BRANCH", value=result.branch)
+        logging_util.emit_kv(key="BRANCH", value=result.branch)
     elif result.status == "detached_head":
         print("git-force-push.sh: not on a named branch", file=sys.stderr)
-    _emit_kv(key="PUSHED", value=str(result.pushed).lower())
-    _emit_kv(key="STATUS", value=result.status)
+    logging_util.emit_kv(key="PUSHED", value=str(result.pushed).lower())
+    logging_util.emit_kv(key="STATUS", value=result.status)
     if result.pushed:
         return 0
     if result.status in {"detached_head", "branch_mismatch", "status_failed"}:
@@ -407,15 +404,15 @@ def rebase_main(argv: list[str]) -> int:
         base_ref=args.base_ref,
     )
     if result.skipped_already_pushed:
-        _emit_kv(key="SKIPPED_ALREADY_PUSHED", value="true")
+        logging_util.emit_kv(key="SKIPPED_ALREADY_PUSHED", value="true")
     if result.skipped_already_fresh:
-        _emit_kv(key="SKIPPED_ALREADY_FRESH", value="true")
+        logging_util.emit_kv(key="SKIPPED_ALREADY_FRESH", value="true")
     if result.conflict_files:
-        _emit_kv(key="CONFLICT_FILES", value=result.conflict_files)
+        logging_util.emit_kv(key="CONFLICT_FILES", value=result.conflict_files)
     if result.rebase_error:
-        _emit_kv(key="REBASE_ERROR", value=result.rebase_error)
+        logging_util.emit_kv(key="REBASE_ERROR", value=result.rebase_error)
     if result.push_error:
-        _emit_kv(key="PUSH_ERROR", value=result.push_error)
+        logging_util.emit_kv(key="PUSH_ERROR", value=result.push_error)
     return result.exit_code
 
 
@@ -440,13 +437,13 @@ def checkpoint_probe_main(argv: list[str]) -> int:
     if rc != 0:
         return rc
     probe = phantom.probe_with_warn(proc, step=f"{args.step_prefix}-post-rebase")
-    _emit_kv(key="PHANTOM_STATUS", value=probe.dirty.status)
+    logging_util.emit_kv(key="PHANTOM_STATUS", value=probe.dirty.status)
     if probe.dirty.reason:
-        _emit_kv(key="PHANTOM_REASON", value=probe.dirty.reason)
+        logging_util.emit_kv(key="PHANTOM_REASON", value=probe.dirty.reason)
     if probe.dirty.status == "phantom":
-        _emit_kv(key="PHANTOM_COUNT", value=probe.dirty.count)
+        logging_util.emit_kv(key="PHANTOM_COUNT", value=probe.dirty.count)
         if probe.dirty.paths_file:
-            _emit_kv(key="PHANTOM_PATHS_FILE", value=probe.dirty.paths_file)
+            logging_util.emit_kv(key="PHANTOM_PATHS_FILE", value=probe.dirty.paths_file)
     if probe.append_warn_error:
-        _emit_kv(key="PHANTOM_APPEND_WARN_ERROR", value=probe.append_warn_error)
+        logging_util.emit_kv(key="PHANTOM_APPEND_WARN_ERROR", value=probe.append_warn_error)
     return 0

--- a/python/larch/implement/ci.py
+++ b/python/larch/implement/ci.py
@@ -27,9 +27,6 @@ from larch.core import proc
 from larch.core import redact
 
 
-def _emit_kv(*, key: str, value: object) -> None:
-    logging_util.emit_kv(key=key, value=str(value))
-
 
 def _parse(*, parser: argparse.ArgumentParser, argv: list[str], usage_exit: int) -> argparse.Namespace | int:
     try:
@@ -39,10 +36,10 @@ def _parse(*, parser: argparse.ArgumentParser, argv: list[str], usage_exit: int)
 
 
 def _status_error_kv() -> None:
-    _emit_kv(key="CI_STATUS", value="error")
-    _emit_kv(key="BEHIND_COUNT", value=0)
-    _emit_kv(key="FAILED_RUN_ID", value="")
-    _emit_kv(key="CONFLICTED", value="false")
+    logging_util.emit_kv(key="CI_STATUS", value="error")
+    logging_util.emit_kv(key="BEHIND_COUNT", value=0)
+    logging_util.emit_kv(key="FAILED_RUN_ID", value="")
+    logging_util.emit_kv(key="CONFLICTED", value="false")
 
 
 def _usage_error(message: str) -> None:
@@ -69,10 +66,10 @@ def _normalize_base_branch(value: str) -> str:
 
 
 def _emit_main_health(status: main_health.MainHealthStatus) -> None:
-    _emit_kv(key="MAIN_CI_STATUS", value=status.status)
-    _emit_kv(key="MAIN_FAILED_RUN_ID", value=status.failed_run_id)
-    _emit_kv(key="MAIN_HEALTH_HEAD_SHA", value=status.head_sha)
-    _emit_kv(key="MAIN_HEALTH_DETAIL", value=status.detail)
+    logging_util.emit_kv(key="MAIN_CI_STATUS", value=status.status)
+    logging_util.emit_kv(key="MAIN_FAILED_RUN_ID", value=status.failed_run_id)
+    logging_util.emit_kv(key="MAIN_HEALTH_HEAD_SHA", value=status.head_sha)
+    logging_util.emit_kv(key="MAIN_HEALTH_DETAIL", value=status.detail)
 
 
 def main_health_main(argv: list[str]) -> int:
@@ -152,10 +149,10 @@ def status_main(argv: list[str]) -> int:
         base_ref=args.base_ref,
         empty_checks_grace=args.empty_checks_grace,
     )
-    _emit_kv(key="CI_STATUS", value=status.status)
-    _emit_kv(key="BEHIND_COUNT", value=status.behind_count)
-    _emit_kv(key="FAILED_RUN_ID", value=status.failed_run_id or "")
-    _emit_kv(key="CONFLICTED", value=str(status.conflicted).lower())
+    logging_util.emit_kv(key="CI_STATUS", value=status.status)
+    logging_util.emit_kv(key="BEHIND_COUNT", value=status.behind_count)
+    logging_util.emit_kv(key="FAILED_RUN_ID", value=status.failed_run_id or "")
+    logging_util.emit_kv(key="CONFLICTED", value=str(status.conflicted).lower())
     return 0
 
 
@@ -211,8 +208,8 @@ def decide_main(argv: list[str]) -> int:
         rebase_count=args.rebase_count,
         fix_attempts=args.fix_attempts,
     )
-    _emit_kv(key="ACTION", value=decision.action)
-    _emit_kv(key="BAIL_REASON", value=decision.bail_reason or "")
+    logging_util.emit_kv(key="ACTION", value=decision.action)
+    logging_util.emit_kv(key="BAIL_REASON", value=decision.bail_reason or "")
     return 0
 
 
@@ -355,7 +352,7 @@ def wait_main(argv: list[str]) -> int:
 
     for line in _wait_output_lines(status=status, decision=decision, iteration=args.iteration, elapsed=elapsed):
         key, _, value = line.partition("=")
-        _emit_kv(key=key, value=value)
+        logging_util.emit_kv(key=key, value=value)
     return 0
 
 
@@ -410,9 +407,9 @@ def failed_jobs_main(argv: list[str]) -> int:
             print(line)
     fixable = logging_util.sanitize_list(",".join(fixable_tokens))
     unfixable = logging_util.sanitize_list(",".join(unfixable_tokens))
-    _emit_kv(key="FAILED_JOBS_COUNT", value=classified.count)
-    _emit_kv(key="FAILED_JOBS_FIXABLE", value=fixable)
-    _emit_kv(key="FAILED_JOBS_UNFIXABLE", value=unfixable)
+    logging_util.emit_kv(key="FAILED_JOBS_COUNT", value=classified.count)
+    logging_util.emit_kv(key="FAILED_JOBS_FIXABLE", value=fixable)
+    logging_util.emit_kv(key="FAILED_JOBS_UNFIXABLE", value=unfixable)
     return 0
 
 
@@ -758,10 +755,10 @@ def distill_log_main(argv: list[str]) -> int:
     if distill_args is None:
         return _distill_usage(error or "ERROR: invalid ci distill-log arguments")
     outcome = _distill_from_gh(distill_args)
-    _emit_kv(key="STATUS", value=outcome.status)
-    _emit_kv(key="OUTPUT", value=outcome.output)
-    _emit_kv(key="FAILED_JOBS_COUNT", value=outcome.failed_jobs_count)
-    _emit_kv(key="BAIL_CLASS", value=outcome.bail_class)
+    logging_util.emit_kv(key="STATUS", value=outcome.status)
+    logging_util.emit_kv(key="OUTPUT", value=outcome.output)
+    logging_util.emit_kv(key="FAILED_JOBS_COUNT", value=outcome.failed_jobs_count)
+    logging_util.emit_kv(key="BAIL_CLASS", value=outcome.bail_class)
     return outcome.exit_code
 
 
@@ -779,7 +776,7 @@ def behind_count_main(argv: list[str]) -> int:
         base_ref=args.base_ref,
         fetch=not args.no_fetch,
     )
-    _emit_kv(key="BEHIND_COUNT", value=count)
+    logging_util.emit_kv(key="BEHIND_COUNT", value=count)
     return 0
 
 
@@ -791,7 +788,7 @@ def rerun_failed_main(argv: list[str]) -> int:
     if isinstance(args, int):
         return args
     result = ci_monitor.rerun_failed(proc, run_id=args.run_id, repo=args.repo)
-    _emit_kv(key="RERUN_SUBMITTED", value=str(result.submitted).lower())
-    _emit_kv(key="ALREADY_RUNNING", value=str(result.already_running).lower())
-    _emit_kv(key="ERROR", value=result.error or "")
+    logging_util.emit_kv(key="RERUN_SUBMITTED", value=str(result.submitted).lower())
+    logging_util.emit_kv(key="ALREADY_RUNNING", value=str(result.already_running).lower())
+    logging_util.emit_kv(key="ERROR", value=result.error or "")
     return 0

--- a/python/larch/implement/ship.py
+++ b/python/larch/implement/ship.py
@@ -60,6 +60,7 @@ from larch.implement import scope_disposition
 from larch.core import config
 from larch.issue import file_oos
 from larch.state import finalize
+from larch import io as larch_io
 from larch.git import gh
 from larch.git import git
 from larch.core import logging_util
@@ -976,18 +977,12 @@ def _postmerge_main_health_gate(
 
 def _read_main_health_sidecar(ctx: RunContext) -> dict[str, str]:
     path = Path(ctx.tmpdir) / "main-health.env"
-    if not path.is_file() or path.is_symlink():
-        return {}
-    try:
-        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
-    except OSError:
-        return {}
-    data: dict[str, str] = {}
-    for line in lines:
-        key, sep, value = line.partition("=")
-        if sep and "\n" not in value and "\r" not in value:
-            data[key] = value
-    return data
+    return larch_io.read_kvs(
+        path,
+        duplicate_policy="last",
+        reject_symlink=True,
+        on_error_default=True,
+    )
 
 
 def _main_health_repair_covers_active_failure(

--- a/python/larch/io.py
+++ b/python/larch/io.py
@@ -440,11 +440,12 @@ def kv_value(
     found = default
     for raw in _line_iter(text):
         if raw.startswith(prefix):
-            found = _strip_cr(value=raw[len(prefix) :], mode=cr_strip)
+            value = _strip_cr(value=raw[len(prefix) :], mode=cr_strip)
             if policy == "first":
-                return found
-            if policy == "last-non-empty" and not found:
+                return value
+            if policy == "last-non-empty" and not value:
                 continue
+            found = value
     return found
 
 

--- a/python/larch/issue/deps_audit.py
+++ b/python/larch/issue/deps_audit.py
@@ -16,6 +16,7 @@ from larch.issue import blocker
 from larch.issue import combine_issues
 from larch.git import gh
 from larch.issue import issue_wire
+from larch.core import logging_util
 from larch.core import proc
 from larch.core import redact
 from larch.errors import ShipError
@@ -34,10 +35,6 @@ def _emit_json(payload: dict[str, Any]) -> int:
     json.dump(payload, sys.stdout, sort_keys=True)
     sys.stdout.write("\n")
     return 0
-
-
-def _emit_kv(*, name: str, value: str) -> None:
-    print(f"{name}={value}")
 
 
 def _load_json_file(path: str, *, desc: str) -> Any:
@@ -391,9 +388,9 @@ def resolve_repo_main(argv: list[str] | None = None) -> int:
             print("ERROR=Could not determine repository", file=sys.stderr)
             return 1
     origin, matches = _origin_slug_matches(repo)
-    _emit_kv(name="REPO", value=repo)
-    _emit_kv(name="ORIGIN_SLUG", value=origin)
-    _emit_kv(name="ORIGIN_MATCHES", value=str(matches).lower())
+    logging_util.emit_kv(key="REPO", value=repo)
+    logging_util.emit_kv(key="ORIGIN_SLUG", value=origin)
+    logging_util.emit_kv(key="ORIGIN_MATCHES", value=str(matches).lower())
     return 0
 
 

--- a/python/larch/report/final_report.py
+++ b/python/larch/report/final_report.py
@@ -43,9 +43,6 @@ _LEGACY_DONE_OUTCOME_LINE_RE = re.compile(
 )
 
 
-_emit_kv = pr_body._emit_kv  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
-
-
 def _read_kv(*, path: Path, key: str, default: str = "") -> str:
     return larch_io.read_kv(path=path, key=key, default=default, first_match=True, cr_strip="strip", on_error_default=False)
 
@@ -1057,9 +1054,9 @@ def write_final_report_main(argv: list[str] | None = None) -> int:
     try:
         args = parser.parse_args(argv)
     except SystemExit:
-        _emit_kv(key="COMMENT_URL", value="")
-        _emit_kv(key="STATUS", value="failed")
-        _emit_kv(key="ERROR", value="usage")
+        logging_util.emit_kv(key="COMMENT_URL", value="")
+        logging_util.emit_kv(key="STATUS", value="failed")
+        logging_util.emit_kv(key="ERROR", value="usage")
         return 2
     # write_final_report must never crash this CLI (#6979): an uncaught composition
     # exception previously escaped as a traceback (rc!=0, no ERROR=) and left the
@@ -1069,10 +1066,10 @@ def write_final_report_main(argv: list[str] | None = None) -> int:
     except Exception as exc:
         rc, url, err = 1, "", f"final report render failed: {exc}"
         logging_util.BreadcrumbWriter().emit(f"final report: {err}", quiet=False)
-    _emit_kv(key="COMMENT_URL", value=url)
-    _emit_kv(key="STATUS", value="ok" if rc == 0 else "failed")
+    logging_util.emit_kv(key="COMMENT_URL", value=url)
+    logging_util.emit_kv(key="STATUS", value="ok" if rc == 0 else "failed")
     if err:
-        _emit_kv(key="ERROR", value=" ".join(err.split())[:500])
+        logging_util.emit_kv(key="ERROR", value=" ".join(err.split())[:500])
     return rc
 
 
@@ -1131,20 +1128,20 @@ def step18b_final_report_main(argv: list[str] | None = None) -> int:
     try:
         args = parser.parse_args(argv)
     except SystemExit:
-        _emit_kv(key="ERROR", value="usage")
+        logging_util.emit_kv(key="ERROR", value="usage")
         return config.EXIT_USAGE
     explicit = None if args.step17_emitted is None else args.step17_emitted == "true"
     emit_body, wfr_rc, present, snapshot, error = step18b_final_report(
         Path(args.implement_tmpdir),
         step17_emitted=explicit,
     )
-    _emit_kv(key="EMIT_BODY", value=str(emit_body).lower())
-    _emit_kv(key="WFR_RC", value=wfr_rc)
-    _emit_kv(key="STEP17_EMITTED_PRESENT", value=str(present).lower())
-    _emit_kv(key="SNAPSHOT_OK", value=snapshot)
+    logging_util.emit_kv(key="EMIT_BODY", value=str(emit_body).lower())
+    logging_util.emit_kv(key="WFR_RC", value=wfr_rc)
+    logging_util.emit_kv(key="STEP17_EMITTED_PRESENT", value=str(present).lower())
+    logging_util.emit_kv(key="SNAPSHOT_OK", value=snapshot)
     # ERROR=<reason> makes a render failure self-identifying instead of a silent
     # EMIT_BODY=false (#6979). Collapse to one line so the KV stream stays parseable.
-    _emit_kv(key="ERROR", value=" ".join(error.split())[:500])
+    logging_util.emit_kv(key="ERROR", value=" ".join(error.split())[:500])
     if error:
         # Mirror the reason to stderr so step-18.sh's append_failure_best_effort
         # (which captures step18b stderr) records it in execution-issues — the

--- a/python/larch/state/admission.py
+++ b/python/larch/state/admission.py
@@ -25,10 +25,6 @@ _TMP_FALLBACK = "/tmp"  # noqa: S108 - parity fallback for larch bootstrap tmpdi
 _transient_retry_sleeper = retry.default_sleeper
 
 
-def _emit_kv(*, key: str, value: str) -> None:
-    logging_util.emit_kv(key=key, value=_single_line(value))
-
-
 def _single_line(value: str) -> str:
     return re.sub(r" +", " ", value.replace("\r", " ").replace("\n", " ")).strip()
 
@@ -88,14 +84,11 @@ def _blockers(*, issue: int, repo: str) -> tuple[int, str]:
     )
     if result.returncode != 0:
         return result.returncode, ""
-    for line in result.stdout.splitlines():
-        if line.startswith("BLOCKERS="):
-            return 0, line.split("=", 1)[1].strip()
-    return 0, ""
+    return 0, larch_io.kv_value(text=result.stdout, key="BLOCKERS", duplicate_policy="first").strip()
 
 
 def _blocker_failure(rc: int) -> int:
-    _emit_kv(key="ADMISSION_ERROR", value=f"blocker check failed (exit {rc})")
+    logging_util.emit_kv(key="ADMISSION_ERROR", value=_single_line(f"blocker check failed (exit {rc})"))
     return 2
 
 
@@ -106,12 +99,15 @@ def _read_parent_sentinel(issue: int) -> bool:
     path = Path(tmpdir) / "parent-issue.md"
     if not path.is_file():
         return False
-    data: dict[str, str] = {}
     try:
-        for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
-            if "=" in line:
-                key, value = line.split("=", 1)
-                data[key] = value.strip()
+        data = {
+            key: value.strip()
+            for key, value in larch_io.read_kvs(
+                path,
+                duplicate_policy="last",
+                on_error_default=True,
+            ).items()
+        }
     except OSError:
         return False
     parent_issue = _normal_issue(data.get("ISSUE_NUMBER", ""))
@@ -130,32 +126,32 @@ def gate_main(argv: list[str]) -> int:
         args = parser.parse_args(argv)
     except SystemExit as exc:
         if int(exc.code or 0) != 0:
-            _emit_kv(key="ADMISSION_ERROR", value="argument validation failed")
+            logging_util.emit_kv(key="ADMISSION_ERROR", value=_single_line("argument validation failed"))
             return 2
         return 0
     issue = _normal_issue(args.issue)
     if issue is None:
-        _emit_kv(key="ADMISSION_ERROR", value="--issue must be a positive integer")
+        logging_util.emit_kv(key="ADMISSION_ERROR", value=_single_line("--issue must be a positive integer"))
         return 2
     repo = args.repo or (_resolve_repo() or "")
     if not repo:
-        _emit_kv(key="ADMISSION_ERROR", value="could not resolve repo (gh repo view failed)")
+        logging_util.emit_kv(key="ADMISSION_ERROR", value=_single_line("could not resolve repo (gh repo view failed)"))
         return 2
     view_rc, raw = _gh_issue_view(issue=issue, repo=repo)
     if view_rc != 0:
         detail = _single_line(raw)
-        _emit_kv(key="ADMISSION_ERROR", value=f"gh issue view failed{': ' + detail if detail else ''}")
+        logging_util.emit_kv(key="ADMISSION_ERROR", value=_single_line(f"gh issue view failed{': ' + detail if detail else ''}"))
         return 2
     try:
         data = json.loads(raw)
     except json.JSONDecodeError:
-        _emit_kv(key="ADMISSION_ERROR", value="issue json parse failed (malformed gh issue view response)")
+        logging_util.emit_kv(key="ADMISSION_ERROR", value=_single_line("issue json parse failed (malformed gh issue view response)"))
         return 2
     title = str(data.get("title") or "")
     state = str(data.get("state") or "")
     labels = data.get("labels") or []
     if state == "CLOSED":
-        _emit_kv(key="ADMISSION_ERROR", value=f"issue #{issue} is CLOSED")
+        logging_util.emit_kv(key="ADMISSION_ERROR", value=_single_line(f"issue #{issue} is CLOSED"))
         return 2
 
     if _read_parent_sentinel(issue):
@@ -163,40 +159,40 @@ def gate_main(argv: list[str]) -> int:
         if blocker_rc != 0:
             return _blocker_failure(blocker_rc)
         if blockers:
-            _emit_kv(key="ADMISSION_RESULT", value="has-blockers")
-            _emit_kv(key="BLOCKERS", value=blockers)
+            logging_util.emit_kv(key="ADMISSION_RESULT", value=_single_line("has-blockers"))
+            logging_util.emit_kv(key="BLOCKERS", value=_single_line(blockers))
             return 4
         if _has_report_prefix(title):
-            _emit_kv(key="ADMISSION_RESULT", value="report-title")
-            _emit_kv(key="TITLE", value=title)
+            logging_util.emit_kv(key="ADMISSION_RESULT", value=_single_line("report-title"))
+            logging_util.emit_kv(key="TITLE", value=_single_line(title))
             return 7
-        _emit_kv(key="ADMISSION_RESULT", value="pass")
-        _emit_kv(key="RESUME", value="true")
+        logging_util.emit_kv(key="ADMISSION_RESULT", value=_single_line("pass"))
+        logging_util.emit_kv(key="RESUME", value=_single_line("true"))
         return 0
 
     if _has_managed_prefix(title):
-        _emit_kv(key="ADMISSION_RESULT", value="managed-prefix")
-        _emit_kv(key="TITLE", value=title)
+        logging_util.emit_kv(key="ADMISSION_RESULT", value=_single_line("managed-prefix"))
+        logging_util.emit_kv(key="TITLE", value=_single_line(title))
         return 5
     if _has_report_prefix(title):
-        _emit_kv(key="ADMISSION_RESULT", value="report-title")
-        _emit_kv(key="TITLE", value=title)
+        logging_util.emit_kv(key="ADMISSION_RESULT", value=_single_line("report-title"))
+        logging_util.emit_kv(key="TITLE", value=_single_line(title))
         return 7
     if any(isinstance(label, dict) and label.get("name") == "audit-report" for label in labels):
-        _emit_kv(key="ADMISSION_RESULT", value="audit-report-label")
+        logging_util.emit_kv(key="ADMISSION_RESULT", value=_single_line("audit-report-label"))
         return 6
     blocker_rc, blockers = _blockers(issue=issue, repo=repo)
     if blocker_rc != 0:
         return _blocker_failure(blocker_rc)
     if blockers:
-        _emit_kv(key="ADMISSION_RESULT", value="has-blockers")
-        _emit_kv(key="BLOCKERS", value=blockers)
+        logging_util.emit_kv(key="ADMISSION_RESULT", value=_single_line("has-blockers"))
+        logging_util.emit_kv(key="BLOCKERS", value=_single_line(blockers))
         return 4
     if not _has_designed_prefix(title):
-        _emit_kv(key="ADMISSION_RESULT", value="missing-designed-prefix")
-        _emit_kv(key="TITLE", value=title)
+        logging_util.emit_kv(key="ADMISSION_RESULT", value=_single_line("missing-designed-prefix"))
+        logging_util.emit_kv(key="TITLE", value=_single_line(title))
         return 5
-    _emit_kv(key="ADMISSION_RESULT", value="pass")
+    logging_util.emit_kv(key="ADMISSION_RESULT", value=_single_line("pass"))
     return 0
 
 
@@ -204,10 +200,7 @@ def _clean_tree() -> str:
     result = _run([sys.executable, str(_PY_CLI), "git", "clean-tree", "--fail-closed"])
     if result.stderr:
         sys.stderr.write(result.stderr)
-    for line in result.stdout.splitlines():
-        if line.startswith("CLEAN="):
-            return line.split("=", 1)[1]
-    return ""
+    return larch_io.kv_value(text=result.stdout, key="CLEAN", duplicate_policy="first")
 
 
 def _stash_check() -> str:
@@ -234,55 +227,52 @@ def preflight_main(argv: list[str]) -> int:
         result = _run(["git", "symbolic-ref", "--short", "HEAD"])
         current = result.stdout.strip() if result.returncode == 0 else ""
         if current != "main":
-            _emit_kv(key="PREFLIGHT", value="fail")
-            _emit_kv(key="PREFLIGHT_ERROR", value=f"Not on main branch (on '{current}'). Switch to main first, or pass --skip-branch-check.")
+            logging_util.emit_kv(key="PREFLIGHT", value=_single_line("fail"))
+            logging_util.emit_kv(key="PREFLIGHT_ERROR", value=_single_line(f"Not on main branch (on '{current}'). Switch to main first, or pass --skip-branch-check."))
             return 1
     if not args.skip_clean_check:
         clean = _clean_tree()
         if clean == "false":
-            _emit_kv(key="PREFLIGHT", value="fail")
-            _emit_kv(key="PREFLIGHT_ERROR", value="Working tree is not clean. Commit or stash changes first.")
+            logging_util.emit_kv(key="PREFLIGHT", value=_single_line("fail"))
+            logging_util.emit_kv(key="PREFLIGHT_ERROR", value=_single_line("Working tree is not clean. Commit or stash changes first."))
             return 2
         if clean != "true":
-            _emit_kv(key="PREFLIGHT", value="fail")
-            _emit_kv(key="PREFLIGHT_ERROR", value="Could not determine working-tree cleanliness (helper produced no CLEAN= line).")
+            logging_util.emit_kv(key="PREFLIGHT", value=_single_line("fail"))
+            logging_util.emit_kv(key="PREFLIGHT_ERROR", value=_single_line("Could not determine working-tree cleanliness (helper produced no CLEAN= line)."))
             return 2
         stash = _stash_check()
         if stash == "nonempty":
-            _emit_kv(key="PREFLIGHT", value="fail")
-            _emit_kv(
-                key="PREFLIGHT_ERROR",
-                value="Git stash is not empty. Apply or drop stashed changes first, for example with git stash pop or git stash drop.",
-            )
+            logging_util.emit_kv(key="PREFLIGHT", value=_single_line("fail"))
+            logging_util.emit_kv(key="PREFLIGHT_ERROR", value=_single_line("Git stash is not empty. Apply or drop stashed changes first, for example with git stash pop or git stash drop."))
             return 2
         if stash != "empty":
-            _emit_kv(key="PREFLIGHT", value="fail")
-            _emit_kv(key="PREFLIGHT_ERROR", value="Could not determine git stash cleanliness. Inspect git stash list and re-run.")
+            logging_util.emit_kv(key="PREFLIGHT", value=_single_line("fail"))
+            logging_util.emit_kv(key="PREFLIGHT_ERROR", value=_single_line("Could not determine git stash cleanliness. Inspect git stash list and re-run."))
             return 2
     fetch = _git_fetch_origin_main()
     if fetch.returncode != 0:
-        _emit_kv(key="PREFLIGHT", value="fail")
-        _emit_kv(key="PREFLIGHT_ERROR", value="git fetch origin main failed.")
+        logging_util.emit_kv(key="PREFLIGHT", value=_single_line("fail"))
+        logging_util.emit_kv(key="PREFLIGHT_ERROR", value=_single_line("git fetch origin main failed."))
         return 3
     if not args.skip_branch_check:
         sync = _run([sys.executable, str(_PY_CLI), "git", "check-main-sync"])
-        fields: dict[str, str] = dict(line.split("=", 1) for line in sync.stdout.splitlines() if "=" in line)
+        fields = larch_io.parse_kv(sync.stdout, duplicate_policy="last")
         sync_status = fields.get("SYNC_STATUS", "")
         sync_error = fields.get("ERROR", "")
         if sync_status == "blocked" or sync.returncode == 1:
-            _emit_kv(key="PREFLIGHT", value="fail")
-            _emit_kv(key="PREFLIGHT_ERROR", value=sync_error or "local main is ahead of origin/main with non-log changes; push or reconcile before re-running")
+            logging_util.emit_kv(key="PREFLIGHT", value=_single_line("fail"))
+            logging_util.emit_kv(key="PREFLIGHT_ERROR", value=_single_line(sync_error or "local main is ahead of origin/main with non-log changes; push or reconcile before re-running"))
             return 3
         if not (sync.returncode == _PROBE_ERROR_EXIT and sync_status == "probe-error") and sync.returncode != 0:
-            _emit_kv(key="PREFLIGHT", value="fail")
-            _emit_kv(key="PREFLIGHT_ERROR", value=sync_error or f"cli.py git check-main-sync exited unexpectedly (exit {sync.returncode})")
+            logging_util.emit_kv(key="PREFLIGHT", value=_single_line("fail"))
+            logging_util.emit_kv(key="PREFLIGHT_ERROR", value=_single_line(sync_error or f"cli.py git check-main-sync exited unexpectedly (exit {sync.returncode})"))
             return 3
     if not args.skip_branch_check and not args.skip_clean_check:
         rebase = _run(["git", "rebase", "origin/main", "--quiet"])
         if rebase.returncode != 0:
             _ = _run(["git", "rebase", "--abort"])
-            _emit_kv(key="PREFLIGHT", value="fail")
-            _emit_kv(key="PREFLIGHT_ERROR", value="git rebase origin/main failed.")
+            logging_util.emit_kv(key="PREFLIGHT", value=_single_line("fail"))
+            logging_util.emit_kv(key="PREFLIGHT_ERROR", value=_single_line("git rebase origin/main failed."))
             return 3
     status = _run(["git", "status", "--porcelain"])
     if not args.skip_clean_check or not status.stdout:
@@ -291,7 +281,7 @@ def preflight_main(argv: list[str]) -> int:
         if sentinel:
             with contextlib.suppress(OSError):
                 Path(sentinel).unlink(missing_ok=True)
-    _emit_kv(key="PREFLIGHT", value="ok")
+    logging_util.emit_kv(key="PREFLIGHT", value=_single_line("ok"))
     return 0
 
 
@@ -346,10 +336,10 @@ def fork_env_main(argv: list[str]) -> int:
     except OSError as exc:
         print(f"admission fork-env: could not write caller-env.sh: {exc}", file=sys.stderr)
         return 2
-    _emit_kv(key="BOOTSTRAP_TMPDIR", value=str(bootstrap_tmpdir))
-    _emit_kv(key="CALLER_ENV_PATH", value=str(caller_env))
-    _emit_kv(key="FORK_REPO", value=fork_repo)
-    _emit_kv(key="UPSTREAM_REPO", value=upstream_repo)
-    _emit_kv(key="FORK_OWNER", value=fork_owner)
-    _emit_kv(key="FORKED_TARGET", value="true")
+    logging_util.emit_kv(key="BOOTSTRAP_TMPDIR", value=_single_line(str(bootstrap_tmpdir)))
+    logging_util.emit_kv(key="CALLER_ENV_PATH", value=_single_line(str(caller_env)))
+    logging_util.emit_kv(key="FORK_REPO", value=_single_line(fork_repo))
+    logging_util.emit_kv(key="UPSTREAM_REPO", value=_single_line(upstream_repo))
+    logging_util.emit_kv(key="FORK_OWNER", value=_single_line(fork_owner))
+    logging_util.emit_kv(key="FORKED_TARGET", value=_single_line("true"))
     return 0

--- a/python/larch/state/session_env.py
+++ b/python/larch/state/session_env.py
@@ -344,9 +344,6 @@ def _emit(text: str) -> None:
     logging_util.emit(text)
 
 
-def _emit_kv(*, key: str, value: str) -> None:
-    logging_util.emit_kv(key=key, value=value)
-
 
 def _err(message: str) -> None:
     logging_util.BreadcrumbWriter().emit(message)
@@ -598,13 +595,10 @@ def _read_kv_raw(path: Path) -> dict[str, str]:
 
 
 def _read_first_raw_key(*, path: Path, key: str) -> str | None:
-    for line in _read_kv_file_text(path).splitlines():
-        if "=" not in line:
-            continue
-        found_key, value = line.split("=", 1)
-        if found_key == key:
-            return value
-    return None
+    if not path.is_file():
+        return None
+    parsed = larch_io.parse_kv(_read_kv_file_text(path), duplicate_policy="first")
+    return parsed.get(key) if key in parsed else None
 
 
 def _first_existing_implement_sentinel(candidate: Path) -> Path | None:
@@ -788,14 +782,13 @@ def _parse_bool_arg(*, value: str, flag: str) -> str:
 def _parse_key_value_file(path: str) -> dict[str, str]:
     if not path or not Path(path).is_file():
         return {}
-    data: dict[str, str] = {}
-    for line in _read_kv_file_text(Path(path)).splitlines():
-        if not line or line.startswith("#") or "=" not in line:
-            continue
-        key, value = line.split("=", 1)
-        if key in CALLER_ENV_KEYS and value:
-            data[key] = value
-    return data
+    parsed = larch_io.parse_kv(
+        _read_kv_file_text(Path(path)),
+        duplicate_policy="last",
+        skip_comments=True,
+        allowed_keys=CALLER_ENV_KEYS,
+    )
+    return {key: value for key, value in parsed.items() if value}
 
 
 def _is_path_under_root(*, path: str, root: str) -> bool:
@@ -1628,20 +1621,20 @@ def write_id_main(argv: list[str]) -> int:
         args = parser.parse_args(argv)
     except SystemExit:
         logging_util.quiet_init(argv0="write-session-id.sh")
-        _emit_kv(key="FAILED", value="true")
-        _emit_kv(key="ERROR", value="unknown flag")
+        logging_util.emit_kv(key="FAILED", value="true")
+        logging_util.emit_kv(key="ERROR", value="unknown flag")
         return 1
     logging_util.quiet_init(argv0="write-session-id.sh")
     if not args.output:
-        _emit_kv(key="FAILED", value="true")
-        _emit_kv(key="ERROR", value="--output is required")
+        logging_util.emit_kv(key="FAILED", value="true")
+        logging_util.emit_kv(key="ERROR", value="--output is required")
         return 1
     try:
         write_id(output=Path(args.output))
         return 0
     except OSError as exc:
-        _emit_kv(key="FAILED", value="true")
-        _emit_kv(key="ERROR", value=str(exc))
+        logging_util.emit_kv(key="FAILED", value="true")
+        logging_util.emit_kv(key="ERROR", value=str(exc))
         return 1
 
 
@@ -1735,7 +1728,7 @@ def write_run_params_main(argv: list[str]) -> int:
             "difficulty_override": args.difficulty,
         }
         _atomic_write(path=out, text=json.dumps(payload, indent=2, sort_keys=False) + "\n")
-        _emit_kv(key="RUN_PARAMS_WRITTEN", value=str(out))
+        logging_util.emit_kv(key="RUN_PARAMS_WRITTEN", value=str(out))
         return 0
     except (OSError, ValueError) as exc:
         _err(f"write-run-params.sh: {exc}")
@@ -1882,8 +1875,8 @@ def entry_gate_main(argv: list[str]) -> int:
     except ValueError as exc:
         return fail(str(exc))
     logging_util.quiet_init(argv0="session-entry-gate.sh")
-    _emit_kv(key="ENTRY_GATE", value=result.entry_gate)
-    _emit_kv(key="SKIP_BRANCH_CHECK", value=result.skip_branch_check)
+    logging_util.emit_kv(key="ENTRY_GATE", value=result.entry_gate)
+    logging_util.emit_kv(key="SKIP_BRANCH_CHECK", value=result.skip_branch_check)
     return 0
 
 
@@ -2204,7 +2197,7 @@ def setup_main(argv: list[str]) -> int:
         return exc.returncode
     for emission in result.stdout_emissions:
         if emission.kind == "kv":
-            _emit_kv(key=emission.key, value=emission.value)
+            logging_util.emit_kv(key=emission.key, value=emission.value)
         else:
             _emit(emission.key)
     for line in result.stderr_diagnostics:

--- a/python/monkeypatch-facade-binding-baseline.json
+++ b/python/monkeypatch-facade-binding-baseline.json
@@ -201,15 +201,6 @@
     "file": "tests/agents/test_agents.py",
     "qualified_symbol": "test_launch_codex_ci_finalize_order_and_token_stdout",
     "facade_module": "larch.agents._run_external",
-    "attribute": "_emit_kv",
-    "defining_module": "larch.agents._types",
-    "occurrence": 9,
-    "reason": "grandfathered monkeypatch facade binding pre-ratchet"
-  },
-  {
-    "file": "tests/agents/test_agents.py",
-    "qualified_symbol": "test_launch_codex_ci_finalize_order_and_token_stdout",
-    "facade_module": "larch.agents._run_external",
     "attribute": "_write",
     "defining_module": "larch.agents._types",
     "occurrence": 4,
@@ -582,15 +573,6 @@
     "attribute": "resolve_model_args",
     "defining_module": "larch.agents._launch_failure",
     "occurrence": 5,
-    "reason": "grandfathered monkeypatch facade binding pre-ratchet"
-  },
-  {
-    "file": "tests/agents/test_agents.py",
-    "qualified_symbol": "test_launch_cursor_ci_finalize_order_and_stall_guard",
-    "facade_module": "larch.agents._run_external",
-    "attribute": "_emit_kv",
-    "defining_module": "larch.agents._types",
-    "occurrence": 11,
     "reason": "grandfathered monkeypatch facade binding pre-ratchet"
   },
   {

--- a/python/suppression-reason-baseline.json
+++ b/python/suppression-reason-baseline.json
@@ -3347,13 +3347,6 @@
   },
   {
     "file": "larch/report/final_report.py",
-    "suppression_kind": "noqa",
-    "text": "noqa: SLF001",
-    "occurrence": 1,
-    "reason": "grandfathered pre-G-Py-11 suppression without inline reason"
-  },
-  {
-    "file": "larch/report/final_report.py",
     "suppression_kind": "pyright-ignore",
     "text": "pyright: ignore[reportPrivateUsage]",
     "occurrence": 1,
@@ -3364,13 +3357,6 @@
     "suppression_kind": "pyright-ignore",
     "text": "pyright: ignore[reportPrivateUsage]",
     "occurrence": 2,
-    "reason": "grandfathered pre-G-Py-11 suppression without inline reason"
-  },
-  {
-    "file": "larch/report/final_report.py",
-    "suppression_kind": "pyright-ignore",
-    "text": "pyright: ignore[reportPrivateUsage]",
-    "occurrence": 3,
     "reason": "grandfathered pre-G-Py-11 suppression without inline reason"
   },
   {

--- a/python/tests/agents/test_agents.py
+++ b/python/tests/agents/test_agents.py
@@ -3742,10 +3742,12 @@ def test_launch_codex_ci_finalize_order_and_token_stdout(
         assert model == "gpt-5.6-terra"
         _ = paths.token_record.write_text(f"TOOL=codex\nMODEL={model}\nTOKEN=1\n", encoding="utf-8")
 
+    real_emit_kv = logging_util.emit_kv
+
     def fake_emit_kv(key: str, value: str | int) -> None:
         if key == "TOKEN_RECORD":
             order.append("token")
-        logging_util.emit_kv(key=key, value=str(value))
+        real_emit_kv(key=key, value=str(value))
 
     def fake_promote(path: Path) -> None:
         order.append("promote")
@@ -3757,8 +3759,8 @@ def test_launch_codex_ci_finalize_order_and_token_stdout(
     def fake_emit_result(output: Path, launcher_exit: int, *, tool: str) -> None:  # noqa: ARG001  # pylint: disable=unused-argument
         assert tool == "codex"
         order.append("emit")
-        logging_util.emit_kv(key="LAUNCHER_EXIT", value=str(config.EXIT_TIMEOUT))
-        logging_util.emit_kv(key="OUTPUT", value=str(output))
+        real_emit_kv(key="LAUNCHER_EXIT", value=str(config.EXIT_TIMEOUT))
+        real_emit_kv(key="OUTPUT", value=str(output))
 
     monkeypatch.setattr(agents.shutil, "which", lambda name: "/usr/bin/true" if name == "codex" else None)
     monkeypatch.setattr(_ci_launcher, "_prepare_codex_home", lambda _home, **_kwargs: (0, ""))
@@ -3769,7 +3771,7 @@ def test_launch_codex_ci_finalize_order_and_token_stdout(
     monkeypatch.setattr(_run_external, "_mirror_codex_quota_from_events", fake_mirror)
     monkeypatch.setattr(_ci_launcher, "_record_launch_timing", fake_record_timing)
     monkeypatch.setattr(_run_external, "_record_usage_from_events", fake_record_usage)
-    monkeypatch.setattr(_run_external, "_emit_kv", fake_emit_kv)
+    monkeypatch.setattr(logging_util, "emit_kv", fake_emit_kv)
     monkeypatch.setattr(_ci_launcher, "_promote_inner_done", fake_promote)
     monkeypatch.setattr(_ci_launcher, "_append_ci_failure", fake_append_failure)
     monkeypatch.setattr(_ci_launcher, "_emit_ci_launcher_result", fake_emit_result)
@@ -4269,10 +4271,12 @@ def test_launch_cursor_ci_finalize_order_and_stall_guard(
         order.append("usage")
         _ = paths.token_record.write_text("TOKEN=1\n", encoding="utf-8")
 
+    real_emit_kv = logging_util.emit_kv
+
     def fake_emit_kv(key: str, value: str | int) -> None:
         if key == "TOKEN_RECORD":
             order.append("token")
-        logging_util.emit_kv(key=key, value=str(value))
+        real_emit_kv(key=key, value=str(value))
 
     def fake_promote(path: Path) -> None:
         order.append("promote")
@@ -4297,7 +4301,7 @@ def test_launch_cursor_ci_finalize_order_and_stall_guard(
     monkeypatch.setattr(_ci_launcher, "_append", fake_append)
     monkeypatch.setattr(_ci_launcher, "_record_launch_timing", fake_record_timing)
     monkeypatch.setattr(_ci_launcher, "_record_cursor_usage_from_output", fake_record_usage)
-    monkeypatch.setattr(_run_external, "_emit_kv", fake_emit_kv)
+    monkeypatch.setattr(logging_util, "emit_kv", fake_emit_kv)
     monkeypatch.setattr(_ci_launcher, "_promote_inner_done", fake_promote)
     monkeypatch.setattr(_ci_launcher, "_append_ci_failure", fake_append_failure)
     monkeypatch.setattr(_ci_launcher, "_emit_ci_launcher_result", fake_emit_result)

--- a/python/tests/core/test_kv_cli.py
+++ b/python/tests/core/test_kv_cli.py
@@ -82,3 +82,38 @@ def test_invalid_match_exits_2(capsys: pytest.CaptureFixture[str], monkeypatch: 
     assert rc == 2
     assert out == ""
     assert "invalid choice" in err
+
+
+def test_file_last_match_forwards_duplicate_policy(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "values.env"
+    _ = source.write_text("KEY=one\nKEY=two\n", encoding="utf-8")
+
+    rc, out, err = run_get(
+        ["--key", "KEY", "--file", str(source), "--match", "last"],
+        capsys,
+        monkeypatch,
+    )
+
+    assert rc == 0
+    assert out == "two\n"
+    assert err == ""
+
+
+def test_stdin_last_non_empty_forwards_policy(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rc, out, err = run_get(
+        ["--key", "KEY", "--match", "last-non-empty"],
+        capsys,
+        monkeypatch,
+        stdin="KEY=one\nKEY=\n",
+    )
+
+    assert rc == 0
+    assert out == "one\n"
+    assert err == ""

--- a/python/tests/design/test_design_router.py
+++ b/python/tests/design/test_design_router.py
@@ -1,0 +1,18 @@
+"""Focused codec policy coverage for design router readers."""
+
+from __future__ import annotations
+
+from larch import io as larch_io
+from larch.design import design_router
+
+
+def test_router_stdout_codec_preserves_ordered_duplicates() -> None:
+    parsed = design_router._parse_stdout_kv(  # pyright: ignore[reportPrivateUsage]
+        "WARN=first\nSTEP=old\nWARN=second\nSTEP=latest\n"
+    )
+    assert parsed == {"WARN": ["first", "second"], "STEP": ["old", "latest"]}
+
+
+def test_router_rename_stdout_uses_last_match() -> None:
+    text = "RENAMED=false\nRENAMED=true\nOTHER=x\n"
+    assert larch_io.kv_value(text=text, key="RENAMED", duplicate_policy="last") == "true"

--- a/python/tests/design/test_design_step_log.py
+++ b/python/tests/design/test_design_step_log.py
@@ -77,3 +77,13 @@ def test_step1_log_requires_conventional_plan_file(tmp_path: Path) -> None:
     )
     assert result.returncode == 2
     assert "plan file not found at conventional path" in result.stderr
+
+
+def test_session_get_keeps_first_match_and_empty_default(tmp_path: Path) -> None:
+    from larch.design import design_step_log  # noqa: PLC0415
+
+    path = tmp_path / "session-env.sh"
+    _ = path.write_text("RUN_ID=first\nRUN_ID=second\nEMPTY=\n", encoding="utf-8")
+    assert design_step_log._session_get(path=path, key="RUN_ID") == "first"  # pyright: ignore[reportPrivateUsage]
+    assert design_step_log._session_get(path=path, key="EMPTY", default="fallback") == "fallback"  # pyright: ignore[reportPrivateUsage]
+    assert design_step_log._session_get(path=path, key="MISSING", default="fallback") == "fallback"  # pyright: ignore[reportPrivateUsage]

--- a/python/tests/git/test_git.py
+++ b/python/tests/git/test_git.py
@@ -1223,8 +1223,10 @@ def test_check_phantom_dirty_parse_error_emits_unknown(monkeypatch: pytest.Monke
 
 
 def test_emit_kv_rejects_multiline_values() -> None:
+    from larch.core import logging_util  # noqa: PLC0415
+
     with pytest.raises(ValueError, match="newline"):
-        git._emit_kv(key="ERROR", value="line1\nline2")  # pyright: ignore[reportPrivateUsage]
+        logging_util.emit_kv(key="ERROR", value="line1\nline2")
 
 
 def test_snapshot_untracked_usage_does_not_create_output(tmp_path: Path) -> None:

--- a/python/tests/implement/test_implement_shell_scripts.py
+++ b/python/tests/implement/test_implement_shell_scripts.py
@@ -98,6 +98,21 @@ def read_key(args: list[str]) -> int:
     return 0
 
 
+def kv_get(args: list[str]) -> int:
+    # Minimal stub for cli.py kv get used by step-18.sh kv_value().
+    key = args[args.index("--key") + 1]
+    file_path = Path(args[args.index("--file") + 1]) if "--file" in args else None
+    try:
+        text = file_path.read_text(encoding="utf-8") if file_path is not None else sys.stdin.read()
+    except OSError:
+        return 1
+    for line in text.splitlines():
+        if line.startswith(key + "="):
+            print(line.split("=", 1)[1])
+            return 0
+    return 1
+
+
 def step18b(args: list[str]) -> int:
     tmp = Path(args[args.index("--implement-tmpdir") + 1])
     sentinel = "true" if (tmp / ".step17-emitted").exists() else "false"
@@ -140,6 +155,8 @@ def main() -> int:
     args = sys.argv[1:]
     if args[:2] == ["session", "read-key"]:
         return read_key(args[2:])
+    if args[:2] == ["kv", "get"]:
+        return kv_get(args[2:])
     if args[:2] == ["final-report", "step18b"]:
         return step18b(args[2:])
     if args[:2] == ["run-log", "append-failure"]:

--- a/skills/design/scripts/design-step3-mav.sh
+++ b/skills/design/scripts/design-step3-mav.sh
@@ -297,7 +297,7 @@ run_post_phase() {
         retally_rc=$?
         set -e
     fi
-    retally_status="$(awk -F= '$1 == "TALLY_PLAN_REVIEW_STATUS" { value=$2 } END { print value }' "$retally_stdout")"
+    retally_status="$(python3 "$CLAUDE_PLUGIN_ROOT/python/cli.py" kv get --file "$retally_stdout" --key TALLY_PLAN_REVIEW_STATUS --match last 2>/dev/null || true)"
     case "$retally_status" in
         ok) ;;
         *) retally_status=tally-error ;;

--- a/skills/implement/scripts/post-tracking-issue.sh
+++ b/skills/implement/scripts/post-tracking-issue.sh
@@ -33,7 +33,7 @@ fail_usage() {
 read_kv() {
     local key=$1 file=$2
     [ -f "$file" ] || return 0
-    awk -v k="$key" 'BEGIN{p=k"="} index($0,p)==1{print substr($0,length(p)+1); exit}' "$file" 2>/dev/null
+    python3 "$PLUGIN_ROOT/python/cli.py" kv get --file "$file" --key "$key" --match first 2>/dev/null || true
 }
 
 IMPLEMENT_TMPDIR=""
@@ -87,7 +87,7 @@ case "$ISSUE" in *[!0-9]*|"") emit_kv POSTED false; emit_kv COMMENT_URL ""; emit
 case "$RUN_ID" in *[!A-Za-z0-9._-]*|"") emit_kv POSTED false; emit_kv COMMENT_URL ""; emit_kv ERROR "RUN_ID must match ^[A-Za-z0-9._-]+$"; exit 1 ;; esac
 
 summary="$IMPLEMENT_TMPDIR/summary-metadata.md"
-version="$(python3 "$PLUGIN_ROOT/python/cli.py" plugin read-version 2>/dev/null | awk -F= '/^LARCH_PLUGIN_VERSION=/{print $2; exit}' || true)"
+version="$(python3 "$PLUGIN_ROOT/python/cli.py" plugin read-version 2>/dev/null | python3 "$PLUGIN_ROOT/python/cli.py" kv get --key LARCH_PLUGIN_VERSION --match first 2>/dev/null || true)"
 [ -n "$version" ] || version="unknown"
 
 {
@@ -122,7 +122,7 @@ if python3 "$PLUGIN_ROOT/python/cli.py" tracking-issue "${args[@]}" >"$out_file"
         printf 'ISSUE_NUMBER=%s\nRUN_ID=%s\nADOPTED=%s\n' "$ISSUE" "$RUN_ID" "$_adopted" > "$PARENT_ISSUE"
     fi
     emit_kv POSTED true
-    emit_kv COMMENT_URL "$(awk -F= '$1=="COMMENT_URL"{print substr($0,index($0,"=")+1); exit}' "$out_file")"
+    emit_kv COMMENT_URL "$(python3 "$PLUGIN_ROOT/python/cli.py" kv get --file "$out_file" --key COMMENT_URL --match first 2>/dev/null || true)"
     exit 0
 fi
 

--- a/skills/implement/scripts/refresh-execution-issues.sh
+++ b/skills/implement/scripts/refresh-execution-issues.sh
@@ -32,11 +32,13 @@ fail_usage() {
 read_kv() {
     local key=$1 file=$2
     [ -f "$file" ] || return 0
-    awk -v k="$key" 'BEGIN{p=k"="} index($0,p)==1{print substr($0,length(p)+1); exit}' "$file" 2>/dev/null
+    python3 "$PLUGIN_ROOT/python/cli.py" kv get --file "$file" --key "$key" --match first 2>/dev/null || true
 }
 
 read_plugin_version() {
-    python3 "$PLUGIN_ROOT/python/cli.py" plugin read-version 2>/dev/null | awk -F= '/^LARCH_PLUGIN_VERSION=/{print $2; exit}'
+    python3 "$PLUGIN_ROOT/python/cli.py" plugin read-version 2>/dev/null \
+        | python3 "$PLUGIN_ROOT/python/cli.py" kv get --key LARCH_PLUGIN_VERSION --match first 2>/dev/null \
+        || true
 }
 
 IMPLEMENT_TMPDIR=""

--- a/skills/implement/scripts/step-18.sh
+++ b/skills/implement/scripts/step-18.sh
@@ -112,7 +112,7 @@ _stall_layer_active() {
 
 kv_value() {
     local key=$1 file=$2
-    awk -F= -v key="$key" '$1==key{print substr($0, index($0, "=") + 1); exit}' "$file" 2>/dev/null
+    python3 "$CLAUDE_PLUGIN_ROOT/python/cli.py" kv get --file "$file" --key "$key" --match first 2>/dev/null || true
 }
 
 append_failure_best_effort() {


### PR DESCRIPTION
## Summary
- Finish the deferred #7347 / #6999 follow-up: migrate remaining plan-listed KEY=value readers to the shared codec / `kv get`, and private emitters to `logging_util.emit_kv`, with focused parity tests.
- Include the lint-fix `suppression-reason-baseline.json` edit that stalled the earlier `/fm` run before `4.r` rebase.
- Resolve rebase conflicts against main (`#7351` review launchers, `#7349` typed PR-body results) while keeping the codec/emitter migration.

## Test plan
- [x] `pytest` focused: `test_kv_cli`, `test_design_step_log`, `test_design_router`, `test_agents` (301 passed)
- [x] `lint kv-codec` clean after baseline refresh
- [ ] CI green on this PR

Related: stall root-cause filed as #7356 (residual of #6199).


Made with [Cursor](https://cursor.com)