### PR TITLE
Fixes #7415: Preserve bug prefix on triage replacements

### DIFF
--- a/python/tests/skills/test_skill_structure.py
+++ b/python/tests/skills/test_skill_structure.py
@@ -225,6 +225,15 @@ def test_design_structure_pin(pin: StructurePin) -> None:
     evaluate_pin(pin)
 
 
+def test_triage_close_replacement_bug_prefix_contract() -> None:
+    text = _read_text("skills/triage/SKILL.md")
+    assert (
+        'For every replacement call, pass `--title-prefix "[BUG] [TRIAGED]"`'
+        in text
+    )
+    assert "from a non-bug or a `valid` verdict" in text
+
+
 def _run_specialized(skill: str) -> list[str]:
     mod_name = SPECIALIZED_MODULES[skill]
     mod = importlib.import_module(f".{mod_name}", package=__package__)

--- a/skills/triage/SKILL.md
+++ b/skills/triage/SKILL.md
@@ -168,6 +168,8 @@ Require `SUCCESS=true`, `RELATION_VERIFIED=true`, the exact requested blocked-by
 
 File follow-ups only through `/issue ... --operator-invoked`, never for public security findings. Invoke `/issue` via the Skill tool. Before each call, repeat the second security gate. Pass a caller sentinel path under `$TRIAGE_TMPDIR`.
 
+Preserve bug status when a close verdict replaces a bug with follow-ups: derive this only from the original Step 1 title, after removing any lifecycle prefix. For every replacement call, pass `--title-prefix "[BUG] [TRIAGED]"` and give `/issue` an untagged title. Do not use this prefix for follow-ups from a non-bug or a `valid` verdict.
+
 > **Continue after child returns.** When `/issue` returns, execute the counter and sentinel checks below; do NOT end the turn or summarize. → shared/subskill-invocation.md#anti-halt
 
 Parse `ISSUES_CREATED`, `ISSUES_FAILED`, `ISSUES_DEDUPLICATED`, and every per-issue result key. Then run:


### PR DESCRIPTION
Fixes #7415.

When a close verdict replaces a bug with follow-up issues, triage now forwards the `[BUG] [TRIAGED]` title prefix to every replacement issue.

Tests:
- `python3 -m pytest python/tests/skills/test_skill_structure.py -q`
- `pre-commit run --files skills/triage/SKILL.md python/tests/skills/test_skill_structure.py`