### PR TITLE
Fix force pushes with explicit refspecs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -332,6 +332,14 @@ repos:
         always_run: true
         files: ^python/.*\.py$
 
+      - id: lint-git-push-refspec
+        name: Require explicit Git push refspecs in python/
+        entry: python3 python/cli.py lint git-push-refspec
+        language: system
+        pass_filenames: false
+        always_run: true
+        files: ^python/.*\.py$
+
       - id: lint-markdown-heading-fence-state
         name: Lint Markdown heading regexes without fence state
         entry: python3 python/cli.py lint markdown-heading-fence-state

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ py-lint-checks-fast:
 	@# is dash): no pipefail, no arrays.
 	@tmp=$$(mktemp -d); rc=0; pids=""; \
 	( cd python && ruff check . ) >"$$tmp/ruff.log" 2>&1 & pids="$$pids $$!:ruff"; \
-	for chk in complexity-baseline agent-tool-contract keyword-only subprocess-via-runner gh-argv-literal wire-artifact-pairing tempfile-dir tmpdir-arg-env-fallback markdown-heading-fence-state doc-pointer-paths self-disarmable-gate unreachable-branch monkeypatch-facade-binding env-via-config-constant kv-codec lifecycle-prefix-literal prefix-case-variant shared-convention-regex renderer-golden-tests suppression-reason pylint-skip-file guideline-no-exception guidelines-note-wrapper-bypass layering flat-tests run-log-walkers module-manifest; do \
+	for chk in complexity-baseline agent-tool-contract keyword-only subprocess-via-runner gh-argv-literal git-push-refspec wire-artifact-pairing tempfile-dir tmpdir-arg-env-fallback markdown-heading-fence-state doc-pointer-paths self-disarmable-gate unreachable-branch monkeypatch-facade-binding env-via-config-constant kv-codec lifecycle-prefix-literal prefix-case-variant shared-convention-regex renderer-golden-tests suppression-reason pylint-skip-file guideline-no-exception guidelines-note-wrapper-bypass layering flat-tests run-log-walkers module-manifest; do \
 		$(PYTHON) python/cli.py lint "$$chk" >"$$tmp/$$chk.log" 2>&1 & pids="$$pids $$!:$$chk"; \
 	done; \
 	for entry in $$pids; do \

--- a/python/larch/cli.py
+++ b/python/larch/cli.py
@@ -588,6 +588,7 @@ _REGISTRY: dict[tuple[str, str], tuple[str, str, bool]] = {
     ("lint", "keyword-only"): ("larch.lint.lint_keyword_only", "main", False),
     ("lint", "subprocess-via-runner"): ("larch.lint.lint_subprocess_via_runner", "main", False),
     ("lint", "gh-argv-literal"): ("larch.lint.lint_gh_argv_literal", "main", False),
+    ("lint", "git-push-refspec"): ("larch.lint.lint_git_push_refspec", "main", False),
     ("lint", "wire-artifact-pairing"): ("larch.lint.lint_wire_artifact_pairing", "main", False),
     ("lint", "tempfile-dir"): ("larch.lint.lint_tempfile_dir", "main", False),
     ("lint", "tmpdir-arg-env-fallback"): ("larch.lint.lint_tmpdir_arg_env_fallback", "main", False),

--- a/python/larch/git/git.py
+++ b/python/larch/git/git.py
@@ -795,9 +795,10 @@ def force_push_with_lease_expecting(
     cwd: str | None = None,
 ) -> CommandResult:
     lease = f"{refspec}:{expected_oid}"
+    push_refspec = f"{refspec}:{refspec}"
     return _run(
         runner,
-        ["git", "push", f"--force-with-lease={lease}", remote],
+        ["git", "push", f"--force-with-lease={lease}", remote, push_refspec],
         cwd=cwd,
     )
 
@@ -1015,7 +1016,7 @@ def force_push_recovery(
             lease = f"refs/heads/{resolved_branch}:{expected_remote_oid}"
             return _run(
                 runner,
-                ["git", "push", f"--force-with-lease={lease}", remote],
+                ["git", "push", f"--force-with-lease={lease}", remote, refspec],
                 cwd=cwd,
             )
         return force_push_with_lease(runner, remote, refspec, cwd=cwd)

--- a/python/larch/git/rebase.py
+++ b/python/larch/git/rebase.py
@@ -550,7 +550,10 @@ def _rebase_push_force_with_lease(
         if not git.try_current_branch(runner, cwd=cwd):
             return False, f"Not on a branch (detached HEAD) before push attempt {push_attempt}"
         def attempt_push() -> tuple[CommandResult, int, str]:
-            result = runner.run(["git", "push", lease_arg], cwd=cwd)
+            result = runner.run(
+                ["git", "push", lease_arg, push_remote, f"HEAD:refs/heads/{branch}"],
+                cwd=cwd,
+            )
             return result, result.returncode, result.stdout + result.stderr
 
         push_result = retry.with_transient_retry(attempt_push).value

--- a/python/larch/lint/lint_git_push_refspec.py
+++ b/python/larch/lint/lint_git_push_refspec.py
@@ -1,0 +1,151 @@
+r"""Require explicit destination refspecs in raw ``["git", "push", ...]`` argv lists.
+
+Git resolves a refspec-less push through ambient ``push.default`` and upstream
+tracking. Test fixtures may suppress an intentional exception with a same-line,
+reason-bearing pragma.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import io
+import re
+import sys
+import tokenize
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+
+TOOL_FAILURE_EXIT = 2
+PUSH_COMMAND_ELEMENTS = 2
+EXPLICIT_PUSH_OPERANDS = 2
+PRAGMA_RE = re.compile(r"#\s*lint-git-push-refspec:\s*ok\s+(\S.*)$")
+
+
+@dataclass(frozen=True)
+class Finding:
+    file: str
+    lineno: int
+
+
+def iter_source_files(python_dir: Path) -> list[Path]:
+    """Return sorted regular, non-symlink Python files in the complete scope."""
+    return [
+        path
+        for path in sorted(python_dir.rglob("*.py"))
+        if path.is_file() and not path.is_symlink()
+    ]
+
+
+def _comment_tokens_by_line(source: str) -> dict[int, tuple[str, ...]]:
+    comments: dict[int, list[str]] = {}
+    try:
+        for token in tokenize.generate_tokens(io.StringIO(source).readline):
+            if token.type == tokenize.COMMENT:
+                comments.setdefault(token.start[0], []).append(token.string)
+    except tokenize.TokenError as exc:
+        raise RuntimeError(f"cannot tokenize source: {exc}") from exc
+    return {line: tuple(values) for line, values in comments.items()}
+
+
+def _is_fixture_pragma(
+    finding: Finding, *, comments_by_line: Mapping[int, tuple[str, ...]]
+) -> bool:
+    return finding.file.startswith("python/tests/") and any(
+        PRAGMA_RE.search(comment) for comment in comments_by_line.get(finding.lineno, ())
+    )
+
+
+def _static_prefix(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if not isinstance(node, ast.JoinedStr):
+        return None
+    prefix = ""
+    for value in node.values:
+        if isinstance(value, ast.Constant) and isinstance(value.value, str):
+            prefix += value.value
+        else:
+            break
+    return prefix
+
+
+def _is_raw_git_push_argv(node: ast.AST) -> bool:
+    if not isinstance(node, ast.List) or len(node.elts) < PUSH_COMMAND_ELEMENTS:
+        return False
+    return _static_prefix(node.elts[0]) == "git" and _static_prefix(node.elts[1]) == "push"
+
+
+def _has_explicit_refspec(node: ast.List) -> bool:
+    operands = 0
+    for element in node.elts[PUSH_COMMAND_ELEMENTS:]:
+        static_prefix = _static_prefix(element)
+        if static_prefix is not None and static_prefix.startswith("-"):
+            continue
+        operands += 1
+    return operands >= EXPLICIT_PUSH_OPERANDS
+
+
+def scan_file(path: Path, *, root: Path) -> list[Finding]:
+    """Return raw Git push argv lists without an explicit refspec operand."""
+    relative = path.relative_to(root).as_posix()
+    try:
+        source = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        raise RuntimeError(f"{relative}: cannot read source: {exc}") from exc
+    try:
+        tree = ast.parse(source, filename=relative)
+    except SyntaxError as exc:
+        raise RuntimeError(f"{relative}: cannot parse source: {exc}") from exc
+    comments_by_line = _comment_tokens_by_line(source)
+    findings: list[Finding] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.List) or not _is_raw_git_push_argv(node) or _has_explicit_refspec(node):
+            continue
+        lineno = getattr(node, "lineno", 0)
+        finding = Finding(file=relative, lineno=lineno if isinstance(lineno, int) else 0)
+        if not _is_fixture_pragma(finding, comments_by_line=comments_by_line):
+            findings.append(finding)
+    return findings
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace | None:
+    parser = argparse.ArgumentParser(prog="cli.py lint git-push-refspec", description=__doc__)
+    _ = parser.add_argument("--root", default=str(Path(__file__).resolve().parents[3]))
+    try:
+        return parser.parse_args(argv)
+    except SystemExit as exc:
+        if exc.code == 0:
+            raise
+        return None
+
+
+def main(argv: list[str] | None = None) -> int:
+    parsed = _parse_args(argv if argv is not None else sys.argv[1:])
+    if parsed is None:
+        return TOOL_FAILURE_EXIT
+    root = Path(str(parsed.root)).resolve()
+    python_dir = root / "python"
+    if not python_dir.is_dir():
+        print(f"lint-git-push-refspec: python directory not found: {python_dir}", file=sys.stderr)
+        return TOOL_FAILURE_EXIT
+    try:
+        findings = [
+            finding
+            for path in iter_source_files(python_dir)
+            for finding in scan_file(path, root=root)
+        ]
+    except RuntimeError as exc:
+        print(f"lint-git-push-refspec: {exc}", file=sys.stderr)
+        return TOOL_FAILURE_EXIT
+    for finding in sorted(findings, key=lambda item: (item.file, item.lineno)):
+        print(
+            f"{finding.file}: line {finding.lineno} contains git push without an explicit refspec",
+            file=sys.stderr,
+        )
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/lint-module-manifest.json
+++ b/python/lint-module-manifest.json
@@ -17,6 +17,7 @@
     {"module": "lint_flat_tests.py", "host_decision": "legacy", "justification": "", "source_issue": 0},
     {"module": "lint_gh_argv_literal.py", "host_decision": "legacy", "justification": "", "source_issue": 0},
     {"module": "lint_gh_body_inline.py", "host_decision": "legacy", "justification": "", "source_issue": 0},
+    {"module": "lint_git_push_refspec.py", "host_decision": "new-module-justified", "justification": "Distinct AST rule for Git push destination operands; lint_gh_argv_literal only rejects raw GitHub CLI ownership bypasses and cannot enforce Git refspec policy (#7489).", "source_issue": 7489},
     {"module": "lint_guideline_no_exception.py", "host_decision": "legacy", "justification": "", "source_issue": 0},
     {"module": "lint_guidelines_note_wrapper_bypass.py", "host_decision": "legacy", "justification": "", "source_issue": 0},
     {"module": "lint_keyword_only.py", "host_decision": "legacy", "justification": "", "source_issue": 0},

--- a/python/tests/git/test_git.py
+++ b/python/tests/git/test_git.py
@@ -821,12 +821,14 @@ def test_force_push_with_lease_expecting_argv() -> None:
                 "push",
                 "--force-with-lease=refs/heads/feat:abc123",
                 "origin",
+                "refs/heads/feat:refs/heads/feat",
             ): CommandResult(
                 (
                     "git",
                     "push",
                     "--force-with-lease=refs/heads/feat:abc123",
                     "origin",
+                    "refs/heads/feat:refs/heads/feat",
                 ),
                 0,
                 "",
@@ -842,6 +844,80 @@ def test_force_push_with_lease_expecting_argv() -> None:
         "abc123",
     )
     assert result.returncode == 0
+
+
+def _run_adverse_git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _make_adverse_push_repo(tmp_path: Path) -> tuple[Path, Path, str, str]:
+    origin = tmp_path / "origin.git"
+    source = tmp_path / "source"
+    repo = tmp_path / "repo"
+    _ = subprocess.run(["git", "init", "--bare", "-q", str(origin)], check=True)
+    _ = subprocess.run(["git", "init", "-q", "-b", "main", str(source)], check=True)
+    _ = _run_adverse_git(source, "config", "user.email", "test@example.com")
+    _ = _run_adverse_git(source, "config", "user.name", "Test")
+    _ = (source / "README.md").write_text("base\n", encoding="utf-8")
+    _ = _run_adverse_git(source, "add", "README.md")
+    _ = _run_adverse_git(source, "commit", "-q", "-m", "base")
+    _ = _run_adverse_git(source, "remote", "add", "origin", str(origin))
+    _ = _run_adverse_git(source, "push", "-q", "-u", "origin", "main")
+    _ = _run_adverse_git(origin, "symbolic-ref", "HEAD", "refs/heads/main")
+    _ = subprocess.run(["git", "clone", "-q", str(origin), str(repo)], check=True)
+    _ = _run_adverse_git(repo, "config", "user.email", "test@example.com")
+    _ = _run_adverse_git(repo, "config", "user.name", "Test")
+    _ = _run_adverse_git(repo, "checkout", "-q", "-b", "feature-x", "origin/main")
+    _ = _run_adverse_git(repo, "push", "-q", "-u", "origin", "feature-x")
+    _ = _run_adverse_git(repo, "branch", "--set-upstream-to=origin/main", "feature-x")
+    _ = _run_adverse_git(repo, "config", "push.default", "upstream")
+    _ = (repo / "feature.txt").write_text("feature\n", encoding="utf-8")
+    _ = _run_adverse_git(repo, "add", "feature.txt")
+    _ = _run_adverse_git(repo, "commit", "-q", "-m", "feature")
+    return (
+        repo,
+        origin,
+        _run_adverse_git(repo, "rev-parse", "origin/feature-x"),
+        _run_adverse_git(origin, "rev-parse", "refs/heads/main"),
+    )
+
+
+def test_force_push_with_lease_expecting_ignores_adverse_tracking(tmp_path: Path) -> None:
+    repo, origin, expected_oid, main_before = _make_adverse_push_repo(tmp_path)
+
+    result = git.force_push_with_lease_expecting(
+        ProcRunner(),
+        "origin",
+        "refs/heads/feature-x",
+        expected_oid,
+        cwd=str(repo),
+    )
+
+    assert result.returncode == 0
+    assert _run_adverse_git(origin, "rev-parse", "refs/heads/feature-x") == _run_adverse_git(repo, "rev-parse", "HEAD")
+    assert _run_adverse_git(origin, "rev-parse", "refs/heads/main") == main_before
+
+
+def test_force_push_recovery_ignores_adverse_tracking(tmp_path: Path) -> None:
+    repo, origin, expected_oid, main_before = _make_adverse_push_repo(tmp_path)
+
+    result = git.force_push_recovery(
+        ProcRunner(),
+        branch="feature-x",
+        expected_remote_oid=expected_oid,
+        cwd=str(repo),
+        sleeper=lambda _seconds: None,
+    )
+
+    assert result.pushed
+    assert result.status == "pushed"
+    assert _run_adverse_git(origin, "rev-parse", "refs/heads/feature-x") == _run_adverse_git(repo, "rev-parse", "HEAD")
+    assert _run_adverse_git(origin, "rev-parse", "refs/heads/main") == main_before
 
 
 def test_rebase_onto_strips_git_dir_override(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/python/tests/git/test_pr.py
+++ b/python/tests/git/test_pr.py
@@ -740,7 +740,7 @@ def _mutating_calls(runner: RecordingRunner) -> list[list[str]]:
         call
         for call in runner.calls
         if call[:3]
-        in (["git", "push", "-u"], ["gh", "pr", "create"], ["gh", "pr", "edit"])  # lint-gh-argv-literal: ok fixture assertion
+        in (["git", "push", "-u"], ["gh", "pr", "create"], ["gh", "pr", "edit"])  # lint-gh-argv-literal: ok fixture assertion # lint-git-push-refspec: ok fixture prefix assertion
     ]
 
 

--- a/python/tests/git/test_push.py
+++ b/python/tests/git/test_push.py
@@ -755,7 +755,7 @@ def test_push_current_branch_uses_explicit_origin_head_refspec() -> None:
     result = push.push_current_branch(runner, sleeper=lambda _s: None)
     assert result.status == "pushed"
     assert result.branch == "feature"
-    assert ["git", "push"] not in runner.calls
+    assert ["git", "push"] not in runner.calls  # lint-git-push-refspec: ok fixture assertion
     assert ["git", "push", "-u", "origin", "HEAD"] in runner.calls
 
 

--- a/python/tests/git/test_rebase.py
+++ b/python/tests/git/test_rebase.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 # pyright: reportPrivateUsage=false, reportAttributeAccessIssue=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false
 
+import subprocess
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -15,7 +16,7 @@ from larch.core import external_defaults
 from larch.git import rebase
 from larch.agents.agents import LaunchFailure, TierAttempt
 from larch.errors import PrePushConflictHandoff, Stalled, TransientNetworkError
-from larch.core.proc import CommandResult
+from larch.core.proc import CommandResult, ProcRunner
 
 
 def _empty_argv_log() -> list[tuple[str, ...]]:
@@ -328,8 +329,8 @@ def test_force_push_oid_and_retry(tmp_path: Path) -> None:
             (("git", "symbolic-ref", "--short", "HEAD"), _ok(("git", "symbolic-ref", "--short", "HEAD"), "feat\n")),
             (("git", "fetch", "origin", "feat", "--quiet"), _ok(("git", "fetch", "origin", "feat", "--quiet"))),
             (
-                ("git", "push", "--force-with-lease=refs/heads/feat:abc", "origin"),
-                _fail(("git", "push", "--force-with-lease=refs/heads/feat:abc", "origin")),
+                ("git", "push", "--force-with-lease=refs/heads/feat:abc", "origin", "refs/heads/feat:refs/heads/feat"),
+                _fail(("git", "push", "--force-with-lease=refs/heads/feat:abc", "origin", "refs/heads/feat:refs/heads/feat")),
             ),
             (("git", "fetch", "origin", "feat", "--quiet"), _ok(("git", "fetch", "origin", "feat", "--quiet"))),
             (("git", "rev-parse", "HEAD"), _ok(("git", "rev-parse", "HEAD"), "deadbeef\n")),
@@ -345,6 +346,65 @@ def test_force_push_oid_and_retry(tmp_path: Path) -> None:
     )
     assert result.returncode == 0
     assert not sleeps
+
+
+def _run_git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _make_adverse_push_repo(tmp_path: Path) -> tuple[Path, Path, str, str]:
+    origin = tmp_path / "origin.git"
+    source = tmp_path / "source"
+    repo = tmp_path / "repo"
+    _ = subprocess.run(["git", "init", "--bare", "-q", str(origin)], check=True)
+    _ = subprocess.run(["git", "init", "-q", "-b", "main", str(source)], check=True)
+    _ = _run_git(source, "config", "user.email", "test@example.com")
+    _ = _run_git(source, "config", "user.name", "Test")
+    _ = (source / "README.md").write_text("base\n", encoding="utf-8")
+    _ = _run_git(source, "add", "README.md")
+    _ = _run_git(source, "commit", "-q", "-m", "base")
+    _ = _run_git(source, "remote", "add", "origin", str(origin))
+    _ = _run_git(source, "push", "-q", "-u", "origin", "main")
+    _ = _run_git(origin, "symbolic-ref", "HEAD", "refs/heads/main")
+    _ = subprocess.run(["git", "clone", "-q", str(origin), str(repo)], check=True)
+    _ = _run_git(repo, "config", "user.email", "test@example.com")
+    _ = _run_git(repo, "config", "user.name", "Test")
+    _ = _run_git(repo, "checkout", "-q", "-b", "feature-x", "origin/main")
+    _ = _run_git(repo, "push", "-q", "-u", "origin", "feature-x")
+    _ = _run_git(repo, "branch", "--set-upstream-to=origin/main", "feature-x")
+    _ = _run_git(repo, "config", "push.default", "upstream")
+    _ = (repo / "feature.txt").write_text("feature\n", encoding="utf-8")
+    _ = _run_git(repo, "add", "feature.txt")
+    _ = _run_git(repo, "commit", "-q", "-m", "feature")
+    return (
+        repo,
+        origin,
+        _run_git(repo, "rev-parse", "origin/feature-x"),
+        _run_git(origin, "rev-parse", "refs/heads/main"),
+    )
+
+
+def test_rebase_force_push_ignores_adverse_tracking(tmp_path: Path) -> None:
+    repo, origin, expected_oid, main_before = _make_adverse_push_repo(tmp_path)
+
+    pushed, error = rebase._rebase_push_force_with_lease(  # pyright: ignore[reportPrivateUsage]
+        ProcRunner(),
+        push_remote="origin",
+        branch="feature-x",
+        expected_remote_oid=expected_oid,
+        cwd=str(repo),
+        sleep_fn=lambda _seconds: None,
+    )
+
+    assert pushed
+    assert not error
+    assert _run_git(origin, "rev-parse", "refs/heads/feature-x") == _run_git(repo, "rev-parse", "HEAD")
+    assert _run_git(origin, "rev-parse", "refs/heads/main") == main_before
 
 
 def test_launch_fn_receives_conflict_csv_and_handoff_flag(tmp_path: Path) -> None:
@@ -764,8 +824,8 @@ def test_rebase_push_force_push_same_ref_recovery(tmp_path: Path) -> None:
                 ("git", "ls-remote", "--heads", "origin", "refs/heads/feat"),
                 "",
             )),
-            (("git", "push", "--force-with-lease=refs/heads/feat:abc"), _fail(
-                ("git", "push", "--force-with-lease=refs/heads/feat:abc"),
+            (("git", "push", "--force-with-lease=refs/heads/feat:abc", "origin", "HEAD:refs/heads/feat"), _fail(
+                ("git", "push", "--force-with-lease=refs/heads/feat:abc", "origin", "HEAD:refs/heads/feat"),
             )),
             (("git", "fetch", "origin", "feat", "--quiet"), _ok(("git", "fetch", "origin", "feat", "--quiet"))),
             (("git", "rev-parse", "HEAD"), _ok(("git", "rev-parse", "HEAD"), "abc\n")),
@@ -856,7 +916,7 @@ def test_rebase_push_retries_transient_force_push(
             (("git", "config", "--get", "branch.feat.remote"), _ok(("git", "config"), "")),
             (("git", "fetch", "origin", "feat", "--quiet"), _ok(("git", "fetch", "origin", "feat", "--quiet"))),
             (("git", "rev-parse", "origin/feat"), _ok(("git", "rev-parse", "origin/feat"), "abc\n")),
-            (("git", "push", "--force-with-lease=refs/heads/feat:abc"), push_once_then_ok),
+            (("git", "push", "--force-with-lease=refs/heads/feat:abc", "origin", "HEAD:refs/heads/feat"), push_once_then_ok),
         ],
         permissive=False,
     )

--- a/python/tests/implement/test_ci_monitor.py
+++ b/python/tests/implement/test_ci_monitor.py
@@ -1763,6 +1763,7 @@ def test_stage_and_push_defer_rebase_uses_typed_rebase_push(tmp_path: Any) -> No
             "push",
             "--force-with-lease=refs/heads/feature:remote",
             "origin",
+            "HEAD:refs/heads/feature",
         ): ok(("git", "push")),
     }
     classified = ci_monitor.classify_failed_jobs(
@@ -2063,7 +2064,7 @@ def test_pending_retry_missing_local_remote_ref_uses_ls_remote_lease(tmp_path: A
         ("git", "ls-remote", "--exit-code", "--heads", "origin", "feature"): ok(("git", "ls-remote"), "remoteoid\trefs/heads/feature\n"),
         ("git", "fetch", "origin", "feature", "--quiet"): ok(("git", "fetch")),
         ("git", "status", "--porcelain", "--untracked-files=all"): ok(("git", "status")),
-        ("git", "push", "--force-with-lease=refs/heads/feature:remoteoid", "origin"): ok(("git", "push")),
+        ("git", "push", "--force-with-lease=refs/heads/feature:remoteoid", "origin", "HEAD:refs/heads/feature"): ok(("git", "push")),
     }
     runner = RecordingRunner(responses)
     pushed, _head, _delta, _did_rebase, pending = ci_monitor.stage_and_push(
@@ -2080,7 +2081,7 @@ def test_pending_retry_missing_local_remote_ref_uses_ls_remote_lease(tmp_path: A
     )
     assert pushed is True
     assert pending is False
-    assert ("git", "push", "--force-with-lease=refs/heads/feature:remoteoid", "origin") in runner.calls
+    assert ("git", "push", "--force-with-lease=refs/heads/feature:remoteoid", "origin", "HEAD:refs/heads/feature") in runner.calls
 
 
 def test_evaluate_failure_pending_reload_failed_jobs_before_force_push(

--- a/python/tests/lint/test_lint_git_push_refspec.py
+++ b/python/tests/lint/test_lint_git_push_refspec.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Protocol
+
+from larch.lint import lint_git_push_refspec as lgpr
+
+
+class CaptureResult(Protocol):
+    err: str
+
+
+class CaptureFixture(Protocol):
+    def readouterr(self) -> CaptureResult: ...
+
+
+def _write_project(root: Path, *, files: dict[str, str]) -> None:
+    for relpath, source in files.items():
+        path = root / "python" / relpath
+        path.parent.mkdir(parents=True, exist_ok=True)
+        _ = path.write_text(source, encoding="utf-8")
+
+
+def test_flags_bare_push_and_accepts_explicit_refspec(tmp_path: Path, capsys: CaptureFixture) -> None:
+    _write_project(
+        tmp_path,
+        files={
+            "bare.py": 'argv = ["git", "push", "origin"]\n',
+            "explicit.py": (
+                'argv = ["git", "push", "--force-with-lease=refs/heads/feat:abc", '
+                '"origin", "HEAD:refs/heads/feat"]\n'
+            ),
+        },
+    )
+
+    assert lgpr.main(["--root", str(tmp_path)]) == 1
+    assert capsys.readouterr().err.splitlines() == [
+        "python/bare.py: line 1 contains git push without an explicit refspec",
+    ]
+
+
+def test_fixture_pragma_suppresses_intentional_config_resolved_push(tmp_path: Path) -> None:
+    _write_project(
+        tmp_path,
+        files={
+            "tests/fixture.py": (
+                'argv = ["git", "push", "origin"] '
+                "# lint-git-push-refspec: ok fixture checks config resolution\n"
+            ),
+        },
+    )
+
+    assert lgpr.main(["--root", str(tmp_path)]) == 0
+
+
+def test_production_pragma_does_not_suppress(tmp_path: Path) -> None:
+    _write_project(
+        tmp_path,
+        files={
+            "prod.py": (
+                'argv = ["git", "push", "origin"] '
+                "# lint-git-push-refspec: ok production exception\n"
+            ),
+        },
+    )
+
+    assert lgpr.main(["--root", str(tmp_path)]) == 1
+
+
+def test_dynamic_argv_elements_remain_tolerant(tmp_path: Path) -> None:
+    _write_project(
+        tmp_path,
+        files={
+            "dynamic.py": 'argv = ["git", "push", remote, refspec]\n',
+            "fstring.py": (
+                'argv = ["git", "push", f"--force-with-lease={lease}", '
+                'remote, f"HEAD:refs/heads/{branch}"]\n'
+            ),
+        },
+    )
+
+    assert lgpr.main(["--root", str(tmp_path)]) == 0
+
+
+def test_invalid_source_and_arguments_fail_closed(tmp_path: Path) -> None:
+    _write_project(tmp_path, files={"broken.py": "def broken(:\n"})
+
+    assert lgpr.main(["--root", str(tmp_path)]) == 2
+    assert lgpr.main(["--unknown"]) == 2

--- a/python/tests/release/test_release.py
+++ b/python/tests/release/test_release.py
@@ -79,7 +79,7 @@ class ReleaseFinishRunner:
             return cr(argv, self.remote_tag)
         if argv[:2] == ["git", "tag"]:
             return cr(argv)
-        if argv[:2] == ["git", "push"]:
+        if argv[:2] == ["git", "push"]:  # lint-git-push-refspec: ok fixture prefix assertion
             return cr(argv)
         if argv[:3] == ["gh", "release", "view"]:  # lint-gh-argv-literal: ok fixture assertion
             return cr(argv, rc=0 if self.release_exists else 1)
@@ -113,7 +113,7 @@ def test_release_finish_remote_lightweight_tag_skips_push_and_edits_release(monk
     assert release_finish.main(["--version","1.2.3","--notes-file",str(notes),"--repo","o/r","--pr","5"]) == 0
     out = capsys.readouterr().out
     assert "RELEASE_ACTION=edit" in out
-    assert not any(call[:2] == ["git", "push"] for call in runner.calls)
+    assert not any(call[:2] == ["git", "push"] for call in runner.calls)  # lint-git-push-refspec: ok fixture assertion
 
 
 def test_release_finish_existing_local_tag_creates_missing_release_and_promotes(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:


### PR DESCRIPTION
Fixes #7489

## Summary
- make all force-push helpers name an explicit destination refspec
- add an AST lint that blocks raw `git push` lists without remote and refspec operands
- cover adverse `push.default=upstream` and tracking behavior with real Git repositories

## Verification
- `make py-lint`
- focused git and lint pytest suites
- changed-file pre-commit hooks