### PR TITLE
Fix #7451: suppress benign plan-review aggregator warning

### DIFF
--- a/python/larch/review/plan_review_round.py
+++ b/python/larch/review/plan_review_round.py
@@ -652,21 +652,25 @@ def _apply_aggregator_status(
     round_num: int,
     agg_kv: dict[str, str],
     returncode: int,
-    values: dict[str, str],
-) -> None:
+    ok_count: int,
+) -> str:
     """Record ``AGGREGATOR_STATUS`` and handle the degraded aggregator outcomes.
 
-    ``insufficient-input`` means too few reviewers reached the aggregator, so it is
-    surfaced as a Warnings execution issue (issue #7353). Any other non-ok, non-disabled
-    status snapshots this round's forensics before the next round overwrites the stable
-    paths (issue #4996); clean aggregations skip the snapshot to avoid committed bytes.
+    ``insufficient-input`` is a degraded-panel warning only when too few reviewer slots
+    completed. A healthy panel can have no findings to aggregate, which is benign. Any
+    other non-ok, non-disabled status snapshots this round's forensics before the next
+    round overwrites the stable paths (issue #4996); clean aggregations skip the snapshot
+    to avoid committed bytes.
     """
     agg_status = _aggregator_status_from_kv(agg_kv=agg_kv, returncode=returncode)
-    values["AGGREGATOR_STATUS"] = agg_status
-    if agg_status == "insufficient-input":
+    if (
+        agg_status == "insufficient-input"
+        and ok_count < review_aggregate.MIN_AGGREGATE_INPUTS
+    ):
         _log_insufficient_input_warning(design=design, round_num=round_num)
     elif agg_status not in {"ok", "disabled"}:
         _snapshot_aggregator_forensics(design=design, round_num=round_num)
+    return agg_status
 
 
 def _lookup_by_output(
@@ -1144,7 +1148,13 @@ def execute_round(
         text=f"round {round_num}: aggregating reviewer findings",
     )
     agg_kv = _parse_kv(agg.stdout)
-    _apply_aggregator_status(design=design, round_num=round_num, agg_kv=agg_kv, returncode=agg.returncode, values=values)
+    values["AGGREGATOR_STATUS"] = _apply_aggregator_status(
+        design=design,
+        round_num=round_num,
+        agg_kv=agg_kv,
+        returncode=agg.returncode,
+        ok_count=ok_count,
+    )
     ballot = design / "ballot.txt"
     proposer_map = design / "proposer-map.tsv"
     if not _aggregation_ok_for_voting(agg_kv=agg_kv, returncode=agg.returncode):

--- a/python/larch/review/review_aggregate.py
+++ b/python/larch/review/review_aggregate.py
@@ -24,7 +24,7 @@ _EMPTY_MERGE_ATTESTATION = "LARCH_AGGREGATOR_EMPTY_MERGE_ATTESTED"
 _SEVERITY_RE = re.compile(r"(?m)^-\s*\*\*Severity\*\*:\s*(major|minor|nit)\s*$", re.IGNORECASE)
 _NIT_SEVERITY_RE = re.compile(r"(?m)^-\s*\*\*Severity\*\*:\s*nit\s*$", re.IGNORECASE)
 _BLANK_SEVERITY_RE = re.compile(r"(?m)^(-\s*\*\*Severity\*\*:\s*)$")
-_MIN_AGGREGATE_INPUTS = 2
+MIN_AGGREGATE_INPUTS = 2
 _MOVE_FAILED_RC = 3
 _VALIDATION_FAILED_RC = 4
 # Issue #4881: the OOS-attribution failure class (#4868) is the only semantically retryable
@@ -846,7 +846,7 @@ def aggregate_findings(argv: list[str]) -> int:  # noqa: PLR0915,RUF100
             _emit_aggregate_result(aggregated=False, input_count=input_count, merged_count=merged_count, reason="validation-failed")
             return 0
     aggregate_input_count = _count_finding_blocks(source_file)
-    if aggregate_input_count < _MIN_AGGREGATE_INPUTS:
+    if aggregate_input_count < MIN_AGGREGATE_INPUTS:
         _emit_aggregate_result(aggregated=False, input_count=input_count, merged_count=merged_count, reason="insufficient-input")
         return 0
     agent = _PLUGIN_ROOT / "agents" / "orchestrator-aggregator.md"

--- a/python/tests/review/test_plan_review_round.py
+++ b/python/tests/review/test_plan_review_round.py
@@ -511,6 +511,29 @@ def test_log_insufficient_input_warning_appends_warning(
     assert "insufficient-input" in note.read_text(encoding="utf-8")
 
 
+def test_apply_aggregator_status_skips_warning_for_healthy_zero_findings_panel(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run_cli(argv: list[str], *, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+        del env
+        calls.append(argv)
+        return subprocess.CompletedProcess(argv, 0, "APPENDED=true\n", "")
+
+    monkeypatch.setattr(plan_review_round, "_run_cli", fake_run_cli)
+    status = plan_review_round._apply_aggregator_status(
+        design=tmp_path,
+        round_num=2,
+        agg_kv={"REASON": "insufficient-input", "AGGREGATED": "false"},
+        returncode=0,
+        ok_count=2,
+    )
+
+    assert status == "insufficient-input"
+    assert not calls
+
+
 def test_execute_round_logs_waterfall_dropped_slot_to_execution_issues(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

- Suppress `insufficient-input` warnings when enough reviewer slots completed with no findings.
- Keep warnings for genuinely underpopulated review panels.

## Tests

- `python3 -m pytest -q python/tests/review/test_plan_review_round.py python/tests/review/test_review_aggregate.py`
- `pre-commit run ruff --files python/larch/review/review_aggregate.py python/larch/review/plan_review_round.py python/tests/review/test_plan_review_round.py`
- `pre-commit run pyright --files python/larch/review/review_aggregate.py python/larch/review/plan_review_round.py python/tests/review/test_plan_review_round.py`

Fixes #7451
