### PR TITLE
Release v53.1.7

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "53.1.6",
+  "version": "53.1.7",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Added
- Added `lint-module-manifest` lint rule with seeded manifest, engine rule, registration, targets, and docs (#7377).

## Changed
- Completed deferred plan steps from a prior `/implement` run (#7367).

## Fixed
- Prevented CI type-check oscillation between pylint C0123 and pyright `reportUnnecessaryIsInstance` (#7375).
- Hardened evidence scan paths in `/analyze-bugs` (#7376).
