### PR TITLE
[DONE] Fixes #7403: preserve issue title prefixes

### DIFF
--- a/python/larch/issue/tracking_issue.py
+++ b/python/larch/issue/tracking_issue.py
@@ -378,9 +378,8 @@ def rename_with_details(
     _validate_tracking_state(state)
     target_prefix = config.TRACKING_ISSUE_PREFIX_BY_STATE[state]
     raw_tail = strip_lifecycle_prefix(current_title)
-    prospective = _truncate_with_prefix(prefix=target_prefix, tail=raw_tail)
-    redacted_prospective = _redact_compose(prospective, context="tracking-issue title")
-    new_title = _truncate_with_prefix(prefix=target_prefix, tail=strip_lifecycle_prefix(redacted_prospective))
+    redacted_tail = _redact_compose(raw_tail, context="tracking-issue title")
+    new_title = _truncate_with_prefix(prefix=target_prefix, tail=redacted_tail)
 
     current_redacted = _redact_compose(current_title, context="tracking-issue title")
     current_prefix = _detect_lifecycle_prefix(current_redacted)

--- a/python/tests/issue/test_tracking_issue.py
+++ b/python/tests/issue/test_tracking_issue.py
@@ -160,6 +160,23 @@ def test_rename_strips_legacy_prefix() -> None:
     assert "[IN PROGRESS]" not in new
 
 
+@pytest.mark.parametrize("current_title", ["[BUG] My feature", "[DESIGNED] [BUG] My feature"])
+def test_rename_prepends_lifecycle_prefix_without_stripping_bug_prefix(
+    current_title: str,
+) -> None:
+    runner = RecordingRunner()
+    new = tracking_issue.rename(
+        runner,
+        "1",
+        "implementing",
+        repo="o/r",
+        current_title=current_title,
+    )
+    assert new == "[IMPLEMENTING] [BUG] My feature"
+    title_index = runner.calls[-1].index("--title") + 1
+    assert runner.calls[-1][title_index] == new
+
+
 def test_append_comment_rejects_invalid_lifecycle_marker() -> None:
     runner = RecordingRunner()
     with pytest.raises(ShipError, match="invalid lifecycle marker"):


### PR DESCRIPTION
Preserves non-lifecycle title signals such as `[BUG]` when lifecycle state changes.

Verification:
- `PYTHONPATH=python python3 -m pytest -q python/tests/issue/test_tracking_issue.py`
- `python3 -m ruff check python/larch/issue/tracking_issue.py python/tests/issue/test_tracking_issue.py`
- `pyright python/larch/issue/tracking_issue.py python/tests/issue/test_tracking_issue.py`

Closes #7403