### PR TITLE
Fixes #7535: move skill closure baseline into lint engine

### DIFF
--- a/python/larch/lint/engine.py
+++ b/python/larch/lint/engine.py
@@ -1417,18 +1417,14 @@ def write_complexity_baseline(
     destination = _validate_baseline_path(path, root=root, write_mode=True)
     intended = serialize_complexity_baseline(rows)
     checked_today = today or datetime.now(UTC).date()
-    expected = parse_complexity_baseline(intended, source=f"baseline {destination}", today=checked_today)
-    try:
-        larch_io.trusted_atomic_write(destination, intended, root=root)
-        read_back = larch_io.read_trusted_text(destination, root=root, reject_cr=True)
-    except (OSError, UnicodeError, ValueError) as exc:
-        raise ScanError(f"failed to write baseline {destination}: {exc}") from exc
-    if read_back != intended:
-        raise ScanError(f"baseline read-back bytes differ after write: {destination}")
-    parsed = parse_complexity_baseline(read_back, source=f"baseline {destination}", today=checked_today)
-    if parsed != expected:
-        raise ScanError(f"baseline read-back records differ after write: {destination}")
-    return parsed
+    return _write_baseline_with_readback(
+        destination,
+        root=root,
+        intended=intended,
+        parse=lambda text: parse_complexity_baseline(
+            text, source=f"baseline {destination}", today=checked_today
+        ),
+    )
 
 
 def migrate_complexity_baseline(
@@ -1824,18 +1820,12 @@ def write_skill_closure_baseline(
         path, root=root, write_mode=True, create_missing_parents=True
     )
     intended = serialize_skill_closure_baseline(rows)
-    expected = parse_skill_closure_baseline(intended, source=str(destination))
-    try:
-        larch_io.trusted_atomic_write(destination, intended, root=root)
-        read_back = larch_io.read_trusted_text(destination, root=root, reject_cr=True)
-    except (OSError, UnicodeError, ValueError) as exc:
-        raise ScanError(f"failed to write baseline {destination}: {exc}") from exc
-    if read_back != intended:
-        raise ScanError(f"baseline read-back bytes differ after write: {destination}")
-    parsed = parse_skill_closure_baseline(read_back, source=str(destination))
-    if parsed != expected:
-        raise ScanError(f"baseline read-back records differ after write: {destination}")
-    return parsed
+    return _write_baseline_with_readback(
+        destination,
+        root=root,
+        intended=intended,
+        parse=lambda text: parse_skill_closure_baseline(text, source=str(destination)),
+    )
 
 
 def _skill_closure_conditional_growth_allowed(
@@ -2388,6 +2378,28 @@ def _baseline_exists(path: Path, *, root: Path) -> bool:
         raise ScanError(f"failed to inspect baseline {path}: {exc}") from exc
 
 
+def _write_baseline_with_readback(
+    destination: Path,
+    *,
+    root: Path,
+    intended: str,
+    parse: Callable[[str], T],
+) -> T:
+    """Atomically publish canonical bytes and verify their typed read-back."""
+    expected = parse(intended)
+    try:
+        larch_io.trusted_atomic_write(destination, intended, root=root)
+        read_back = larch_io.read_trusted_text(destination, root=root, reject_cr=True)
+    except (OSError, UnicodeError, ValueError) as exc:
+        raise ScanError(f"failed to write baseline {destination}: {exc}") from exc
+    if read_back != intended:
+        raise ScanError(f"baseline read-back bytes differ after write: {destination}")
+    parsed = parse(read_back)
+    if parsed != expected:
+        raise ScanError(f"baseline read-back records differ after write: {destination}")
+    return parsed
+
+
 def _identity_baseline_kind(row: IdentityBaselineRow) -> IdentityBaselineKind:
     if isinstance(row, KeywordOnlyBaselineRow):
         return "keyword_only"
@@ -2589,14 +2601,14 @@ def write_identity_baseline(  # noqa: PLR0913 - public baseline-write contract i
             "missing baseline reasons for live findings; supply initial_reason:\n  " + labels
         )
     intended = serialize_identity_baseline(written)
-    try:
-        larch_io.trusted_atomic_write(destination, intended, root=root)
-        read_back = larch_io.read_trusted_text(destination, root=root, reject_cr=True)
-    except (OSError, UnicodeError, ValueError) as exc:
-        raise ScanError(f"failed to write baseline {destination}: {exc}") from exc
-    if read_back != intended:
-        raise ScanError(f"baseline read-back bytes differ after write: {destination}")
-    parsed = parse_identity_baseline(read_back, kind=kind, source=f"baseline {destination}")
+    parsed = _write_baseline_with_readback(
+        destination,
+        root=root,
+        intended=intended,
+        parse=lambda text: parse_identity_baseline(
+            text, kind=kind, source=f"baseline {destination}"
+        ),
+    )
     ordered = sorted(written, key=identity_baseline_sort_key)
     if parsed != ordered:
         raise ScanError(f"baseline read-back records differ after write: {destination}")

--- a/python/larch/lint/engine.py
+++ b/python/larch/lint/engine.py
@@ -1524,6 +1524,376 @@ def complexity_history_events(
     return grouped
 
 
+# Skill-closure rows are aggregate records, not source-level findings.  Keep
+# their exact schema and ratchet policy here with the other engine-owned
+# baseline contracts, while closure discovery remains in its dedicated module.
+SKILL_CLOSURE_RATCHETED_TARGETS = ("design", "implement", "review", "panel-tier")
+SKILL_CLOSURE_FILE_RATCHET_TARGETS = frozenset({"panel-tier"})
+SKILL_CLOSURE_METRIC_FIELDS = (
+    "skill_md_lines",
+    "skill_md_estimated_tokens",
+    "skill_md_content_estimated_tokens",
+    "closure_lines",
+    "closure_estimated_tokens",
+    "closure_content_estimated_tokens",
+)
+SKILL_CLOSURE_CONDITIONAL_METRIC_FIELDS = (
+    "conditional_lines",
+    "conditional_estimated_tokens",
+    "conditional_content_estimated_tokens",
+)
+_SKILL_CLOSURE_CONDITIONAL_TO_EAGER_METRIC = {
+    "conditional_lines": "closure_lines",
+    "conditional_estimated_tokens": "closure_estimated_tokens",
+    "conditional_content_estimated_tokens": "closure_content_estimated_tokens",
+}
+_SKILL_CLOSURE_FIELDS = frozenset(
+    {
+        "skill",
+        *SKILL_CLOSURE_METRIC_FIELDS,
+        "files",
+        *SKILL_CLOSURE_CONDITIONAL_METRIC_FIELDS,
+        "conditional_files",
+    }
+)
+SKILL_CLOSURE_BASELINE_KEYS = _SKILL_CLOSURE_FIELDS
+
+
+@dataclass(frozen=True)
+class SkillClosureBaselineRow:
+    """One immutable aggregate skill-closure baseline record."""
+
+    skill: str
+    skill_md_lines: int
+    skill_md_estimated_tokens: int
+    skill_md_content_estimated_tokens: int
+    closure_lines: int
+    closure_estimated_tokens: int
+    closure_content_estimated_tokens: int
+    files: tuple[str, ...]
+    conditional_lines: int
+    conditional_estimated_tokens: int
+    conditional_content_estimated_tokens: int
+    conditional_files: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class SkillClosureGrowthArgs:
+    """Validated arguments for the skill-closure growth lint command."""
+
+    root: Path
+    write: bool
+    skill: str | None
+
+
+@dataclass(frozen=True)
+class SkillClosureReportArgs:
+    """Validated arguments for the skill-closure report command."""
+
+    root: Path
+
+
+def parse_skill_closure_report_argv(
+    argv: Sequence[str], *, default_root: Path
+) -> SkillClosureReportArgs | None:
+    """Parse the established scan-only skill-closure report command surface."""
+    parser = argparse.ArgumentParser(
+        prog="cli.py skill-closure report",
+        description="Report and ratchet always-loaded prompt-source closure size.",
+    )
+    _ = parser.add_argument("--root", default=str(default_root))
+    try:
+        parsed = parser.parse_args(argv)
+    except SystemExit as exc:
+        if exc.code == 0:
+            raise
+        return None
+    return SkillClosureReportArgs(root=Path(cast("str", parsed.root)).resolve())
+
+
+def parse_skill_closure_growth_argv(
+    argv: Sequence[str], *, default_root: Path
+) -> SkillClosureGrowthArgs | None:
+    """Parse the established skill-closure growth command surface."""
+    parser = argparse.ArgumentParser(
+        prog="cli.py lint skill-closure-growth",
+        description="Report and ratchet always-loaded prompt-source closure size.",
+    )
+    _ = parser.add_argument("--root", default=str(default_root))
+    _ = parser.add_argument(
+        "--write", action="store_true", help="regenerate the committed baseline"
+    )
+    _ = parser.add_argument(
+        "--skill", choices=SKILL_CLOSURE_RATCHETED_TARGETS, help="check one ratcheted target"
+    )
+    try:
+        parsed = parser.parse_args(argv)
+    except SystemExit as exc:
+        if exc.code == 0:
+            raise
+        return None
+    write = bool(parsed.write)
+    skill = cast("str | None", parsed.skill)
+    if write and skill is not None:
+        print("--skill is check-only; --write regenerates all ratcheted targets", file=sys.stderr)
+        return None
+    return SkillClosureGrowthArgs(
+        root=Path(cast("str", parsed.root)).resolve(), write=write, skill=skill
+    )
+
+
+def _skill_closure_metric(
+    value: object, *, source: str, index: int, field: str
+) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise ScanError(f"{source}: record {index} has invalid {field}")
+    return value
+
+
+def _skill_closure_files(
+    value: object, *, source: str, index: int, field: str, allow_empty: bool
+) -> tuple[str, ...]:
+    if not isinstance(value, list) or (not value and not allow_empty):
+        raise ScanError(f"{source}: record {index} has invalid {field}")
+    paths: list[str] = []
+    for raw in cast("list[object]", value):
+        if (
+            not isinstance(raw, str)
+            or not _nonempty_single_line(raw)
+            or raw.startswith("/")
+            or "\\" in raw
+        ):
+            raise ScanError(f"{source}: record {index} has invalid {field}")
+        path = Path(raw)
+        if path.as_posix() != raw or any(
+            part in {"", ".", ".."} for part in path.parts
+        ):
+            raise ScanError(f"{source}: record {index} has invalid {field}")
+        paths.append(raw)
+    if len(paths) != len(set(paths)):
+        raise ScanError(f"{source}: record {index} has duplicate {field}")
+    return tuple(paths)
+
+
+def _skill_closure_row(
+    raw: object, *, source: str, index: int
+) -> SkillClosureBaselineRow:
+    if not isinstance(raw, dict):
+        raise ScanError(f"{source}: record {index} must be an object")
+    record = cast("Mapping[str, object]", raw)
+    if frozenset(record) != _SKILL_CLOSURE_FIELDS:
+        raise ScanError(
+            f"{source}: record {index} must have exactly {sorted(_SKILL_CLOSURE_FIELDS)}"
+        )
+    skill = record["skill"]
+    if not isinstance(skill, str) or skill not in SKILL_CLOSURE_RATCHETED_TARGETS:
+        raise ScanError(f"{source}: record {index} has invalid skill")
+    return SkillClosureBaselineRow(
+        skill=skill,
+        skill_md_lines=_skill_closure_metric(
+            record["skill_md_lines"], source=source, index=index, field="skill_md_lines"
+        ),
+        skill_md_estimated_tokens=_skill_closure_metric(
+            record["skill_md_estimated_tokens"],
+            source=source,
+            index=index,
+            field="skill_md_estimated_tokens",
+        ),
+        skill_md_content_estimated_tokens=_skill_closure_metric(
+            record["skill_md_content_estimated_tokens"],
+            source=source,
+            index=index,
+            field="skill_md_content_estimated_tokens",
+        ),
+        closure_lines=_skill_closure_metric(
+            record["closure_lines"], source=source, index=index, field="closure_lines"
+        ),
+        closure_estimated_tokens=_skill_closure_metric(
+            record["closure_estimated_tokens"],
+            source=source,
+            index=index,
+            field="closure_estimated_tokens",
+        ),
+        closure_content_estimated_tokens=_skill_closure_metric(
+            record["closure_content_estimated_tokens"],
+            source=source,
+            index=index,
+            field="closure_content_estimated_tokens",
+        ),
+        files=_skill_closure_files(
+            record["files"], source=source, index=index, field="files", allow_empty=False
+        ),
+        conditional_lines=_skill_closure_metric(
+            record["conditional_lines"],
+            source=source,
+            index=index,
+            field="conditional_lines",
+        ),
+        conditional_estimated_tokens=_skill_closure_metric(
+            record["conditional_estimated_tokens"],
+            source=source,
+            index=index,
+            field="conditional_estimated_tokens",
+        ),
+        conditional_content_estimated_tokens=_skill_closure_metric(
+            record["conditional_content_estimated_tokens"],
+            source=source,
+            index=index,
+            field="conditional_content_estimated_tokens",
+        ),
+        conditional_files=_skill_closure_files(
+            record["conditional_files"],
+            source=source,
+            index=index,
+            field="conditional_files",
+            allow_empty=True,
+        ),
+    )
+
+
+def _validate_skill_closure_rows(
+    rows: Sequence[SkillClosureBaselineRow], *, source: str
+) -> list[SkillClosureBaselineRow]:
+    skills = [row.skill for row in rows]
+    if len(skills) != len(set(skills)) or frozenset(skills) != frozenset(
+        SKILL_CLOSURE_RATCHETED_TARGETS
+    ):
+        raise ScanError(f"{source}: baseline must contain one row per ratcheted target")
+    return sorted(rows, key=lambda row: row.skill)
+
+
+def parse_skill_closure_baseline(text: str, *, source: str) -> list[SkillClosureBaselineRow]:
+    """Parse exact aggregate closure records and reject incomplete target sets."""
+    try:
+        decoded = cast("object", json.loads(text))
+    except json.JSONDecodeError as exc:
+        raise ScanError(f"{source}: cannot load baseline: {exc}") from exc
+    if not isinstance(decoded, list):
+        raise ScanError(f"{source}: baseline must be a top-level JSON array")
+    rows = [
+        _skill_closure_row(raw, source=source, index=index)
+        for index, raw in enumerate(cast("list[object]", decoded), start=1)
+    ]
+    return _validate_skill_closure_rows(rows, source=source)
+
+
+def load_skill_closure_baseline(
+    path: str | Path, *, root: Path
+) -> list[SkillClosureBaselineRow]:
+    """Trusted-read and parse a complete aggregate closure baseline."""
+    destination = _validate_baseline_path(path, root=root, write_mode=False)
+    if not _baseline_exists(destination, root=root):
+        raise ScanError(f"baseline not found: {destination}")
+    try:
+        text = larch_io.read_trusted_text(destination, root=root, reject_cr=True)
+    except (OSError, UnicodeError, ValueError) as exc:
+        raise ScanError(f"cannot read baseline {destination}: {exc}") from exc
+    return parse_skill_closure_baseline(text, source=str(destination))
+
+
+def skill_closure_row_record(row: SkillClosureBaselineRow) -> dict[str, object]:
+    """Render one aggregate record using the committed canonical fields."""
+    return {
+        "skill": row.skill,
+        "skill_md_lines": row.skill_md_lines,
+        "skill_md_estimated_tokens": row.skill_md_estimated_tokens,
+        "skill_md_content_estimated_tokens": row.skill_md_content_estimated_tokens,
+        "closure_lines": row.closure_lines,
+        "closure_estimated_tokens": row.closure_estimated_tokens,
+        "closure_content_estimated_tokens": row.closure_content_estimated_tokens,
+        "files": list(row.files),
+        "conditional_lines": row.conditional_lines,
+        "conditional_estimated_tokens": row.conditional_estimated_tokens,
+        "conditional_content_estimated_tokens": row.conditional_content_estimated_tokens,
+        "conditional_files": list(row.conditional_files),
+    }
+
+
+def serialize_skill_closure_baseline(rows: Sequence[SkillClosureBaselineRow]) -> str:
+    """Serialize complete aggregate closure rows byte-stably."""
+    ordered = _validate_skill_closure_rows(rows, source="skill-closure baseline")
+    records = [skill_closure_row_record(row) for row in ordered]
+    return json.dumps(records, indent=2, sort_keys=True) + "\n"
+
+
+def write_skill_closure_baseline(
+    path: str | Path, *, root: Path, rows: Sequence[SkillClosureBaselineRow]
+) -> list[SkillClosureBaselineRow]:
+    """Atomically write a complete baseline and prove byte/record read-back."""
+    destination = _validate_baseline_path(
+        path, root=root, write_mode=True, create_missing_parents=True
+    )
+    intended = serialize_skill_closure_baseline(rows)
+    expected = parse_skill_closure_baseline(intended, source=str(destination))
+    try:
+        larch_io.trusted_atomic_write(destination, intended, root=root)
+        read_back = larch_io.read_trusted_text(destination, root=root, reject_cr=True)
+    except (OSError, UnicodeError, ValueError) as exc:
+        raise ScanError(f"failed to write baseline {destination}: {exc}") from exc
+    if read_back != intended:
+        raise ScanError(f"baseline read-back bytes differ after write: {destination}")
+    parsed = parse_skill_closure_baseline(read_back, source=str(destination))
+    if parsed != expected:
+        raise ScanError(f"baseline read-back records differ after write: {destination}")
+    return parsed
+
+
+def _skill_closure_conditional_growth_allowed(
+    live: SkillClosureBaselineRow, baseline: SkillClosureBaselineRow, metric: str
+) -> bool:
+    moved_to_conditional = (
+        set(baseline.files) - set(baseline.conditional_files)
+    ) & set(live.conditional_files)
+    if not moved_to_conditional:
+        return False
+    eager_metric = _SKILL_CLOSURE_CONDITIONAL_TO_EAGER_METRIC[metric]
+    live_total = getattr(live, eager_metric) + getattr(live, metric)
+    baseline_total = getattr(baseline, eager_metric) + getattr(baseline, metric)
+    return live_total <= baseline_total
+
+
+def skill_closure_growth_violations(
+    live_rows: Sequence[SkillClosureBaselineRow],
+    baseline_rows: Sequence[SkillClosureBaselineRow],
+) -> list[str]:
+    """Compare selected live aggregate rows against a complete typed baseline."""
+    _validate_skill_closure_rows(baseline_rows, source="skill-closure baseline")
+    selected = list(live_rows)
+    if not selected or len({row.skill for row in selected}) != len(selected):
+        raise ScanError("live skill-closure rows must select unique ratcheted targets")
+    if any(row.skill not in SKILL_CLOSURE_RATCHETED_TARGETS for row in selected):
+        raise ScanError("live skill-closure rows contain an invalid ratcheted target")
+    baseline_by_skill = {row.skill: row for row in baseline_rows}
+    violations: list[str] = []
+    for live in selected:
+        baseline = baseline_by_skill[live.skill]
+        violations.extend(
+            f"{live.skill}: {metric} {getattr(live, metric)} > baseline {getattr(baseline, metric)}"
+            for metric in SKILL_CLOSURE_METRIC_FIELDS
+            if getattr(live, metric) > getattr(baseline, metric)
+        )
+        if live.skill == "review":
+            violations.extend(
+                f"{live.skill}: {metric} {getattr(live, metric)} > baseline {getattr(baseline, metric)}"
+                for metric in SKILL_CLOSURE_CONDITIONAL_METRIC_FIELDS
+                if getattr(live, metric) > getattr(baseline, metric)
+                and not _skill_closure_conditional_growth_allowed(live, baseline, metric)
+            )
+        baseline_files = set(baseline.files) | set(baseline.conditional_files)
+        live_files = set(live.files) | set(live.conditional_files)
+        violations.extend(
+            f"{live.skill}: baseline-tracked file dropped {path}"
+            for path in sorted(baseline_files - live_files)
+        )
+        if live.skill in SKILL_CLOSURE_FILE_RATCHET_TARGETS:
+            violations.extend(
+                f"{live.skill}: files added {path}"
+                for path in live.files
+                if path not in set(baseline.files)
+            )
+    return violations
+
+
 # These intentionally-small schemas cover lints whose identities do not fit the
 # location/metric/occurrence baseline families above.  Keeping them here gives
 # those lints the same trusted read, strict JSON, duplicate, and atomic-write
@@ -1935,7 +2305,30 @@ def _validate_baseline_component(path: Path, *, is_parent: bool) -> bool:
     return True
 
 
-def _validate_baseline_path(raw: str | Path, *, root: Path, write_mode: bool) -> Path:
+def _create_baseline_parent(path: Path) -> None:
+    """Create one absent baseline parent and immediately revalidate its type."""
+    try:
+        _ = path.lstat()
+    except FileNotFoundError:
+        pass
+    except OSError as exc:
+        raise ScanError(f"failed to inspect baseline path {path}: {exc}") from exc
+    else:
+        raise ScanError(f"baseline parent changed while validating: {path}")
+    try:
+        path.mkdir()
+    except OSError as exc:
+        raise ScanError(f"failed to create baseline parent {path}: {exc}") from exc
+    _ = _validate_baseline_component(path, is_parent=True)
+
+
+def _validate_baseline_path(
+    raw: str | Path,
+    *,
+    root: Path,
+    write_mode: bool,
+    create_missing_parents: bool = False,
+) -> Path:
     text = str(raw)
     if not _is_single_line(text):
         raise ScanError("baseline path must be a non-empty single-line path")
@@ -1954,10 +2347,14 @@ def _validate_baseline_path(raw: str | Path, *, root: Path, write_mode: bool) ->
     components = relative.parts
     for index, component in enumerate(components):
         current = current / component
-        exists = _validate_baseline_component(
-            current,
-            is_parent=index < len(components) - 1,
-        )
+        is_parent = index < len(components) - 1
+        try:
+            exists = _validate_baseline_component(current, is_parent=is_parent)
+        except ScanError:
+            if not (write_mode and create_missing_parents and is_parent):
+                raise
+            _create_baseline_parent(current)
+            exists = True
         if not exists:
             break
     if write_mode and not absolute.parent.is_dir():

--- a/python/larch/lint/engine.py
+++ b/python/larch/lint/engine.py
@@ -1086,19 +1086,11 @@ BaselineRow: TypeAlias = (
 # schemas so trusted I/O and structural read-back stay centralized.
 ComplexityCode = Literal["C901", "PLR0911", "PLR0912", "PLR0913", "PLR0915"]
 COMPLEXITY_CODES = frozenset({"C901", "PLR0911", "PLR0912", "PLR0913", "PLR0915"})
-_COMPLEXITY_FIELDS = (
-    "file",
-    "code",
-    "qualified_symbol",
-    "metric",
-    "added_at",
-    "history",
-    "source_issue",
-    "reason",
-    "operator_override",
+_COMPLEXITY_LEGACY_FIELDS = frozenset(
+    {"file", "code", "qualified_symbol", "metric"}
 )
-_COMPLEXITY_REQUIRED_FIELDS = frozenset(_COMPLEXITY_FIELDS[:6])
-_COMPLEXITY_OPTIONAL_FIELDS = frozenset(_COMPLEXITY_FIELDS[6:])
+_COMPLEXITY_REQUIRED_FIELDS = _COMPLEXITY_LEGACY_FIELDS | {"added_at", "history"}
+_COMPLEXITY_OPTIONAL_FIELDS = frozenset({"source_issue", "reason", "operator_override"})
 _COMPLEXITY_HISTORY_FIELDS = frozenset({"date", "metric"})
 _COMPLEXITY_OVERRIDE_FIELDS = frozenset({"reason", "issue"})
 
@@ -1300,7 +1292,7 @@ def _parse_complexity_row(  # noqa: C901 - exact legacy schema validation is int
     unknown = keys - _COMPLEXITY_REQUIRED_FIELDS - _COMPLEXITY_OPTIONAL_FIELDS
     if unknown:
         raise ScanError(f"{source}: record {index} has unknown fields {sorted(unknown)}")
-    required = _COMPLEXITY_REQUIRED_FIELDS if strict else frozenset(_COMPLEXITY_FIELDS[:4])
+    required = _COMPLEXITY_REQUIRED_FIELDS if strict else _COMPLEXITY_LEGACY_FIELDS
     missing = required - keys
     if missing:
         raise ScanError(f"{source}: record {index} missing required fields {sorted(missing)}")

--- a/python/larch/lint/engine.py
+++ b/python/larch/lint/engine.py
@@ -1857,7 +1857,7 @@ def skill_closure_growth_violations(
     baseline_rows: Sequence[SkillClosureBaselineRow],
 ) -> list[str]:
     """Compare selected live aggregate rows against a complete typed baseline."""
-    _validate_skill_closure_rows(baseline_rows, source="skill-closure baseline")
+    _ = _validate_skill_closure_rows(baseline_rows, source="skill-closure baseline")
     selected = list(live_rows)
     if not selected or len({row.skill for row in selected}) != len(selected):
         raise ScanError("live skill-closure rows must select unique ratcheted targets")

--- a/python/larch/lint/lint_skill_closure_growth.py
+++ b/python/larch/lint/lint_skill_closure_growth.py
@@ -81,40 +81,7 @@ class FileMetrics:
     content_estimated_tokens: int
 
 
-@dataclass(frozen=True)
-class SkillClosureResult:
-    skill: str
-    skill_md_lines: int
-    skill_md_estimated_tokens: int
-    skill_md_content_estimated_tokens: int
-    closure_lines: int
-    closure_estimated_tokens: int
-    closure_content_estimated_tokens: int
-    files: tuple[str, ...]
-    conditional_lines: int
-    conditional_estimated_tokens: int
-    conditional_content_estimated_tokens: int
-    conditional_files: tuple[str, ...]
-
-
-    def to_engine_row(self) -> engine.SkillClosureBaselineRow:
-        """Project scan results onto the engine-owned aggregate schema."""
-        return engine.SkillClosureBaselineRow(
-            self.skill,
-            self.skill_md_lines,
-            self.skill_md_estimated_tokens,
-            self.skill_md_content_estimated_tokens,
-            self.closure_lines,
-            self.closure_estimated_tokens,
-            self.closure_content_estimated_tokens,
-            self.files,
-            self.conditional_lines,
-            self.conditional_estimated_tokens,
-            self.conditional_content_estimated_tokens,
-            self.conditional_files,
-        )
-
-
+SkillClosureResult: TypeAlias = engine.SkillClosureBaselineRow
 BaselineRow: TypeAlias = engine.SkillClosureBaselineRow
 
 
@@ -556,7 +523,7 @@ def write_baseline(path: Path, results: Iterable[SkillClosureResult]) -> None:
     _ = engine.write_skill_closure_baseline(
         path,
         root=root,
-        rows=[result.to_engine_row() for result in results],
+        rows=list(results),
     )
 
 
@@ -636,7 +603,7 @@ def main(argv: list[str] | None = None) -> int:
         return TOOL_FAILURE_EXIT
 
     violations = engine.skill_closure_growth_violations(
-        [result.to_engine_row() for result in results], baseline
+        results, baseline
     )
     if not violations:
         return 0

--- a/python/larch/lint/lint_skill_closure_growth.py
+++ b/python/larch/lint/lint_skill_closure_growth.py
@@ -2,40 +2,24 @@
 
 from __future__ import annotations
 
-import argparse
-import json
 import re
 import sys
 from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TypedDict, cast
+from typing import TypeAlias
+
+from larch.lint import engine
 
 TOOL_FAILURE_EXIT = 2
 BASELINE_RELPATH = Path("python/skill-closure-baseline.json")
-GATED_SKILLS = ("design", "implement", "review")
+GATED_SKILLS = engine.SKILL_CLOSURE_RATCHETED_TARGETS[:3]
 PANEL_TIER_TARGET = "panel-tier"
-RATCHETED_TARGETS = (*GATED_SKILLS, PANEL_TIER_TARGET)
-FILE_RATCHET_TARGETS = frozenset({PANEL_TIER_TARGET})
-METRIC_FIELDS = (
-    "skill_md_lines",
-    "skill_md_estimated_tokens",
-    "skill_md_content_estimated_tokens",
-    "closure_lines",
-    "closure_estimated_tokens",
-    "closure_content_estimated_tokens",
-)
-CONDITIONAL_METRIC_FIELDS = (
-    "conditional_lines",
-    "conditional_estimated_tokens",
-    "conditional_content_estimated_tokens",
-)
-CONDITIONAL_TO_CLOSURE_METRIC = {
-    "conditional_lines": "closure_lines",
-    "conditional_estimated_tokens": "closure_estimated_tokens",
-    "conditional_content_estimated_tokens": "closure_content_estimated_tokens",
-}
-BASELINE_KEYS = frozenset({"skill", *METRIC_FIELDS, "files", *CONDITIONAL_METRIC_FIELDS, "conditional_files"})
+RATCHETED_TARGETS = engine.SKILL_CLOSURE_RATCHETED_TARGETS
+FILE_RATCHET_TARGETS = engine.SKILL_CLOSURE_FILE_RATCHET_TARGETS
+METRIC_FIELDS = engine.SKILL_CLOSURE_METRIC_FIELDS
+CONDITIONAL_METRIC_FIELDS = engine.SKILL_CLOSURE_CONDITIONAL_METRIC_FIELDS
+BASELINE_KEYS = engine.SKILL_CLOSURE_BASELINE_KEYS
 PLUGIN_ROOT_PREFIX = "${CLAUDE_PLUGIN_ROOT}/"
 CONDITIONAL_SECTIONS_BY_SKILL: dict[str, frozenset[str]] = {
     "design": frozenset(
@@ -86,27 +70,8 @@ CONDITIONAL_REFERENCE_RE = re.compile(
 )
 
 
-class BaselineRowDict(TypedDict):
-    skill: str
-    skill_md_lines: int
-    skill_md_estimated_tokens: int
-    skill_md_content_estimated_tokens: int
-    closure_lines: int
-    closure_estimated_tokens: int
-    closure_content_estimated_tokens: int
-    files: list[str]
-    conditional_lines: int
-    conditional_estimated_tokens: int
-    conditional_content_estimated_tokens: int
-    conditional_files: list[str]
-
-
 class ScanError(ValueError):
     """Raised when closure scanning cannot produce a trusted result."""
-
-
-class BaselineError(ValueError):
-    """Raised when the committed closure baseline cannot be trusted."""
 
 
 @dataclass(frozen=True)
@@ -131,37 +96,26 @@ class SkillClosureResult:
     conditional_content_estimated_tokens: int
     conditional_files: tuple[str, ...]
 
-    def to_baseline_row(self) -> BaselineRowDict:
-        return {
-            "skill": self.skill,
-            "skill_md_lines": self.skill_md_lines,
-            "skill_md_estimated_tokens": self.skill_md_estimated_tokens,
-            "skill_md_content_estimated_tokens": self.skill_md_content_estimated_tokens,
-            "closure_lines": self.closure_lines,
-            "closure_estimated_tokens": self.closure_estimated_tokens,
-            "closure_content_estimated_tokens": self.closure_content_estimated_tokens,
-            "files": list(self.files),
-            "conditional_lines": self.conditional_lines,
-            "conditional_estimated_tokens": self.conditional_estimated_tokens,
-            "conditional_content_estimated_tokens": self.conditional_content_estimated_tokens,
-            "conditional_files": list(self.conditional_files),
-        }
+
+    def to_engine_row(self) -> engine.SkillClosureBaselineRow:
+        """Project scan results onto the engine-owned aggregate schema."""
+        return engine.SkillClosureBaselineRow(
+            self.skill,
+            self.skill_md_lines,
+            self.skill_md_estimated_tokens,
+            self.skill_md_content_estimated_tokens,
+            self.closure_lines,
+            self.closure_estimated_tokens,
+            self.closure_content_estimated_tokens,
+            self.files,
+            self.conditional_lines,
+            self.conditional_estimated_tokens,
+            self.conditional_content_estimated_tokens,
+            self.conditional_files,
+        )
 
 
-@dataclass(frozen=True)
-class BaselineRow:
-    skill: str
-    skill_md_lines: int
-    skill_md_estimated_tokens: int
-    skill_md_content_estimated_tokens: int
-    closure_lines: int
-    closure_estimated_tokens: int
-    closure_content_estimated_tokens: int
-    files: tuple[str, ...]
-    conditional_lines: int
-    conditional_estimated_tokens: int
-    conditional_content_estimated_tokens: int
-    conditional_files: tuple[str, ...]
+BaselineRow: TypeAlias = engine.SkillClosureBaselineRow
 
 
 @dataclass(frozen=True)
@@ -597,183 +551,16 @@ def scan_all(root: Path) -> list[SkillClosureResult]:
     return [scan_target(root, target) for target in RATCHETED_TARGETS]
 
 
-def _validate_int(value: object, *, source: Path, index: int, key: str) -> int:
-    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
-        raise BaselineError(f"{source}: record {index} has invalid {key}")
-    return value
-
-
-def _validate_files(value: object, *, source: Path, index: int, key: str, allow_empty: bool = False) -> tuple[str, ...]:
-    if not isinstance(value, list) or (not value and not allow_empty):
-        raise BaselineError(f"{source}: record {index} has invalid {key}")
-    entries = cast("list[object]", value)
-    result: list[str] = []
-    for item in entries:
-        if not isinstance(item, str) or not item or item.startswith("/"):
-            raise BaselineError(f"{source}: record {index} has invalid {key}")
-        path = Path(item)
-        if any(part in {"", ".", ".."} for part in path.parts):
-            raise BaselineError(f"{source}: record {index} has invalid {key}")
-        result.append(path.as_posix())
-    if len(set(result)) != len(result):
-        raise BaselineError(f"{source}: record {index} has duplicate {key}")
-    return tuple(result)
-
-
-def _validate_baseline_row(item: object, *, source: Path, index: int) -> BaselineRow:
-    if not isinstance(item, dict):
-        raise BaselineError(f"{source}: record {index} must be an object")
-    row = cast("dict[str, object]", item)
-    if set(row.keys()) != set(BASELINE_KEYS):
-        raise BaselineError(f"{source}: record {index} must have exactly {sorted(BASELINE_KEYS)}")
-    skill = row["skill"]
-    if not isinstance(skill, str) or skill not in RATCHETED_TARGETS:
-        raise BaselineError(f"{source}: record {index} has invalid skill")
-    return BaselineRow(
-        skill=skill,
-        skill_md_lines=_validate_int(row["skill_md_lines"], source=source, index=index, key="skill_md_lines"),
-        skill_md_estimated_tokens=_validate_int(
-            row["skill_md_estimated_tokens"],
-            source=source,
-            index=index,
-            key="skill_md_estimated_tokens",
-        ),
-        skill_md_content_estimated_tokens=_validate_int(
-            row["skill_md_content_estimated_tokens"],
-            source=source,
-            index=index,
-            key="skill_md_content_estimated_tokens",
-        ),
-        closure_lines=_validate_int(row["closure_lines"], source=source, index=index, key="closure_lines"),
-        closure_estimated_tokens=_validate_int(
-            row["closure_estimated_tokens"],
-            source=source,
-            index=index,
-            key="closure_estimated_tokens",
-        ),
-        closure_content_estimated_tokens=_validate_int(
-            row["closure_content_estimated_tokens"],
-            source=source,
-            index=index,
-            key="closure_content_estimated_tokens",
-        ),
-        files=_validate_files(row["files"], source=source, index=index, key="files"),
-        conditional_lines=_validate_int(
-            row["conditional_lines"],
-            source=source,
-            index=index,
-            key="conditional_lines",
-        ),
-        conditional_estimated_tokens=_validate_int(
-            row["conditional_estimated_tokens"],
-            source=source,
-            index=index,
-            key="conditional_estimated_tokens",
-        ),
-        conditional_content_estimated_tokens=_validate_int(
-            row["conditional_content_estimated_tokens"],
-            source=source,
-            index=index,
-            key="conditional_content_estimated_tokens",
-        ),
-        conditional_files=_validate_files(
-            row["conditional_files"],
-            source=source,
-            index=index,
-            key="conditional_files",
-            allow_empty=True,
-        ),
+def write_baseline(path: Path, results: Iterable[SkillClosureResult]) -> None:
+    root = path.parent.parent if path.parent.name == "python" else path.parent
+    _ = engine.write_skill_closure_baseline(
+        path,
+        root=root,
+        rows=[result.to_engine_row() for result in results],
     )
 
 
-def load_baseline(path: Path) -> list[BaselineRow]:
-    try:
-        raw: object = json.loads(path.read_text(encoding="utf-8"))
-    except FileNotFoundError as exc:
-        raise BaselineError(f"baseline not found: {path}") from exc
-    except UnicodeDecodeError as exc:
-        raise BaselineError(f"cannot read baseline {path}: {exc}") from exc
-    except (OSError, json.JSONDecodeError) as exc:
-        raise BaselineError(f"cannot read baseline {path}: {exc}") from exc
-    if not isinstance(raw, list):
-        raise BaselineError(f"{path}: baseline must be a top-level array")
-    entries = cast("list[object]", raw)
-    rows = [_validate_baseline_row(item, source=path, index=index) for index, item in enumerate(entries, start=1)]
-    skills = [row.skill for row in rows]
-    if sorted(skills) != sorted(RATCHETED_TARGETS) or len(set(skills)) != len(skills):
-        raise BaselineError(f"{path}: baseline must contain one row per ratcheted target")
-    return rows
-
-
-def _canonical_json(results: Iterable[SkillClosureResult]) -> str:
-    rows = [result.to_baseline_row() for result in sorted(results, key=lambda item: item.skill)]
-    return json.dumps(rows, indent=2, sort_keys=True) + "\n"
-
-
-def write_baseline(path: Path, results: Iterable[SkillClosureResult]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    _ = path.write_text(_canonical_json(results), encoding="utf-8")
-
-
-def _conditional_growth_allowed_by_tier_move(result: SkillClosureResult, row: BaselineRow, metric: str) -> bool:
-    moved_to_conditional = (set(row.files) - set(row.conditional_files)) & set(result.conditional_files)
-    if not moved_to_conditional:
-        return False
-    eager_metric = CONDITIONAL_TO_CLOSURE_METRIC[metric]
-    live_combined = getattr(result, eager_metric) + getattr(result, metric)
-    baseline_combined = getattr(row, eager_metric) + getattr(row, metric)
-    return live_combined <= baseline_combined
-
-
-def _growth_violations(live: list[SkillClosureResult], baseline: list[BaselineRow]) -> list[str]:
-    baseline_by_skill = {row.skill: row for row in baseline}
-    violations: list[str] = []
-    for result in live:
-        row = baseline_by_skill[result.skill]
-        for metric in METRIC_FIELDS:
-            live_value = getattr(result, metric)
-            baseline_value = getattr(row, metric)
-            if live_value > baseline_value:
-                violations.append(f"{result.skill}: {metric} {live_value} > baseline {baseline_value}")
-        if result.skill == "review":
-            for metric in CONDITIONAL_METRIC_FIELDS:
-                live_value = getattr(result, metric)
-                baseline_value = getattr(row, metric)
-                if live_value > baseline_value:
-                    if _conditional_growth_allowed_by_tier_move(result, row, metric):
-                        continue
-                    violations.append(f"{result.skill}: {metric} {live_value} > baseline {baseline_value}")
-        baseline_tracked_files = set(row.files) | set(row.conditional_files)
-        live_tracked_files = set(result.files) | set(result.conditional_files)
-        violations.extend(
-            f"{result.skill}: baseline-tracked file dropped {rel}"
-            for rel in sorted(baseline_tracked_files - live_tracked_files)
-        )
-        if result.skill in FILE_RATCHET_TARGETS:
-            baseline_files = set(row.files)
-            violations.extend(
-                f"{result.skill}: files added {rel}"
-                for rel in result.files
-                if rel not in baseline_files
-            )
-    return violations
-
-
-def _parse_args(argv: list[str], *, prog: str, allow_write: bool) -> argparse.Namespace | None:
-    parser = argparse.ArgumentParser(prog=prog, description=__doc__)
-    _ = parser.add_argument("--root", default=str(Path.cwd()))
-    if allow_write:
-        _ = parser.add_argument("--write", action="store_true", help="regenerate the committed baseline")
-        _ = parser.add_argument("--skill", choices=RATCHETED_TARGETS, help="check one ratcheted target")
-    try:
-        return parser.parse_args(argv)
-    except SystemExit as exc:
-        if exc.code == 0:
-            raise
-        return None
-
-
-def _coerce_root(root_text: str, *, prog: str) -> Path | None:
+def _coerce_root(root_text: str | Path, *, prog: str) -> Path | None:
     root = Path(root_text).resolve()
     if not root.is_dir():
         print(f"{prog}: --root is not a directory: {root}", file=sys.stderr)
@@ -811,10 +598,8 @@ def _print_report(results: list[SkillClosureResult]) -> None:
 
 
 def report_main(argv: list[str] | None = None) -> int:
-    parsed = _parse_args(
-        argv if argv is not None else sys.argv[1:],
-        prog="cli.py skill-closure report",
-        allow_write=False,
+    parsed = engine.parse_skill_closure_report_argv(
+        argv if argv is not None else sys.argv[1:], default_root=Path.cwd()
     )
     if parsed is None:
         return TOOL_FAILURE_EXIT
@@ -831,10 +616,8 @@ def report_main(argv: list[str] | None = None) -> int:
 
 
 def main(argv: list[str] | None = None) -> int:
-    parsed = _parse_args(
-        argv if argv is not None else sys.argv[1:],
-        prog="cli.py lint skill-closure-growth",
-        allow_write=True,
+    parsed = engine.parse_skill_closure_growth_argv(
+        argv if argv is not None else sys.argv[1:], default_root=Path.cwd()
     )
     if parsed is None:
         return TOOL_FAILURE_EXIT
@@ -842,19 +625,19 @@ def main(argv: list[str] | None = None) -> int:
     if root is None:
         return TOOL_FAILURE_EXIT
     try:
-        if parsed.write and parsed.skill:
-            raise BaselineError("--skill is check-only; --write regenerates all ratcheted targets")
         if parsed.write:
             results = scan_all(root)
             write_baseline(root / BASELINE_RELPATH, results)
             return 0
         results = [scan_target(root, parsed.skill)] if parsed.skill else scan_all(root)
-        baseline = load_baseline(root / BASELINE_RELPATH)
-    except (BaselineError, ScanError) as exc:
+        baseline = engine.load_skill_closure_baseline(BASELINE_RELPATH, root=root)
+    except (engine.ScanError, ScanError) as exc:
         print(f"lint skill-closure-growth: {exc}", file=sys.stderr)
         return TOOL_FAILURE_EXIT
 
-    violations = _growth_violations(results, baseline)
+    violations = engine.skill_closure_growth_violations(
+        [result.to_engine_row() for result in results], baseline
+    )
     if not violations:
         return 0
     for violation in violations:

--- a/python/lint-engine-adoption-baseline.json
+++ b/python/lint-engine-adoption-baseline.json
@@ -88,22 +88,6 @@
     "rule_id": "engine-adoption"
   },
   {
-    "anchor": "baseline-io",
-    "line": 852,
-    "message": "direct *-baseline.json I/O outside shared lint engine",
-    "path": "python/larch/lint/lint_skill_closure_growth.py",
-    "reason": "Pre-engine legacy lint module; grandfathered until ported onto larch.lint.engine (#6967).",
-    "rule_id": "engine-adoption"
-  },
-  {
-    "anchor": "argparse-construction",
-    "line": 763,
-    "message": "legacy ArgumentParser construction outside shared lint engine",
-    "path": "python/larch/lint/lint_skill_closure_growth.py",
-    "reason": "Pre-engine legacy lint module; grandfathered until ported onto larch.lint.engine (#6967).",
-    "rule_id": "engine-adoption"
-  },
-  {
     "anchor": "argparse-construction",
     "line": 20,
     "message": "legacy ArgumentParser construction outside shared lint engine",

--- a/python/tests/lint/test_lint_engine.py
+++ b/python/tests/lint/test_lint_engine.py
@@ -10,6 +10,7 @@ import os
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import cast
 
 import pytest
 from larch.lint import engine as lint_engine
@@ -139,6 +140,55 @@ def test_identity_baseline_writer_rejects_mismatched_rows_before_writing(
         )
 
     assert baseline.read_text(encoding="utf-8") == "[]\n"
+
+
+def test_skill_closure_baseline_committed_payload_is_byte_stable(tmp_path: Path) -> None:
+    repo = Path(__file__).resolve().parents[3]
+    payload = (repo / "python" / "skill-closure-baseline.json").read_text(
+        encoding="utf-8"
+    )
+    baseline = tmp_path / "python" / "skill-closure-baseline.json"
+    baseline.parent.mkdir()
+    _ = baseline.write_text(payload, encoding="utf-8")
+
+    rows = lint_engine.load_skill_closure_baseline(
+        "python/skill-closure-baseline.json", root=tmp_path
+    )
+    written = lint_engine.write_skill_closure_baseline(
+        "python/skill-closure-baseline.json", root=tmp_path, rows=rows
+    )
+
+    assert written == rows
+    assert baseline.read_text(encoding="utf-8") == payload
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda payload: payload.pop(),
+        lambda payload: payload.append(dict(payload[0])),
+        lambda payload: payload.append({**payload[0], "skill": "unknown"}),
+        lambda payload: payload[0].update({"closure_lines": True}),
+        lambda payload: payload[0].update({"files": ["../outside.md"]}),
+        lambda payload: payload[0].update({"files": ["skills\\design\\SKILL.md"]}),
+        lambda payload: payload[0].update({"unknown": 1}),
+    ],
+)
+def test_skill_closure_baseline_parser_rejects_untrusted_aggregate_rows(
+    mutation: Callable[[list[dict[str, object]]], None],
+) -> None:
+    repo = Path(__file__).resolve().parents[3]
+    payload = json.loads(
+        (repo / "python" / "skill-closure-baseline.json").read_text(encoding="utf-8")
+    )
+    assert isinstance(payload, list)
+    records = [dict(item) for item in cast("list[dict[str, object]]", payload)]
+    mutation(records)
+
+    with pytest.raises(lint_engine.ScanError):
+        _ = lint_engine.parse_skill_closure_baseline(
+            json.dumps(records), source="fixture"
+        )
 
 
 def _rule(

--- a/python/tests/lint/test_lint_engine.py
+++ b/python/tests/lint/test_lint_engine.py
@@ -165,17 +165,17 @@ def test_skill_closure_baseline_committed_payload_is_byte_stable(tmp_path: Path)
 @pytest.mark.parametrize(
     "mutation",
     [
-        lambda payload: payload.pop(),
-        lambda payload: payload.append(dict(payload[0])),
-        lambda payload: payload.append({**payload[0], "skill": "unknown"}),
-        lambda payload: payload[0].update({"closure_lines": True}),
-        lambda payload: payload[0].update({"files": ["../outside.md"]}),
-        lambda payload: payload[0].update({"files": ["skills\\design\\SKILL.md"]}),
-        lambda payload: payload[0].update({"unknown": 1}),
+        "missing",
+        "duplicate",
+        "extra",
+        "bool",
+        "parent",
+        "backslash",
+        "unknown",
     ],
 )
 def test_skill_closure_baseline_parser_rejects_untrusted_aggregate_rows(
-    mutation: Callable[[list[dict[str, object]]], None],
+    mutation: str,
 ) -> None:
     repo = Path(__file__).resolve().parents[3]
     payload = json.loads(
@@ -183,7 +183,20 @@ def test_skill_closure_baseline_parser_rejects_untrusted_aggregate_rows(
     )
     assert isinstance(payload, list)
     records = [dict(item) for item in cast("list[dict[str, object]]", payload)]
-    mutation(records)
+    if mutation == "missing":
+        _ = records.pop()
+    elif mutation == "duplicate":
+        records.append(dict(records[0]))
+    elif mutation == "extra":
+        records.append({**records[0], "skill": "unknown"})
+    elif mutation == "bool":
+        records[0]["closure_lines"] = True
+    elif mutation == "parent":
+        records[0]["files"] = ["../outside.md"]
+    elif mutation == "backslash":
+        records[0]["files"] = ["skills\\design\\SKILL.md"]
+    else:
+        records[0]["unknown"] = 1
 
     with pytest.raises(lint_engine.ScanError):
         _ = lint_engine.parse_skill_closure_baseline(


### PR DESCRIPTION
Fixes #7535.

Moves typed aggregate closure-baseline parsing, validation, comparison, CLI arguments, and trusted atomic I/O into `larch.lint.engine` while preserving scanner and report behavior.

Tests: `python3 -m pytest -q python/tests/lint/test_lint_skill_closure_growth.py python/tests/lint/test_lint_engine.py python/tests/lint/test_lint_engine_adoption.py`; targeted Ruff, Pyright, and Pylint.