### PR TITLE
Fixes #7536: Share identity baseline schemas

### DIFF
--- a/python/larch/lint/engine.py
+++ b/python/larch/lint/engine.py
@@ -1575,57 +1575,43 @@ def _validate_identity_row_kinds(
         raise ScanError(f"{source}: identity baseline rows use the wrong schema")
 
 
-def _identity_baseline_row(  # noqa: C901  # pylint: disable=too-many-boolean-expressions
-    record: Mapping[str, object], *, kind: IdentityBaselineKind, index: int, source: str
-) -> IdentityBaselineRow:
+def _require_identity_keys(
+    record: Mapping[str, object], *, expected: frozenset[str], index: int, source: str
+) -> None:
     keys = frozenset(record)
-    if kind == "keyword_only":
-        expected = frozenset({"file", "qualified_symbol"})
-        if keys != expected:
-            raise ScanError(f"{source}: baseline row {index} has unsupported keys")
-        file_name = record["file"]
-        symbol = record["qualified_symbol"]
-        if not _is_single_line(file_name) or not _is_single_line(symbol):
-            raise ScanError(f"{source}: baseline row {index} has invalid keyword-only identity")
-        return KeywordOnlyBaselineRow(cast("str", file_name), cast("str", symbol))
-    if kind == "wire_artifact_pairing":
-        expected = frozenset({"artifact", "side", "reason"})
-        if keys != expected:
-            raise ScanError(f"{source}: baseline row {index} has unsupported keys")
-        artifact, side, reason = record["artifact"], record["side"], record["reason"]
-        allowed_sides = {"external-writer", "external-reader", "intentionally-one-sided"}
-        if not _nonempty_single_line(artifact) or side not in allowed_sides or not _nonempty_single_line(reason):
-            raise ScanError(f"{source}: baseline row {index} has invalid wire-artifact row")
-        return WireArtifactPairingBaselineRow(
-            cast("str", artifact),
-            cast("Literal['external-writer', 'external-reader', 'intentionally-one-sided']", side),
-            cast("str", reason),
-        )
-    if kind == "renderer_golden_tests":
-        expected = frozenset({"file", "function_name", "reason"})
-        if keys != expected:
-            raise ScanError(f"{source}: baseline row {index} has unsupported keys")
-        file_name, function_name, reason = record["file"], record["function_name"], record["reason"]
-        normalized = normalize_python_file_path(file_name) if isinstance(file_name, str) else ""
-        parts = normalized.split("/")
-        if (
-            not _is_single_line(file_name)
-            or normalized != file_name
-            or not normalized.startswith("larch/report/")
-            or not normalized.endswith(".py")
-            or "" in parts
-            or "." in parts
-            or ".." in parts
-            or not _nonempty_single_line(function_name)
-            or not _nonempty_single_line(reason)
-        ):
-            raise ScanError(f"{source}: baseline row {index} has invalid renderer row")
-        return RendererGoldenTestsBaselineRow(
-            cast("str", file_name), cast("str", function_name), cast("str", reason)
-        )
-    expected = frozenset({"guideline_id", "reason"})
     if keys != expected:
         raise ScanError(f"{source}: baseline row {index} has unsupported keys")
+
+
+def _keyword_only_identity_row(record: Mapping[str, object], *, index: int, source: str) -> KeywordOnlyBaselineRow:
+    _require_identity_keys(record, expected=frozenset({"file", "qualified_symbol"}), index=index, source=source)
+    file_name, symbol = record["file"], record["qualified_symbol"]
+    if not _is_single_line(file_name) or not _is_single_line(symbol):
+        raise ScanError(f"{source}: baseline row {index} has invalid keyword-only identity")
+    return KeywordOnlyBaselineRow(cast("str", file_name), cast("str", symbol))
+
+
+def _wire_artifact_identity_row(record: Mapping[str, object], *, index: int, source: str) -> WireArtifactPairingBaselineRow:
+    _require_identity_keys(record, expected=frozenset({"artifact", "side", "reason"}), index=index, source=source)
+    artifact, side, reason = record["artifact"], record["side"], record["reason"]
+    allowed_sides = {"external-writer", "external-reader", "intentionally-one-sided"}
+    if not _nonempty_single_line(artifact) or side not in allowed_sides or not _nonempty_single_line(reason):
+        raise ScanError(f"{source}: baseline row {index} has invalid wire-artifact row")
+    return WireArtifactPairingBaselineRow(cast("str", artifact), cast("Literal['external-writer', 'external-reader', 'intentionally-one-sided']", side), cast("str", reason))
+
+
+def _renderer_identity_row(record: Mapping[str, object], *, index: int, source: str) -> RendererGoldenTestsBaselineRow:
+    _require_identity_keys(record, expected=frozenset({"file", "function_name", "reason"}), index=index, source=source)
+    file_name, function_name, reason = record["file"], record["function_name"], record["reason"]
+    normalized = normalize_python_file_path(file_name) if isinstance(file_name, str) else ""
+    invalid_path = not _is_single_line(file_name) or normalized != file_name or not normalized.startswith("larch/report/") or not normalized.endswith(".py") or bool({"", ".", ".."}.intersection(normalized.split("/")))
+    if invalid_path or not _nonempty_single_line(function_name) or not _nonempty_single_line(reason):
+        raise ScanError(f"{source}: baseline row {index} has invalid renderer row")
+    return RendererGoldenTestsBaselineRow(cast("str", file_name), cast("str", function_name), cast("str", reason))
+
+
+def _guideline_identity_row(record: Mapping[str, object], *, index: int, source: str) -> GuidelineNoExceptionBaselineRow:
+    _require_identity_keys(record, expected=frozenset({"guideline_id", "reason"}), index=index, source=source)
     guideline_id, reason = record["guideline_id"], record["reason"]
     if (
         not _nonempty_single_line(guideline_id)
@@ -1634,6 +1620,16 @@ def _identity_baseline_row(  # noqa: C901  # pylint: disable=too-many-boolean-ex
     ):
         raise ScanError(f"{source}: baseline row {index} has invalid guideline row")
     return GuidelineNoExceptionBaselineRow(cast("str", guideline_id), cast("str", reason))
+
+
+def _identity_baseline_row(record: Mapping[str, object], *, kind: IdentityBaselineKind, index: int, source: str) -> IdentityBaselineRow:
+    if kind == "keyword_only":
+        return _keyword_only_identity_row(record, index=index, source=source)
+    if kind == "wire_artifact_pairing":
+        return _wire_artifact_identity_row(record, index=index, source=source)
+    if kind == "renderer_golden_tests":
+        return _renderer_identity_row(record, index=index, source=source)
+    return _guideline_identity_row(record, index=index, source=source)
 
 
 def parse_identity_baseline(

--- a/python/larch/lint/engine.py
+++ b/python/larch/lint/engine.py
@@ -1080,6 +1080,126 @@ BaselineRow: TypeAlias = (
 )
 
 
+# These intentionally-small schemas cover lints whose identities do not fit the
+# location/metric/occurrence baseline families above.  Keeping them here gives
+# those lints the same trusted read, strict JSON, duplicate, and atomic-write
+# contract without weakening their committed payloads into free-form records.
+IdentityBaselineKind = Literal[
+    "keyword_only", "wire_artifact_pairing", "renderer_golden_tests", "guideline_no_exception"
+]
+
+
+@dataclass(frozen=True)
+class KeywordOnlyBaselineRow:
+    """Reason-less identity for one keyword-only exception."""
+
+    file: str
+    qualified_symbol: str
+
+    @property
+    def identity(self) -> tuple[str, str]:
+        return (self.file, self.qualified_symbol)
+
+
+@dataclass(frozen=True)
+class WireArtifactPairingBaselineRow:
+    """Reason-bearing identity for an intentionally one-sided artifact."""
+
+    artifact: str
+    side: Literal["external-writer", "external-reader", "intentionally-one-sided"]
+    reason: str
+
+    @property
+    def identity(self) -> tuple[str, str]:
+        return (self.artifact, self.side)
+
+
+@dataclass(frozen=True)
+class RendererGoldenTestsBaselineRow:
+    """Reason-bearing identity for one renderer test-coverage exception."""
+
+    file: str
+    function_name: str
+    reason: str
+
+    @property
+    def identity(self) -> tuple[str, str]:
+        return (self.file, self.function_name)
+
+
+@dataclass(frozen=True)
+class GuidelineNoExceptionBaselineRow:
+    """Reason-bearing identity for one guideline exception."""
+
+    guideline_id: str
+    reason: str
+
+    @property
+    def identity(self) -> tuple[str]:
+        return (self.guideline_id,)
+
+
+IdentityBaselineRow: TypeAlias = (
+    KeywordOnlyBaselineRow
+    | WireArtifactPairingBaselineRow
+    | RendererGoldenTestsBaselineRow
+    | GuidelineNoExceptionBaselineRow
+)
+
+
+@dataclass(frozen=True)
+class IdentityLintCli:
+    """Shared CLI shape for an identity-baseline lint with a custom scanner."""
+
+    prog: str
+    description: str
+    baseline_filename: str
+    writable: bool = False
+    positional_root: bool = False
+
+
+@dataclass(frozen=True)
+class IdentityLintArgs:
+    """Validated operator arguments for an identity-baseline lint."""
+
+    root: Path
+    write_baseline: bool
+    initial_reason: str | None
+
+
+def parse_identity_lint_argv(
+    argv: Sequence[str], *, cli: IdentityLintCli, default_root: Path
+) -> IdentityLintArgs | None:
+    """Parse a custom-scanner lint's compatible root/write command surface."""
+    parser = argparse.ArgumentParser(prog=cli.prog, description=cli.description)
+    if cli.positional_root:
+        _ = parser.add_argument("positional_root", nargs="?", help="Optional repository root.")
+        _ = parser.add_argument("--root", help="Repository root (overrides positional root).")
+    else:
+        _ = parser.add_argument("--root", default=str(default_root))
+    if cli.writable:
+        _ = parser.add_argument("--write", action="store_true", help=f"Regenerate {cli.baseline_filename} from live findings.")
+        _ = parser.add_argument("--initial-reason", help="Reason used for new live findings during --write.")
+    try:
+        parsed = parser.parse_args(argv)
+    except SystemExit as exc:
+        if exc.code == 0:
+            raise
+        return None
+    root_text = (
+        cast("str | None", parsed.root) or cast("str | None", getattr(parsed, "positional_root", None))
+    )
+    initial_reason = cast("str | None", getattr(parsed, "initial_reason", None))
+    if initial_reason is not None and not _nonempty_single_line(initial_reason):
+        print("--initial-reason must be non-empty", file=sys.stderr)
+        return None
+    return IdentityLintArgs(
+        root=Path(root_text).resolve() if root_text else default_root.resolve(),
+        write_baseline=bool(getattr(parsed, "write", False)),
+        initial_reason=initial_reason,
+    )
+
+
 def _baseline_kind(row: BaselineRow) -> BaselineKind:
     if isinstance(row, GenericBaselineRow):
         return "generic"
@@ -1425,6 +1545,225 @@ def _baseline_exists(path: Path, *, root: Path) -> bool:
         return larch_io.trusted_file_present(path, root=root)
     except OSError as exc:
         raise ScanError(f"failed to inspect baseline {path}: {exc}") from exc
+
+
+def _identity_baseline_kind(row: IdentityBaselineRow) -> IdentityBaselineKind:
+    if isinstance(row, KeywordOnlyBaselineRow):
+        return "keyword_only"
+    if isinstance(row, WireArtifactPairingBaselineRow):
+        return "wire_artifact_pairing"
+    if isinstance(row, RendererGoldenTestsBaselineRow):
+        return "renderer_golden_tests"
+    return "guideline_no_exception"
+
+
+def identity_baseline_identity(row: IdentityBaselineRow) -> tuple[object, ...]:
+    """Return a schema's stable, reason-free baseline identity."""
+    return row.identity
+
+
+def identity_baseline_sort_key(row: IdentityBaselineRow) -> tuple[object, ...]:
+    """Return deterministic schema-local ordering for a typed identity row."""
+    return (_identity_baseline_kind(row), *row.identity)
+
+
+def _validate_identity_row_kinds(
+    rows: Sequence[IdentityBaselineRow], *, kind: IdentityBaselineKind, source: str
+) -> None:
+    """Reject a mixed or caller-mismatched schema before comparison or publication."""
+    if any(_identity_baseline_kind(row) != kind for row in rows):
+        raise ScanError(f"{source}: identity baseline rows use the wrong schema")
+
+
+def _identity_baseline_row(  # noqa: C901  # pylint: disable=too-many-boolean-expressions
+    record: Mapping[str, object], *, kind: IdentityBaselineKind, index: int, source: str
+) -> IdentityBaselineRow:
+    keys = frozenset(record)
+    if kind == "keyword_only":
+        expected = frozenset({"file", "qualified_symbol"})
+        if keys != expected:
+            raise ScanError(f"{source}: baseline row {index} has unsupported keys")
+        file_name = record["file"]
+        symbol = record["qualified_symbol"]
+        if not _is_single_line(file_name) or not _is_single_line(symbol):
+            raise ScanError(f"{source}: baseline row {index} has invalid keyword-only identity")
+        return KeywordOnlyBaselineRow(cast("str", file_name), cast("str", symbol))
+    if kind == "wire_artifact_pairing":
+        expected = frozenset({"artifact", "side", "reason"})
+        if keys != expected:
+            raise ScanError(f"{source}: baseline row {index} has unsupported keys")
+        artifact, side, reason = record["artifact"], record["side"], record["reason"]
+        allowed_sides = {"external-writer", "external-reader", "intentionally-one-sided"}
+        if not _nonempty_single_line(artifact) or side not in allowed_sides or not _nonempty_single_line(reason):
+            raise ScanError(f"{source}: baseline row {index} has invalid wire-artifact row")
+        return WireArtifactPairingBaselineRow(
+            cast("str", artifact),
+            cast("Literal['external-writer', 'external-reader', 'intentionally-one-sided']", side),
+            cast("str", reason),
+        )
+    if kind == "renderer_golden_tests":
+        expected = frozenset({"file", "function_name", "reason"})
+        if keys != expected:
+            raise ScanError(f"{source}: baseline row {index} has unsupported keys")
+        file_name, function_name, reason = record["file"], record["function_name"], record["reason"]
+        normalized = normalize_python_file_path(file_name) if isinstance(file_name, str) else ""
+        parts = normalized.split("/")
+        if (
+            not _is_single_line(file_name)
+            or normalized != file_name
+            or not normalized.startswith("larch/report/")
+            or not normalized.endswith(".py")
+            or "" in parts
+            or "." in parts
+            or ".." in parts
+            or not _nonempty_single_line(function_name)
+            or not _nonempty_single_line(reason)
+        ):
+            raise ScanError(f"{source}: baseline row {index} has invalid renderer row")
+        return RendererGoldenTestsBaselineRow(
+            cast("str", file_name), cast("str", function_name), cast("str", reason)
+        )
+    expected = frozenset({"guideline_id", "reason"})
+    if keys != expected:
+        raise ScanError(f"{source}: baseline row {index} has unsupported keys")
+    guideline_id, reason = record["guideline_id"], record["reason"]
+    if (
+        not _nonempty_single_line(guideline_id)
+        or re.fullmatch(r"G-[A-Za-z][A-Za-z0-9-]*-\d+", cast("str", guideline_id)) is None
+        or not _nonempty_single_line(reason)
+    ):
+        raise ScanError(f"{source}: baseline row {index} has invalid guideline row")
+    return GuidelineNoExceptionBaselineRow(cast("str", guideline_id), cast("str", reason))
+
+
+def parse_identity_baseline(
+    text: str, *, kind: IdentityBaselineKind, source: str
+) -> list[IdentityBaselineRow]:
+    """Parse one exact identity schema, rejecting unknown, missing, and duplicate rows."""
+    try:
+        decoded = cast("object", json.loads(text))
+    except json.JSONDecodeError as exc:
+        raise ScanError(f"{source}: invalid JSON baseline: {exc.msg}") from exc
+    if not isinstance(decoded, list):
+        raise ScanError(f"{source}: baseline must be a top-level JSON array")
+    raw_rows = cast("list[object]", decoded)
+    rows = [
+        _identity_baseline_row(cast("Mapping[str, object]", raw), kind=kind, index=index, source=source)
+        if isinstance(raw, dict)
+        else _identity_baseline_row({}, kind=kind, index=index, source=source)
+        for index, raw in enumerate(raw_rows)
+    ]
+    identities: set[tuple[object, ...]] = set()
+    for row in rows:
+        identity = identity_baseline_identity(row)
+        if identity in identities:
+            raise ScanError(f"{source}: duplicate baseline identity")
+        identities.add(identity)
+    return sorted(rows, key=identity_baseline_sort_key)
+
+
+def load_identity_baseline(
+    path: str | Path,
+    *,
+    root: Path,
+    kind: IdentityBaselineKind,
+    allow_missing: bool = False,
+) -> list[IdentityBaselineRow]:
+    """Read an exact identity baseline through the engine's trusted-file policy."""
+    destination = _validate_baseline_path(path, root=root, write_mode=False)
+    if not _baseline_exists(destination, root=root):
+        if allow_missing:
+            return []
+        raise ScanError(f"failed to read baseline {destination}: file does not exist")
+    try:
+        text = larch_io.read_trusted_text(destination, root=root, reject_cr=True)
+    except (OSError, UnicodeError, ValueError) as exc:
+        raise ScanError(f"cannot read baseline {destination}: {exc}") from exc
+    return parse_identity_baseline(text, kind=kind, source=f"baseline {destination}")
+
+
+def serialize_identity_baseline(rows: Sequence[IdentityBaselineRow]) -> str:
+    """Serialize typed identity rows in their legacy field order."""
+    records: list[dict[str, object]] = []
+    for row in sorted(rows, key=identity_baseline_sort_key):
+        if isinstance(row, KeywordOnlyBaselineRow):
+            records.append({"file": row.file, "qualified_symbol": row.qualified_symbol})
+        elif isinstance(row, WireArtifactPairingBaselineRow):
+            records.append({"artifact": row.artifact, "side": row.side, "reason": row.reason})
+        elif isinstance(row, RendererGoldenTestsBaselineRow):
+            records.append({"file": row.file, "function_name": row.function_name, "reason": row.reason})
+        else:
+            records.append({"guideline_id": row.guideline_id, "reason": row.reason})
+    return json.dumps(records, indent=2) + "\n"
+
+
+def compare_identity_baseline(
+    live_rows: Sequence[IdentityBaselineRow], baseline_rows: Sequence[IdentityBaselineRow]
+) -> tuple[list[IdentityBaselineRow], list[IdentityBaselineRow], list[IdentityBaselineRow]]:
+    """Return new, stale, and matching rows by each schema's stable identity."""
+    if live_rows and baseline_rows and _identity_baseline_kind(live_rows[0]) != _identity_baseline_kind(baseline_rows[0]):
+        raise ScanError("live findings and baseline rows use different shapes")
+    baseline_by_id = {identity_baseline_identity(row): row for row in baseline_rows}
+    live_ids = {identity_baseline_identity(row) for row in live_rows}
+    new = [row for row in live_rows if identity_baseline_identity(row) not in baseline_by_id]
+    stale = [row for row in baseline_rows if identity_baseline_identity(row) not in live_ids]
+    matched = [row for row in live_rows if identity_baseline_identity(row) in baseline_by_id]
+    return (
+        sorted(new, key=identity_baseline_sort_key),
+        sorted(stale, key=identity_baseline_sort_key),
+        sorted(matched, key=identity_baseline_sort_key),
+    )
+
+
+def write_identity_baseline(  # noqa: PLR0913 - public baseline-write contract is explicit.
+    path: str | Path,
+    *,
+    root: Path,
+    kind: IdentityBaselineKind,
+    live_rows: Sequence[IdentityBaselineRow],
+    baseline_rows: Sequence[IdentityBaselineRow],
+    initial_reason: str | None = None,
+) -> list[IdentityBaselineRow]:
+    """Preserve reasons, atomically write, and byte/structure-read-back an identity baseline."""
+    destination = _validate_baseline_path(path, root=root, write_mode=True)
+    _validate_identity_row_kinds(live_rows, kind=kind, source="live findings")
+    _validate_identity_row_kinds(baseline_rows, kind=kind, source="baseline")
+    previous = {identity_baseline_identity(row): row for row in baseline_rows}
+    written: list[IdentityBaselineRow] = []
+    missing_reason_ids: list[tuple[object, ...]] = []
+    for row in live_rows:
+        prior = previous.get(identity_baseline_identity(row))
+        if isinstance(row, KeywordOnlyBaselineRow):
+            written.append(row)
+            continue
+        reason = getattr(prior, "reason", None) if prior is not None else initial_reason
+        if not _nonempty_single_line(reason):
+            missing_reason_ids.append(identity_baseline_identity(row))
+            continue
+        if isinstance(row, WireArtifactPairingBaselineRow):
+            written.append(WireArtifactPairingBaselineRow(row.artifact, row.side, cast("str", reason)))
+        elif isinstance(row, RendererGoldenTestsBaselineRow):
+            written.append(RendererGoldenTestsBaselineRow(row.file, row.function_name, cast("str", reason)))
+        else:
+            written.append(GuidelineNoExceptionBaselineRow(row.guideline_id, cast("str", reason)))
+    if missing_reason_ids:
+        labels = "\n  ".join(":".join(str(value) for value in identity) for identity in missing_reason_ids)
+        raise ScanError(
+            "missing baseline reasons for live findings; supply initial_reason:\n  " + labels
+        )
+    intended = serialize_identity_baseline(written)
+    try:
+        larch_io.trusted_atomic_write(destination, intended, root=root)
+        read_back = larch_io.read_trusted_text(destination, root=root, reject_cr=True)
+    except (OSError, UnicodeError, ValueError) as exc:
+        raise ScanError(f"failed to write baseline {destination}: {exc}") from exc
+    if read_back != intended:
+        raise ScanError(f"baseline read-back bytes differ after write: {destination}")
+    parsed = parse_identity_baseline(read_back, kind=kind, source=f"baseline {destination}")
+    ordered = sorted(written, key=identity_baseline_sort_key)
+    if parsed != ordered:
+        raise ScanError(f"baseline read-back records differ after write: {destination}")
+    return ordered
 
 
 def _finding_occurrence_values(

--- a/python/larch/lint/lint_guideline_no_exception.py
+++ b/python/larch/lint/lint_guideline_no_exception.py
@@ -3,30 +3,29 @@
 
 from __future__ import annotations
 
-import argparse
-import json
 import re
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TypedDict, cast
 
 from larch.core.architectural_guidelines import (
     GUIDELINE_HEADING_RE,
     GUIDELINES_FILENAME,
     _MARKDOWN_HEADING_RE,  # pyright: ignore[reportPrivateUsage]  # plan requires the shared parser boundary regex.
 )
+from larch.lint.engine import (
+    GuidelineNoExceptionBaselineRow,
+    IdentityLintCli,
+    ScanError,
+    compare_identity_baseline,
+    load_identity_baseline,
+    parse_identity_lint_argv,
+)
 
 TOOL_FAILURE_EXIT = 2
 BASELINE_FILENAME = "guideline-no-exception-baseline.json"
-BASELINE_KEYS = frozenset({"guideline_id", "reason"})
 GUIDELINE_ID_RE = re.compile(r"^G-[A-Za-z0-9-]+-\d+$")
 NO_EXCEPTION_DEVIATE_RE = re.compile(r"^- Deviate when:\s*(n/a|never)\b")
-
-
-class Record(TypedDict):
-    guideline_id: str
-    reason: str
 
 
 class BaselineError(ValueError):
@@ -55,54 +54,6 @@ class Finding:
 
 def _format_record_id(record_id: str) -> str:
     return record_id
-
-
-def _validate_guideline_id(value: object, *, source: Path, index: int) -> str:
-    if not isinstance(value, str) or GUIDELINE_ID_RE.fullmatch(value) is None:
-        raise BaselineError(f"{source}: record {index} has invalid guideline_id")
-    return value
-
-
-def _validate_record(item: object, *, index: int, source: Path) -> Record:
-    if not isinstance(item, dict):
-        raise BaselineError(f"{source}: record {index} must have exactly {sorted(BASELINE_KEYS)}")
-    record = cast("dict[str, object]", item)
-    if set(record) != set(BASELINE_KEYS):
-        raise BaselineError(f"{source}: record {index} must have exactly {sorted(BASELINE_KEYS)}")
-    guideline_id: str = _validate_guideline_id(record["guideline_id"], source=source, index=index)
-    reason: object = record["reason"]
-    if not isinstance(reason, str) or not reason.strip():
-        raise BaselineError(f"{source}: record {index} has invalid reason")
-    return {"guideline_id": guideline_id, "reason": reason}
-
-
-def _first_duplicate(values: list[str]) -> str | None:
-    seen: set[str] = set()
-    for value in values:
-        if value in seen:
-            return value
-        seen.add(value)
-    return None
-
-
-def load_baseline(path: Path) -> list[Record]:
-    """Load and validate the committed no-exception baseline."""
-    try:
-        data: object = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, UnicodeDecodeError) as exc:
-        raise BaselineError(f"{path}: cannot read baseline: {exc}") from exc
-    except json.JSONDecodeError as exc:
-        raise BaselineError(f"{path}: invalid JSON: {exc}") from exc
-    if not isinstance(data, list):
-        raise BaselineError(f"{path}: baseline must be a top-level JSON array")
-    records: list[Record] = [
-        _validate_record(item, index=index, source=path)
-        for index, item in enumerate(cast("list[object]", data))
-    ]
-    duplicate: str | None = _first_duplicate([record["guideline_id"] for record in records])
-    if duplicate is not None:
-        raise BaselineError(f"{path}: duplicate baseline identity {_format_record_id(duplicate)}")
-    return records
 
 
 def _read_guidelines(path: Path) -> str:
@@ -203,65 +154,61 @@ def _finding_sort_key(finding: Finding) -> tuple[str, int]:
     return (finding.guideline_id, finding.deviate_line)
 
 
-def _run_check(*, guidelines_path: Path, baseline_path: Path) -> int:
+def _run_check(*, root: Path, guidelines_path: Path, baseline_path: Path) -> int:
     try:
-        baseline_records: list[Record] = load_baseline(baseline_path)
+        baseline_records = load_identity_baseline(
+            baseline_path, root=root, kind="guideline_no_exception"
+        )
         findings: list[Finding] = scan_guidelines(guidelines_path)
-    except BaselineError as exc:
+    except (BaselineError, ScanError) as exc:
         print(f"lint-guideline-no-exception: {exc}", file=sys.stderr)
         return TOOL_FAILURE_EXIT
-    baseline_keys: frozenset[str] = frozenset(record["guideline_id"] for record in baseline_records)
-    live_keys: frozenset[str] = frozenset(finding.key() for finding in findings)
-    new_findings: list[Finding] = []
-    warned: list[Finding] = []
+    live_rows = [GuidelineNoExceptionBaselineRow(finding.guideline_id, "") for finding in findings]
+    new_rows, stale_rows, warned_rows = compare_identity_baseline(live_rows, baseline_records)
+    new_ids = {row.guideline_id for row in new_rows if isinstance(row, GuidelineNoExceptionBaselineRow)}
+    warned_ids = {row.guideline_id for row in warned_rows if isinstance(row, GuidelineNoExceptionBaselineRow)}
     for finding in sorted(findings, key=_finding_sort_key):
-        if finding.key() in baseline_keys:
-            warned.append(finding)
-        else:
-            new_findings.append(finding)
-    stale_keys: list[str] = sorted(baseline_keys - live_keys)
-    for finding in warned:
+        if finding.guideline_id not in warned_ids:
+            continue
         print(
             f"warning: {finding.guideline_id} line {finding.deviate_line} "
             "has a no-exception deviate clause (baselined)",
             file=sys.stderr,
         )
-    for finding in new_findings:
+    for finding in sorted(findings, key=_finding_sort_key):
+        if finding.guideline_id not in new_ids:
+            continue
         print(
             f"{GUIDELINES_FILENAME}:{finding.deviate_line}: {finding.guideline_id} "
             "has a no-exception deviate clause; promote it, add a real deviate clause, "
             f"or add a reason to {BASELINE_FILENAME}",
             file=sys.stderr,
         )
-    for key in stale_keys:
-        print(f"stale baseline row: {_format_record_id(key)}", file=sys.stderr)
-    return 1 if new_findings or stale_keys else 0
+    for row in stale_rows:
+        if isinstance(row, GuidelineNoExceptionBaselineRow):
+            print(f"stale baseline row: {_format_record_id(row.guideline_id)}", file=sys.stderr)
+    return 1 if new_rows or stale_rows else 0
 
 
-def _parse_args(argv: list[str]) -> argparse.Namespace | None:
-    parser = argparse.ArgumentParser(
-        prog="cli.py lint guideline-no-exception",
-        description=__doc__,
-    )
-    _ = parser.add_argument("--root", default=str(Path(__file__).resolve().parents[3]))
-    try:
-        return parser.parse_args(argv)
-    except SystemExit as exc:
-        if exc.code == 0:
-            raise
-        return None
+CLI = IdentityLintCli(
+    prog="cli.py lint guideline-no-exception", description=__doc__ or "",
+    baseline_filename=BASELINE_FILENAME,
+)
 
 
 def main(argv: list[str] | None = None) -> int:
-    parsed: argparse.Namespace | None = _parse_args(argv if argv is not None else sys.argv[1:])
+    parsed = parse_identity_lint_argv(
+        argv if argv is not None else sys.argv[1:], cli=CLI,
+        default_root=Path(__file__).resolve().parents[3],
+    )
     if parsed is None:
         return TOOL_FAILURE_EXIT
-    root: Path = Path(str(parsed.root)).resolve()
+    root = parsed.root
     if not root.is_dir():
         print(f"lint-guideline-no-exception: --root is not a directory: {root}", file=sys.stderr)
         return TOOL_FAILURE_EXIT
     return _run_check(
-        guidelines_path=root / GUIDELINES_FILENAME,
+        root=root, guidelines_path=root / GUIDELINES_FILENAME,
         baseline_path=root / "python" / BASELINE_FILENAME,
     )
 

--- a/python/larch/lint/lint_keyword_only.py
+++ b/python/larch/lint/lint_keyword_only.py
@@ -27,8 +27,17 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TypedDict, cast
 
+from larch.lint.engine import (
+    IdentityLintCli,
+    KeywordOnlyBaselineRow,
+    ScanError,
+    compare_identity_baseline,
+    load_identity_baseline,
+    parse_identity_lint_argv,
+    write_identity_baseline,
+)
+
 TOOL_FAILURE_EXIT = 2
-BASELINE_KEYS = frozenset({"file", "qualified_symbol"})
 EXEMPTION_KEYS = frozenset({"file", "qualified_symbol", "reason"})
 EXEMPT_FILENAMES = frozenset({"conftest.py", "test_support.py", "review_test_support.py"})
 SELF_LIKE = frozenset({"self", "cls"})
@@ -394,50 +403,6 @@ def iter_source_files(python_dir: Path) -> list[Path]:
     )
 
 
-def _record_key(r: Record) -> tuple[str, str]:
-    return (r["file"], r["qualified_symbol"])
-
-
-def load_baseline(path: Path) -> list[Record]:
-    """Load and validate the baseline JSON array."""
-    try:
-        raw: str = path.read_text(encoding="utf-8")
-    except OSError as exc:
-        raise BaselineError(f"{path}: cannot read baseline: {exc}") from exc
-    try:
-        data: object = json.loads(raw)
-    except json.JSONDecodeError as exc:
-        raise BaselineError(f"{path}: invalid JSON: {exc}") from exc
-    if not isinstance(data, list):
-        raise BaselineError(f"{path}: baseline must be a top-level JSON array")
-    items: list[object] = cast("list[object]", data)
-    result: list[Record] = []
-    for i, item in enumerate(items):
-        if not isinstance(item, dict):
-            raise BaselineError(
-                f"{path}: record {i} must have exactly {sorted(BASELINE_KEYS)}"
-            )
-        record: dict[str, object] = cast("dict[str, object]", item)
-        if set(record) != set(BASELINE_KEYS):
-            raise BaselineError(
-                f"{path}: record {i} must have exactly {sorted(BASELINE_KEYS)}"
-            )
-        file_val: object = record["file"]
-        sym_val: object = record["qualified_symbol"]
-        if not isinstance(file_val, str) or not file_val:
-            raise BaselineError(f"{path}: record {i} has invalid file")
-        if not isinstance(sym_val, str) or not sym_val:
-            raise BaselineError(f"{path}: record {i} has invalid qualified_symbol")
-        result.append({"file": file_val, "qualified_symbol": sym_val})
-    return result
-
-
-def serialize_baseline(records: list[Record]) -> str:
-    """Return canonical baseline JSON: key-sorted, 2-space indent, trailing newline."""
-    ordered: list[Record] = sorted(records, key=_record_key)
-    return json.dumps(ordered, indent=2) + "\n"
-
-
 def _collect_all(
     python_dir: Path, *, exemption_keys: frozenset[tuple[str, str]]
 ) -> list[Record]:
@@ -450,84 +415,82 @@ def _collect_all(
 
 
 def _run_write(
+    root: Path,
     python_dir: Path,
     *,
     baseline_path: Path,
     exemption_keys: frozenset[tuple[str, str]],
 ) -> int:
-    records: list[Record] = _collect_all(python_dir, exemption_keys=exemption_keys)
-    _ = baseline_path.write_text(serialize_baseline(records), encoding="utf-8")
+    records = [
+        KeywordOnlyBaselineRow(record["file"], record["qualified_symbol"])
+        for record in _collect_all(python_dir, exemption_keys=exemption_keys)
+    ]
+    try:
+        existing = load_identity_baseline(
+            baseline_path, root=root, kind="keyword_only"
+        )
+        written = write_identity_baseline(
+            baseline_path, root=root, kind="keyword_only", live_rows=records, baseline_rows=existing
+        )
+    except ScanError as exc:
+        print(f"lint-keyword-only: {exc}", file=sys.stderr)
+        return TOOL_FAILURE_EXIT
     print(
-        f"lint-keyword-only: wrote {len(records)} records to {baseline_path}",
+        f"lint-keyword-only: wrote {len(written)} records to {baseline_path}",
         file=sys.stderr,
     )
     return 0
 
 
 def _run_check(
+    root: Path,
     python_dir: Path,
     *,
     baseline_path: Path,
     exemption_keys: frozenset[tuple[str, str]],
 ) -> int:
     try:
-        baseline_records: list[Record] = load_baseline(baseline_path)
-    except BaselineError as exc:
+        baseline_records = load_identity_baseline(
+            baseline_path, root=root, kind="keyword_only"
+        )
+    except ScanError as exc:
         print(f"lint-keyword-only: {exc}", file=sys.stderr)
         return TOOL_FAILURE_EXIT
-    baseline_set: frozenset[tuple[str, str]] = frozenset(
-        _record_key(r) for r in baseline_records
-    )
-    live_records: list[Record] = _collect_all(python_dir, exemption_keys=exemption_keys)
-    new_violations: list[Record] = []
-    warned: list[Record] = []
-    for rec in live_records:
-        key: tuple[str, str] = _record_key(rec)
-        if key in baseline_set:
-            warned.append(rec)
-        else:
-            new_violations.append(rec)
+    live_records = [
+        KeywordOnlyBaselineRow(record["file"], record["qualified_symbol"])
+        for record in _collect_all(python_dir, exemption_keys=exemption_keys)
+    ]
+    new_rows, _stale, matched_rows = compare_identity_baseline(live_records, baseline_records)
+    new_violations = [row for row in new_rows if isinstance(row, KeywordOnlyBaselineRow)]
+    warned = [row for row in matched_rows if isinstance(row, KeywordOnlyBaselineRow)]
     for rec in warned:
         print(
-            f"warning: {rec['file']}:{rec['qualified_symbol']} missing * (baselined)",
+            f"warning: {rec.file}:{rec.qualified_symbol} missing * (baselined)",
             file=sys.stderr,
         )
     for rec in new_violations:
         print(
-            f"{rec['file']}:{rec['qualified_symbol']} missing *"
+            f"{rec.file}:{rec.qualified_symbol} missing *"
             f" (2+ positional non-self/cls params)",
             file=sys.stderr,
         )
     return 1 if new_violations else 0
 
 
-def _parse_args(argv: list[str]) -> argparse_module.Namespace | None:
-    parser = argparse_module.ArgumentParser(
-        prog="cli.py lint keyword-only", description=__doc__
-    )
-    _ = parser.add_argument(
-        "--root", default=str(Path(__file__).resolve().parents[3])
-    )
-    _ = parser.add_argument(
-        "--write",
-        action="store_true",
-        help="Regenerate keyword-only-baseline.json from live AST scan.",
-    )
-    try:
-        return parser.parse_args(argv)
-    except SystemExit as exc:
-        if exc.code == 0:
-            raise
-        return None
+CLI = IdentityLintCli(
+    prog="cli.py lint keyword-only", description=__doc__ or "",
+    baseline_filename="keyword-only-baseline.json", writable=True,
+)
 
 
 def main(argv: list[str] | None = None) -> int:
-    parsed: argparse_module.Namespace | None = _parse_args(
-        argv=argv if argv is not None else sys.argv[1:]
+    parsed = parse_identity_lint_argv(
+        argv if argv is not None else sys.argv[1:], cli=CLI,
+        default_root=Path(__file__).resolve().parents[3],
     )
     if parsed is None:
         return TOOL_FAILURE_EXIT
-    root: Path = Path(parsed.root).resolve()
+    root = parsed.root
     python_dir: Path = root / "python"
     if not python_dir.is_dir():
         print(
@@ -542,12 +505,12 @@ def main(argv: list[str] | None = None) -> int:
     except BaselineError as exc:
         print(f"lint-keyword-only: {exc}", file=sys.stderr)
         return TOOL_FAILURE_EXIT
-    if parsed.write:
+    if parsed.write_baseline:
         return _run_write(
-            python_dir=python_dir, baseline_path=baseline_path, exemption_keys=exemption_keys
+            root, python_dir=python_dir, baseline_path=baseline_path, exemption_keys=exemption_keys
         )
     return _run_check(
-        python_dir=python_dir, baseline_path=baseline_path, exemption_keys=exemption_keys
+        root, python_dir=python_dir, baseline_path=baseline_path, exemption_keys=exemption_keys
     )
 
 

--- a/python/larch/lint/lint_renderer_golden_tests.py
+++ b/python/larch/lint/lint_renderer_golden_tests.py
@@ -9,10 +9,8 @@ row.
 
 from __future__ import annotations
 
-import argparse
 import ast
 import io
-import json
 import re
 from re import Pattern
 import sys
@@ -20,21 +18,21 @@ import tokenize
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TypedDict, cast
 
-from larch.lint.engine import first_duplicate as _first_duplicate
-from larch.lint.engine import normalize_python_file_path
+from larch.lint.engine import (
+    IdentityLintCli,
+    RendererGoldenTestsBaselineRow,
+    ScanError,
+    compare_identity_baseline,
+    first_duplicate as _first_duplicate,
+    load_identity_baseline,
+    parse_identity_lint_argv,
+    write_identity_baseline,
+)
 
 TOOL_FAILURE_EXIT = 2
 BASELINE_FILENAME = "renderer-golden-tests-baseline.json"
-BASELINE_KEYS = frozenset({"file", "function_name", "reason"})
 PRAGMA_RE = re.compile(r"#\s*lint-renderer-golden-tests:\s*ok\s+(\S.*)$")
-
-
-class Record(TypedDict):
-    file: str
-    function_name: str
-    reason: str
 
 
 class BaselineError(ValueError):
@@ -52,26 +50,6 @@ class Candidate:
 
 
 Finding = Candidate
-
-
-def _has_bad_path_parts(parts: list[str]) -> bool:
-    return "" in parts or "." in parts or ".." in parts
-
-
-def _validate_normalized_file(value: object, *, source: Path, index: int) -> str:
-    if not isinstance(value, str) or not value:
-        raise BaselineError(f"{source}: record {index} has invalid file")
-    normalized: str = normalize_python_file_path(value)
-    parts: list[str] = normalized.split("/")
-    if (
-        normalized != value
-        or normalized.startswith("/")
-        or not normalized.startswith("larch/report/")
-        or not normalized.endswith(".py")
-        or _has_bad_path_parts(parts)
-    ):
-        raise BaselineError(f"{source}: record {index} has invalid file")
-    return normalized
 
 
 def _candidate_name(name: str) -> bool:
@@ -152,59 +130,9 @@ def _covered_names(test_files: Iterable[Path], *, python_dir: Path, names: set[s
     return covered
 
 
-def _record_key(record: Record) -> tuple[str, str]:
-    return (record["file"], record["function_name"])
-
-
-def _candidate_sort_key(candidate: Candidate) -> tuple[str, str]:
-    return candidate.key()
-
-
-def _validate_record(item: object, *, index: int, source: Path) -> Record:
-    if not isinstance(item, dict):
-        raise BaselineError(f"{source}: record {index} must have exactly {sorted(BASELINE_KEYS)}")
-    record = cast("dict[str, object]", item)
-    if set(record) != set(BASELINE_KEYS):
-        raise BaselineError(f"{source}: record {index} must have exactly {sorted(BASELINE_KEYS)}")
-    file_name: str = _validate_normalized_file(record["file"], source=source, index=index)
-    function_name: object = record["function_name"]
-    reason: object = record["reason"]
-    if not isinstance(function_name, str) or not function_name:
-        raise BaselineError(f"{source}: record {index} has invalid function_name")
-    if not isinstance(reason, str) or not reason.strip():
-        raise BaselineError(f"{source}: record {index} has invalid reason")
-    return {"file": file_name, "function_name": function_name, "reason": reason}
-
-
-def load_baseline(path: Path) -> list[Record]:
-    """Load and validate the committed baseline."""
-    try:
-        data: object = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, UnicodeDecodeError) as exc:
-        raise BaselineError(f"{path}: cannot read baseline: {exc}") from exc
-    except json.JSONDecodeError as exc:
-        raise BaselineError(f"{path}: invalid JSON: {exc}") from exc
-    if not isinstance(data, list):
-        raise BaselineError(f"{path}: baseline must be a top-level JSON array")
-    records: list[Record] = [
-        _validate_record(item, index=index, source=path)
-        for index, item in enumerate(cast("list[object]", data))
-    ]
-    duplicate: tuple[str, str] | None = _first_duplicate(_record_key(record) for record in records)
-    if duplicate is not None:
-        raise BaselineError(f"{path}: duplicate baseline identity {format_key(duplicate)}")
-    return records
-
-
 def format_key(key: tuple[str, str]) -> str:
     file_name, function_name = key
     return f"{file_name}:{function_name}"
-
-
-def serialize_baseline(records: list[Record]) -> str:
-    """Return canonical sorted JSON for the baseline."""
-    ordered: list[Record] = sorted(records, key=_record_key)
-    return json.dumps(ordered, indent=2) + "\n"
 
 
 def _collect_all(
@@ -270,30 +198,8 @@ def _live_findings(report_dir: Path, *, report_test_dir: Path, python_dir: Path)
     return _findings_for_candidates(unsuppressed, report_test_dir=report_test_dir, python_dir=python_dir)
 
 
-def _records_for_write(
-    findings: list[Finding], *, baseline_path: Path, initial_reason: str | None
-) -> list[Record]:
-    preserved: dict[tuple[str, str], str] = {}
-    if baseline_path.is_file():
-        preserved = {_record_key(record): record["reason"] for record in load_baseline(baseline_path)}
-    reason_default: str | None = initial_reason.strip() if initial_reason is not None else None
-    records: list[Record] = []
-    missing: list[str] = []
-    for finding in sorted(findings, key=_candidate_sort_key):
-        reason: str | None = preserved.get(finding.key()) or reason_default
-        if reason is None:
-            missing.append(format_key(finding.key()))
-            continue
-        records.append(
-            {"file": finding.file, "function_name": finding.function_name, "reason": reason}
-        )
-    if missing:
-        joined: str = "\n  ".join(missing)
-        raise BaselineError("missing baseline reasons for live renderer golden-test findings:\n  " + joined)
-    return records
-
-
-def _run_write(
+def _run_write(  # noqa: PLR0913 - scanner inputs mirror the established command contract.
+    root: Path,
     report_dir: Path,
     *,
     report_test_dir: Path,
@@ -305,88 +211,81 @@ def _run_write(
         findings: list[Finding] = _live_findings(
             report_dir, report_test_dir=report_test_dir, python_dir=python_dir
         )
-        records: list[Record] = _records_for_write(
-            findings, baseline_path=baseline_path, initial_reason=initial_reason
+        baseline_rows = load_identity_baseline(
+            baseline_path, root=root, kind="renderer_golden_tests", allow_missing=True
         )
-    except BaselineError as exc:
+        records = [
+            RendererGoldenTestsBaselineRow(finding.file, finding.function_name, "")
+            for finding in findings
+        ]
+        written = write_identity_baseline(
+            baseline_path, root=root, kind="renderer_golden_tests", live_rows=records,
+            baseline_rows=baseline_rows, initial_reason=initial_reason,
+        )
+    except (BaselineError, ScanError) as exc:
         print(f"lint-renderer-golden-tests: {exc}", file=sys.stderr)
         return TOOL_FAILURE_EXIT
-    _ = baseline_path.write_text(serialize_baseline(records), encoding="utf-8")
     print(
-        f"lint-renderer-golden-tests: wrote {len(records)} records to {baseline_path}",
+        f"lint-renderer-golden-tests: wrote {len(written)} records to {baseline_path}",
         file=sys.stderr,
     )
     return 0
 
 
 def _run_check(
-    report_dir: Path, *, report_test_dir: Path, python_dir: Path, baseline_path: Path
+    root: Path, report_dir: Path, *, report_test_dir: Path, python_dir: Path, baseline_path: Path
 ) -> int:
     try:
-        baseline_records: list[Record] = load_baseline(baseline_path)
+        baseline_records = load_identity_baseline(
+            baseline_path, root=root, kind="renderer_golden_tests"
+        )
         findings: list[Finding] = _live_findings(
             report_dir, report_test_dir=report_test_dir, python_dir=python_dir
         )
-    except BaselineError as exc:
+    except (BaselineError, ScanError) as exc:
         print(f"lint-renderer-golden-tests: {exc}", file=sys.stderr)
         return TOOL_FAILURE_EXIT
-    baseline_keys: frozenset[tuple[str, str]] = frozenset(
-        _record_key(record) for record in baseline_records
-    )
-    live_keys: frozenset[tuple[str, str]] = frozenset(finding.key() for finding in findings)
-    new_findings: list[Finding] = []
-    warned: list[Finding] = []
-    for finding in sorted(findings, key=_candidate_sort_key):
-        if finding.key() in baseline_keys:
-            warned.append(finding)
-        else:
-            new_findings.append(finding)
-    stale_keys: list[tuple[str, str]] = sorted(baseline_keys - live_keys)
-    for finding in warned:
+    live_rows = [RendererGoldenTestsBaselineRow(f.file, f.function_name, "") for f in findings]
+    new_rows, stale_rows, warned_rows = compare_identity_baseline(live_rows, baseline_records)
+    new_keys = {row.identity for row in new_rows if isinstance(row, RendererGoldenTestsBaselineRow)}
+    warned_keys = {row.identity for row in warned_rows if isinstance(row, RendererGoldenTestsBaselineRow)}
+    for finding in findings:
+        if finding.key() not in warned_keys:
+            continue
         print(
             "warning: "
             f"{finding.file}:{finding.function_name} line {finding.lineno} "
             "has no whole-identifier reference in python/tests/report/*.py (baselined)",
             file=sys.stderr,
         )
-    for finding in new_findings:
+    for finding in findings:
+        if finding.key() not in new_keys:
+            continue
         print(
             f"{finding.file}:{finding.function_name} line {finding.lineno} "
             "has no whole-identifier reference in python/tests/report/*.py",
             file=sys.stderr,
         )
-    for key in stale_keys:
-        print(f"stale baseline row: {format_key(key)}", file=sys.stderr)
-    return 1 if new_findings or stale_keys else 0
+    for row in stale_rows:
+        if isinstance(row, RendererGoldenTestsBaselineRow):
+            print(f"stale baseline row: {format_key(row.identity)}", file=sys.stderr)
+    return 1 if new_rows or stale_rows else 0
 
 
-def _parse_args(argv: list[str]) -> argparse.Namespace | None:
-    parser = argparse.ArgumentParser(
-        prog="cli.py lint renderer-golden-tests", description=__doc__
-    )
-    _ = parser.add_argument("--root", default=str(Path(__file__).resolve().parents[3]))
-    _ = parser.add_argument(
-        "--write",
-        action="store_true",
-        help=f"Regenerate {BASELINE_FILENAME} from live AST scan.",
-    )
-    _ = parser.add_argument(
-        "--initial-reason",
-        help="Reason used for live findings without preserved baseline reasons.",
-    )
-    try:
-        return parser.parse_args(argv)
-    except SystemExit as exc:
-        if exc.code == 0:
-            raise
-        return None
+CLI = IdentityLintCli(
+    prog="cli.py lint renderer-golden-tests", description=__doc__ or "",
+    baseline_filename=BASELINE_FILENAME, writable=True,
+)
 
 
 def main(argv: list[str] | None = None) -> int:
-    parsed: argparse.Namespace | None = _parse_args(argv if argv is not None else sys.argv[1:])
+    parsed = parse_identity_lint_argv(
+        argv if argv is not None else sys.argv[1:], cli=CLI,
+        default_root=Path(__file__).resolve().parents[3],
+    )
     if parsed is None:
         return TOOL_FAILURE_EXIT
-    root: Path = Path(str(parsed.root)).resolve()
+    root = parsed.root
     python_dir: Path = root / "python"
     report_dir: Path = python_dir / "larch" / "report"
     if not report_dir.is_dir():
@@ -394,20 +293,16 @@ def main(argv: list[str] | None = None) -> int:
         return TOOL_FAILURE_EXIT
     report_test_dir: Path = python_dir / "tests" / "report"
     baseline_path: Path = python_dir / BASELINE_FILENAME
-    initial_reason: str | None = cast("str | None", parsed.initial_reason)
-    if initial_reason is not None and not initial_reason.strip():
-        print("lint-renderer-golden-tests: --initial-reason must be non-empty", file=sys.stderr)
-        return TOOL_FAILURE_EXIT
-    if bool(parsed.write):
+    if parsed.write_baseline:
         return _run_write(
-            report_dir,
+            root, report_dir,
             report_test_dir=report_test_dir,
             python_dir=python_dir,
             baseline_path=baseline_path,
-            initial_reason=initial_reason,
+            initial_reason=parsed.initial_reason,
         )
     return _run_check(
-        report_dir, report_test_dir=report_test_dir, python_dir=python_dir, baseline_path=baseline_path
+        root, report_dir, report_test_dir=report_test_dir, python_dir=python_dir, baseline_path=baseline_path
     )
 
 

--- a/python/larch/lint/lint_wire_artifact_pairing.py
+++ b/python/larch/lint/lint_wire_artifact_pairing.py
@@ -8,7 +8,6 @@ reason-bearing baseline.
 
 from __future__ import annotations
 
-import argparse
 import ast
 import json
 import re
@@ -18,6 +17,16 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal, TypedDict, cast
+
+from larch.lint.engine import (
+    IdentityLintCli,
+    ScanError,
+    WireArtifactPairingBaselineRow,
+    compare_identity_baseline,
+    load_identity_baseline,
+    parse_identity_lint_argv,
+    write_identity_baseline,
+)
 
 TOOL_FAILURE_EXIT = 2
 MANIFEST_FILENAME = "wire-artifact-manifest.json"
@@ -44,12 +53,6 @@ Kind = Literal["basename", "relative_path"]
 class ManifestRow(TypedDict):
     artifact: str
     kind: Kind
-
-
-class BaselineRow(TypedDict):
-    artifact: str
-    side: str
-    reason: str
 
 
 @dataclass(frozen=True)
@@ -112,35 +115,6 @@ def load_manifest(path: Path) -> list[ManifestRow]:
     return rows
 
 
-def _validate_baseline_row(item: object, *, index: int, source: Path) -> BaselineRow:
-    if not isinstance(item, dict):
-        raise BaselineError(f"{source}: baseline row {index} must be an object")
-    record = cast("dict[str, object]", item)
-    if set(record) != set(BASELINE_KEYS):
-        raise BaselineError(f"{source}: baseline row {index} must have exactly {sorted(BASELINE_KEYS)}")
-    artifact = record["artifact"]
-    side = record["side"]
-    reason = record["reason"]
-    if not isinstance(artifact, str) or not artifact:
-        raise BaselineError(f"{source}: baseline row {index} has invalid artifact")
-    if not isinstance(side, str) or side not in SIDES:
-        raise BaselineError(f"{source}: baseline row {index} has invalid side")
-    if not isinstance(reason, str) or not reason.strip():
-        raise BaselineError(f"{source}: baseline row {index} has invalid reason")
-    return {"artifact": artifact, "side": side, "reason": reason}
-
-
-def load_baseline(path: Path) -> list[BaselineRow]:
-    """Load and validate the committed baseline. Missing baseline means none."""
-    if not path.is_file():
-        return []
-    rows = [_validate_baseline_row(item, index=index, source=path) for index, item in enumerate(_json_load(path, label="baseline"))]
-    duplicate = _first_duplicate((row["artifact"],) for row in rows)
-    if duplicate is not None:
-        raise BaselineError(f"{path}: duplicate baseline identity {duplicate[0]}")
-    return rows
-
-
 def _first_duplicate(keys: Iterable[tuple[str, ...]]) -> tuple[str, ...] | None:
     seen: set[tuple[str, ...]] = set()
     for key in keys:
@@ -148,6 +122,18 @@ def _first_duplicate(keys: Iterable[tuple[str, ...]]) -> tuple[str, ...] | None:
             return key
         seen.add(key)
     return None
+
+
+def _load_pairing_baseline(path: Path, *, root: Path) -> list[WireArtifactPairingBaselineRow]:
+    """Keep the legacy one-row-per-artifact policy above engine row identity."""
+    rows = load_identity_baseline(
+        path, root=root, kind="wire_artifact_pairing", allow_missing=True
+    )
+    typed = [row for row in rows if isinstance(row, WireArtifactPairingBaselineRow)]
+    duplicate = _first_duplicate((row.artifact,) for row in typed)
+    if duplicate is not None:
+        raise ScanError(f"{path}: duplicate baseline artifact {duplicate[0]}")
+    return typed
 
 
 def _is_excluded_python_path(relative: Path) -> bool:
@@ -385,104 +371,89 @@ def collect_findings(root: Path, manifest_rows: list[ManifestRow]) -> list[Findi
     return sorted(findings, key=lambda finding: finding.key())
 
 
-def serialize_baseline(rows: list[BaselineRow]) -> str:
-    ordered = sorted(rows, key=lambda row: row["artifact"])
-    return json.dumps(ordered, indent=2) + "\n"
-
-
-def _records_for_write(
-    findings: list[Finding],
-    *,
-    baseline_rows: list[BaselineRow],
-    initial_reason: str | None,
-) -> list[BaselineRow]:
-    preserved = {row["artifact"]: row for row in baseline_rows}
-    default_reason = initial_reason.strip() if initial_reason is not None else None
-    records: list[BaselineRow] = []
-    missing: list[str] = []
-    for finding in findings:
-        old = preserved.get(finding.artifact)
-        if old is not None:
-            records.append(old)
-        elif default_reason:
-            records.append({"artifact": finding.artifact, "side": "intentionally-one-sided", "reason": default_reason})
-        else:
-            missing.append(f"{finding.kind}:{finding.artifact}")
-    if missing:
-        raise BaselineError("missing baseline reasons for live wire artifacts:\n  " + "\n  ".join(missing))
-    return records
-
-
 def _run_write(root: Path, *, manifest_path: Path, baseline_path: Path, initial_reason: str | None) -> int:
     try:
         manifest_rows = load_manifest(manifest_path)
-        baseline_rows = load_baseline(baseline_path)
+        baseline_rows = _load_pairing_baseline(baseline_path, root=root)
         findings = collect_findings(root, manifest_rows)
-        records = _records_for_write(findings, baseline_rows=baseline_rows, initial_reason=initial_reason)
-    except BaselineError as exc:
+        preserved_sides = {row.artifact: row.side for row in baseline_rows}
+        records = [
+            WireArtifactPairingBaselineRow(
+                finding.artifact,
+                cast("Literal['external-writer', 'external-reader', 'intentionally-one-sided']", preserved_sides.get(finding.artifact, "intentionally-one-sided")),
+                "",
+            )
+            for finding in findings
+        ]
+        written = write_identity_baseline(
+            baseline_path, root=root, kind="wire_artifact_pairing", live_rows=records,
+            baseline_rows=baseline_rows, initial_reason=initial_reason,
+        )
+    except (BaselineError, ScanError) as exc:
         print(f"lint-wire-artifact-pairing: {exc}", file=sys.stderr)
         return TOOL_FAILURE_EXIT
-    _ = baseline_path.write_text(serialize_baseline(records), encoding="utf-8")
-    print(f"lint-wire-artifact-pairing: wrote {len(records)} records to {baseline_path}", file=sys.stderr)
+    print(f"lint-wire-artifact-pairing: wrote {len(written)} records to {baseline_path}", file=sys.stderr)
     return 0
 
 
 def _run_check(root: Path, *, manifest_path: Path, baseline_path: Path) -> int:
     try:
         manifest_rows = load_manifest(manifest_path)
-        baseline_rows = load_baseline(baseline_path)
-        baseline_artifacts = frozenset(row["artifact"] for row in baseline_rows)
+        baseline_rows = _load_pairing_baseline(baseline_path, root=root)
         findings = collect_findings(root, manifest_rows)
-    except BaselineError as exc:
+    except (BaselineError, ScanError) as exc:
         print(f"lint-wire-artifact-pairing: {exc}", file=sys.stderr)
         return TOOL_FAILURE_EXIT
-    new_findings = [finding for finding in findings if finding.artifact not in baseline_artifacts]
-    warned = [finding for finding in findings if finding.artifact in baseline_artifacts]
-    for finding in warned:
+    live_rows = [
+        WireArtifactPairingBaselineRow(
+            finding.artifact,
+            cast("Literal['external-writer', 'external-reader', 'intentionally-one-sided']", next((row.side for row in baseline_rows if row.artifact == finding.artifact), "intentionally-one-sided")),
+            "",
+        )
+        for finding in findings
+    ]
+    new_rows, _stale, warned_rows = compare_identity_baseline(live_rows, baseline_rows)
+    new_artifacts = {row.artifact for row in new_rows if isinstance(row, WireArtifactPairingBaselineRow)}
+    warned_artifacts = {row.artifact for row in warned_rows if isinstance(row, WireArtifactPairingBaselineRow)}
+    for finding in findings:
+        if finding.artifact not in warned_artifacts:
+            continue
         print(
             f"warning: {finding.kind}:{finding.artifact} has reader evidence but no production writer (baselined)",
             file=sys.stderr,
         )
-    for finding in new_findings:
+    for finding in findings:
+        if finding.artifact not in new_artifacts:
+            continue
         print(
             f"{finding.kind}:{finding.artifact} has reader evidence but no production writer; add a writer or baseline a one-sided artifact",
             file=sys.stderr,
         )
-    return 1 if new_findings else 0
+    return 1 if new_rows else 0
 
 
-def _parse_args(argv: list[str]) -> argparse.Namespace | None:
-    parser = argparse.ArgumentParser(prog="cli.py lint wire-artifact-pairing", description=__doc__)
-    _ = parser.add_argument("positional_root", nargs="?", help="Optional repository root.")
-    _ = parser.add_argument("--root", help="Repository root (overrides positional root).")
-    _ = parser.add_argument("--write", action="store_true", help=f"Regenerate {BASELINE_FILENAME} from live findings.")
-    _ = parser.add_argument("--initial-reason", help="Reason used for new live findings during --write.")
-    try:
-        return parser.parse_args(argv)
-    except SystemExit as exc:
-        if exc.code == 0:
-            raise
-        return None
+CLI = IdentityLintCli(
+    prog="cli.py lint wire-artifact-pairing", description=__doc__ or "",
+    baseline_filename=BASELINE_FILENAME, writable=True, positional_root=True,
+)
 
 
 def main(argv: list[str] | None = None) -> int:
-    parsed = _parse_args(argv if argv is not None else sys.argv[1:])
+    parsed = parse_identity_lint_argv(
+        argv if argv is not None else sys.argv[1:], cli=CLI,
+        default_root=Path(__file__).resolve().parents[3],
+    )
     if parsed is None:
         return TOOL_FAILURE_EXIT
-    root_text = cast("str | None", parsed.root) or cast("str | None", parsed.positional_root)
-    root = Path(root_text).resolve() if root_text else Path(__file__).resolve().parents[3]
+    root = parsed.root
     python_dir = root / "python"
     if not python_dir.is_dir():
         print(f"lint-wire-artifact-pairing: python directory not found: {python_dir}", file=sys.stderr)
         return TOOL_FAILURE_EXIT
     manifest_path = python_dir / MANIFEST_FILENAME
     baseline_path = python_dir / BASELINE_FILENAME
-    initial_reason = cast("str | None", parsed.initial_reason)
-    if initial_reason is not None and not initial_reason.strip():
-        print("lint-wire-artifact-pairing: --initial-reason must be non-empty", file=sys.stderr)
-        return TOOL_FAILURE_EXIT
-    if bool(parsed.write):
-        return _run_write(root, manifest_path=manifest_path, baseline_path=baseline_path, initial_reason=initial_reason)
+    if parsed.write_baseline:
+        return _run_write(root, manifest_path=manifest_path, baseline_path=baseline_path, initial_reason=parsed.initial_reason)
     return _run_check(root, manifest_path=manifest_path, baseline_path=baseline_path)
 
 

--- a/python/lint-engine-adoption-baseline.json
+++ b/python/lint-engine-adoption-baseline.json
@@ -65,33 +65,9 @@
   },
   {
     "anchor": "argparse-construction",
-    "line": 242,
-    "message": "legacy ArgumentParser construction outside shared lint engine",
-    "path": "python/larch/lint/lint_guideline_no_exception.py",
-    "reason": "Pre-engine legacy lint module; grandfathered until ported onto larch.lint.engine (#6967).",
-    "rule_id": "engine-adoption"
-  },
-  {
-    "anchor": "argparse-construction",
     "line": 107,
     "message": "legacy ArgumentParser construction outside shared lint engine",
     "path": "python/larch/lint/lint_guidelines_note_wrapper_bypass.py",
-    "reason": "Pre-engine legacy lint module; grandfathered until ported onto larch.lint.engine (#6967).",
-    "rule_id": "engine-adoption"
-  },
-  {
-    "anchor": "baseline-io",
-    "line": 459,
-    "message": "direct *-baseline.json I/O outside shared lint engine",
-    "path": "python/larch/lint/lint_keyword_only.py",
-    "reason": "Pre-engine legacy lint module; grandfathered until ported onto larch.lint.engine (#6967).",
-    "rule_id": "engine-adoption"
-  },
-  {
-    "anchor": "argparse-construction",
-    "line": 505,
-    "message": "legacy ArgumentParser construction outside shared lint engine",
-    "path": "python/larch/lint/lint_keyword_only.py",
     "reason": "Pre-engine legacy lint module; grandfathered until ported onto larch.lint.engine (#6967).",
     "rule_id": "engine-adoption"
   },
@@ -108,22 +84,6 @@
     "line": 32,
     "message": "legacy ArgumentParser construction outside shared lint engine",
     "path": "python/larch/lint/lint_readability_preamble.py",
-    "reason": "Pre-engine legacy lint module; grandfathered until ported onto larch.lint.engine (#6967).",
-    "rule_id": "engine-adoption"
-  },
-  {
-    "anchor": "baseline-io",
-    "line": 314,
-    "message": "direct *-baseline.json I/O outside shared lint engine",
-    "path": "python/larch/lint/lint_renderer_golden_tests.py",
-    "reason": "Pre-engine legacy lint module; grandfathered until ported onto larch.lint.engine (#6967).",
-    "rule_id": "engine-adoption"
-  },
-  {
-    "anchor": "argparse-construction",
-    "line": 364,
-    "message": "legacy ArgumentParser construction outside shared lint engine",
-    "path": "python/larch/lint/lint_renderer_golden_tests.py",
     "reason": "Pre-engine legacy lint module; grandfathered until ported onto larch.lint.engine (#6967).",
     "rule_id": "engine-adoption"
   },
@@ -180,22 +140,6 @@
     "line": 19,
     "message": "legacy ArgumentParser construction outside shared lint engine",
     "path": "python/larch/lint/lint_tier1a.py",
-    "reason": "Pre-engine legacy lint module; grandfathered until ported onto larch.lint.engine (#6967).",
-    "rule_id": "engine-adoption"
-  },
-  {
-    "anchor": "baseline-io",
-    "line": 425,
-    "message": "direct *-baseline.json I/O outside shared lint engine",
-    "path": "python/larch/lint/lint_wire_artifact_pairing.py",
-    "reason": "Pre-engine legacy lint module; grandfathered until ported onto larch.lint.engine (#6967).",
-    "rule_id": "engine-adoption"
-  },
-  {
-    "anchor": "argparse-construction",
-    "line": 455,
-    "message": "legacy ArgumentParser construction outside shared lint engine",
-    "path": "python/larch/lint/lint_wire_artifact_pairing.py",
     "reason": "Pre-engine legacy lint module; grandfathered until ported onto larch.lint.engine (#6967).",
     "rule_id": "engine-adoption"
   }

--- a/python/tests/lint/test_lint_engine.py
+++ b/python/tests/lint/test_lint_engine.py
@@ -96,6 +96,51 @@ def _git_ok_runner(root: Path, tracked: Sequence[str]) -> RecordingRunner:
     )
 
 
+@pytest.mark.parametrize(
+    ("filename", "kind"),
+    [
+        ("keyword-only-baseline.json", "keyword_only"),
+        ("wire-artifact-pairing-baseline.json", "wire_artifact_pairing"),
+        ("renderer-golden-tests-baseline.json", "renderer_golden_tests"),
+        ("guideline-no-exception-baseline.json", "guideline_no_exception"),
+    ],
+)
+def test_identity_baseline_schemas_parse_committed_payloads(
+    filename: str, kind: lint_engine.IdentityBaselineKind
+) -> None:
+    repo = Path(__file__).resolve().parents[3]
+    payload = (repo / "python" / filename).read_text(encoding="utf-8")
+
+    rows = lint_engine.parse_identity_baseline(
+        payload, kind=kind, source=filename
+    )
+
+    assert lint_engine.serialize_identity_baseline(rows) == payload
+
+
+def test_identity_baseline_writer_rejects_mismatched_rows_before_writing(
+    tmp_path: Path
+) -> None:
+    baseline = tmp_path / "python" / "keyword-only-baseline.json"
+    baseline.parent.mkdir()
+    _ = baseline.write_text("[]\n", encoding="utf-8")
+
+    with pytest.raises(lint_engine.ScanError, match="wrong schema"):
+        _ = lint_engine.write_identity_baseline(
+            baseline,
+            root=tmp_path,
+            kind="keyword_only",
+            live_rows=[
+                lint_engine.RendererGoldenTestsBaselineRow(
+                    "larch/report/demo.py", "_render_demo", "reason"
+                )
+            ],
+            baseline_rows=[],
+        )
+
+    assert baseline.read_text(encoding="utf-8") == "[]\n"
+
+
 def _rule(
     *,
     detect: Callable[[SourceFile], list[Finding]] | None = None,

--- a/python/tests/lint/test_lint_engine_adoption.py
+++ b/python/tests/lint/test_lint_engine_adoption.py
@@ -568,8 +568,6 @@ def test_committed_tree_projection_covers_legacy_and_spares_engine() -> None:
         )
     live_ids = {(f.path, f.rule_id, f.message, f.anchor) for f in live}
     assert live_ids == identities
-    keyword = f"{SCOPE}/lint_keyword_only.py"
-    assert any(row[0] == keyword and row[3] == lint.ANCHOR_ARGPARSE for row in live_ids)
     for clean in (
         f"{SCOPE}/lint_engine_adoption.py",
         f"{SCOPE}/lint_pylint_skip_file.py",
@@ -579,5 +577,9 @@ def test_committed_tree_projection_covers_legacy_and_spares_engine() -> None:
         f"{SCOPE}/lint_module_manifest.py",
         f"{SCOPE}/lint_tmpdir_arg_env_fallback.py",
         f"{SCOPE}/lint_self_disarmable_gate.py",
+        f"{SCOPE}/lint_keyword_only.py",
+        f"{SCOPE}/lint_wire_artifact_pairing.py",
+        f"{SCOPE}/lint_renderer_golden_tests.py",
+        f"{SCOPE}/lint_guideline_no_exception.py",
     ):
         assert not any(row[0] == clean for row in live_ids)


### PR DESCRIPTION
## Summary
- add typed identity-baseline schemas to the shared lint engine
- migrate keyword-only, wire-artifact pairing, renderer golden-test, and guideline lints
- remove their engine-adoption baseline exemptions

## Verification
- pytest focused lint suite (207 passed)
- ruff, pyright, pylint, and engine-adoption lint

Closes #7536