### PR TITLE
Fixes #7380: default Tier A report context

### DIFF
--- a/python/larch/state/_report.py
+++ b/python/larch/state/_report.py
@@ -792,7 +792,7 @@ def dedup_tier_a_report(args: argparse.Namespace) -> int:
                 return 1
             slice_file.write_text("", encoding="utf-8")
     context_file_str = getattr(args, "context_file", "") or ""
-    ctx = Path(context_file_str) if context_file_str else None
+    ctx = Path(context_file_str) if context_file_str else tmpdir / "session-env.sh"
     run_id = _read_run_id(tmpdir=tmpdir, session_env_file=ctx)
     authorized, auth_reason = _session_env_report.check_live_mutation_auth(
         context_file=ctx,

--- a/python/skill-closure-baseline.json
+++ b/python/skill-closure-baseline.json
@@ -41,8 +41,8 @@
     "closure_content_estimated_tokens": 48450,
     "closure_estimated_tokens": 48573,
     "closure_lines": 1371,
-    "conditional_content_estimated_tokens": 18009,
-    "conditional_estimated_tokens": 18054,
+    "conditional_content_estimated_tokens": 18051,
+    "conditional_estimated_tokens": 18097,
     "conditional_files": [
       "skills/implement/references/extracted-script-registry.md",
       "skills/implement/references/bootstrap-recovery.md",

--- a/python/tests/state/test_stall_recovery.py
+++ b/python/tests/state/test_stall_recovery.py
@@ -2562,7 +2562,6 @@ def test_dedup_tier_a_report_normalizes_helper_output(
     rc = stall_recovery.dedup_tier_a_report_main([
         "--implement-tmpdir", str(tmp_path),
         "--body-file", str(body_file),
-        "--context-file", str(ctx),
     ])
 
     assert rc == 0
@@ -3207,8 +3206,8 @@ def test_classify_generic_publish_tail_without_plan_write_stays_unrecoverable(
     assert "RESUME_HINT=none" in out
 
 
-def test_dedup_tier_a_report_refuses_without_context(tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch) -> None:
-    """dedup-tier-a-report must refuse when no valid context is provided."""
+def test_dedup_tier_a_report_refuses_without_authorized_session(tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch) -> None:
+    """dedup-tier-a-report must refuse when its default session context is invalid."""
     monkeypatch.delenv(config.LIVE_MUTATION_TEST_DENY_KEY, raising=False)
     body = tmp_path / "issue-input.md"
     _ = body.write_text("### [Bug] test\nbody text\n", encoding="utf-8")

--- a/skills/implement/references/stall-recovery.md
+++ b/skills/implement/references/stall-recovery.md
@@ -98,7 +98,7 @@ Tier A keeps the current `/larch:issue` filing target:
 
 1. Compose `issue-input` and treat compose output as artifact metadata only.
 2. If dry-run is active, skip dedup and `/larch:issue`, then write the terminal sentinel with `STALL_RECOVERY_REPORT_STATUS=dry-run`.
-3. Run `python3 "$CLAUDE_PLUGIN_ROOT/python/cli.py" stall-recovery dedup-tier-a-report`.
+3. Run `python3 "$CLAUDE_PLUGIN_ROOT/python/cli.py" stall-recovery dedup-tier-a-report`. It defaults its mutation context to `$IMPLEMENT_TMPDIR/session-env.sh`; an explicit `--context-file` remains available for a trusted file in that same session directory.
 4. Branch only on `STALL_RECOVERY_REPORT_STATUS`.
 5. On `dedup-comment`, skip `/larch:issue`.
 6. On `no-match` or `lookup-failed-open`, call `/larch:issue --input-file ... --no-dedup`.


### PR DESCRIPTION
Fixes #7380.

Defaults `dedup-tier-a-report` to the authenticated session context documented for Tier A recovery while retaining fail-closed authorization.

Checks:
- `python3 -m pytest -q python/tests/state/test_stall_recovery.py`
- scoped Ruff and Pyright
- scoped markdownlint