### PR TITLE
Release v53.1.18

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "53.1.17",
+  "version": "53.1.18",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## What's Changed in v53.1.18

### Added

- Bug-treadmill adoption ratchet with public wiring and documentation (#7506)

### Changed

- Migrate remaining exact queue-runner test doubles to the unified contract (#7514)
- Port design Step 3.5 settle in-process (#7515)

### Fixed

- Working branch left behind after `/fm` run now deleted (#7511)
- Design-log flush PR left unmerged by a `/design` run (#7512)
