### PR TITLE
Fix #7450: Block terminal shipping without a PR

### DIFF
--- a/python/larch/implement/dispatch_step18.py
+++ b/python/larch/implement/dispatch_step18.py
@@ -19,8 +19,18 @@ from larch.implement.dispatch_helpers import (
     _rehydrate_larch_triplet,
     _rehydrate_plugin_root,
 )
+from larch.errors import ShipError
+from larch.issue import execution_issues
+from larch.state import finalize
 from larch.implement.dispatch_leg import _run_cli_capture
 from larch.state._tokens import _abandoned_checks_bgjob_stall_step
+
+
+_TERMINAL_SHIPPING_REFUSAL_REASON = "step18-terminal-shipping-without-pr"
+_TERMINAL_SHIPPING_REFUSAL_ENTRY = (
+    "- **Step 18 terminal gate**: refused terminal `shipping` without PR evidence; "
+    "preserved the session for stall recovery."
+)
 
 
 def _stall_layer_active(value: str) -> bool:
@@ -98,6 +108,58 @@ def _normalize_outcome_for_step18(implement_tmpdir: Path, *, memory_layer: str, 
     return _parse_kv(result.stdout if result.returncode == 0 else "")
 
 
+def _is_terminal_shipping_without_pr(normalized: dict[str, str]) -> bool:
+    return (
+        normalized.get("IMPLEMENT_NORMALIZED_OUTCOME") == "shipping"
+        and not normalized.get("IMPLEMENT_PR_NUMBER", "").strip()
+    )
+
+
+def _record_terminal_shipping_refusal(*, implement_tmpdir: Path) -> bool:
+    """Persist the terminal-gate refusal before returning a hard failure.
+
+    ``shipping`` is only valid for a committed, pre-PR snapshot.  Once Step 18
+    starts terminal finalization, retaining that label would otherwise permit a
+    teardown that loses the session needed to recover the failed ship attempt.
+    """
+    state_path = implement_tmpdir / "finalize-state.sh"
+    if state_path.is_symlink():
+        return False
+    try:
+        state: dict[str, str] = finalize.read_finalize_state(state_path)
+        state.update(
+            {
+                "BAIL_REASON": _TERMINAL_SHIPPING_REFUSAL_REASON,
+                "EXIT_CODE": str(config.EXIT_INTERNAL_ERROR),
+                "PHASE": "stalled",
+                "STALL_STEP": "8",
+                "STALL_TRACKING": "true",
+                "STEP18_GATE_REFUSAL": _TERMINAL_SHIPPING_REFUSAL_REASON,
+            }
+        )
+        finalize.write_finalize_state_merged(path=state_path, data=state)
+        persisted: dict[str, str] = finalize.read_finalize_state(state_path)
+        expected = {
+            "BAIL_REASON": _TERMINAL_SHIPPING_REFUSAL_REASON,
+            "EXIT_CODE": str(config.EXIT_INTERNAL_ERROR),
+            "PHASE": "stalled",
+            "STALL_STEP": "8",
+            "STALL_TRACKING": "true",
+            "STEP18_GATE_REFUSAL": _TERMINAL_SHIPPING_REFUSAL_REASON,
+        }
+        if any(persisted.get(key) != value for key, value in expected.items()):
+            return False
+        issue_log = implement_tmpdir / "execution-issues.md"
+        execution_issues.append_execution_issue(
+            issue_log,
+            category="Tool Failures",
+            entry=_TERMINAL_SHIPPING_REFUSAL_ENTRY,
+        )
+        return _TERMINAL_SHIPPING_REFUSAL_ENTRY in issue_log.read_text(encoding="utf-8")
+    except (OSError, ShipError):
+        return False
+
+
 def step_18_gate_finalize_main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="cli.py implement step-18-gate-finalize")
     parser.add_argument("--implement-tmpdir", default="")
@@ -123,9 +185,20 @@ def step_18_gate_finalize_main(argv: list[str] | None = None) -> int:
         _emit_kv(key="NEXT_ACTION", value="stall-recovery")
         return 0
 
-    _emit_kv(key="STALL_RECOVERY_REQUIRED", value="false")
     print("⏩ 18a: stall recovery: no stall detected")
-    _normalize_outcome_for_step18(implement_tmpdir, memory_layer=layers.memory, env=env)
+    normalized = _normalize_outcome_for_step18(implement_tmpdir, memory_layer=layers.memory, env=env)
+    if _is_terminal_shipping_without_pr(normalized):
+        persisted = _record_terminal_shipping_refusal(implement_tmpdir=implement_tmpdir)
+        _emit_kv(key="STALL_RECOVERY_REQUIRED", value="true" if persisted else "unknown")
+        _emit_kv(key="TERMINAL_FINALIZE_REFUSED", value="true")
+        _emit_kv(key="STATUS", value="blocked")
+        _emit_kv(key="OUTCOME", value="stalled")
+        _emit_kv(key="NEXT_ACTION", value="tool-failure")
+        if not persisted:
+            print("implement step-18-gate-finalize: cannot persist terminal shipping refusal", file=sys.stderr)
+        return config.EXIT_INTERNAL_ERROR
+
+    _emit_kv(key="STALL_RECOVERY_REQUIRED", value="false")
 
     # lint-subprocess-via-runner: ok composite must invoke the existing Bash finalize fence verbatim
     child = subprocess.run(

--- a/python/tests/implement/test_implement_dispatch.py
+++ b/python/tests/implement/test_implement_dispatch.py
@@ -44,6 +44,7 @@ from larch.core import process_identity
 from larch.core import logging_util
 from larch.outcomes import Outcome
 from larch.report import run_logs
+from larch.state import finalize
 
 from test_support import make_implement_tmpdir
 
@@ -2358,6 +2359,8 @@ def _install_step18_normalize(
     monkeypatch: pytest.MonkeyPatch,
     *,
     succeeded: bool,
+    outcome: str = "pr-created",
+    pr_number: str = "1",
     calls: list[list[str]] | None = None,
 ) -> None:
     def fake_capture(args: Sequence[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
@@ -2366,7 +2369,11 @@ def _install_step18_normalize(
         return subprocess.CompletedProcess(
             list(args),
             0,
-            f"IMPLEMENT_OUTCOME_SUCCEEDED={'true' if succeeded else 'false'}\n",
+            (
+                f"IMPLEMENT_NORMALIZED_OUTCOME={outcome}\n"
+                f"IMPLEMENT_PR_NUMBER={pr_number}\n"
+                f"IMPLEMENT_OUTCOME_SUCCEEDED={'true' if succeeded else 'false'}\n"
+            ),
             "",
         )
 
@@ -2478,6 +2485,40 @@ def test_step18_gate_finalize_active_stall_breaks_out_without_finalize(
     assert "STALL_TRACKING_DISK=1\n" in captured.out
     assert "STALL_RECOVERY_REQUIRED=true\n" in captured.out
     assert captured.out.rstrip().endswith("NEXT_ACTION=stall-recovery")
+
+
+def test_step18_gate_finalize_refuses_terminal_shipping_without_pr(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    tmp = make_implement_tmpdir(tmp_path)
+    _install_step18_normalize(monkeypatch, succeeded=False, outcome="shipping", pr_number="")
+    monkeypatch.setattr(
+        implement_dispatch.subprocess,
+        "run",
+        lambda *_a, **_k: pytest.fail("finalize must not run for terminal shipping without a PR"),
+    )
+
+    assert implement_dispatch.step_18_gate_finalize_main(["--implement-tmpdir", str(tmp)]) == config.EXIT_INTERNAL_ERROR
+
+    captured = capsys.readouterr()
+    assert "IMPLEMENT_NORMALIZED_OUTCOME=shipping\n" in captured.out
+    assert "STALL_RECOVERY_REQUIRED=true\n" in captured.out
+    assert "TERMINAL_FINALIZE_REFUSED=true\n" in captured.out
+    assert "STATUS=blocked\n" in captured.out
+    assert "OUTCOME=stalled\n" in captured.out
+    assert captured.out.rstrip().endswith("NEXT_ACTION=tool-failure")
+    state = finalize.read_finalize_state(tmp / "finalize-state.sh")
+    assert state["BAIL_REASON"] == "step18-terminal-shipping-without-pr"
+    assert state["EXIT_CODE"] == str(config.EXIT_INTERNAL_ERROR)
+    assert state["PHASE"] == "stalled"
+    assert state["STALL_STEP"] == "8"
+    assert state["STALL_TRACKING"] == "true"
+    assert state["STEP18_GATE_REFUSAL"] == "step18-terminal-shipping-without-pr"
+    execution_issues = (tmp / "execution-issues.md").read_text(encoding="utf-8")
+    assert "### Tool Failures" in execution_issues
+    assert "Step 18 terminal gate" in execution_issues
 
 
 def test_step18_gate_finalize_abandoned_checks_bgjob_breaks_out_without_finalize(


### PR DESCRIPTION
## Summary

- Block Step 18 terminal finalization when normalization reports the in-flight `shipping` outcome without PR evidence.
- Persist a stalled failure overlay and Tool Failure record so recovery retains the implementation session.
- Add a regression test proving the finalizer and teardown are not invoked.

## Validation

- `python3 -m pytest -q tests/implement/test_implement_dispatch.py -k 'step18_gate_finalize'`
- `ruff check larch/implement/dispatch_step18.py tests/implement/test_implement_dispatch.py`
- `pylint -j 0 larch/implement/dispatch_step18.py tests/implement/test_implement_dispatch.py`
- `pyright larch/implement/dispatch_step18.py tests/implement/test_implement_dispatch.py`

Fixes #7450
