### PR TITLE
Fixes #7391: Resolve transient execution issues

### DIFF
--- a/python/larch/issue/execution_issues.py
+++ b/python/larch/issue/execution_issues.py
@@ -22,10 +22,12 @@ from larch.report.run_log_batch import (
     _EXECUTION_ISSUE_CATEGORIES,  # pyright: ignore[reportPrivateUsage]  # shared writer uses the canonical category set.
     _normalize_body_for_hash,  # pyright: ignore[reportPrivateUsage]  # shared writer preserves the established hash grammar.
     _redact_batch_payload,  # pyright: ignore[reportPrivateUsage]  # shared writer uses the existing fail-closed redaction path.
+    execution_issue_identity,
 )
 
 VALIDATION_FAILED_RC = 2
 _WARNINGS_CATEGORY = "Warnings"
+_RESOLUTION_EVENT = "resolved"
 
 
 def emit_kv( *,key: str, value: object) -> None:
@@ -42,6 +44,39 @@ def sha256_file(path: str | Path) -> str:
 
 def normalize_body_for_hash(text: str) -> str:
     return _normalize_body_for_hash(text)
+
+
+def execution_issue_id(*, category: str, body: str) -> str:
+    """Return the stable identity used by append and resolution ledger records."""
+    return execution_issue_identity(category=category, body=body)
+
+
+def execution_issue_resolution_record(*, category: str, entry: str, resolution: str) -> str:
+    """Serialize an append-only resolution event for an execution-issue record."""
+    return json.dumps({
+        "event": _RESOLUTION_EVENT,
+        "issue_ids": [execution_issue_id(category=category, body=entry)],
+        "resolution": resolution,
+    }, separators=(",", ":"), sort_keys=True)
+
+
+def execution_issue_batch_has_resolution(*, batch_text: str, category: str, entry: str) -> bool:
+    """Whether the ledger already records this entry as resolved."""
+    issue_id = execution_issue_id(category=category, body=entry)
+    for raw in batch_text.splitlines():
+        try:
+            row: object = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(row, dict):
+            continue
+        row_dict = cast("dict[str, object]", row)
+        if row_dict.get("event") != _RESOLUTION_EVENT:
+            continue
+        issue_ids = row_dict.get("issue_ids")
+        if isinstance(issue_ids, list) and issue_id in issue_ids:
+            return True
+    return False
 
 
 def _is_fence(line: str) -> bool:
@@ -365,6 +400,27 @@ def append_execution_issue(log: Path, *, category: str, entry: str) -> None:
         text = "\n".join(lines).rstrip() + "\n"
     log.parent.mkdir(parents=True, exist_ok=True)
     log.write_text(text, encoding="utf-8")
+
+
+def resolve_execution_issue(log: Path, *, entry: str) -> bool:
+    """Remove an open entry from the mutable log after its durable resolution.
+
+    Committed batches remain append-only: callers first append
+    :func:`execution_issue_resolution_record`, then use this helper to prevent a
+    still-live copy from being merged back into the final report.
+    """
+    if log.is_symlink() or (log.exists() and not log.is_file()):
+        raise OSError(f"refusing to resolve through non-regular log file: {log}")
+    if not log.is_file():
+        return False
+    lines = log.read_text(encoding="utf-8").splitlines()
+    try:
+        lines.remove(entry)
+    except ValueError:
+        return False
+    text = "\n".join(lines).rstrip() + "\n"
+    log.write_text(text, encoding="utf-8")
+    return True
 
 
 def append_execution_issue_main(argv: list[str] | None = None) -> int:

--- a/python/larch/report/exec_issue_detail.py
+++ b/python/larch/report/exec_issue_detail.py
@@ -15,6 +15,7 @@ from typing import cast
 from larch.core import config
 from larch.core import proc
 from larch.core import redact
+from larch.report.run_log_batch import execution_issue_identity
 
 EXEC_CATEGORIES = frozenset({"Tool Failures", "External Reviewer Issues"})
 WARN_CATEGORY = "Warnings"
@@ -237,9 +238,35 @@ def structured_body_dedupe_keys(body: str, category: str) -> set[str]:
 
 
 def _parse_ndjson_structured_rows(rows: list[dict[str, object]]) -> IssueDetailGroups:
+    active_rows: list[dict[str, object]] = []
+    for source_row in rows:
+        if source_row.get("event") == "resolved":
+            issue_ids = source_row.get("issue_ids")
+            if isinstance(issue_ids, list):
+                resolved: set[str] = set()
+                issue_id_items = cast("list[object]", issue_ids)
+                for issue_id_obj in issue_id_items:
+                    if isinstance(issue_id_obj, str):
+                        resolved.add(issue_id_obj)
+                active_rows = [
+                    active_row
+                    for active_row in active_rows
+                    if active_row.get("issue_id") not in resolved
+                ]
+            continue
+        category_obj = source_row.get("category")
+        body_obj = source_row.get("body")
+        active_row = source_row
+        if isinstance(category_obj, str) and isinstance(body_obj, str) and not isinstance(source_row.get("issue_id"), str):
+            active_row = {
+                **source_row,
+                "issue_id": execution_issue_identity(category=category_obj, body=body_obj),
+            }
+        active_rows.append(active_row)
+
     exec_events: list[IssueEvent] = []
     warn_events: list[IssueEvent] = []
-    for row in rows:
+    for row in active_rows:
         category_obj = row.get("category")
         body_obj = row.get("body")
         category = category_obj if isinstance(category_obj, str) else ""
@@ -269,9 +296,12 @@ def _parse_ndjson_legacy(path: Path) -> LoadResult:
             parsed.append(None)
     dict_rows = [cast("dict[str, object]", row) for row in parsed if isinstance(row, dict)]
     all_dicts = bool(parsed) and len(dict_rows) == len(parsed)
-    all_categorized = bool(dict_rows) and all(isinstance(row.get("category"), str) for row in dict_rows)
-    structured_rows = [row for row in dict_rows if isinstance(row.get("category"), str)]
-    if all_dicts and all_categorized:
+    def is_structured(row: dict[str, object]) -> bool:
+        return isinstance(row.get("category"), str) or row.get("event") == "resolved"
+
+    all_structured = bool(dict_rows) and all(is_structured(row) for row in dict_rows)
+    structured_rows = [row for row in dict_rows if is_structured(row)]
+    if all_dicts and all_structured:
         return LoadResult(_parse_ndjson_structured_rows(dict_rows), listing_degraded=False)
 
     body_parts = [

--- a/python/larch/report/final_report.py
+++ b/python/larch/report/final_report.py
@@ -11,6 +11,7 @@ import os
 import re
 import subprocess
 import sys
+import tempfile
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import cast
@@ -875,18 +876,103 @@ def _append_needs_user_execution_issue(
         )
 
 
-def _prime_needs_user_execution_issue(implement_tmpdir: Path, *, outcome: str) -> tuple[str, str]:
+def _resolve_needs_user_execution_issue(
+    implement_tmpdir: Path,
+    *,
+    run_dir: Path,
+    reason: str,
+    next_action: str,
+) -> str:
+    """Record a durable resolution before removing the live needs-user entry."""
+    pending = f"; pending NEXT_ACTION={next_action}" if next_action else ""
+    entry = f"- ship route: merge and CI watch skipped — needs user (reason: {reason}{pending})"
+    batch_path = run_dir / "execution-issues.ndjson"
+    if batch_path.is_file():
+        try:
+            batch_text = batch_path.read_text(encoding="utf-8", errors="replace")
+            if not execution_issues.execution_issue_batch_has_resolution(
+                batch_text=batch_text, category="Tool Failures", entry=entry,
+            ):
+                record = execution_issues.execution_issue_resolution_record(
+                    category="Tool Failures", entry=entry, resolution="merge-completed",
+                )
+                with tempfile.NamedTemporaryFile(
+                    "w", delete=False, dir=run_dir, encoding="utf-8",
+                ) as handle:
+                    record_path = Path(handle.name)
+                    _ = handle.write(record + "\n")
+                try:
+                    # Function-scoped import avoids the run-log flush import cycle.
+                    from larch.report import run_logs  # noqa: PLC0415 - local import avoids the run-log flush import cycle.
+
+                    append_result = run_logs.log_append(
+                        log_root=implement_tmpdir / "larch-logs",
+                        skill="implement",
+                        run_id=run_dir.name,
+                        batch="execution-issues",
+                        record_file=str(record_path),
+                    )
+                    appended = append_result.path.read_text(encoding="utf-8", errors="replace")
+                    if not execution_issues.execution_issue_batch_has_resolution(
+                        batch_text=appended, category="Tool Failures", entry=entry,
+                    ):
+                        return "execution-issue resolution was not persisted"
+                finally:
+                    record_path.unlink(missing_ok=True)
+        except (OSError, ValueError, json.JSONDecodeError) as exc:
+            return f"execution-issue resolution failed: {exc}"
+    try:
+        execution_issues.resolve_execution_issue(
+            implement_tmpdir / "execution-issues.md", entry=entry,
+        )
+    except OSError as exc:
+        return f"execution-issue live resolution failed: {exc}"
+    return ""
+
+
+def _prime_needs_user_execution_issue(
+    implement_tmpdir: Path,
+    *,
+    outcome: str,
+    run_dir: Path,
+) -> tuple[str, str]:
     """Append the needs-user exec-issues row when the handoff applies (#7074).
 
     Returns ``(reason, next_action)`` (both empty when it does not apply). Callers
     must load the issue counts *after* this so the appended row is counted.
     """
+    resolution_error = _resolve_stale_needs_user_handoff(
+        implement_tmpdir, run_dir=run_dir, outcome=outcome,
+    )
+    if resolution_error:
+        raise ShipError(resolution_error)
     needs_user = _needs_user_ship_handoff(implement_tmpdir, outcome=outcome)
     if needs_user is None:
         return "", ""
     reason, next_action = needs_user
     _append_needs_user_execution_issue(implement_tmpdir, reason=reason, next_action=next_action)
     return reason, next_action
+
+
+def _resolve_stale_needs_user_handoff(
+    implement_tmpdir: Path,
+    *,
+    run_dir: Path,
+    outcome: str,
+) -> str:
+    """Resolve a prior ship handoff once a terminal merge supersedes it."""
+    if outcome not in _MERGE_COMPLETED_OUTCOMES:
+        return ""
+    handoff = implement_tmpdir / ".ship-route-exit-handoff.env"
+    reason = _read_kv(path=handoff, key="NEEDS_USER_REASON")
+    if not reason:
+        return ""
+    return _resolve_needs_user_execution_issue(
+        implement_tmpdir,
+        run_dir=run_dir,
+        reason=reason,
+        next_action=_read_kv(path=handoff, key="NEXT_ACTION"),
+    )
 
 
 def write_final_report(
@@ -932,7 +1018,9 @@ def write_final_report(
     # and CI watch, so it must not render as ✅ DONE. Prime the exec-issues row from
     # the committed handoff *before* loading the issue counts so the row is counted.
     needs_user_reason, needs_user_next_action = _prime_needs_user_execution_issue(
-        implement_tmpdir, outcome=outcome
+        implement_tmpdir,
+        outcome=outcome,
+        run_dir=implement_tmpdir / "larch-logs" / "implement" / run_id,
     )
     run_dir, load_result, exec_count, warn_count = _issue_load_result_for_run(
         implement_tmpdir=implement_tmpdir, run_id=run_id

--- a/python/larch/report/run_log_batch.py
+++ b/python/larch/report/run_log_batch.py
@@ -424,6 +424,11 @@ def _normalize_body_for_hash(body: str) -> str:
     return "\n".join(lines)
 
 
+def execution_issue_identity(*, category: str, body: str) -> str:
+    """Return the stable identity for an execution-issue ledger entry."""
+    return hashlib.sha256(f"{category}\0{_normalize_body_for_hash(body)}".encode()).hexdigest()
+
+
 _APPEND_LOCK_ATTEMPTS = 100
 
 

--- a/python/tests/issue/test_execution_issues.py
+++ b/python/tests/issue/test_execution_issues.py
@@ -93,6 +93,26 @@ def test_append_execution_issue_rejects_symlink_log(tmp_path: Path) -> None:
         execution_issues.append_execution_issue(log, category="Warnings", entry="- warning")
 
 
+def test_resolve_execution_issue_removes_only_the_matching_live_entry(tmp_path: Path) -> None:
+    log = tmp_path / "execution-issues.md"
+    _ = log.write_text("### Tool Failures\n- one\n- two\n", encoding="utf-8")
+
+    assert execution_issues.resolve_execution_issue(log, entry="- one") is True
+    assert execution_issues.resolve_execution_issue(log, entry="- absent") is False
+    assert log.read_text(encoding="utf-8") == "### Tool Failures\n- two\n"
+
+
+def test_execution_issue_resolution_record_uses_the_entry_identity() -> None:
+    record = json.loads(execution_issues.execution_issue_resolution_record(
+        category="Tool Failures", entry="- transient", resolution="recovered",
+    ))
+
+    assert record["event"] == "resolved"
+    assert record["issue_ids"] == [
+        execution_issues.execution_issue_id(category="Tool Failures", body="- transient")
+    ]
+
+
 def test_flush_execution_issues_writes_sentinel_and_clears_log(tmp_path: Path) -> None:
     issue_log = tmp_path / "execution-issues.md"
     _ = issue_log.write_text("### Warnings\n- one\n", encoding="utf-8")

--- a/python/tests/report/test_exec_issue_detail.py
+++ b/python/tests/report/test_exec_issue_detail.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any
 from larch.core import config
 from larch.core.proc import CommandResult
 from larch.report import exec_issue_detail
+from larch.report.run_log_batch import execution_issue_identity
 
 if TYPE_CHECKING:
     import pytest
@@ -27,6 +28,25 @@ def test_parses_markdown_sections_fence_aware_and_ignores_other_sections() -> No
     assert exec_issue_detail.count_issue_groups(groups) == (1, 1)
     assert groups.exec_issues[0].display_text == "lint: drift"
     assert groups.warnings[0].display_text == "plain warning"
+
+
+def test_resolution_event_hides_an_earlier_ndjson_issue_and_keeps_later_recurrence(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    body = "- transient blocker\n  with diagnostic context\n"
+    issue_id = execution_issue_identity(category="Tool Failures", body=body)
+    records = [
+        {"category": "Tool Failures", "body": body},
+        {"event": "resolved", "issue_ids": [issue_id], "resolution": "recovered"},
+        {"category": "Tool Failures", "body": body},
+    ]
+    _ = (run_dir / "execution-issues.ndjson").write_text(
+        "\n".join(json.dumps(record) for record in records) + "\n", encoding="utf-8",
+    )
+
+    result = exec_issue_detail.load_issue_detail_groups(tmp_path, run_dir=run_dir)
+
+    assert exec_issue_detail.count_load_result(result) == (1, 0)
 
 
 def test_section_heading_inside_open_fence_is_boundary() -> None:

--- a/python/tests/report/test_final_report.py
+++ b/python/tests/report/test_final_report.py
@@ -190,6 +190,38 @@ def test_write_final_report_renders_needs_user_from_handoff(tmp_path: Path, monk
     assert "pending NEXT_ACTION=assessments" in summary
 
 
+def test_write_final_report_resolves_persisted_needs_user_handoff_after_merge(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_minimal_state(tmp_path)
+    _stub_cost_and_assessment(monkeypatch)
+    (tmp_path / "ship-pr-state.sh").write_text(
+        "PR_NUMBER=1\nPR_URL=https://github.com/o/r/pull/1\nMERGE_RESULT=merged\n",
+        encoding="utf-8",
+    )
+    (tmp_path / ".ship-route-exit-handoff.env").write_text(
+        "NEEDS_USER_REASON=architectural-assessments\nNEXT_ACTION=assessments\n",
+        encoding="utf-8",
+    )
+    entry = "- ship route: merge and CI watch skipped — needs user (reason: architectural-assessments; pending NEXT_ACTION=assessments)"
+    issue_id = final_report.execution_issues.execution_issue_id(category="Tool Failures", body=entry)
+    run_dir = tmp_path / "larch-logs" / "implement" / "run1"
+    run_dir.mkdir(parents=True)
+    _ = (run_dir / "execution-issues.ndjson").write_text(
+        json.dumps({"category": "Tool Failures", "body": entry + "\n", "issue_id": issue_id}) + "\n",
+        encoding="utf-8",
+    )
+
+    rc, _url, err = final_report.write_final_report(tmp_path, comment_only=True)
+
+    assert (rc, err) == (0, "")
+    summary = (tmp_path / "summary-final.md").read_text(encoding="utf-8")
+    assert "merge and CI watch skipped" not in summary
+    records = [json.loads(line) for line in (run_dir / "execution-issues.ndjson").read_text(encoding="utf-8").splitlines()]
+    assert records[-1]["event"] == "resolved"
+
+
 def test_write_final_report_no_handoff_keeps_normal_outcome(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
     _write_minimal_state(tmp_path)
     _stub_cost_and_assessment(monkeypatch)


### PR DESCRIPTION
## Summary

- model resolved execution issues as append-only ledger events
- resolve stale needs-user ship handoffs when their PR is merged
- hide resolved entries while preserving historical run-log evidence

## Validation

- `python3 -m pytest python/tests/issue/test_execution_issues.py python/tests/report/test_exec_issue_detail.py python/tests/report/test_final_report.py`
- `make py-lint FILES=…`

Fixes #7391