### PR TITLE
Fixes #7508: fail closed on local branch cleanup

### DIFF
--- a/python/larch/state/finalize.py
+++ b/python/larch/state/finalize.py
@@ -336,9 +336,14 @@ def _local_cleanup(
         return LocalCleanupResult(cleanup_success=False, current_branch=current, branch_deleted=False)
     branch_check = runner.run(["git", "check-ref-format", "--branch", branch], cwd=cwd)
     if branch_check.returncode != 0:
+        return LocalCleanupResult(cleanup_success=False, current_branch=current, branch_deleted=False)
+    branch_ref = runner.run(["git", "show-ref", "--verify", "--quiet", f"refs/heads/{branch}"], cwd=cwd)
+    if branch_ref.returncode == 1:
         return LocalCleanupResult(cleanup_success=True, current_branch=current, branch_deleted=False)
+    if branch_ref.returncode != 0:
+        return LocalCleanupResult(cleanup_success=False, current_branch=current, branch_deleted=False)
     deleted = runner.run(["git", "branch", "-D", "--", branch], cwd=cwd).returncode == 0
-    return LocalCleanupResult(cleanup_success=True, current_branch=current, branch_deleted=deleted)
+    return LocalCleanupResult(cleanup_success=deleted, current_branch=current, branch_deleted=deleted)
 
 
 def postbump(
@@ -497,6 +502,14 @@ def postmerge(
 
     cleanup = _local_cleanup(runner=runner, branch=branch, cwd=cwd)
     cleanup_status = "success" if cleanup.cleanup_success else "partial"
+    if not cleanup.cleanup_success:
+        return FinalizeResult(
+            Outcome.STALLED,
+            "local-cleanup-failed",
+            f"failed to delete local branch {branch}",
+            local_cleanup_status=cleanup_status,
+            branch_deleted=cleanup.branch_deleted,
+        )
 
     expected_title = ctx.pr_title or ""
     actual = git.log_subject(runner, "HEAD", cwd=cwd)

--- a/python/larch/state/session_env.py
+++ b/python/larch/state/session_env.py
@@ -2259,6 +2259,27 @@ def _transient_run(argv: list[str]) -> proc.CommandResult:
     return last
 
 
+@dataclass(frozen=True)
+class BranchDeleteResult:
+    cleanup_success: bool
+    branch_deleted: bool
+
+
+def _delete_local_branch(branch: str) -> BranchDeleteResult:
+    branch_ref = proc.run(["git", "show-ref", "--verify", "--quiet", f"refs/heads/{branch}"])
+    if branch_ref.returncode == 1:
+        print(f"Local branch {branch} was already deleted", file=sys.stderr)
+        return BranchDeleteResult(cleanup_success=True, branch_deleted=False)
+    if branch_ref.returncode != 0:
+        print(f"❌ Failed to check local branch {branch}", file=sys.stderr)
+        return BranchDeleteResult(cleanup_success=False, branch_deleted=False)
+    print(f"🔄 Deleting local branch {branch}...", file=sys.stderr)
+    if proc.run(["git", "branch", "-D", "--", branch]).returncode == 0:
+        return BranchDeleteResult(cleanup_success=True, branch_deleted=True)
+    print(f"❌ Failed to delete local branch {branch}", file=sys.stderr)
+    return BranchDeleteResult(cleanup_success=False, branch_deleted=False)
+
+
 def local_cleanup_main(argv: list[str]) -> int:
     parser = argparse.ArgumentParser(prog="session local-cleanup", add_help=False)
     parser.add_argument("--branch", default="")
@@ -2311,13 +2332,11 @@ def local_cleanup_main(argv: list[str]) -> int:
             else:
                 print("❌ Failed to pull origin main", file=sys.stderr)
             return 0
-        print(f"🔄 Deleting local branch {args.branch}...", file=sys.stderr)
-        if proc.run(["git", "branch", "-D", "--", args.branch]).returncode == 0:
-            branch_deleted = "true"
-        else:
-            print(f"⚠ Failed to delete branch {args.branch} (may already be deleted)", file=sys.stderr)
-        cleanup_success = "true"
-        print("✅ Local cleanup complete", file=sys.stderr)
+        branch_result = _delete_local_branch(args.branch)
+        if branch_result.cleanup_success:
+            branch_deleted = "true" if branch_result.branch_deleted else "false"
+            cleanup_success = "true"
+            print("✅ Local cleanup complete", file=sys.stderr)
         return 0
     finally:
         print(f"CLEANUP_SUCCESS={cleanup_success}")

--- a/python/tests/state/test_finalize.py
+++ b/python/tests/state/test_finalize.py
@@ -117,6 +117,7 @@ def test_postmerge_verifies_main_title(tmp_path: Path) -> None:
             CommandResult(("git", "rev-list", "--count", "origin/main..HEAD"), 0, "0\n", "", 0.01),
             CommandResult(("git", "pull", "--ff-only", "origin", "main"), 0, "", "", 0.01),
             CommandResult(("git", "check-ref-format", "--branch", "feat"), 0, "", "", 0.01),
+            CommandResult(("git", "show-ref", "--verify", "--quiet", "refs/heads/feat"), 0, "", "", 0.01),
             CommandResult(("git", "branch", "-D", "--", "feat"), 0, "", "", 0.01),
             CommandResult(("git", "log", "-1", "--format=%s", "HEAD"), 0, "Implement thing (#7)\n", "", 0.01),
         ],
@@ -127,7 +128,7 @@ def test_postmerge_verifies_main_title(tmp_path: Path) -> None:
     assert result.branch_deleted is True
 
 
-def test_postmerge_exposes_branch_delete_failure(tmp_path: Path) -> None:
+def test_postmerge_stalls_when_local_branch_delete_fails(tmp_path: Path) -> None:
     runner = RecordingRunner(
         responses=[
             CommandResult(("git", "checkout", "main"), 0, "", "", 0.01),
@@ -136,12 +137,14 @@ def test_postmerge_exposes_branch_delete_failure(tmp_path: Path) -> None:
             CommandResult(("git", "rev-list", "--count", "origin/main..HEAD"), 0, "0\n", "", 0.01),
             CommandResult(("git", "pull", "--ff-only", "origin", "main"), 0, "", "", 0.01),
             CommandResult(("git", "check-ref-format", "--branch", "feat"), 0, "", "", 0.01),
+            CommandResult(("git", "show-ref", "--verify", "--quiet", "refs/heads/feat"), 0, "", "", 0.01),
             CommandResult(("git", "branch", "-D", "--", "feat"), 1, "", "busy", 0.01),
-            CommandResult(("git", "log", "-1", "--format=%s", "HEAD"), 0, "Implement thing (#7)\n", "", 0.01),
         ],
     )
     result = finalize.postmerge(runner=runner, ctx=_ctx(tmp_path), cwd=str(tmp_path))
-    assert result.local_cleanup_status == "success"
+    assert result.outcome is finalize.Outcome.STALLED
+    assert result.status == "local-cleanup-failed"
+    assert result.local_cleanup_status == "partial"
     assert result.branch_deleted is False
 
 
@@ -502,6 +505,7 @@ def test_local_cleanup_does_not_reset_on_empty_orphan_evidence(tmp_path: Path) -
             CommandResult(("git", "diff", "--name-only", "base", "HEAD"), 0, "", "", 0.01),
             CommandResult(("git", "pull", "--ff-only", "origin", "main"), 0, "", "", 0.01),
             CommandResult(("git", "check-ref-format", "--branch", "feat"), 0, "", "", 0.01),
+            CommandResult(("git", "show-ref", "--verify", "--quiet", "refs/heads/feat"), 0, "", "", 0.01),
             CommandResult(("git", "branch", "-D", "--", "feat"), 0, "", "", 0.01),
             CommandResult(("git", "log", "-1", "--format=%s", "HEAD"), 0, "Implement thing (#7)\n", "", 0.01),
         ],

--- a/python/tests/state/test_session_env.py
+++ b/python/tests/state/test_session_env.py
@@ -1940,6 +1940,20 @@ def test_local_cleanup_flush_orphan_non_flush_and_squash_gap(tmp_path: Path) -> 
     assert _git(["rev-parse", "HEAD"], cwd=squash_repo).stdout.strip() == expected
 
 
+@pytest.mark.skipif(shutil.which("git") is None, reason="git required for local-cleanup integration tests")
+def test_local_cleanup_reports_branch_delete_failure(tmp_path: Path) -> None:
+    repo = _setup_remote_repo(tmp_path, "branch-delete-failure")
+    worktree = tmp_path / "feature-worktree"
+    _git(["worktree", "add", "-q", str(worktree), "feature"], cwd=repo)
+
+    result = _run_local_cleanup(repo)
+
+    assert "CLEANUP_SUCCESS=false" in result.stdout
+    assert "BRANCH_DELETED=false" in result.stdout
+    assert "Failed to delete local branch feature" in result.stderr
+    assert _git(["branch", "--show-current"], cwd=worktree).stdout.strip() == "feature"
+
+
 def test_write_and_clear_implement_env_pointer(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     home = tmp_path / "home"
     monkeypatch.setenv("HOME", str(home))


### PR DESCRIPTION
## Summary

- Treat a failed local feature-branch deletion as a post-merge stall.
- Preserve idempotent cleanup when the branch was already removed.
- Cover both the finalizer and session cleanup command with regressions.

## Verification

- `cd python && python3 -m pytest -q tests/state/test_finalize.py`
- `cd python && python3 -m pytest -q tests/state/test_session_env.py`
- Targeted ruff, pylint, pyright, complexity, unreachable-branch, and subprocess-via-runner checks.

Closes #7508
