### PR TITLE
Fixes #7547: Fail closed on missing tracking issue titles

### DIFF
--- a/python/larch/state/finalize.py
+++ b/python/larch/state/finalize.py
@@ -13,7 +13,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import cast
 
 from larch.core import config, process_identity
 from larch import io as larch_io
@@ -534,17 +534,25 @@ def _rename_issue(
     issue = ctx.issue_number or ctx.issue
     if not issue or ctx.repo_unavailable:
         return "skipped"
-    current = ctx.pr_title or f"Issue {issue}"
     result = gh.issue_view_field_read(runner, str(issue), "title,state", repo=ctx.repo, cwd=cwd)
     if result.returncode != 0:
         return "failed"
+    current = ""
+    issue_state = ""
     try:
-        data: Any = json.loads(result.stdout or "{}")
-        if state == "stalled" and str(data.get("state", "")).upper() != "OPEN":
-            return "skipped"
-        current = str(data.get("title") or current)
+        parsed: object = json.loads(result.stdout or "{}")
+        if isinstance(parsed, dict):
+            data = cast("dict[str, object]", parsed)
+            title = data.get("title")
+            if isinstance(title, str) and title.strip():
+                current = title
+                issue_state = str(data.get("state", ""))
     except json.JSONDecodeError:
+        pass
+    if not current:
         return "failed"
+    if state == "stalled" and issue_state.upper() != "OPEN":
+        return "skipped"
     try:
         _ = tracking_issue.rename(
             runner,

--- a/python/tests/state/test_finalize.py
+++ b/python/tests/state/test_finalize.py
@@ -96,6 +96,21 @@ def test_title_matches_empty_expected_rejected() -> None:
     assert not finalize._title_matches(actual="Anything", expected="", pr_number=7)
 
 
+@pytest.mark.parametrize(
+    "payload",
+    ["", "{}", '{"title":"","state":"OPEN"}', '{"title":null,"state":"OPEN"}', "[]"],
+)
+def test_rename_issue_fails_without_a_valid_issue_title(tmp_path: Path, payload: str) -> None:
+    runner = RecordingRunner(
+        responses=[CommandResult(("gh", "issue", "view"), 0, payload, "", 0.01)],
+    )
+
+    status = finalize._rename_issue(runner=runner, ctx=_ctx(tmp_path), state="done", cwd=str(tmp_path))
+
+    assert status == "failed"
+    assert not any(call[1:3] == ["issue", "edit"] for call in runner.calls)
+
+
 def test_postmerge_skips_draft_without_done_manifest(tmp_path: Path) -> None:
     runner = RecordingRunner()
     ctx = _ctx(tmp_path, draft=True)


### PR DESCRIPTION
## Summary

- reject empty, missing, null, or malformed tracking-issue title payloads
- prevent fallback to PR-derived titles during finalize
- add focused regression coverage

## Validation

- python3 -m pytest python/tests/state/test_finalize.py -q
- changed-file Ruff, Pylint, and Pyright checks

Closes #7547