### PR TITLE
Release v53.1.15

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "53.1.14",
+  "version": "53.1.15",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## What's Changed

### Added
- Add `tmpdir-arg-env-fallback` lint so CLI verbs fall back to `IMPLEMENT_TMPDIR` when `--tmpdir` expands empty (#7482)

### Changed
- Centralize shared lint scaffolding (#7475)
- Consolidate duplicated test boilerplate outside `tests/lint` (#7470)
