### PR TITLE
Fix required unreachable-branch baseline handling

### DIFF
--- a/python/larch/lint/engine.py
+++ b/python/larch/lint/engine.py
@@ -173,6 +173,7 @@ class LintRule:
     occurrence_baseline: bool = False
     stale_baseline_on_clean_scan: bool = False
     occurrence_pattern_field: OccurrencePatternField = "pattern_name"
+    require_baseline: bool = False
 
 
 def _is_single_line(value: object) -> bool:
@@ -196,6 +197,8 @@ def _validate_rule(rule: LintRule) -> None:  # noqa: C901, PLR0912 - rule field 
         raise ScanError("lint rule allow_inline_suppression must be a bool")
     if not _is_exact_bool(rule.occurrence_baseline):
         raise ScanError("lint rule occurrence_baseline must be a bool")
+    if not _is_exact_bool(rule.require_baseline):
+        raise ScanError("lint rule require_baseline must be a bool")
     if not _is_exact_bool(rule.stale_baseline_on_clean_scan):
         raise ScanError("lint rule stale_baseline_on_clean_scan must be a bool")
     if rule.occurrence_pattern_field not in ("pattern_name", "normalized_condition"):
@@ -1390,7 +1393,8 @@ def run_rule(  # noqa: C901, PLR0912, PLR0913 - public API preserves direct keyw
     With no baseline options this preserves the scan-only contract. Baseline
     checks return ``0`` for fully baselined findings, ``1`` for new or grown
     findings, and ``2`` for invalid state, strict stale rows, or I/O failures.
-    Occurrence baselines may be absent when the live scan is clean.
+    Occurrence baselines may be absent when the live scan is clean unless the
+    rule requires a baseline.
     """
     try:
         _validate_baseline_options(
@@ -1423,7 +1427,7 @@ def run_rule(  # noqa: C901, PLR0912, PLR0913 - public API preserves direct keyw
                         "rule.occurrence_baseline"
                     )
             elif not write_baseline:
-                if rule.occurrence_baseline:
+                if rule.occurrence_baseline and not rule.require_baseline:
                     baseline_absent = True
                 else:
                     raise ScanError(

--- a/python/larch/lint/lint_unreachable_branch.py
+++ b/python/larch/lint/lint_unreachable_branch.py
@@ -75,6 +75,7 @@ RULE = LintRule(
     pathspecs=PATHSPECS,
     source_filter=is_production_source_path,
     occurrence_baseline=True,
+    require_baseline=True,
     stale_baseline_on_clean_scan=False,
     occurrence_pattern_field="normalized_condition",
 )

--- a/python/tests/lint/test_lint_engine.py
+++ b/python/tests/lint/test_lint_engine.py
@@ -106,6 +106,7 @@ def _rule(
     pathspecs: tuple[str, ...] | None = None,
     source_filter: Callable[[str], bool] | None = None,
     occurrence_baseline: bool = False,
+    require_baseline: bool = False,
     stale_baseline_on_clean_scan: bool = False,
     occurrence_pattern_field: str = "pattern_name",
 ) -> LintRule:
@@ -129,6 +130,7 @@ def _rule(
         pathspecs=pathspecs,
         source_filter=source_filter,
         occurrence_baseline=occurrence_baseline,
+        require_baseline=require_baseline,
         stale_baseline_on_clean_scan=stale_baseline_on_clean_scan,
         occurrence_pattern_field=occurrence_pattern_field,  # type: ignore[arg-type]  # str literal narrower than OccurrencePatternField; test helper widens to str
     )
@@ -782,6 +784,15 @@ def test_allow_inline_suppression_rejects_non_bool(tmp_path: Path) -> None:
     assert code == EXIT_ERROR
     assert out == ""
     assert "allow_inline_suppression" in err
+
+
+def test_require_baseline_rejects_non_bool(tmp_path: Path) -> None:
+    rule = _occurrence_rule()
+    object.__setattr__(rule, "require_baseline", 1)  # type: ignore[misc]
+    code, out, err = _invoke(rule, tmp_path, _git_ok_runner(tmp_path, []))
+    assert code == EXIT_ERROR
+    assert out == ""
+    assert "require_baseline" in err
 
 
 def test_detector_and_config_validation(tmp_path: Path) -> None:
@@ -2195,6 +2206,41 @@ def test_occurrence_absent_baseline_clean_and_live(tmp_path: Path) -> None:
     assert code2 == EXIT_ERROR
     assert out2 == ""
     assert "required baseline missing" in err2
+
+
+def test_required_occurrence_baseline_rejects_missing_file_before_clean_scan(
+    tmp_path: Path,
+) -> None:
+    _write_files(tmp_path, {"python/larch/mod.py": "x = 1\n"})
+    baseline = tmp_path / "python" / "missing.json"
+    rule = _occurrence_rule(
+        detect=lambda _source: [],
+        require_baseline=True,
+    )
+
+    code, out, err = _invoke(
+        rule,
+        tmp_path,
+        _git_ok_runner(tmp_path, ["python/larch/mod.py"]),
+        baseline_path=baseline,
+    )
+
+    assert code == EXIT_ERROR
+    assert out == ""
+    assert f"failed to read baseline {baseline}: file does not exist" in err
+
+    write_code, write_out, write_err = _invoke(
+        rule,
+        tmp_path,
+        _git_ok_runner(tmp_path, ["python/larch/mod.py"]),
+        baseline_path=baseline,
+        write_baseline=True,
+    )
+
+    assert write_code == EXIT_CLEAN
+    assert write_out == ""
+    assert write_err == ""
+    assert baseline.read_text(encoding="utf-8") == "[]\n"
 
 
 def test_pathspecs_and_source_filter_exclude_before_load(tmp_path: Path) -> None:

--- a/python/tests/lint/test_lint_engine.py
+++ b/python/tests/lint/test_lint_engine.py
@@ -2213,8 +2213,12 @@ def test_required_occurrence_baseline_rejects_missing_file_before_clean_scan(
 ) -> None:
     _write_files(tmp_path, {"python/larch/mod.py": "x = 1\n"})
     baseline = tmp_path / "python" / "missing.json"
+
+    def clean_detect(_source: SourceFile) -> list[Finding]:
+        return []
+
     rule = _occurrence_rule(
-        detect=lambda _source: [],
+        detect=clean_detect,
         require_baseline=True,
     )
 

--- a/python/tests/lint/test_lint_unreachable_branch.py
+++ b/python/tests/lint/test_lint_unreachable_branch.py
@@ -317,6 +317,9 @@ def test_adapted_findings_pass_occurrence_baseline_validation() -> None:
 
 def test_malformed_source_exits_2(tmp_path: Path) -> None:
     _write_files(tmp_path, {"python/larch/mod.py": "def broken(\n"})
+    _ = (tmp_path / "python" / lint.BASELINE_FILENAME).write_text(
+        "[]\n", encoding="utf-8"
+    )
     runner = _git_ok_runner(tmp_path, ["python/larch/mod.py"])
     code, out, err = _invoke_rule(tmp_path, runner, strict_stale=False)
     assert code == EXIT_ERROR
@@ -440,6 +443,17 @@ def test_new_finding_exits_1(tmp_path: Path) -> None:
     assert "lint-unreachable-branch" in out
 
 
+def test_clean_scan_without_baseline_exits_2(tmp_path: Path) -> None:
+    _write_files(tmp_path, {"python/larch/mod.py": COMPLIANT})
+    runner = _git_ok_runner(tmp_path, ["python/larch/mod.py"])
+
+    code, out, err = _invoke_rule(tmp_path, runner, strict_stale=False)
+
+    assert code == EXIT_ERROR
+    assert out == ""
+    assert "failed to read baseline" in err
+
+
 def test_noop_regeneration_is_byte_identical(tmp_path: Path) -> None:
     _write_files(tmp_path, {"python/larch/mod.py": VIOLATING})
     baseline = tmp_path / "python" / lint.BASELINE_FILENAME
@@ -466,6 +480,7 @@ def test_main_empty_initial_reason_exits_2(tmp_path: Path) -> None:
 
 def test_rule_contract_flags() -> None:
     assert lint.RULE.occurrence_baseline is True
+    assert lint.RULE.require_baseline is True
     assert lint.RULE.allow_inline_suppression is False
     assert lint.RULE.occurrence_pattern_field == "normalized_condition"
     assert lint.RULE.syntax_policy == "raise"


### PR DESCRIPTION
## Summary

- make required occurrence baselines fail closed when absent
- require the unreachable-branch rule baseline while preserving baseline regeneration
- cover optional and required baseline behavior

## Verification

- `PYTHONPATH=python python3 -m pytest python/tests/lint/test_lint_engine.py python/tests/lint/test_lint_unreachable_branch.py`
- `python3 -m ruff check python/larch/lint/engine.py python/larch/lint/lint_unreachable_branch.py python/tests/lint/test_lint_engine.py python/tests/lint/test_lint_unreachable_branch.py`
- `PYTHONPATH=python python3 python/cli.py lint unreachable-branch`

Fixes #7396