### PR TITLE
Fixes #7379: commit regenerated Step 3 baseline

### DIFF
--- a/python/larch/implement/dispatch_commit_route.py
+++ b/python/larch/implement/dispatch_commit_route.py
@@ -1241,7 +1241,14 @@ def _step4_pathspec_with_step3_self_edits(
         and record.path in dirty_paths
         and not Path(record.path).is_absolute()
         and ".." not in Path(record.path).parts
-        and file_sha256(repo_root, record.path) == record.post_sha256
+        # A green Step 3 re-entry may regenerate a known generated file after
+        # lint-fix recorded its digest. The configured allowlist is the
+        # independent evidence that this stale digest remains safe to absorb;
+        # all other paths still require an exact attribution digest.
+        and (
+            file_sha256(repo_root, record.path) == record.post_sha256
+            or record.path in config.REBASE_AUTORESOLVE_GENERATED_FILES
+        )
     }
     paths = sorted(set(_read_nul_pathspec(pathspec)) | self_edit_paths)
     if not self_edit_paths:

--- a/python/tests/implement/test_implement_dispatch.py
+++ b/python/tests/implement/test_implement_dispatch.py
@@ -5147,6 +5147,79 @@ def test_run_step4_commit_leg_absorbs_attributed_step3_lint_fix_path(
     )
 
 
+def test_run_step4_commit_leg_absorbs_regenerated_allowlisted_step3_lint_fix_path(
+    repo: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    impl = make_implement_tmpdir(tmp_path)
+    baseline = repo / "python" / "skill-closure-baseline.json"
+    baseline.parent.mkdir()
+    baseline.write_text('{"revision": 0}\n', encoding="utf-8")
+    _git(repo, "add", str(baseline.relative_to(repo)))
+    _git(repo, "commit", "-m", "add skill closure baseline")
+    baseline.write_text('{"revision": 1}\n', encoding="utf-8")
+    _ = self_edit_log.record_self_edits(
+        tmpdir=impl,
+        source="lint-fix:step3",
+        paths=[str(baseline.relative_to(repo))],
+        repo_root=repo,
+    )
+    # A second Step 3 checks entry regenerates the baseline after lint-fix
+    # recorded its first digest.
+    baseline.write_text('{"revision": 2}\n', encoding="utf-8")
+    (impl / "implementation-commit-message.txt").write_text("Implement thing\n", encoding="utf-8")
+    (impl / "implementation-commit-paths.nul").write_bytes(b"README.md\0")
+    calls: list[list[str]] = []
+
+    def fake_run_leg(*, argv: Sequence[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append(list(argv))
+        return subprocess.CompletedProcess(list(argv), 0, "COMMITTED=true\nSHA=abc\n", "")
+
+    monkeypatch.setattr(implement_dispatch, "_run_leg_with_timeout", fake_run_leg)  # lint-monkeypatch-binding: ok both re-export facades are patched for this regression
+    monkeypatch.setattr(dispatch_commit_route, "_run_leg_with_timeout", fake_run_leg)  # lint-monkeypatch-binding: ok both re-export facades are patched for this regression
+
+    outcome, stdout = dispatch_commit_route._run_step4_commit_leg(impl, deadline_ms=123)
+
+    assert outcome == "continue"
+    assert "COMMIT_ROUTE_OUTCOME=continue\n" in stdout
+    assert calls[0][-2] == str(impl / "step4-commit-paths.nul")
+    assert (impl / "step4-commit-paths.nul").read_bytes() == (
+        b"README.md\0python/skill-closure-baseline.json\0"
+    )
+
+
+def test_step4_pathspec_excludes_stale_unallowlisted_self_edit(
+    repo: Path,
+    tmp_path: Path,
+) -> None:
+    impl = make_implement_tmpdir(tmp_path)
+    path = repo / "python" / "suppression-reason-baseline.json"
+    path.parent.mkdir()
+    path.write_text('{"revision": 0}\n', encoding="utf-8")
+    _git(repo, "add", str(path.relative_to(repo)))
+    _git(repo, "commit", "-m", "add ordinary baseline")
+    path.write_text('{"revision": 1}\n', encoding="utf-8")
+    _ = self_edit_log.record_self_edits(
+        tmpdir=impl,
+        source="lint-fix:step3",
+        paths=[str(path.relative_to(repo))],
+        repo_root=repo,
+    )
+    path.write_text('{"revision": 2}\n', encoding="utf-8")
+    pathspec = impl / "implementation-commit-paths.nul"
+    pathspec.write_bytes(b"README.md\0")
+
+    refreshed, refresh_ok = dispatch_commit_route._step4_pathspec_with_step3_self_edits(
+        implement_tmpdir=impl,
+        pathspec=pathspec,
+        repo_root=repo,
+    )
+
+    assert refresh_ok is True
+    assert refreshed == pathspec
+
+
 def test_run_step4_commit_leg_failure_seeds_step4_stall(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Closes #7379.\n\nIncludes regression coverage for a second regeneration and the non-allowlisted safety boundary.