### PR TITLE
Fixes #7474: consolidate remaining lint baselines

### DIFF
--- a/python/larch/lint/engine.py
+++ b/python/larch/lint/engine.py
@@ -39,7 +39,8 @@ PYTHON_EXCLUDED_DIRS = frozenset(
     {".git", "node_modules", ".venv", ".agents", "__pycache__"}
 )
 SyntaxPolicy = Literal["fail", "skip", "raise"]
-OccurrencePatternField = Literal["pattern_name", "normalized_condition"]
+OccurrencePatternField = str
+OccurrenceFields = tuple[str, ...]
 SourceFilter = Callable[[str], bool]
 DuplicateKey = TypeVar("DuplicateKey", bound=Hashable)
 _MARKDOWN_FENCE_RE = re.compile(r"^[ \t]*(`{3,}|~{3,})([^`~]*)$")
@@ -114,6 +115,7 @@ class Finding:
     anchor: str | None = None
     pattern_name: str | None = None
     occurrence: int | None = None
+    occurrence_values: tuple[tuple[str, str], ...] = ()
 
 
 @dataclass(frozen=True)
@@ -184,6 +186,7 @@ class LintRule:
     occurrence_baseline: bool = False
     stale_baseline_on_clean_scan: bool = False
     occurrence_pattern_field: OccurrencePatternField = "pattern_name"
+    occurrence_fields: OccurrenceFields | None = None
     require_baseline: bool = False
     prepare_corpus: PrepareCorpus | None = None
 
@@ -265,6 +268,7 @@ class RuleCli:
     error_label: str | None = None
     default_root: Path = Path(__file__).resolve().parents[3]
     scoped_paths: tuple[str, ...] | None = None
+    strict_stale: bool = True
 
 
 def run_rule_cli(
@@ -323,7 +327,7 @@ def run_rule_cli(
         baseline_path=root / "python" / cli.baseline_filename,
         write_baseline=write_baseline,
         initial_reason=None if initial_reason is None else str(initial_reason),
-        strict_stale=not write_baseline,
+        strict_stale=cli.strict_stale and not write_baseline,
     )
 
 
@@ -341,6 +345,13 @@ def _is_exact_bool(value: object) -> bool:
     return isinstance(value, bool)
 
 
+def _occurrence_field_names(rule: LintRule) -> OccurrenceFields:
+    """Return the ordered legacy JSON fields that identify one occurrence."""
+    if rule.occurrence_fields is None:
+        return (rule.occurrence_pattern_field,)
+    return rule.occurrence_fields
+
+
 def _validate_rule(rule: LintRule) -> None:  # noqa: C901, PLR0912 - rule field validation is intentional
     if not _is_single_line(rule.rule_id):
         raise ScanError("lint rule rule_id must be a non-empty single-line string")
@@ -352,10 +363,18 @@ def _validate_rule(rule: LintRule) -> None:  # noqa: C901, PLR0912 - rule field 
         raise ScanError("lint rule require_baseline must be a bool")
     if not _is_exact_bool(rule.stale_baseline_on_clean_scan):
         raise ScanError("lint rule stale_baseline_on_clean_scan must be a bool")
-    if rule.occurrence_pattern_field not in ("pattern_name", "normalized_condition"):
+    if not _is_single_line(rule.occurrence_pattern_field):
         raise ScanError(
-            "lint rule occurrence_pattern_field must be "
-            "'pattern_name' or 'normalized_condition'"
+            "lint rule occurrence_pattern_field must be a non-empty single-line string"
+        )
+    occurrence_fields = _occurrence_field_names(rule)
+    if not rule.occurrence_baseline and rule.occurrence_fields is not None:
+        raise ScanError("occurrence_fields requires rule.occurrence_baseline")
+    if len(set(occurrence_fields)) != len(occurrence_fields) or any(
+        not _is_single_line(field) for field in occurrence_fields
+    ):
+        raise ScanError(
+            "lint rule occurrence_fields must contain unique non-empty single-line strings"
         )
     if (
         not rule.occurrence_baseline
@@ -645,6 +664,7 @@ def _validate_finding(  # noqa: C901, PLR0912 - finding field validation is inte
     anchor = finding.anchor
     pattern_name = finding.pattern_name
     occurrence = finding.occurrence
+    occurrence_values = finding.occurrence_values
     if path != source.path:
         raise ScanError(f"finding path {path!r} does not match source {source.path!r}")
     if rule_id != rule.rule_id:
@@ -674,10 +694,25 @@ def _validate_finding(  # noqa: C901, PLR0912 - finding field validation is inte
         )
     if occurrence is not None and occurrence < 1:
         raise ScanError("finding occurrence must be a positive int when present")
-    has_occurrence = pattern_name is not None or occurrence is not None
-    if has_occurrence and (pattern_name is None or occurrence is None):
+    occurrence_fields = _occurrence_field_names(rule)
+    has_occurrence = pattern_name is not None or occurrence is not None or occurrence_values
+    if occurrence_values:
+        if not rule.occurrence_baseline:
+            raise ScanError("finding occurrence_values require rule.occurrence_baseline")
+        if tuple(key for key, _ in occurrence_values) != occurrence_fields or any(
+            not _is_single_line(key) or not _is_single_line(value)
+            for key, value in occurrence_values
+        ):
+            raise ScanError(
+                "finding occurrence_values must match the rule occurrence_fields"
+            )
+    if has_occurrence and occurrence is None:
+        raise ScanError("finding occurrence requires a positive occurrence value")
+    if has_occurrence and not occurrence_values and occurrence_fields and (
+        pattern_name is None or len(occurrence_fields) != 1
+    ):
         raise ScanError(
-            "finding pattern_name and occurrence must be provided together"
+            "finding occurrence baseline requires values for every occurrence field"
         )
     if rule.occurrence_baseline:
         if not has_occurrence or qualified_symbol is None:
@@ -704,6 +739,7 @@ def _validate_finding(  # noqa: C901, PLR0912 - finding field validation is inte
         anchor=anchor,
         pattern_name=pattern_name,
         occurrence=occurrence,
+        occurrence_values=occurrence_values,
     )
 
 
@@ -857,10 +893,16 @@ class OccurrenceBaselineRow:
     pattern_name: str
     occurrence: int
     reason: str
+    values: tuple[tuple[str, str], ...] = ()
 
     @property
-    def identity(self) -> tuple[str, str, str, int]:
-        return (self.path, self.qualified_symbol, self.pattern_name, self.occurrence)
+    def occurrence_values(self) -> tuple[tuple[str, str], ...]:
+        """Return explicit fields, retaining the original single-field constructor."""
+        return self.values or (("pattern_name", self.pattern_name),)
+
+    @property
+    def identity(self) -> tuple[object, ...]:
+        return (self.path, self.qualified_symbol, *self.occurrence_values, self.occurrence)
 
 
 BaselineRow: TypeAlias = (
@@ -885,7 +927,7 @@ def _baseline_sort_key(row: BaselineRow) -> tuple[object, ...]:
         "occurrence",
         row.path,
         row.qualified_symbol,
-        row.pattern_name,
+        row.occurrence_values,
         row.occurrence,
     )
 
@@ -900,8 +942,9 @@ def _baseline_row_display(row: BaselineRow) -> str:
     if isinstance(row, SymbolMetricBaselineRow):
         return f"{row.path}:{row.qualified_symbol}: {row.rule_id} metric {row.metric}"
     file_name = _occurrence_json_file(row.path)
+    values = " ".join(f"{key}={value}" for key, value in row.occurrence_values)
     return (
-        f"{file_name}:{row.qualified_symbol} {row.pattern_name}#{row.occurrence}"
+        f"{file_name}:{row.qualified_symbol} {values}#{row.occurrence}"
     )
 
 
@@ -1003,11 +1046,10 @@ def _occurrence_baseline_row(
     *,
     index: int,
     source: str,
-    pattern_field: OccurrencePatternField,
+    occurrence_fields: OccurrenceFields,
 ) -> OccurrenceBaselineRow:
     file_name = record["file"]
     qualified_symbol = record["qualified_symbol"]
-    pattern_name = record[pattern_field]
     occurrence = record["occurrence"]
     reason = record["reason"]
     if not isinstance(file_name, str):
@@ -1015,8 +1057,12 @@ def _occurrence_baseline_row(
     path = _occurrence_repo_path(file_name, source=source, index=index)
     if not _is_single_line(qualified_symbol):
         raise ScanError(f"{source}: baseline row {index} has invalid qualified_symbol")
-    if not _is_single_line(pattern_name):
-        raise ScanError(f"{source}: baseline row {index} has invalid {pattern_field}")
+    values: list[tuple[str, str]] = []
+    for field_name in occurrence_fields:
+        value = record[field_name]
+        if not _is_single_line(value):
+            raise ScanError(f"{source}: baseline row {index} has invalid {field_name}")
+        values.append((field_name, cast("str", value)))
     if (
         not isinstance(occurrence, int)
         or isinstance(occurrence, bool)
@@ -1028,37 +1074,56 @@ def _occurrence_baseline_row(
     return OccurrenceBaselineRow(
         path,
         cast("str", qualified_symbol),
-        cast("str", pattern_name),
+        values[0][1] if values else "",
         occurrence,
         cast("str", reason),
+        tuple(values),
     )
 
 
-def _parse_baseline_row(raw: object, *, index: int, source: str) -> BaselineRow:
+def _parse_baseline_row(
+    raw: object,
+    *,
+    index: int,
+    source: str,
+    occurrence_fields: OccurrenceFields,
+) -> BaselineRow:
     if not isinstance(raw, dict):
         raise ScanError(f"{source}: baseline row {index} must be an object")
     record = cast("dict[str, object]", raw)
     generic_keys = frozenset({"path", "line", "rule_id", "message", "reason"})
     anchored_generic_keys = generic_keys | {"anchor"}
     symbol_keys = frozenset({"path", "rule_id", "qualified_symbol", "metric", "reason"})
-    occurrence_pattern_keys = frozenset(
-        {"file", "qualified_symbol", "pattern_name", "occurrence", "reason"}
-    )
-    occurrence_normalized_keys = frozenset(
-        {"file", "qualified_symbol", "normalized_condition", "occurrence", "reason"}
+    occurrence_keys = frozenset(
+        {"file", "qualified_symbol", *occurrence_fields, "occurrence", "reason"}
     )
     keys = frozenset(record)
     if keys in {generic_keys, anchored_generic_keys}:
         return _generic_baseline_row(record, index=index, source=source)
     if keys == symbol_keys:
         return _symbol_metric_baseline_row(record, index=index, source=source)
-    if keys == occurrence_pattern_keys:
+    if keys == occurrence_keys:
         return _occurrence_baseline_row(
-            record, index=index, source=source, pattern_field="pattern_name"
+            record,
+            index=index,
+            source=source,
+            occurrence_fields=occurrence_fields,
         )
-    if keys == occurrence_normalized_keys:
-        return _occurrence_baseline_row(
-            record, index=index, source=source, pattern_field="normalized_condition"
+    if occurrence_fields == ("pattern_name",) and keys == frozenset(
+        {"file", "qualified_symbol", "normalized_condition", "occurrence", "reason"}
+    ):
+        parsed = _occurrence_baseline_row(
+            record,
+            index=index,
+            source=source,
+            occurrence_fields=("normalized_condition",),
+        )
+        return OccurrenceBaselineRow(
+            parsed.path,
+            parsed.qualified_symbol,
+            parsed.pattern_name,
+            parsed.occurrence,
+            parsed.reason,
         )
     raise ScanError(f"{source}: baseline row {index} has unsupported keys")
 
@@ -1081,7 +1146,12 @@ def _validate_baseline_rows(
     return validated
 
 
-def _parse_baseline_text(text: str, *, source: str) -> list[BaselineRow]:
+def _parse_baseline_text(
+    text: str,
+    *,
+    source: str,
+    occurrence_fields: OccurrenceFields = ("pattern_name",),
+) -> list[BaselineRow]:
     try:
         decoded = cast("object", json.loads(text))
     except json.JSONDecodeError as exc:
@@ -1090,7 +1160,12 @@ def _parse_baseline_text(text: str, *, source: str) -> list[BaselineRow]:
         raise ScanError(f"{source}: baseline must be a top-level JSON array")
     raw_rows = cast("list[object]", decoded)
     rows = [
-        _parse_baseline_row(raw, index=index, source=source)
+        _parse_baseline_row(
+            raw,
+            index=index,
+            source=source,
+            occurrence_fields=occurrence_fields,
+        )
         for index, raw in enumerate(raw_rows)
     ]
     return _validate_baseline_rows(rows, source=source)
@@ -1144,12 +1219,21 @@ def _validate_baseline_path(raw: str | Path, *, root: Path, write_mode: bool) ->
     return absolute
 
 
-def _load_baseline(path: Path, *, root: Path) -> list[BaselineRow]:
+def _load_baseline(
+    path: Path,
+    *,
+    root: Path,
+    occurrence_fields: OccurrenceFields = ("pattern_name",),
+) -> list[BaselineRow]:
     try:
         text = larch_io.read_trusted_text(path, root=root, reject_cr=True)
     except (OSError, UnicodeError, ValueError) as exc:
         raise ScanError(f"failed to read baseline {path}: {exc}") from exc
-    return _parse_baseline_text(text, source=f"baseline {path}")
+    return _parse_baseline_text(
+        text,
+        source=f"baseline {path}",
+        occurrence_fields=occurrence_fields,
+    )
 
 
 def _baseline_exists(path: Path, *, root: Path) -> bool:
@@ -1159,10 +1243,21 @@ def _baseline_exists(path: Path, *, root: Path) -> bool:
         raise ScanError(f"failed to inspect baseline {path}: {exc}") from exc
 
 
-def _project_finding(finding: Finding) -> BaselineRow:
+def _finding_occurrence_values(
+    finding: Finding, *, occurrence_fields: OccurrenceFields
+) -> tuple[tuple[str, str], ...]:
+    if finding.occurrence_values:
+        return finding.occurrence_values
+    if len(occurrence_fields) == 1 and finding.pattern_name is not None:
+        return ((occurrence_fields[0], finding.pattern_name),)
+    return ()
+
+
+def _project_finding(
+    finding: Finding, *, occurrence_fields: OccurrenceFields = ("pattern_name",)
+) -> BaselineRow:
     if (
-        finding.pattern_name is not None
-        and finding.occurrence is not None
+        finding.occurrence is not None
         and finding.qualified_symbol is not None
     ):
         if finding.metric is not None:
@@ -1172,9 +1267,10 @@ def _project_finding(finding: Finding) -> BaselineRow:
         return OccurrenceBaselineRow(
             finding.path,
             finding.qualified_symbol,
-            finding.pattern_name,
+            finding.pattern_name or "",
             finding.occurrence,
             "",
+            _finding_occurrence_values(finding, occurrence_fields=occurrence_fields),
         )
     if finding.qualified_symbol is None and finding.metric is None:
         return GenericBaselineRow(
@@ -1193,8 +1289,13 @@ def _project_finding(finding: Finding) -> BaselineRow:
     )
 
 
-def _project_findings(findings: Sequence[Finding]) -> list[BaselineRow]:
-    rows = [_project_finding(finding) for finding in findings]
+def _project_findings(
+    findings: Sequence[Finding], *, occurrence_fields: OccurrenceFields = ("pattern_name",)
+) -> list[BaselineRow]:
+    rows = [
+        _project_finding(finding, occurrence_fields=occurrence_fields)
+        for finding in findings
+    ]
     kinds = {_baseline_kind(row) for row in rows}
     if len(kinds) > 1:
         raise ScanError("baseline-active findings have mixed row shapes")
@@ -1243,7 +1344,8 @@ def _ensure_compatible_shapes(
 
 
 def _baseline_comparison(
-    live_rows: Sequence[BaselineRow], baseline_rows: Sequence[BaselineRow]
+    live_rows: Sequence[BaselineRow],
+    baseline_rows: Sequence[BaselineRow],
 ) -> tuple[list[BaselineRow], list[BaselineRow]]:
     _ensure_compatible_shapes(live_rows, baseline_rows)
     indexed = {_baseline_identity(row): row for row in baseline_rows}
@@ -1251,8 +1353,8 @@ def _baseline_comparison(
     seen: set[tuple[object, ...]] = set()
     for row in live_rows:
         identity = _baseline_identity(row)
-        seen.add(identity)
         prior = indexed.get(identity)
+        seen.add(identity)
         if prior is None:
             active.append(row)
         elif isinstance(row, SymbolMetricBaselineRow):
@@ -1266,32 +1368,39 @@ def _baseline_comparison(
 
 
 def _occurrence_record(
-    row: OccurrenceBaselineRow, *, pattern_field: OccurrencePatternField
+    row: OccurrenceBaselineRow, *, occurrence_fields: OccurrenceFields
 ) -> dict[str, object]:
     file_name = _occurrence_json_file(row.path)
-    if pattern_field == "normalized_condition":
+    values = dict(row.occurrence_values)
+    if row.values == () and len(occurrence_fields) == 1:
+        values = {occurrence_fields[0]: row.pattern_name}
+    if occurrence_fields == ("normalized_condition",):
         # Legacy unreachable-branch field order (occurrence before condition).
         return {
             "file": file_name,
             "qualified_symbol": row.qualified_symbol,
             "occurrence": row.occurrence,
-            "normalized_condition": row.pattern_name,
+            "normalized_condition": values["normalized_condition"],
             "reason": row.reason,
         }
-    return {
+    record: dict[str, object] = {
         "file": file_name,
         "qualified_symbol": row.qualified_symbol,
-        "pattern_name": row.pattern_name,
-        "occurrence": row.occurrence,
-        "reason": row.reason,
     }
+    record.update(values)
+    record["occurrence"] = row.occurrence
+    record["reason"] = row.reason
+    return record
 
 
 def _serialized_baseline(
     rows: Sequence[BaselineRow],
     *,
-    occurrence_pattern_field: OccurrencePatternField = "pattern_name",
+    occurrence_fields: OccurrenceFields = ("pattern_name",),
+    occurrence_pattern_field: OccurrencePatternField | None = None,
 ) -> str:
+    if occurrence_pattern_field is not None:
+        occurrence_fields = (occurrence_pattern_field,)
     records: list[dict[str, object]] = []
     for row in sorted(rows, key=_baseline_sort_key):
         if isinstance(row, GenericBaselineRow):
@@ -1318,7 +1427,7 @@ def _serialized_baseline(
         else:
             # Preserve legacy field order and omit sort_keys for byte-stable rewrites.
             records.append(
-                _occurrence_record(row, pattern_field=occurrence_pattern_field)
+                _occurrence_record(row, occurrence_fields=occurrence_fields)
             )
     if rows and isinstance(rows[0], OccurrenceBaselineRow):
         return json.dumps(records, indent=2) + "\n"
@@ -1370,6 +1479,7 @@ def _rows_for_write(
                     row.pattern_name,
                     row.occurrence,
                     reason,
+                    row.values,
                 )
             )
     return written
@@ -1380,10 +1490,10 @@ def _publish_baseline(
     *,
     root: Path,
     rows: Sequence[BaselineRow],
-    occurrence_pattern_field: OccurrencePatternField = "pattern_name",
+    occurrence_fields: OccurrenceFields = ("pattern_name",),
 ) -> None:
     intended = _serialized_baseline(
-        rows, occurrence_pattern_field=occurrence_pattern_field
+        rows, occurrence_fields=occurrence_fields
     )
     try:
         larch_io.trusted_atomic_write(path, intended, root=root)
@@ -1396,7 +1506,11 @@ def _publish_baseline(
     if read_back != intended:
         raise ScanError(f"baseline read-back bytes differ after write: {path}")
     try:
-        parsed = _parse_baseline_text(read_back, source=f"baseline {path}")
+        parsed = _parse_baseline_text(
+            read_back,
+            source=f"baseline {path}",
+            occurrence_fields=occurrence_fields,
+        )
     except ScanError as exc:
         raise ScanError(f"baseline read-back validation failed: {exc}") from exc
     if parsed != sorted(rows, key=_baseline_sort_key):
@@ -1470,13 +1584,19 @@ def _validate_baseline_options(
 
 
 def _findings_for_active_rows(
-    findings: Sequence[Finding], active_rows: Sequence[BaselineRow]
+    findings: Sequence[Finding],
+    active_rows: Sequence[BaselineRow],
+    *,
+    occurrence_fields: OccurrenceFields = ("pattern_name",),
 ) -> list[Finding]:
     active = {_baseline_identity(row) for row in active_rows}
     rendered = [
         finding
         for finding in findings
-        if _baseline_identity(_project_finding(finding)) in active
+        if _baseline_identity(
+            _project_finding(finding, occurrence_fields=occurrence_fields)
+        )
+        in active
     ]
     rendered.sort(
         key=lambda item: (
@@ -1501,9 +1621,9 @@ def _run_with_baseline(  # noqa: PLR0913 - keeps baseline data flow explicit.
     initial_reason: str | None,
     strict_stale: bool,
     paths: Sequence[str | Path] | None,
-    occurrence_pattern_field: OccurrencePatternField = "pattern_name",
+    occurrence_fields: OccurrenceFields = ("pattern_name",),
 ) -> tuple[int, list[Finding], list[str]]:
-    live_rows = _project_findings(collected)
+    live_rows = _project_findings(collected, occurrence_fields=occurrence_fields)
     if write_baseline:
         written = _rows_for_write(
             live_rows, baseline_rows, initial_reason=initial_reason
@@ -1512,7 +1632,7 @@ def _run_with_baseline(  # noqa: PLR0913 - keeps baseline data flow explicit.
             destination,
             root=root,
             rows=written,
-            occurrence_pattern_field=occurrence_pattern_field,
+            occurrence_fields=occurrence_fields,
         )
         return EXIT_CLEAN, [], []
     scoped_baseline = _selected_baseline_rows(baseline_rows, root=root, paths=paths)
@@ -1525,7 +1645,9 @@ def _run_with_baseline(  # noqa: PLR0913 - keeps baseline data flow explicit.
         raise StrictStaleError(warnings)
     return (
         EXIT_FINDINGS if active_rows else EXIT_CLEAN,
-        _findings_for_active_rows(collected, active_rows),
+        _findings_for_active_rows(
+            collected, active_rows, occurrence_fields=occurrence_fields
+        ),
         warnings,
     )
 
@@ -1567,7 +1689,11 @@ def run_rule(  # noqa: C901, PLR0912, PLR0913 - public API preserves direct keyw
                 baseline_path, root=repo_root, write_mode=write_baseline
             )
             if _baseline_exists(destination, root=repo_root):
-                baseline_rows = _load_baseline(destination, root=repo_root)
+                baseline_rows = _load_baseline(
+                    destination,
+                    root=repo_root,
+                    occurrence_fields=_occurrence_field_names(rule),
+                )
                 if rule.occurrence_baseline:
                     if baseline_rows and _baseline_kind(baseline_rows[0]) != "occurrence":
                         raise ScanError(
@@ -1619,7 +1745,7 @@ def run_rule(  # noqa: C901, PLR0912, PLR0913 - public API preserves direct keyw
                 initial_reason=initial_reason,
                 strict_stale=strict_stale,
                 paths=paths,
-                occurrence_pattern_field=rule.occurrence_pattern_field,
+                occurrence_fields=_occurrence_field_names(rule),
             )
     except StrictStaleError as exc:
         for warning in exc.warnings:

--- a/python/larch/lint/lint_layering.py
+++ b/python/larch/lint/lint_layering.py
@@ -10,22 +10,23 @@ New violations fail unless covered by an inline pragma.
 
 from __future__ import annotations
 
-import argparse
 import ast
-import json
-import re
 import sys
-from collections import Counter
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TypedDict, cast
+from typing import cast
 
+from larch.core import proc
 from larch.lint.engine import (
-    first_duplicate as _first_duplicate,
     is_exempt_python_source,
-    normalize_python_file_path,
+    is_production_python_path,
     ordered_ast_child_nodes,
     qualified_symbol,
+    Finding as EngineFinding,
+    LintRule,
+    RuleCli,
+    SourceFile,
+    run_rule_cli,
 )
 
 TOOL_FAILURE_EXIT = 2
@@ -34,8 +35,7 @@ BASELINE_KEYS = frozenset({"file", "qualified_symbol", "imported_package", "occu
 EXEMPT_FILENAMES = frozenset({"conftest.py", "test_support.py", "review_test_support.py"})
 EXCLUDED_DIRS = frozenset({".git", "node_modules", ".venv", ".agents", "__pycache__"})
 MODULE_SYMBOL = "<module>"
-PRAGMA_RE = re.compile(r"#\s*lint-layering:\s*ok\s+(\S.*)$")
-STANDALONE_PRAGMA_RE = re.compile(r"^\s*#\s*lint-layering:\s*ok\s+(\S.*)$")
+SUPPRESSION_TOKEN = "lint-layering"
 
 # Tier 0: leaf utils (no outbound larch imports needed)
 # Tier 1: larch.core
@@ -64,18 +64,6 @@ PACKAGE_TIER: dict[str, int] = {
 }
 
 
-class Record(TypedDict):
-    file: str
-    qualified_symbol: str
-    imported_package: str
-    occurrence: int
-    reason: str
-
-
-class BaselineError(ValueError):
-    """Raised when a baseline file cannot be trusted."""
-
-
 @dataclass(frozen=True)
 class Finding:
     file: str
@@ -86,22 +74,6 @@ class Finding:
 
     def key(self) -> tuple[str, str, str, int]:
         return (self.file, self.qualified_symbol, self.imported_package, self.occurrence)
-
-
-def _validate_normalized_file(value: object, *, source: Path, index: int, kind: str) -> str:
-    if not isinstance(value, str) or not value:
-        raise BaselineError(f"{source}: {kind} {index} has invalid file")
-    normalized = normalize_python_file_path(value)
-    parts = normalized.split("/")
-    if (
-        normalized != value
-        or normalized.startswith("/")
-        or "" in parts
-        or "." in parts
-        or ".." in parts
-    ):
-        raise BaselineError(f"{source}: {kind} {index} has invalid file")
-    return normalized
 
 
 def iter_source_files(larch_dir: Path) -> list[Path]:
@@ -266,334 +238,68 @@ def scan_file(path: Path, *, python_dir: Path, importer_pkg: str, importer_tier:
     _collect_scope(tree.body, prefix=(), ctx=ctx)
     return ctx.findings
 
-
-def _record_key(record: Record) -> tuple[str, str, str, int]:
-    return (
-        record["file"],
-        record["qualified_symbol"],
-        record["imported_package"],
-        record["occurrence"],
+def detect(source: SourceFile) -> list[EngineFinding]:
+    """Adapt layering findings to the shared baseline engine."""
+    if not source.path.startswith("python/larch/"):
+        return []
+    normalized_file = source.path.removeprefix("python/")
+    importer_pkg = _importer_package(normalized_file)
+    if importer_pkg is None:
+        return []
+    importer_tier = _package_tier(importer_pkg)
+    if importer_tier < 0:
+        return []
+    tree = cast("ast.Module", source.python_ast)
+    ctx = _ScopeCtx(
+        normalized_file=normalized_file,
+        importer_pkg=importer_pkg,
+        importer_tier=importer_tier,
+        findings=[],
     )
-
-
-def _relocation_key(item: Finding | Record) -> tuple[str, str, str, int]:
-    if isinstance(item, Finding):
-        return (
-            Path(item.file).name,
-            item.qualified_symbol,
-            item.imported_package,
-            item.occurrence,
-        )
-    return (
-        Path(item["file"]).name,
-        item["qualified_symbol"],
-        item["imported_package"],
-        item["occurrence"],
-    )
-
-
-def _finding_sort_key(finding: Finding) -> tuple[str, str, str, int]:
-    return finding.key()
-
-
-def _validate_record(item: object, *, index: int, source: Path) -> Record:
-    if not isinstance(item, dict):
-        raise BaselineError(f"{source}: record {index} must have exactly {sorted(BASELINE_KEYS)}")
-    record = cast("dict[str, object]", item)
-    if set(record) != set(BASELINE_KEYS):
-        raise BaselineError(f"{source}: record {index} must have exactly {sorted(BASELINE_KEYS)}")
-    file_name = _validate_normalized_file(record["file"], source=source, index=index, kind="record")
-    qualified_symbol = record["qualified_symbol"]
-    imported_package = record["imported_package"]
-    occurrence = record["occurrence"]
-    reason = record["reason"]
-    if not isinstance(qualified_symbol, str) or not qualified_symbol:
-        raise BaselineError(f"{source}: record {index} has invalid qualified_symbol")
-    if not isinstance(imported_package, str) or not imported_package.startswith("larch"):
-        raise BaselineError(f"{source}: record {index} has invalid imported_package")
-    if not isinstance(occurrence, int) or isinstance(occurrence, bool) or occurrence < 1:
-        raise BaselineError(f"{source}: record {index} has invalid occurrence")
-    if not isinstance(reason, str) or not reason.strip():
-        raise BaselineError(f"{source}: record {index} has invalid reason")
-    return {
-        "file": file_name,
-        "qualified_symbol": qualified_symbol,
-        "imported_package": imported_package,
-        "occurrence": occurrence,
-        "reason": reason,
-    }
-
-
-def load_baseline(path: Path) -> list[Record]:
-    """Load and validate the committed baseline."""
-    try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-    except OSError as exc:
-        raise BaselineError(f"{path}: cannot read baseline: {exc}") from exc
-    except json.JSONDecodeError as exc:
-        raise BaselineError(f"{path}: invalid JSON: {exc}") from exc
-    if not isinstance(data, list):
-        raise BaselineError(f"{path}: baseline must be a top-level JSON array")
-    items = cast("list[object]", data)
-    records = [
-        _validate_record(item, index=index, source=path)
-        for index, item in enumerate(items)
-    ]
-    duplicate = _first_duplicate(_record_key(record) for record in records)
-    if duplicate is not None:
-        raise BaselineError(f"{path}: duplicate baseline identity {format_key(duplicate)}")
-    return records
-
-
-def _has_inline_pragma(
-    finding: Finding, *, source_lines_by_file: dict[str, tuple[str, ...]]
-) -> bool:
-    lines = source_lines_by_file.get(finding.file, ())
-    index = finding.lineno - 1
-    if 0 <= index < len(lines) and PRAGMA_RE.search(lines[index]):
-        return True
-    previous = index - 1
-    return 0 <= previous < len(lines) and STANDALONE_PRAGMA_RE.match(lines[previous]) is not None
-
-
-def _source_lines(path: Path) -> tuple[str, ...]:
-    try:
-        return tuple(path.read_text(encoding="utf-8").splitlines())
-    except OSError:
-        return ()
-
-
-def _collect_all(
-    python_dir: Path,
-) -> tuple[list[Finding], dict[str, tuple[str, ...]]]:
-    larch_dir = python_dir / "larch"
-    findings: list[Finding] = []
-    source_lines_by_file: dict[str, tuple[str, ...]] = {}
-    for path in iter_source_files(larch_dir):
-        normalized = path.relative_to(python_dir).as_posix()
-        importer_pkg = _importer_package(normalized)
-        if importer_pkg is None:
-            continue
-        importer_tier = _package_tier(importer_pkg)
-        if importer_tier < 0:
-            continue
-        source_lines_by_file[normalized] = _source_lines(path)
-        findings.extend(
-            scan_file(path, python_dir=python_dir, importer_pkg=importer_pkg, importer_tier=importer_tier)
-        )
-    return findings, source_lines_by_file
-
-
-def _check_duplicate_live(findings: list[Finding]) -> str | None:
-    duplicate = _first_duplicate(finding.key() for finding in findings)
-    if duplicate is None:
-        return None
-    return f"duplicate live identity {format_key(duplicate)}"
-
-
-def _filter_suppressed(
-    findings: list[Finding],
-    *,
-    source_lines_by_file: dict[str, tuple[str, ...]],
-) -> list[Finding]:
+    _collect_scope(tree.body, prefix=(), ctx=ctx)
     return [
-        finding
-        for finding in findings
-        if not _has_inline_pragma(finding, source_lines_by_file=source_lines_by_file)
+        EngineFinding(
+            path=source.path,
+            line=finding.lineno,
+            rule_id="layering",
+            message=f"imports higher layer {finding.imported_package}",
+            qualified_symbol=finding.qualified_symbol,
+            pattern_name=finding.imported_package,
+            occurrence=finding.occurrence,
+        )
+        for finding in ctx.findings
     ]
 
 
-def format_key(key: tuple[str, str, str, int]) -> str:
-    file_name, qualified_symbol, imported_package, occurrence = key
-    return f"{file_name}:{qualified_symbol} {imported_package}#{occurrence}"
-
-
-def serialize_baseline(records: list[Record]) -> str:
-    """Return canonical sorted JSON for the baseline."""
-    ordered = sorted(records, key=_record_key)
-    return json.dumps(ordered, indent=2) + "\n"
-
-
-def _records_for_write(
-    findings: list[Finding],
-    *,
-    baseline_path: Path,
-    initial_reason: str | None,
-) -> list[Record]:
-    preserved: dict[tuple[str, str, str, int], str] = {}
-    baseline_relocation_counts: Counter[tuple[str, str, str, int]] = Counter()
-    relocation_reasons: dict[tuple[str, str, str, int], str] = {}
-    has_baseline = baseline_path.is_file()
-    if has_baseline:
-        baseline_records = load_baseline(baseline_path)
-        preserved = {_record_key(record): record["reason"] for record in baseline_records}
-        baseline_relocation_counts = Counter(_relocation_key(record) for record in baseline_records)
-        relocation_reasons = {
-            _relocation_key(record): record["reason"]
-            for record in baseline_records
-            if baseline_relocation_counts[_relocation_key(record)] == 1
-        }
-    live_relocation_counts = Counter(_relocation_key(finding) for finding in findings)
-    reason_default = initial_reason.strip() if initial_reason is not None else None
-    records: list[Record] = []
-    missing: list[str] = []
-    for finding in sorted(findings, key=_finding_sort_key):
-        reason = preserved.get(finding.key())
-        relocation_key = _relocation_key(finding)
-        baseline_relocation_count = baseline_relocation_counts[relocation_key]
-        live_relocation_count = live_relocation_counts[relocation_key]
-        if (
-            reason is None
-            and baseline_relocation_count == 1
-            and live_relocation_count == 1
-        ):
-            reason = relocation_reasons[relocation_key]
-        elif reason is None and has_baseline and (
-            baseline_relocation_count > 1 or live_relocation_count > 1
-        ):
-            raise BaselineError(
-                "ambiguous relocation key for live layering finding "
-                f"{format_key(finding.key())}"
-            )
-        if reason is None and reason_default:
-            reason = reason_default
-        if reason is None:
-            missing.append(format_key(finding.key()))
-            continue
-        records.append(
-            {
-                "file": finding.file,
-                "qualified_symbol": finding.qualified_symbol,
-                "imported_package": finding.imported_package,
-                "occurrence": finding.occurrence,
-                "reason": reason,
-            }
-        )
-    if missing:
-        joined = "\n  ".join(missing)
-        raise BaselineError(
-            "missing baseline reasons for live layering findings:\n  " + joined
-        )
-    return records
-
-
-def _run_write(
-    python_dir: Path,
-    *,
-    baseline_path: Path,
-    initial_reason: str | None,
-) -> int:
-    try:
-        all_findings, source_lines_by_file = _collect_all(python_dir)
-        duplicate = _check_duplicate_live(all_findings)
-        if duplicate is not None:
-            raise BaselineError(duplicate)
-        findings = _filter_suppressed(all_findings, source_lines_by_file=source_lines_by_file)
-        records = _records_for_write(findings, baseline_path=baseline_path, initial_reason=initial_reason)
-    except BaselineError as exc:
-        print(f"lint-layering: {exc}", file=sys.stderr)
-        return TOOL_FAILURE_EXIT
-    _ = baseline_path.write_text(serialize_baseline(records), encoding="utf-8")
-    print(f"lint-layering: wrote {len(records)} records to {baseline_path}", file=sys.stderr)
-    return 0
-
-
-def _run_check(
-    python_dir: Path,
-    *,
-    baseline_path: Path,
-) -> int:
-    try:
-        baseline_records = load_baseline(baseline_path)
-        all_findings, source_lines_by_file = _collect_all(python_dir)
-        duplicate = _check_duplicate_live(all_findings)
-        if duplicate is not None:
-            raise BaselineError(duplicate)
-    except BaselineError as exc:
-        print(f"lint-layering: {exc}", file=sys.stderr)
-        return TOOL_FAILURE_EXIT
-    baseline_keys = frozenset(_record_key(record) for record in baseline_records)
-    live_findings = _filter_suppressed(all_findings, source_lines_by_file=source_lines_by_file)
-    new_findings: list[Finding] = []
-    warned: list[Finding] = []
-    for finding in sorted(live_findings, key=_finding_sort_key):
-        if finding.key() in baseline_keys:
-            warned.append(finding)
-        else:
-            new_findings.append(finding)
-    for finding in warned:
-        print(
-            "warning: "
-            f"{finding.file}:{finding.qualified_symbol} imports from {finding.imported_package} "
-            f"occurrence {finding.occurrence} (baselined)",
-            file=sys.stderr,
-        )
-    for finding in new_findings:
-        print(
-            f"{finding.file}:{finding.qualified_symbol} imports from {finding.imported_package} "
-            f"occurrence {finding.occurrence}; "
-            "this violates the larch package layering contract: add a baseline entry with a reason or refactor",
-            file=sys.stderr,
-        )
-    return 1 if new_findings else 0
-
-
-def _parse_args(argv: list[str]) -> argparse.Namespace | None:
-    parser = argparse.ArgumentParser(
-        prog="cli.py lint layering", description=__doc__
-    )
-    _ = parser.add_argument("--root", default=str(Path(__file__).resolve().parents[3]))
-    _ = parser.add_argument(
-        "--write",
-        action="store_true",
-        help=f"Regenerate {BASELINE_FILENAME} from live AST scan.",
-    )
-    _ = parser.add_argument(
-        "--initial-reason",
-        help="Reason used for live findings without preserved baseline reasons.",
-    )
-    try:
-        return parser.parse_args(argv)
-    except SystemExit as exc:
-        if exc.code == 0:
-            raise
-        return None
-
-
-def _resolve_python_dir(root: Path) -> Path | None:
-    python_dir = root / "python"
-    if not python_dir.is_dir():
-        print(f"lint-layering: python directory not found: {python_dir}", file=sys.stderr)
-        return None
-    larch_dir = python_dir / "larch"
-    if not larch_dir.is_dir():
-        print(f"lint-layering: larch directory not found: {larch_dir}", file=sys.stderr)
-        return None
-    return python_dir
+RULE = LintRule(
+    rule_id="layering",
+    description="Ratchet larch imports toward the package-tier contract",
+    detect=detect,
+    syntax_policy="skip",
+    suppression_token=SUPPRESSION_TOKEN,
+    pathspecs=("python/larch",),
+    source_filter=is_production_python_path,
+    occurrence_baseline=True,
+    occurrence_pattern_field="imported_package",
+    require_baseline=True,
+)
 
 
 def main(argv: list[str] | None = None) -> int:
-    parsed = _parse_args(argv if argv is not None else sys.argv[1:])
-    if parsed is None:
-        return TOOL_FAILURE_EXIT
-    python_dir = _resolve_python_dir(Path(str(parsed.root)).resolve())
-    if python_dir is None:
-        return TOOL_FAILURE_EXIT
-    baseline_path = python_dir / BASELINE_FILENAME
-    initial_reason = cast("str | None", parsed.initial_reason)
-    if initial_reason is not None and not initial_reason.strip():
-        print("lint-layering: --initial-reason must be non-empty", file=sys.stderr)
-        return TOOL_FAILURE_EXIT
-    if bool(parsed.write):
-        return _run_write(python_dir, baseline_path=baseline_path, initial_reason=initial_reason)
-    if not baseline_path.is_file():
-        print(
-            f"lint-layering: baseline not found: {baseline_path}; "
-            "run with --write --initial-reason '...' to generate",
-            file=sys.stderr,
-        )
-        return TOOL_FAILURE_EXIT
-    return _run_check(python_dir, baseline_path=baseline_path)
+    """Run the layering ratchet or regenerate its baseline."""
+    return run_rule_cli(
+        argv if argv is not None else sys.argv[1:],
+        rule=RULE,
+        cli=RuleCli(
+            prog="cli.py lint layering",
+            description=__doc__,
+            baseline_filename=BASELINE_FILENAME,
+            error_label="lint-layering",
+            scoped_paths=("python/larch",),
+            strict_stale=False,
+        ),
+        runner=proc.ProcRunner(),
+    )
 
 
 if __name__ == "__main__":

--- a/python/larch/lint/lint_tempfile_dir.py
+++ b/python/larch/lint/lint_tempfile_dir.py
@@ -7,41 +7,33 @@ python/tempfile-dir-baseline.json with a required reason per row.
 
 from __future__ import annotations
 
-import argparse
 import ast
-import json
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TypedDict, cast
+from typing import cast
 
+from larch.core import proc
 from larch.lint.engine import (
-    first_duplicate as _first_duplicate,
+    Finding as EngineFinding,
+    LintRule,
+    RuleCli,
+    SourceFile,
     is_exempt_python_source,
-    normalize_python_file_path,
+    is_production_python_path,
     ordered_ast_child_nodes,
     qualified_symbol,
+    run_rule_cli,
 )
 
 TOOL_FAILURE_EXIT = 2
 BASELINE_FILENAME = "tempfile-dir-baseline.json"
+SUPPRESSION_TOKEN = "lint-tempfile-dir"
 ALLOWED_CALLEES = frozenset({"mkstemp", "mkdtemp", "NamedTemporaryFile", "TemporaryDirectory"})
 BASELINE_KEYS = frozenset({"file", "qualified_symbol", "callee", "occurrence", "reason"})
 EXEMPT_FILENAMES = frozenset({"conftest.py", "test_support.py", "review_test_support.py"})
 EXCLUDED_DIRS = frozenset({".git", "node_modules", ".venv", ".agents", "__pycache__"})
 MODULE_SYMBOL = "<module>"
-
-
-class Record(TypedDict):
-    file: str
-    qualified_symbol: str
-    callee: str
-    occurrence: int
-    reason: str
-
-
-class BaselineError(ValueError):
-    """Raised when the baseline cannot be trusted."""
 
 
 @dataclass(frozen=True)
@@ -54,24 +46,6 @@ class Finding:
 
     def key(self) -> tuple[str, str, str, int]:
         return (self.file, self.qualified_symbol, self.callee, self.occurrence)
-
-
-def _validate_normalized_file(value: object, *, source: Path, index: int) -> str:
-    if not isinstance(value, str) or not value:
-        raise BaselineError(f"{source}: record {index} has invalid file")
-    normalized = normalize_python_file_path(value)
-    parts = normalized.split("/")
-    if (  # pylint: disable=too-many-boolean-expressions  # 7-condition path-component guard; splitting would obscure intent
-        normalized != value
-        or normalized.startswith("/")
-        or not normalized.startswith("larch/")
-        or not normalized.endswith(".py")
-        or "" in parts
-        or "." in parts
-        or ".." in parts
-    ):
-        raise BaselineError(f"{source}: record {index} has invalid file")
-    return normalized
 
 
 def iter_source_files(larch_dir: Path) -> list[Path]:
@@ -170,217 +144,61 @@ def scan_file(path: Path, *, larch_dir: Path) -> list[Finding]:
     )
     return findings
 
-
-def _record_key(record: Record) -> tuple[str, str, str, int]:
-    return (
-        record["file"],
-        record["qualified_symbol"],
-        record["callee"],
-        record["occurrence"],
+def detect(source: SourceFile) -> list[EngineFinding]:
+    """Adapt tempfile findings to the shared baseline engine."""
+    if not source.path.startswith("python/larch/"):
+        return []
+    tree = cast("ast.Module", source.python_ast)
+    legacy: list[Finding] = []
+    _collect_scope(
+        tree.body,
+        prefix=(),
+        normalized_file=source.path.removeprefix("python/"),
+        findings=legacy,
     )
-
-
-def _finding_sort_key(finding: Finding) -> tuple[str, str, str, int]:
-    return finding.key()
-
-
-def _validate_record(item: object, *, index: int, source: Path) -> Record:
-    if not isinstance(item, dict):
-        raise BaselineError(f"{source}: record {index} must have exactly {sorted(BASELINE_KEYS)}")
-    record = cast("dict[str, object]", item)
-    if set(record) != set(BASELINE_KEYS):
-        raise BaselineError(f"{source}: record {index} must have exactly {sorted(BASELINE_KEYS)}")
-    file_name = _validate_normalized_file(record["file"], source=source, index=index)
-    qualified_symbol = record["qualified_symbol"]
-    callee = record["callee"]
-    occurrence = record["occurrence"]
-    reason = record["reason"]
-    if not isinstance(qualified_symbol, str) or not qualified_symbol:
-        raise BaselineError(f"{source}: record {index} has invalid qualified_symbol")
-    if not isinstance(callee, str) or callee not in ALLOWED_CALLEES:
-        raise BaselineError(f"{source}: record {index} has invalid callee")
-    if not isinstance(occurrence, int) or isinstance(occurrence, bool) or occurrence < 1:
-        raise BaselineError(f"{source}: record {index} has invalid occurrence")
-    if not isinstance(reason, str) or not reason.strip():
-        raise BaselineError(f"{source}: record {index} has invalid reason")
-    return {
-        "file": file_name,
-        "qualified_symbol": qualified_symbol,
-        "callee": callee,
-        "occurrence": occurrence,
-        "reason": reason,
-    }
-
-
-def load_baseline(path: Path) -> list[Record]:
-    """Load and validate the committed baseline."""
-    try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-    except OSError as exc:
-        raise BaselineError(f"{path}: cannot read baseline: {exc}") from exc
-    except json.JSONDecodeError as exc:
-        raise BaselineError(f"{path}: invalid JSON: {exc}") from exc
-    if not isinstance(data, list):
-        raise BaselineError(f"{path}: baseline must be a top-level JSON array")
-    records = [_validate_record(item, index=index, source=path) for index, item in enumerate(cast("list[object]", data))]
-    duplicate = _first_duplicate(_record_key(record) for record in records)
-    if duplicate is not None:
-        raise BaselineError(f"{path}: duplicate baseline identity {format_key(duplicate)}")
-    return records
-
-
-def _collect_all(larch_dir: Path) -> list[Finding]:
-    findings: list[Finding] = []
-    for path in iter_source_files(larch_dir):
-        findings.extend(scan_file(path, larch_dir=larch_dir))
-    return findings
-
-
-def _check_duplicate_live(findings: list[Finding]) -> str | None:
-    duplicate = _first_duplicate(finding.key() for finding in findings)
-    if duplicate is None:
-        return None
-    return f"duplicate live identity {format_key(duplicate)}"
-
-
-def format_key(key: tuple[str, str, str, int]) -> str:
-    file_name, qualified_symbol, callee, occurrence = key
-    return f"{file_name}:{qualified_symbol} {callee}#{occurrence}"
-
-
-def serialize_baseline(records: list[Record]) -> str:
-    """Return canonical sorted JSON for the baseline."""
-    ordered = sorted(records, key=_record_key)
-    return json.dumps(ordered, indent=2) + "\n"
-
-
-def _records_for_write(
-    findings: list[Finding],
-    *,
-    baseline_path: Path,
-    initial_reason: str | None,
-) -> list[Record]:
-    preserved: dict[tuple[str, str, str, int], str] = {}
-    if baseline_path.is_file():
-        preserved = {_record_key(record): record["reason"] for record in load_baseline(baseline_path)}
-    reason_default = initial_reason.strip() if initial_reason is not None else None
-    records: list[Record] = []
-    missing: list[str] = []
-    for finding in sorted(findings, key=_finding_sort_key):
-        reason = preserved.get(finding.key()) or reason_default
-        if reason is None:
-            missing.append(format_key(finding.key()))
-            continue
-        records.append(
-            {
-                "file": finding.file,
-                "qualified_symbol": finding.qualified_symbol,
-                "callee": finding.callee,
-                "occurrence": finding.occurrence,
-                "reason": reason,
-            }
+    return [
+        EngineFinding(
+            path=source.path,
+            line=finding.lineno,
+            rule_id="tempfile-dir",
+            message=f"calls tempfile.{finding.callee} without dir=",
+            qualified_symbol=finding.qualified_symbol,
+            pattern_name=finding.callee,
+            occurrence=finding.occurrence,
         )
-    if missing:
-        joined = "\n  ".join(missing)
-        raise BaselineError("missing baseline reasons for live tempfile findings:\n  " + joined)
-    return records
+        for finding in legacy
+    ]
 
 
-def _run_write(
-    larch_dir: Path,
-    *,
-    baseline_path: Path,
-    initial_reason: str | None,
-) -> int:
-    try:
-        findings = _collect_all(larch_dir)
-        duplicate = _check_duplicate_live(findings)
-        if duplicate is not None:
-            raise BaselineError(duplicate)
-        records = _records_for_write(
-            findings,
-            baseline_path=baseline_path,
-            initial_reason=initial_reason,
-        )
-    except BaselineError as exc:
-        print(f"lint-tempfile-dir: {exc}", file=sys.stderr)
-        return TOOL_FAILURE_EXIT
-    _ = baseline_path.write_text(serialize_baseline(records), encoding="utf-8")
-    print(f"lint-tempfile-dir: wrote {len(records)} records to {baseline_path}", file=sys.stderr)
-    return 0
-
-
-def _run_check(larch_dir: Path, *, baseline_path: Path) -> int:
-    try:
-        baseline_records = load_baseline(baseline_path)
-        findings = _collect_all(larch_dir)
-        duplicate = _check_duplicate_live(findings)
-        if duplicate is not None:
-            raise BaselineError(duplicate)
-    except BaselineError as exc:
-        print(f"lint-tempfile-dir: {exc}", file=sys.stderr)
-        return TOOL_FAILURE_EXIT
-    baseline_keys = frozenset(_record_key(record) for record in baseline_records)
-    new_findings: list[Finding] = []
-    warned: list[Finding] = []
-    for finding in sorted(findings, key=_finding_sort_key):
-        if finding.key() in baseline_keys:
-            warned.append(finding)
-        else:
-            new_findings.append(finding)
-    for finding in warned:
-        print(
-            "warning: "
-            f"{finding.file}:{finding.qualified_symbol} calls tempfile.{finding.callee} "
-            f"occurrence {finding.occurrence} line {finding.lineno} (baselined)",
-            file=sys.stderr,
-        )
-    for finding in new_findings:
-        print(
-            f"{finding.file}:{finding.qualified_symbol} calls tempfile.{finding.callee} "
-            f"occurrence {finding.occurrence} line {finding.lineno}; pass an explicit dir=",
-            file=sys.stderr,
-        )
-    return 1 if new_findings else 0
-
-
-def _parse_args(argv: list[str]) -> argparse.Namespace | None:
-    parser = argparse.ArgumentParser(prog="cli.py lint tempfile-dir", description=__doc__)
-    _ = parser.add_argument("--root", default=str(Path(__file__).resolve().parents[3]))
-    _ = parser.add_argument(
-        "--write",
-        action="store_true",
-        help=f"Regenerate {BASELINE_FILENAME} from live AST scan.",
-    )
-    _ = parser.add_argument(
-        "--initial-reason",
-        help="Reason used for live findings without preserved baseline reasons.",
-    )
-    try:
-        return parser.parse_args(argv)
-    except SystemExit as exc:
-        if exc.code == 0:
-            raise
-        return None
+RULE = LintRule(
+    rule_id="tempfile-dir",
+    description="Ratchet tempfile creation toward explicit scratch directories",
+    detect=detect,
+    syntax_policy="skip",
+    suppression_token=SUPPRESSION_TOKEN,
+    pathspecs=("python/larch",),
+    source_filter=is_production_python_path,
+    occurrence_baseline=True,
+    occurrence_pattern_field="callee",
+    require_baseline=True,
+)
 
 
 def main(argv: list[str] | None = None) -> int:
-    parsed = _parse_args(argv if argv is not None else sys.argv[1:])
-    if parsed is None:
-        return TOOL_FAILURE_EXIT
-    root = Path(str(parsed.root)).resolve()
-    larch_dir = root / "python" / "larch"
-    if not larch_dir.is_dir():
-        print(f"lint-tempfile-dir: larch directory not found: {larch_dir}", file=sys.stderr)
-        return TOOL_FAILURE_EXIT
-    baseline_path = root / "python" / BASELINE_FILENAME
-    initial_reason = cast("str | None", parsed.initial_reason)
-    if initial_reason is not None and not initial_reason.strip():
-        print("lint-tempfile-dir: --initial-reason must be non-empty", file=sys.stderr)
-        return TOOL_FAILURE_EXIT
-    if bool(parsed.write):
-        return _run_write(larch_dir, baseline_path=baseline_path, initial_reason=initial_reason)
-    return _run_check(larch_dir, baseline_path=baseline_path)
+    """Run the tempfile-directory ratchet or regenerate its baseline."""
+    return run_rule_cli(
+        argv if argv is not None else sys.argv[1:],
+        rule=RULE,
+        cli=RuleCli(
+            prog="cli.py lint tempfile-dir",
+            description=__doc__,
+            baseline_filename=BASELINE_FILENAME,
+            error_label="lint-tempfile-dir",
+            scoped_paths=("python/larch",),
+            strict_stale=False,
+        ),
+        runner=proc.ProcRunner(),
+    )
 
 
 if __name__ == "__main__":

--- a/python/tests/lint/test_lint_engine.py
+++ b/python/tests/lint/test_lint_engine.py
@@ -2128,7 +2128,7 @@ def test_occurrence_normalized_condition_round_trip_and_field_order(
 ) -> None:
     _write_files(tmp_path, {"python/larch/mod.py": "x = 1\n"})
     baseline = tmp_path / "python" / "occ.json"
-    row = {
+    row: dict[str, object] = {
         "file": "larch/mod.py",
         "qualified_symbol": "parse",
         "occurrence": 1,
@@ -2181,7 +2181,7 @@ def test_occurrence_normalized_condition_round_trip_and_field_order(
 def test_occurrence_baseline_accepts_rule_specific_field_name(tmp_path: Path) -> None:
     _write_files(tmp_path, {"python/larch/mod.py": "x = 1\n"})
     baseline = tmp_path / "python" / "occ.json"
-    row = {
+    row: dict[str, object] = {
         "file": "larch/mod.py",
         "qualified_symbol": "run",
         "callee": "mkstemp",
@@ -2224,7 +2224,7 @@ def test_occurrence_baseline_accepts_ordered_multi_field_identity(
 ) -> None:
     _write_files(tmp_path, {"python/larch/mod.py": "x = 1\n"})
     baseline = tmp_path / "python" / "occ.json"
-    row = {
+    row: dict[str, object] = {
         "file": "larch/mod.py",
         "qualified_symbol": "run",
         "token": "[DONE]",

--- a/python/tests/lint/test_lint_engine.py
+++ b/python/tests/lint/test_lint_engine.py
@@ -2178,6 +2178,96 @@ def test_occurrence_normalized_condition_round_trip_and_field_order(
     ]
 
 
+def test_occurrence_baseline_accepts_rule_specific_field_name(tmp_path: Path) -> None:
+    _write_files(tmp_path, {"python/larch/mod.py": "x = 1\n"})
+    baseline = tmp_path / "python" / "occ.json"
+    row = {
+        "file": "larch/mod.py",
+        "qualified_symbol": "run",
+        "callee": "mkstemp",
+        "occurrence": 1,
+        "reason": "kept",
+    }
+    _write_baseline(baseline, [row])
+
+    def _detect(source: SourceFile) -> list[Finding]:
+        return [
+            Finding(
+                path=source.path,
+                line=1,
+                rule_id="demo-rule",
+                message="calls tempfile.mkstemp without dir=",
+                qualified_symbol="run",
+                pattern_name="mkstemp",
+                occurrence=1,
+            )
+        ]
+
+    rule = _occurrence_rule(detect=_detect, occurrence_pattern_field="callee")
+    code, out, err = _invoke(
+        rule,
+        tmp_path,
+        _git_ok_runner(tmp_path, ["python/larch/mod.py"]),
+        baseline_path=baseline,
+        write_baseline=True,
+        initial_reason="bootstrap",
+    )
+
+    assert code == EXIT_CLEAN
+    assert out == ""
+    assert err == ""
+    assert json.loads(baseline.read_text(encoding="utf-8")) == [row]
+
+
+def test_occurrence_baseline_accepts_ordered_multi_field_identity(
+    tmp_path: Path,
+) -> None:
+    _write_files(tmp_path, {"python/larch/mod.py": "x = 1\n"})
+    baseline = tmp_path / "python" / "occ.json"
+    row = {
+        "file": "larch/mod.py",
+        "qualified_symbol": "run",
+        "token": "[DONE]",
+        "context": "startswith",
+        "occurrence": 1,
+        "reason": "kept",
+    }
+    _write_baseline(baseline, [row])
+
+    def _detect(source: SourceFile) -> list[Finding]:
+        return [
+            Finding(
+                path=source.path,
+                line=1,
+                rule_id="demo-rule",
+                message="uses a lifecycle title token",
+                qualified_symbol="run",
+                occurrence=1,
+                occurrence_values=(("token", "[DONE]"), ("context", "startswith")),
+            )
+        ]
+
+    rule = LintRule(
+        rule_id="demo-rule",
+        description="demo",
+        detect=_detect,
+        syntax_policy="fail",
+        suppression_token="demo",  # noqa: S106 - fixture pragma token, not secret
+        occurrence_baseline=True,
+        occurrence_fields=("token", "context"),
+    )
+    code, out, err = _invoke(
+        rule,
+        tmp_path,
+        _git_ok_runner(tmp_path, ["python/larch/mod.py"]),
+        baseline_path=baseline,
+    )
+
+    assert code == EXIT_CLEAN
+    assert out == ""
+    assert err == ""
+
+
 def test_occurrence_absent_baseline_clean_and_live(tmp_path: Path) -> None:
     _write_files(tmp_path, {"python/larch/mod.py": "x = 1\n"})
     baseline = tmp_path / "python" / "missing.json"

--- a/python/tests/lint/test_lint_layering.py
+++ b/python/tests/lint/test_lint_layering.py
@@ -1,426 +1,69 @@
+"""Detector coverage for the layering lint rule."""
+
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
-import pytest
-
-from larch.lint import lint_layering as ll
+from larch.lint import lint_layering as lint
 
 
-def _write_project(
-    root: Path,
-    *,
-    files: dict[str, str],
-    baseline: object,
-) -> Path:
-    python_dir = root / "python"
-    (python_dir / "larch").mkdir(parents=True, exist_ok=True)
-    for relpath, source in files.items():
-        path = python_dir / relpath
-        path.parent.mkdir(parents=True, exist_ok=True)
-        _ = path.write_text(source, encoding="utf-8")
-    _ = (python_dir / ll.BASELINE_FILENAME).write_text(json.dumps(baseline), encoding="utf-8")
-    return python_dir
-
-
-# ---------------------------------------------------------------------------
-# _importer_package
-# ---------------------------------------------------------------------------
-
-
-def test_importer_package_core() -> None:
-    assert ll._importer_package("larch/core/proc.py") == "larch.core"  # type: ignore[reportPrivateUsage]
-
-
-def test_importer_package_domain() -> None:
-    assert ll._importer_package("larch/state/session_env.py") == "larch.state"  # type: ignore[reportPrivateUsage]
-
-
-def test_importer_package_leaf_module() -> None:
-    assert ll._importer_package("larch/errors.py") == "larch.errors"  # type: ignore[reportPrivateUsage]
-
-
-def test_importer_package_cli_module() -> None:
-    assert ll._importer_package("larch/cli.py") == "larch.cli"  # type: ignore[reportPrivateUsage]
-
-
-def test_importer_package_non_larch() -> None:
-    assert ll._importer_package("cli.py") is None  # type: ignore[reportPrivateUsage]
-
-
-def test_importer_package_root_init() -> None:
-    assert ll._importer_package("larch/__init__.py") == "larch"  # type: ignore[reportPrivateUsage]
-
-
-def test_importer_package_subpackage_init() -> None:
-    assert ll._importer_package("larch/core/__init__.py") == "larch.core"  # type: ignore[reportPrivateUsage]
-
-
-# ---------------------------------------------------------------------------
-# _package_tier
-# ---------------------------------------------------------------------------
-
-
-def test_tier_leaf() -> None:
-    assert ll._package_tier("larch") == 0  # type: ignore[reportPrivateUsage]
-    assert ll._package_tier("larch.errors") == 0  # type: ignore[reportPrivateUsage]
-    assert ll._package_tier("larch.io") == 0  # type: ignore[reportPrivateUsage]
-    assert ll._package_tier("larch.outcomes") == 0  # type: ignore[reportPrivateUsage]
-
-
-def test_tier_core() -> None:
-    assert ll._package_tier("larch.core") == 1  # type: ignore[reportPrivateUsage]
-
-
-def test_tier_domain() -> None:
-    assert ll._package_tier("larch.state") == 2  # type: ignore[reportPrivateUsage]
-    assert ll._package_tier("larch.implement") == 2  # type: ignore[reportPrivateUsage]
-    assert ll._package_tier("larch.git") == 2  # type: ignore[reportPrivateUsage]
-
-
-def test_tier_cli() -> None:
-    assert ll._package_tier("larch.cli") == 3  # type: ignore[reportPrivateUsage]
-
-
-def test_tier_unknown_larch_defaults_to_domain() -> None:
-    assert ll._package_tier("larch.newpkg") == 2  # type: ignore[reportPrivateUsage]
-
-
-# ---------------------------------------------------------------------------
-# scan_file — violation detection
-# ---------------------------------------------------------------------------
-
-
-def test_core_importing_domain_is_violation(tmp_path: Path) -> None:
-    python_dir = tmp_path / "python"
-    larch_core = python_dir / "larch" / "core"
-    larch_core.mkdir(parents=True)
-    source = "from larch.state import session_env\n"
-    path = larch_core / "bad.py"
+def _write(path: Path, source: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
     _ = path.write_text(source, encoding="utf-8")
 
-    findings = ll.scan_file(
-        path, python_dir=python_dir, importer_pkg="larch.core", importer_tier=1
-    )
-    assert len(findings) == 1
-    assert findings[0].imported_package == "larch.state"
-    assert findings[0].qualified_symbol == "<module>"
-    assert findings[0].occurrence == 1
 
-
-def test_domain_importing_core_is_ok(tmp_path: Path) -> None:
+def test_detects_higher_layer_imports_and_preserves_occurrences(tmp_path: Path) -> None:
     python_dir = tmp_path / "python"
-    larch_state = python_dir / "larch" / "state"
-    larch_state.mkdir(parents=True)
-    source = "from larch.core import proc\n"
-    path = larch_state / "foo.py"
-    _ = path.write_text(source, encoding="utf-8")
-
-    findings = ll.scan_file(
-        path, python_dir=python_dir, importer_pkg="larch.state", importer_tier=2
+    path = python_dir / "larch" / "core" / "mod.py"
+    _write(
+        path,
+        "from larch.state import first\n"
+        "from larch.state import second\n"
+        "\n"
+        "def nested():\n"
+        "    from larch.review import value\n",
     )
-    assert not findings
 
-
-def test_domain_importing_cli_is_violation(tmp_path: Path) -> None:
-    python_dir = tmp_path / "python"
-    larch_state = python_dir / "larch" / "state"
-    larch_state.mkdir(parents=True)
-    source = "from larch.cli import COMMANDS\n"
-    path = larch_state / "bad.py"
-    _ = path.write_text(source, encoding="utf-8")
-
-    findings = ll.scan_file(
-        path, python_dir=python_dir, importer_pkg="larch.state", importer_tier=2
+    findings = lint.scan_file(
+        path,
+        python_dir=python_dir,
+        importer_pkg="larch.core",
+        importer_tier=1,
     )
-    assert len(findings) == 1
-    assert findings[0].imported_package == "larch.cli"
 
-
-def test_core_importing_leaf_is_ok(tmp_path: Path) -> None:
-    python_dir = tmp_path / "python"
-    larch_core = python_dir / "larch" / "core"
-    larch_core.mkdir(parents=True)
-    source = "from larch.outcomes import Outcome\n"
-    path = larch_core / "config.py"
-    _ = path.write_text(source, encoding="utf-8")
-
-    findings = ll.scan_file(
-        path, python_dir=python_dir, importer_pkg="larch.core", importer_tier=1
-    )
-    assert not findings
-
-
-def test_same_package_import_is_ok(tmp_path: Path) -> None:
-    python_dir = tmp_path / "python"
-    larch_core = python_dir / "larch" / "core"
-    larch_core.mkdir(parents=True)
-    source = "from larch.core import config\n"
-    path = larch_core / "proc.py"
-    _ = path.write_text(source, encoding="utf-8")
-
-    findings = ll.scan_file(
-        path, python_dir=python_dir, importer_pkg="larch.core", importer_tier=1
-    )
-    assert not findings
-
-
-def test_occurrence_counter_per_package(tmp_path: Path) -> None:
-    python_dir = tmp_path / "python"
-    larch_core = python_dir / "larch" / "core"
-    larch_core.mkdir(parents=True)
-    source = (
-        "from larch.state import A\n"
-        "from larch.state import B\n"
-    )
-    path = larch_core / "multi.py"
-    _ = path.write_text(source, encoding="utf-8")
-
-    findings = ll.scan_file(
-        path, python_dir=python_dir, importer_pkg="larch.core", importer_tier=1
-    )
-    assert len(findings) == 2
-    assert findings[0].occurrence == 1
-    assert findings[1].occurrence == 2
-
-
-def test_import_inside_function_is_detected(tmp_path: Path) -> None:
-    python_dir = tmp_path / "python"
-    larch_core = python_dir / "larch" / "core"
-    larch_core.mkdir(parents=True)
-    source = "def f():\n    from larch.state import X\n"
-    path = larch_core / "lazy.py"
-    _ = path.write_text(source, encoding="utf-8")
-
-    findings = ll.scan_file(
-        path, python_dir=python_dir, importer_pkg="larch.core", importer_tier=1
-    )
-    assert len(findings) == 1
-    assert findings[0].qualified_symbol == "f"
-
-
-def test_barrel_import_unknown_subpackage_is_violation(tmp_path: Path) -> None:
-    python_dir = tmp_path / "python"
-    larch_core = python_dir / "larch" / "core"
-    larch_core.mkdir(parents=True)
-    source = "from larch import newpkg\n"
-    path = larch_core / "barrel.py"
-    _ = path.write_text(source, encoding="utf-8")
-
-    findings = ll.scan_file(
-        path, python_dir=python_dir, importer_pkg="larch.core", importer_tier=1
-    )
-    assert len(findings) == 1
-    assert findings[0].imported_package == "larch.newpkg"
-
-
-def test_relative_imports_same_package_ok(tmp_path: Path) -> None:
-    python_dir = tmp_path / "python"
-    larch_core = python_dir / "larch" / "core"
-    larch_core.mkdir(parents=True)
-    source = "from . import config\n"
-    path = larch_core / "relative.py"
-    _ = path.write_text(source, encoding="utf-8")
-
-    findings = ll.scan_file(
-        path, python_dir=python_dir, importer_pkg="larch.core", importer_tier=1
-    )
-    assert not findings
-
-
-def test_relative_import_upward_is_violation(tmp_path: Path) -> None:
-    python_dir = tmp_path / "python"
-    larch_core = python_dir / "larch" / "core"
-    larch_core.mkdir(parents=True)
-    source = "from ..state import session_env\n"
-    path = larch_core / "relative.py"
-    _ = path.write_text(source, encoding="utf-8")
-
-    findings = ll.scan_file(
-        path, python_dir=python_dir, importer_pkg="larch.core", importer_tier=1
-    )
-    assert len(findings) == 1
-    assert findings[0].imported_package == "larch.state"
-
-
-# ---------------------------------------------------------------------------
-# Inline pragma suppression
-# ---------------------------------------------------------------------------
-
-
-def test_inline_pragma_suppresses_violation(tmp_path: Path) -> None:
-    python_dir = tmp_path / "python"
-    larch_core = python_dir / "larch" / "core"
-    larch_core.mkdir(parents=True)
-    source = "from larch.state import X  # lint-layering: ok architectural dep\n"
-    path = larch_core / "pragmatest.py"
-    _ = path.write_text(source, encoding="utf-8")
-
-    findings = ll.scan_file(
-        path, python_dir=python_dir, importer_pkg="larch.core", importer_tier=1
-    )
-    # finding is still emitted by scan_file; suppression happens in _filter_suppressed
-    assert len(findings) == 1
-    source_lines: dict[str, tuple[str, ...]] = {
-        "larch/core/pragmatest.py": tuple(source.splitlines())
-    }
-    suppressed = ll._filter_suppressed(findings, source_lines_by_file=source_lines)  # type: ignore[reportPrivateUsage]
-    assert not suppressed
-
-
-# ---------------------------------------------------------------------------
-# Baseline load / validate
-# ---------------------------------------------------------------------------
-
-
-def test_load_baseline_valid(tmp_path: Path) -> None:
-    data = [
-        {
-            "file": "larch/core/foo.py",
-            "qualified_symbol": "<module>",
-            "imported_package": "larch.state",
-            "occurrence": 1,
-            "reason": "grandfathered",
-        }
+    assert [(item.qualified_symbol, item.imported_package, item.occurrence) for item in findings] == [
+        ("<module>", "larch.state", 1),
+        ("<module>", "larch.state", 2),
+        ("nested", "larch.review", 1),
     ]
-    baseline_path = tmp_path / ll.BASELINE_FILENAME
-    _ = baseline_path.write_text(json.dumps(data), encoding="utf-8")
-    records = ll.load_baseline(baseline_path)
-    assert len(records) == 1
-    assert records[0]["imported_package"] == "larch.state"
 
 
-def test_load_baseline_rejects_extra_keys(tmp_path: Path) -> None:
-    data = [
-        {
-            "file": "larch/core/foo.py",
-            "qualified_symbol": "<module>",
-            "imported_package": "larch.state",
-            "occurrence": 1,
-            "reason": "r",
-            "extra": "bad",
-        }
-    ]
-    baseline_path = tmp_path / ll.BASELINE_FILENAME
-    _ = baseline_path.write_text(json.dumps(data), encoding="utf-8")
-    with pytest.raises(ll.BaselineError, match="must have exactly"):
-        _ = ll.load_baseline(baseline_path)
-
-
-def test_load_baseline_rejects_duplicate(tmp_path: Path) -> None:
-    row = {
-        "file": "larch/core/foo.py",
-        "qualified_symbol": "<module>",
-        "imported_package": "larch.state",
-        "occurrence": 1,
-        "reason": "r",
-    }
-    baseline_path = tmp_path / ll.BASELINE_FILENAME
-    _ = baseline_path.write_text(json.dumps([row, row]), encoding="utf-8")
-    with pytest.raises(ll.BaselineError, match="duplicate"):
-        _ = ll.load_baseline(baseline_path)
-
-
-def test_load_baseline_rejects_empty_reason(tmp_path: Path) -> None:
-    data = [
-        {
-            "file": "larch/core/foo.py",
-            "qualified_symbol": "<module>",
-            "imported_package": "larch.state",
-            "occurrence": 1,
-            "reason": "   ",
-        }
-    ]
-    baseline_path = tmp_path / ll.BASELINE_FILENAME
-    _ = baseline_path.write_text(json.dumps(data), encoding="utf-8")
-    with pytest.raises(ll.BaselineError, match="invalid reason"):
-        _ = ll.load_baseline(baseline_path)
-
-
-def test_load_baseline_rejects_invalid_imported_package(tmp_path: Path) -> None:
-    data = [
-        {
-            "file": "larch/core/foo.py",
-            "qualified_symbol": "<module>",
-            "imported_package": "not_larch",
-            "occurrence": 1,
-            "reason": "r",
-        }
-    ]
-    baseline_path = tmp_path / ll.BASELINE_FILENAME
-    _ = baseline_path.write_text(json.dumps(data), encoding="utf-8")
-    with pytest.raises(ll.BaselineError, match="invalid imported_package"):
-        _ = ll.load_baseline(baseline_path)
-
-
-# ---------------------------------------------------------------------------
-# End-to-end main() — check mode
-# ---------------------------------------------------------------------------
-
-
-def test_main_check_passes_when_baselined(tmp_path: Path) -> None:
-    baseline = [
-        {
-            "file": "larch/core/bad.py",
-            "qualified_symbol": "<module>",
-            "imported_package": "larch.state",
-            "occurrence": 1,
-            "reason": "test",
-        }
-    ]
-    _ = _write_project(
-        tmp_path,
-        files={"larch/core/bad.py": "from larch.state import X\n"},
-        baseline=baseline,
-    )
-    rc = ll.main(["--root", str(tmp_path)])
-    assert rc == 0
-
-
-def test_main_check_fails_on_new_violation(tmp_path: Path) -> None:
-    _ = _write_project(
-        tmp_path,
-        files={"larch/core/bad.py": "from larch.state import X\n"},
-        baseline=[],
-    )
-    rc = ll.main(["--root", str(tmp_path)])
-    assert rc == 1
-
-
-def test_main_write_generates_baseline(tmp_path: Path) -> None:
+def test_relative_imports_resolve_against_importer_package(tmp_path: Path) -> None:
     python_dir = tmp_path / "python"
-    larch_core = python_dir / "larch" / "core"
-    larch_core.mkdir(parents=True)
-    _ = (python_dir / "larch" / "core" / "bad.py").write_text(
-        "from larch.state import X\n", encoding="utf-8"
+    path = python_dir / "larch" / "core" / "mod.py"
+    _write(path, "from ..state import value\n")
+
+    findings = lint.scan_file(
+        path,
+        python_dir=python_dir,
+        importer_pkg="larch.core",
+        importer_tier=1,
     )
-    rc = ll.main([
-        "--root", str(tmp_path),
-        "--write",
-        "--initial-reason", "test reason",
-    ])
-    assert rc == 0
-    baseline_path = python_dir / ll.BASELINE_FILENAME
-    assert baseline_path.is_file()
-    records = json.loads(baseline_path.read_text(encoding="utf-8"))
-    assert len(records) == 1
-    assert records[0]["reason"] == "test reason"
-    assert records[0]["imported_package"] == "larch.state"
+
+    assert [(item.imported_package, item.occurrence) for item in findings] == [("larch.state", 1)]
 
 
-def test_main_check_no_baseline_exits_tool_failure(tmp_path: Path) -> None:
-    python_dir = tmp_path / "python"
-    (python_dir / "larch").mkdir(parents=True)
-    rc = ll.main(["--root", str(tmp_path)])
-    assert rc == ll.TOOL_FAILURE_EXIT
+def test_iter_source_files_excludes_tests_and_generated_directories(tmp_path: Path) -> None:
+    larch_dir = tmp_path / "python" / "larch"
+    for relpath in [
+        "core/test_mod.py",
+        "core/conftest.py",
+        "core/.venv/vendor.py",
+        "core/__pycache__/generated.py",
+        "core/prod.py",
+    ]:
+        _write(larch_dir / relpath, "")
 
-
-def test_main_check_no_violations_exits_zero(tmp_path: Path) -> None:
-    _ = _write_project(
-        tmp_path,
-        files={"larch/core/clean.py": "from larch.core import config\n"},
-        baseline=[],
-    )
-    rc = ll.main(["--root", str(tmp_path)])
-    assert rc == 0
+    assert [path.relative_to(larch_dir.parent).as_posix() for path in lint.iter_source_files(larch_dir)] == [
+        "larch/core/prod.py"
+    ]

--- a/python/tests/lint/test_lint_tempfile_dir.py
+++ b/python/tests/lint/test_lint_tempfile_dir.py
@@ -1,109 +1,61 @@
+"""Detector coverage for the tempfile-dir lint rule."""
+
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
-import pytest
-
-from larch.lint import lint_tempfile_dir as ltd
+from larch.lint import lint_tempfile_dir as lint
 
 
-def _record(
-    *,
-    file: str = "larch/mod.py",
-    qualified_symbol: str = "run",
-    callee: str = "mkstemp",
-    occurrence: int = 1,
-    reason: str = "grandfathered",
-    **extra: object,
-) -> dict[str, object]:
-    record: dict[str, object] = {
-        "file": file,
-        "qualified_symbol": qualified_symbol,
-        "callee": callee,
-        "occurrence": occurrence,
-        "reason": reason,
-    }
-    record.update(extra)
-    return record
+def _write_source(path: Path, body: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _ = path.write_text("import tempfile\n\n" + body, encoding="utf-8")
 
 
-def _write_project(root: Path, *, files: dict[str, str], baseline: object | None) -> None:
-    python_dir = root / "python"
-    for relpath, source in files.items():
-        path = python_dir / relpath
-        path.parent.mkdir(parents=True, exist_ok=True)
-        _ = path.write_text(source, encoding="utf-8")
-    if baseline is not None:
-        _ = (python_dir / ltd.BASELINE_FILENAME).write_text(json.dumps(baseline), encoding="utf-8")
-
-
-def _source(body: str) -> str:
-    return "import tempfile\n\ndef run():\n" + body
-
-
-def test_tempfile_factories_without_dir_are_detected(tmp_path: Path) -> None:
+def test_detects_factories_without_dir_and_counts_all_calls(tmp_path: Path) -> None:
     larch_dir = tmp_path / "python" / "larch"
-    larch_dir.mkdir(parents=True)
     path = larch_dir / "mod.py"
-    _ = path.write_text(
-        _source(
-            "    tempfile.mkstemp()\n"
-            "    tempfile.mkdtemp()\n"
-            "    tempfile.NamedTemporaryFile()\n"
-            "    tempfile.TemporaryDirectory()\n"
-        ),
-        encoding="utf-8",
+    _write_source(
+        path,
+        "def run(scratch):\n"
+        "    tempfile.mkstemp(dir=scratch)\n"
+        "    tempfile.mkdtemp()\n"
+        "    tempfile.NamedTemporaryFile()\n"
+        "    tempfile.TemporaryDirectory()\n",
     )
 
-    assert [finding.callee for finding in ltd.scan_file(path, larch_dir=larch_dir)] == [
-        "mkstemp",
-        "mkdtemp",
-        "NamedTemporaryFile",
-        "TemporaryDirectory",
-    ]
+    findings = lint.scan_file(path, larch_dir=larch_dir)
 
-
-def test_calls_with_dir_are_ignored_and_occurrences_count_all_calls(tmp_path: Path) -> None:
-    larch_dir = tmp_path / "python" / "larch"
-    larch_dir.mkdir(parents=True)
-    path = larch_dir / "mod.py"
-    _ = path.write_text(
-        _source(
-            "    tempfile.mkstemp(dir=scratch)\n"
-            "    tempfile.mkstemp(\n"
-            "        dir=scratch,\n"
-            "    )\n"
-            "    tempfile.mkstemp()\n"
-        ),
-        encoding="utf-8",
-    )
-
-    assert ltd.scan_file(path, larch_dir=larch_dir) == [
-        ltd.Finding("larch/mod.py", "run", "mkstemp", 3, 8)
-    ]
-
-
-def test_with_context_expression_counts_before_nested_body_call(tmp_path: Path) -> None:
-    larch_dir = tmp_path / "python" / "larch"
-    larch_dir.mkdir(parents=True)
-    path = larch_dir / "mod.py"
-    _ = path.write_text(
-        "import tempfile\n\n"
-        "def run():\n"
-        "    with tempfile.TemporaryDirectory() as tmp:\n"
-        "        tempfile.mkdtemp(dir=tmp)\n"
-        "        tempfile.NamedTemporaryFile()\n",
-        encoding="utf-8",
-    )
-
-    assert [(finding.callee, finding.occurrence) for finding in ltd.scan_file(path, larch_dir=larch_dir)] == [
-        ("TemporaryDirectory", 1),
+    assert [(item.callee, item.occurrence) for item in findings] == [
+        ("mkdtemp", 2),
         ("NamedTemporaryFile", 3),
+        ("TemporaryDirectory", 4),
     ]
 
 
-def test_scope_excludes_tests_and_vendor_cache_dirs(tmp_path: Path) -> None:
+def test_nested_scope_and_with_context_preserve_occurrence_order(tmp_path: Path) -> None:
+    larch_dir = tmp_path / "python" / "larch"
+    path = larch_dir / "mod.py"
+    _write_source(
+        path,
+        "def run():\n"
+        "    with tempfile.TemporaryDirectory() as scratch:\n"
+        "        tempfile.mkstemp(dir=scratch)\n"
+        "        tempfile.NamedTemporaryFile()\n"
+        "    def nested():\n"
+        "        tempfile.mkdtemp()\n",
+    )
+
+    findings = lint.scan_file(path, larch_dir=larch_dir)
+
+    assert [(item.qualified_symbol, item.callee, item.occurrence) for item in findings] == [
+        ("run", "TemporaryDirectory", 1),
+        ("run", "NamedTemporaryFile", 3),
+        ("run.nested", "mkdtemp", 1),
+    ]
+
+
+def test_iter_source_files_omits_tests_and_generated_directories(tmp_path: Path) -> None:
     larch_dir = tmp_path / "python" / "larch"
     for relpath in [
         "test_mod.py",
@@ -115,110 +67,8 @@ def test_scope_excludes_tests_and_vendor_cache_dirs(tmp_path: Path) -> None:
         "__pycache__/generated.py",
         "prod.py",
     ]:
-        path = larch_dir / relpath
-        path.parent.mkdir(parents=True, exist_ok=True)
-        _ = path.write_text("import tempfile\n", encoding="utf-8")
+        _write_source(larch_dir / relpath, "")
 
-    assert [path.relative_to(larch_dir.parent).as_posix() for path in ltd.iter_source_files(larch_dir)] == [
+    assert [path.relative_to(larch_dir.parent).as_posix() for path in lint.iter_source_files(larch_dir)] == [
         "larch/prod.py"
     ]
-
-
-def test_baseline_suppresses_existing_findings_reason_excluded_from_identity(
-    tmp_path: Path, capsys: pytest.CaptureFixture[str]
-) -> None:
-    _write_project(
-        tmp_path,
-        files={"larch/mod.py": _source("    tempfile.mkstemp()\n")},
-        baseline=[_record(reason="kept")],
-    )
-
-    assert ltd.main(["--root", str(tmp_path)]) == 0
-    assert "warning: larch/mod.py:run calls tempfile.mkstemp occurrence 1" in capsys.readouterr().err
-
-
-def test_new_finding_exits_1(tmp_path: Path) -> None:
-    _write_project(
-        tmp_path,
-        files={"larch/mod.py": _source("    tempfile.mkstemp()\n")},
-        baseline=[],
-    )
-
-    assert ltd.main(["--root", str(tmp_path)]) == 1
-
-
-@pytest.mark.parametrize(
-    "payload",
-    [
-        [_record(reason="")],
-        [{"file": "larch/mod.py", "qualified_symbol": "run", "callee": "mkstemp", "occurrence": 1}],
-        [_record(extra="nope")],
-        [_record(file="python/larch/mod.py")],
-        [_record(file="mod.py")],
-    ],
-)
-def test_malformed_extra_key_empty_reason_and_bad_path_rows_exit_2(
-    tmp_path: Path, payload: object
-) -> None:
-    _write_project(
-        tmp_path,
-        files={"larch/mod.py": _source("    tempfile.mkstemp()\n")},
-        baseline=payload,
-    )
-
-    assert ltd.main(["--root", str(tmp_path)]) == 2
-
-
-def test_duplicate_baseline_identity_exits_2(tmp_path: Path) -> None:
-    row = _record()
-    _write_project(
-        tmp_path,
-        files={"larch/mod.py": _source("    tempfile.mkstemp()\n")},
-        baseline=[row, row],
-    )
-
-    assert ltd.main(["--root", str(tmp_path)]) == 2
-
-
-def test_write_preserves_reasons_and_shrinks_obsolete_rows(tmp_path: Path) -> None:
-    _write_project(
-        tmp_path,
-        files={"larch/mod.py": _source("    tempfile.mkstemp()\n")},
-        baseline=[_record(reason="kept"), _record(callee="mkdtemp", reason="obsolete")],
-    )
-
-    assert ltd.main(["--root", str(tmp_path), "--write"]) == 0
-    rows = json.loads((tmp_path / "python" / ltd.BASELINE_FILENAME).read_text(encoding="utf-8"))
-    assert rows == [_record(reason="kept")]
-
-
-def test_write_fails_when_new_rows_lack_reasons(tmp_path: Path) -> None:
-    _write_project(
-        tmp_path,
-        files={"larch/mod.py": _source("    tempfile.mkstemp()\n    tempfile.mkdtemp()\n")},
-        baseline=[_record()],
-    )
-
-    assert ltd.main(["--root", str(tmp_path), "--write"]) == 2
-
-
-def test_missing_baseline_exits_2_in_check_mode(tmp_path: Path) -> None:
-    _write_project(
-        tmp_path,
-        files={"larch/mod.py": _source("    tempfile.mkstemp()\n")},
-        baseline=None,
-    )
-
-    assert ltd.main(["--root", str(tmp_path)]) == 2
-
-
-def test_absent_baseline_bootstrap_succeeds(tmp_path: Path) -> None:
-    _write_project(
-        tmp_path,
-        files={"larch/mod.py": _source("    tempfile.mkstemp()\n")},
-        baseline=None,
-    )
-
-    assert ltd.main(["--root", str(tmp_path), "--write", "--initial-reason", "bootstrap"]) == 0
-    rows = json.loads((tmp_path / "python" / ltd.BASELINE_FILENAME).read_text(encoding="utf-8"))
-    assert rows == [_record(reason="bootstrap")]


### PR DESCRIPTION
## Summary

- move layering and tempfile baseline validation, rendering, suppression parsing, and CLI handling onto `larch.lint.engine`
- extend the engine for rule-specific and multi-field occurrence baseline identities while retaining existing wire compatibility
- replace duplicated lifecycle fixture assertions with focused detector coverage plus shared-engine regression tests

Fixes #7474.

## Validation

- `python3 -m pytest -q python/tests/lint/test_lint_engine.py python/tests/lint/test_lint_unreachable_branch.py python/tests/lint/test_lint_layering.py python/tests/lint/test_lint_tempfile_dir.py`
- focused Ruff and pyright checks
- `python3 python/cli.py lint layering`
- `python3 python/cli.py lint tempfile-dir`

`make py-lint-duplicate-code` was launched locally but its parallel similarity runner did not terminate in this session; CI will provide the authoritative run.