### PR TITLE
Fixes #7469: consolidate duplicated test boilerplate

### DIFF
--- a/python/review_test_support.py
+++ b/python/review_test_support.py
@@ -570,11 +570,18 @@ def write_aggregate_counting_dispatch_stub(
     fail_attempts: int,
     fail_body: str,
     success_body: str,
+    env_log: Path | None = None,
 ) -> None:
     """Dispatch stub that emits ``fail_body`` for the first ``fail_attempts`` invocations, then
     ``success_body``. Each invocation increments ``counter_file`` so a test can assert how many
-    aggregator dispatches the bounded validation-retry loop performed.
+    aggregator dispatches the bounded validation-retry loop performed. When supplied, ``env_log``
+    records the panel-payload byte count for each invocation.
     """
+    env_log_write = (
+        f'printf \'%s\\n\' "${{LARCH_PANEL_PAYLOAD_BYTES:-0}}" >> "{env_log}"\n'
+        if env_log is not None
+        else ""
+    )
     write_executable(
         path=path,
         body=f"""#!/usr/bin/env bash
@@ -595,7 +602,7 @@ n=0
 [[ -f "$counter" ]] && n=$(cat "$counter")
 n=$((n + 1))
 printf '%s' "$n" > "$counter"
-if [[ "$n" -le {fail_attempts} ]]; then
+{env_log_write}if [[ "$n" -le {fail_attempts} ]]; then
   cat > "$out" <<'FAILBODY'
 {fail_body}
 FAILBODY

--- a/python/test_support.py
+++ b/python/test_support.py
@@ -3,21 +3,25 @@
 from __future__ import annotations
 
 import os
+import shlex
+import stat
 import subprocess
 import sys
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Self
+from typing import Self, TypeVar
 
 from larch.agents import collect_results
 from larch.core.proc import CommandResult
 from larch.core.run_context import RunContext
+from larch.implement import scope_disposition
 
 from tests.support.repo_contract import ROOT, repo_root
 from tests.support.review_wire import plan_review_slot_line, slot_manifest_ndjson
 
 CLI = ROOT / "python" / "cli.py"
+T = TypeVar("T")
 
 # Session/tmpdir builders depend on the root contract above; re-export after it.
 from tests.support.session import (  # noqa: E402  # pylint: disable=wrong-import-position
@@ -41,15 +45,18 @@ __all__ = [
     "PR_VIEW_OPEN_JSON",
     "ROOT",
     "RecordingRunner",
+    "capture_start",
     "completed",
     "gh_pr_view",
     "gh_result",
+    "make_committed_repo",
     "make_design_tmpdir",
     "make_implement_tmpdir",
     "make_run_context",
     "make_zero_findings_plan_review_fake_cli",
     "merge_admin_responses",
     "ok",
+    "operator_repo_with_remote",
     "repo_root",
     "run_cli",
     "run_params_text",
@@ -57,6 +64,8 @@ __all__ = [
     "seed_plan",
     "seed_run_params",
     "write_design_source_env",
+    "write_gh_pr_stub",
+    "write_required_plan_coverage",
     "write_session_env",
 ]
 
@@ -67,6 +76,15 @@ def _empty_calls() -> list[list[str]]:
 
 def _empty_results() -> list[CommandResult]:
     return []
+
+
+def capture_start(captured: list[T]) -> Callable[[T], int]:
+    """Return a successful starter fake that records its specification."""
+    def fake_start(spec: T) -> int:
+        captured.append(spec)
+        return 0
+
+    return fake_start
 
 
 @dataclass
@@ -114,10 +132,13 @@ class RecordingRunner:
 def run_cli(
     *args: str,
     env: dict[str, str] | None = None,
+    quiet_disable: bool = False,
 ) -> subprocess.CompletedProcess[str]:
     """Run python/cli.py in a subprocess with CLAUDE_PLUGIN_ROOT set to the repo root."""
     merged = os.environ.copy()
     merged["CLAUDE_PLUGIN_ROOT"] = str(ROOT)
+    if quiet_disable:
+        merged["LARCH_QUIET_DISABLE"] = "1"
     if env:
         merged.update(env)
     return subprocess.run(
@@ -128,6 +149,91 @@ def run_cli(
         capture_output=True,
         check=False,
     )
+
+
+def write_gh_pr_stub(
+    path: Path, *, pr_create_rc: int, capture_path: Path | None = None
+) -> None:
+    """Write a ``gh`` stub for PR-create and PR-merge fixture flows."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    capture_path_arg = shlex.quote(str(capture_path) if capture_path else "")
+    _ = path.write_text(
+        "#!/usr/bin/env bash\n"
+        f"CAPTURE_PATH={capture_path_arg}\n"
+        'if [ "$1" = "pr" ] && [ "$2" = "create" ]; then\n'
+        '  if [ -n "$CAPTURE_PATH" ]; then\n'
+        '    {\n'
+        "      printf '%s\\n' '__ARGV__'\n"
+        "      for arg in \"$@\"; do printf '%s\\n' \"$arg\"; done\n"
+        "      printf '%s\\n' '__BODY__'\n"
+        '      body_file=""\n'
+        '      while [ "$#" -gt 0 ]; do\n'
+        '        if [ "$1" = "--body-file" ]; then\n'
+        '          shift\n'
+        '          body_file="${1-}"\n'
+        '          break\n'
+        '        fi\n'
+        '        shift\n'
+        '      done\n'
+        '      if [ -n "$body_file" ]; then cat "$body_file"; fi\n'
+        '    } > "$CAPTURE_PATH"\n'
+        '  fi\n'
+        f"  if [ {pr_create_rc} -ne 0 ]; then echo 'gh: pr create failed' >&2; exit {pr_create_rc}; fi\n"
+        "  echo 'https://github.com/o/r/pull/77'\n"
+        "  exit 0\n"
+        "fi\n"
+        'if [ "$1" = "pr" ] && [ "$2" = "merge" ]; then exit 0; fi\n'
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+def operator_repo_with_remote(tmp_path: Path) -> Path:
+    """Create a committed ``main`` fixture repository with a bare ``origin`` remote."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    for args in (("init", "-q"), ("checkout", "-q", "-b", "main"),
+                 ("config", "user.email", "t@example.com"), ("config", "user.name", "t")):
+        _ = subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True)
+    _ = (repo / "README.md").write_text("seed\n", encoding="utf-8")
+    for args in (("add", "README.md"), ("commit", "-q", "-m", "seed")):
+        _ = subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True)
+    origin = tmp_path / "origin.git"
+    _ = subprocess.run(["git", "init", "-q", "--bare", str(origin)], cwd=tmp_path, check=True, capture_output=True)
+    for args in (("remote", "add", "origin", str(origin)), ("push", "-q", "-u", "origin", "main")):
+        _ = subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True)
+    return repo
+
+
+def make_committed_repo(tmp_path: Path) -> Path:
+    """Create a minimal committed repository for implementation-session tests."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    for args in (("init",), ("config", "user.email", "test@example.com"),
+                 ("config", "user.name", "Test")):
+        _ = subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True)
+    _ = (repo / "tracked").write_text("base\n", encoding="utf-8")
+    for args in (("add", "tracked"), ("commit", "-m", "base")):
+        _ = subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True)
+    return repo.resolve()
+
+
+def write_required_plan_coverage(
+    tmp_path: Path,
+    *,
+    fingerprint: str,
+) -> None:
+    """Write the high-coverage disposition fixture used by PR tests."""
+    coverage = scope_disposition.PlanCoverage(
+        total=1, touched=0, untouched=1, untouched_percent=100, band="high",
+        plan_paths=("a.py",), touched_paths=(), untouched_paths=("a.py",),
+        todos_left_count=0, todos_left=(), fingerprint=fingerprint,
+        disposition_required=True, plan_fidelity_forced=True,
+        coverage_file=str(tmp_path / "plan-coverage.json"),
+        untouched_file=str(tmp_path / "untouched.txt"), todos_file=str(tmp_path / "todos.txt"),
+    )
+    scope_disposition.write_coverage(coverage, tmpdir=tmp_path)
 
 
 # Shared RunContext defaults for ship-pr unit tests; override fields via

--- a/python/tests/calibration/test_difficulty_calibration.py
+++ b/python/tests/calibration/test_difficulty_calibration.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any
 from larch.calibration import difficulty
 from larch.calibration import difficulty_calibration as dc
 from larch.review import voting
+from tests.support.review_wire import code_review_classification_row
 
 if TYPE_CHECKING:
     import pytest
@@ -98,31 +99,7 @@ def _design_tsv(run: Path, round_num: int, *rows: str) -> None:
 
 
 def _code_row(fid: str, result: str, *, scope: str = "", severity: str = "major") -> str:
-    values = [
-        fid,
-        "reviewer",
-        result,
-        "YES",
-        "true",
-        severity,
-        "good",
-        "false",
-        "cursor-validity",
-        "NO",
-        "true",
-        "minor",
-        "good",
-        "false",
-        "codex-plan-fidelity",
-        "NO",
-        "true",
-        "minor",
-        "good",
-        "false",
-        "codex-pragmatism",
-        scope,
-    ]
-    return "\t".join(values)
+    return code_review_classification_row(fid, result, scope=scope, severity1=severity)
 
 
 def _implement_tsv(run: Path, round_num: int, *rows: str) -> None:

--- a/python/tests/design/test_design_dialectic.py
+++ b/python/tests/design/test_design_dialectic.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 
 from larch.design import design_dialectic
+from tests.support.design_wire import dialectic_candidate_json
 
 
 def _write_plan(tmp_path: Path, text: str = "## Plan\n\ndiff_lines: 1\n") -> None:
@@ -406,21 +407,7 @@ def test_promote_skips_when_drafter_pick_mismatches_final_plan(tmp_path: Path, c
     _write_plan(tmp_path, "## Original\n\ndiff_lines: 1\n")
     raw = tmp_path / design_dialectic.RAW_PENDING
     raw.write_text(
-        json.dumps(
-            {
-                "decisions": [
-                    {
-                        "id": "fork",
-                        "title": "Fork",
-                        "option_a": "Use SQLite",
-                        "option_b": "Use JSON files",
-                        "tradeoff": "Different failure modes",
-                        "drafter_pick": "option_a",
-                        "why_this_matters": "Operator should see it",
-                    }
-                ]
-            }
-        ),
+        dialectic_candidate_json(option_a="Use SQLite", option_b="Use JSON files"),
         encoding="utf-8",
     )
     _write_plan(tmp_path, "## Final\n\nUse JSON files for storage.\n\ndiff_lines: 1\n")

--- a/python/tests/design/test_design_lifecycle.py
+++ b/python/tests/design/test_design_lifecycle.py
@@ -42,7 +42,7 @@ from larch.core import architectural_guidelines
 from larch.core import logging_util
 from larch.core.proc import CommandResult
 from larch.report import progress_file
-from tests.support.design_wire import plan_body, run_params_json, write_result_env
+from tests.support.design_wire import dialectic_candidate_json, plan_body, run_params_json, write_result_env
 from larch.core import proc as proc_module
 from larch.state import session_env
 from larch.state import stall_recovery
@@ -6649,21 +6649,7 @@ def test_step2b_drafter_promoted_fingerprint_matches_postplan_plan(
             (design / "plan.txt").write_text("## Draft\n\nUse SQLite.\n\ndiff_lines: 1\n", encoding="utf-8")
             (design / "step2b-drafter-status.txt").write_text("PLAN_WRITTEN=true\n", encoding="utf-8")
             (design / ".dialectic-raw-pending.json").write_text(
-                json.dumps(
-                    {
-                        "decisions": [
-                            {
-                                "id": "fork",
-                                "title": "Fork",
-                                "option_a": "Use SQLite",
-                                "option_b": "Use JSON files",
-                                "tradeoff": "Different failure modes",
-                                "drafter_pick": "option_a",
-                                "why_this_matters": "Operator should see it",
-                            }
-                        ]
-                    }
-                ),
+                dialectic_candidate_json(option_a="Use SQLite", option_b="Use JSON files"),
                 encoding="utf-8",
             )
         if args[2:4] == ["design", "dialectic-promote-candidates"]:

--- a/python/tests/design/test_design_log_publish_flow.py
+++ b/python/tests/design/test_design_log_publish_flow.py
@@ -4,8 +4,6 @@
 from __future__ import annotations
 
 import os
-import shlex
-import stat
 import subprocess
 import sys
 from pathlib import Path
@@ -14,6 +12,8 @@ from typing import Any
 import pytest
 from larch.design import design_log_publish_flow
 from larch.design import design_summary
+from test_support import operator_repo_with_remote as _operator_repo_with_remote
+from test_support import write_gh_pr_stub as _write_gh_stub
 
 RUN_ID = "ABCDEF01-2345-6789-ABCD-EF0123456789"
 LOG_BRANCH = f"larch-logs/design-{RUN_ID}"
@@ -21,60 +21,6 @@ LOG_BRANCH = f"larch-logs/design-{RUN_ID}"
 
 def _git(*argv: str, cwd: Path) -> None:
     _ = subprocess.run(["git", *argv], cwd=cwd, check=True, capture_output=True)
-
-
-def _write_gh_stub(
-    path: Path, *, pr_create_rc: int, capture_path: Path | None = None
-) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    capture_path_arg = shlex.quote(str(capture_path) if capture_path else "")
-    _ = path.write_text(
-        "#!/usr/bin/env bash\n"
-        f"CAPTURE_PATH={capture_path_arg}\n"
-        'if [ "$1" = "pr" ] && [ "$2" = "create" ]; then\n'
-        '  if [ -n "$CAPTURE_PATH" ]; then\n'
-        '    {\n'
-        "      printf '%s\\n' '__ARGV__'\n"
-        "      for arg in \"$@\"; do printf '%s\\n' \"$arg\"; done\n"
-        "      printf '%s\\n' '__BODY__'\n"
-        '      body_file=""\n'
-        '      while [ "$#" -gt 0 ]; do\n'
-        '        if [ "$1" = "--body-file" ]; then\n'
-        '          shift\n'
-        '          body_file="${1-}"\n'
-        '          break\n'
-        '        fi\n'
-        '        shift\n'
-        '      done\n'
-        '      if [ -n "$body_file" ]; then cat "$body_file"; fi\n'
-        '    } > "$CAPTURE_PATH"\n'
-        '  fi\n'
-        f"  if [ {pr_create_rc} -ne 0 ]; then echo 'gh: pr create failed' >&2; exit {pr_create_rc}; fi\n"
-        "  echo 'https://github.com/o/r/pull/77'\n"
-        "  exit 0\n"
-        "fi\n"
-        'if [ "$1" = "pr" ] && [ "$2" = "merge" ]; then exit 0; fi\n'
-        "exit 0\n",
-        encoding="utf-8",
-    )
-    path.chmod(path.stat().st_mode | stat.S_IXUSR)
-
-
-def _operator_repo_with_remote(tmp_path: Path) -> Path:
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    _git("init", "-q", cwd=repo)
-    _git("checkout", "-q", "-b", "main", cwd=repo)
-    _git("config", "user.email", "t@example.com", cwd=repo)
-    _git("config", "user.name", "t", cwd=repo)
-    _ = (repo / "README.md").write_text("seed\n", encoding="utf-8")
-    _git("add", "README.md", cwd=repo)
-    _git("commit", "-q", "-m", "seed", cwd=repo)
-    origin = tmp_path / "origin.git"
-    _git("init", "-q", "--bare", str(origin), cwd=tmp_path)
-    _git("remote", "add", "origin", str(origin), cwd=repo)
-    _git("push", "-q", "-u", "origin", "main", cwd=repo)
-    return repo
 
 
 def _operator_repo_with_guidelines(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:

--- a/python/tests/design/test_design_pause.py
+++ b/python/tests/design/test_design_pause.py
@@ -8,13 +8,14 @@ import json
 import io
 import os
 import subprocess
-import stat
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from larch.design import design_pause
 from larch.design import design_log_publish_flow
 from larch.design import design_summary
+from test_support import operator_repo_with_remote as _operator_repo_with_remote
+from test_support import write_gh_pr_stub as _write_gh_stub
 
 if TYPE_CHECKING:
     import pytest
@@ -29,43 +30,6 @@ _MARKER_END = "<!-- larch:design-pause:end -->"
 def test_parse_pause_payload_normalizes_keys_before_last_value_selection() -> None:
     payload = f"{_MARKER_START}\nSTEP=old\n STEP =new\nSTEP=latest\n{_MARKER_END}\n"
     assert design_pause._parse_pause_payload(payload) == {"STEP": "latest"}  # pyright: ignore[reportPrivateUsage]
-
-
-def _git(*argv: str, cwd: Path) -> None:
-    _ = subprocess.run(["git", *argv], cwd=cwd, check=True, capture_output=True)
-
-
-def _write_gh_stub(path: Path, *, pr_create_rc: int) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    _ = path.write_text(
-        "#!/usr/bin/env bash\n"
-        'if [ "$1" = "pr" ] && [ "$2" = "create" ]; then\n'
-        f"  if [ {pr_create_rc} -ne 0 ]; then echo 'gh: pr create failed' >&2; exit {pr_create_rc}; fi\n"
-        "  echo 'https://github.com/o/r/pull/77'\n"
-        "  exit 0\n"
-        "fi\n"
-        'if [ "$1" = "pr" ] && [ "$2" = "merge" ]; then exit 0; fi\n'
-        "exit 0\n",
-        encoding="utf-8",
-    )
-    path.chmod(path.stat().st_mode | stat.S_IXUSR)
-
-
-def _operator_repo_with_remote(tmp_path: Path) -> Path:
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    _git("init", "-q", cwd=repo)
-    _git("checkout", "-q", "-b", "main", cwd=repo)
-    _git("config", "user.email", "t@example.com", cwd=repo)
-    _git("config", "user.name", "t", cwd=repo)
-    _ = (repo / "README.md").write_text("seed\n", encoding="utf-8")
-    _git("add", "README.md", cwd=repo)
-    _git("commit", "-q", "-m", "seed", cwd=repo)
-    origin = tmp_path / "origin.git"
-    _git("init", "-q", "--bare", str(origin), cwd=tmp_path)
-    _git("remote", "add", "origin", str(origin), cwd=repo)
-    _git("push", "-q", "-u", "origin", "main", cwd=repo)
-    return repo
 
 
 def _pause_marker_body(

--- a/python/tests/git/test_gh.py
+++ b/python/tests/git/test_gh.py
@@ -11,11 +11,11 @@ import pytest
 
 from larch.core import config
 from larch.git import gh
-from larch.implement import scope_disposition
 from larch.errors import NeedsUserInput, ShipError, TransientNetworkError
 from larch.core.proc import CommandResult
 
 from test_support import RecordingRunner as _RecordingRunner
+from test_support import write_required_plan_coverage
 
 
 @dataclass
@@ -1545,25 +1545,7 @@ def test_job_durations_raises_on_failed_read() -> None:
 
 
 def _write_scope_required_coverage(tmp_path: Path) -> None:
-    coverage = scope_disposition.PlanCoverage(
-        total=1,
-        touched=0,
-        untouched=1,
-        untouched_percent=100,
-        band="high",
-        plan_paths=("a.py",),
-        touched_paths=(),
-        untouched_paths=("a.py",),
-        todos_left_count=0,
-        todos_left=(),
-        fingerprint="fp-required",
-        disposition_required=True,
-        plan_fidelity_forced=True,
-        coverage_file=str(tmp_path / "plan-coverage.json"),
-        untouched_file=str(tmp_path / "untouched.txt"),
-        todos_file=str(tmp_path / "todos.txt"),
-    )
-    scope_disposition.write_coverage(coverage, tmpdir=tmp_path)
+    write_required_plan_coverage(tmp_path, fingerprint="fp-required")
 
 
 def test_pr_edit_body_file_scope_refusal_no_edit(

--- a/python/tests/git/test_pr.py
+++ b/python/tests/git/test_pr.py
@@ -16,7 +16,7 @@ from larch.git import pr as pr_module
 from larch.errors import NeedsUserInput, ShipError
 from larch.core.proc import CommandResult, Runner
 
-from test_support import RecordingRunner, make_run_context
+from test_support import RecordingRunner, make_run_context, write_required_plan_coverage
 
 if TYPE_CHECKING:
     from larch.core.run_context import RunContext
@@ -724,25 +724,7 @@ def test_create_branch_main_no_kvs_on_non_success(
 
 
 def _write_required_coverage(tmp_path: Path) -> None:
-    coverage = pr_module.scope_disposition.PlanCoverage(
-        total=1,
-        touched=0,
-        untouched=1,
-        untouched_percent=100,
-        band="high",
-        plan_paths=("a.py",),
-        touched_paths=(),
-        untouched_paths=("a.py",),
-        todos_left_count=0,
-        todos_left=(),
-        fingerprint="fp-required",
-        disposition_required=True,
-        plan_fidelity_forced=True,
-        coverage_file=str(tmp_path / "plan-coverage.json"),
-        untouched_file=str(tmp_path / "untouched.txt"),
-        todos_file=str(tmp_path / "todos.txt"),
-    )
-    pr_module.scope_disposition.write_coverage(coverage, tmpdir=tmp_path)
+    write_required_plan_coverage(tmp_path, fingerprint="fp-required")
 
 
 def _write_scope_required_plan(tmp_path: Path) -> None:

--- a/python/tests/implement/test_run_step_checks.py
+++ b/python/tests/implement/test_run_step_checks.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
-import subprocess
 import os
 import types
-from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -11,32 +9,15 @@ import pytest
 
 from larch.implement import checks_result_identity as identity
 from larch.implement import dispatch_commit_route as route
+from test_support import capture_start as _capture_spec
+from test_support import make_committed_repo
 
 if TYPE_CHECKING:
     from larch.bgjob import model
 
 
-def _capture_spec(captured: list[model.JobSpec]) -> Callable[[model.JobSpec], int]:
-    def fake_start(spec: model.JobSpec) -> int:
-        captured.append(spec)
-        return 0
-
-    return fake_start
-
-
-def _git(repo: Path, *args: str) -> None:
-    _ = subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True)
-
-
 def _session(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, Path]:
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    _git(repo, "init")
-    _git(repo, "config", "user.email", "test@example.com")
-    _git(repo, "config", "user.name", "Test")
-    _ = (repo / "tracked").write_text("base\n", encoding="utf-8")
-    _git(repo, "add", "tracked")
-    _git(repo, "commit", "-m", "base")
+    repo = make_committed_repo(tmp_path)
     impl = tmp_path / "impl"
     impl.mkdir()
     _ = (impl / "session-env.sh").write_text(f"REPO_ROOT={repo.resolve()}\n", encoding="utf-8")
@@ -44,7 +25,7 @@ def _session(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, Pat
     monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(Path(__file__).resolve().parents[3]))
     monkeypatch.setenv("LARCH_CLAUDE_PID", str(os.getpid()))
     monkeypatch.setattr(route.bgjob_daemon, "owner_identity_from_env", lambda _pid: object())  # pyright: ignore[reportUnknownArgumentType, reportUnknownLambdaType]
-    return impl, repo.resolve()
+    return impl, repo
 
 
 def test_step3_composite_preserves_site_budget_and_flags(

--- a/python/tests/implement/test_step_6_entry.py
+++ b/python/tests/implement/test_step_6_entry.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-import subprocess
 import os
-from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -10,36 +8,19 @@ import pytest
 
 from larch.implement import checks_result_identity as identity
 from larch.implement import dispatch_commit_route as route
+from test_support import capture_start as _capture_spec
+from test_support import make_committed_repo
 
 if TYPE_CHECKING:
     from larch.bgjob import model
-
-
-def _capture_spec(captured: list[model.JobSpec]) -> Callable[[model.JobSpec], int]:
-    def fake_start(spec: model.JobSpec) -> int:
-        captured.append(spec)
-        return 0
-
-    return fake_start
 
 
 def _start_ok(_spec: model.JobSpec) -> int:
     return 0
 
 
-def _git(repo: Path, *args: str) -> None:
-    _ = subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True)
-
-
 def _session(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, Path]:
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    _git(repo, "init")
-    _git(repo, "config", "user.email", "test@example.com")
-    _git(repo, "config", "user.name", "Test")
-    _ = (repo / "tracked").write_text("base\n", encoding="utf-8")
-    _git(repo, "add", "tracked")
-    _git(repo, "commit", "-m", "base")
+    repo = make_committed_repo(tmp_path)
     impl = tmp_path / "impl"
     impl.mkdir()
     _ = (impl / "session-env.sh").write_text(f"REPO_ROOT={repo.resolve()}\n", encoding="utf-8")
@@ -47,7 +28,7 @@ def _session(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, Pat
     monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(Path(__file__).resolve().parents[3]))
     monkeypatch.setenv("LARCH_CLAUDE_PID", str(os.getpid()))
     monkeypatch.setattr(route.bgjob_daemon, "owner_identity_from_env", lambda _pid: object())  # pyright: ignore[reportUnknownArgumentType, reportUnknownLambdaType]
-    return impl, repo.resolve()
+    return impl, repo
 
 
 def test_parent_seeds_identity_and_forwards_child_arguments(

--- a/python/tests/issue/test_rejected_analysis.py
+++ b/python/tests/issue/test_rejected_analysis.py
@@ -12,6 +12,7 @@ from larch.errors import ShipError
 from larch.issue import rejected_analysis as ra
 from larch.report import run_log_corpus
 from larch.review import voting
+from tests.support.review_wire import code_review_classification_row
 
 
 def _started() -> str:
@@ -38,31 +39,14 @@ def _write_implement_fixture(root: Path, *, run_id: str = "RUN-1", finding_id: s
         encoding="utf-8",
     )
     header = voting.CODE_REVIEW_FINDINGS_CLASSIFICATION_HEADER
-    row = "\t".join(
-        [
-            finding_id,
-            "cursor-specialist",
-            "rejected",
-            vote1,
-            "true",
-            severity1,
-            "good",
-            "false",
-            "cursor-validity",
-            vote2,
-            "true",
-            "minor",
-            "good",
-            "false",
-            "codex-plan-fidelity",
-            "NO",
-            "true",
-            "minor",
-            "good",
-            "false",
-            "codex-pragmatism",
-            scope,
-        ]
+    row = code_review_classification_row(
+        finding_id,
+        "rejected",
+        reviewer="cursor-specialist",
+        vote1=vote1,
+        severity1=severity1,
+        vote2=vote2,
+        scope=scope,
     )
     (round_dir / "findings-classification.tsv").write_text(header + "\n" + row + "\n", encoding="utf-8")
     return run

--- a/python/tests/review/test_review_aggregate.py
+++ b/python/tests/review/test_review_aggregate.py
@@ -399,39 +399,13 @@ def test_aggregate_oos_retry_threads_payload_bytes_into_env_and_manifest(tmp_pat
     dispatch = tmp_path / "payload-dispatch.sh"
     env_log = tmp_path / "payload-env.log"
     counter = tmp_path / "dispatch-count.txt"
-    rts.write_executable(
-        path=dispatch,
-        body=f"""#!/usr/bin/env bash
-set -euo pipefail
-slots=""
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --slots-file) slots="${{2:?}}"; shift 2 ;;
-    --require-result-pattern) shift 2 ;;
-    --codex-present|--cursor-present|--mode|--diff-file|--plan-file|--feature-file|--scope-files|--description-text) shift 2 ;;
-    *) shift 1 ;;
-  esac
-done
-[[ -n "$slots" && -f "$slots" ]] || exit 2
-out=$(jq -r '.output' "$slots")
-n=0
-[[ -f "{counter}" ]] && n=$(cat "{counter}")
-n=$((n + 1))
-printf '%s' "$n" > "{counter}"
-printf '%s\n' "${{LARCH_PANEL_PAYLOAD_BYTES:-0}}" >> "{env_log}"
-if [[ "$n" -eq 1 ]]; then
-  cat > "$out" <<'FAILBODY'
-{_OOS_ATTR_FAIL}
-FAILBODY
-else
-  cat > "$out" <<'OKBODY'
-{_OOS_ATTR_SUCCESS}
-OKBODY
-fi
-paths_out="${{slots}}.output-files"
-printf '%s\n' "$out" > "$paths_out"
-printf 'DISPATCH_OK=true\nALL_OUTPUT_FILES=%s\nALL_OUTPUT_FILES_PATH=%s\nALL_OUTPUT_TOOLS=cursor\n' "$out" "$paths_out"
-""",
+    rts.write_aggregate_counting_dispatch_stub(
+        dispatch,
+        counter_file=counter,
+        fail_attempts=1,
+        fail_body=_OOS_ATTR_FAIL,
+        success_body=_OOS_ATTR_SUCCESS,
+        env_log=env_log,
     )
 
     result = run_review(

--- a/python/tests/review/test_review_and_fix.py
+++ b/python/tests/review/test_review_and_fix.py
@@ -24,6 +24,7 @@ from larch.review import round_runner
 from larch.review import snapshot
 from _pytest.mark.structures import Mark, MarkDecorator
 from test_support import ok
+from tests.support.review_wire import panel_manifest_ndjson, panel_manifest_row
 
 
 def _mark(name: str) -> MarkDecorator:
@@ -915,15 +916,13 @@ def test_surface_dropped_reviewer_warning_static_straggler_with_dynamic_manifest
     dropped.write_text("testing\tcursor\tstraggler-dropped\tcut\n", encoding="utf-8")
     manifest = tmp_path / "panel-manifest.ndjson"
     manifest.write_text(
-        json.dumps(
-            {
-                "slot": "dyn-dyn-lint-escalation",
-                "tool": "cursor",
-                "output": str(tmp_path / "dyn-dyn-lint-escalation-output.txt"),
-                "agent": "agents/reviewer.md",
-            }
-        )
-        + "\n",
+        panel_manifest_ndjson([
+            panel_manifest_row(
+                "dyn-dyn-lint-escalation",
+                "cursor",
+                tmp_path / "dyn-dyn-lint-escalation-output.txt",
+            )
+        ]),
         encoding="utf-8",
     )
 

--- a/python/tests/review/test_review_pipeline.py
+++ b/python/tests/review/test_review_pipeline.py
@@ -20,6 +20,7 @@ from larch.review.review_types import ReviewCoreStatus
 from larch.rendering import rendering
 import review_test_support as rts
 from larch.review import voting
+from tests.support.review_wire import panel_manifest_ndjson, panel_manifest_row
 
 ROOT = rts.ROOT
 CLI = rts.CLI
@@ -1109,15 +1110,13 @@ def test_check_reviewer_failure_threshold_counts_dynamic_straggler_drop_with_man
     dropped.write_text("dyn-dyn-lint-escalation\tcursor\tstraggler-dropped\tcut\n", encoding="utf-8")
     manifest = tmp_path / "panel-manifest.ndjson"
     manifest.write_text(
-        json.dumps(
-            {
-                "slot": "dyn-dyn-lint-escalation",
-                "tool": "cursor",
-                "output": str(tmp_path / "dyn-dyn-lint-escalation-output.txt"),
-                "agent": "agents/reviewer.md",
-            }
-        )
-        + "\n",
+        panel_manifest_ndjson([
+            panel_manifest_row(
+                "dyn-dyn-lint-escalation",
+                "cursor",
+                tmp_path / "dyn-dyn-lint-escalation-output.txt",
+            )
+        ]),
         encoding="utf-8",
     )
 

--- a/python/tests/review/test_review_tally.py
+++ b/python/tests/review/test_review_tally.py
@@ -4,7 +4,6 @@ import csv
 import json
 import os
 import subprocess
-import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -14,6 +13,7 @@ if TYPE_CHECKING:
 from larch.review import review_tally
 from larch.review import review_core_body
 import review_test_support as rts
+from test_support import run_cli
 from larch.review import voting
 from tests.support.review_wire import ballot_snippet, make_finding_block
 
@@ -67,18 +67,7 @@ def _tsv_row_list(path: Path) -> list[dict[str, str]]:
 
 
 def _run_cli(*args: str, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
-    merged = os.environ.copy()
-    merged["LARCH_QUIET_DISABLE"] = "1"
-    if env:
-        merged.update(env)
-    return subprocess.run(
-        [sys.executable, str(CLI), *args],
-        cwd=ROOT,
-        env=merged,
-        text=True,
-        capture_output=True,
-        check=False,
-    )
+    return run_cli(*args, env=env, quiet_disable=True)
 
 
 def run_review(

--- a/python/tests/support/design_wire.py
+++ b/python/tests/support/design_wire.py
@@ -6,6 +6,7 @@ that exercise malformed or legacy wire data should keep their literals inline.
 
 from __future__ import annotations
 
+import json
 import re
 from collections.abc import Mapping, Sequence
 from pathlib import Path
@@ -21,6 +22,15 @@ PlanHeadingKind = Literal["NEW", "UPDATED"]
 _PLAN_HEADING_KINDS: frozenset[HeadingKind] = frozenset(get_args(PlanHeadingKind))
 PlanSection = tuple[PlanHeadingKind, str]
 ResultEnvRows = Mapping[str, str] | Sequence[tuple[str, str]]
+
+
+def dialectic_candidate_json(*, option_a: str, option_b: str) -> str:
+    """Serialize one ordinary dialectic decision fixture."""
+    return json.dumps({"decisions": [{
+        "id": "fork", "title": "Fork", "option_a": option_a, "option_b": option_b,
+        "tradeoff": "Different failure modes", "drafter_pick": "option_a",
+        "why_this_matters": "Operator should see it",
+    }]})
 
 
 def _validate_env_key(key: str) -> None:

--- a/python/tests/support/review_wire.py
+++ b/python/tests/support/review_wire.py
@@ -118,3 +118,21 @@ def slot_manifest_ndjson(rows: Sequence[WireRow]) -> str:
 def panel_manifest_ndjson(rows: Sequence[WireRow]) -> str:
     """Serialize shared panel-manifest rows using the canonical NDJSON contract."""
     return slot_manifest_ndjson(rows)
+
+
+def code_review_classification_row(  # noqa: PLR0913 - columns are a wire-format fixture.
+    finding_id: str,
+    result: str,
+    *,
+    reviewer: str = "reviewer",
+    vote1: str = "YES",
+    severity1: str = "major",
+    vote2: str = "NO",
+    scope: str = "",
+) -> str:
+    """Build one ordinary code-review findings-classification TSV row."""
+    return (
+        f"{finding_id}\t{reviewer}\t{result}\t{vote1}\ttrue\t{severity1}\tgood\tfalse\t"
+        f"cursor-validity\t{vote2}\ttrue\tminor\tgood\tfalse\tcodex-plan-fidelity\t"
+        f"NO\ttrue\tminor\tgood\tfalse\tcodex-pragmatism\t{scope}"
+    )


### PR DESCRIPTION
Fixes #7469.

## Summary

- Consolidate repeated test setup and wire-format builders into existing support modules.
- Preserve hermetic repository, CLI, and reviewer fixture behavior.

## Verification

- `ruff check` on all changed Python files
- `pytest` on the affected test modules
- `make py-lint-duplicate-code`
