### PR TITLE
Fixes #7538: migrate complexity history to lint engine

### DIFF
--- a/python/larch/lint/engine.py
+++ b/python/larch/lint/engine.py
@@ -1261,10 +1261,12 @@ def _complexity_history(value: object, *, source: str, index: int, today: date) 
         raise ScanError(f"{source}: record {index} has invalid history")
     entries: list[ComplexityHistoryEntry] = []
     previous: date | None = None
-    for item in value:
-        if not isinstance(item, dict) or frozenset(item) != _COMPLEXITY_HISTORY_FIELDS:
+    for raw_item in cast("list[object]", value):
+        if not isinstance(raw_item, dict):
             raise ScanError(f"{source}: record {index} has malformed history entry")
-        entry = cast("Mapping[str, object]", item)
+        entry = cast("dict[str, object]", raw_item)
+        if frozenset(entry) != _COMPLEXITY_HISTORY_FIELDS:
+            raise ScanError(f"{source}: record {index} has malformed history entry")
         event_date = _complexity_date(entry["date"], source=source, index=index, field="history date", today=today)
         parsed_date = date.fromisoformat(event_date)
         if previous is not None and parsed_date < previous:
@@ -1275,9 +1277,11 @@ def _complexity_history(value: object, *, source: str, index: int, today: date) 
 
 
 def _complexity_override(value: object, *, source: str, index: int) -> ComplexityOperatorOverride:
-    if not isinstance(value, dict) or frozenset(value) != _COMPLEXITY_OVERRIDE_FIELDS:
+    if not isinstance(value, dict):
         raise ScanError(f"{source}: record {index} has invalid operator_override")
-    override = cast("Mapping[str, object]", value)
+    override = cast("dict[str, object]", value)
+    if frozenset(override) != _COMPLEXITY_OVERRIDE_FIELDS:
+        raise ScanError(f"{source}: record {index} has invalid operator_override")
     if not _nonempty_single_line(override["reason"]):
         raise ScanError(f"{source}: record {index} has invalid operator_override reason")
     issue = override["issue"]
@@ -1323,7 +1327,7 @@ def _parse_complexity_row(  # noqa: C901 - exact legacy schema validation is int
     return ComplexityBaselineRow(
         cast("str", file_name), cast("ComplexityCode", code), cast("str", symbol),
         _complexity_metric(record["metric"], source=source, index=index),
-        added_at, history, cast("int | None", source_issue), cast("str | None", reason), override,
+        added_at, history, source_issue, cast("str | None", reason), override,
     )
 
 
@@ -1338,7 +1342,12 @@ def parse_complexity_baseline(
     if not isinstance(decoded, list):
         raise ScanError(f"{source}: baseline must be a top-level JSON array")
     checked_today = today or datetime.now(UTC).date()
-    rows = [_parse_complexity_row(row, source=source, index=index, strict=strict, today=checked_today) for index, row in enumerate(decoded)]
+    rows = [
+        _parse_complexity_row(
+            row, source=source, index=index, strict=strict, today=checked_today
+        )
+        for index, row in enumerate(cast("list[object]", decoded))
+    ]
     duplicates = complexity_duplicate_identities(rows)
     if duplicates:
         raise ScanError("duplicate baseline complexity identities:\n" + "\n".join(duplicates))
@@ -1437,7 +1446,7 @@ def migrate_complexity_baseline(
     rows = parse_complexity_baseline(text, source=str(destination), strict=False, today=today)
     migrated_count = sum(
         isinstance(raw, dict) and ("added_at" not in raw or "history" not in raw)
-        for raw in decoded
+        for raw in cast("list[object]", decoded)
     )
     before = {row.identity: row.metric for row in rows}
     migrated = [

--- a/python/larch/lint/engine.py
+++ b/python/larch/lint/engine.py
@@ -20,6 +20,7 @@ import tokenize
 from collections.abc import Callable, Hashable, Iterable, Mapping, Sequence
 from contextlib import suppress
 from dataclasses import dataclass, field
+from datetime import UTC, date, datetime
 from pathlib import Path
 from typing import Literal, TypeAlias, TypeVar, cast
 
@@ -1078,6 +1079,440 @@ class OccurrenceBaselineRow:
 BaselineRow: TypeAlias = (
     GenericBaselineRow | SymbolMetricBaselineRow | OccurrenceBaselineRow
 )
+
+
+# Complexity rows retain a richer historical contract than the generic metric
+# baseline.  They deliberately live beside the other engine-owned baseline
+# schemas so trusted I/O and structural read-back stay centralized.
+ComplexityCode = Literal["C901", "PLR0911", "PLR0912", "PLR0913", "PLR0915"]
+COMPLEXITY_CODES = frozenset({"C901", "PLR0911", "PLR0912", "PLR0913", "PLR0915"})
+_COMPLEXITY_FIELDS = (
+    "file",
+    "code",
+    "qualified_symbol",
+    "metric",
+    "added_at",
+    "history",
+    "source_issue",
+    "reason",
+    "operator_override",
+)
+_COMPLEXITY_REQUIRED_FIELDS = frozenset(_COMPLEXITY_FIELDS[:6])
+_COMPLEXITY_OPTIONAL_FIELDS = frozenset(_COMPLEXITY_FIELDS[6:])
+_COMPLEXITY_HISTORY_FIELDS = frozenset({"date", "metric"})
+_COMPLEXITY_OVERRIDE_FIELDS = frozenset({"reason", "issue"})
+
+
+@dataclass(frozen=True)
+class ComplexityHistoryEntry:
+    """One dated complexity metric event."""
+
+    date: str
+    metric: int
+
+
+@dataclass(frozen=True)
+class ComplexityOperatorOverride:
+    """One active operator-approved repeat-bump exception."""
+
+    reason: str
+    issue: int
+
+
+@dataclass(frozen=True)
+class ComplexityLiveRow:
+    """A current Ruff observation before baseline metadata is merged."""
+
+    file: str
+    code: ComplexityCode
+    qualified_symbol: str
+    metric: int
+
+    @property
+    def identity(self) -> tuple[str, str, str]:
+        """Return the metric-independent complexity identity."""
+        return (self.file, self.code, self.qualified_symbol)
+
+
+@dataclass(frozen=True)
+class ComplexityBaselineRow:
+    """Immutable typed representation of one complexity baseline record."""
+
+    file: str
+    code: ComplexityCode
+    qualified_symbol: str
+    metric: int
+    added_at: str
+    history: tuple[ComplexityHistoryEntry, ...]
+    source_issue: int | None = None
+    reason: str | None = None
+    operator_override: ComplexityOperatorOverride | None = None
+
+    @property
+    def identity(self) -> tuple[str, str, str]:
+        """Return the metric-independent complexity identity."""
+        return (self.file, self.code, self.qualified_symbol)
+
+
+@dataclass(frozen=True)
+class ComplexityHistoryEvent:
+    """One metric increase event attributed to its baseline row."""
+
+    event_date: date
+    record: ComplexityBaselineRow
+    history_index: int
+    metric: int
+
+
+@dataclass(frozen=True)
+class ComplexityBaselineArgs:
+    """Validated compatible arguments for the complexity-baseline CLI."""
+
+    root: Path
+    write: bool
+    reason: str | None
+    migrate: bool
+
+
+@dataclass(frozen=True)
+class ComplexityDebtArgs:
+    """Validated arguments for the complexity-debt report command."""
+
+    root: Path
+    report: bool
+
+
+def parse_complexity_baseline_argv(
+    argv: Sequence[str], *, default_root: Path
+) -> ComplexityBaselineArgs | None:
+    """Parse the established complexity-baseline command surface."""
+    parser = argparse.ArgumentParser(
+        prog="cli.py lint complexity-baseline",
+        description="Ratchet ruff complexity findings against a committed production baseline.",
+    )
+    _ = parser.add_argument("--root", default=str(default_root))
+    _ = parser.add_argument("--write", action="store_true")
+    _ = parser.add_argument("--reason")
+    _ = parser.add_argument("--migrate", action="store_true")
+    try:
+        parsed = parser.parse_args(argv)
+    except SystemExit as exc:
+        if exc.code == 0:
+            raise
+        return None
+    reason = cast("str | None", parsed.reason)
+    if parsed.migrate and parsed.write:
+        print("--migrate and --write are incompatible", file=sys.stderr)
+        return None
+    if reason is not None and (not parsed.write or parsed.migrate or not _nonempty_single_line(reason)):
+        print("--reason is only valid with --write and must be non-empty", file=sys.stderr)
+        return None
+    return ComplexityBaselineArgs(
+        root=Path(cast("str", parsed.root)).resolve(),
+        write=bool(parsed.write),
+        reason=reason.strip() if reason is not None else None,
+        migrate=bool(parsed.migrate),
+    )
+
+
+def parse_complexity_debt_argv(
+    argv: Sequence[str], *, default_root: Path
+) -> ComplexityDebtArgs | None:
+    """Parse the established complexity-debt reporting command surface."""
+    parser = argparse.ArgumentParser(
+        prog="cli.py lint complexity-debt",
+        description="Render the operator-facing complexity-baseline debt report.",
+    )
+    _ = parser.add_argument("--report", action="store_true")
+    _ = parser.add_argument("--root", default=str(default_root))
+    try:
+        parsed = parser.parse_args(argv)
+    except SystemExit as exc:
+        if exc.code == 0:
+            raise
+        return None
+    if not parsed.report:
+        return None
+    return ComplexityDebtArgs(
+        root=Path(cast("str", parsed.root)).resolve(), report=True
+    )
+
+
+def _complexity_date(value: object, *, source: str, index: int, field: str, today: date) -> str:
+    if not isinstance(value, str):
+        raise ScanError(f"{source}: record {index} has invalid {field}")
+    try:
+        parsed = date.fromisoformat(value)
+    except ValueError as exc:
+        raise ScanError(f"{source}: record {index} has invalid {field}") from exc
+    if parsed.isoformat() != value or parsed > today:
+        raise ScanError(f"{source}: record {index} has invalid {field}")
+    return value
+
+
+def _complexity_metric(value: object, *, source: str, index: int, field: str = "metric") -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise ScanError(f"{source}: record {index} has invalid {field}")
+    return value
+
+
+def _complexity_history(value: object, *, source: str, index: int, today: date) -> tuple[ComplexityHistoryEntry, ...]:
+    if not isinstance(value, list):
+        raise ScanError(f"{source}: record {index} has invalid history")
+    entries: list[ComplexityHistoryEntry] = []
+    previous: date | None = None
+    for item in value:
+        if not isinstance(item, dict) or frozenset(item) != _COMPLEXITY_HISTORY_FIELDS:
+            raise ScanError(f"{source}: record {index} has malformed history entry")
+        entry = cast("Mapping[str, object]", item)
+        event_date = _complexity_date(entry["date"], source=source, index=index, field="history date", today=today)
+        parsed_date = date.fromisoformat(event_date)
+        if previous is not None and parsed_date < previous:
+            raise ScanError(f"{source}: record {index} has date-decreasing history")
+        entries.append(ComplexityHistoryEntry(event_date, _complexity_metric(entry["metric"], source=source, index=index, field="history metric")))
+        previous = parsed_date
+    return tuple(entries)
+
+
+def _complexity_override(value: object, *, source: str, index: int) -> ComplexityOperatorOverride:
+    if not isinstance(value, dict) or frozenset(value) != _COMPLEXITY_OVERRIDE_FIELDS:
+        raise ScanError(f"{source}: record {index} has invalid operator_override")
+    override = cast("Mapping[str, object]", value)
+    if not _nonempty_single_line(override["reason"]):
+        raise ScanError(f"{source}: record {index} has invalid operator_override reason")
+    issue = override["issue"]
+    if not isinstance(issue, int) or isinstance(issue, bool) or issue <= 0:
+        raise ScanError(f"{source}: record {index} has invalid operator_override issue")
+    return ComplexityOperatorOverride(cast("str", override["reason"]), issue)
+
+
+def _parse_complexity_row(  # noqa: C901 - exact legacy schema validation is intentionally centralized.
+    raw: object, *, source: str, index: int, strict: bool, today: date
+) -> ComplexityBaselineRow:
+    if not isinstance(raw, dict):
+        raise ScanError(f"{source}: record {index} must be an object")
+    record = cast("Mapping[str, object]", raw)
+    keys = frozenset(record)
+    unknown = keys - _COMPLEXITY_REQUIRED_FIELDS - _COMPLEXITY_OPTIONAL_FIELDS
+    if unknown:
+        raise ScanError(f"{source}: record {index} has unknown fields {sorted(unknown)}")
+    required = _COMPLEXITY_REQUIRED_FIELDS if strict else frozenset(_COMPLEXITY_FIELDS[:4])
+    missing = required - keys
+    if missing:
+        raise ScanError(f"{source}: record {index} missing required fields {sorted(missing)}")
+    file_name, code, symbol = record["file"], record["code"], record["qualified_symbol"]
+    if not _nonempty_single_line(file_name) or normalize_python_file_path(cast("str", file_name)) != file_name:
+        raise ScanError(f"{source}: record {index} has invalid file")
+    if not isinstance(code, str) or code not in COMPLEXITY_CODES:
+        raise ScanError(f"{source}: record {index} has invalid code")
+    if not _nonempty_single_line(symbol):
+        raise ScanError(f"{source}: record {index} has invalid qualified_symbol")
+    added_at = record.get("added_at", "legacy")
+    if added_at != "legacy":
+        added_at = _complexity_date(added_at, source=source, index=index, field="added_at", today=today)
+    if not isinstance(added_at, str):
+        raise ScanError(f"{source}: record {index} has invalid added_at")
+    history = _complexity_history(record.get("history", []), source=source, index=index, today=today)
+    source_issue = record.get("source_issue")
+    if source_issue is not None and (not isinstance(source_issue, int) or isinstance(source_issue, bool) or source_issue <= 0):
+        raise ScanError(f"{source}: record {index} has invalid source_issue")
+    reason = record.get("reason")
+    if reason is not None and not _nonempty_single_line(reason):
+        raise ScanError(f"{source}: record {index} has invalid reason")
+    override = _complexity_override(record["operator_override"], source=source, index=index) if "operator_override" in record else None
+    return ComplexityBaselineRow(
+        cast("str", file_name), cast("ComplexityCode", code), cast("str", symbol),
+        _complexity_metric(record["metric"], source=source, index=index),
+        added_at, history, cast("int | None", source_issue), cast("str | None", reason), override,
+    )
+
+
+def parse_complexity_baseline(
+    text: str, *, source: str, strict: bool = True, today: date | None = None
+) -> list[ComplexityBaselineRow]:
+    """Parse exact complexity records and reject malformed or duplicate identities."""
+    try:
+        decoded = cast("object", json.loads(text))
+    except json.JSONDecodeError as exc:
+        raise ScanError(f"{source}: cannot load baseline: {exc}") from exc
+    if not isinstance(decoded, list):
+        raise ScanError(f"{source}: baseline must be a top-level JSON array")
+    checked_today = today or datetime.now(UTC).date()
+    rows = [_parse_complexity_row(row, source=source, index=index, strict=strict, today=checked_today) for index, row in enumerate(decoded)]
+    duplicates = complexity_duplicate_identities(rows)
+    if duplicates:
+        raise ScanError("duplicate baseline complexity identities:\n" + "\n".join(duplicates))
+    return rows
+
+
+def complexity_duplicate_identities(rows: Sequence[ComplexityBaselineRow | ComplexityLiveRow]) -> list[str]:
+    """Return repeated complexity identities as stable diagnostic lines."""
+    seen: set[tuple[str, str, str]] = set()
+    duplicates: list[str] = []
+    for row in rows:
+        if row.identity in seen:
+            file_name, code, symbol = row.identity
+            duplicates.append(f"{file_name}:{symbol} {code}")
+        else:
+            seen.add(row.identity)
+    return duplicates
+
+
+def load_complexity_baseline(
+    path: str | Path,
+    *,
+    root: Path,
+    strict: bool = True,
+    today: date | None = None,
+    allow_missing: bool = False,
+) -> list[ComplexityBaselineRow]:
+    """Trusted-read and parse the complexity baseline through the engine."""
+    destination = _validate_baseline_path(path, root=root, write_mode=False)
+    if not _baseline_exists(destination, root=root):
+        if allow_missing:
+            return []
+        raise ScanError(f"{destination}: cannot load baseline: file does not exist")
+    try:
+        text = larch_io.read_trusted_text(destination, root=root, reject_cr=True)
+    except (OSError, UnicodeError, ValueError) as exc:
+        raise ScanError(f"{destination}: cannot load baseline: {exc}") from exc
+    return parse_complexity_baseline(text, source=str(destination), strict=strict, today=today)
+
+
+def complexity_row_record(row: ComplexityBaselineRow) -> dict[str, object]:
+    """Render one typed row in the legacy field order without null optionals."""
+    result: dict[str, object] = {
+        "file": row.file, "code": row.code, "qualified_symbol": row.qualified_symbol,
+        "metric": row.metric, "added_at": row.added_at,
+        "history": [{"date": item.date, "metric": item.metric} for item in row.history],
+    }
+    if row.source_issue is not None:
+        result["source_issue"] = row.source_issue
+    if row.reason is not None:
+        result["reason"] = row.reason
+    if row.operator_override is not None:
+        result["operator_override"] = {"reason": row.operator_override.reason, "issue": row.operator_override.issue}
+    return result
+
+
+def serialize_complexity_baseline(rows: Sequence[ComplexityBaselineRow]) -> str:
+    """Serialize canonical complexity records preserving legacy field order."""
+    records = [complexity_row_record(row) for row in sorted(rows, key=lambda row: row.identity)]
+    return json.dumps(records, indent=2) + "\n"
+
+
+def write_complexity_baseline(
+    path: str | Path, *, root: Path, rows: Sequence[ComplexityBaselineRow], today: date | None = None
+) -> list[ComplexityBaselineRow]:
+    """Atomically publish and byte/structure-read-back typed complexity rows."""
+    destination = _validate_baseline_path(path, root=root, write_mode=True)
+    intended = serialize_complexity_baseline(rows)
+    checked_today = today or datetime.now(UTC).date()
+    expected = parse_complexity_baseline(intended, source=f"baseline {destination}", today=checked_today)
+    try:
+        larch_io.trusted_atomic_write(destination, intended, root=root)
+        read_back = larch_io.read_trusted_text(destination, root=root, reject_cr=True)
+    except (OSError, UnicodeError, ValueError) as exc:
+        raise ScanError(f"failed to write baseline {destination}: {exc}") from exc
+    if read_back != intended:
+        raise ScanError(f"baseline read-back bytes differ after write: {destination}")
+    parsed = parse_complexity_baseline(read_back, source=f"baseline {destination}", today=checked_today)
+    if parsed != expected:
+        raise ScanError(f"baseline read-back records differ after write: {destination}")
+    return parsed
+
+
+def migrate_complexity_baseline(
+    path: str | Path, *, root: Path, today: date | None = None
+) -> int:
+    """Add only missing migration metadata while proving metric projection parity."""
+    destination = _validate_baseline_path(path, root=root, write_mode=False)
+    try:
+        text = larch_io.read_trusted_text(destination, root=root, reject_cr=True)
+        decoded = cast("object", json.loads(text))
+    except (OSError, UnicodeError, ValueError, json.JSONDecodeError) as exc:
+        raise ScanError(f"{destination}: cannot load baseline: {exc}") from exc
+    if not isinstance(decoded, list):
+        raise ScanError(f"{destination}: baseline must be a top-level JSON array")
+    rows = parse_complexity_baseline(text, source=str(destination), strict=False, today=today)
+    migrated_count = sum(
+        isinstance(raw, dict) and ("added_at" not in raw or "history" not in raw)
+        for raw in decoded
+    )
+    before = {row.identity: row.metric for row in rows}
+    migrated = [
+        ComplexityBaselineRow(
+            row.file, row.code, row.qualified_symbol, row.metric, row.added_at,
+            row.history, row.source_issue, row.reason, row.operator_override,
+        )
+        for row in rows
+    ]
+    after = {row.identity: row.metric for row in migrated}
+    if before != after:
+        raise ScanError(f"{path}: migration would change the identity-to-metric projection")
+    _ = write_complexity_baseline(destination, root=root, rows=migrated, today=today)
+    return migrated_count
+
+
+def merge_complexity_baseline(
+    *, live_rows: Sequence[ComplexityLiveRow], stored_rows: Sequence[ComplexityBaselineRow], reason: str | None, today: date
+) -> list[ComplexityBaselineRow]:
+    """Merge live metrics with historical metadata, requiring reasons for growth."""
+    live_duplicates = complexity_duplicate_identities(live_rows)
+    if live_duplicates:
+        raise ScanError("duplicate live complexity identities:\n" + "\n".join(live_duplicates))
+    stored_duplicates = complexity_duplicate_identities(stored_rows)
+    if stored_duplicates:
+        raise ScanError("duplicate baseline complexity identities:\n" + "\n".join(stored_duplicates))
+    stored_by_identity = {row.identity: row for row in stored_rows}
+    merged: list[ComplexityBaselineRow] = []
+    for live in live_rows:
+        stored = stored_by_identity.get(live.identity)
+        if stored is None:
+            if reason is None:
+                raise ScanError("--reason is required for a new baseline row")
+            merged.append(ComplexityBaselineRow(live.file, live.code, live.qualified_symbol, live.metric, today.isoformat(), (ComplexityHistoryEntry(today.isoformat(), live.metric),), reason=reason))
+            continue
+        history = stored.history
+        next_reason = stored.reason
+        if live.metric > stored.metric:
+            if reason is None:
+                raise ScanError("--reason is required for a metric increase")
+            history = (*history, ComplexityHistoryEntry(today.isoformat(), live.metric))
+            next_reason = reason
+        merged.append(ComplexityBaselineRow(live.file, live.code, live.qualified_symbol, live.metric, stored.added_at, history, stored.source_issue, next_reason, stored.operator_override))
+    return sorted(merged, key=lambda row: row.identity)
+
+
+def complexity_regressions(
+    *, live_rows: Sequence[ComplexityLiveRow], baseline_rows: Sequence[ComplexityBaselineRow]
+) -> list[str]:
+    """Return new identities and metric growth against typed baseline rows."""
+    baseline = {row.identity: row.metric for row in baseline_rows}
+    failures: list[str] = []
+    for row in live_rows:
+        previous = baseline.get(row.identity)
+        label = f"{row.file}:{row.qualified_symbol} {row.code}"
+        if previous is None:
+            failures.append(f"{label} (new)")
+        elif row.metric > previous:
+            failures.append(f"{label} metric {row.metric} > baseline {previous}")
+    return failures
+
+
+def complexity_history_events(
+    rows: Sequence[ComplexityBaselineRow], *, legacy_start: int = 0
+) -> dict[tuple[str, str], list[ComplexityHistoryEvent]]:
+    """Group deterministic metric-growth events for repeat-bump consumers."""
+    grouped: dict[tuple[str, str], list[ComplexityHistoryEvent]] = {}
+    for row in rows:
+        start = legacy_start if row.added_at == "legacy" else 1
+        for history_index, item in enumerate(row.history[start:], start=start):
+            event = ComplexityHistoryEvent(date.fromisoformat(item.date), row, history_index, item.metric)
+            grouped.setdefault((row.file, row.qualified_symbol), []).append(event)
+    for events in grouped.values():
+        events.sort(key=lambda event: (event.event_date, *event.record.identity, event.history_index))
+    return grouped
 
 
 # These intentionally-small schemas cover lints whose identities do not fit the

--- a/python/larch/lint/lint_complexity_baseline.py
+++ b/python/larch/lint/lint_complexity_baseline.py
@@ -260,17 +260,23 @@ def _load_ruff_items(result: RuffResult) -> list[object]:
     return cast("list[object]", data)
 
 
-def _parse_live_records(*, items: Sequence[object], python_dir: Path) -> tuple[list[ComplexityLiveRow], list[str]]:
+def _parse_live_records(  # noqa: C901 - parses untrusted Ruff JSON at one boundary.
+    *, items: Sequence[object], python_dir: Path
+) -> tuple[list[ComplexityLiveRow], list[str]]:
     rows: list[ComplexityLiveRow] = []
     failures: list[str] = []
     source_cache: dict[str, str] = {}
     span_cache: dict[str, list[SymbolSpan]] = {}
     for item in items:
-        if not isinstance(item, dict) or not isinstance(item.get("filename"), str):
+        if not isinstance(item, dict):
             failures.append("<unknown>: malformed ruff JSON item")
             continue
-        mapping = cast("Mapping[str, object]", item)
-        filename = normalize_file_path(cast("str", mapping["filename"]))
+        mapping = cast("dict[str, object]", item)
+        raw_filename = mapping.get("filename")
+        if not isinstance(raw_filename, str):
+            failures.append("<unknown>: malformed ruff JSON item")
+            continue
+        filename = normalize_file_path(raw_filename)
         if is_exempt_path(filename):
             continue
         source = source_cache.get(filename)

--- a/python/larch/lint/lint_complexity_baseline.py
+++ b/python/larch/lint/lint_complexity_baseline.py
@@ -1,157 +1,91 @@
-"""Ratchet ruff complexity findings against a committed production baseline.
+"""Ratchet Ruff complexity findings through the shared lint engine.
 
-The baseline identity deliberately comes from source, not from ruff's display
-message. ``qualified_symbol`` is AST-derived for every rule: PLR messages carry
-only metrics, and C901's message-local name is still ambiguous across nesting.
-``file`` paths are normalized so audit runs from ``cwd=python/`` do not split
-keys across ``./ship.py`` and ``ship.py``. Baseline rows omit line numbers so
-innocent edits above a function do not require rebaselining.
-
-The default mode checks live findings against the baseline and fails on
-regressions. ``--write`` instead regenerates ``complexity-baseline.json`` from
-live ruff output: it is the mechanical entrypoint that emits the per-file
-grandfather rows, so the baseline is never hand-maintained. Generation reuses
-the same fail-closed collection as the check -- a ruff tool failure, an
-unparseable finding, or a duplicate live identity aborts before any write -- and
-the emitted rows are sorted canonically so an unchanged tree regenerates
-byte-identically.
-
-Committed baselines carry a nine-field schema: the four identity fields plus
-``added_at`` and ``history`` (required), and optional ``source_issue``,
-``reason``, and ``operator_override``. ``--migrate`` grandfathers legacy or
-partially migrated records in place by adding only the missing ``added_at``
-and ``history`` fields. ``--write --reason TEXT`` merges live findings with
-stored metadata, preserving operator-authored overrides without creating them.
+Ruff invocation and AST-qualified-symbol resolution remain local because they
+describe this lint's source domain.  The engine owns the complexity baseline
+schema, trusted I/O, comparisons, migration, and atomic publication.
 """
 
 from __future__ import annotations
 
-import argparse
 import ast
 import json
 import re
 import subprocess
 import sys
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import UTC, date, datetime
 from itertools import pairwise
 from pathlib import Path
-from typing import NotRequired, TypedDict, cast
+from typing import TYPE_CHECKING, TypeAlias, cast
 
-COMPLEXITY_CODES = ("C901", "PLR0911", "PLR0912", "PLR0913", "PLR0915")
+from larch.lint.engine import (
+    COMPLEXITY_CODES,
+    ComplexityBaselineRow,
+    ComplexityHistoryEvent,
+    ComplexityLiveRow,
+    ScanError,
+    complexity_duplicate_identities,
+    complexity_history_events,
+    complexity_regressions,
+    complexity_row_record,
+    load_complexity_baseline,
+    merge_complexity_baseline,
+    migrate_complexity_baseline,
+    parse_complexity_baseline,
+    parse_complexity_baseline_argv,
+    serialize_complexity_baseline,
+    write_complexity_baseline,
+)
+
+if TYPE_CHECKING:
+    from larch.lint.engine import ComplexityCode
+
 TOOL_FAILURE_EXIT = 2
 REPEAT_BUMP_DAYS = 14
-IDENTITY_KEYS = frozenset({"file", "code", "qualified_symbol", "metric"})
-STRICT_REQUIRED_KEYS = IDENTITY_KEYS | {"added_at", "history"}
-OPTIONAL_KEYS = frozenset({"source_issue", "reason", "operator_override"})
-ALL_KEYS = STRICT_REQUIRED_KEYS | OPTIONAL_KEYS
-HISTORY_ENTRY_KEYS = frozenset({"date", "metric"})
-OPERATOR_OVERRIDE_KEYS = frozenset({"reason", "issue"})
-FIELD_ORDER = (
-    "file",
-    "code",
-    "qualified_symbol",
-    "metric",
-    "added_at",
-    "history",
-    "source_issue",
-    "reason",
-    "operator_override",
-)
-EXEMPT_FILENAMES = frozenset(
-    {"conftest.py", "test_support.py", "review_test_support.py"}
-)
 METRIC_RE = re.compile(r"\((\d+)\s*>\s*\d+\)")
 RUFF_ARGS = (
-    "ruff",
-    "check",
-    ".",
-    "--no-cache",
-    "--select",
-    ",".join(COMPLEXITY_CODES),
-    "--output-format",
-    "json",
-    "--config",
-    "ruff-complexity-audit.toml",
+    "ruff", "check", ".", "--no-cache", "--select", ",".join(sorted(COMPLEXITY_CODES)),
+    "--output-format", "json", "--config", "ruff-complexity-audit.toml",
 )
-
-
-class HistoryEntry(TypedDict):
-    date: str
-    metric: int
-
-
-class OperatorOverride(TypedDict):
-    reason: str
-    issue: int
-
-
-class Record(TypedDict):
-    file: str
-    code: str
-    qualified_symbol: str
-    metric: int
-    added_at: NotRequired[str]
-    history: NotRequired[list[HistoryEntry]]
-    source_issue: NotRequired[int]
-    reason: NotRequired[str]
-    operator_override: NotRequired[OperatorOverride]
-
-
-BaselineIndex = dict[tuple[str, str, str], int]
-SymbolSpan = tuple[int, int, str]
-
-
-class BaselineError(ValueError):
-    """Raised when the committed baseline cannot be trusted."""
+EXEMPT_FILENAMES = frozenset({"conftest.py", "test_support.py", "review_test_support.py"})
+SymbolSpan: TypeAlias = tuple[int, int, str]
+Record: TypeAlias = dict[str, object]
+BaselineError = ScanError
+HistoryEvent = ComplexityHistoryEvent
 
 
 @dataclass(frozen=True)
 class RuffResult:
+    """Captured Ruff process result, retained as the external-tool seam."""
+
     returncode: int
     stdout: str
     stderr: str
 
 
-@dataclass(frozen=True)
-class HistoryEvent:
-    """One metric-increase event attributed to a baseline record."""
-
-    event_date: date
-    record: Record
-    history_index: int
-    metric: int
-
-
 def normalize_file_path(raw: str) -> str:
-    """Return a normalized repo-relative path under the python directory."""
+    """Return a normalized repo-relative path under the Python directory."""
     normalized = raw.replace("\\", "/")
     marker = "/python/"
     if marker in normalized:
         normalized = normalized.rsplit(marker, maxsplit=1)[1]
     while normalized.startswith("./"):
         normalized = normalized[2:]
-    if normalized == "python":
-        return ""
     return normalized.removeprefix("python/")
 
 
 def is_exempt_path(path: str) -> bool:
-    """Return whether a normalized path is pytest-facing and not production."""
+    """Return whether a normalized path is pytest-facing and out of scope."""
     name = Path(path).name
-    return (
-        name.startswith("test_") and name.endswith(".py")
-    ) or name in EXEMPT_FILENAMES
+    return (name.startswith("test_") and name.endswith(".py")) or name in EXEMPT_FILENAMES
 
 
-def parse_metric( *,code: str, message: str) -> int | None:
-    """Extract the observed complexity count from a ruff message."""
+def parse_metric(*, code: str, message: str) -> int | None:
+    """Extract the observed complexity count from a Ruff message."""
     _ = code
     match = METRIC_RE.search(message)
-    if match is None:
-        return None
-    return int(match.group(1))
+    return int(match.group(1)) if match is not None else None
 
 
 def _collect_symbol_spans(source: str) -> list[SymbolSpan] | None:
@@ -159,10 +93,9 @@ def _collect_symbol_spans(source: str) -> list[SymbolSpan] | None:
         tree = ast.parse(source)
     except SyntaxError:
         return None
-
     spans: list[SymbolSpan] = []
 
-    def visit( *,node: ast.AST, prefix: tuple[str, ...]) -> None:
+    def visit(*, node: ast.AST, prefix: tuple[str, ...]) -> None:
         if isinstance(node, ast.ClassDef):
             for child in ast.iter_child_nodes(node):
                 visit(node=child, prefix=(*prefix, node.name))
@@ -182,172 +115,39 @@ def _collect_symbol_spans(source: str) -> list[SymbolSpan] | None:
     return spans
 
 
-def _resolve_from_spans( *,spans: list[SymbolSpan], row: int) -> str | None:
-    matches = [
-        (start, end, symbol) for start, end, symbol in spans if start <= row <= end
-    ]
+def _resolve_from_spans(*, spans: Sequence[SymbolSpan], row: int) -> str | None:
+    matches = [(start, end, symbol) for start, end, symbol in spans if start <= row <= end]
     if not matches:
         return None
     return min(matches, key=lambda item: (item[1] - item[0], -item[0]))[2]
 
 
-def resolve_qualified_symbol( *,source: str, row: int) -> str | None:
+def resolve_qualified_symbol(*, source: str, row: int) -> str | None:
     """Resolve the innermost function or method enclosing a one-based row."""
     spans = _collect_symbol_spans(source)
-    if spans is None:
-        return None
-    return _resolve_from_spans(spans=spans, row=row)
+    return None if spans is None else _resolve_from_spans(spans=spans, row=row)
 
 
 def parse_violation_record(
     ruff_json_item: object, *, file_source: str
 ) -> Record | None:
-    """Normalize one ruff JSON finding into a stable baseline record."""
+    """Compatibility projection of one Ruff violation for focused callers."""
     if not isinstance(ruff_json_item, dict):
         return None
     item = cast("Mapping[str, object]", ruff_json_item)
-    filename = item.get("filename")
-    code = item.get("code")
-    message = item.get("message")
-    location = item.get("location")
-    if (
-        not isinstance(filename, str)
-        or not isinstance(code, str)
-        or not isinstance(message, str)
-    ):
+    filename, code, message, location = (
+        item.get("filename"), item.get("code"), item.get("message"), item.get("location")
+    )
+    if not isinstance(filename, str) or not isinstance(code, str) or not isinstance(message, str):
         return None
     if code not in COMPLEXITY_CODES or not isinstance(location, dict):
         return None
-    location_record = cast("Mapping[str, object]", location)
-    row = location_record.get("row")
-    if not isinstance(row, int):
-        return None
+    row = cast("Mapping[str, object]", location).get("row")
     metric = parse_metric(code=code, message=message)
-    qualified_symbol = resolve_qualified_symbol(source=file_source, row=row)
-    if metric is None or qualified_symbol is None:
+    symbol = resolve_qualified_symbol(source=file_source, row=row) if isinstance(row, int) else None
+    if metric is None or symbol is None:
         return None
-    return {
-        "file": normalize_file_path(filename),
-        "code": code,
-        "qualified_symbol": qualified_symbol,
-        "metric": metric,
-    }
-
-
-def _validate_identity(
-    record: Mapping[str, object], *, index: int, source: Path
-) -> tuple[str, str, str, int]:
-    file_name = record["file"]
-    code = record["code"]
-    qualified_symbol = record["qualified_symbol"]
-    metric = record["metric"]
-    if (
-        not isinstance(file_name, str)
-        or not file_name
-        or normalize_file_path(file_name) != file_name
-    ):
-        raise BaselineError(f"{source}: record {index} has invalid file")
-    if not isinstance(code, str) or code not in COMPLEXITY_CODES:
-        raise BaselineError(f"{source}: record {index} has invalid code")
-    if not isinstance(qualified_symbol, str) or not qualified_symbol:
-        raise BaselineError(f"{source}: record {index} has invalid qualified_symbol")
-    if not isinstance(metric, int) or isinstance(metric, bool) or metric < 0:
-        raise BaselineError(f"{source}: record {index} has invalid metric")
-    return file_name, code, qualified_symbol, metric
-
-
-def _validate_history(
-    history: object, *, index: int, source: Path
-) -> list[HistoryEntry]:
-    if not isinstance(history, list):
-        raise BaselineError(f"{source}: record {index} has invalid history")
-    entries: list[HistoryEntry] = []
-    previous_date: date | None = None
-    for entry in cast("list[object]", history):
-        if not isinstance(entry, dict):
-            raise BaselineError(f"{source}: record {index} has malformed history entry")
-        entry_map = cast("Mapping[str, object]", entry)
-        if set(entry_map) != set(HISTORY_ENTRY_KEYS):
-            raise BaselineError(f"{source}: record {index} has malformed history entry")
-        date = entry_map["date"]
-        entry_metric = entry_map["metric"]
-        if not isinstance(date, str):
-            raise BaselineError(f"{source}: record {index} has invalid history date")
-        parsed_date = _parse_baseline_date(date, field="history date", index=index, source=source)
-        if previous_date is not None and parsed_date < previous_date:
-            raise BaselineError(
-                f"{source}: record {index} has date-decreasing history"
-            )
-        if (
-            not isinstance(entry_metric, int)
-            or isinstance(entry_metric, bool)
-            or entry_metric < 0
-        ):
-            raise BaselineError(f"{source}: record {index} has invalid history metric")
-        entries.append({"date": date, "metric": entry_metric})
-        previous_date = parsed_date
-    return entries
-
-
-def _validate_operator_override(
-    value: object, *, index: int, source: Path
-) -> OperatorOverride:
-    if not isinstance(value, dict):
-        raise BaselineError(f"{source}: record {index} has invalid operator_override")
-    value_map = cast("Mapping[str, object]", value)
-    if set(value_map) != set(OPERATOR_OVERRIDE_KEYS):
-        raise BaselineError(f"{source}: record {index} has invalid operator_override")
-    reason = value_map["reason"]
-    issue = value_map["issue"]
-    if not isinstance(reason, str) or not reason or reason != reason.strip():
-        raise BaselineError(
-            f"{source}: record {index} has invalid operator_override reason"
-        )
-    if not isinstance(issue, int) or isinstance(issue, bool) or issue <= 0:
-        raise BaselineError(
-            f"{source}: record {index} has invalid operator_override issue"
-        )
-    return {"reason": reason, "issue": issue}
-
-
-def _check_record_keys(
-    keys: set[str], *, index: int, source: Path, strict: bool
-) -> None:
-    unknown = keys - ALL_KEYS
-    if unknown:
-        raise BaselineError(f"{source}: record {index} has unknown fields {sorted(unknown)}")
-    missing_identity = IDENTITY_KEYS - keys
-    if missing_identity:
-        raise BaselineError(
-            f"{source}: record {index} missing identity fields {sorted(missing_identity)}"
-        )
-    if not strict:
-        return
-    missing_required = STRICT_REQUIRED_KEYS - keys
-    if missing_required:
-        raise BaselineError(
-            f"{source}: record {index} missing required fields {sorted(missing_required)}"
-        )
-
-
-def _validate_added_at(value: object, *, index: int, source: Path) -> str:
-    if not isinstance(value, str):
-        raise BaselineError(f"{source}: record {index} has invalid added_at")
-    if value != "legacy":
-        _ = _parse_baseline_date(value, field="added_at", index=index, source=source)
-    return value
-
-
-def _validate_source_issue(value: object, *, index: int, source: Path) -> int:
-    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
-        raise BaselineError(f"{source}: record {index} has invalid source_issue")
-    return value
-
-
-def _validate_reason(value: object, *, index: int, source: Path) -> str:
-    if not isinstance(value, str) or not value or value != value.strip():
-        raise BaselineError(f"{source}: record {index} has invalid reason")
-    return value
+    return {"file": normalize_file_path(filename), "code": code, "qualified_symbol": symbol, "metric": metric}
 
 
 def utc_today() -> date:
@@ -355,604 +155,241 @@ def utc_today() -> date:
     return datetime.now(UTC).date()
 
 
-def _parse_baseline_date(
-    value: str, *, field: str, index: int, source: Path
-) -> date:
-    """Parse one strict UTC date and reject future values."""
-    try:
-        parsed = date.fromisoformat(value)
-    except ValueError as exc:
-        raise BaselineError(f"{source}: record {index} has invalid {field}") from exc
-    if parsed.isoformat() != value or parsed > utc_today():
-        raise BaselineError(f"{source}: record {index} has invalid {field}")
-    return parsed
+def _root_for_baseline(path: Path) -> Path:
+    """Infer a safe root for legacy library callers that pass only a path."""
+    return path.parent.parent if path.parent.name == "python" else path.parent
 
 
-def _validate_record(
-    item: object, *, index: int, source: Path, strict: bool
-) -> Record:
-    """Validate one raw baseline record.
-
-    ``strict`` requires the committed ``added_at``/``history`` fields (used
-    by ``load_baseline``); non-strict validates whatever fields are present
-    without requiring them (used by ``migrate_baseline`` on legacy or
-    partially migrated input). Both reject unknown fields and missing
-    identity fields.
-    """
-    if not isinstance(item, dict):
-        raise BaselineError(f"{source}: record {index} must be an object")
-    record = cast("Mapping[str, object]", item)
-    keys = set(record)
-    _check_record_keys(keys, index=index, source=source, strict=strict)
-    file_name, code, qualified_symbol, metric = _validate_identity(
-        record, index=index, source=source
-    )
-    result: Record = {
-        "file": file_name,
-        "code": code,
-        "qualified_symbol": qualified_symbol,
-        "metric": metric,
-    }
-    if "added_at" in keys:
-        result["added_at"] = _validate_added_at(
-            record["added_at"], index=index, source=source
-        )
-    if "history" in keys:
-        result["history"] = _validate_history(record["history"], index=index, source=source)
-    if "source_issue" in keys:
-        result["source_issue"] = _validate_source_issue(
-            record["source_issue"], index=index, source=source
-        )
-    if "reason" in keys:
-        result["reason"] = _validate_reason(record["reason"], index=index, source=source)
-    if "operator_override" in keys:
-        result["operator_override"] = _validate_operator_override(
-            record["operator_override"], index=index, source=source
-        )
-    return result
+def _typed_rows(records: Sequence[Record], *, source: Path, strict: bool = True) -> list[ComplexityBaselineRow]:
+    return parse_complexity_baseline(json.dumps(list(records)), source=str(source), strict=strict, today=utc_today())
 
 
 def load_baseline(path: Path | str) -> list[Record]:
-    """Load and validate the top-level baseline JSON array."""
+    """Compatibility adapter over the engine-owned typed baseline parser."""
     baseline_path = Path(path)
-    try:
-        data = json.loads(baseline_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        raise BaselineError(f"{baseline_path}: cannot load baseline: {exc}") from exc
-    if not isinstance(data, list):
-        raise BaselineError(f"{baseline_path}: baseline must be a top-level JSON array")
-    items = cast("list[object]", data)
-    return [
-        _validate_record(item, index=index, source=baseline_path, strict=True)
-        for index, item in enumerate(items)
-    ]
+    rows = load_complexity_baseline(baseline_path, root=_root_for_baseline(baseline_path), today=utc_today())
+    return [complexity_row_record(row) for row in rows]
 
 
-def _record_key(record: Record) -> tuple[str, str, str]:
+def serialize_baseline(records: Sequence[Record]) -> str:
+    """Compatibility serializer retaining the committed field order."""
+    rows = _typed_rows(records, source=Path("<records>"))
+    return serialize_complexity_baseline(rows)
+
+
+def write_baseline(*, path: Path, records: Sequence[Record]) -> None:
+    """Compatibility write adapter; engine performs all actual baseline I/O."""
+    rows = _typed_rows(records, source=path)
+    _ = write_complexity_baseline(path, root=_root_for_baseline(path), rows=rows, today=utc_today())
+
+
+def migrate_baseline(path: Path) -> int:
+    """Compatibility migration adapter backed by the engine."""
+    return migrate_complexity_baseline(path, root=_root_for_baseline(path), today=utc_today())
+
+
+def _record_identity(record: Mapping[str, object]) -> tuple[str, str, str]:
     return (str(record["file"]), str(record["code"]), str(record["qualified_symbol"]))
 
 
-def index_baseline(records: list[Record]) -> BaselineIndex:
-    """Map baseline identity to the allowed observed metric."""
-    return {_record_key(record): int(record["metric"]) for record in records}
+def _legacy_live_row(record: Mapping[str, object]) -> ComplexityLiveRow:
+    file_name, code, symbol = _record_identity(record)
+    return ComplexityLiveRow(
+        file_name,
+        cast("ComplexityCode", code),
+        symbol,
+        cast("int", record["metric"]),
+    )
 
 
-def find_duplicate_keys(records: list[Record]) -> list[str]:
-    """Return duplicate baseline identities as human-readable lines."""
-    seen: set[tuple[str, str, str]] = set()
-    duplicates: list[str] = []
-    for record in records:
-        key = _record_key(record)
-        if key in seen:
-            file_name, code, qualified_symbol = key
-            duplicates.append(f"{file_name}:{qualified_symbol} {code}")
-        else:
-            seen.add(key)
-    return duplicates
+def find_duplicate_keys(records: Sequence[Record]) -> list[str]:
+    """Return duplicate complexity identities for legacy callers."""
+    live = [_legacy_live_row(record) for record in records]
+    return complexity_duplicate_identities(live)
 
 
-def find_regressions( *,
-    live_records: list[Record], baseline_index: BaselineIndex
-) -> list[str]:
-    """Return new identities and metric growth compared with the baseline."""
+def index_baseline(records: Sequence[Record]) -> dict[tuple[str, str, str], int]:
+    """Map the metric-independent record identity to its allowed metric."""
+    return {
+        _record_identity(record): cast("int", record["metric"])
+        for record in records
+    }
+
+
+def find_regressions(*, live_records: Sequence[Record], baseline_index: Mapping[tuple[str, str, str], int]) -> list[str]:
+    """Compatibility comparison helper retaining existing diagnostics."""
     regressions: list[str] = []
     for record in live_records:
-        key = _record_key(record)
-        live_metric = int(record["metric"])
-        baseline_metric = baseline_index.get(key)
-        file_name, code, qualified_symbol = key
-        if baseline_metric is None:
-            regressions.append(f"{file_name}:{qualified_symbol} {code} (new)")
-        elif live_metric > baseline_metric:
-            regressions.append(
-                f"{file_name}:{qualified_symbol} {code} metric {live_metric} > baseline {baseline_metric}"
-            )
+        file_name, code, symbol = _record_identity(record)
+        metric = cast("int", record["metric"])
+        baseline = baseline_index.get((file_name, code, symbol))
+        if baseline is None:
+            regressions.append(f"{file_name}:{symbol} {code} (new)")
+        elif metric > baseline:
+            regressions.append(f"{file_name}:{symbol} {code} metric {metric} > baseline {baseline}")
     return regressions
+
+
+def merge_baseline(*, live_records: Sequence[Record], stored_records: Sequence[Record], reason: str | None, today: date, source: Path) -> list[Record]:
+    """Compatibility adapter for callers still passing mapping-shaped records."""
+    del source
+    live = [_legacy_live_row(record) for record in live_records]
+    stored = _typed_rows(stored_records, source=Path("<stored>"))
+    return [complexity_row_record(row) for row in merge_complexity_baseline(live_rows=live, stored_rows=stored, reason=reason, today=today)]
 
 
 def _run_ruff(python_dir: Path) -> RuffResult:
     try:
-        proc = subprocess.run(
-            list(RUFF_ARGS),
-            cwd=python_dir,
-            check=False,
-            capture_output=True,
-            text=True,
-        )
+        proc = subprocess.run(list(RUFF_ARGS), cwd=python_dir, check=False, capture_output=True, text=True)
     except OSError as exc:
         return RuffResult(returncode=2, stdout="", stderr=str(exc))
-    return RuffResult(
-        returncode=proc.returncode, stdout=proc.stdout, stderr=proc.stderr
-    )
+    return RuffResult(proc.returncode, proc.stdout, proc.stderr)
 
 
 def _load_ruff_items(result: RuffResult) -> list[object]:
     if result.returncode >= TOOL_FAILURE_EXIT:
-        raise BaselineError(f"ruff exited {result.returncode}: {result.stderr.strip()}")
+        raise ScanError(f"ruff exited {result.returncode}: {result.stderr.strip()}")
     if not result.stdout.strip():
-        raise BaselineError("ruff produced empty JSON output")
+        raise ScanError("ruff produced empty JSON output")
     try:
         data = json.loads(result.stdout)
     except json.JSONDecodeError as exc:
-        raise BaselineError(f"ruff produced invalid JSON: {exc}") from exc
+        raise ScanError(f"ruff produced invalid JSON: {exc}") from exc
     if not isinstance(data, list):
-        raise BaselineError("ruff JSON output must be a list")
+        raise ScanError("ruff JSON output must be a list")
     return cast("list[object]", data)
 
 
-def _read_source( *,
-    python_dir: Path, normalized_file: str, cache: dict[str, str]
-) -> str | None:
-    cached = cache.get(normalized_file)
-    if cached is not None:
-        return cached
-    path = python_dir / normalized_file
-    try:
-        source = path.read_text(encoding="utf-8")
-    except OSError:
-        return None
-    cache[normalized_file] = source
-    return source
-
-
-def _parse_live_record( *,
-    item: Mapping[str, object],
-    normalized_file: str,
-    source: str,
-    span_cache: dict[str, list[SymbolSpan]],
-) -> Record | None:
-    code = item.get("code")
-    message = item.get("message")
-    location = item.get("location")
-    if (
-        not isinstance(code, str)
-        or not isinstance(message, str)
-        or code not in COMPLEXITY_CODES
-    ):
-        return None
-    if not isinstance(location, dict):
-        return None
-    location_record = cast("Mapping[str, object]", location)
-    row = location_record.get("row")
-    if not isinstance(row, int):
-        return None
-    spans = span_cache.get(normalized_file)
-    if spans is None:
-        collected = _collect_symbol_spans(source)
-        if collected is None:
-            return None
-        spans = collected
-        span_cache[normalized_file] = spans
-    qualified_symbol = _resolve_from_spans(spans=spans, row=row)
-    metric = parse_metric(code=code, message=message)
-    if qualified_symbol is None or metric is None:
-        return None
-    return {
-        "file": normalized_file,
-        "code": code,
-        "qualified_symbol": qualified_symbol,
-        "metric": metric,
-    }
-
-
-def _parse_live_records( *,
-    items: list[object], python_dir: Path
-) -> tuple[list[Record], list[str]]:
-    records: list[Record] = []
+def _parse_live_records(*, items: Sequence[object], python_dir: Path) -> tuple[list[ComplexityLiveRow], list[str]]:
+    rows: list[ComplexityLiveRow] = []
     failures: list[str] = []
     source_cache: dict[str, str] = {}
     span_cache: dict[str, list[SymbolSpan]] = {}
     for item in items:
-        if not isinstance(item, dict):
+        if not isinstance(item, dict) or not isinstance(item.get("filename"), str):
             failures.append("<unknown>: malformed ruff JSON item")
             continue
-        item_mapping = cast("Mapping[str, object]", item)
-        filename = item_mapping.get("filename")
-        if not isinstance(filename, str):
-            failures.append("<unknown>: malformed ruff JSON item")
+        mapping = cast("Mapping[str, object]", item)
+        filename = normalize_file_path(cast("str", mapping["filename"]))
+        if is_exempt_path(filename):
             continue
-        normalized_file = normalize_file_path(filename)
-        if is_exempt_path(normalized_file):
-            continue
-        source = _read_source(python_dir=python_dir, normalized_file=normalized_file, cache=source_cache)
+        source = source_cache.get(filename)
         if source is None:
-            failures.append(f"{normalized_file}: cannot read source")
+            try:
+                source = (python_dir / filename).read_text(encoding="utf-8")
+            except OSError:
+                failures.append(f"{filename}: cannot read source")
+                continue
+            source_cache[filename] = source
+        code, message, location = mapping.get("code"), mapping.get("message"), mapping.get("location")
+        row = cast("Mapping[str, object]", location).get("row") if isinstance(location, dict) else None
+        if not isinstance(code, str) or code not in COMPLEXITY_CODES or not isinstance(message, str) or not isinstance(row, int):
+            failures.append(f"{filename}: cannot parse violation")
             continue
-        record = _parse_live_record(item=item_mapping, normalized_file=normalized_file, source=source, span_cache=span_cache)
-        if record is None:
-            failures.append(f"{normalized_file}: cannot parse violation")
+        spans = span_cache.get(filename)
+        if spans is None:
+            spans = _collect_symbol_spans(source)
+            if spans is None:
+                failures.append(f"{filename}: cannot parse violation")
+                continue
+            span_cache[filename] = spans
+        metric = parse_metric(code=code, message=message)
+        symbol = _resolve_from_spans(spans=spans, row=row)
+        if metric is None or symbol is None:
+            failures.append(f"{filename}: cannot parse violation")
             continue
-        records.append(record)
-    return records, failures
+        rows.append(ComplexityLiveRow(filename, cast("ComplexityCode", code), symbol, metric))
+    return rows, failures
 
 
-def _parse_args(argv: list[str]) -> argparse.Namespace | None:
-    parser = argparse.ArgumentParser(
-        prog="cli.py lint complexity-baseline", description=__doc__
-    )
-    _ = parser.add_argument("--root", default=str(Path(__file__).resolve().parents[3]))
-    _ = parser.add_argument(
-        "--write",
-        action="store_true",
-        help=(
-            "Regenerate complexity-baseline.json from live ruff output "
-            "instead of checking against it."
-        ),
-    )
-    _ = parser.add_argument(
-        "--reason",
-        help="Required for a new baseline row or metric increase during --write.",
-    )
-    _ = parser.add_argument(
-        "--migrate",
-        action="store_true",
-        help=(
-            "Grandfather legacy or partially migrated baseline records in "
-            "place instead of checking or writing."
-        ),
-    )
-    try:
-        return parser.parse_args(argv)
-    except SystemExit as exc:
-        if exc.code == 0:
-            raise
-        return None
-
-
-def _collect_live_records(python_dir: Path) -> list[Record]:
-    """Run ruff and return validated live records, fail-closed on any defect."""
-    ruff_items = _load_ruff_items(_run_ruff(python_dir))
-    live_records, parse_failures = _parse_live_records(items=ruff_items, python_dir=python_dir)
-    if parse_failures:
-        raise BaselineError("\n".join(parse_failures))
-    live_duplicates = find_duplicate_keys(live_records)
-    if live_duplicates:
-        raise BaselineError(
-            "duplicate live complexity identities:\n" + "\n".join(live_duplicates)
-        )
-    return live_records
-
-
-def _canonical_record(record: Record) -> dict[str, object]:
-    mapping = cast("Mapping[str, object]", record)
-    return {key: mapping[key] for key in FIELD_ORDER if key in mapping}
-
-
-def serialize_baseline(records: list[Record]) -> str:
-    """Return canonical baseline JSON: key-sorted, 2-space, trailing newline."""
-    ordered = sorted(records, key=_record_key)
-    canonical = [_canonical_record(record) for record in ordered]
-    return json.dumps(canonical, indent=2) + "\n"
-
-
-def write_baseline( *,path: Path, records: list[Record]) -> None:
-    """Write the canonical baseline JSON for ``records`` to ``path``."""
-    _ = path.write_text(serialize_baseline(records), encoding="utf-8")
-
-
-def migrate_baseline(path: Path) -> int:
-    """Grandfather legacy or partially migrated records in ``path`` in place.
-
-    Adds only the missing ``added_at: "legacy"`` and ``history: []`` fields;
-    every other identity and optional field is preserved verbatim. Fails
-    closed on unknown fields, missing identity fields, or a changed
-    ``(file, code, qualified_symbol) -> metric`` projection. Returns the
-    count of records that gained migration metadata.
-    """
-    try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        raise BaselineError(f"{path}: cannot load baseline: {exc}") from exc
-    if not isinstance(data, list):
-        raise BaselineError(f"{path}: baseline must be a top-level JSON array")
-    items = cast("list[object]", data)
-    validated = [
-        _validate_record(item, index=index, source=path, strict=False)
-        for index, item in enumerate(items)
-    ]
-    before_projection = {_record_key(record): record["metric"] for record in validated}
-
-    migrated_count = 0
-    migrated: list[Record] = []
-    for record in validated:
-        added_at = record.get("added_at")
-        history = record.get("history")
-        if added_at is None or history is None:
-            migrated_count += 1
-        new_record: Record = {
-            "file": record["file"],
-            "code": record["code"],
-            "qualified_symbol": record["qualified_symbol"],
-            "metric": record["metric"],
-            "added_at": added_at if added_at is not None else "legacy",
-            "history": history if history is not None else [],
-        }
-        if "source_issue" in record:
-            new_record["source_issue"] = record["source_issue"]
-        if "reason" in record:
-            new_record["reason"] = record["reason"]
-        if "operator_override" in record:
-            new_record["operator_override"] = record["operator_override"]
-        migrated.append(new_record)
-
-    after_projection = {_record_key(record): record["metric"] for record in migrated}
-    if before_projection != after_projection:
-        raise BaselineError(
-            f"{path}: migration would change the identity-to-metric projection"
-        )
-    write_baseline(path=path, records=migrated)
-    return migrated_count
-
-
-def _required_metadata(record: Record) -> tuple[str, list[HistoryEntry]]:
-    """Return strict metadata or fail closed when a caller passed a live row."""
-    added_at = record.get("added_at")
-    history = record.get("history")
-    if added_at is None or history is None:
-        raise BaselineError("baseline record is missing required metadata")
-    return added_at, history
-
-
-def _copy_preserved_metadata(*, record: Record, stored: Record) -> Record:
-    """Build one live row while retaining metadata only from its stored match."""
-    added_at, stored_history = _required_metadata(stored)
-    merged: Record = {
-        "file": record["file"],
-        "code": record["code"],
-        "qualified_symbol": record["qualified_symbol"],
-        "metric": record["metric"],
-        "added_at": added_at,
-        "history": [
-            {"date": entry["date"], "metric": entry["metric"]}
-            for entry in stored_history
-        ],
-    }
-    if "source_issue" in stored:
-        merged["source_issue"] = stored["source_issue"]
-    if "reason" in stored:
-        merged["reason"] = stored["reason"]
-    if "operator_override" in stored:
-        override = stored["operator_override"]
-        merged["operator_override"] = {
-            "reason": override["reason"],
-            "issue": override["issue"],
-        }
-    return merged
-
-
-def merge_baseline(
-    *,
-    live_records: list[Record],
-    stored_records: list[Record],
-    reason: str | None,
-    today: date,
-    source: Path,
-) -> list[Record]:
-    """Merge live results with trusted metadata, rejecting unreasoned growth."""
-    duplicates = find_duplicate_keys(stored_records)
+def _collect_live_records(python_dir: Path) -> list[ComplexityLiveRow]:
+    """Run Ruff and return validated current observations."""
+    rows, failures = _parse_live_records(items=_load_ruff_items(_run_ruff(python_dir)), python_dir=python_dir)
+    if failures:
+        raise ScanError("\n".join(failures))
+    duplicates = complexity_duplicate_identities(rows)
     if duplicates:
-        raise BaselineError("duplicate baseline complexity identities:\n" + "\n".join(duplicates))
-    stored_by_key: dict[tuple[str, str, str], Record] = {
-        _record_key(record): record for record in stored_records
-    }
-    merged: list[Record] = []
-    for live_record in live_records:
-        stored = stored_by_key.get(_record_key(live_record))
-        if stored is None:
-            if reason is None:
-                raise BaselineError("--reason is required for a new baseline row")
-            merged.append(
-                {
-                    **live_record,
-                    "added_at": today.isoformat(),
-                    "history": [{"date": today.isoformat(), "metric": live_record["metric"]}],
-                    "reason": reason,
-                }
-            )
-            continue
-        next_record = _copy_preserved_metadata(record=live_record, stored=stored)
-        if live_record["metric"] > stored["metric"]:
-            if reason is None:
-                raise BaselineError("--reason is required for a metric increase")
-            _, history = _required_metadata(next_record)
-            history.append(
-                {"date": today.isoformat(), "metric": live_record["metric"]}
-            )
-            next_record["reason"] = reason
-        merged.append(next_record)
-    validated = [
-        _validate_record(record, index=index, source=source, strict=True)
-        for index, record in enumerate(merged)
-    ]
-    if find_duplicate_keys(validated):
-        raise BaselineError("duplicate merged complexity identities")
-    return validated
+        raise ScanError("duplicate live complexity identities:\n" + "\n".join(duplicates))
+    return rows
 
 
-def _run_write(*, python_dir: Path, baseline_path: Path, reason: str | None) -> int:
-    try:
-        live_records = _collect_live_records(python_dir)
-        stored_records = load_baseline(baseline_path) if baseline_path.exists() else []
-        merged_records = merge_baseline(
-            live_records=live_records,
-            stored_records=stored_records,
-            reason=reason,
-            today=utc_today(),
-            source=baseline_path,
-        )
-    except BaselineError as exc:
-        print(f"lint-complexity-baseline: {exc}", file=sys.stderr)
-        return 2
-    write_baseline(path=baseline_path, records=merged_records)
-    print(
-        f"lint-complexity-baseline: wrote {len(merged_records)} "
-        f"records to {baseline_path}",
-        file=sys.stderr,
-    )
-    return 0
-
-
-def _run_migrate( *,baseline_path: Path) -> int:
-    try:
-        migrated_count = migrate_baseline(baseline_path)
-    except BaselineError as exc:
-        print(f"lint-complexity-baseline: {exc}", file=sys.stderr)
-        return 2
-    print(
-        f"lint-complexity-baseline: migrated {migrated_count} "
-        f"records in {baseline_path}",
-        file=sys.stderr,
-    )
-    return 0
-
-
-def history_events(records: list[Record]) -> dict[tuple[str, str], list[HistoryEvent]]:
-    """Return deterministic metric-growth events grouped by file and symbol."""
-    grouped: dict[tuple[str, str], list[HistoryEvent]] = {}
-    for record in records:
-        added_at, history = _required_metadata(record)
-        start = 0 if added_at == "legacy" else 1
-        for history_index, entry in enumerate(history[start:], start=start):
-            event = HistoryEvent(
-                event_date=date.fromisoformat(entry["date"]),
-                record=record,
-                history_index=history_index,
-                metric=entry["metric"],
-            )
-            symbol_key = (record["file"], record["qualified_symbol"])
-            grouped.setdefault(symbol_key, []).append(event)
-    for events in grouped.values():
-        events.sort(
-            key=lambda event: (
-                event.event_date,
-                *_record_key(event.record),
-                event.history_index,
-            )
-        )
-    return grouped
+def history_events(records: Sequence[Record]) -> dict[tuple[str, str], list[HistoryEvent]]:
+    """Compatibility adapter retaining the historical event-report API."""
+    return complexity_history_events(_typed_rows(records, source=Path("<records>")))
 
 
 def _format_event(event: HistoryEvent) -> str:
-    return (
-        f"{event.event_date.isoformat()} [{event.record['code']}] "
-        f"metric {event.metric}"
-    )
+    return f"{event.event_date.isoformat()} [{event.record.code}] metric {event.metric}"
 
 
-def repeat_bump_failures(records: list[Record]) -> list[str]:
+def repeat_bump_failures(records: Sequence[Record]) -> list[str]:
     """Return every unoverridden second bump inside the inclusive 14-day window."""
     failures: list[str] = []
     for (file_name, symbol), events in sorted(history_events(records).items()):
         for previous, current in pairwise(events):
-            if (current.event_date - previous.event_date).days > REPEAT_BUMP_DAYS:
+            if (current.event_date - previous.event_date).days > REPEAT_BUMP_DAYS or current.record.operator_override is not None:
                 continue
-            if "operator_override" in current.record:
-                continue
-            failures.append(
-                f"repeat complexity bumps for {file_name}:{symbol}: "
-                f"{_format_event(previous)}; {_format_event(current)}. "
-                "Simplify the function, split it, or add an operator override."
-            )
+            failures.append(f"repeat complexity bumps for {file_name}:{symbol}: {_format_event(previous)}; {_format_event(current)}. Simplify the function, split it, or add an operator override.")
     return failures
 
 
-def active_overrides(records: list[Record]) -> list[str]:
+def active_overrides(records: Sequence[Record]) -> list[str]:
     """Render all active manual override records in canonical identity order."""
-    lines: list[str] = []
-    for record in sorted(records, key=_record_key):
-        override = record.get("operator_override")
-        if override is None:
-            continue
-        lines.append(
-            f"active operator override: {record['file']}:{record['qualified_symbol']} "
-            f"[{record['code']}] issue #{override['issue']}: {override['reason']}"
-        )
-    return lines
+    return [
+        f"active operator override: {row.file}:{row.qualified_symbol} [{row.code}] issue #{row.operator_override.issue}: {row.operator_override.reason}"
+        for row in _typed_rows(records, source=Path("<records>"))
+        if row.operator_override is not None
+    ]
 
 
-def _run_check( *,python_dir: Path, baseline_path: Path) -> int:
+def _run_write(*, root: Path, python_dir: Path, baseline_path: Path, reason: str | None) -> int:
     try:
-        live_records = _collect_live_records(python_dir)
-        baseline_records = load_baseline(baseline_path)
-        baseline_duplicates = find_duplicate_keys(baseline_records)
-        if baseline_duplicates:
-            raise BaselineError(
-                "duplicate baseline complexity identities:\n"
-                + "\n".join(baseline_duplicates)
-            )
-    except BaselineError as exc:
+        live = _collect_live_records(python_dir)
+        stored = load_complexity_baseline(
+            baseline_path, root=root, today=utc_today(), allow_missing=True
+        )
+        merged = merge_complexity_baseline(live_rows=live, stored_rows=stored, reason=reason, today=utc_today())
+        _ = write_complexity_baseline(baseline_path, root=root, rows=merged, today=utc_today())
+    except ScanError as exc:
         print(f"lint-complexity-baseline: {exc}", file=sys.stderr)
-        return 2
+        return TOOL_FAILURE_EXIT
+    print(f"lint-complexity-baseline: wrote {len(merged)} records to {baseline_path}", file=sys.stderr)
+    return 0
 
-    failures = repeat_bump_failures(baseline_records)
-    regressions = find_regressions(
-        live_records=live_records, baseline_index=index_baseline(baseline_records)
-    )
-    for regression in regressions:
-        print(regression, file=sys.stderr)
-    for failure in failures:
-        print(failure, file=sys.stderr)
-    for override in active_overrides(baseline_records):
-        print(override, file=sys.stderr)
+
+def _run_check(*, root: Path, python_dir: Path, baseline_path: Path) -> int:
+    try:
+        live = _collect_live_records(python_dir)
+        baseline = load_complexity_baseline(baseline_path, root=root, today=utc_today())
+    except ScanError as exc:
+        print(f"lint-complexity-baseline: {exc}", file=sys.stderr)
+        return TOOL_FAILURE_EXIT
+    regressions = complexity_regressions(live_rows=live, baseline_rows=baseline)
+    records = [complexity_row_record(row) for row in baseline]
+    failures = repeat_bump_failures(records)
+    for line in [*regressions, *failures, *active_overrides(records)]:
+        print(line, file=sys.stderr)
     return 1 if regressions or failures else 0
 
 
-def _validated_write_reason(parsed: argparse.Namespace) -> tuple[str | None, str | None]:
-    """Return a normalized writer reason or the one mode-validation error."""
-    if parsed.migrate and parsed.write:
-        return None, "--migrate and --write are incompatible"
-    reason = parsed.reason
-    if reason is None:
-        return None, None
-    if not parsed.write or parsed.migrate or not reason.strip():
-        return None, "--reason is a nonblank --write-only option"
-    return reason.strip(), None
-
-
 def main(argv: list[str] | None = None) -> int:
-    parsed = _parse_args(argv=argv if argv is not None else sys.argv[1:])
+    """Run the compatible complexity baseline check, write, or migration mode."""
+    parsed = parse_complexity_baseline_argv(argv if argv is not None else sys.argv[1:], default_root=Path(__file__).resolve().parents[3])
     if parsed is None:
-        return 2
-    root = Path(parsed.root).resolve()
-    python_dir = root / "python"
+        return TOOL_FAILURE_EXIT
+    python_dir = parsed.root / "python"
     if not python_dir.is_dir():
-        print(
-            f"lint-complexity-baseline: python directory not found: {python_dir}",
-            file=sys.stderr,
-        )
-        return 2
-
+        print(f"lint-complexity-baseline: python directory not found: {python_dir}", file=sys.stderr)
+        return TOOL_FAILURE_EXIT
     baseline_path = python_dir / "complexity-baseline.json"
-    reason, mode_error = _validated_write_reason(parsed)
-    if mode_error is not None:
-        print(f"lint-complexity-baseline: {mode_error}", file=sys.stderr)
-        return 2
     if parsed.migrate:
-        return _run_migrate(baseline_path=baseline_path)
+        try:
+            count = migrate_complexity_baseline(baseline_path, root=parsed.root, today=utc_today())
+        except ScanError as exc:
+            print(f"lint-complexity-baseline: {exc}", file=sys.stderr)
+            return TOOL_FAILURE_EXIT
+        print(f"lint-complexity-baseline: migrated {count} records in {baseline_path}", file=sys.stderr)
+        return 0
     if parsed.write:
-        return _run_write(python_dir=python_dir, baseline_path=baseline_path, reason=reason)
-    return _run_check(python_dir=python_dir, baseline_path=baseline_path)
-
-
-if __name__ == "__main__":
-    raise SystemExit(main())
+        return _run_write(root=parsed.root, python_dir=python_dir, baseline_path=baseline_path, reason=parsed.reason)
+    return _run_check(root=parsed.root, python_dir=python_dir, baseline_path=baseline_path)

--- a/python/larch/lint/lint_complexity_debt.py
+++ b/python/larch/lint/lint_complexity_debt.py
@@ -2,19 +2,20 @@
 
 from __future__ import annotations
 
-import argparse
-import sys
-from datetime import date, timedelta
+from collections.abc import Mapping, Sequence
+from datetime import UTC, date, datetime, timedelta
+import json
 from pathlib import Path
+import sys
+from typing import cast
 
-from larch.lint.lint_complexity_baseline import (
-    BaselineError,
-    Record,
-    active_overrides,
-    find_duplicate_keys,
-    history_events,
-    load_baseline,
-    utc_today,
+from larch.lint.engine import (
+    ComplexityBaselineRow,
+    ScanError,
+    complexity_history_events,
+    load_complexity_baseline,
+    parse_complexity_baseline,
+    parse_complexity_debt_argv,
 )
 
 UNDER_14_DAYS = 14
@@ -23,34 +24,26 @@ RECENT_BUMP_DAYS = 30
 MINIMUM_REPEAT_EVENTS = 2
 
 
-def _parse_args(argv: list[str]) -> argparse.Namespace | None:
-    parser = argparse.ArgumentParser(
-        prog="cli.py lint complexity-debt", description=__doc__
+def _typed_records(
+    records: Sequence[ComplexityBaselineRow | Mapping[str, object]], *, today: date
+) -> list[ComplexityBaselineRow]:
+    """Accept legacy mapping fixtures while runtime callers use typed rows."""
+    if all(isinstance(record, ComplexityBaselineRow) for record in records):
+        return list(cast("Sequence[ComplexityBaselineRow]", records))
+    return parse_complexity_baseline(
+        json.dumps(list(records)), source="complexity debt records", today=today
     )
-    _ = parser.add_argument("--report", action="store_true", help="Render the debt report.")
-    _ = parser.add_argument("--root", default=str(Path(__file__).resolve().parents[3]))
-    try:
-        parsed = parser.parse_args(argv)
-    except SystemExit as exc:
-        if exc.code == 0:
-            raise
-        return None
-    return parsed if parsed.report else None
 
 
-def _age_bucket_counts(records: list[Record], today: date) -> tuple[int, int, int, int]:
-    under_14 = 0
-    through_90 = 0
-    over_90 = 0
-    legacy = 0
+def _age_bucket_counts(
+    records: Sequence[ComplexityBaselineRow], today: date
+) -> tuple[int, int, int, int]:
+    under_14 = through_90 = over_90 = legacy = 0
     for record in records:
-        added_at = record.get("added_at")
-        if added_at is None:
-            raise BaselineError("baseline record is missing required metadata")
-        if added_at == "legacy":
+        if record.added_at == "legacy":
             legacy += 1
             continue
-        age = (today - date.fromisoformat(added_at)).days
+        age = (today - date.fromisoformat(record.added_at)).days
         if age < UNDER_14_DAYS:
             under_14 += 1
         elif age <= THROUGH_90_DAYS:
@@ -60,72 +53,81 @@ def _age_bucket_counts(records: list[Record], today: date) -> tuple[int, int, in
     return under_14, through_90, over_90, legacy
 
 
-def _recent_repeat_lines(records: list[Record], today: date) -> list[str]:
-    lines: list[str] = []
+def _recent_repeat_lines(
+    records: Sequence[ComplexityBaselineRow], today: date
+) -> list[str]:
+    """Render the established detail-rich repeat-bump diagnostics."""
     cutoff = today - timedelta(days=RECENT_BUMP_DAYS)
-    for (file_name, symbol), events in sorted(history_events(records).items()):
+    lines: list[str] = []
+    for (file_name, symbol), events in sorted(complexity_history_events(records).items()):
         recent = [event for event in events if event.event_date >= cutoff]
         if len(recent) < MINIMUM_REPEAT_EVENTS:
             continue
         details = "; ".join(
-            f"{event.event_date.isoformat()} [{event.record['code']}] metric {event.metric}"
+            f"{event.event_date.isoformat()} [{event.record.code}] metric {event.metric}"
             for event in recent
         )
         lines.append(f"  {file_name}:{symbol}: {details}")
     return lines
 
 
-def render_report(records: list[Record], *, today: date) -> str:
+def _active_overrides(records: Sequence[ComplexityBaselineRow]) -> list[str]:
+    return [
+        f"{record.file}:{record.qualified_symbol} [{record.code}] "
+        f"issue #{record.operator_override.issue}: {record.operator_override.reason}"
+        for record in sorted(records, key=lambda row: row.identity)
+        if record.operator_override is not None
+    ]
+
+
+def render_report(
+    records: Sequence[ComplexityBaselineRow | Mapping[str, object]], *, today: date
+) -> str:
     """Render every debt section deterministically, including empty sections."""
-    under_14, through_90, over_90, legacy = _age_bucket_counts(records, today)
-    lines = ["Complexity debt report", f"Total entries: {len(records)}", "", "Age buckets:"]
-    lines.extend(
-        [
-            f"  under 14 days: {under_14}",
-            f"  14 through 90 days: {through_90}",
-            f"  over 90 days: {over_90}",
-            f"  legacy: {legacy}",
-            "",
-            "Top 10 by metric:",
-        ]
-    )
-    top = sorted(
-        records,
-        key=lambda record: (-record["metric"], record["file"], record["code"], record["qualified_symbol"]),
-    )[:10]
+    typed_records = _typed_records(records, today=today)
+    under_14, through_90, over_90, legacy = _age_bucket_counts(typed_records, today)
+    lines = ["Complexity debt report", f"Total entries: {len(typed_records)}", "", "Age buckets:"]
+    lines.extend([
+        f"  under 14 days: {under_14}",
+        f"  14 through 90 days: {through_90}",
+        f"  over 90 days: {over_90}",
+        f"  legacy: {legacy}",
+        "",
+        "Top 10 by metric:",
+    ])
+    top = sorted(typed_records, key=lambda row: (-row.metric, *row.identity))[:10]
     if top:
-        lines.extend(
-            f"  {record['metric']} | {record['file']} | {record['code']} | {record['qualified_symbol']}"
-            for record in top
-        )
+        lines.extend(f"  {row.metric} | {row.file} | {row.code} | {row.qualified_symbol}" for row in top)
     else:
         lines.append("  (none)")
     lines.extend(["", "Symbols with at least two bumps in the last 30 days:"])
-    recent = _recent_repeat_lines(records, today)
-    lines.extend(recent or ["  (none)"])
+    lines.extend(_recent_repeat_lines(typed_records, today) or ["  (none)"])
     lines.extend(["", "Active operator overrides:"])
-    overrides = active_overrides(records)
-    lines.extend((f"  {line}" for line in overrides) if overrides else ["  (none)"])
+    overrides = _active_overrides(typed_records)
+    if overrides:
+        lines.extend(f"  {line}" for line in overrides)
+    else:
+        lines.append("  (none)")
     return "\n".join(lines) + "\n"
 
 
+def _utc_today() -> date:
+    return datetime.now(UTC).date()
+
+
 def main(argv: list[str] | None = None) -> int:
-    parsed = _parse_args(argv if argv is not None else sys.argv[1:])
+    """Load the typed engine baseline and render its debt report."""
+    parsed = parse_complexity_debt_argv(
+        argv if argv is not None else sys.argv[1:], default_root=Path(__file__).resolve().parents[3]
+    )
     if parsed is None:
         print("lint-complexity-debt: --report is required", file=sys.stderr)
         return 2
-    baseline_path = Path(parsed.root).resolve() / "python" / "complexity-baseline.json"
+    baseline_path = parsed.root / "python" / "complexity-baseline.json"
     try:
-        records = load_baseline(baseline_path)
-        duplicates = find_duplicate_keys(records)
-        if duplicates:
-            raise BaselineError("duplicate baseline complexity identities:\n" + "\n".join(duplicates))
-    except BaselineError as exc:
+        records = load_complexity_baseline(baseline_path, root=parsed.root, today=_utc_today())
+    except ScanError as exc:
         print(f"lint-complexity-debt: {exc}", file=sys.stderr)
         return 2
-    print(render_report(records, today=utc_today()), end="")
+    print(render_report(records, today=_utc_today()), end="")
     return 0
-
-
-if __name__ == "__main__":
-    raise SystemExit(main())

--- a/python/lint-engine-adoption-baseline.json
+++ b/python/lint-engine-adoption-baseline.json
@@ -16,30 +16,6 @@
     "rule_id": "engine-adoption"
   },
   {
-    "anchor": "baseline-io",
-    "line": 806,
-    "message": "direct *-baseline.json I/O outside shared lint engine",
-    "path": "python/larch/lint/lint_complexity_baseline.py",
-    "reason": "Pre-engine legacy lint module; grandfathered until ported onto larch.lint.engine (#6967).",
-    "rule_id": "engine-adoption"
-  },
-  {
-    "anchor": "argparse-construction",
-    "line": 590,
-    "message": "legacy ArgumentParser construction outside shared lint engine",
-    "path": "python/larch/lint/lint_complexity_baseline.py",
-    "reason": "Pre-engine legacy lint module; grandfathered until ported onto larch.lint.engine (#6967).",
-    "rule_id": "engine-adoption"
-  },
-  {
-    "anchor": "argparse-construction",
-    "line": 27,
-    "message": "legacy ArgumentParser construction outside shared lint engine",
-    "path": "python/larch/lint/lint_complexity_debt.py",
-    "reason": "Pre-engine legacy lint module; grandfathered until ported onto larch.lint.engine (#6967).",
-    "rule_id": "engine-adoption"
-  },
-  {
     "anchor": "argparse-construction",
     "line": 48,
     "message": "legacy ArgumentParser construction outside shared lint engine",

--- a/python/tests/lint/test_lint_complexity_baseline.py
+++ b/python/tests/lint/test_lint_complexity_baseline.py
@@ -8,6 +8,7 @@ from typing import cast
 import pytest
 
 from larch import cli
+from larch.lint import engine
 from larch.lint import lint_complexity_baseline as lcb
 from larch.lint import lint_complexity_debt as lcd
 from larch.lint.lint_complexity_baseline import BaselineError, Record, RuffResult
@@ -469,9 +470,72 @@ def test_migrate_cli_reports_migrated_count(
 
 def test_checked_in_baseline_strict_loads_and_serializes_byte_stable() -> None:
     baseline_path = Path(__file__).resolve().parents[2] / "complexity-baseline.json"
-    records = lcb.load_baseline(baseline_path)
-    assert not lcb.find_duplicate_keys(records)
-    assert lcb.serialize_baseline(records) == baseline_path.read_text(encoding="utf-8")
+    records = engine.load_complexity_baseline(
+        baseline_path, root=baseline_path.parents[1]
+    )
+    assert not engine.complexity_duplicate_identities(records)
+    assert engine.serialize_complexity_baseline(records) == baseline_path.read_text(
+        encoding="utf-8"
+    )
+
+
+def test_engine_write_preserves_unchanged_complexity_baseline_bytes(
+    tmp_path: Path,
+) -> None:
+    source_path = Path(__file__).resolve().parents[2] / "complexity-baseline.json"
+    python_dir = tmp_path / "python"
+    python_dir.mkdir()
+    baseline_path = python_dir / "complexity-baseline.json"
+    original = source_path.read_text(encoding="utf-8")
+    _ = baseline_path.write_text(original, encoding="utf-8")
+    rows = engine.load_complexity_baseline(baseline_path, root=tmp_path)
+    _ = engine.write_complexity_baseline(baseline_path, root=tmp_path, rows=rows)
+    assert baseline_path.read_text(encoding="utf-8") == original
+
+
+def test_engine_rejects_symlinked_complexity_baseline(tmp_path: Path) -> None:
+    python_dir = tmp_path / "python"
+    python_dir.mkdir()
+    target = tmp_path / "target.json"
+    _ = target.write_text("[]\n", encoding="utf-8")
+    baseline_path = python_dir / "complexity-baseline.json"
+    baseline_path.symlink_to(target)
+    with pytest.raises(engine.ScanError, match="symlinked"):
+        _ = engine.load_complexity_baseline(baseline_path, root=tmp_path)
+
+
+def test_engine_write_fails_closed_when_read_back_bytes_differ(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    python_dir = tmp_path / "python"
+    python_dir.mkdir()
+    baseline_path = python_dir / "complexity-baseline.json"
+    rows = engine.parse_complexity_baseline(
+        json.dumps([base_record()]), source="test", today=date(2026, 7, 14)
+    )
+    monkeypatch.setattr(
+        engine.larch_io,
+        "read_trusted_text",
+        lambda *_args, **_kwargs: "[]\n",
+    )
+    with pytest.raises(engine.ScanError, match="read-back bytes differ"):
+        _ = engine.write_complexity_baseline(
+            baseline_path, root=tmp_path, rows=rows, today=date(2026, 7, 14)
+        )
+
+
+def test_engine_merge_records_one_deterministic_growth_event() -> None:
+    stored = engine.parse_complexity_baseline(
+        json.dumps([base_record(metric=17, history=[{"date": "2026-07-01", "metric": 17}])]),
+        source="test",
+        today=date(2026, 7, 14),
+    )
+    live = [engine.ComplexityLiveRow("proc.py", "PLR0913", "ProcRunner.run", 18)]
+    merged = engine.merge_complexity_baseline(
+        live_rows=live, stored_rows=stored, reason="growth", today=date(2026, 7, 14)
+    )
+    assert merged[0].history[-1] == engine.ComplexityHistoryEntry("2026-07-14", 18)
+    assert merged[0].reason == "growth"
 
 
 def test_main_passes_when_live_records_match_baseline(
@@ -889,7 +953,7 @@ def test_write_growth_appends_history_and_preserves_manual_override(
     written_record = written[0]
     assert written_record.get("added_at") == "2026-07-12"
     history = written_record.get("history")
-    assert history is not None
+    assert isinstance(history, list)
     assert history[-1] == {"date": lcb.utc_today().isoformat(), "metric": 18}
     assert written_record.get("reason") == "urgent API"
     assert written_record.get("source_issue") == 7156
@@ -949,14 +1013,15 @@ def test_dated_seed_is_not_a_bump_and_equal_dates_are_deterministic() -> None:
 
 
 def test_debt_report_has_all_sections_and_cli_registration(
-    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     write_project(
         tmp_path,
         baseline=[
-            base_record(
-                metric=22,
-                history=[
+                base_record(
+                    metric=22,
+                    added_at="legacy",
+                    history=[
                     {"date": "2026-07-01", "metric": 20},
                     {"date": "2026-07-10", "metric": 22},
                 ],
@@ -964,6 +1029,7 @@ def test_debt_report_has_all_sections_and_cli_registration(
             )
         ],
     )
+    monkeypatch.setattr(lcd, "_utc_today", lambda: date(2026, 7, 14))
     assert cli.main(["lint", "complexity-debt", "--root", str(tmp_path), "--report"]) == 0
     report = capsys.readouterr().out
     assert "Total entries: 1" in report
@@ -971,6 +1037,8 @@ def test_debt_report_has_all_sections_and_cli_registration(
     assert "Top 10 by metric:" in report
     assert "Symbols with at least two bumps in the last 30 days:" in report
     assert "Active operator overrides:" in report
+    assert "2026-07-01 [PLR0913] metric 20; 2026-07-10 [PLR0913] metric 22" in report
+    assert "issue #7156: tracked debt" in report
     assert cli.main(["lint", "complexity-debt", "--root", str(tmp_path)]) == 2
 
 

--- a/python/tests/lint/test_lint_complexity_baseline.py
+++ b/python/tests/lint/test_lint_complexity_baseline.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import json
 from datetime import date
 from pathlib import Path
-from typing import cast
-
 import pytest
 
 from larch import cli
@@ -507,6 +505,9 @@ def test_engine_rejects_symlinked_complexity_baseline(tmp_path: Path) -> None:
 def test_engine_write_fails_closed_when_read_back_bytes_differ(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    def mismatched_read(*_args: object, **_kwargs: object) -> str:
+        return "[]\n"
+
     python_dir = tmp_path / "python"
     python_dir.mkdir()
     baseline_path = python_dir / "complexity-baseline.json"
@@ -516,7 +517,7 @@ def test_engine_write_fails_closed_when_read_back_bytes_differ(
     monkeypatch.setattr(
         engine.larch_io,
         "read_trusted_text",
-        lambda *_args, **_kwargs: "[]\n",
+        mismatched_read,
     )
     with pytest.raises(engine.ScanError, match="read-back bytes differ"):
         _ = engine.write_complexity_baseline(
@@ -1006,7 +1007,7 @@ def test_dated_seed_is_not_a_bump_and_equal_dates_are_deterministic() -> None:
             history=[{"date": "2026-07-10", "metric": 11}],
         ),
     ]
-    validated: list[Record] = [cast("Record", record) for record in records]
+    validated: list[Record] = records
     failures = lcb.repeat_bump_failures(validated)
     assert len(failures) == 1
     assert "[PLR0911] metric 9; 2026-07-10 [PLR0912] metric 11" in failures[0]


### PR DESCRIPTION
Fixes #7538

Moves complexity baseline storage, validation, migration, comparison, and safe publication into `larch.lint.engine` while retaining the existing CLI and debt diagnostics.

Validation:
- `python3 -m pytest python/tests/lint/test_lint_complexity_baseline.py -q`
- Ruff, Pyright, and Pylint on changed Python files
- `python3 python/cli.py lint engine-adoption --root .`
- `python3 python/cli.py lint complexity-baseline --root .`