### PR TITLE
Release v53.1.10

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "53.1.9",
+  "version": "53.1.10",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Added

- **Bug-treadmill: unreachable-branch migration.** Migrated unreachable-branch analysis into the bug-treadmill feature pipeline. ([#7397](https://github.com/character-ai/larch/pull/7397))
- **Bug-treadmill: introduced-risk and class-completeness verdicts.** Added `introduced_risk` and `class_completeness` verdict support to the bug-treadmill: agent schema, ledger ingestion, and dedicated report sections. ([#7414](https://github.com/character-ai/larch/pull/7414))

## Changed

- **Doc-pointer-paths lint.** Cleaned up stale file pointer references in SECURITY.md and added a `doc-pointer-paths` lint to detect future drift. ([#7410](https://github.com/character-ai/larch/pull/7410))
- **Removed Mermaid lint toolchain.** Dropped the Mermaid diagram linting toolchain. ([#7421](https://github.com/character-ai/larch/pull/7421))

## Fixed

- **Transient blockers no longer linger as open exec issues.** Blockers that resolved transiently were incorrectly left open in the final exec-issue report; they are now closed correctly. ([#7399](https://github.com/character-ai/larch/pull/7399))
- **Preserve issue title prefixes.** Issue title prefixes (such as `[BUG]`, `[DONE]`) are now preserved when updating issue titles. ([#7406](https://github.com/character-ai/larch/pull/7406))
- **`/triage` replacement issues tagged `[BUG] [TRIAGED]`.** When `/triage` closes an issue and files replacements, the replacement issues now receive the `[BUG] [TRIAGED]` title prefix. ([#7418](https://github.com/character-ai/larch/pull/7418))
- **Skill closure root defaults to CWD.** The skill closure check now defaults the search root to the current working directory when no explicit root is configured. ([#7419](https://github.com/character-ai/larch/pull/7419))
- **Rebase checkpoints include generated-file autoresolve.** Steps 4.r, 7.r, and 7a.r rebase checkpoints in `/implement` now apply generated-file autoresolve, preventing stalls on auto-resolvable conflicts. ([#7420](https://github.com/character-ai/larch/pull/7420))
- **Cursor: `type: ignore` suppressions in test files include G-Py-11 reasons.** Cursor-generated `type: ignore` suppressions in test files now include the required inline reason comment. ([#7422](https://github.com/character-ai/larch/pull/7422))
- **Bound analyze-bugs consumer scans.** Consumer scans in `/analyze-bugs` are now bounded to prevent runaway searches. ([#7423](https://github.com/character-ai/larch/pull/7423))
- **Record-escalation stall recovery with unexported `IMPLEMENT_TMPDIR`.** Stall-recovery record-escalation no longer fails with an invalid ledger path when `IMPLEMENT_TMPDIR` is not exported to the environment. ([#7425](https://github.com/character-ai/larch/pull/7425))
- **Unreachable-branch required-baseline handling.** Fixed handling of required baselines for unreachable-branch analysis. ([#7426](https://github.com/character-ai/larch/pull/7426))
