### PR TITLE
Fix #7454: auto-merge learn-from-bugs state PRs with squash

### DIFF
--- a/python/larch/issue/learn_from_bugs.py
+++ b/python/larch/issue/learn_from_bugs.py
@@ -1976,7 +1976,7 @@ def _resolve_pr_outcome(
         raise StatePublishError(
             STATE_PUBLISH_PR_CREATE_FAILED, "the identified state PR is not open"
         )
-    merge = gh.pr_merge(runner, number, repo=ctx.request.repo, merge_method="merge", admin=True)
+    merge = gh.pr_merge(runner, number, repo=ctx.request.repo, merge_method="squash", admin=True)
     merged_state = _pr_state(runner, ctx, number)
     merged_at = gh.command(
         runner,

--- a/python/tests/issue/test_learn_from_bugs.py
+++ b/python/tests/issue/test_learn_from_bugs.py
@@ -2086,6 +2086,7 @@ def _run_publish(
     responses: list[CommandResult],
     *,
     precreate_worktree: bool = False,
+    runner: RecordingRunner | None = None,
 ) -> tuple[int, dict[str, str]]:
     run_dir = tmp_path / "run"
     run_dir.mkdir(exist_ok=True)
@@ -2096,9 +2097,8 @@ def _run_publish(
     # present. Clear those vars so the offline call sequence stays hermetic.
     monkeypatch.delenv("SHIP_PR_STATE_FILE", raising=False)
     monkeypatch.delenv(config.ENV_IMPLEMENT_TMPDIR, raising=False)
-    monkeypatch.setattr(
-        learn_from_bugs, "_runner", lambda: RecordingRunner.strict_queue(*responses)
-    )
+    active_runner = runner if runner is not None else RecordingRunner.strict_queue(*responses)
+    monkeypatch.setattr(learn_from_bugs, "_runner", lambda: active_runner)
     rc = learn_from_bugs.state_publish_main(
         [
             "--root", str(tmp_path),
@@ -2128,6 +2128,21 @@ def test_state_publish_fresh_success_merges(
     assert out["STATE_PUBLISH_STATUS"] == learn_from_bugs.STATE_PUBLISH_MERGED
     assert out["PR_NUMBER"] == "7"
     assert out["PR_URL"] == "https://github.com/o/r/pull/7"
+
+
+def test_state_publish_fresh_success_requests_admin_squash(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    responses = _publish_ok_responses()
+    runner = RecordingRunner.strict_queue(*responses)
+
+    rc, out = _run_publish(monkeypatch, capsys, tmp_path, responses, runner=runner)
+
+    assert rc == 0
+    assert out["STATE_PUBLISH_STATUS"] == learn_from_bugs.STATE_PUBLISH_MERGED
+    assert runner.calls[18] == [  # lint-gh-argv-literal: ok exact regression assertion
+        "gh", "pr", "merge", "7", "--repo", "o/r", "--squash", "--admin",
+    ]
 
 
 def test_state_publish_invalid_branch_name(

--- a/skills/learn-from-bugs/SKILL.md
+++ b/skills/learn-from-bugs/SKILL.md
@@ -183,7 +183,7 @@ Use this one fragment for all three marker-producing paths: default mode after S
 
 This is a shared definition, not an immediate Step 4 action: first branch on `FILE_MODE` below. Default mode runs it before Step 5; filing mode runs it only after the no-residual or successful-create path has finished. Do not publish before that mode-specific work completes.
 
-Run the whole fragment as one Bash call. `learn-from-bugs state-publish` owns the entire flow behind `python/cli.py`: it validates the checkout and origin, resolves and fetches the repository default branch, derives and reserves a collision-free state branch, then publishes the marker from a disposable clean detached worktree, so filing artifacts and unrelated operator changes remain untouched in `ANALYSIS_ROOT`. It invokes `learn-from-bugs write-state` exactly once against that worktree, commits only the marker with `--only`, opens the state PR with a file-backed body, and attempts an immediate `--admin --merge`:
+Run the whole fragment as one Bash call. `learn-from-bugs state-publish` owns the entire flow behind `python/cli.py`: it validates the checkout and origin, resolves and fetches the repository default branch, derives and reserves a collision-free state branch, then publishes the marker from a disposable clean detached worktree, so filing artifacts and unrelated operator changes remain untouched in `ANALYSIS_ROOT`. It invokes `learn-from-bugs write-state` exactly once against that worktree, commits only the marker with `--only`, opens the state PR with a file-backed body, and attempts an immediate `--admin --squash`:
 
 ```bash
 set -euo pipefail


### PR DESCRIPTION
## Summary

- merge state-publication PRs with the repository-supported admin squash method
- pin the exact GitHub CLI argv in the state-publication regression test
- align the skill contract with the runtime behavior

## Verification

- `python3 -m pytest python/tests/issue/test_learn_from_bugs.py -q`
- changed-file ruff, pylint, pyright, and pre-commit checks

Fixes #7454