### PR TITLE
Fixes #7274: unify review tally contracts

### DIFF
--- a/python/larch/review/review_core_body.py
+++ b/python/larch/review/review_core_body.py
@@ -6,12 +6,14 @@
 from __future__ import annotations
 
 import contextlib
+import io
 import os
 import re
 import shutil
 import time
 from collections.abc import Mapping, Sequence
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from larch.core import config, logging_util, proc
 from larch.calibration import difficulty
@@ -41,6 +43,9 @@ from larch.review.review_prune import (
     reviewer_prune_record,
     write_prune_decision_env,
 )
+
+if TYPE_CHECKING:
+    from larch.review import review_tally
 
 
 def _review_commands() -> ReviewCommands:
@@ -280,9 +285,18 @@ def _flush_round_log(*, review_tmpdir: Path, run_id: str, round_num: int) -> Non
     if not run_id or not implement or not Path(implement).is_dir():
         return
     _ensure_prune_sidecars(review_tmpdir=review_tmpdir, round_num=round_num)
-    _run_python_cli(
-        ["run-log", "write-round", "--log-root", str(Path(implement) / "larch-logs"), "--skill", "implement", "--run-id", run_id, "--round", str(round_num), "--source-dir", str(review_tmpdir)]
-    )
+    from larch.report import run_logs  # noqa: PLC0415 - avoids the report finalization import cycle during review-core module loading.
+
+    with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
+        _ = run_logs.larch_log_write_round_main(
+            [
+                "--log-root", str(Path(implement) / "larch-logs"),
+                "--skill", "implement",
+                "--run-id", run_id,
+                "--round", str(round_num),
+                "--source-dir", str(review_tmpdir),
+            ]
+        )
 
 
 def _parse_nonnegative_int(value: str, *, default: int = 0) -> int:
@@ -469,6 +483,30 @@ def _emit_review_core_result(result: ReviewCoreResult) -> int:
     return result.rc
 
 
+def _run_tally_request(*, commands: ReviewCommands, request: review_tally.TallyRequest) -> proc.CommandResult:
+    if commands.tally:
+        return _run_command_string(command=commands.tally, args=request.to_argv())
+    from larch.review import review_tally  # noqa: PLC0415 - keeps review-pipeline imports acyclic until tally execution.
+
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+        try:
+            result = review_tally.tally_code_votes(request)
+        except SystemExit as exc:
+            returncode = int(exc.code) if isinstance(exc.code, int) else 2
+        else:
+            result.emit()
+            returncode = result.rc
+    return proc.CommandResult(
+        argv=("tally-code-votes", *request.to_argv()),
+        returncode=returncode,
+        stdout=stdout.getvalue(),
+        stderr=stderr.getvalue(),
+        duration=0.0,
+    )
+
+
 def _emit_tally(*, commands: ReviewCommands, args: Sequence[str], out_file: Path, runner: object = None) -> dict[str, str]:
     if commands.emit:
         result = _run_command_string(command=commands.emit, args=args)
@@ -521,30 +559,22 @@ def _zero_findings_branch(*,  # noqa: PLR0913,RUF100
     rows: list[tuple[str, object]] = list(prefix_rows)
     voter = review_tmpdir / "zero-findings-voter.txt"
     _write_text(path=voter, text="")
-    tally_args = [
-        "--ballot-file",
-        str(review_tmpdir / "findings.md"),
-        "--review-tmpdir",
-        str(review_tmpdir),
-        "--cursor-available",
-        cursor_available,
-        "--codex-available",
-        codex_available,
-        "--round-num",
-        str(round_num),
-        "--voter-files",
-        str(voter),
-    ]
-    if session_env_path:
-        tally_args.extend(["--session-env-path", session_env_path])
-    if panel_manifest and Path(panel_manifest).is_file():
-        tally_args.extend(["--manifest-file", panel_manifest])
-    if collector_results.is_file():
-        tally_args.extend(["--collector-results-file", str(collector_results)])
-    if not_substantive:
-        tally_args.extend(["--not-substantive-count", str(not_substantive)])
+    from larch.review import review_tally  # noqa: PLC0415 - keeps review-pipeline imports acyclic until tally execution.
+
+    request = review_tally.TallyRequest(
+        ballot_file=str(review_tmpdir / "findings.md"),
+        review_tmpdir=str(review_tmpdir),
+        voter_files=(str(voter),),
+        session_env_path=session_env_path,
+        manifest_file=panel_manifest if panel_manifest and Path(panel_manifest).is_file() else "",
+        collector_results_file=str(collector_results) if collector_results.is_file() else "",
+        not_substantive_count=str(not_substantive),
+        cursor_available=cursor_available,
+        codex_available=codex_available,
+        round_num=str(round_num),
+    )
     _snapshot_oos(review_tmpdir=review_tmpdir, stem="zero-findings", session_env_path=session_env_path)
-    tally_result = _run_command_string(command=commands.tally, args=tally_args) if commands.tally else _call_maybe_override(command="", review_name="tally-code-votes", args=tally_args)
+    tally_result = _run_tally_request(commands=commands, request=request)
     tally_out = review_tmpdir / "review-core-zero-findings-tally.env"
     _write_text(path=tally_out, text=tally_result.stdout)
     tally = _kv_parse(tally_result.stdout)
@@ -666,34 +696,25 @@ def _dispatch_voters_for_ballot(ctx: ReviewCoreBranchContext) -> tuple[list[str]
 
 
 def _tally_voted_ballot(ctx: ReviewCoreBranchContext, *, proposer_map: Path, voter_files: list[str], voter_tools: list[str], out_name: str) -> tuple[proc.CommandResult, dict[str, str]]:
-    tally_args = [
-        "--ballot-file",
-        str(ctx.review_tmpdir / "findings.md"),
-        "--review-tmpdir",
-        str(ctx.review_tmpdir),
-        "--cursor-available",
-        ctx.cursor_available,
-        "--codex-available",
-        ctx.codex_available,
-        "--round-num",
-        str(ctx.round_num),
-        "--proposer-map-file",
-        str(proposer_map),
-    ]
-    if ctx.session_env_path:
-        tally_args.extend(["--session-env-path", ctx.session_env_path])
-    if ctx.scope_files and Path(ctx.scope_files).is_file() and Path(ctx.scope_files).stat().st_size:
-        tally_args.extend(["--scope-files", ctx.scope_files])
-    if ctx.plan_file and Path(ctx.plan_file).is_file():
-        tally_args.extend(["--plan-file", ctx.plan_file])
-    if ctx.panel_manifest and Path(ctx.panel_manifest).is_file():
-        tally_args.extend(["--manifest-file", ctx.panel_manifest])
-    if ctx.collector_results.is_file():
-        tally_args.extend(["--collector-results-file", str(ctx.collector_results)])
-    if ctx.not_substantive:
-        tally_args.extend(["--not-substantive-count", str(ctx.not_substantive)])
-    tally_args.extend(["--voter-files", *voter_files, "--voter-tools", *voter_tools])
-    tally_result = _run_command_string(command=ctx.commands.tally, args=tally_args) if ctx.commands.tally else _call_maybe_override(command="", review_name="tally-code-votes", args=tally_args)
+    from larch.review import review_tally  # noqa: PLC0415 - keeps review-pipeline imports acyclic until tally execution.
+
+    request = review_tally.TallyRequest(
+        ballot_file=str(ctx.review_tmpdir / "findings.md"),
+        review_tmpdir=str(ctx.review_tmpdir),
+        voter_files=tuple(voter_files),
+        voter_tools=tuple(voter_tools),
+        session_env_path=ctx.session_env_path,
+        scope_files=ctx.scope_files if ctx.scope_files and Path(ctx.scope_files).is_file() and Path(ctx.scope_files).stat().st_size else "",
+        plan_file=ctx.plan_file if ctx.plan_file and Path(ctx.plan_file).is_file() else "",
+        manifest_file=ctx.panel_manifest if ctx.panel_manifest and Path(ctx.panel_manifest).is_file() else "",
+        collector_results_file=str(ctx.collector_results) if ctx.collector_results.is_file() else "",
+        not_substantive_count=str(ctx.not_substantive),
+        cursor_available=ctx.cursor_available,
+        codex_available=ctx.codex_available,
+        round_num=str(ctx.round_num),
+        proposer_map_file=str(proposer_map),
+    )
+    tally_result = _run_tally_request(commands=ctx.commands, request=request)
     tally = _kv_parse(tally_result.stdout)
     _write_text(path=ctx.review_tmpdir / out_name, text=tally_result.stdout)
     return tally_result, tally
@@ -1136,22 +1157,27 @@ def _review_core_body(
             rows.append((f"VOTER_{idx}_TOOL", voters[f"VOTER_{idx}_TOOL"]))
         if status:
             rows.append((f"VOTER_{idx}_STATUS", status))
-    tally_args = ["--ballot-file", str(review_tmpdir / "findings.md"), "--review-tmpdir", str(review_tmpdir), "--cursor-available", cursor_available, "--codex-available", codex_available, "--round-num", str(round_num), "--proposer-map-file", str(proposer_map)]
-    if session_env_path:
-        tally_args.extend(["--session-env-path", session_env_path])
-    if scope_files and Path(scope_files).is_file() and Path(scope_files).stat().st_size:
-        tally_args.extend(["--scope-files", scope_files])
-    if _get(parsed=parsed, key="--plan-file") and Path(_get(parsed=parsed, key="--plan-file")).is_file():
-        tally_args.extend(["--plan-file", _get(parsed=parsed, key="--plan-file")])
-    if panel_manifest and Path(panel_manifest).is_file():
-        tally_args.extend(["--manifest-file", panel_manifest])
-    if collector_results.is_file():
-        tally_args.extend(["--collector-results-file", str(collector_results)])
-    if not_substantive:
-        tally_args.extend(["--not-substantive-count", str(not_substantive)])
-    tally_args.extend(["--voter-files", *voter_files, "--voter-tools", *voter_tools])
+    plan_file = _get(parsed=parsed, key="--plan-file")
+    from larch.review import review_tally  # noqa: PLC0415 - keeps review-pipeline imports acyclic until tally execution.
+
+    request = review_tally.TallyRequest(
+        ballot_file=str(review_tmpdir / "findings.md"),
+        review_tmpdir=str(review_tmpdir),
+        voter_files=tuple(voter_files),
+        voter_tools=tuple(voter_tools),
+        session_env_path=session_env_path,
+        scope_files=scope_files if scope_files and Path(scope_files).is_file() and Path(scope_files).stat().st_size else "",
+        plan_file=plan_file if plan_file and Path(plan_file).is_file() else "",
+        manifest_file=panel_manifest if panel_manifest and Path(panel_manifest).is_file() else "",
+        collector_results_file=str(collector_results) if collector_results.is_file() else "",
+        not_substantive_count=str(not_substantive),
+        cursor_available=cursor_available,
+        codex_available=codex_available,
+        round_num=str(round_num),
+        proposer_map_file=str(proposer_map),
+    )
     _progress_note(tmpdir=progress_tmpdir, step="5", text=f"round {round_num}: tallying votes")
-    tally_result = _run_command_string(command=commands.tally, args=tally_args) if commands.tally else _call_maybe_override(command="", review_name="tally-code-votes", args=tally_args)
+    tally_result = _run_tally_request(commands=commands, request=request)
     tally = _kv_parse(tally_result.stdout)
     _write_text(path=review_tmpdir / "review-core-tally.env", text=tally_result.stdout)
     if tally_result.returncode != 0 and not tally.get("TALLY_STATUS"):

--- a/python/larch/review/review_tally.py
+++ b/python/larch/review/review_tally.py
@@ -13,7 +13,8 @@ import sys
 import tempfile
 from contextlib import suppress
 from collections import defaultdict
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
 from pathlib import Path
 from typing import NoReturn, cast
 
@@ -33,6 +34,128 @@ _CLASSIFICATION_HEADER = (
     "finding_id\treviewer_slots\tvoting_result\tv1_vote\tv1_correctness\tv1_severity\tv1_quality\tv1_uncertain\tv2_vote\tv2_correctness\tv2_severity\tv2_quality\tv2_uncertain\tv3_vote\tv3_correctness\tv3_severity\tv3_quality\tv3_uncertain\tscope"
 )
 _OOS_AGGREGATE_POOL = "oos-aggregate-pool.md"
+
+
+@dataclass(frozen=True)
+class TallyRequest:
+    """Inputs for one code-review vote tally, shared by CLI and in-process callers."""
+
+    ballot_file: str
+    review_tmpdir: str
+    voter_files: tuple[str, ...]
+    voter_tools: tuple[str, ...] = ()
+    session_env_path: str = ""
+    scope_files: str = ""
+    plan_file: str = ""
+    manifest_file: str = ""
+    collector_results_file: str = ""
+    not_substantive_count: str = "0"
+    cursor_available: str = ""
+    codex_available: str = ""
+    round_num: str = "1"
+    both_down: str = "false"
+    proposer_map_file: str = ""
+
+    def to_argv(self) -> list[str]:
+        argv = [
+            "--ballot-file", self.ballot_file,
+            "--review-tmpdir", self.review_tmpdir,
+            "--cursor-available", self.cursor_available,
+            "--codex-available", self.codex_available,
+            "--round-num", self.round_num,
+        ]
+        if self.proposer_map_file:
+            argv.extend(["--proposer-map-file", self.proposer_map_file])
+        for flag, value in (
+            ("--session-env-path", self.session_env_path),
+            ("--scope-files", self.scope_files),
+            ("--plan-file", self.plan_file),
+            ("--manifest-file", self.manifest_file),
+            ("--collector-results-file", self.collector_results_file),
+        ):
+            if value:
+                argv.extend([flag, value])
+        if self.not_substantive_count != "0":
+            argv.extend(["--not-substantive-count", self.not_substantive_count])
+        if self.both_down != "false":
+            argv.extend(["--both-down", self.both_down])
+        argv.extend(["--voter-files", *self.voter_files])
+        if self.voter_tools:
+            argv.extend(["--voter-tools", *self.voter_tools])
+        return argv
+
+
+@dataclass(frozen=True)
+class TallyResult:
+    """One complete tally outcome and the stable KV contract it emits."""
+
+    rc: int
+    status: str = ""
+    accepted_count: int = 0
+    rejected_count: int = 0
+    exonerated_count: int = 0
+    neutral_count: int = 0
+    oos_accepted_count: int = 0
+    oos_rejected_count: int = 0
+    out_of_scope_drift_count: int = 0
+    voting_tally_file: Path | None = None
+    tally_file: Path | None = None
+    accepted_findings_file: Path | None = None
+    rejected_findings_file: Path | None = None
+    oos_accepted_file: Path | None = None
+    oos_file: Path | None = None
+    eligible_voter_count: int = 0
+    voter_count: int = 0
+    parse_failed_count: int = 0
+    findings_classification_tsv_file: Path | None = None
+    under_quorum_items: tuple[str, ...] = ()
+    voting_skipped_warning: str = ""
+    yield_tsv_file: Path | None = None
+    warnings: tuple[str, ...] = ()
+    error: str = ""
+
+    @classmethod
+    def failure(cls, message: str) -> TallyResult:
+        return cls(rc=2, error=message)
+
+    def emit(self) -> None:
+        if self.error:
+            print(self.error, file=sys.stderr)
+            return
+        for warning in self.warnings:
+            logging_util.emit_kv(key="WARN", value=warning)
+        rows = (
+            ("TALLY_STATUS", self.status),
+            ("ACCEPTED_COUNT", self.accepted_count),
+            ("REJECTED_COUNT", self.rejected_count),
+            ("EXONERATED_COUNT", self.exonerated_count),
+            ("NEUTRAL_COUNT", self.neutral_count),
+            ("OOS_ACCEPTED_COUNT", self.oos_accepted_count),
+            ("OOS_REJECTED_COUNT", self.oos_rejected_count),
+            ("OUT_OF_SCOPE_DRIFT_COUNT", self.out_of_scope_drift_count),
+            ("VOTING_TALLY_FILE", self.voting_tally_file),
+            ("TALLY_FILE", self.tally_file),
+            ("ACCEPTED_FINDINGS_FILE", self.accepted_findings_file),
+            ("REJECTED_FINDINGS_FILE", self.rejected_findings_file),
+            ("OOS_ACCEPTED_FILE", self.oos_accepted_file),
+            ("OOS_FILE", self.oos_file),
+            ("TALLY_OK", "true"),
+            ("ELIGIBLE_VOTER_COUNT", self.eligible_voter_count),
+            ("VOTER_COUNT", self.voter_count),
+        )
+        for key, value in rows:
+            if value is not None:
+                logging_util.emit_kv(key=key, value=str(value) if isinstance(value, Path) else value)
+        if self.status == "ok":
+            logging_util.emit_kv(key="UNDER_QUORUM_COUNT", value=len(self.under_quorum_items))
+            logging_util.emit_kv(key="UNDER_QUORUM_ITEMS", value=", ".join(self.under_quorum_items))
+        logging_util.emit_kv(key="PARSE_FAILED_COUNT", value=self.parse_failed_count)
+        if self.voting_skipped_warning:
+            logging_util.emit_kv(key="VOTING_SKIPPED_WARNING", value=self.voting_skipped_warning)
+        if self.findings_classification_tsv_file is not None:
+            logging_util.emit_kv(key="FINDINGS_CLASSIFICATION_TSV_FILE", value=str(self.findings_classification_tsv_file))
+        if self.yield_tsv_file is not None:
+            logging_util.emit_kv(key="YIELD_TSV_FILE", value=str(self.yield_tsv_file))
 
 
 def _error(message: str) -> int:
@@ -77,7 +200,7 @@ def _parse_multi(*, argv: list[str], flag: str) -> tuple[list[str], list[str]]:
     return rest, out
 
 
-def _parse_tally_args(argv: list[str]) -> argparse.Namespace:
+def _parse_tally_args(argv: list[str]) -> TallyRequest:
     rest, voter_files = _parse_multi(argv=argv, flag="--voter-files")
     rest, voter_tools = _parse_multi(argv=rest, flag="--voter-tools")
     parser = argparse.ArgumentParser(prog="tally-code-votes")
@@ -95,9 +218,23 @@ def _parse_tally_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--both-down", default="false")
     parser.add_argument("--proposer-map-file", default="")
     args = parser.parse_args(rest)
-    args.voter_files = voter_files
-    args.voter_tools = voter_tools
-    return args
+    return TallyRequest(
+        ballot_file=args.ballot_file,
+        review_tmpdir=args.review_tmpdir,
+        voter_files=tuple(voter_files),
+        voter_tools=tuple(voter_tools),
+        session_env_path=args.session_env_path,
+        scope_files=args.scope_files,
+        plan_file=args.plan_file,
+        manifest_file=args.manifest_file,
+        collector_results_file=args.collector_results_file,
+        not_substantive_count=args.not_substantive_count,
+        cursor_available=args.cursor_available,
+        codex_available=args.codex_available,
+        round_num=args.round_num,
+        both_down=args.both_down,
+        proposer_map_file=args.proposer_map_file,
+    )
 
 
 def _nested_implement_round(*, review_tmpdir: Path, session_env_path: str) -> bool:
@@ -194,7 +331,7 @@ def _classification_row(*,
 def _voter_votes_and_severities(
     cells: list[tuple[str, str, str, str, str, str | None]],
     *,
-    voter_tools: list[str],
+    voter_tools: Sequence[str],
     three_slot: bool,
 ) -> tuple[list[tuple[str, str]], list[str]]:
     if three_slot:
@@ -657,7 +794,7 @@ def _write_final_tally_outputs(*,
     tally_env: Path,
     counts_text: str,
     review_tmpdir: Path,
-    args: argparse.Namespace,
+    args: TallyRequest,
     ledger_entries: list[dict[str, object]],
 ) -> None:
     findings_ledger.write_round(
@@ -668,20 +805,15 @@ def _write_final_tally_outputs(*,
     _append(path=tally_env, text=counts_text)
 
 
-def tally_code_votes(argv: list[str]) -> int:
-    logging_util.quiet_init(argv0="tally-code-votes")
-    try:
-        args = _parse_tally_args(argv)
-    except SystemExit as exc:
-        return int(exc.code) if isinstance(exc.code, int) else 2
+def tally_code_votes(args: TallyRequest) -> TallyResult:
     ballot_file = Path(args.ballot_file)
     review_tmpdir = Path(args.review_tmpdir)
     if not ballot_file.is_file():
-        return _error("tally-code-votes: --ballot-file must name a file")
+        return TallyResult.failure("tally-code-votes: --ballot-file must name a file")
     if args.manifest_file and not Path(args.manifest_file).is_file():
-        return _error("tally-code-votes: --manifest-file must name a file")
+        return TallyResult.failure("tally-code-votes: --manifest-file must name a file")
     if not str(args.round_num).isdigit() or int(args.round_num) <= 0:
-        return _error("tally-code-votes: --round-num must be a positive integer")
+        return TallyResult.failure("tally-code-votes: --round-num must be a positive integer")
     try:
         proposer_map_file, proposer_sidecar_required = _resolve_proposer_map(
             ballot_file=ballot_file,
@@ -689,12 +821,12 @@ def tally_code_votes(argv: list[str]) -> int:
             explicit_map=str(args.proposer_map_file or "")
         )
     except voting.TallyError as exc:
-        return _error(f"tally-code-votes: {exc}")
+        return TallyResult.failure(f"tally-code-votes: {exc}")
     active_bonus = voting.unique_finder_bonus_from_env()
     review_tmpdir.mkdir(parents=True, exist_ok=True)
     three_slot = bool(args.voter_tools)
     if three_slot and (len(args.voter_files) != _THREE_SLOT_COUNT or len(args.voter_tools) != _THREE_SLOT_COUNT):
-        return _error("tally-code-votes: --voter-tools requires exactly three --voter-files and three tool labels")
+        return TallyResult.failure("tally-code-votes: --voter-tools requires exactly three --voter-files and three tool labels")
     accepted_file = review_tmpdir / "accepted-findings.md"
     rejected_file = review_tmpdir / "rejected-findings.md"
     oos_accepted_file = review_tmpdir / "oos-accepted-review.md"
@@ -712,7 +844,7 @@ def tally_code_votes(argv: list[str]) -> int:
     try:
         blocks = _block_files(ballot_file=ballot_file, review_tmpdir=review_tmpdir)
     except RuntimeError:
-        return _error("tally-code-votes: duplicate or malformed FINDING/OOS headings in ballot")
+        return TallyResult.failure("tally-code-votes: duplicate or malformed FINDING/OOS headings in ballot")
     ballot_id_set = {block.stem for block in blocks}
     _write(path=class_tsv, text=voting.code_review_classification_header() + "\n" if three_slot else _CLASSIFICATION_HEADER + "\n")
     not_substantive_count = int(args.not_substantive_count) if str(args.not_substantive_count).isdigit() else 0
@@ -729,29 +861,17 @@ def tally_code_votes(argv: list[str]) -> int:
             args=args,
             ledger_entries=[],
         )
-        for key, value in {
-            "TALLY_STATUS": "skipped-empty-findings",
-            "ACCEPTED_COUNT": "0",
-            "REJECTED_COUNT": "0",
-            "EXONERATED_COUNT": "0",
-            "NEUTRAL_COUNT": "0",
-            "OOS_ACCEPTED_COUNT": "0",
-            "OOS_REJECTED_COUNT": "0",
-            "OUT_OF_SCOPE_DRIFT_COUNT": "0",
-            "VOTING_TALLY_FILE": str(voting_tally_file),
-            "TALLY_FILE": str(tally_env),
-            "ACCEPTED_FINDINGS_FILE": str(accepted_file),
-            "REJECTED_FINDINGS_FILE": str(rejected_file),
-            "OOS_ACCEPTED_FILE": str(oos_accepted_out),
-            "OOS_FILE": str(oos_file),
-            "TALLY_OK": "true",
-            "ELIGIBLE_VOTER_COUNT": "0",
-            "VOTER_COUNT": "0",
-            "PARSE_FAILED_COUNT": "0",
-            "FINDINGS_CLASSIFICATION_TSV_FILE": str(class_tsv),
-        }.items():
-            logging_util.emit_kv(key=key, value=value)
-        return 0
+        return TallyResult(
+            rc=0,
+            status="skipped-empty-findings",
+            voting_tally_file=voting_tally_file,
+            tally_file=tally_env,
+            accepted_findings_file=accepted_file,
+            rejected_findings_file=rejected_file,
+            oos_accepted_file=oos_accepted_out,
+            oos_file=oos_file,
+            findings_classification_tsv_file=class_tsv,
+        )
     eligible = 0
     effective_files: list[str] = []
     effective_slot = [False, False, False]
@@ -831,7 +951,7 @@ def tally_code_votes(argv: list[str]) -> int:
                 publish=lambda _result: None,
             )
         except RuntimeError as exc:
-            return _error(f"tally-code-votes: {exc}")
+            return TallyResult.failure(f"tally-code-votes: {exc}")
         warning = "**⚠ Degraded code-review panel: 0 judges available. Panel tier: main-agent-required. Manual adjudication needed.**"
         zero_lines = ["# Code Review Voting Tally\n\n", f"{warning}\n\n"]
         if not_substantive_count > 0:
@@ -843,30 +963,20 @@ def tally_code_votes(argv: list[str]) -> int:
             )
         zero_lines.append(voting.render_voter_agreement_and_severity_scoreboards([]))
         _write(path=voting_tally_file, text="".join(zero_lines))
-        for key, value in {
-            "TALLY_STATUS": "main-agent-vote-required",
-            "ACCEPTED_COUNT": "0",
-            "REJECTED_COUNT": "0",
-            "EXONERATED_COUNT": "0",
-            "NEUTRAL_COUNT": "0",
-            "OOS_ACCEPTED_COUNT": "0",
-            "OOS_REJECTED_COUNT": "0",
-            "OUT_OF_SCOPE_DRIFT_COUNT": "0",
-            "VOTING_TALLY_FILE": str(voting_tally_file),
-            "TALLY_FILE": str(tally_env),
-            "ACCEPTED_FINDINGS_FILE": str(accepted_file),
-            "REJECTED_FINDINGS_FILE": str(rejected_file),
-            "OOS_ACCEPTED_FILE": str(oos_accepted_out),
-            "OOS_FILE": str(oos_file),
-            "TALLY_OK": "true",
-            "ELIGIBLE_VOTER_COUNT": str(eligible),
-            "VOTER_COUNT": "0",
-            "PARSE_FAILED_COUNT": str(parse_failed),
-            "VOTING_SKIPPED_WARNING": warning,
-            "FINDINGS_CLASSIFICATION_TSV_FILE": str(class_tsv),
-        }.items():
-            logging_util.emit_kv(key=key, value=value)
-        return 0
+        return TallyResult(
+            rc=0,
+            status="main-agent-vote-required",
+            voting_tally_file=voting_tally_file,
+            tally_file=tally_env,
+            accepted_findings_file=accepted_file,
+            rejected_findings_file=rejected_file,
+            oos_accepted_file=oos_accepted_out,
+            oos_file=oos_file,
+            eligible_voter_count=eligible,
+            parse_failed_count=parse_failed,
+            findings_classification_tsv_file=class_tsv,
+            voting_skipped_warning=warning,
+        )
     score_rows: list[tuple[str, str, str, int]] = []
     bonus_by_reviewer: defaultdict[str, float] = defaultdict(float)
     sole_finder_reward_count = 0
@@ -1037,7 +1147,7 @@ def tally_code_votes(argv: list[str]) -> int:
             item_contexts(), serialize=serialize, security_hook=lambda context: _security_block(context.block_path), publish=publish
         )
     except RuntimeError as exc:
-        return _error(f"tally-code-votes: {exc}")
+        return TallyResult.failure(f"tally-code-votes: {exc}")
     if under_quorum_items:
         tally_lines.insert(
             1,
@@ -1085,10 +1195,13 @@ def tally_code_votes(argv: list[str]) -> int:
     tally_lines.append("\n")
     tally_lines.append(voting.render_voter_agreement_and_severity_scoreboards(agreement_rows))
     _write(path=voting_tally_file, text="".join(tally_lines))
+    warnings: list[str] = []
     if args.manifest_file:
         archetype_map = _write_archetype_map(Path(args.manifest_file))
-        for orphan in _write_yield_tsv(yield_path=yield_tsv, archetype_map=archetype_map, score_rows=score_rows):
-            logging_util.emit_kv(key="WARN", value=f"yield TSV missing manifest entry for reviewer basename: {orphan}")
+        warnings.extend(
+            f"yield TSV missing manifest entry for reviewer basename: {orphan}"
+            for orphan in _write_yield_tsv(yield_path=yield_tsv, archetype_map=archetype_map, score_rows=score_rows)
+        )
     _write_final_tally_outputs(
         tally_env=tally_env,
         counts_text=f"ACCEPTED_COUNT={accepted}\nREJECTED_COUNT={rejected}\nEXONERATED_COUNT={exonerated}\nNEUTRAL_COUNT={neutral}\nOOS_ACCEPTED_COUNT={oos_accepted}\nOOS_REJECTED_COUNT={oos_rejected}\n",
@@ -1096,37 +1209,40 @@ def tally_code_votes(argv: list[str]) -> int:
         args=args,
         ledger_entries=ledger_entries
     )
-    for key, value in {
-        "TALLY_STATUS": "ok",
-        "ACCEPTED_COUNT": str(accepted),
-        "REJECTED_COUNT": str(rejected),
-        "EXONERATED_COUNT": str(exonerated),
-        "NEUTRAL_COUNT": str(neutral),
-        "OOS_ACCEPTED_COUNT": str(oos_accepted),
-        "OOS_REJECTED_COUNT": str(oos_rejected),
-        "OUT_OF_SCOPE_DRIFT_COUNT": str(drift),
-        "VOTING_TALLY_FILE": str(voting_tally_file),
-        "TALLY_FILE": str(tally_env),
-        "ACCEPTED_FINDINGS_FILE": str(accepted_file),
-        "REJECTED_FINDINGS_FILE": str(rejected_file),
-        "OOS_ACCEPTED_FILE": str(oos_accepted_out),
-        "OOS_FILE": str(oos_file),
-        "TALLY_OK": "true",
-        "ELIGIBLE_VOTER_COUNT": str(eligible),
-        "VOTER_COUNT": str(effective),
-        "UNDER_QUORUM_COUNT": str(len(under_quorum_items)),
-        "UNDER_QUORUM_ITEMS": ", ".join(under_quorum_items),
-        "PARSE_FAILED_COUNT": str(parse_failed),
-        "FINDINGS_CLASSIFICATION_TSV_FILE": str(class_tsv),
-    }.items():
-        logging_util.emit_kv(key=key, value=value)
-    if args.manifest_file:
-        logging_util.emit_kv(key="YIELD_TSV_FILE", value=str(yield_tsv))
-    return 0
+    return TallyResult(
+        rc=0,
+        status="ok",
+        accepted_count=accepted,
+        rejected_count=rejected,
+        exonerated_count=exonerated,
+        neutral_count=neutral,
+        oos_accepted_count=oos_accepted,
+        oos_rejected_count=oos_rejected,
+        out_of_scope_drift_count=drift,
+        voting_tally_file=voting_tally_file,
+        tally_file=tally_env,
+        accepted_findings_file=accepted_file,
+        rejected_findings_file=rejected_file,
+        oos_accepted_file=oos_accepted_out,
+        oos_file=oos_file,
+        eligible_voter_count=eligible,
+        voter_count=effective,
+        parse_failed_count=parse_failed,
+        findings_classification_tsv_file=class_tsv,
+        under_quorum_items=tuple(under_quorum_items),
+        yield_tsv_file=yield_tsv if args.manifest_file else None,
+        warnings=tuple(warnings),
+    )
 
 
 def tally_code_votes_main(argv: list[str]) -> int:
-    return tally_code_votes(argv)
+    logging_util.quiet_init(argv0="tally-code-votes")
+    try:
+        result = tally_code_votes(_parse_tally_args(argv))
+    except SystemExit as exc:
+        return int(exc.code) if isinstance(exc.code, int) else 2
+    result.emit()
+    return result.rc
 
 
 def _parse_emit_args(argv: list[str]) -> argparse.Namespace:

--- a/python/larch/review/round_runner.py
+++ b/python/larch/review/round_runner.py
@@ -605,55 +605,43 @@ def _build_targeted_dispatch_args(
     return dispatch_args
 
 
-def _build_targeted_tally_args(
+def _build_targeted_tally_request(
     round_dir: Path,
     core: dict[str, str],
     args: argparse.Namespace,
     merged_voter_files: list[str],
     voter_tools: list[str],
-) -> list[str] | None:
+) -> review_tally.TallyRequest | None:
     findings = round_dir / "findings.md"
     proposer_map = round_dir / "proposer-map.tsv"
     if not findings.is_file() or not proposer_map.is_file() or not merged_voter_files or len(merged_voter_files) != len(voter_tools):
         return None
-    tally_args = [
-        "--ballot-file",
-        str(findings),
-        "--review-tmpdir",
-        str(round_dir),
-        "--cursor-available",
-        str(args.cursor_available),
-        "--codex-available",
-        str(args.codex_available),
-        "--round-num",
-        str(args.round_num),
-        "--proposer-map-file",
-        str(proposer_map),
-    ]
     session_env_path = getattr(args, "session_env_path", "")
-    if session_env_path:
-        tally_args.extend(["--session-env-path", str(session_env_path)])
     gather = _parse_env_file(round_dir / "review-core-gather.env")
     scope_files = gather.get("FILE_LIST_FILE", "")
-    if scope_files and Path(scope_files).is_file() and Path(scope_files).stat().st_size:
-        tally_args.extend(["--scope-files", scope_files])
     plan_file = getattr(args, "plan_file", "")
-    if plan_file and Path(plan_file).is_file():
-        tally_args.extend(["--plan-file", str(plan_file)])
     panel_manifest = round_dir / "panel-manifest.ndjson"
-    if panel_manifest.is_file():
-        tally_args.extend(["--manifest-file", str(panel_manifest)])
     collector_results = round_dir / "collector-results.env"
-    if collector_results.is_file():
-        tally_args.extend(["--collector-results-file", str(collector_results)])
     threshold = _parse_env_file(round_dir / "review-core-threshold.env")
     not_substantive = _strict_env_int(threshold, "NOT_SUBSTANTIVE_SLOTS")
-    if not_substantive is not None and not_substantive > 0:
-        tally_args.extend(["--not-substantive-count", str(not_substantive)])
-    if core.get("PANEL_MANIFEST") and "--manifest-file" not in tally_args and Path(core["PANEL_MANIFEST"]).is_file():
-        tally_args.extend(["--manifest-file", core["PANEL_MANIFEST"]])
-    tally_args.extend(["--voter-files", *merged_voter_files, "--voter-tools", *voter_tools])
-    return tally_args
+    core_manifest = core.get("PANEL_MANIFEST", "")
+    manifest_file = str(panel_manifest) if panel_manifest.is_file() else core_manifest if core_manifest and Path(core_manifest).is_file() else ""
+    return review_tally.TallyRequest(
+        ballot_file=str(findings),
+        review_tmpdir=str(round_dir),
+        voter_files=tuple(merged_voter_files),
+        voter_tools=tuple(voter_tools),
+        session_env_path=str(session_env_path),
+        scope_files=scope_files if scope_files and Path(scope_files).is_file() and Path(scope_files).stat().st_size else "",
+        plan_file=str(plan_file) if plan_file and Path(plan_file).is_file() else "",
+        manifest_file=manifest_file,
+        collector_results_file=str(collector_results) if collector_results.is_file() else "",
+        not_substantive_count=str(not_substantive) if not_substantive is not None and not_substantive > 0 else "0",
+        cursor_available=str(args.cursor_available),
+        codex_available=str(args.codex_available),
+        round_num=str(args.round_num),
+        proposer_map_file=str(proposer_map),
+    )
 
 
 def _build_targeted_emit_args(round_dir: Path, core: dict[str, str], tally_env_path: Path, args: argparse.Namespace) -> list[str] | None:
@@ -820,19 +808,18 @@ def _run_under_quorum_revote(
             under_quorum_ids=item_ids,
             output_paths=merged_paths,
         )
-        tally_args = _build_targeted_tally_args(round_dir, core, args, merged, slots.voter_tools)
-        ok = tally_args is not None
+        tally_request = _build_targeted_tally_request(round_dir, core, args, merged, slots.voter_tools)
+        ok = tally_request is not None
     else:
-        tally_args = None
+        tally_request = None
     tally_env_path = revote_dir / "review-core-targeted-tally.env"
     backup_dir = revote_dir / "pre-targeted-final"
-    if ok and tally_args is not None:
+    if ok and tally_request is not None:
         _backup_targeted_artifacts(round_dir, backup_dir)
         commands = review_core_body._review_commands()  # noqa: SLF001 - targeted retry reuses review-core command overrides.
-        tally_result = (
-            review_core_body._run_command_string(command=commands.tally, args=tally_args)  # noqa: SLF001 - targeted retry reuses review-core command overrides.
-            if commands.tally
-            else review_core_body._call_maybe_override(command="", review_name="tally-code-votes", args=tally_args)  # noqa: SLF001 - targeted retry reuses review-core command overrides.
+        tally_result = review_core_body._run_tally_request(  # noqa: SLF001 - targeted retry reuses review-core command overrides.
+            commands=commands,
+            request=tally_request,
         )
         _write_text(path=tally_env_path, text=tally_result.stdout)
         tally = _parse_env_file(tally_env_path)

--- a/python/tests/review/test_review_and_fix.py
+++ b/python/tests/review/test_review_and_fix.py
@@ -4579,8 +4579,9 @@ def test_under_quorum_retry_revotes_only_targeted_items(tmp_path: Path, monkeypa
         voter_2.write_text("FINDING_1: NO -- targeted direct\n", encoding="utf-8")
         return ok(tuple(str(item) for item in argv), f"VOTER_1_PATH={voter_1}\nVOTER_1_TOOL=codex-validity\nVOTER_2_PATH={voter_2}\nVOTER_2_TOOL=codex-plan-fidelity\nVOTER_3_PATH={revote_dir / 'missing.txt'}\nVOTER_3_TOOL=codex-pragmatism\n")
 
-    def fake_tally(*, command: str, review_name: str, args, runner=None):
-        del command, review_name, runner
+    def fake_tally(*, commands: object, request: review_tally.TallyRequest):
+        del commands
+        args = request.to_argv()
         tally_argv.extend(str(item) for item in args)
         round_dir = Path(args[args.index("--review-tmpdir") + 1])
         (round_dir / "voting-tally.md").write_text("clean targeted tally\n", encoding="utf-8")
@@ -4602,7 +4603,7 @@ def test_under_quorum_retry_revotes_only_targeted_items(tmp_path: Path, monkeypa
         return ()
 
     monkeypatch.setattr(round_runner.review_core_body, "_run_python_cli", fake_dispatch)
-    monkeypatch.setattr(round_runner.review_core_body, "_call_maybe_override", fake_tally)
+    monkeypatch.setattr(round_runner.review_core_body, "_run_tally_request", fake_tally)
     monkeypatch.setattr(round_runner.review_core_body, "_emit_tally", fake_emit)
     monkeypatch.setattr(round_runner.review_core_body, "_record_prune_round", fake_record_prune_round)
 

--- a/python/tests/review/test_review_tally.py
+++ b/python/tests/review/test_review_tally.py
@@ -111,6 +111,75 @@ def _mk_ballot(path: Path) -> None:
     )
 
 
+def test_tally_request_serializes_shared_cli_contract() -> None:
+    request = review_tally.TallyRequest(
+        ballot_file="ballot.md",
+        review_tmpdir="review",
+        voter_files=("voter-1.txt", "voter-2.txt", "voter-3.txt"),
+        voter_tools=("codex-validity", "codex-plan-fidelity", "codex-pragmatism"),
+        session_env_path="session.env",
+        scope_files="scope.txt",
+        plan_file="plan.md",
+        manifest_file="panel.ndjson",
+        collector_results_file="collector.env",
+        not_substantive_count="2",
+        cursor_available="true",
+        codex_available="true",
+        round_num="2",
+        proposer_map_file="proposer-map.tsv",
+    )
+
+    assert request.to_argv() == [
+        "--ballot-file", "ballot.md",
+        "--review-tmpdir", "review",
+        "--cursor-available", "true",
+        "--codex-available", "true",
+        "--round-num", "2",
+        "--proposer-map-file", "proposer-map.tsv",
+        "--session-env-path", "session.env",
+        "--scope-files", "scope.txt",
+        "--plan-file", "plan.md",
+        "--manifest-file", "panel.ndjson",
+        "--collector-results-file", "collector.env",
+        "--not-substantive-count", "2",
+        "--voter-files", "voter-1.txt", "voter-2.txt", "voter-3.txt",
+        "--voter-tools", "codex-validity", "codex-plan-fidelity", "codex-pragmatism",
+    ]
+
+
+def test_tally_result_emits_one_stable_kv_contract(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    result = review_tally.TallyResult(
+        rc=0,
+        status="ok",
+        accepted_count=1,
+        rejected_count=2,
+        exonerated_count=3,
+        neutral_count=4,
+        oos_accepted_count=5,
+        oos_rejected_count=6,
+        out_of_scope_drift_count=7,
+        voting_tally_file=tmp_path / "voting-tally.md",
+        tally_file=tmp_path / "review-tally.env",
+        accepted_findings_file=tmp_path / "accepted-findings.md",
+        rejected_findings_file=tmp_path / "rejected-findings.md",
+        oos_accepted_file=tmp_path / "oos-accepted-review.md",
+        oos_file=tmp_path / "oos.md",
+        eligible_voter_count=3,
+        voter_count=2,
+        parse_failed_count=1,
+        findings_classification_tsv_file=tmp_path / "classification.tsv",
+        under_quorum_items=("FINDING_2",),
+    )
+
+    result.emit()
+
+    rows = dict(line.split("=", 1) for line in capsys.readouterr().out.splitlines() if "=" in line)
+    assert rows["TALLY_STATUS"] == "ok"
+    assert rows["ACCEPTED_COUNT"] == "1"
+    assert rows["UNDER_QUORUM_ITEMS"] == "FINDING_2"
+    assert rows["FINDINGS_CLASSIFICATION_TSV_FILE"] == str(tmp_path / "classification.tsv")
+
+
 def test_emit_tally_writes_summary_json(tmp_path: Path) -> None:
     tally = tmp_path / "review-tally.env"
     _ = tally.write_text("ACCEPTED_COUNT=0\nREJECTED_COUNT=0\nNEUTRAL_COUNT=0\n", encoding="utf-8")


### PR DESCRIPTION
Closes #7274

## Summary
- Add frozen tally request/result contracts with one KV emitter.
- Run review tally and round-log writes in process while retaining external agent dispatch and override seams.
- Share tally argument construction across review-core and targeted retries.

## Verification
- `python3 -m pytest -q python/tests/review/test_review_tally.py python/tests/review/test_review_pipeline.py`
- `python3 -m pytest -q python/tests/review/test_review_and_fix.py::test_under_quorum_retry_revotes_only_targeted_items`
- Changed-file pyright, ruff, and pylint checks.

## Architecture
This preserves CLI KV compatibility, uses frozen dataclasses across the new in-process boundary, and keeps the report import cycle broken through a documented function-local import. No architectural-invariant deviations.