### PR TITLE
Release v53.1.8

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "53.1.7",
+  "version": "53.1.8",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Fixed

- Migrate checks repair-loop to site-qualified background job launch so the foreground path no longer times out the Bash tool and leaves the orchestrator without `NEXT_ACTION` output. (#7382)
- Default the session context for the Tier A stall-recovery dedup report when the context is absent. (#7383)
- Include the regenerated lint-fix skill-closure baseline in the Step 4 commit so Step 4.r rebase is no longer blocked. (#7384)
