### PR TITLE
Release v53.1.17

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "53.1.16",
+  "version": "53.1.17",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## v53.1.17

### Fixed

- Force pushes with explicit refspecs ([#7496](https://github.com/character-ai/larch/pull/7496))
- Review panel straggler wait and unknown failure classification when Codex or Cursor API calls fail ([#7497](https://github.com/character-ai/larch/pull/7497))

### Changed

- Lifecycle-prefix mutation helpers are now single-sourced ([#7495](https://github.com/character-ai/larch/pull/7495))
- Removed the unreachable pre-Step-5c sanitizer surface ([#7498](https://github.com/character-ai/larch/pull/7498))
- Shared KV codec adoption completed in the design module ([#7499](https://github.com/character-ai/larch/pull/7499))
- Duplicated design session wrappers retired ([#7500](https://github.com/character-ai/larch/pull/7500))
- Report-token vendor bucket descriptors centralized ([#7501](https://github.com/character-ai/larch/pull/7501))
- GitHub layer returns typed open-issue rows ([#7502](https://github.com/character-ai/larch/pull/7502))
- Report Markdown block replacement shared across modules ([#7504](https://github.com/character-ai/larch/pull/7504))
