### PR TITLE
Release v53.1.14

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "53.1.13",
+  "version": "53.1.14",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Added

- `/status` resolves pinned vendor model IDs against live model lists.

## Changed

- Removed the design lifecycle facade.
- Shrunk the review pipeline facade.
- Shrunk `run_logs.py` and `analyze_issues.py`.

## Fixed

- Checks lint-fix lane now uses descriptors.
- `/learn-from-bugs` state PRs now auto-merge with squash.
- Suppressed a benign warning from the plan-review aggregator.
- Blocked terminal shipping when no PR exists.
- Fixed feature branches incorrectly tracking `origin/main` at creation (root cause of #7405).
