### PR TITLE
Fixes #7467: centralize shared lint scaffolding

### DIFF
--- a/python/larch/lint/engine.py
+++ b/python/larch/lint/engine.py
@@ -9,6 +9,7 @@ stderr, then returns 0 / 1 / 2.
 from __future__ import annotations
 
 import ast
+import argparse
 import io
 import json
 import os
@@ -16,11 +17,11 @@ import re
 import stat
 import sys
 import tokenize
-from collections.abc import Callable, Iterable, Mapping, Sequence
+from collections.abc import Callable, Hashable, Iterable, Mapping, Sequence
 from contextlib import suppress
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Literal, TypeAlias, cast
+from typing import Literal, TypeAlias, TypeVar, cast
 
 from larch import io as larch_io
 from larch.core.proc import CommandResult, Runner
@@ -31,9 +32,16 @@ EXIT_ERROR = 2
 SYNTAX_FAIL_MESSAGE = "unable to parse Python"
 GIT_DIAGNOSTIC_MAX_CHARS = 200
 PYTHON_TREE_PREFIX = "python/"
+PYTHON_TEST_EXEMPT_FILENAMES = frozenset(
+    {"conftest.py", "test_support.py", "review_test_support.py"}
+)
+PYTHON_EXCLUDED_DIRS = frozenset(
+    {".git", "node_modules", ".venv", ".agents", "__pycache__"}
+)
 SyntaxPolicy = Literal["fail", "skip", "raise"]
 OccurrencePatternField = Literal["pattern_name", "normalized_condition"]
 SourceFilter = Callable[[str], bool]
+DuplicateKey = TypeVar("DuplicateKey", bound=Hashable)
 _MARKDOWN_FENCE_RE = re.compile(r"^[ \t]*(`{3,}|~{3,})([^`~]*)$")
 
 
@@ -178,6 +186,145 @@ class LintRule:
     occurrence_pattern_field: OccurrencePatternField = "pattern_name"
     require_baseline: bool = False
     prepare_corpus: PrepareCorpus | None = None
+
+
+def normalize_python_file_path(raw: str) -> str:
+    """Return a normalized POSIX path relative to the ``python/`` tree."""
+    normalized = raw.replace("\\", "/")
+    marker = "/python/"
+    if marker in normalized:
+        normalized = normalized.rsplit(marker, maxsplit=1)[1]
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    return normalized.removeprefix(PYTHON_TREE_PREFIX)
+
+
+def is_exempt_python_source(path: Path) -> bool:
+    """Return whether a Python test or shared test helper is out of scope."""
+    name = path.name
+    return (
+        (name.startswith("test_") and name.endswith(".py"))
+        or name in PYTHON_TEST_EXEMPT_FILENAMES
+    )
+
+
+def is_production_python_path(rel_path: str, *, prefix: str = PYTHON_TREE_PREFIX) -> bool:
+    """Check a repo-relative production Python path before loading its source."""
+    if not rel_path.startswith(prefix) or not rel_path.endswith(".py"):
+        return False
+    relative = Path(rel_path[len(prefix) :])
+    return not (
+        is_exempt_python_source(relative)
+        or bool(PYTHON_EXCLUDED_DIRS.intersection(relative.parts))
+    )
+
+
+def qualified_symbol(prefix: tuple[str, ...], *, module_symbol: str = "<module>") -> str:
+    """Render a nested AST scope as its stable baseline symbol."""
+    return ".".join(prefix) if prefix else module_symbol
+
+
+def ordered_ast_child_nodes(node: ast.AST) -> list[ast.AST]:
+    """Return AST children in source order, including ``with`` expressions."""
+    def position(child: ast.AST, index: int) -> tuple[int, int, int]:
+        if isinstance(child, ast.withitem):
+            context_expr = child.context_expr
+            return (
+                getattr(context_expr, "lineno", 10**9),
+                getattr(context_expr, "col_offset", 10**9),
+                index,
+            )
+        return (
+            getattr(child, "lineno", 10**9),
+            getattr(child, "col_offset", 10**9),
+            index,
+        )
+
+    indexed = list(enumerate(ast.iter_child_nodes(node)))
+    indexed.sort(key=lambda item: position(item[1], item[0]))
+    return [child for _, child in indexed]
+
+
+def first_duplicate(keys: Iterable[DuplicateKey]) -> DuplicateKey | None:
+    """Return the first repeated stable identity, or ``None`` when unique."""
+    seen: set[DuplicateKey] = set()
+    for key in keys:
+        if key in seen:
+            return key
+        seen.add(key)
+    return None
+
+
+@dataclass(frozen=True)
+class RuleCli:
+    """Stable command-line contract for an engine-backed lint rule."""
+
+    prog: str
+    description: str | None
+    baseline_filename: str | None = None
+    error_label: str | None = None
+    default_root: Path = Path(__file__).resolve().parents[3]
+    scoped_paths: tuple[str, ...] | None = None
+
+
+def run_rule_cli(
+    argv: Sequence[str],
+    *,
+    rule: LintRule,
+    cli: RuleCli,
+    runner: Runner,
+) -> int:
+    """Parse the standard lint argv and run an engine rule.
+
+    The shared contract keeps every rule's root, baseline, strict-stale, and
+    reason validation identical. Rules with bespoke positional arguments keep
+    their own entrypoint and still call :func:`run_rule` directly.
+    """
+    parser = argparse.ArgumentParser(prog=cli.prog, description=cli.description)
+    _ = parser.add_argument(
+        "--root",
+        default=str(cli.default_root),
+        help="Repository root (default: checkout containing this module).",
+    )
+    if cli.baseline_filename is not None:
+        _ = parser.add_argument(
+            "--write",
+            action="store_true",
+            help=f"Regenerate {cli.baseline_filename} from the live scan.",
+        )
+        _ = parser.add_argument(
+            "--initial-reason",
+            help="Reason for live findings that have no preserved baseline reason.",
+        )
+    try:
+        parsed = parser.parse_args(argv)
+    except SystemExit as exc:
+        if exc.code == 0:
+            raise
+        return EXIT_ERROR
+
+    root = Path(str(parsed.root)).resolve()
+    if cli.baseline_filename is None:
+        return run_rule(rule, root, runner, paths=cli.scoped_paths)
+
+    initial_reason = parsed.initial_reason
+    if initial_reason is not None and not str(initial_reason).strip():
+        print(
+            f"{cli.error_label or cli.prog}: --initial-reason must be non-empty",
+            file=sys.stderr,
+        )
+        return EXIT_ERROR
+    write_baseline = bool(parsed.write)
+    return run_rule(
+        rule,
+        root,
+        runner,
+        paths=None if write_baseline else cli.scoped_paths,
+        baseline_path=root / "python" / cli.baseline_filename,
+        write_baseline=write_baseline,
+        initial_reason=None if initial_reason is None else str(initial_reason),
+        strict_stale=not write_baseline,
+    )
 
 
 def _is_single_line(value: object) -> bool:

--- a/python/larch/lint/lint_env_via_config_constant.py
+++ b/python/larch/lint/lint_env_via_config_constant.py
@@ -15,10 +15,17 @@ import json
 import re
 import sys
 from collections import Counter
-from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import NotRequired, TypedDict, cast
+
+from larch.lint.engine import (
+    first_duplicate as _first_duplicate,
+    is_exempt_python_source,
+    normalize_python_file_path,
+    ordered_ast_child_nodes,
+    qualified_symbol,
+)
 
 TOOL_FAILURE_EXIT = 2
 BASELINE_FILENAME = "env-via-config-constant-baseline.json"
@@ -84,23 +91,10 @@ class Finding:
         )
 
 
-def normalize_file_path(raw: str) -> str:
-    """Return a normalized POSIX path relative to python/."""
-    normalized = raw.replace("\\", "/")
-    marker = "/python/"
-    if marker in normalized:
-        normalized = normalized.rsplit(marker, maxsplit=1)[1]
-    while normalized.startswith("./"):
-        normalized = normalized[2:]
-    if normalized == "python":
-        return ""
-    return normalized.removeprefix("python/")
-
-
 def _validate_normalized_file(value: object, *, source: Path, index: int, kind: str) -> str:
     if not isinstance(value, str) or not value:
         raise BaselineError(f"{source}: {kind} {index} has invalid file")
-    normalized = normalize_file_path(value)
+    normalized = normalize_python_file_path(value)
     parts = normalized.split("/")
     if (
         normalized != value
@@ -113,17 +107,11 @@ def _validate_normalized_file(value: object, *, source: Path, index: int, kind: 
     return normalized
 
 
-def is_exempt_path(path: Path) -> bool:
-    """Return whether a source file is outside production lint scope."""
-    name = path.name
-    return (name.startswith("test_") and name.endswith(".py")) or name in EXEMPT_FILENAMES
-
-
 def iter_source_files(python_dir: Path) -> list[Path]:
     """Return recursively discovered production Python files, sorted."""
     result: list[Path] = []
     for path in sorted(python_dir.rglob("*.py")):
-        if not path.is_file() or path.is_symlink() or is_exempt_path(path):
+        if not path.is_file() or path.is_symlink() or is_exempt_python_source(path):
             continue
         relative = path.relative_to(python_dir)
         if EXCLUDED_DIRS.intersection(relative.parts):
@@ -179,23 +167,6 @@ def parse_config_constants(config_path: Path, *, allow_duplicate_values: bool) -
     return constants
 
 
-def _qualified(prefix: tuple[str, ...]) -> str:
-    return ".".join(prefix) if prefix else MODULE_SYMBOL
-
-
-def _ordered_child_nodes(node: ast.AST) -> list[ast.AST]:
-    children = list(ast.iter_child_nodes(node))
-    indexed = list(enumerate(children))
-    indexed.sort(
-        key=lambda item: (
-            getattr(item[1], "lineno", 10**9),
-            getattr(item[1], "col_offset", 10**9),
-            item[0],
-        )
-    )
-    return [node for _, node in indexed]
-
-
 def _is_os_environ(node: ast.AST) -> bool:
     return (
         isinstance(node, ast.Attribute)
@@ -243,7 +214,7 @@ def _collect_scope(
     findings: list[Finding],
 ) -> None:
     occurrence = 0
-    symbol = _qualified(prefix)
+    symbol = qualified_symbol(prefix, module_symbol=MODULE_SYMBOL)
 
     def walk(node: ast.AST) -> None:
         nonlocal occurrence
@@ -283,7 +254,7 @@ def _collect_scope(
                         lineno=lineno if isinstance(lineno, int) else 0,
                     )
                 )
-        for child in _ordered_child_nodes(node):
+        for child in ordered_ast_child_nodes(node):
             walk(child)
 
     for statement in body:
@@ -498,17 +469,6 @@ def _collect_all(
         source_lines_by_file[normalized] = _source_lines(path)
         findings.extend(scan_file(path, python_dir=python_dir, env_constants=env_constants))
     return findings, source_lines_by_file
-
-
-def _first_duplicate(
-    keys: Iterable[tuple[str, str, str, str, str, int]],
-) -> tuple[str, str, str, str, str, int] | None:
-    seen: set[tuple[str, str, str, str, str, int]] = set()
-    for key in keys:
-        if key in seen:
-            return key
-        seen.add(key)
-    return None
 
 
 def _check_duplicate_live(findings: list[Finding]) -> str | None:

--- a/python/larch/lint/lint_kv_codec.py
+++ b/python/larch/lint/lint_kv_codec.py
@@ -8,7 +8,6 @@ the strict, reason-bearing baseline; inline comments cannot suppress a gate.
 
 from __future__ import annotations
 
-import argparse
 import ast
 import hashlib
 import re
@@ -17,7 +16,7 @@ from pathlib import Path
 from typing import cast
 
 from larch.core import proc
-from larch.lint.engine import Finding, LintRule, SourceFile, run_rule
+from larch.lint.engine import Finding, LintRule, RuleCli, SourceFile, run_rule_cli
 
 RULE_ID = "kv-codec"
 SUPPRESSION_TOKEN = "lint-kv-codec"
@@ -143,36 +142,19 @@ RULE = LintRule(
 )
 
 
-def _parse_args(argv: list[str]) -> argparse.Namespace | None:
-    parser = argparse.ArgumentParser(prog="cli.py lint kv-codec")
-    _ = parser.add_argument("--root", default=str(Path(__file__).resolve().parents[3]))
-    _ = parser.add_argument("--write", action="store_true")
-    _ = parser.add_argument("--initial-reason")
-    try:
-        return parser.parse_args(argv)
-    except SystemExit as exc:
-        if exc.code == 0:
-            raise
-        return None
-
-
 def main(argv: list[str] | None = None) -> int:
     """Run the kv-codec ratchet or regenerate its checked-in baseline."""
-    parsed = _parse_args(argv if argv is not None else sys.argv[1:])
-    if parsed is None:
-        return 2
-    root = Path(str(parsed.root)).resolve()
-    write_baseline = bool(parsed.write)
-    reason = None if parsed.initial_reason is None else str(parsed.initial_reason)
-    return run_rule(
-        RULE,
-        root,
-        proc.ProcRunner(),
-        paths=None if write_baseline else ["python/larch", "scripts", "skills"],
-        baseline_path=root / "python" / BASELINE_FILENAME,
-        write_baseline=write_baseline,
-        initial_reason=reason,
-        strict_stale=not write_baseline,
+    return run_rule_cli(
+        argv if argv is not None else sys.argv[1:],
+        rule=RULE,
+        cli=RuleCli(
+            prog="cli.py lint kv-codec",
+            description=__doc__,
+            baseline_filename=BASELINE_FILENAME,
+            error_label="lint-kv-codec",
+            scoped_paths=("python/larch", "scripts", "skills"),
+        ),
+        runner=proc.ProcRunner(),
     )
 
 

--- a/python/larch/lint/lint_layering.py
+++ b/python/larch/lint/lint_layering.py
@@ -16,10 +16,17 @@ import json
 import re
 import sys
 from collections import Counter
-from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TypedDict, cast
+
+from larch.lint.engine import (
+    first_duplicate as _first_duplicate,
+    is_exempt_python_source,
+    normalize_python_file_path,
+    ordered_ast_child_nodes,
+    qualified_symbol,
+)
 
 TOOL_FAILURE_EXIT = 2
 BASELINE_FILENAME = "layering-baseline.json"
@@ -81,21 +88,10 @@ class Finding:
         return (self.file, self.qualified_symbol, self.imported_package, self.occurrence)
 
 
-def normalize_file_path(raw: str) -> str:
-    """Return a normalized POSIX path relative to python/."""
-    normalized = raw.replace("\\", "/")
-    marker = "/python/"
-    if marker in normalized:
-        normalized = normalized.rsplit(marker, maxsplit=1)[1]
-    while normalized.startswith("./"):
-        normalized = normalized[2:]
-    return normalized.removeprefix("python/")
-
-
 def _validate_normalized_file(value: object, *, source: Path, index: int, kind: str) -> str:
     if not isinstance(value, str) or not value:
         raise BaselineError(f"{source}: {kind} {index} has invalid file")
-    normalized = normalize_file_path(value)
+    normalized = normalize_python_file_path(value)
     parts = normalized.split("/")
     if (
         normalized != value
@@ -108,17 +104,11 @@ def _validate_normalized_file(value: object, *, source: Path, index: int, kind: 
     return normalized
 
 
-def is_exempt_path(path: Path) -> bool:
-    """Return whether a source file is outside production lint scope."""
-    name = path.name
-    return (name.startswith("test_") and name.endswith(".py")) or name in EXEMPT_FILENAMES
-
-
 def iter_source_files(larch_dir: Path) -> list[Path]:
     """Return recursively discovered production Python files under larch/, sorted."""
     result: list[Path] = []
     for path in sorted(larch_dir.rglob("*.py")):
-        if not path.is_file() or path.is_symlink() or is_exempt_path(path):
+        if not path.is_file() or path.is_symlink() or is_exempt_python_source(path):
             continue
         relative = path.relative_to(larch_dir.parent)
         if EXCLUDED_DIRS.intersection(relative.parts):
@@ -207,23 +197,6 @@ def _importee_packages(node: ast.stmt, *, importer_pkg: str) -> list[str]:
     return []
 
 
-def _qualified(prefix: tuple[str, ...]) -> str:
-    return ".".join(prefix) if prefix else MODULE_SYMBOL
-
-
-def _ordered_child_nodes(node: ast.AST) -> list[ast.AST]:
-    children = list(ast.iter_child_nodes(node))
-    indexed = list(enumerate(children))
-    indexed.sort(
-        key=lambda item: (
-            getattr(item[1], "lineno", 10**9),
-            getattr(item[1], "col_offset", 10**9),
-            item[0],
-        )
-    )
-    return [n for _, n in indexed]
-
-
 @dataclass
 class _ScopeCtx:
     normalized_file: str
@@ -238,7 +211,7 @@ def _collect_scope(
     prefix: tuple[str, ...],
     ctx: _ScopeCtx,
 ) -> None:
-    symbol = _qualified(prefix)
+    symbol = qualified_symbol(prefix, module_symbol=MODULE_SYMBOL)
     occurrence_by_importee: dict[str, int] = {}
 
     def walk(node: ast.AST) -> None:
@@ -267,7 +240,7 @@ def _collect_scope(
                         )
                     )
             return
-        for child in _ordered_child_nodes(node):
+        for child in ordered_ast_child_nodes(node):
             walk(child)
 
     for statement in body:
@@ -409,17 +382,6 @@ def _collect_all(
             scan_file(path, python_dir=python_dir, importer_pkg=importer_pkg, importer_tier=importer_tier)
         )
     return findings, source_lines_by_file
-
-
-def _first_duplicate(
-    keys: Iterable[tuple[str, str, str, int]],
-) -> tuple[str, str, str, int] | None:
-    seen: set[tuple[str, str, str, int]] = set()
-    for key in keys:
-        if key in seen:
-            return key
-        seen.add(key)
-    return None
 
 
 def _check_duplicate_live(findings: list[Finding]) -> str | None:

--- a/python/larch/lint/lint_lifecycle_prefix_literal.py
+++ b/python/larch/lint/lint_lifecycle_prefix_literal.py
@@ -16,7 +16,7 @@ import json
 import re
 import sys
 from collections import Counter
-from collections.abc import Iterable, Mapping
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 import tokenize
@@ -24,6 +24,13 @@ from typing import TypedDict, cast
 
 from larch.core import config
 from larch.issue import title_match
+from larch.lint.engine import (
+    first_duplicate as _first_duplicate,
+    is_exempt_python_source,
+    normalize_python_file_path,
+    ordered_ast_child_nodes,
+    qualified_symbol,
+)
 
 TOOL_FAILURE_EXIT = 2
 BASELINE_FILENAME = "lifecycle-prefix-literal-baseline.json"
@@ -106,19 +113,6 @@ class Finding:
 OccurrenceKey = tuple[str, str, str, str, str]
 
 
-def normalize_file_path(raw: str) -> str:
-    """Return a normalized POSIX path relative to python/."""
-    normalized: str = raw.replace("\\", "/")
-    marker = "/python/"
-    if marker in normalized:
-        normalized = normalized.rsplit(marker, maxsplit=1)[1]
-    while normalized.startswith("./"):
-        normalized = normalized[2:]
-    if normalized == "python":
-        return ""
-    return normalized.removeprefix("python/")
-
-
 def _has_bad_path_parts(parts: list[str]) -> bool:
     return "" in parts or "." in parts or ".." in parts
 
@@ -126,7 +120,7 @@ def _has_bad_path_parts(parts: list[str]) -> bool:
 def _validate_normalized_file(value: object, *, source: Path, index: int) -> str:
     if not isinstance(value, str) or not value:
         raise BaselineError(f"{source}: record {index} has invalid file")
-    normalized: str = normalize_file_path(value)
+    normalized: str = normalize_python_file_path(value)
     parts: list[str] = normalized.split("/")
     if (
         normalized != value
@@ -139,17 +133,11 @@ def _validate_normalized_file(value: object, *, source: Path, index: int) -> str
     return normalized
 
 
-def is_exempt_path(path: Path) -> bool:
-    """Return whether a source file is outside production lint scope."""
-    name: str = path.name
-    return (name.startswith("test_") and name.endswith(".py")) or name in EXEMPT_FILENAMES
-
-
 def iter_source_files(larch_dir: Path) -> list[Path]:
     """Return recursively discovered production Python files under larch/, sorted."""
     result: list[Path] = []
     for path in sorted(larch_dir.rglob("*.py")):
-        if not path.is_file() or path.is_symlink() or is_exempt_path(path):
+        if not path.is_file() or path.is_symlink() or is_exempt_python_source(path):
             continue
         relative: Path = path.relative_to(larch_dir.parent)
         if EXCLUDED_DIRS.intersection(relative.parts):
@@ -189,25 +177,6 @@ def build_token_map() -> dict[str, TokenInfo]:
         add(prefix, constant=f"config.TRACKING_ISSUE_PREFIX_BY_STATE[{state_literal}]")
     add(title_match.BUG_PREFIX, constant="title_match.BUG_PREFIX")
     return tokens
-
-
-def _qualified(prefix: tuple[str, ...]) -> str:
-    return ".".join(prefix) if prefix else MODULE_SYMBOL
-
-
-def _child_position(node: ast.AST, *, index: int) -> tuple[int, int, int]:
-    return (
-        getattr(node, "lineno", 10**9),
-        getattr(node, "col_offset", 10**9),
-        index,
-    )
-
-
-def _ordered_child_nodes(node: ast.AST) -> list[ast.AST]:
-    children: list[ast.AST] = list(ast.iter_child_nodes(node))
-    indexed: list[tuple[int, ast.AST]] = list(enumerate(children))
-    indexed.sort(key=lambda item: _child_position(item[1], index=item[0]))
-    return [child for _, child in indexed]
 
 
 def _literal_text(node: ast.AST) -> str | None:
@@ -427,7 +396,7 @@ def _collect_scope(
     findings: list[Finding],
 ) -> None:
     occurrence_counts: Counter[OccurrenceKey] = Counter()
-    symbol: str = _qualified(prefix)
+    symbol: str = qualified_symbol(prefix, module_symbol=MODULE_SYMBOL)
     recorder = ScopeRecorder(
         findings=findings,
         occurrence_counts=occurrence_counts,
@@ -458,7 +427,7 @@ def _collect_scope(
         lineno: int = lineno_value if isinstance(lineno_value, int) else 0
         for context, match in _contexts_for_node(node, token_infos=token_infos):
             recorder.record(context=context, match=match, lineno=lineno)
-        for child in _ordered_child_nodes(node):
+        for child in ordered_ast_child_nodes(node):
             walk(child)
 
     for statement in body:
@@ -538,17 +507,6 @@ def _validate_record(item: object, *, index: int, source: Path) -> Record:
         "occurrence": occurrence,
         "reason": reason,
     }
-
-
-def _first_duplicate(
-    keys: Iterable[tuple[str, str, str, str, str, int]],
-) -> tuple[str, str, str, str, str, int] | None:
-    seen: set[tuple[str, str, str, str, str, int]] = set()
-    for key in keys:
-        if key in seen:
-            return key
-        seen.add(key)
-    return None
 
 
 def load_baseline(path: Path) -> list[Record]:

--- a/python/larch/lint/lint_markdown_heading_fence_state.py
+++ b/python/larch/lint/lint_markdown_heading_fence_state.py
@@ -8,13 +8,11 @@ codec. Mechanically backs G-Md-3 / #6676.
 
 from __future__ import annotations
 
-import argparse
 import ast
 import sys
-from pathlib import Path
 
 from larch.core import proc
-from larch.lint.engine import EXIT_ERROR, Finding, LintRule, SourceFile, run_rule
+from larch.lint.engine import Finding, LintRule, RuleCli, SourceFile, run_rule_cli
 from larch.lint.markdown_heading_fence_state_detector import (
     SUPPRESSION,
     is_production_source_path,
@@ -67,56 +65,18 @@ RULE = LintRule(
 )
 
 
-def _parse_args(argv: list[str]) -> argparse.Namespace | None:
-    parser = argparse.ArgumentParser(
-        prog="cli.py lint markdown-heading-fence-state",
-        description=__doc__,
-    )
-    _ = parser.add_argument(
-        "--root",
-        default=str(Path(__file__).resolve().parents[3]),
-        help="Repository root (default: checkout containing this module).",
-    )
-    _ = parser.add_argument(
-        "--write",
-        action="store_true",
-        help=f"Regenerate {BASELINE_FILENAME} from the live AST scan.",
-    )
-    _ = parser.add_argument(
-        "--initial-reason",
-        help="Reason for live findings that have no preserved baseline reason.",
-    )
-    try:
-        return parser.parse_args(argv)
-    except SystemExit as exc:
-        if exc.code == 0:
-            raise
-        return None
-
-
 def main(argv: list[str] | None = None) -> int:
     """CLI entry registered as ``python3 python/cli.py lint markdown-heading-fence-state``."""
-    parsed = _parse_args(argv if argv is not None else sys.argv[1:])
-    if parsed is None:
-        return EXIT_ERROR
-    root = Path(str(parsed.root)).resolve()
-    baseline_path = root / "python" / BASELINE_FILENAME
-    initial_reason = parsed.initial_reason
-    if initial_reason is not None and not str(initial_reason).strip():
-        print(
-            "lint-markdown-heading-fence-state: --initial-reason must be non-empty",
-            file=sys.stderr,
-        )
-        return EXIT_ERROR
-    return run_rule(
-        RULE,
-        root,
-        proc.ProcRunner(),
-        paths=None,
-        baseline_path=baseline_path,
-        write_baseline=bool(parsed.write),
-        initial_reason=None if initial_reason is None else str(initial_reason),
-        strict_stale=not bool(parsed.write),
+    return run_rule_cli(
+        argv if argv is not None else sys.argv[1:],
+        rule=RULE,
+        cli=RuleCli(
+            prog="cli.py lint markdown-heading-fence-state",
+            description=__doc__,
+            baseline_filename=BASELINE_FILENAME,
+            error_label="lint-markdown-heading-fence-state",
+        ),
+        runner=proc.ProcRunner(),
     )
 
 

--- a/python/larch/lint/lint_monkeypatch_facade_binding.py
+++ b/python/larch/lint/lint_monkeypatch_facade_binding.py
@@ -14,10 +14,16 @@ import ast
 import json
 import re
 import sys
-from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TypedDict, cast
+
+from larch.lint.engine import (
+    first_duplicate as _first_duplicate,
+    normalize_python_file_path,
+    ordered_ast_child_nodes,
+    qualified_symbol,
+)
 
 TOOL_FAILURE_EXIT = 2
 BASELINE_FILENAME = "monkeypatch-facade-binding-baseline.json"
@@ -224,17 +230,6 @@ class ModuleResolver:
         return None
 
 
-def normalize_file_path(raw: str) -> str:
-    """Return a normalized POSIX path relative to python/."""
-    normalized = raw.replace("\\", "/")
-    marker = "/python/"
-    if marker in normalized:
-        normalized = normalized.rsplit(marker, maxsplit=1)[1]
-    while normalized.startswith("./"):
-        normalized = normalized[2:]
-    return normalized.removeprefix("python/")
-
-
 def _is_regular_under(path: Path, root: Path) -> bool:
     try:
         _ = path.relative_to(root)
@@ -266,7 +261,7 @@ def _is_valid_test_file(value: str) -> bool:
 def _validate_normalized_file(value: object, *, source: Path, index: int) -> str:
     if not isinstance(value, str) or not value:
         raise BaselineError(f"{source}: record {index} has invalid file")
-    normalized = normalize_file_path(value)
+    normalized = normalize_python_file_path(value)
     if normalized != value or not _is_valid_test_file(normalized):
         raise BaselineError(f"{source}: record {index} has invalid file")
     return normalized
@@ -362,32 +357,6 @@ def _import_binding_source(statement: ast.stmt, attribute: str, *, current: Modu
         if bound_name == attribute:
             return base_module or alias.name
     return None
-
-
-def _qualified(prefix: tuple[str, ...]) -> str:
-    return ".".join(prefix) if prefix else MODULE_SYMBOL
-
-
-def _child_position(node: ast.AST, *, index: int) -> tuple[int, int, int]:
-    if isinstance(node, ast.withitem):
-        context_expr = node.context_expr
-        return (
-            getattr(context_expr, "lineno", 10**9),
-            getattr(context_expr, "col_offset", 10**9),
-            index,
-        )
-    return (
-        getattr(node, "lineno", 10**9),
-        getattr(node, "col_offset", 10**9),
-        index,
-    )
-
-
-def _ordered_child_nodes(node: ast.AST) -> list[ast.AST]:
-    children = list(ast.iter_child_nodes(node))
-    indexed = list(enumerate(children))
-    indexed.sort(key=lambda item: _child_position(item[1], index=item[0]))
-    return [child for _, child in indexed]
 
 
 def _build_import_map(
@@ -539,7 +508,7 @@ def _collect_scope(
     state: ScanState,
 ) -> None:
     occurrence = 0
-    symbol = _qualified(prefix)
+    symbol = qualified_symbol(prefix, module_symbol=MODULE_SYMBOL)
 
     def walk(node: ast.AST) -> None:
         nonlocal occurrence
@@ -576,7 +545,7 @@ def _collect_scope(
                         suppressed=_has_suppression(state.lines, line_number),
                     )
                 )
-        for child in _ordered_child_nodes(node):
+        for child in ordered_ast_child_nodes(node):
             walk(child)
 
     for statement in body:
@@ -706,17 +675,6 @@ def _validate_record(item: object, *, index: int, source: Path) -> Record:
         "occurrence": occurrence,
         "reason": reason,
     }
-
-
-def _first_duplicate(
-    keys: Iterable[tuple[str, str, str, str, str, int]],
-) -> tuple[str, str, str, str, str, int] | None:
-    seen: set[tuple[str, str, str, str, str, int]] = set()
-    for key in keys:
-        if key in seen:
-            return key
-        seen.add(key)
-    return None
 
 
 def load_baseline(path: Path) -> list[Record]:

--- a/python/larch/lint/lint_pylint_skip_file.py
+++ b/python/larch/lint/lint_pylint_skip_file.py
@@ -12,15 +12,13 @@ this gate (I-Gate-1 / G-Enf-2).
 
 from __future__ import annotations
 
-import argparse
 import io
 import re
 import sys
 import tokenize
-from pathlib import Path
 
 from larch.core import proc
-from larch.lint.engine import Finding, LintRule, SourceFile, run_rule
+from larch.lint.engine import Finding, LintRule, RuleCli, SourceFile, run_rule_cli
 
 RULE_ID = "pylint-skip-file"
 SUPPRESSION_TOKEN = "lint-pylint-skip-file"
@@ -117,56 +115,19 @@ RULE = LintRule(
 )
 
 
-def _parse_args(argv: list[str]) -> argparse.Namespace | None:
-    parser = argparse.ArgumentParser(
-        prog="cli.py lint pylint-skip-file",
-        description=__doc__,
-    )
-    _ = parser.add_argument(
-        "--root",
-        default=str(Path(__file__).resolve().parents[3]),
-        help="Repository root (default: checkout containing this module).",
-    )
-    _ = parser.add_argument(
-        "--write",
-        action="store_true",
-        help=f"Regenerate {BASELINE_FILENAME} from the live scan.",
-    )
-    _ = parser.add_argument(
-        "--initial-reason",
-        help="Reason for live findings that have no preserved baseline reason.",
-    )
-    try:
-        return parser.parse_args(argv)
-    except SystemExit as exc:
-        if exc.code == 0:
-            raise
-        return None
-
-
 def main(argv: list[str] | None = None) -> int:
     """CLI entry registered as ``python3 python/cli.py lint pylint-skip-file``."""
-    parsed = _parse_args(argv if argv is not None else sys.argv[1:])
-    if parsed is None:
-        return 2
-    root = Path(str(parsed.root)).resolve()
-    baseline_path = root / "python" / BASELINE_FILENAME
-    initial_reason = parsed.initial_reason
-    if initial_reason is not None and not str(initial_reason).strip():
-        print("lint-pylint-skip-file: --initial-reason must be non-empty", file=sys.stderr)
-        return 2
-    write_baseline = bool(parsed.write)
-    # write_baseline forbids filtered paths; detect() self-scopes to python/larch/.
-    paths: list[str] | None = None if write_baseline else [SCOPE_PREFIX.rstrip("/")]
-    return run_rule(
-        RULE,
-        root,
-        proc.ProcRunner(),
-        paths=paths,
-        baseline_path=baseline_path,
-        write_baseline=write_baseline,
-        initial_reason=None if initial_reason is None else str(initial_reason),
-        strict_stale=not write_baseline,
+    return run_rule_cli(
+        argv if argv is not None else sys.argv[1:],
+        rule=RULE,
+        cli=RuleCli(
+            prog="cli.py lint pylint-skip-file",
+            description=__doc__,
+            baseline_filename=BASELINE_FILENAME,
+            error_label="lint-pylint-skip-file",
+            scoped_paths=(SCOPE_PREFIX.rstrip("/"),),
+        ),
+        runner=proc.ProcRunner(),
     )
 
 

--- a/python/larch/lint/lint_renderer_golden_tests.py
+++ b/python/larch/lint/lint_renderer_golden_tests.py
@@ -22,6 +22,9 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TypedDict, cast
 
+from larch.lint.engine import first_duplicate as _first_duplicate
+from larch.lint.engine import normalize_python_file_path
+
 TOOL_FAILURE_EXIT = 2
 BASELINE_FILENAME = "renderer-golden-tests-baseline.json"
 BASELINE_KEYS = frozenset({"file", "function_name", "reason"})
@@ -51,19 +54,6 @@ class Candidate:
 Finding = Candidate
 
 
-def normalize_file_path(raw: str) -> str:
-    """Return a normalized POSIX path relative to python/."""
-    normalized: str = raw.replace("\\", "/")
-    marker = "/python/"
-    if marker in normalized:
-        normalized = normalized.rsplit(marker, maxsplit=1)[1]
-    while normalized.startswith("./"):
-        normalized = normalized[2:]
-    if normalized == "python":
-        return ""
-    return normalized.removeprefix("python/")
-
-
 def _has_bad_path_parts(parts: list[str]) -> bool:
     return "" in parts or "." in parts or ".." in parts
 
@@ -71,7 +61,7 @@ def _has_bad_path_parts(parts: list[str]) -> bool:
 def _validate_normalized_file(value: object, *, source: Path, index: int) -> str:
     if not isinstance(value, str) or not value:
         raise BaselineError(f"{source}: record {index} has invalid file")
-    normalized: str = normalize_file_path(value)
+    normalized: str = normalize_python_file_path(value)
     parts: list[str] = normalized.split("/")
     if (
         normalized != value
@@ -184,15 +174,6 @@ def _validate_record(item: object, *, index: int, source: Path) -> Record:
     if not isinstance(reason, str) or not reason.strip():
         raise BaselineError(f"{source}: record {index} has invalid reason")
     return {"file": file_name, "function_name": function_name, "reason": reason}
-
-
-def _first_duplicate(keys: Iterable[tuple[str, str]]) -> tuple[str, str] | None:
-    seen: set[tuple[str, str]] = set()
-    for key in keys:
-        if key in seen:
-            return key
-        seen.add(key)
-    return None
 
 
 def load_baseline(path: Path) -> list[Record]:

--- a/python/larch/lint/lint_subprocess_via_runner.py
+++ b/python/larch/lint/lint_subprocess_via_runner.py
@@ -19,6 +19,13 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TypedDict, cast
 
+from larch.lint.engine import (
+    is_exempt_python_source,
+    normalize_python_file_path,
+    ordered_ast_child_nodes,
+    qualified_symbol,
+)
+
 TOOL_FAILURE_EXIT = 2
 BASELINE_FILENAME = "subprocess-via-runner-baseline.json"
 EXEMPTIONS_FILENAME = "subprocess-via-runner-exemptions.json"
@@ -88,23 +95,10 @@ class GhFinding:
         return (self.file, self.qualified_symbol, self.occurrence)
 
 
-def normalize_file_path(raw: str) -> str:
-    """Return a normalized POSIX path relative to python/."""
-    normalized = raw.replace("\\", "/")
-    marker = "/python/"
-    if marker in normalized:
-        normalized = normalized.rsplit(marker, maxsplit=1)[1]
-    while normalized.startswith("./"):
-        normalized = normalized[2:]
-    if normalized == "python":
-        return ""
-    return normalized.removeprefix("python/")
-
-
 def _validate_normalized_file(value: object, *, source: Path, index: int, kind: str) -> str:
     if not isinstance(value, str) or not value:
         raise BaselineError(f"{source}: {kind} {index} has invalid file")
-    normalized = normalize_file_path(value)
+    normalized = normalize_python_file_path(value)
     parts = normalized.split("/")
     if (
         normalized != value
@@ -117,17 +111,11 @@ def _validate_normalized_file(value: object, *, source: Path, index: int, kind: 
     return normalized
 
 
-def is_exempt_path(path: Path) -> bool:
-    """Return whether a source file is outside production lint scope."""
-    name = path.name
-    return (name.startswith("test_") and name.endswith(".py")) or name in EXEMPT_FILENAMES
-
-
 def iter_source_files(python_dir: Path) -> list[Path]:
     """Return recursively discovered production Python files, sorted."""
     result: list[Path] = []
     for path in sorted(python_dir.rglob("*.py")):
-        if not path.is_file() or path.is_symlink() or is_exempt_path(path):
+        if not path.is_file() or path.is_symlink() or is_exempt_python_source(path):
             continue
         relative = path.relative_to(python_dir)
         if EXCLUDED_DIRS.intersection(relative.parts):
@@ -137,23 +125,6 @@ def iter_source_files(python_dir: Path) -> list[Path]:
             continue
         result.append(path)
     return result
-
-
-def _qualified(prefix: tuple[str, ...]) -> str:
-    return ".".join(prefix) if prefix else MODULE_SYMBOL
-
-
-def _ordered_child_nodes(node: ast.AST) -> list[ast.AST]:
-    children = list(ast.iter_child_nodes(node))
-    indexed = list(enumerate(children))
-    indexed.sort(
-        key=lambda item: (
-            getattr(item[1], "lineno", 10**9),
-            getattr(item[1], "col_offset", 10**9),
-            item[0],
-        )
-    )
-    return [node for _, node in indexed]
 
 
 def _subprocess_callee(node: ast.AST) -> str | None:
@@ -190,7 +161,7 @@ def _collect_scope(
     findings: list[Finding],
 ) -> None:
     occurrence = 0
-    symbol = _qualified(prefix)
+    symbol = qualified_symbol(prefix, module_symbol=MODULE_SYMBOL)
 
     def walk(node: ast.AST) -> None:
         nonlocal occurrence
@@ -223,7 +194,7 @@ def _collect_scope(
                     lineno=lineno if isinstance(lineno, int) else 0,
                 )
             )
-        for child in _ordered_child_nodes(node):
+        for child in ordered_ast_child_nodes(node):
             walk(child)
 
     for statement in body:
@@ -238,7 +209,7 @@ def _collect_gh_scope(
     findings: list[GhFinding],
 ) -> None:
     occurrence = 0
-    symbol = _qualified(prefix)
+    symbol = qualified_symbol(prefix, module_symbol=MODULE_SYMBOL)
 
     def walk(node: ast.AST) -> None:
         nonlocal occurrence
@@ -269,7 +240,7 @@ def _collect_gh_scope(
                     lineno=lineno if isinstance(lineno, int) else 0,
                 )
             )
-        for child in _ordered_child_nodes(node):
+        for child in ordered_ast_child_nodes(node):
             walk(child)
 
     for statement in body:

--- a/python/larch/lint/lint_suppression_reason.py
+++ b/python/larch/lint/lint_suppression_reason.py
@@ -14,11 +14,13 @@ import json
 import re
 import sys
 import tokenize
-from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 from re import Pattern
 from typing import TypedDict, cast
+
+from larch.lint.engine import first_duplicate as _first_duplicate
+from larch.lint.engine import normalize_python_file_path
 
 TOOL_FAILURE_EXIT = 2
 BASELINE_FILENAME = "suppression-reason-baseline.json"
@@ -157,19 +159,6 @@ class SegmentMatch:
     reason: str | None = None
 
 
-def normalize_file_path(raw: str) -> str:
-    """Return a normalized POSIX path relative to python/."""
-    normalized: str = raw.replace("\\", "/")
-    marker = "/python/"
-    if marker in normalized:
-        normalized = normalized.rsplit(marker, maxsplit=1)[1]
-    while normalized.startswith("./"):
-        normalized = normalized[2:]
-    if normalized == "python":
-        return ""
-    return normalized.removeprefix("python/")
-
-
 def _bad_path_parts(parts: list[str]) -> bool:
     return "" in parts or "." in parts or ".." in parts
 
@@ -195,7 +184,7 @@ def _invalid_normalized_parts(normalized: str, parts: list[str]) -> bool:
 def _validate_normalized_file(value: object, *, source: Path, index: int) -> str:
     if not isinstance(value, str) or not value:
         raise BaselineError(f"{source}: record {index} has invalid file")
-    normalized: str = normalize_file_path(value)
+    normalized: str = normalize_python_file_path(value)
     parts: list[str] = normalized.split("/")
     if normalized != value or _invalid_normalized_parts(normalized, parts):
         raise BaselineError(f"{source}: record {index} has invalid file")
@@ -481,15 +470,6 @@ def _validate_record(item: object, *, index: int, source: Path) -> Record:
         "occurrence": occurrence,
         "reason": reason,
     }
-
-
-def _first_duplicate(keys: Iterable[tuple[str, str, str, int]]) -> tuple[str, str, str, int] | None:
-    seen: set[tuple[str, str, str, int]] = set()
-    for key in keys:
-        if key in seen:
-            return key
-        seen.add(key)
-    return None
 
 
 def load_baseline(path: Path) -> list[Record]:

--- a/python/larch/lint/lint_tempfile_dir.py
+++ b/python/larch/lint/lint_tempfile_dir.py
@@ -11,10 +11,17 @@ import argparse
 import ast
 import json
 import sys
-from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TypedDict, cast
+
+from larch.lint.engine import (
+    first_duplicate as _first_duplicate,
+    is_exempt_python_source,
+    normalize_python_file_path,
+    ordered_ast_child_nodes,
+    qualified_symbol,
+)
 
 TOOL_FAILURE_EXIT = 2
 BASELINE_FILENAME = "tempfile-dir-baseline.json"
@@ -49,21 +56,10 @@ class Finding:
         return (self.file, self.qualified_symbol, self.callee, self.occurrence)
 
 
-def normalize_file_path(raw: str) -> str:
-    """Return a normalized POSIX path relative to python/."""
-    normalized = raw.replace("\\", "/")
-    marker = "/python/"
-    if marker in normalized:
-        normalized = normalized.rsplit(marker, maxsplit=1)[1]
-    while normalized.startswith("./"):
-        normalized = normalized[2:]
-    return normalized.removeprefix("python/")
-
-
 def _validate_normalized_file(value: object, *, source: Path, index: int) -> str:
     if not isinstance(value, str) or not value:
         raise BaselineError(f"{source}: record {index} has invalid file")
-    normalized = normalize_file_path(value)
+    normalized = normalize_python_file_path(value)
     parts = normalized.split("/")
     if (  # pylint: disable=too-many-boolean-expressions  # 7-condition path-component guard; splitting would obscure intent
         normalized != value
@@ -78,49 +74,17 @@ def _validate_normalized_file(value: object, *, source: Path, index: int) -> str
     return normalized
 
 
-def is_exempt_path(path: Path) -> bool:
-    """Return whether a source file is outside production lint scope."""
-    name = path.name
-    return (name.startswith("test_") and name.endswith(".py")) or name in EXEMPT_FILENAMES
-
-
 def iter_source_files(larch_dir: Path) -> list[Path]:
     """Return recursively discovered production Python files under larch/, sorted."""
     result: list[Path] = []
     for path in sorted(larch_dir.rglob("*.py")):
-        if not path.is_file() or path.is_symlink() or is_exempt_path(path):
+        if not path.is_file() or path.is_symlink() or is_exempt_python_source(path):
             continue
         relative = path.relative_to(larch_dir.parent)
         if EXCLUDED_DIRS.intersection(relative.parts):
             continue
         result.append(path)
     return result
-
-
-def _qualified(prefix: tuple[str, ...]) -> str:
-    return ".".join(prefix) if prefix else MODULE_SYMBOL
-
-
-def _child_position(node: ast.AST, *, index: int) -> tuple[int, int, int]:
-    if isinstance(node, ast.withitem):
-        context_expr = node.context_expr
-        return (
-            getattr(context_expr, "lineno", 10**9),
-            getattr(context_expr, "col_offset", 10**9),
-            index,
-        )
-    return (
-        getattr(node, "lineno", 10**9),
-        getattr(node, "col_offset", 10**9),
-        index,
-    )
-
-
-def _ordered_child_nodes(node: ast.AST) -> list[ast.AST]:
-    children = list(ast.iter_child_nodes(node))
-    indexed = list(enumerate(children))
-    indexed.sort(key=lambda item: _child_position(item[1], index=item[0]))
-    return [node for _, node in indexed]
 
 
 def _tempfile_callee(node: ast.AST) -> str | None:
@@ -146,7 +110,7 @@ def _collect_scope(
     findings: list[Finding],
 ) -> None:
     occurrence = 0
-    symbol = _qualified(prefix)
+    symbol = qualified_symbol(prefix, module_symbol=MODULE_SYMBOL)
 
     def walk(node: ast.AST) -> None:
         nonlocal occurrence
@@ -180,7 +144,7 @@ def _collect_scope(
                         lineno=lineno if isinstance(lineno, int) else 0,
                     )
                 )
-        for child in _ordered_child_nodes(node):
+        for child in ordered_ast_child_nodes(node):
             walk(child)
 
     for statement in body:
@@ -246,17 +210,6 @@ def _validate_record(item: object, *, index: int, source: Path) -> Record:
         "occurrence": occurrence,
         "reason": reason,
     }
-
-
-def _first_duplicate(
-    keys: Iterable[tuple[str, str, str, int]],
-) -> tuple[str, str, str, int] | None:
-    seen: set[tuple[str, str, str, int]] = set()
-    for key in keys:
-        if key in seen:
-            return key
-        seen.add(key)
-    return None
 
 
 def load_baseline(path: Path) -> list[Record]:

--- a/python/larch/lint/lint_unreachable_branch.py
+++ b/python/larch/lint/lint_unreachable_branch.py
@@ -7,18 +7,16 @@ occurrence codec and legacy ``normalized_condition`` field name.
 
 from __future__ import annotations
 
-import argparse
 import ast
 import sys
-from pathlib import Path
 
 from larch.core import proc
 from larch.lint.engine import (
-    EXIT_ERROR,
     Finding as EngineFinding,
     LintRule,
+    RuleCli,
     SourceFile,
-    run_rule,
+    run_rule_cli,
 )
 from larch.lint.unreachable_branch_detector import (  # pylint: disable=unused-import  # re-export
     SUPPRESSION,
@@ -81,56 +79,18 @@ RULE = LintRule(
 )
 
 
-def _parse_args(argv: list[str]) -> argparse.Namespace | None:
-    parser = argparse.ArgumentParser(
-        prog="cli.py lint unreachable-branch",
-        description=__doc__,
-    )
-    _ = parser.add_argument(
-        "--root",
-        default=str(Path(__file__).resolve().parents[3]),
-        help="Repository root (default: checkout containing this module).",
-    )
-    _ = parser.add_argument(
-        "--write",
-        action="store_true",
-        help=f"Regenerate {BASELINE_FILENAME} from the live AST scan.",
-    )
-    _ = parser.add_argument(
-        "--initial-reason",
-        help="Reason for live findings that have no preserved baseline reason.",
-    )
-    try:
-        return parser.parse_args(argv)
-    except SystemExit as exc:
-        if exc.code == 0:
-            raise
-        return None
-
-
 def main(argv: list[str] | None = None) -> int:
     """CLI entry registered as ``python3 python/cli.py lint unreachable-branch``."""
-    parsed = _parse_args(argv if argv is not None else sys.argv[1:])
-    if parsed is None:
-        return EXIT_ERROR
-    root = Path(str(parsed.root)).resolve()
-    baseline_path = root / "python" / BASELINE_FILENAME
-    initial_reason = parsed.initial_reason
-    if initial_reason is not None and not str(initial_reason).strip():
-        print(
-            "lint-unreachable-branch: --initial-reason must be non-empty",
-            file=sys.stderr,
-        )
-        return EXIT_ERROR
-    return run_rule(
-        RULE,
-        root,
-        proc.ProcRunner(),
-        paths=None,
-        baseline_path=baseline_path,
-        write_baseline=bool(parsed.write),
-        initial_reason=None if initial_reason is None else str(initial_reason),
-        strict_stale=not bool(parsed.write),
+    return run_rule_cli(
+        argv if argv is not None else sys.argv[1:],
+        rule=RULE,
+        cli=RuleCli(
+            prog="cli.py lint unreachable-branch",
+            description=__doc__,
+            baseline_filename=BASELINE_FILENAME,
+            error_label="lint-unreachable-branch",
+        ),
+        runner=proc.ProcRunner(),
     )
 
 

--- a/python/larch/lint/markdown_heading_fence_state_detector.py
+++ b/python/larch/lint/markdown_heading_fence_state_detector.py
@@ -16,7 +16,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 
-from larch.lint.engine import ScanError
+from larch.lint.engine import ScanError, is_exempt_python_source, qualified_symbol
 
 SUPPRESSION = "lint-markdown-heading-fence-state"
 PRAGMA_RE = re.compile(rf"#\s*{re.escape(SUPPRESSION)}:\s*ok\s+(\S.*)$")
@@ -44,10 +44,7 @@ class HeadingFenceHit:
     pattern_name: str
 
 
-def is_exempt_path(path: Path) -> bool:
-    """Return whether a source file is outside production lint scope."""
-    name = path.name
-    return (name.startswith("test_") and name.endswith(".py")) or name in EXEMPT_FILENAMES
+is_exempt_path = is_exempt_python_source
 
 
 def is_production_source_path(rel_path: str) -> bool:
@@ -59,10 +56,6 @@ def is_production_source_path(rel_path: str) -> bool:
         return False
     under_python = rel_path[len(PYTHON_TREE_PREFIX) :]
     return not bool(EXCLUDED_DIRS.intersection(Path(under_python).parts))
-
-
-def _qualified(prefix: tuple[str, ...]) -> str:
-    return ".".join(prefix) if prefix else MODULE_SYMBOL
 
 
 def _comment_tokens_by_line(source: str) -> dict[int, tuple[str, ...]]:
@@ -343,7 +336,10 @@ def _walk_statements(
                 fence_guard_names=set(state.fence_guard_names),
                 findings=state.findings,
                 occurrence=0,
-                symbol=_qualified((*state.symbol.split("."), statement.name))
+                symbol=qualified_symbol(
+                    (*state.symbol.split("."), statement.name),
+                    module_symbol=MODULE_SYMBOL,
+                )
                 if state.symbol != MODULE_SYMBOL
                 else statement.name,
                 repo_path=state.repo_path,

--- a/python/larch/lint/unreachable_branch_detector.py
+++ b/python/larch/lint/unreachable_branch_detector.py
@@ -16,7 +16,12 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 
-from larch.lint.engine import ScanError
+from larch.lint.engine import (
+    ScanError,
+    is_exempt_python_source,
+    normalize_python_file_path,
+    qualified_symbol,
+)
 
 SUPPRESSION = "lint-unreachable-branch"
 PRAGMA_RE = re.compile(rf"#\s*{re.escape(SUPPRESSION)}:\s*ok\s+(\S.*)$")
@@ -39,21 +44,8 @@ class Finding:
         return (self.file, self.qualified_symbol, self.occurrence, self.normalized_condition)
 
 
-def normalize_file_path(raw: str) -> str:
-    """Return a normalized POSIX path relative to python/."""
-    normalized = raw.replace("\\", "/")
-    marker = "/python/"
-    if marker in normalized:
-        normalized = normalized.rsplit(marker, maxsplit=1)[1]
-    while normalized.startswith("./"):
-        normalized = normalized[2:]
-    return normalized.removeprefix("python/")
-
-
-def is_exempt_path(path: Path) -> bool:
-    """Return whether a source file is outside production lint scope."""
-    name = path.name
-    return (name.startswith("test_") and name.endswith(".py")) or name in EXEMPT_FILENAMES
+normalize_file_path = normalize_python_file_path
+is_exempt_path = is_exempt_python_source
 
 
 def is_production_source_path(rel_path: str) -> bool:
@@ -78,10 +70,6 @@ def iter_source_files(larch_dir: Path) -> list[Path]:
             continue
         result.append(path)
     return result
-
-
-def _qualified(prefix: tuple[str, ...]) -> str:
-    return ".".join(prefix) if prefix else MODULE_SYMBOL
 
 
 def _comment_tokens_by_line(source: str) -> dict[int, tuple[str, ...]]:
@@ -504,7 +492,7 @@ def _scan_function(
     comments_by_line: Mapping[int, tuple[str, ...]],
     findings: list[Finding],
 ) -> None:
-    symbol = _qualified((*prefix, node.name))
+    symbol = qualified_symbol((*prefix, node.name), module_symbol=MODULE_SYMBOL)
     occurrence_counter = [0]
     # Per-function occurrence should count findings in this function only for
     # baseline identity; use a local counter then rewrite occurrence as


### PR DESCRIPTION
## Summary

Centralizes repeated lint-rule scaffolding in `larch.lint.engine` and migrates the affected lint modules to use it. This preserves existing lint baseline formats and verdict behavior while removing repeated CLI, path-normalization, AST traversal, and duplicate-identity code.

Closes #7467.

Remaining duplicate-code cleanup is tracked by #7474.

## Verification

- `make py-lint`
- Focused lint regression suite: 459 passed
- `make py-lint-duplicate-code` (still reports remaining clusters; follow-up #7474)