### PR TITLE
Fixes #7510: recover design-log PR identity

### DIFF
--- a/python/larch/design/design_log_publish_flow.py
+++ b/python/larch/design/design_log_publish_flow.py
@@ -21,7 +21,6 @@ from larch.git import gh
 from larch.design.design_summary import resolve_summary_mode
 from larch.report.run_log_batch import append_execution_issue
 
-_PR_URL_RE = re.compile(r"/pull/([0-9]+)")
 _RUN_LOG_COMMIT_SCRUB_FAILURE_RE = re.compile(
     r"(secret survived scrubbing|scrub_log_secrets|scrub-log-secrets|scrubber|scrub_error)",
     re.IGNORECASE,
@@ -395,7 +394,6 @@ def _publish_design_logs(
         return (False, "", "", "", "0")
     branch = f"larch-logs/design-{request.run_id}"
     cli = str(request.plugin_root / "python" / "cli.py")
-    repo_args = ["--repo", request.repo] if request.repo else []
     wt_parent = _design_log_worktree_parent(request.design_tmpdir)
     worktree = wt_parent / "wt"
     branch_created = False
@@ -496,38 +494,32 @@ def _publish_design_logs(
             )
             keep_branch_for_recovery = True
             return (False, "", "", branch, scrub_violations)
-        body_file = wt_parent / "pr-body.txt"
-        _ = body_file.write_text(
-            f"Automated design log directory for run {request.run_id}. "
-            f"Merged once required CI checks pass (issue #{request.issue}).\n",
-            encoding="utf-8",
-        )
-        pr = gh.command(
-            proc,
-            [
-                "pr",
-                "create",
-                "--head",
-                branch,
-                "--base",
-                _default_base_ref(repo_root),
-                "--title",
-                f"chore(larch-logs): design run {request.run_id} (issue #{request.issue})",
-                "--body-file",
-                str(body_file),
-                *repo_args,
-            ],
-            cwd=repo_root,
-        )
-        if pr.returncode != 0:
+        try:
+            pr, _ = gh.pr_create(
+                proc,
+                repo=request.repo or None,
+                branch=branch,
+                base=_default_base_ref(repo_root),
+                title=(
+                    f"chore(larch-logs): design run {request.run_id} "
+                    f"(issue #{request.issue})"
+                ),
+                body=(
+                    f"Automated design log directory for run {request.run_id}. "
+                    f"Merged once required CI checks pass (issue #{request.issue}).\n"
+                ),
+                assignee=None,
+                cwd=repo_root,
+            )
+        except gh.ShipError as exc:
             print(
-                f"design log-publish: gh pr create failed; pushed branch {branch} kept for recovery: {pr.stderr.strip()}",
+                f"design log-publish: gh pr create failed; pushed branch {branch} "
+                f"kept for recovery: {exc}",
                 file=sys.stderr,
             )
             return (False, "", "", branch, scrub_violations)
-        pr_url = pr.stdout.strip().splitlines()[-1] if pr.stdout.strip() else ""
-        match: re.Match[str] | None = _PR_URL_RE.search(pr_url)
-        pr_number = match.group(1) if match else ""
+        pr_number = str(pr.number)
+        pr_url = pr.url
         # Launch the wait-then-admin-merge waiter detached so the log PR squashes
         # in once required CI checks pass, without stalling the /design orchestrator
         # on CI (preserving the non-blocking goal of #4404). GitHub-native --auto
@@ -538,10 +530,9 @@ def _publish_design_logs(
         # bypassing only the review gate (#4524). Best-effort: a launch failure
         # leaves the PR open for manual/CI merge and the working tree is already
         # clean either way.
-        if pr_number:
-            _spawn_detached_admin_merge(
-                cli=cli, pr_number=pr_number, repo=request.repo, repo_root=repo_root
-            )
+        _spawn_detached_admin_merge(
+            cli=cli, pr_number=pr_number, repo=request.repo, repo_root=repo_root
+        )
         return (True, pr_number, pr_url, "", scrub_violations)
     finally:
         _ = _run(["git", "worktree", "remove", "--force", str(worktree)], cwd=repo_root)

--- a/python/test_support.py
+++ b/python/test_support.py
@@ -160,9 +160,11 @@ def write_gh_pr_stub(
     _ = path.write_text(
         "#!/usr/bin/env bash\n"
         f"CAPTURE_PATH={capture_path_arg}\n"
+        'STATE_FILE="${0}.branch"\n'
+        'REPO_FILE="${0}.repo"\n'
         'if [ "$1" = "pr" ] && [ "$2" = "create" ]; then\n'
         '  if [ -n "$CAPTURE_PATH" ]; then\n'
-        '    {\n'
+        '    (\n'
         "      printf '%s\\n' '__ARGV__'\n"
         "      for arg in \"$@\"; do printf '%s\\n' \"$arg\"; done\n"
         "      printf '%s\\n' '__BODY__'\n"
@@ -176,10 +178,27 @@ def write_gh_pr_stub(
         '        shift\n'
         '      done\n'
         '      if [ -n "$body_file" ]; then cat "$body_file"; fi\n'
-        '    } > "$CAPTURE_PATH"\n'
+        '    ) > "$CAPTURE_PATH"\n'
         '  fi\n'
+        '  head_ref=""\n'
+        '  repo=""\n'
+        '  while [ "$#" -gt 0 ]; do\n'
+        '    if [ "$1" = "--head" ]; then shift; head_ref="${1-}"; fi\n'
+        '    if [ "$1" = "--repo" ]; then shift; repo="${1-}"; fi\n'
+        '    shift\n'
+        '  done\n'
+        '  printf "%s\\n" "$head_ref" > "$STATE_FILE"\n'
+        '  printf "%s\\n" "${repo:-o/r}" > "$REPO_FILE"\n'
         f"  if [ {pr_create_rc} -ne 0 ]; then echo 'gh: pr create failed' >&2; exit {pr_create_rc}; fi\n"
-        "  echo 'https://github.com/o/r/pull/77'\n"
+        '  repo="$(cat "$REPO_FILE")"\n'
+        '  printf "https://github.com/%s/pull/77\\n" "$repo"\n'
+        "  exit 0\n"
+        "fi\n"
+        'if [ "$1" = "pr" ] && [ "$2" = "list" ]; then echo "[]"; exit 0; fi\n'
+        'if [ "$1" = "pr" ] && [ "$2" = "view" ]; then\n'
+        '  head_ref="$(cat "$STATE_FILE")"\n'
+        '  repo="$(cat "$REPO_FILE")"\n'
+        '  printf \'{"number":77,"url":"https://github.com/%s/pull/77","state":"OPEN","headRefName":"%s"}\\n\' "$repo" "$head_ref"\n'
         "  exit 0\n"
         "fi\n"
         'if [ "$1" = "pr" ] && [ "$2" = "merge" ]; then exit 0; fi\n'

--- a/python/tests/git/test_gh.py
+++ b/python/tests/git/test_gh.py
@@ -305,6 +305,29 @@ def test_pr_create_resolves_success_from_post_create_list() -> None:
     assert "--json" not in runner.calls[1]
 
 
+def test_pr_create_resolves_success_without_stdout_from_post_create_list() -> None:
+    """A successful create with no URL must still recover the branch's PR."""
+    runner = RecordingRunner(
+        responses=[
+            CommandResult(("gh", "pr", "list"), 0, "[]", "", 0.01),
+            CommandResult(("gh", "pr", "create"), 0, "", "", 0.01),
+            CommandResult(
+                ("gh", "pr", "list"),
+                0,
+                '[{"number":124,"url":"https://github.com/o/r/pull/124","state":"OPEN","headRefName":"feat"}]',
+                "",
+                0.01,
+            ),
+        ],
+    )
+
+    pr, created = gh.pr_create(runner, repo="o/r", branch="feat", title="t", body="b")
+
+    assert created is True
+    assert pr.number == 124
+    assert pr.url == "https://github.com/o/r/pull/124"
+
+
 def test_pr_create_resolves_success_from_stdout_url_when_list_lags() -> None:
     runner = RecordingRunner(
         responses=[


### PR DESCRIPTION
Closes #7510

Use the typed PR-creation helper so design-log publishing resolves the PR by branch and always launches its CI merge waiter, even when `gh pr create` emits no URL.