### PR TITLE
Release v53.1.19

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "53.1.18",
+  "version": "53.1.19",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Added

- New lint for truthiness-based status routing (#7517)
- Revived R0801 duplicate-code enforcement as a shrink-only baseline ratchet (#7525)
- Prevention batch from the 2026-07-15 `/learn-from-bugs` run: result-env key-parity lint, invariant I-Lane-1, and guidelines G-Idem-5, G-Orch-7, G-Obs-7, G-Obs-8 (#7526)
- Gate for diff-introduced Python clones before merge (#7527)
- Prompt-layer reuse-before-write protections against copy-paste duplication (#7531)

## Changed

- Completed shared KV codec adoption in orchestration flows (#7513)
- Ported design Step 3b entry in-process (#7518)
- Migrated legacy lints onto the engine (#7521)
- Completed shared KV codec adoption in state and reporting flows (#7524)

## Fixed

- Arch-assessor guidelines notes with G-identifiers caused submit to return invalid-note (#7522)
- Occurrence baseline round-trip hardening (#7528)
