### PR TITLE
Release v53.1.6

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "53.1.5",
+  "version": "53.1.6",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Added

- `learn-from-bugs`: added host integration, size-budget control, and cheaper-alternative proposal contract with prevent-guideline support (#7339)
- Unified KEY=value env codec with Bash funnel for contract normalization (#7344)
- Markdown-heading-fence-state migrated to bug-treadmill lint engine (#7360)
- `/learn-from-bugs` state publication moved behind `python/cli.py` command (#7363)
- Bash-linter fence scanners ported onto the Python lint engine (#7371)

## Changed

- Bootstrap split into typed API foundations (#7342), report layer (#7348), and agent/calibration/git layer (#7349)
- Bootstrap refactored to typed APIs (#7362)
- Final-report write parity and Makefile targets added (#7350)
- Read-only review launchers migrated to Python (#7351)
- CI and implementation launchers migrated to Python (#7369)
- `/design` terminal output now preserves Review Phase Detail Gantt charts (#7357)
- `/implement` deferred plan work completed (#7358, #7368)
- `/design` split-child failure recovery added (#7345)
- Review tally cluster unified under contract-unification (#7361)
- Design publish cluster unified under contract-unification (#7365)
- Issue and OOS cluster unified under contract-unification (#7372)

## Fixed

- `/implement` coder no longer produces incomplete work that cannot be retried (#7346)
- Round 2 review panel no longer collapses to one reviewer when floor pruning removes productive Cursor slots with mixed rejection rates (#7354)
- Lint-fix self-edit in Step 3 commit is now staged correctly so Step 4.r rebase does not stall (#7359)
- Waterfall-dropped reviewer slots and aggregator insufficient-input events now log to `execution-issues.md` (#7364)
