### PR TITLE
Fixes #7411: Require suppression reasons in implementer prompts

### DIFF
--- a/agents/_implementer-base.md
+++ b/agents/_implementer-base.md
@@ -46,6 +46,8 @@ Preventive checks, not hard guards:
 
 ## Runtime type validation
 
+Follow G-Py-11: every lint or type suppression needs an inline reason. Use `# type: ignore[code]  # reason`, `# noqa: CODE - reason`, or `# pylint: disable=check  # reason`; bare suppressions fail architectural review.
+
 Treat a declared type as the contract for internal values. Do not add a runtime type check after a type annotation and surrounding guards already narrow the value; remove the check instead. Add validation only at an untyped or untrusted boundary where it enforces a runtime property the annotation alone cannot.
 
 When exact-type validation is genuinely required, such as rejecting `bool` or subclasses for an `int` input, use `type(value) is not int` with `# pylint: disable=unidiomatic-typecheck  # exact runtime type rejects bool and subclasses`. When `isinstance()` remains necessary at a dynamic boundary but pyright cannot see that boundary, use `# type: ignore[reportUnnecessaryIsInstance]  # runtime value originates outside the typed boundary`. Do not add both suppressions or suppress a check that can be omitted. See `docs/linting.md#runtime-type-validation` before introducing either form.

--- a/agents/codex-implementer.md
+++ b/agents/codex-implementer.md
@@ -67,6 +67,8 @@ Preventive checks, not hard guards:
 
 ## Runtime type validation
 
+Follow G-Py-11: every lint or type suppression needs an inline reason. Use `# type: ignore[code]  # reason`, `# noqa: CODE - reason`, or `# pylint: disable=check  # reason`; bare suppressions fail architectural review.
+
 Treat a declared type as the contract for internal values. Do not add a runtime type check after a type annotation and surrounding guards already narrow the value; remove the check instead. Add validation only at an untyped or untrusted boundary where it enforces a runtime property the annotation alone cannot.
 
 When exact-type validation is genuinely required, such as rejecting `bool` or subclasses for an `int` input, use `type(value) is not int` with `# pylint: disable=unidiomatic-typecheck  # exact runtime type rejects bool and subclasses`. When `isinstance()` remains necessary at a dynamic boundary but pyright cannot see that boundary, use `# type: ignore[reportUnnecessaryIsInstance]  # runtime value originates outside the typed boundary`. Do not add both suppressions or suppress a check that can be omitted. See `docs/linting.md#runtime-type-validation` before introducing either form.

--- a/agents/cursor-implementer.md
+++ b/agents/cursor-implementer.md
@@ -73,6 +73,8 @@ Preventive checks, not hard guards:
 
 ## Runtime type validation
 
+Follow G-Py-11: every lint or type suppression needs an inline reason. Use `# type: ignore[code]  # reason`, `# noqa: CODE - reason`, or `# pylint: disable=check  # reason`; bare suppressions fail architectural review.
+
 Treat a declared type as the contract for internal values. Do not add a runtime type check after a type annotation and surrounding guards already narrow the value; remove the check instead. Add validation only at an untyped or untrusted boundary where it enforces a runtime property the annotation alone cannot.
 
 When exact-type validation is genuinely required, such as rejecting `bool` or subclasses for an `int` input, use `type(value) is not int` with `# pylint: disable=unidiomatic-typecheck  # exact runtime type rejects bool and subclasses`. When `isinstance()` remains necessary at a dynamic boundary but pyright cannot see that boundary, use `# type: ignore[reportUnnecessaryIsInstance]  # runtime value originates outside the typed boundary`. Do not add both suppressions or suppress a check that can be omitted. See `docs/linting.md#runtime-type-validation` before introducing either form.

--- a/python/skill-closure-baseline.json
+++ b/python/skill-closure-baseline.json
@@ -72,9 +72,9 @@
     "skill_md_lines": 879
   },
   {
-    "closure_content_estimated_tokens": 58334,
-    "closure_estimated_tokens": 58570,
-    "closure_lines": 3068,
+    "closure_content_estimated_tokens": 58498,
+    "closure_estimated_tokens": 58735,
+    "closure_lines": 3074,
     "conditional_content_estimated_tokens": 0,
     "conditional_estimated_tokens": 0,
     "conditional_files": [],

--- a/scripts/test-prompt-template-invariants.sh
+++ b/scripts/test-prompt-template-invariants.sh
@@ -275,6 +275,12 @@ assert_contains "cursor implementer PLR0911 checklist" \
     'PLR0911 is enforced; when a function is near the return limit' "$REPO_ROOT/agents/cursor-implementer.md"
 assert_contains "implementer base runtime type-validation guidance" \
     'Treat a declared type as the contract for internal values.' "$REPO_ROOT/agents/_implementer-base.md"
+assert_contains "implementer base G-Py-11 suppression guidance" \
+    'Follow G-Py-11: every lint or type suppression needs an inline reason.' "$REPO_ROOT/agents/_implementer-base.md"
+assert_contains "codex implementer G-Py-11 suppression guidance" \
+    'Follow G-Py-11: every lint or type suppression needs an inline reason.' "$REPO_ROOT/agents/codex-implementer.md"
+assert_contains "cursor implementer G-Py-11 suppression guidance" \
+    'Follow G-Py-11: every lint or type suppression needs an inline reason.' "$REPO_ROOT/agents/cursor-implementer.md"
 assert_contains "cursor implementer pylint type-check suppression guidance" \
     'pylint: disable=unidiomatic-typecheck' "$REPO_ROOT/agents/cursor-implementer.md"
 assert_contains "cursor implementer pyright type-check suppression guidance" \


### PR DESCRIPTION
## Summary

- Add explicit G-Py-11 inline-reason guidance to the shared implementer prompt.
- Regenerate the Codex and Cursor implementer prompts.
- Cover the source and generated prompts in the template-invariant harness.

## Verification

- `python3 python/cli.py generate codex-implementer --check`
- `python3 python/cli.py generate cursor-implementer --check`
- `make test-prompt-template-invariants`
- `pre-commit run --files agents/_implementer-base.md agents/codex-implementer.md agents/cursor-implementer.md scripts/test-prompt-template-invariants.sh`
- `python3 -m pytest python/tests/lint/test_lint_skill_closure_growth.py -q`
- `python3 python/cli.py lint skill-closure-growth`

Fixes #7411
