### PR TITLE
Fixes #7276: replace OOS CLI re-entry

### DIFF
--- a/python/complexity-baseline.json
+++ b/python/complexity-baseline.json
@@ -4770,6 +4770,16 @@
   {
     "file": "larch/issue/issue_create.py",
     "code": "C901",
+    "qualified_symbol": "add_blocked_by",
+    "metric": 14,
+    "added_at": "2026-07-14",
+    "history": [],
+    "source_issue": 7276,
+    "reason": "Typed API retains the established dependency retry branches."
+  },
+  {
+    "file": "larch/issue/issue_create.py",
+    "code": "C901",
     "qualified_symbol": "add_blocked_by_main",
     "metric": 20,
     "added_at": "legacy",
@@ -4782,6 +4792,16 @@
     "metric": 23,
     "added_at": "legacy",
     "history": []
+  },
+  {
+    "file": "larch/issue/issue_create.py",
+    "code": "C901",
+    "qualified_symbol": "create_one",
+    "metric": 16,
+    "added_at": "2026-07-14",
+    "history": [],
+    "source_issue": 7276,
+    "reason": "Typed API retains the established issue-create fallback branches."
   },
   {
     "file": "larch/issue/issue_create.py",
@@ -4834,10 +4854,30 @@
   {
     "file": "larch/issue/issue_create.py",
     "code": "PLR0911",
+    "qualified_symbol": "add_blocked_by",
+    "metric": 9,
+    "added_at": "2026-07-14",
+    "history": [],
+    "source_issue": 7276,
+    "reason": "Typed API returns one explicit result for each retry outcome."
+  },
+  {
+    "file": "larch/issue/issue_create.py",
+    "code": "PLR0911",
     "qualified_symbol": "add_blocked_by_main",
     "metric": 11,
     "added_at": "legacy",
     "history": []
+  },
+  {
+    "file": "larch/issue/issue_create.py",
+    "code": "PLR0911",
+    "qualified_symbol": "create_one",
+    "metric": 12,
+    "added_at": "2026-07-14",
+    "history": [],
+    "source_issue": 7276,
+    "reason": "Typed API returns one explicit result for each create outcome."
   },
   {
     "file": "larch/issue/issue_create.py",
@@ -4866,6 +4906,16 @@
   {
     "file": "larch/issue/issue_create.py",
     "code": "PLR0912",
+    "qualified_symbol": "add_blocked_by",
+    "metric": 14,
+    "added_at": "2026-07-14",
+    "history": [],
+    "source_issue": 7276,
+    "reason": "Typed API preserves dependency validation and retry branches."
+  },
+  {
+    "file": "larch/issue/issue_create.py",
+    "code": "PLR0912",
     "qualified_symbol": "add_blocked_by_main",
     "metric": 22,
     "added_at": "legacy",
@@ -4878,6 +4928,16 @@
     "metric": 22,
     "added_at": "legacy",
     "history": []
+  },
+  {
+    "file": "larch/issue/issue_create.py",
+    "code": "PLR0912",
+    "qualified_symbol": "create_one",
+    "metric": 16,
+    "added_at": "2026-07-14",
+    "history": [],
+    "source_issue": 7276,
+    "reason": "Typed API preserves create authorization and fallback branches."
   },
   {
     "file": "larch/issue/issue_create.py",

--- a/python/larch/issue/issue_create.py
+++ b/python/larch/issue/issue_create.py
@@ -57,15 +57,6 @@ def _flat_error(*, text: str, limit: int = 500) -> str:
     return " ".join(redact_secrets_outbound(text).split())[:limit]
 
 
-def _redact_checked(text: str) -> tuple[str | None, int]:
-    try:
-        return redact_secrets_outbound(text), 0
-    except Exception as exc:  # pragma: no cover - defensive seam for tests
-        emit_kv(key="ISSUE_FAILED", value="true")
-        emit_kv(key="ISSUE_ERROR", value=f"redaction:{exc}")
-        return None, 3
-
-
 @dataclass(frozen=True)
 class ParsedItem:
     title: str
@@ -74,6 +65,52 @@ class ParsedItem:
     vote: str = ""
     phase: str = ""
     malformed: bool = False
+
+
+@dataclass(frozen=True)
+class ParseInputResult:
+    """The parsed OOS items and materialized body paths for one input file."""
+
+    items: tuple[ParsedItem, ...] = ()
+    body_paths: tuple[Path | None, ...] = ()
+    mode: str = "generic"
+    error: str = ""
+    exit_code: int = 0
+
+
+@dataclass(frozen=True)
+class CreateIssueResult:
+    """The durable outcome of one GitHub issue creation request."""
+
+    title: str = ""
+    number: str = ""
+    url: str = ""
+    issue_id: str = ""
+    error: str = ""
+    duplicate: bool = False
+    labels: tuple[str, ...] = ()
+    dry_run: bool = False
+    exit_code: int = 0
+
+
+@dataclass(frozen=True)
+class BlockedByResult:
+    """The outcome of adding one native GitHub blocked-by relationship."""
+
+    client: str
+    blocker: str
+    added: bool
+    error: str = ""
+    exit_code: int = 0
+
+
+@dataclass(frozen=True)
+class CleanupResult:
+    """The best-effort outcome of closing an orphaned issue."""
+
+    issue: str
+    closed: bool
+    error: str = ""
 
 
 # Mutable parser state: methods update current_* / pending_* / items in place while scanning.
@@ -250,6 +287,51 @@ def parse_issue_input(text: str) -> tuple[list[ParsedItem], str]:
     return state.items, state.parse_mode
 
 
+def parse_input(*, input_file: Path, output_dir: Path) -> ParseInputResult:
+    """Parse one issue-input file and materialize each non-empty body once."""
+    if not input_file.is_file():
+        return ParseInputResult(error=f"input file not found: {input_file}", exit_code=1)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_dir = output_dir.resolve()
+    items, mode = parse_issue_input(input_file.read_text(encoding="utf-8"))
+    body_paths: list[Path | None] = []
+    for item_index, item in enumerate(items, start=1):
+        if not item.body:
+            body_paths.append(None)
+            continue
+        body_path = output_dir / f"item-{item_index}-body.txt"
+        try:
+            body_path.write_text(item.body, encoding="utf-8")
+        except OSError as exc:
+            return ParseInputResult(error=f"failed to write body file {body_path}: {exc}", exit_code=1)
+        body_paths.append(body_path)
+    return ParseInputResult(items=tuple(items), body_paths=tuple(body_paths), mode=mode)
+
+
+def emit_parse_input_result(result: ParseInputResult) -> int:
+    """Emit the stable CLI KV contract for :func:`parse_input`."""
+    if result.exit_code:
+        warn(f"ERROR: {result.error}")
+        return result.exit_code
+    for item_index, item in enumerate(result.items, start=1):
+        emit_kv(key=f"ITEM_{item_index}_TITLE", value=item.title)
+        body_path = result.body_paths[item_index - 1]
+        if body_path is not None:
+            emit_kv(key=f"ITEM_{item_index}_BODY_FILE", value=str(body_path))
+        if item.malformed:
+            emit_kv(key=f"ITEM_{item_index}_MALFORMED", value="true")
+        if item.reviewer:
+            emit_kv(key=f"ITEM_{item_index}_REVIEWER", value=item.reviewer)
+        if item.vote:
+            emit_kv(key=f"ITEM_{item_index}_VOTE_TALLY", value=item.vote)
+        if item.phase:
+            emit_kv(key=f"ITEM_{item_index}_PHASE", value=item.phase)
+    emit_kv(key="ITEMS_TOTAL", value=len(result.items))
+    titles = ", ".join(f"{i}={item.title[:60]}" for i, item in enumerate(result.items, start=1))
+    warn(f"▶ parse-input: {len(result.items)} items parsed (mode={result.mode})" + (f": {titles}" if titles else ""))
+    return 0
+
+
 def parse_input_main(argv: list[str]) -> int:
     input_file = ""
     output_dir = ""
@@ -274,36 +356,7 @@ def parse_input_main(argv: list[str]) -> int:
         warn("ERROR: --output-dir is required")
         warn("Usage: parse-input --input-file FILE --output-dir DIR")
         return 1
-    source = Path(input_file)
-    if not source.is_file():
-        warn(f"ERROR: input file not found: {input_file}")
-        return 1
-    out_dir = Path(output_dir)
-    out_dir.mkdir(parents=True, exist_ok=True)
-    out_dir = out_dir.resolve()
-    items, mode = parse_issue_input(source.read_text(encoding="utf-8"))
-    for item_index, item in enumerate(items, start=1):
-        emit_kv(key=f"ITEM_{item_index}_TITLE", value=item.title)
-        if item.body:
-            body_path = out_dir / f"item-{item_index}-body.txt"
-            try:
-                body_path.write_text(item.body, encoding="utf-8")
-            except OSError as exc:
-                warn(f"ERROR: failed to write body file {body_path}: {exc}")
-                return 1
-            emit_kv(key=f"ITEM_{item_index}_BODY_FILE", value=str(body_path))
-        if item.malformed:
-            emit_kv(key=f"ITEM_{item_index}_MALFORMED", value="true")
-        if item.reviewer:
-            emit_kv(key=f"ITEM_{item_index}_REVIEWER", value=item.reviewer)
-        if item.vote:
-            emit_kv(key=f"ITEM_{item_index}_VOTE_TALLY", value=item.vote)
-        if item.phase:
-            emit_kv(key=f"ITEM_{item_index}_PHASE", value=item.phase)
-    emit_kv(key="ITEMS_TOTAL", value=len(items))
-    titles = ", ".join(f"{i}={item.title[:60]}" for i, item in enumerate(items, start=1))
-    warn(f"▶ parse-input: {len(items)} items parsed (mode={mode})" + (f": {titles}" if titles else ""))
-    return 0
+    return emit_parse_input_result(parse_input(input_file=Path(input_file), output_dir=Path(output_dir)))
 
 
 def _parse_create_args(argv: list[str]) -> tuple[dict[str, object], str | None]:
@@ -380,26 +433,25 @@ def _is_oos_issue_body(body_content: str) -> bool:
     return body_content == heading or body_content.startswith(f"{heading}\n")
 
 
-def _emit_issue_failed(message: str, *, code: int = 2) -> int:
-    emit_kv(key="ISSUE_FAILED", value="true")
-    emit_kv(key="ISSUE_ERROR", value=message)
-    return code
+def _issue_failed(message: str, *, code: int = 2, title: str = "") -> CreateIssueResult:
+    return CreateIssueResult(title=title, error=message, exit_code=code)
 
 
-def _create_one_body_content(parsed: dict[str, object]) -> tuple[str, int]:
+def _create_one_body_content(parsed: dict[str, object]) -> tuple[str, CreateIssueResult | None]:
     body_file = str(parsed.get("body_file") or "")
     if not body_file:
-        return "", 0
+        return "", None
     path = Path(body_file)
     if not path.is_file():
-        return "", _emit_issue_failed(f"body file not found: {body_file}", code=1)
+        return "", _issue_failed(f"body file not found: {body_file}", code=1)
     body_content = path.read_text(encoding="utf-8")
     if not body_content:
-        return "", 0
-    redacted_body, redaction_rc = _redact_checked(body_content)
-    if redaction_rc:
-        return "", redaction_rc
-    return redacted_body or "", 0
+        return "", None
+    try:
+        redacted_body = redact_secrets_outbound(body_content)
+    except Exception as exc:  # pragma: no cover - defensive seam for tests
+        return "", _issue_failed(f"redaction:{exc}", code=3)
+    return redacted_body, None
 
 
 def _parse_issue_json(output: str) -> tuple[str, str, str] | None:
@@ -456,77 +508,60 @@ def _rollback_orphan(repo: str, number: str, url: str, *, close_error: str = "")
     warn(f"ROLLBACK_FAILED: could not close orphan issue #{number} ({url}): {detail}. Manually close.")
 
 
-def _resolve_created_issue_id(*, repo: str, number: str, url: str, final_title: str) -> int:
+def _resolve_created_issue_id(*, repo: str, number: str, url: str, final_title: str) -> CreateIssueResult:
     lookup = _gh_read(["api", f"/repos/{repo}/issues/{number}", "--jq", ".id"])
     issue_id = lookup.stdout.strip()
     if lookup.returncode == 0 and _positive_int(value=issue_id):
-        emit_kv(key="ISSUE_NUMBER", value=number)
-        emit_kv(key="ISSUE_URL", value=url)
-        emit_kv(key="ISSUE_ID", value=issue_id)
-        emit_kv(key="ISSUE_TITLE", value=final_title)
-        return 0
+        return CreateIssueResult(title=final_title, number=number, url=url, issue_id=issue_id)
     if lookup.returncode == 0 and issue_id and not _positive_int(value=issue_id):
         _rollback_orphan(repo, number, url, close_error=lookup.stderr)
-        return _emit_issue_failed(f"id-lookup returned non-numeric id for #{number} (output: {_flat_error(text=lookup.stderr or issue_id)})")
+        return _issue_failed(f"id-lookup returned non-numeric id for #{number} (output: {_flat_error(text=lookup.stderr or issue_id)})", title=final_title)
     _rollback_orphan(repo, number, url, close_error=lookup.stderr)
-    return _emit_issue_failed(f"id-lookup failed for #{number} after create: {_flat_error(text=lookup.stderr)}")
+    return _issue_failed(f"id-lookup failed for #{number} after create: {_flat_error(text=lookup.stderr)}", title=final_title)
 
 
-def _resolve_created_from_output(*, repo: str, output: str, final_title: str) -> int:
+def _resolve_created_from_output(*, repo: str, output: str, final_title: str) -> CreateIssueResult:
     parsed = _parse_created_url(output)
     if not parsed:
-        return _emit_issue_failed(f"gh issue create did not emit a URL (output: {_flat_error(text=output)})")
+        return _issue_failed(f"gh issue create did not emit a URL (output: {_flat_error(text=output)})", title=final_title)
     number, url = parsed
     lookup = _gh_read(["api", f"/repos/{repo}/issues/{number}", "--jq", ".id"])
     issue_id = lookup.stdout.strip()
     if lookup.returncode == 0 and _positive_int(value=issue_id):
-        emit_kv(key="ISSUE_NUMBER", value=number)
-        emit_kv(key="ISSUE_URL", value=url)
-        emit_kv(key="ISSUE_ID", value=issue_id)
-        emit_kv(key="ISSUE_TITLE", value=final_title)
-        return 0
+        return CreateIssueResult(title=final_title, number=number, url=url, issue_id=issue_id)
     if lookup.returncode == 0 and issue_id and not _positive_int(value=issue_id):
         _rollback_orphan(repo, number, url, close_error=lookup.stderr)
-        return _emit_issue_failed(f"id-lookup returned non-numeric id for #{number} (output: {_flat_error(text=lookup.stderr or issue_id)})")
+        return _issue_failed(f"id-lookup returned non-numeric id for #{number} (output: {_flat_error(text=lookup.stderr or issue_id)})", title=final_title)
     _rollback_orphan(repo, number, url, close_error=lookup.stderr)
-    return _emit_issue_failed(f"id-lookup failed for #{number} after create: {_flat_error(text=lookup.stderr)}")
+    return _issue_failed(f"id-lookup failed for #{number} after create: {_flat_error(text=lookup.stderr)}", title=final_title)
 
 
-def _create_fallback(*, repo: str, gh_args: list[str], final_title: str) -> int:
+def _create_fallback(*, repo: str, gh_args: list[str], final_title: str) -> CreateIssueResult:
     created = gh.command(proc, gh_args)
     if created.returncode != 0:
-        return _emit_issue_failed(_flat_error(text=created.stderr))
+        return _issue_failed(_flat_error(text=created.stderr), title=final_title)
     return _resolve_created_from_output(repo=repo, output=created.stdout, final_title=final_title)
 
 
-def create_one_main(argv: list[str]) -> int:
-    parsed, error = _parse_create_args(argv)
-    if error:
-        warn(error)
-        return 1
+def create_one(parsed: dict[str, object]) -> CreateIssueResult:
+    """Create one issue through the typed in-process API."""
     title = str(parsed.get("title") or "")
     if not title:
-        warn("Usage: create-one --title TITLE [--title-prefix PREFIX] [--label L]...")
-        return 1
-    redacted_title, redaction_rc = _redact_checked(title)
-    if redaction_rc:
-        return redaction_rc
-    title = redacted_title or ""
+        return _issue_failed("--title is required", code=1)
+    try:
+        title = redact_secrets_outbound(title)
+    except Exception as exc:  # pragma: no cover - defensive seam for tests
+        return _issue_failed(f"redaction:{exc}", code=3)
     dry_run = bool(parsed.get("dry_run"))
     title_prefix = str(parsed.get("title_prefix") or "")
     final_title = _normalize_title_prefix(title=title, title_prefix=title_prefix)
+    labels_obj = parsed.get("labels")
+    labels = tuple(str(label) for label in labels_obj) if isinstance(labels_obj, list) else ()
     if dry_run:
-        labels_obj = parsed.get("labels")
-        labels = labels_obj if isinstance(labels_obj, list) else []
-        emit_kv(key="DRY_RUN", value="true")
-        emit_kv(key="DRY_RUN_TITLE", value=final_title)
-        emit_kv(key="ISSUE_TITLE", value=final_title)
-        if labels:
-            emit_kv(key="DRY_RUN_LABELS", value=",".join(str(label) for label in labels))
-        return 0
-    body_content, body_rc = _create_one_body_content(parsed)
-    if body_rc:
-        return body_rc
+        return CreateIssueResult(title=final_title, labels=labels, dry_run=True)
+    body_content, body_error = _create_one_body_content(parsed)
+    if body_error is not None:
+        return body_error
     if not title_prefix and _is_oos_issue_body(body_content):
         final_title = _normalize_title_prefix(title=title, title_prefix="[OOS]")
     context_file_str = str(parsed.get("context_file") or "")
@@ -540,19 +575,18 @@ def create_one_main(argv: list[str]) -> int:
             trusted_root=Path(str(parsed["trusted_root"])) if parsed.get("trusted_root") else None,
         )
         if not authorized:
-            emit_kv(key=config.LIVE_MUTATION_REFUSAL_STATUS, value="true")
-            emit_kv(key="ISSUE_FAILED", value="true")
-            emit_kv(key="ISSUE_ERROR", value=f"{config.LIVE_MUTATION_REFUSAL_REASON}:{auth_reason}")
-            return config.EXIT_MUTATION_REFUSED
+            return _issue_failed(
+                f"{config.LIVE_MUTATION_REFUSAL_REASON}:{auth_reason}",
+                code=config.EXIT_MUTATION_REFUSED,
+                title=final_title,
+            )
     repo = str(parsed.get("repo") or "")
     if not repo:
         repo = _resolve_repo()
         if not repo and not dry_run:
-            return _emit_issue_failed("could not determine repo")
-    labels_obj = parsed.get("labels")
-    labels = labels_obj if isinstance(labels_obj, list) else []
-    valid_labels = _valid_labels(repo, [str(label) for label in labels], dry_run=dry_run)
-    with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as body_tmp:
+            return _issue_failed("could not determine repo", title=final_title)
+    valid_labels = _valid_labels(repo, list(labels), dry_run=dry_run)
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", dir=tempfile.gettempdir(), delete=False) as body_tmp:
         body_tmp.write(body_content)
         body_tmp_path = body_tmp.name
     try:
@@ -565,11 +599,7 @@ def create_one_main(argv: list[str]) -> int:
             json_status = _issue_create_json_status(result.stdout)
             if json_status == "ok":
                 number, url, issue_id = _parse_issue_json(result.stdout) or ("", "", "")
-                emit_kv(key="ISSUE_NUMBER", value=number)
-                emit_kv(key="ISSUE_URL", value=url)
-                emit_kv(key="ISSUE_ID", value=issue_id)
-                emit_kv(key="ISSUE_TITLE", value=final_title)
-                return 0
+                return CreateIssueResult(title=final_title, number=number, url=url, issue_id=issue_id, labels=tuple(valid_labels))
             if json_status == "resolve_id":
                 data = json.loads(result.stdout)
                 return _resolve_created_issue_id(
@@ -580,13 +610,43 @@ def create_one_main(argv: list[str]) -> int:
                 )
             if json_status == "empty_fields":
                 redacted_output = _flat_error(text=result.stdout)
-                return _emit_issue_failed(f"gh issue create returned JSON with empty field(s) (output: {redacted_output})")
+                return _issue_failed(f"gh issue create returned JSON with empty field(s) (output: {redacted_output})", title=final_title)
             return _resolve_created_from_output(repo=repo, output=result.stdout, final_title=final_title)
         if unknown_json:
             return _create_fallback(repo=repo, gh_args=gh_args, final_title=final_title)
-        return _emit_issue_failed(_flat_error(text=result.stderr))
+        return _issue_failed(_flat_error(text=result.stderr), title=final_title)
     finally:
         Path(body_tmp_path).unlink(missing_ok=True)
+
+
+def emit_create_issue_result(result: CreateIssueResult) -> int:
+    """Emit the stable CLI KV contract for :func:`create_one`."""
+    if result.exit_code:
+        if result.exit_code == config.EXIT_MUTATION_REFUSED:
+            emit_kv(key=config.LIVE_MUTATION_REFUSAL_STATUS, value="true")
+        emit_kv(key="ISSUE_FAILED", value="true")
+        emit_kv(key="ISSUE_ERROR", value=result.error)
+        return result.exit_code
+    if result.dry_run:
+        emit_kv(key="DRY_RUN", value="true")
+        emit_kv(key="DRY_RUN_TITLE", value=result.title)
+        emit_kv(key="ISSUE_TITLE", value=result.title)
+        if result.labels:
+            emit_kv(key="DRY_RUN_LABELS", value=",".join(result.labels))
+        return 0
+    emit_kv(key="ISSUE_NUMBER", value=result.number)
+    emit_kv(key="ISSUE_URL", value=result.url)
+    emit_kv(key="ISSUE_ID", value=result.issue_id)
+    emit_kv(key="ISSUE_TITLE", value=result.title)
+    return 0
+
+
+def create_one_main(argv: list[str]) -> int:
+    parsed, error = _parse_create_args(argv)
+    if error:
+        warn(error)
+        return 1
+    return emit_create_issue_result(create_one(parsed))
 
 
 def allocate_candidates(*, total_items: int, rows_text: str) -> list[int]:
@@ -681,44 +741,23 @@ def _positive_int(value: str) -> bool:
     return value.isdigit() and int(value) > 0
 
 
-def _blocked_failure(*, client: str, blocker: str, message: str, code: int = 2) -> int:
-    emit_kv(key="BLOCKED_BY_FAILED", value="true")
-    emit_kv(key="CLIENT", value=client)
-    emit_kv(key="BLOCKER", value=blocker)
+def _blocked_failure(*, client: str, blocker: str, message: str, code: int = 2) -> BlockedByResult:
     try:
         error_text = _flat_error(text=message)
     except Exception as exc:  # pragma: no cover - defensive seam for tests
-        emit_kv(key="ERROR", value=f"redaction:{exc}")
-        return 3
-    emit_kv(key="ERROR", value=error_text)
-    return code
+        return BlockedByResult(client=client, blocker=blocker, added=False, error=f"redaction:{exc}", exit_code=3)
+    return BlockedByResult(client=client, blocker=blocker, added=False, error=error_text, exit_code=code)
 
 
-def add_blocked_by_main(argv: list[str], sleep_fn: Callable[[float], None] = time.sleep) -> int:
-    client = ""
-    blocker = ""
-    blocker_id = ""
-    repo = ""
-    index = 0
-    while index < len(argv):
-        arg = argv[index]
-        if arg in {"--client-issue", "--blocker-issue", "--blocker-id", "--repo"} and index + 1 < len(argv):
-            value = argv[index + 1]
-            if arg == "--client-issue":
-                client = value
-            elif arg == "--blocker-issue":
-                blocker = value
-            elif arg == "--blocker-id":
-                blocker_id = value
-            else:
-                repo = value
-            index += 2
-        else:
-            warn(f"Unknown option: {arg}")
-            return 1
-    if not client or not blocker:
-        warn("Usage: add-blocked-by --client-issue N --blocker-issue M [--blocker-id ID] [--repo OWNER/REPO]")
-        return 1
+def add_blocked_by(
+    *,
+    client: str,
+    blocker: str,
+    blocker_id: str = "",
+    repo: str = "",
+    sleep_fn: Callable[[float], None] = time.sleep,
+) -> BlockedByResult:
+    """Add one dependency edge with the CLI's retry and idempotency contract."""
     if not _positive_int(value=client) or not _positive_int(value=blocker):
         return _blocked_failure(client=client, blocker=blocker, message="client-issue and blocker-issue must be positive integers", code=1)
     if blocker_id and not _positive_int(value=blocker_id):
@@ -741,7 +780,7 @@ def add_blocked_by_main(argv: list[str], sleep_fn: Callable[[float], None] = tim
             sleep_fn(10)
         elif attempt == THIRD_ATTEMPT:
             sleep_fn(30)
-        with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as tmp:
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8", dir=tempfile.gettempdir(), delete=False) as tmp:
             tmp.write(body)
             tmp_path = tmp.name
         try:
@@ -750,19 +789,53 @@ def add_blocked_by_main(argv: list[str], sleep_fn: Callable[[float], None] = tim
             Path(tmp_path).unlink(missing_ok=True)
         err = result.stderr or result.stdout
         if result.returncode == 0:
-            emit_kv(key="BLOCKED_BY_ADDED", value="true")
-            emit_kv(key="CLIENT", value=client)
-            emit_kv(key="BLOCKER", value=blocker)
-            return 0
+            return BlockedByResult(client=client, blocker=blocker, added=True)
         if re.search(r"HTTP 404|status 404|404 Not Found", err, re.IGNORECASE):
             return _blocked_failure(client=client, blocker=blocker, message=f"feature-unavailable: {err}")
         if re.search(r"HTTP 422", err, re.IGNORECASE) and IDEMPOTENT_RE.search(err):
-            emit_kv(key="BLOCKED_BY_ADDED", value="true")
-            emit_kv(key="CLIENT", value=client)
-            emit_kv(key="BLOCKER", value=blocker)
-            return 0
+            return BlockedByResult(client=client, blocker=blocker, added=True)
         last_error = err
     return _blocked_failure(client=client, blocker=blocker, message=f"all 3 attempts failed: {last_error}")
+
+
+def emit_blocked_by_result(result: BlockedByResult) -> int:
+    """Emit the stable CLI KV contract for :func:`add_blocked_by`."""
+    if result.added:
+        emit_kv(key="BLOCKED_BY_ADDED", value="true")
+    else:
+        emit_kv(key="BLOCKED_BY_FAILED", value="true")
+    emit_kv(key="CLIENT", value=result.client)
+    emit_kv(key="BLOCKER", value=result.blocker)
+    if result.error:
+        emit_kv(key="ERROR", value=result.error)
+    return result.exit_code
+
+
+def add_blocked_by_main(argv: list[str], sleep_fn: Callable[[float], None] = time.sleep) -> int:
+    values: dict[str, str] = {}
+    index = 0
+    while index < len(argv):
+        arg = argv[index]
+        if arg in {"--client-issue", "--blocker-issue", "--blocker-id", "--repo"} and index + 1 < len(argv):
+            values[arg] = argv[index + 1]
+            index += 2
+        else:
+            warn(f"Unknown option: {arg}")
+            return 1
+    client = values.get("--client-issue", "")
+    blocker = values.get("--blocker-issue", "")
+    if not client or not blocker:
+        warn("Usage: add-blocked-by --client-issue N --blocker-issue M [--blocker-id ID] [--repo OWNER/REPO]")
+        return 1
+    return emit_blocked_by_result(
+        add_blocked_by(
+            client=client,
+            blocker=blocker,
+            blocker_id=values.get("--blocker-id", ""),
+            repo=values.get("--repo", ""),
+            sleep_fn=sleep_fn,
+        )
+    )
 
 
 def _title_archival(title: str) -> bool:
@@ -995,6 +1068,29 @@ def write_sentinel_main(argv: list[str]) -> int:
     return 0
 
 
+def cleanup_failed(*, issue: str, repo: str = "") -> CleanupResult:
+    """Best-effort cleanup used after a partially-created OOS batch."""
+    if not issue.isdigit():
+        return CleanupResult(issue=issue, closed=False, error="invalid or missing --issue-number")
+    if not repo:
+        repo = _resolve_repo()
+        if not repo:
+            return CleanupResult(issue=issue, closed=False, error="could not determine repo")
+    result = gh.issue_close(proc, issue, repo=repo, reason="not planned")
+    if result.returncode == 0:
+        return CleanupResult(issue=issue, closed=True)
+    return CleanupResult(issue=issue, closed=False, error=_flat_error(text=result.stderr))
+
+
+def emit_cleanup_result(result: CleanupResult) -> int:
+    """Emit the stable CLI KV contract for :func:`cleanup_failed`."""
+    emit_kv(key="CLOSED", value=str(result.closed).lower())
+    emit_kv(key="ISSUE", value=result.issue)
+    if result.error:
+        emit_kv(key="ERROR", value=result.error)
+    return 0
+
+
 def cleanup_failed_main(argv: list[str]) -> int:
     issue = ""
     repo = ""
@@ -1009,28 +1105,5 @@ def cleanup_failed_main(argv: list[str]) -> int:
             index += 2
         else:
             warn(f"Unknown option: {arg}")
-            emit_kv(key="CLOSED", value="false")
-            emit_kv(key="ISSUE", value=issue or "unknown")
-            emit_kv(key="ERROR", value=f"unknown option: {arg}")
-            return 0
-    if not issue.isdigit():
-        emit_kv(key="CLOSED", value="false")
-        emit_kv(key="ISSUE", value=issue)
-        emit_kv(key="ERROR", value="invalid or missing --issue-number")
-        return 0
-    if not repo:
-        repo = _resolve_repo()
-        if not repo:
-            emit_kv(key="CLOSED", value="false")
-            emit_kv(key="ISSUE", value=issue)
-            emit_kv(key="ERROR", value="could not determine repo")
-            return 0
-    result = gh.issue_close(proc, issue, repo=repo, reason="not planned")
-    if result.returncode == 0:
-        emit_kv(key="CLOSED", value="true")
-        emit_kv(key="ISSUE", value=issue)
-    else:
-        emit_kv(key="CLOSED", value="false")
-        emit_kv(key="ISSUE", value=issue)
-        emit_kv(key="ERROR", value=_flat_error(text=result.stderr))
-    return 0
+            return emit_cleanup_result(CleanupResult(issue=issue or "unknown", closed=False, error=f"unknown option: {arg}"))
+    return emit_cleanup_result(cleanup_failed(issue=issue, repo=repo))

--- a/python/larch/issue/oos_filer.py
+++ b/python/larch/issue/oos_filer.py
@@ -25,11 +25,12 @@ from larch.core import proc
 from larch.errors import ShipError
 from larch.git import gh
 from larch.issue import file_oos
+from larch.issue import issue_create
 from larch.issue import oos_priority
+from larch.report import run_logs
 from larch.review.review_types import is_security_block_text, parse_canonical_heading
 from larch.state import session_env as _session_env_oos
 
-_CLI = Path(__file__).resolve().parents[2] / "cli.py"
 _GITHUB_URL_RE = re.compile(r"https://[^\s|)]+/issues/\d+")
 _FILED_URL_LINE_RE = re.compile(r"^[ \t]*-[ \t]+\*\*Filed[ \t]URL\*\*[ \t]*:[ \t]+(https://[^\s]+/issues/\d+)", re.MULTILINE)
 _INTRA_BATCH_DEP_FIELD_COUNT = 2
@@ -85,14 +86,6 @@ def _repo_root() -> Path:
     if result.returncode == 0 and result.stdout.strip():
         return Path(result.stdout.strip())
     return Path.cwd()
-
-
-def _run_cli(args: list[str], *, input_text: str | None = None) -> subprocess.CompletedProcess[str]:
-    return subprocess.run([sys.executable, str(_CLI), *args], input=input_text, text=True, capture_output=True, check=False)
-
-
-def _parse_kv(text: str) -> dict[str, str]:
-    return larch_io.parse_kv(text, cr_strip="strip")
 
 
 def _is_security_block(block: str) -> bool:
@@ -403,8 +396,8 @@ def _materialize_sentinel_recovery_evidence(*, tmpdir: Path, filed: list[FiledIs
     path.write_text("\n".join(blocks), encoding="utf-8")
 
 
-def _run_disposition_checkpoint(tmpdir: Path) -> subprocess.CompletedProcess[str]:
-    return _run_cli(["oos", "disposition-checkpoint", "--implement-tmpdir", str(tmpdir)])
+def _run_disposition_checkpoint(tmpdir: Path) -> int:
+    return file_oos.disposition_checkpoint_main(["--implement-tmpdir", str(tmpdir)])
 
 
 def _after_checkpoint(
@@ -419,7 +412,7 @@ def _after_checkpoint(
 ) -> tuple[int, dict[str, object]]:
     checkpoint = _run_disposition_checkpoint(tmpdir)
     urls = [issue.url for issue in filed]
-    if checkpoint.returncode == _SECURITY_SIDECAR_CHECKPOINT_RC:
+    if checkpoint == _SECURITY_SIDECAR_CHECKPOINT_RC:
         stats = _write_run_statistics(
             tmpdir=tmpdir,
             run_id=run_id,
@@ -436,12 +429,12 @@ def _after_checkpoint(
             "run_statistics_written": bool(urls and stats.is_file()),
             "step9a1_stamped": False,
         }
-    if checkpoint.returncode != 0:
+    if checkpoint != 0:
         try:
             stamped = _stamp_manifest(tmpdir, run_id, value=False)
         except RuntimeError:
             stamped = False
-        return checkpoint.returncode or 1, {
+        return checkpoint or 1, {
             "status": "disposition_checkpoint_failed",
             "accepted_count": accepted_count,
             "filed_count": len(filed) if filed_count is None else filed_count,
@@ -508,8 +501,11 @@ def _maybe_combine_with_codex(tmpdir: Path, text: str, *, codex_timeout: int) ->
     if not _codex_available():
         _append_warning(tmpdir=tmpdir, message="Codex unavailable; filing the pre-combine OOS batch.")
         return text
-    result = _run_cli(
+    cli_path = Path(__file__).resolve().parents[2] / "cli.py"
+    result = subprocess.run(  # lint-subprocess-via-runner: ok fixed cli.py command deliberately crosses to the external Codex agent boundary
         [
+            sys.executable,
+            str(cli_path),
             "agent",
             "launch-codex-exec",
             "--output",
@@ -525,6 +521,9 @@ def _maybe_combine_with_codex(tmpdir: Path, text: str, *, codex_timeout: int) ->
             "--add-dir",
             str(tmpdir),
         ],
+        text=True,
+        capture_output=True,
+        check=False,
     )
     if result.returncode != 0 or not output_path.is_file():
         _append_warning(tmpdir=tmpdir, message="Codex combine failed; filing the pre-combine OOS batch.")
@@ -690,7 +689,7 @@ def _cleanup_created_issues(
         number = issue.url.rsplit("/", 1)[-1]
         if not number.isdigit():
             continue
-        _ = _run_cli(["issue", "cleanup-failed", "--issue-number", number, *([] if not repo else ["--repo", repo])])
+        _ = issue_create.cleanup_failed(issue=number, repo=repo)
 
 
 def _body_bytes(text: str) -> int:
@@ -744,13 +743,18 @@ def _is_capped_rollup_body(body: str) -> bool:
     return "OOS_ISSUES_PER_RUN_CAP" in body and "rolled up" in body
 
 
-def _body_files_for_item(*, tmpdir: Path, item_index: int, fields: dict[str, str]) -> list[Path]:
-    raw_path = Path(fields.get(f"ITEM_{item_index}_BODY_FILE", ""))
-    body = raw_path.read_text(encoding="utf-8", errors="replace") if raw_path.is_file() else ""
+def _body_files_for_item(
+    *,
+    tmpdir: Path,
+    item_index: int,
+    item: issue_create.ParsedItem,
+    body_path: Path | None,
+) -> list[Path]:
+    body = body_path.read_text(encoding="utf-8", errors="replace") if body_path is not None and body_path.is_file() else ""
     body = file_oos._sanitize_public_text(body)  # pyright: ignore[reportPrivateUsage]
-    reviewer = file_oos._sanitize_public_text(fields.get(f"ITEM_{item_index}_REVIEWER", ""))  # pyright: ignore[reportPrivateUsage]
-    phase = file_oos._sanitize_public_text(fields.get(f"ITEM_{item_index}_PHASE", "implement"))  # pyright: ignore[reportPrivateUsage]
-    vote = file_oos._sanitize_public_text(fields.get(f"ITEM_{item_index}_VOTE_TALLY", "N/A"))  # pyright: ignore[reportPrivateUsage]
+    reviewer = file_oos._sanitize_public_text(item.reviewer)  # pyright: ignore[reportPrivateUsage]
+    phase = file_oos._sanitize_public_text(item.phase or "implement")  # pyright: ignore[reportPrivateUsage]
+    vote = file_oos._sanitize_public_text(item.vote or "N/A")  # pyright: ignore[reportPrivateUsage]
     if reviewer or phase or vote:
         body = _wrap_oos_body(body, reviewer=reviewer, phase=phase, vote=vote)
     out_dir = tmpdir / "oos-issue-bodies"
@@ -785,21 +789,10 @@ def _apply_intra_batch_edges(
         blocked_number = issue_numbers.get(blocked_index, "")
         if not blocker_number.isdigit() or not blocked_number.isdigit():
             continue
-        intra = _run_cli(
-            [
-                "issue",
-                "add-blocked-by",
-                "--client-issue",
-                blocked_number,
-                "--blocker-issue",
-                blocker_number,
-                *([] if not repo else ["--repo", repo]),
-            ],
-        )
-        intra_kv = _parse_kv(intra.stdout)
-        if intra.returncode != 0 or intra_kv.get("BLOCKED_BY_FAILED") == "true":
-            detail = intra_kv.get("ERROR") or intra.stderr or intra.stdout or "intra-batch add-blocked-by failed"
-            _append_tool_failure(tmpdir=tmpdir, site="step-9a1-oos-file", tool="issue add-blocked-by", rc=intra.returncode or 1, output=detail)
+        intra = issue_create.add_blocked_by(client=blocked_number, blocker=blocker_number, repo=repo)
+        if intra.exit_code != 0 or not intra.added:
+            detail = intra.error or "intra-batch add-blocked-by failed"
+            _append_tool_failure(tmpdir=tmpdir, site="step-9a1-oos-file", tool="issue add-blocked-by", rc=intra.exit_code or 1, output=detail)
             _cleanup_created_issues(tmpdir, filed, repo=repo)
             return False
     return True
@@ -838,12 +831,11 @@ def _run_issue_batch(
     sanitized_input = bodies_dir / "oos-combined-sanitized.md"
     sanitized_input.write_text(file_oos._sanitize_public_text(combined.read_text(encoding="utf-8", errors="replace")), encoding="utf-8")  # pyright: ignore[reportPrivateUsage]
 
-    parsed = _run_cli(["issue", "parse-input", "--input-file", str(sanitized_input), "--output-dir", str(bodies_dir)])
-    if parsed.returncode != 0:
-        _append_tool_failure(tmpdir=tmpdir, site="step-9a1-oos-file", tool="issue parse-input", rc=parsed.returncode, output=parsed.stderr or parsed.stdout)
+    parsed = issue_create.parse_input(input_file=sanitized_input, output_dir=bodies_dir)
+    if parsed.exit_code != 0:
+        _append_tool_failure(tmpdir=tmpdir, site="step-9a1-oos-file", tool="issue parse-input", rc=parsed.exit_code, output=parsed.error)
         return BatchResult([], 1, "hard_create")
-    fields = _parse_kv(parsed.stdout)
-    total = int(fields.get("ITEMS_TOTAL", "0") or "0")
+    total = len(parsed.items)
     if not _probe_tracking_blocker(tmpdir=tmpdir, repo=repo, issue_number=issue_number):
         return BatchResult([], 1, "hard_create")
 
@@ -856,11 +848,12 @@ def _run_issue_batch(
     failure_mode: Literal["none", "hard_create", "priority_label", "priority_provision"] = "none"
     priority_label_ready: bool | None = None
     for item_index in create_order:
-        title = file_oos._sanitize_public_text(fields.get(f"ITEM_{item_index}_TITLE", "")).strip()  # pyright: ignore[reportPrivateUsage]
+        item = parsed.items[item_index - 1]
+        title = file_oos._sanitize_public_text(item.title).strip()  # pyright: ignore[reportPrivateUsage]
         # Never publish an empty public issue: if the parser flagged this item
         # malformed (no/empty Description body), skip filing and fail loud
         # instead of creating an issue with a blank `## Description` (#5260).
-        if fields.get(f"ITEM_{item_index}_MALFORMED", "") == "true":
+        if item.malformed:
             detail = f"skipped malformed accepted-OOS item (empty/unparseable Description); not filing empty public issue: {title or f'item {item_index}'}"
             _append_tool_failure(tmpdir=tmpdir, site="step-9a1-oos-file", tool="issue create-one", rc=1, output=detail)
             continue
@@ -871,36 +864,29 @@ def _run_issue_batch(
             failures += 1
             failure_mode = "priority_provision"
             continue
-        body_files = _body_files_for_item(tmpdir=tmpdir, item_index=item_index, fields=fields)
+        body_files = _body_files_for_item(tmpdir=tmpdir, item_index=item_index, item=item, body_path=parsed.body_paths[item_index - 1])
         source_ids = stable_ids_by_item.get(item_index, ()) if stable_ids_by_item else ()
         primary_stable = source_ids[0] if source_ids else f"OOS_{item_index}"
         total_parts = len(body_files)
         for part_index, body_file in enumerate(body_files, start=1):
             part_title = title if total_parts == 1 else f"{title} (part {part_index}/{total_parts})"
-            args = [
-                "issue",
-                "create-one",
-                "--title",
-                part_title,
-                "--title-prefix",
-                "[OOS]",
-                "--body-file",
-                str(body_file),
-            ]
+            create_args: dict[str, object] = {
+                "title": part_title,
+                "title_prefix": "[OOS]",
+                "body_file": str(body_file),
+                "labels": [oos_priority.OOS_CORRECTNESS_LABEL] if item_priority else [],
+            }
             if repo:
-                args.extend(["--repo", repo])
-            if item_priority:
-                args.extend(["--label", oos_priority.OOS_CORRECTNESS_LABEL])
+                create_args["repo"] = repo
             if context_file is not None:
-                args.extend(["--context-file", str(context_file), "--run-id", run_id, "--trusted-root", str(tmpdir)])
-            created = _run_cli(args)
-            kv = _parse_kv(created.stdout)
-            if created.returncode != 0 or kv.get("ISSUE_FAILED") == "true":
+                create_args.update({"context_file": str(context_file), "run_id": run_id, "trusted_root": str(tmpdir)})
+            created = issue_create.create_one(create_args)
+            if created.exit_code != 0:
                 failures += 1
                 _cleanup_created_issues(tmpdir, filed, repo=repo)
                 return BatchResult(filed, failures, "hard_create")
-            url = kv.get("ISSUE_URL") or kv.get(f"ISSUE_{item_index}_URL") or kv.get("ISSUE_DUPLICATE_OF_URL") or kv.get(f"ISSUE_{item_index}_DUPLICATE_OF_URL")
-            duplicate = bool(kv.get("ISSUE_DUPLICATE_OF_URL") or kv.get(f"ISSUE_{item_index}_DUPLICATE_OF_URL"))
+            url = created.url
+            duplicate = created.duplicate
             filed_issue: FiledIssue | None = None
             if url:
                 part_stable = primary_stable if part_index == 1 else f"{primary_stable}:part{part_index}"
@@ -919,15 +905,14 @@ def _run_issue_batch(
                     _handle_priority_label_failure(filed_issue, filed, tmpdir, url, repo)
                     break
                 filed.append(filed_issue)
-            number = kv.get("ISSUE_NUMBER") or ""
+            number = created.number
             if part_index == 1 and number.isdigit():
                 issue_numbers[item_index] = number
             if issue_number and number.isdigit():
-                blocked = _run_cli(["issue", "add-blocked-by", "--client-issue", number, "--blocker-issue", issue_number, *([] if not repo else ["--repo", repo])])
-                blocked_kv = _parse_kv(blocked.stdout)
-                if blocked.returncode != 0 or blocked_kv.get("BLOCKED_BY_FAILED") == "true":
-                    detail = blocked_kv.get("ERROR") or blocked.stderr or blocked.stdout or "add-blocked-by failed"
-                    _append_tool_failure(tmpdir=tmpdir, site="step-9a1-oos-file", tool="issue add-blocked-by", rc=blocked.returncode or 1, output=detail)
+                blocked = issue_create.add_blocked_by(client=number, blocker=issue_number, repo=repo)
+                if blocked.exit_code != 0 or not blocked.added:
+                    detail = blocked.error or "add-blocked-by failed"
+                    _append_tool_failure(tmpdir=tmpdir, site="step-9a1-oos-file", tool="issue add-blocked-by", rc=blocked.exit_code or 1, output=detail)
                     _cleanup_created_issues(tmpdir, filed, repo=repo)
                     return BatchResult(filed, 1, "hard_create")
         item_edges = [edge for edge in intra_batch_edges if edge[1] == item_index]
@@ -1080,24 +1065,27 @@ def _stamp_manifest(tmpdir: Path, run_id: str, *, value: bool) -> bool:
     manifest = tmpdir / "larch-logs" / "implement" / run_id / "manifest.json"
     if not manifest.is_file():
         return False
-    result = _run_cli(
-        [
-            "run-log",
-            "manifest",
-            "--log-root",
-            str(tmpdir / "larch-logs"),
-            "--skill",
-            "implement",
-            "--run-id",
-            run_id,
-            "--field",
-            f"steps_ran.step9a1={'true' if value else 'false'}",
-        ],
-    )
-    if result.returncode != 0:
-        detail = (result.stderr or result.stdout or "manifest update failed").strip()
-        raise RuntimeError(f"run-log manifest steps_ran.step9a1 update failed: {detail[:300]}")
+    try:
+        run_logs._update_manifest_v2(path=manifest, updates={"steps_ran.step9a1": value})  # pyright: ignore[reportPrivateUsage]  # direct typed replacement for cli.py manifest re-entry
+    except (OSError, ValueError) as exc:
+        raise RuntimeError(f"run-log manifest steps_ran.step9a1 update failed: {str(exc)[:300]}") from exc
     return True
+
+
+def _file_conflict_deps(*, input_file: Path, output_file: Path) -> tuple[int, str]:
+    """Materialize the in-process dependency plan with CLI-compatible failure data."""
+    try:
+        cluster_cap, global_cap = file_oos._file_conflict_caps()  # pyright: ignore[reportPrivateUsage]  # preserve the CLI's cap validation before writing
+        file_oos._write_file_conflict_deps(  # pyright: ignore[reportPrivateUsage]  # preserve the CLI's atomic write and stale-output cleanup contract
+            input_file,
+            output_file,
+            cluster_cap=cluster_cap,
+            global_cap=global_cap,
+        )
+    except (OSError, ValueError) as exc:
+        output_file.unlink(missing_ok=True)
+        return 1, str(exc)
+    return 0, ""
 
 
 def _recover_persisted_blocks(
@@ -1203,21 +1191,21 @@ def _file(args: argparse.Namespace) -> tuple[int, dict[str, object]]:
         _append_tool_failure(tmpdir=tmpdir, site="step-9a1-oos-file", tool="oos issue-cap", rc=1, output=str(exc))
         return 1, {"status": "issue_cap_failed", "accepted_count": accepted_count, "filed_count": 0, "deduplicated_count": 0, "urls": [], "run_statistics_written": False, "step9a1_stamped": False}
     deps = tmpdir / "oos-intra-batch-deps.tsv"
-    deps_result = _run_cli(["oos", "file-conflict-deps", "--input-file", str(combined), "--output", str(deps)])
+    deps_rc, deps_error = _file_conflict_deps(input_file=combined, output_file=deps)
     deps_path: Path | None = None
-    if deps_result.returncode == 0:
+    if deps_rc == 0:
         if deps.is_file() and deps.stat().st_size > 0:
             deps_path = deps
     else:
         warning = (
-            f"**⚠ /implement: oos-file-conflict pre-pass failed (exit {deps_result.returncode}) — "
+            f"**⚠ /implement: oos-file-conflict pre-pass failed (exit {deps_rc}) — "
             "proceeding without caller-supplied serialization edges; review accepted-OOS Descriptions "
             "before greenlighting parallel workers**"
         )
         _append_warning(tmpdir=tmpdir, message=warning)
-        detail = deps_result.stderr or deps_result.stdout or warning
-        _append_tool_failure(tmpdir=tmpdir, site="step-9a1-oos-file", tool="oos file-conflict-deps", rc=deps_result.returncode or 1, output=detail)
-        if deps_result.returncode == 1:
+        detail = deps_error or warning
+        _append_tool_failure(tmpdir=tmpdir, site="step-9a1-oos-file", tool="oos file-conflict-deps", rc=deps_rc or 1, output=detail)
+        if deps_rc == 1:
             deps.unlink(missing_ok=True)
     # issue_cap may have rewritten `combined` in place (rolling surplus blocks
     # into one aggregate). Map stable IDs from the post-cap file the batch

--- a/python/tests/issue/test_issue_create.py
+++ b/python/tests/issue/test_issue_create.py
@@ -4,11 +4,11 @@
 from __future__ import annotations
 
 import json
+from dataclasses import FrozenInstanceError
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-if TYPE_CHECKING:
-    import pytest
+import pytest
 
 from larch.core import config as _issue_create_config
 from larch.issue import issue_create
@@ -149,6 +149,19 @@ def test_parse_input_oos_and_malformed_body_file(tmp_path: Path, capsys: Any) ->
     assert "ITEM_4_TITLE=title only" in out
     assert "ITEM_4_BODY_FILE=" not in out
     assert (out_dir / "item-1-body.txt").read_text(encoding="utf-8") == "body"
+
+
+def test_parse_input_returns_frozen_typed_result(tmp_path: Path) -> None:
+    input_file = tmp_path / "items.md"
+    input_file.write_text("### OOS_1: first\n- **Description**: body\n", encoding="utf-8")
+
+    result = issue_create.parse_input(input_file=input_file, output_dir=tmp_path / "out")
+
+    assert result.exit_code == 0
+    assert result.items[0].title == "first"
+    assert result.body_paths[0] == (tmp_path / "out" / "item-1-body.txt").resolve()
+    with pytest.raises(FrozenInstanceError):
+        result.mode = "changed"  # type: ignore[misc]  # frozen-result regression assertion
 
 
 def test_parse_input_finding_format_oos_captures_body(tmp_path: Path, capsys: Any) -> None:

--- a/python/tests/issue/test_oos_filer.py
+++ b/python/tests/issue/test_oos_filer.py
@@ -9,10 +9,12 @@ import io
 import json
 import subprocess
 from pathlib import Path
+from typing import cast
 
 import pytest
 from larch.core import config
 from larch.core.proc import CommandResult
+from larch import io as larch_io
 from larch.issue import file_oos
 from larch.issue import issue_create
 from larch.issue import oos_filer
@@ -64,6 +66,7 @@ class FakeCli:
         self.fail_blocked_by = False
         self.blocker_probe_rc = 0
         self.checkpoint_rc = 0
+        self.manifest_rc = 0
         self.file_conflict_deps_rc = 0
         self.file_conflict_deps_text: str | None = None
         self.file_conflict_deps_write_output = True
@@ -71,7 +74,7 @@ class FakeCli:
     def __call__(self, args: list[str], *, input_text: str | None = None) -> subprocess.CompletedProcess[str]:
         self.calls.append(args)
         if args[:2] == ["run-log", "manifest"]:
-            return _cp(args)
+            return _cp(args, stderr="manifest update failed" if self.manifest_rc else "", rc=self.manifest_rc)
         if args[:2] == ["oos", "disposition-checkpoint"]:
             return _cp(args, stderr="checkpoint failed" if self.checkpoint_rc else "", rc=self.checkpoint_rc)
         if args[:2] == ["oos", "file-conflict-deps"]:
@@ -154,14 +157,74 @@ def _write_oos(tmp_path: Path, text: str) -> None:
 
 
 def _run(tmp_path: Path, fake: FakeCli, monkeypatch: pytest.MonkeyPatch) -> tuple[int, dict[str, object]]:
-    monkeypatch.setattr(oos_filer, "_run_cli", fake)
+    original_parse = issue_create.parse_input
+    original_stamp = oos_filer._stamp_manifest
+
+    def parse_input(*, input_file: Path, output_dir: Path) -> issue_create.ParseInputResult:
+        _ = fake(["issue", "parse-input", "--input-file", str(input_file), "--output-dir", str(output_dir)])
+        return original_parse(input_file=input_file, output_dir=output_dir)
+
+    def create_one(parsed: dict[str, object]) -> issue_create.CreateIssueResult:
+        args = ["issue", "create-one", "--title", str(parsed["title"]), "--title-prefix", str(parsed["title_prefix"]), "--body-file", str(parsed["body_file"])]
+        if repo := str(parsed.get("repo", "")):
+            args.extend(["--repo", repo])
+        labels = parsed.get("labels", [])
+        if isinstance(labels, list):
+            for label in cast("list[object]", labels):
+                args.extend(["--label", str(label)])
+        completed = fake(args)
+        fields = larch_io.parse_kv(completed.stdout, cr_strip="strip")
+        if completed.returncode or fields.get("ISSUE_FAILED") == "true":
+            return issue_create.CreateIssueResult(error=fields.get("ISSUE_ERROR", "create failed"), exit_code=completed.returncode or 1)
+        return issue_create.CreateIssueResult(
+            title=fields.get("ISSUE_TITLE", ""),
+            number=fields.get("ISSUE_NUMBER", ""),
+            url=fields.get("ISSUE_URL") or fields.get("ISSUE_DUPLICATE_OF_URL", ""),
+            duplicate=bool(fields.get("ISSUE_DUPLICATE_OF_URL")),
+        )
+
+    def add_blocked_by(*, client: str, blocker: str, repo: str = "", **_kwargs: object) -> issue_create.BlockedByResult:
+        completed = fake(["issue", "add-blocked-by", "--client-issue", client, "--blocker-issue", blocker, *([] if not repo else ["--repo", repo])])
+        fields = larch_io.parse_kv(completed.stdout, cr_strip="strip")
+        return issue_create.BlockedByResult(client=client, blocker=blocker, added=not completed.returncode and fields.get("BLOCKED_BY_FAILED") != "true", error=fields.get("ERROR", ""), exit_code=completed.returncode)
+
+    def cleanup_failed(*, issue: str, repo: str = "") -> issue_create.CleanupResult:
+        completed = fake(["issue", "cleanup-failed", "--issue-number", issue, *([] if not repo else ["--repo", repo])])
+        return issue_create.CleanupResult(issue=issue, closed=completed.returncode == 0)
+
+    def checkpoint(_tmpdir: Path) -> int:
+        return fake(["oos", "disposition-checkpoint", "--implement-tmpdir", str(_tmpdir)]).returncode
+
+    def conflict_deps(*, input_file: Path, output_file: Path) -> tuple[int, str]:
+        completed = fake(["oos", "file-conflict-deps", "--input-file", str(input_file), "--output", str(output_file)])
+        return completed.returncode, completed.stderr or completed.stdout
+
+    def stamp_manifest(_tmpdir: Path, run_id: str, *, value: bool) -> bool:
+        completed = fake(["run-log", "manifest", "--run-id", run_id, "--field", f"steps_ran.step9a1={'true' if value else 'false'}"])
+        if completed.returncode:
+            raise RuntimeError(completed.stderr or completed.stdout)
+        return original_stamp(_tmpdir, run_id, value=value)
+
+    def external_run(args: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        return fake(args[2:])
+
+    monkeypatch.setattr(issue_create, "parse_input", parse_input)
+    monkeypatch.setattr(issue_create, "create_one", create_one)
+    monkeypatch.setattr(issue_create, "add_blocked_by", add_blocked_by)
+    monkeypatch.setattr(issue_create, "cleanup_failed", cleanup_failed)
+    monkeypatch.setattr(oos_filer, "_run_disposition_checkpoint", checkpoint)
+    monkeypatch.setattr(oos_filer, "_file_conflict_deps", conflict_deps)
+    monkeypatch.setattr(oos_filer, "_stamp_manifest", stamp_manifest)
+    monkeypatch.setattr(oos_filer.subprocess, "run", external_run)
     monkeypatch.setattr(oos_filer, "_repo_root", lambda: tmp_path)
     monkeypatch.setattr(oos_filer, "_probe_tracking_blocker", lambda **_a: fake.blocker_probe_rc == 0)  # type: ignore[arg-type]
     monkeypatch.setattr(oos_filer._session_env_oos, "check_live_mutation_auth", lambda **_kwargs: (True, "session"))
     monkeypatch.delenv(config.LIVE_MUTATION_TEST_DENY_KEY, raising=False)
-    rc = oos_filer.cmd_file(["--implement-tmpdir", str(tmp_path), "--codex-timeout", "1",
-                              "--context-file", str(tmp_path / "session-env.sh")])
-    return rc, {}
+    output = io.StringIO()
+    with contextlib.redirect_stdout(output):
+        rc = oos_filer.cmd_file(["--implement-tmpdir", str(tmp_path), "--codex-timeout", "1",
+                                  "--context-file", str(tmp_path / "session-env.sh")])
+    return rc, json.loads(output.getvalue())
 
 
 def test_empty_batch_writes_zero_statistics_and_stamps_true(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -173,6 +236,15 @@ def test_empty_batch_writes_zero_statistics_and_stamps_true(tmp_path: Path, monk
     assert any("steps_ran.step9a1=true" in call for call in fake.calls for call in call)
     assert any(call[:2] == ["oos", "disposition-checkpoint"] for call in fake.calls)
     assert not any(call[:2] == ["issue", "create-one"] for call in fake.calls)
+
+
+def test_oos_filer_keeps_cli_reentry_only_for_external_codex() -> None:
+    source = Path(oos_filer.__file__).read_text(encoding="utf-8")
+    assert "def _run_cli" not in source
+    assert "issue_create.parse_input(" in source
+    assert "issue_create.create_one(" in source
+    assert "issue_create.add_blocked_by(" in source
+    assert "issue_create.cleanup_failed(" in source
 
 
 def test_single_item_files_issue_and_writes_sentinel(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -322,10 +394,7 @@ def test_security_sidecar_does_not_block_non_security_oos(tmp_path: Path, monkey
     _write_oos(tmp_path, "### OOS_1: Public follow-up\n- **Description**: File this public item.\n")
     fake = FakeCli(tmp_path)
     fake.checkpoint_rc = 3
-    buf = io.StringIO()
-    with contextlib.redirect_stdout(buf):
-        rc, _payload = _run(tmp_path, fake, monkeypatch)
-    payload = json.loads(buf.getvalue())
+    rc, payload = _run(tmp_path, fake, monkeypatch)
 
     assert rc == 3
     assert payload["status"] == "security_sidecar_present"
@@ -689,22 +758,8 @@ def test_checkpoint_failure_manifest_stamp_error_still_reports_checkpoint_failed
     _write_oos(tmp_path, "### OOS_1: First\n- **Description**: A.\n")
     fake = FakeCli(tmp_path)
     fake.checkpoint_rc = 2
-
-    def run_cli(args: list[str], *, input_text: str | None = None) -> subprocess.CompletedProcess[str]:
-        if args[:2] == ["run-log", "manifest"]:
-            return _cp(args, stderr="manifest update failed", rc=1)
-        return fake(args, input_text=input_text)
-
-    monkeypatch.setattr(oos_filer, "_run_cli", run_cli)
-    monkeypatch.setattr(oos_filer, "_repo_root", lambda: tmp_path)
-    monkeypatch.setattr(oos_filer, "_probe_tracking_blocker", lambda **_a: True)  # type: ignore[arg-type]
-    monkeypatch.delenv(config.LIVE_MUTATION_TEST_DENY_KEY, raising=False)
-    monkeypatch.setattr(oos_filer._session_env_oos, "check_live_mutation_auth", lambda **_kwargs: (True, "session"))
-    buf = io.StringIO()
-    with contextlib.redirect_stdout(buf):
-        rc = oos_filer.cmd_file(["--implement-tmpdir", str(tmp_path), "--codex-timeout", "1",
-                                  "--context-file", str(tmp_path / "session-env.sh")])
-    output = json.loads(buf.getvalue())
+    fake.manifest_rc = 1
+    rc, output = _run(tmp_path, fake, monkeypatch)
     assert rc != 0
     assert output["status"] == "disposition_checkpoint_failed"
     assert output["step9a1_stamped"] is False
@@ -745,16 +800,6 @@ def test_sentinel_recovery_materializes_strict_evidence_for_real_checkpoint(
         encoding="utf-8",
     )
 
-    def fake_run(args: list[str], *, input_text: str | None = None) -> subprocess.CompletedProcess[str]:
-        _ = input_text
-        if args[:2] == ["oos", "disposition-checkpoint"]:
-            rc = file_oos.disposition_checkpoint_main(["--implement-tmpdir", str(tmp_path)])
-            return _cp(args, rc=rc)
-        fake.calls.append(args)
-        if args[:2] == ["run-log", "manifest"]:
-            return _cp(args)
-        return _cp(args)
-
     def fake_subprocess_run(argv: list[str], **_: object) -> subprocess.CompletedProcess[str]:
         if argv[:3] == ["git", "merge-base", "HEAD"]:
             return _cp(argv, stdout="base\n")
@@ -769,12 +814,8 @@ def test_sentinel_recovery_materializes_strict_evidence_for_real_checkpoint(
         return _cp(argv)
 
     fake = FakeCli(tmp_path)
-    monkeypatch.setattr(oos_filer, "_run_cli", fake_run)
     monkeypatch.setattr(file_oos.subprocess, "run", fake_subprocess_run)
-    monkeypatch.delenv(config.LIVE_MUTATION_TEST_DENY_KEY, raising=False)
-    monkeypatch.setattr(oos_filer._session_env_oos, "check_live_mutation_auth", lambda **_kwargs: (True, "session"))
-    rc = oos_filer.cmd_file(["--implement-tmpdir", str(tmp_path), "--codex-timeout", "1",
-                              "--context-file", str(tmp_path / "session-env.sh")])
+    rc, _payload = _run(tmp_path, fake, monkeypatch)
     assert rc == 0
     accepted = tmp_path / "oos-accepted-main-agent.md"
     assert accepted.is_file()
@@ -788,22 +829,8 @@ def test_success_path_manifest_stamp_failure_returns_zero_with_stamped_false(
     _setup(tmp_path)
     _write_oos(tmp_path, "### OOS_1: First\n- **Description**: A.\n")
     fake = FakeCli(tmp_path)
-
-    def run_cli(args: list[str], *, input_text: str | None = None) -> subprocess.CompletedProcess[str]:
-        if args[:2] == ["run-log", "manifest"]:
-            return _cp(args, stderr="manifest update failed", rc=1)
-        return fake(args, input_text=input_text)
-
-    monkeypatch.setattr(oos_filer, "_run_cli", run_cli)
-    monkeypatch.setattr(oos_filer, "_repo_root", lambda: tmp_path)
-    monkeypatch.setattr(oos_filer, "_probe_tracking_blocker", lambda **_a: True)  # type: ignore[arg-type]
-    monkeypatch.delenv(config.LIVE_MUTATION_TEST_DENY_KEY, raising=False)
-    monkeypatch.setattr(oos_filer._session_env_oos, "check_live_mutation_auth", lambda **_kwargs: (True, "session"))
-    buf = io.StringIO()
-    with contextlib.redirect_stdout(buf):
-        rc = oos_filer.cmd_file(["--implement-tmpdir", str(tmp_path), "--codex-timeout", "1",
-                                  "--context-file", str(tmp_path / "session-env.sh")])
-    output = json.loads(buf.getvalue())
+    fake.manifest_rc = 1
+    rc, output = _run(tmp_path, fake, monkeypatch)
     # run-statistics must have been written (issued filed OK)
     assert (tmp_path / "larch-logs" / "implement" / "run-1" / "run-statistics.md").is_file()
     # stamp failure is handled gracefully: exit 0, step9a1_stamped=False
@@ -1143,16 +1170,7 @@ def test_priority_provision_failure_still_files_non_priority_survivor(
         return _cp(args, stderr="label failed", rc=1)
 
     monkeypatch.setattr(oos_filer, "_run_gh", fake_gh)
-    monkeypatch.setattr(oos_filer, "_run_cli", fake)
-    monkeypatch.setattr(oos_filer, "_repo_root", lambda: tmp_path)
-    monkeypatch.setattr(oos_filer, "_probe_tracking_blocker", lambda **_a: True)  # type: ignore[arg-type]
-    monkeypatch.delenv(config.LIVE_MUTATION_TEST_DENY_KEY, raising=False)
-    monkeypatch.setattr(oos_filer._session_env_oos, "check_live_mutation_auth", lambda **_kwargs: (True, "session"))
-    buf = io.StringIO()
-    with contextlib.redirect_stdout(buf):
-        rc = oos_filer.cmd_file(["--implement-tmpdir", str(tmp_path), "--codex-timeout", "1",
-                                  "--context-file", str(tmp_path / "session-env.sh")])
-    payload = json.loads(buf.getvalue())
+    rc, payload = _run(tmp_path, fake, monkeypatch)
 
     assert rc == 1
     assert payload["status"] == "priority_provision_partial_failure"
@@ -1205,25 +1223,10 @@ def test_priority_label_partial_failure_preserves_cosmetic_survivor(
     def fake_gh(args: list[str]) -> subprocess.CompletedProcess[str]:
         return _cp(args)
 
-    original_run_cli = fake.__call__
-
-    def run_cli(args: list[str], *, input_text: str | None = None) -> subprocess.CompletedProcess[str]:
-        if args[:2] == ["issue", "cleanup-failed"]:
-            cleanup_calls.append(args)
-        return original_run_cli(args, input_text=input_text)
-
     monkeypatch.setattr(oos_filer, "_run_gh", fake_gh)
     _stub_priority_label_add(monkeypatch, fail_once=True)
-    monkeypatch.setattr(oos_filer, "_run_cli", run_cli)
-    monkeypatch.setattr(oos_filer, "_repo_root", lambda: tmp_path)
-    monkeypatch.setattr(oos_filer, "_probe_tracking_blocker", lambda **_a: True)  # type: ignore[arg-type]
-    monkeypatch.delenv(config.LIVE_MUTATION_TEST_DENY_KEY, raising=False)
-    monkeypatch.setattr(oos_filer._session_env_oos, "check_live_mutation_auth", lambda **_kwargs: (True, "session"))
-    buf = io.StringIO()
-    with contextlib.redirect_stdout(buf):
-        rc = oos_filer.cmd_file(["--implement-tmpdir", str(tmp_path), "--codex-timeout", "1",
-                                  "--context-file", str(tmp_path / "session-env.sh")])
-    payload = json.loads(buf.getvalue())
+    rc, payload = _run(tmp_path, fake, monkeypatch)
+    cleanup_calls.extend(call for call in fake.calls if call[:2] == ["issue", "cleanup-failed"])
 
     assert rc == 1
     assert payload["status"] == "priority_label_partial_failure"
@@ -1284,16 +1287,7 @@ def test_multipart_priority_label_failure_stops_later_parts(
 
     monkeypatch.setattr(oos_filer, "_run_gh", fake_gh)
     _stub_priority_label_add(monkeypatch, fail=True)
-    monkeypatch.setattr(oos_filer, "_run_cli", fake)
-    monkeypatch.setattr(oos_filer, "_repo_root", lambda: tmp_path)
-    monkeypatch.setattr(oos_filer, "_probe_tracking_blocker", lambda **_a: True)  # type: ignore[arg-type]
-    monkeypatch.delenv(config.LIVE_MUTATION_TEST_DENY_KEY, raising=False)
-    monkeypatch.setattr(oos_filer._session_env_oos, "check_live_mutation_auth", lambda **_kwargs: (True, "session"))
-    buf = io.StringIO()
-    with contextlib.redirect_stdout(buf):
-        rc = oos_filer.cmd_file(["--implement-tmpdir", str(tmp_path), "--codex-timeout", "1",
-                                  "--context-file", str(tmp_path / "session-env.sh")])
-    payload = json.loads(buf.getvalue())
+    rc, payload = _run(tmp_path, fake, monkeypatch)
 
     assert rc == 1
     assert payload["status"] == "issue_batch_failed"
@@ -1319,20 +1313,13 @@ def test_duplicate_high_risk_label_failure_still_persisted_for_retry(
 
     monkeypatch.setattr(oos_filer, "_run_gh", fake_gh)
     _stub_priority_label_add(monkeypatch, fail=True)
-    monkeypatch.setattr(oos_filer, "_run_cli", fake)
-    monkeypatch.setattr(oos_filer, "_repo_root", lambda: tmp_path)
-    monkeypatch.setattr(oos_filer, "_probe_tracking_blocker", lambda **_a: True)  # type: ignore[arg-type]
-    monkeypatch.delenv(config.LIVE_MUTATION_TEST_DENY_KEY, raising=False)
-    monkeypatch.setattr(oos_filer._session_env_oos, "check_live_mutation_auth", lambda **_kwargs: (True, "session"))
-    buf = io.StringIO()
-    with contextlib.redirect_stdout(buf):
-        rc = oos_filer.cmd_file(["--implement-tmpdir", str(tmp_path), "--codex-timeout", "1",
-                                  "--context-file", str(tmp_path / "session-env.sh")])
-    payload = json.loads(buf.getvalue())
+    rc, payload = _run(tmp_path, fake, monkeypatch)
 
     assert rc == 1
     assert payload["status"] == "priority_label_partial_failure"
-    assert "https://github.com/owner/repo/issues/101" in payload["urls"]
+    urls = payload["urls"]
+    assert isinstance(urls, list)
+    assert "https://github.com/owner/repo/issues/101" in urls
     assert "https://github.com/owner/repo/issues/101" in (tmp_path / "oos-issues-created.md").read_text(encoding="utf-8")
 
 


### PR DESCRIPTION
Fixes #7276

Replace OOS in-package `cli.py` re-entry with frozen typed result APIs for parsing, issue creation, blocked-by mutation, and cleanup. Keep CLI KV emission at the command boundary and retain the external Codex combine subprocess.

Validation:
- `make py-lint`
- focused issue/OOS/redaction tests
- `make py-test` running locally