### PR TITLE
Fixes #7541: eliminate runtime contract twins

### DIFF
--- a/python/larch/design/clarify.py
+++ b/python/larch/design/clarify.py
@@ -809,13 +809,15 @@ def _append_clarify_failure(
 ) -> None:
     """Record a clarify warning through the shared design failure logger."""
     _ = design_core.append_failure(
-        plugin_root=plugin_root,
-        design_tmpdir=design_tmpdir,
-        site=site,
-        tool=tool,
-        exit_code=exit_code,
-        category="Warnings",
-        output_file=output_file,
+        request=design_core.FailureLogRequest(
+            plugin_root=plugin_root,
+            design_tmpdir=design_tmpdir,
+            site=site,
+            tool=tool,
+            exit_code=exit_code,
+            category="Warnings",
+            output_file=output_file,
+        ),
         env=env,
         runner=proc.run,
     )

--- a/python/larch/design/clarify.py
+++ b/python/larch/design/clarify.py
@@ -36,6 +36,21 @@ ROUTE_STATE_ALLOW = frozenset({"REPO"})
 REQUEST_STATE_ALLOW = frozenset(
     {"REQUEST_ID", "REQUEST_BODY_FILE", "PLAN_FILE", "RESPONSE_FILE", "ISSUE_NUMBER", "REPO"}
 )
+CLARIFY_RESULT_ENV_ALLOW = frozenset({
+    "CLARIFY_FETCH_STATUS",
+    "CLARIFY_PUBLISH_STATUS",
+    "ISSUE_NUMBER",
+    "PLAN_FILE",
+    "PLAN_WRITE_OK",
+    "PUBLISH_OK",
+    "RENAMED",
+    "REPO",
+    "REQUEST_BODY_FILE",
+    "REQUEST_ID",
+    "RESPONSE_FILE",
+    "STATE",
+    "SUMMARY_OUTCOME",
+})
 
 _MARKER_RE = re.compile(
     r"^\s*<!--\s+larch:clarify-(request|response)\s+id=([1-9][0-9]*)\s*-->\s*$"
@@ -730,13 +745,12 @@ def _build_driver_env(args: DesignClarifyArgs) -> tuple[dict[str, str], Path, Pa
 
 
 def _write_result_env(*, path: str | Path, rows: list[tuple[str, str]]) -> None:
-    destination = Path(path)
-    if destination.is_symlink():
-        raise _ClarifyValidationError(f"refusing symlink result env: {destination}")
-    for _key, value in rows:
-        if "\n" in value or "\r" in value:
-            raise _ClarifyValidationError("refusing result env value with newline")
-    larch_io.atomic_write(path=destination, text=larch_io.format_kvs(rows), prefix=f".{destination.name}.")
+    try:
+        design_terminal.phase_driver_write_result_env(
+            path=path, kvs=rows, allow_keys=CLARIFY_RESULT_ENV_ALLOW
+        )
+    except (OSError, ValueError) as exc:
+        raise _ClarifyValidationError(str(exc)) from exc
 
 
 def _read_result_env(*, path: str | Path, allow_keys: frozenset[str]) -> dict[str, str]:
@@ -784,7 +798,8 @@ def _run_cli(
 
 
 def _append_clarify_failure(
-    *, plugin_root: Path,
+    *,
+    plugin_root: Path,
     design_tmpdir: Path,
     env: dict[str, str],
     site: str,
@@ -792,9 +807,18 @@ def _append_clarify_failure(
     exit_code: int,
     output_file: Path,
 ) -> None:
-    # Single-line argv mirrors design_core._append_failure to avoid R0801
-    # duplicate-code collision with decompose._append_failure's multi-line form.
-    _ = _run_cli(plugin_root, env, "run-log", "append-failure", "--log", str(design_tmpdir / "execution-issues.md"), "--site", site, "--tool", tool, "--exit-code", str(exit_code), "--category", "Warnings", "--output-file", str(output_file), "--redact")
+    """Record a clarify warning through the shared design failure logger."""
+    _ = design_core.append_failure(
+        plugin_root=plugin_root,
+        design_tmpdir=design_tmpdir,
+        site=site,
+        tool=tool,
+        exit_code=exit_code,
+        category="Warnings",
+        output_file=output_file,
+        env=env,
+        runner=proc.run,
+    )
 
 
 def _stage_failed_clarify(
@@ -808,14 +832,15 @@ def _stage_failed_clarify(
         detail_log.write_text("clarify failure\n", encoding="utf-8")
     stdout_log = design_tmpdir / "design-clarify-stage.stdout.log"
     stderr_log = design_tmpdir / "design-clarify-stage.stderr.log"
-    # Single-line argv avoids an R0801 duplicate-code collision with
-    # test_design_lifecycle._stage_args's multi-line form (mirrors the
-    # _append_clarify_failure single-line convention above).
     rc = design_core.capture_contract_stream_to_paths(
         design_terminal.stage_terminal_state_core,
         stdout_log,
         stderr_log,
-        ["--design-tmpdir", str(design_tmpdir), "--outcome", "failed-clarify", "--step", "clarify", "--phase", "clarify-loop", "--site", "clarify-loop", "--trigger", "failed", "--bail-reason", "clarify-hard-halt", "--exit-code", str(exit_code), "--source-script", "clarify-loop", "--summary-outcome", "failed-clarify", "--failure-detail-log", str(detail_log)],
+        design_terminal.clarify_failure_stage_args(
+            design_tmpdir=design_tmpdir,
+            exit_code=str(exit_code),
+            detail_log=detail_log,
+        ),
     )
     if rc != 0:
         _append_clarify_failure(

--- a/python/larch/design/design_core.py
+++ b/python/larch/design/design_core.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from collections.abc import Callable, Iterable, Mapping
 
 from larch import io as larch_io
-from larch.core import config, logging_util
+from larch.core import config, logging_util, proc
 from larch.core import redact
 from larch.state.session_env import validate_design_tmpdir
 
@@ -241,11 +241,12 @@ def _cli_cmd(plugin_root: Path, *args: str) -> list[str]:
     return [sys.executable, str(plugin_root / "python" / "cli.py"), *args]
 
 
-def _append_failure(*, plugin_root: Path, design_tmpdir: Path, site: str, tool: str, exit_code: int | str, category: str, output_file: Path) -> bool:
-    result = subprocess.run(
+def append_failure(*, plugin_root: Path, design_tmpdir: Path, site: str, tool: str, exit_code: int | str, category: str, output_file: Path, env: Mapping[str, str] | None = None, runner: Callable[..., proc.CommandResult] = proc.run) -> bool:
+    result = runner(
         _cli_cmd(plugin_root, "run-log", "append-failure", "--log", str(design_tmpdir / "execution-issues.md"), "--site", site, "--tool", tool, "--exit-code", str(exit_code), "--category", category, "--output-file", str(output_file), "--redact"),
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-        check=False,
+        env={**os.environ, **env} if env is not None else None,
     )
     return result.returncode == 0
+
+
+_append_failure = append_failure

--- a/python/larch/design/design_core.py
+++ b/python/larch/design/design_core.py
@@ -9,6 +9,7 @@ import os
 import subprocess
 import sys
 import traceback
+from dataclasses import dataclass
 from pathlib import Path
 from collections.abc import Callable, Iterable, Mapping
 
@@ -241,12 +242,43 @@ def _cli_cmd(plugin_root: Path, *args: str) -> list[str]:
     return [sys.executable, str(plugin_root / "python" / "cli.py"), *args]
 
 
-def append_failure(*, plugin_root: Path, design_tmpdir: Path, site: str, tool: str, exit_code: int | str, category: str, output_file: Path, env: Mapping[str, str] | None = None, runner: Callable[..., proc.CommandResult] = proc.run) -> bool:
+@dataclass(frozen=True)
+class FailureLogRequest:
+    """One structured request to record a design execution failure."""
+
+    plugin_root: Path
+    design_tmpdir: Path
+    site: str
+    tool: str
+    exit_code: int | str
+    category: str
+    output_file: Path
+
+
+def append_failure(
+    *,
+    request: FailureLogRequest,
+    env: Mapping[str, str] | None = None,
+    runner: Callable[..., proc.CommandResult] = proc.run,
+) -> bool:
+    """Append one failure record through the canonical run-log command."""
     result = runner(
-        _cli_cmd(plugin_root, "run-log", "append-failure", "--log", str(design_tmpdir / "execution-issues.md"), "--site", site, "--tool", tool, "--exit-code", str(exit_code), "--category", category, "--output-file", str(output_file), "--redact"),
+        _cli_cmd(request.plugin_root, "run-log", "append-failure", "--log", str(request.design_tmpdir / "execution-issues.md"), "--site", request.site, "--tool", request.tool, "--exit-code", str(request.exit_code), "--category", request.category, "--output-file", str(request.output_file), "--redact"),
         env={**os.environ, **env} if env is not None else None,
     )
     return result.returncode == 0
 
 
-_append_failure = append_failure
+def _append_failure(*, plugin_root: Path, design_tmpdir: Path, site: str, tool: str, exit_code: int | str, category: str, output_file: Path) -> bool:
+    """Compatibility wrapper for established design failure-log call sites."""
+    return append_failure(
+        request=FailureLogRequest(
+            plugin_root=plugin_root,
+            design_tmpdir=design_tmpdir,
+            site=site,
+            tool=tool,
+            exit_code=exit_code,
+            category=category,
+            output_file=output_file,
+        )
+    )

--- a/python/larch/design/design_postplan.py
+++ b/python/larch/design/design_postplan.py
@@ -13,6 +13,7 @@ from collections.abc import Sequence
 
 from larch.git.repo_roots import consumer_repo_root
 from larch.design.design_session import step2b5_next_action_for
+from larch.design.design_terminal import phase_driver_write_result_env
 
 
 # Drift-detection keys read from drift-baseline.env
@@ -28,6 +29,20 @@ POSTPLAN_EMIT_KEYS = (
     "DRIFT_MULTIPLE", "DRIFT_PLAN_RATIO", "DRIFT_DIFF_RATIO", "BASELINE_PLAN_LINES",
     "BASELINE_DIFF_LINES", "PARTITION_REQUESTED",
 )
+POSTPLAN_RESULT_ENV_ALLOW = frozenset({
+    *POSTPLAN_EMIT_KEYS,
+    "FIRM_HEADINGS",
+    "OVERSIZE_OVERRIDE",
+    "SNAPSHOT_STATUS",
+    "STEP2B5_EXIT_RC",
+    "STEP2B5_NEXT_ACTION",
+    "STEP2B5_STATUS",
+    "SURFACES_TOUCHED",
+    "VALIDATE_SKIPPED_COUNT",
+    "VALIDATE_UNSAFE_TOKEN_COUNT",
+    "VALIDATE_LOG_FILE",
+    "VALIDATE_MISSING_SCRIPT_COUNT",
+})
 
 
 def _plugin_root() -> Path:
@@ -43,8 +58,10 @@ def _parse_kv(text: str) -> dict[str, str]:
 
 def _write_result_env(*, path: Path, kvs: dict[str, str]) -> bool:
     try:
-        larch_io.write_kvs(path=path, values=kvs, atomic=False, create_parent=False)
-    except OSError:
+        phase_driver_write_result_env(
+            path=path, kvs=kvs.items(), allow_keys=POSTPLAN_RESULT_ENV_ALLOW
+        )
+    except (OSError, ValueError):
         return False
     return True
 

--- a/python/larch/design/design_publish.py
+++ b/python/larch/design/design_publish.py
@@ -20,8 +20,47 @@ from larch.core import architectural_guidelines, config, proc
 from larch.report.run_log_batch import append_execution_issue
 from larch.design import design_step0_env, plan_grammar
 from larch.design.design_core import capture_contract_stream_to_paths
-from larch.design.design_terminal import extend_publish_failure_stage_args, stage_terminal_state_core
+from larch.design.design_terminal import (
+    extend_publish_failure_stage_args,
+    phase_driver_write_result_env,
+    stage_terminal_state_core,
+)
 from larch.git.repo_roots import consumer_repo_root
+
+PUBLISH_RESULT_ENV_ALLOW = frozenset({
+    "ARCHITECTURE_SOURCE",
+    "ARCH_GUIDE_ASSESSMENT_ARTIFACT",
+    "ARCH_GUIDE_ASSESSMENT_PRESENT",
+    "ARCH_GUIDE_ASSESSMENT_REQUIRED",
+    "ARCH_GUIDE_ASSESSMENT_STATUS",
+    "ARCH_INVARIANT_ASSESSMENT_ARTIFACT",
+    "ARCH_INVARIANT_ASSESSMENT_PRESENT",
+    "ARCH_INVARIANT_ASSESSMENT_REQUIRED",
+    "ARCH_INVARIANT_ASSESSMENT_STATUS",
+    "DESIGNED_ADMISSION_READY",
+    "FINAL_SUMMARY_PATH",
+    "LATEST_PHASE",
+    "LOG_PUBLISH_ATTEMPTED",
+    "LOG_PUBLISH_COMPLETED",
+    "LOG_RECOVERY_BRANCH",
+    "NEW_TITLE",
+    "PLAN_WRITE_OK",
+    "PR_NUMBER",
+    "PR_URL",
+    "PUBLISH_ATTEMPT_ID",
+    "PUBLISH_OK",
+    "PUBLISH_RC_SOURCE",
+    "PUBLISH_REFUSE_REASON",
+    "RECOVERY_BRANCH",
+    "RENAMED",
+    "UPSERT_STATUS",
+    "VALIDATE_DEFECT_COUNT",
+    "VALIDATE_LOG_FILE",
+    "VALIDATE_MISSING_SCRIPT_COUNT",
+    "VALIDATE_SKIPPED_COUNT",
+    "VALIDATE_STATUS",
+    "VALIDATE_UNSAFE_TOKEN_COUNT",
+})
 
 
 @dataclass(frozen=True)
@@ -62,7 +101,9 @@ def _emit_rows(rows: list[tuple[str, str]]) -> None:
 
 def _write_result_env(*, path: Path, rows: list[tuple[str, str]]) -> bool:
     try:
-        larch_io.write_kvs(path=path, values=rows, atomic=True, create_parent=False, mode=0o600)
+        phase_driver_write_result_env(
+            path=path, kvs=rows, allow_keys=PUBLISH_RESULT_ENV_ALLOW
+        )
     except (OSError, ValueError):
         return False
     return True

--- a/python/larch/design/design_step0.py
+++ b/python/larch/design/design_step0.py
@@ -41,7 +41,12 @@ from larch.design.design_step0_env import (
     ROUTE_STATE_KEYS,
     CONFIGURATION_ERROR_RC,
 )
-from larch.design.design_terminal import _replay_warn_error, phase_driver_read_result_env, stage_terminal_state_core
+from larch.design.design_terminal import (
+    _replay_warn_error,
+    clarify_failure_stage_args,
+    phase_driver_read_result_env,
+    stage_terminal_state_core,
+)
 from larch.git.repo_roots import consumer_repo_root
 from larch.state import session_env
 
@@ -701,7 +706,11 @@ def step0_clarify_hard_halt_main(argv: Sequence[str]) -> int:
         stage_terminal_state_core,
         stdout_log,
         stderr_log,
-        ["--design-tmpdir", str(design_tmpdir), "--outcome", "failed-clarify", "--step", "clarify", "--phase", "clarify-loop", "--site", "clarify-loop", "--trigger", "failed", "--bail-reason", "clarify-hard-halt", "--exit-code", ns.exit_code or "1", "--source-script", "clarify-loop", "--summary-outcome", "failed-clarify", "--failure-detail-log", str(detail)],
+        clarify_failure_stage_args(
+            design_tmpdir=design_tmpdir,
+            exit_code=ns.exit_code or "1",
+            detail_log=detail,
+        ),
     )
     stdout_text = stdout_log.read_text(encoding="utf-8", errors="replace") if stdout_log.is_file() else ""
     if "STAGED=false" in stdout_text.splitlines():

--- a/python/larch/design/design_terminal.py
+++ b/python/larch/design/design_terminal.py
@@ -72,13 +72,19 @@ def phase_driver_read_result_env(*, path: str | Path, allow_keys: Iterable[str])
     return [(key, value) for key, values in rows.items() for value in values]
 
 
-def phase_driver_write_result_env(*, path: str | Path, kvs: Iterable[tuple[str, str] | str]) -> None:
+def phase_driver_write_result_env(
+    *,
+    path: str | Path,
+    kvs: Iterable[tuple[str, str] | str],
+    allow_keys: Iterable[str] = PHASE_RESULT_ENV_ALLOW_KEYS,
+) -> None:
     """Atomically write allowlisted KEY=VALUE records to a result-env file.
 
     The trust boundary mirrors the shell phase driver: symlink targets are
     refused, keys must be allowlisted shell variable names, and values may not
     contain CR/LF bytes.
     """
+    allowed = set(allow_keys)
     dest = Path(path)
     if dest.is_symlink():
         raise OSError(f"refusing to write symlink result env: {dest}")
@@ -91,7 +97,7 @@ def phase_driver_write_result_env(*, path: str | Path, kvs: Iterable[tuple[str, 
             key, _, value = item.partition("=")
         else:
             key, value = item
-        if key not in PHASE_RESULT_ENV_ALLOW_KEYS or not _valid_var_name(key):
+        if key not in allowed or not _valid_var_name(key):
             raise ValueError(f"result env key is not allowlisted: {key}")
         if "\n" in value or "\r" in value:
             raise ValueError(f"result env value contains newline: {key}")
@@ -103,6 +109,25 @@ def phase_driver_write_result_env(*, path: str | Path, kvs: Iterable[tuple[str, 
         nofollow=True,
         mode=0o600,
     )
+
+
+def clarify_failure_stage_args(
+    *, design_tmpdir: Path, exit_code: str, detail_log: Path
+) -> list[str]:
+    """Return the shared terminal-state argv for a failed clarify loop."""
+    return [
+        "--design-tmpdir", str(design_tmpdir),
+        "--outcome", "failed-clarify",
+        "--step", "clarify",
+        "--phase", "clarify-loop",
+        "--site", "clarify-loop",
+        "--trigger", "failed",
+        "--bail-reason", "clarify-hard-halt",
+        "--exit-code", exit_code,
+        "--source-script", "clarify-loop",
+        "--summary-outcome", "failed-clarify",
+        "--failure-detail-log", str(detail_log),
+    ]
 
 
 def phase_driver_recreate_result_env(*, path: str | Path, design_tmpdir: str | Path) -> None:

--- a/python/larch/design/design_terminal.py
+++ b/python/larch/design/design_terminal.py
@@ -76,7 +76,7 @@ def phase_driver_write_result_env(
     *,
     path: str | Path,
     kvs: Iterable[tuple[str, str] | str],
-    allow_keys: Iterable[str] = PHASE_RESULT_ENV_ALLOW_KEYS,
+    allow_keys: Iterable[str] | None = None,
 ) -> None:
     """Atomically write allowlisted KEY=VALUE records to a result-env file.
 
@@ -84,7 +84,7 @@ def phase_driver_write_result_env(
     refused, keys must be allowlisted shell variable names, and values may not
     contain CR/LF bytes.
     """
-    allowed = set(allow_keys)
+    allowed = set(PHASE_RESULT_ENV_ALLOW_KEYS if allow_keys is None else allow_keys)
     dest = Path(path)
     if dest.is_symlink():
         raise OSError(f"refusing to write symlink result env: {dest}")

--- a/python/larch/report/run_log_batch.py
+++ b/python/larch/report/run_log_batch.py
@@ -41,6 +41,33 @@ _QUIET_LOG_RE = re.compile(r"^larch-quiet-[A-Za-z0-9._-]+-[0-9]+\.log$")
 _PLACEHOLDER_RUN_ID_RE = re.compile(r"^run-[0-9]+$")
 
 
+def parse_preterminal_outcome_label(text: str) -> str | None:
+    """Return the normalized outcome label from a final-summary heading."""
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line.startswith("## /"):
+            continue
+        colon_index = line.rfind(": ")
+        dash_index = line.rfind(" — ")
+        separator_index = max(colon_index, dash_index)
+        if separator_index < 0:
+            continue
+        separator_len = 3 if dash_index > colon_index else 2
+        label = line[separator_index + separator_len :].strip().lower()
+        return label or None
+    return None
+
+
+def parse_preterminal_outcome_label_from_run_dir(run_dir: Path) -> str | None:
+    """Read and parse a final-summary outcome label when the summary exists."""
+    summary = run_dir / "final-summary.md"
+    if not summary.is_file():
+        return None
+    return parse_preterminal_outcome_label(
+        summary.read_text(encoding="utf-8", errors="replace")
+    )
+
+
 @dataclass(frozen=True)
 class BatchInfo:
     extension: str

--- a/python/larch/report/run_log_commit.py
+++ b/python/larch/report/run_log_commit.py
@@ -36,6 +36,7 @@ from larch.report.run_log_batch import (
     _validate_slug,
     _warn_placeholder_run_id,
     is_placeholder_run_id,
+    parse_preterminal_outcome_label_from_run_dir,
     validate_run_id_slug,
 )
 from larch.report.run_log_manifest import (
@@ -756,30 +757,10 @@ def _publish_breadcrumbs_with_warning(*, log_root: Path, dest: Path) -> None:
 
 
 def _check_preterminal_commit_blocked(log_root: Path, skill: str, run_id: str) -> str | None:
-    """Return a blocked message if the run should not be committed pre-terminally, else None.
-
-    Inline copy to avoid a cyclic import with run_log_flush.
-    Mirrors _preterminal_outcome_commit_blocked / _parse_preterminal_outcome_label.
-    """
+    """Return a blocked message if the run should not be committed pre-terminally."""
     run_dir = _run_dir(log_root=log_root, skill=skill, run_id=run_id)
-    summary_path = run_dir / "final-summary.md"
     try:
-        if not summary_path.is_file():
-            return None
-        summary_text = summary_path.read_text(encoding="utf-8", errors="replace")
-        outcome_label: str | None = None
-        for raw_line in summary_text.splitlines():
-            fsline = raw_line.strip()
-            if not fsline.startswith("## /"):
-                continue
-            colon_i = fsline.rfind(": ")
-            dash_i = fsline.rfind(" — ")
-            sep_i = max(colon_i, dash_i)
-            if sep_i < 0:
-                continue
-            sep_len = 3 if dash_i > colon_i else 2
-            outcome_label = (fsline[sep_i + sep_len:].strip().lower()) or None
-            break
+        outcome_label = parse_preterminal_outcome_label_from_run_dir(run_dir)
         if outcome_label is not None and outcome_label in config.PRETERMINAL_FORBIDDEN_OUTCOME_LABELS:
             raw_msg = (
                 f"refusing pre-terminal run-log commit with terminal outcome label {outcome_label!r};"

--- a/python/larch/report/run_log_flush.py
+++ b/python/larch/report/run_log_flush.py
@@ -36,6 +36,8 @@ from larch.report.run_log_batch import (
     _read_kv_file,
     _read_state_kv,
     _write_batch,
+    parse_preterminal_outcome_label,
+    parse_preterminal_outcome_label_from_run_dir,
 )
 from larch.report.run_log_manifest import (
     REFRESH_SKIP_RECOVERY_FAILED,
@@ -536,26 +538,11 @@ _PRETERMINAL_BLOCK_MESSAGE_MAX_CHARS = 300
 
 
 def _parse_preterminal_outcome_label(text: str) -> str | None:
-    for raw_line in text.splitlines():
-        line = raw_line.strip()
-        if not line.startswith("## /"):
-            continue
-        colon_index = line.rfind(": ")
-        dash_index = line.rfind(" — ")
-        separator_index = max(colon_index, dash_index)
-        if separator_index < 0:
-            continue
-        separator_len = 3 if dash_index > colon_index else 2
-        label = line[separator_index + separator_len:].strip().lower()
-        return label or None
-    return None
+    return parse_preterminal_outcome_label(text)
 
 
 def _parse_preterminal_outcome_label_from_run_dir(run_dir: Path) -> str | None:
-    summary = run_dir / "final-summary.md"
-    if not summary.is_file():
-        return None
-    return _parse_preterminal_outcome_label(summary.read_text(encoding="utf-8", errors="replace"))
+    return parse_preterminal_outcome_label_from_run_dir(run_dir)
 
 
 def _check_preterminal_outcome_label(outcome: str) -> None:

--- a/python/larch/review/_voting_calibration.py
+++ b/python/larch/review/_voting_calibration.py
@@ -22,7 +22,12 @@ from larch.core import logging_util
 from larch.core import proc
 from larch.git import repo_roots
 from larch.report import run_log_corpus
-from larch.review.review_types import JudgeSeverity, ReviewVote
+from larch.review.review_types import (
+    JudgeSeverity,
+    ReviewVote,
+    code_review_classification_header,
+    code_review_classification_required_fields,
+)
 
 # ---------------------------------------------------------------------------
 # Calibration-only constants (private; not re-exported to voting.py callers).
@@ -30,39 +35,19 @@ from larch.review.review_types import JudgeSeverity, ReviewVote
 _SEVERITY_VALUES = {severity.value for severity in JudgeSeverity}
 _LEGACY_SEVERITY_MAP = {"blocker": JudgeSeverity.major.value, "uncertain": ""}
 
-_CODE_REVIEW_COMPACT_CLASSIFICATION_HEADER = (
-    "finding_id\treviewer_slots\tvoting_result\tv1_vote\tv1_correctness\tv1_severity\tv1_quality\tv1_uncertain\tv2_vote\tv2_correctness\tv2_severity\tv2_quality\tv2_uncertain\tv3_vote\tv3_correctness\tv3_severity\tv3_quality\tv3_uncertain"
+_CODE_REVIEW_COMPACT_CLASSIFICATION_HEADER = code_review_classification_header(
+    include_tools=False, include_scope=False
 )
 
 _DESIGN_CLASSIFICATION_REQUIRED = frozenset(
     {"finding_id", "finding_reviewers", "voting_result", "v1_vote", "v2_vote", "v3_vote"}
 )
-_CODE_REVIEW_COMPACT_REQUIRED = frozenset(_CODE_REVIEW_COMPACT_CLASSIFICATION_HEADER.split("\t"))
-# Keep in sync with CODE_REVIEW_FINDINGS_CLASSIFICATION_HEADER in voting.py.
-_CODE_REVIEW_TOOL_REQUIRED = frozenset({
-    "finding_id",
-    "reviewer_slots",
-    "voting_result",
-    "v1_vote",
-    "v1_correctness",
-    "v1_severity",
-    "v1_quality",
-    "v1_uncertain",
-    "v1_tool",
-    "v2_vote",
-    "v2_correctness",
-    "v2_severity",
-    "v2_quality",
-    "v2_uncertain",
-    "v2_tool",
-    "v3_vote",
-    "v3_correctness",
-    "v3_severity",
-    "v3_quality",
-    "v3_uncertain",
-    "v3_tool",
-    "scope",
-})
+_CODE_REVIEW_COMPACT_REQUIRED = code_review_classification_required_fields(
+    include_tools=False, include_scope=False
+)
+_CODE_REVIEW_TOOL_REQUIRED = code_review_classification_required_fields(
+    include_tools=True, include_scope=True
+)
 
 _DESIGN_VOTER_FALLBACKS = {
     1: "codex-validity",

--- a/python/larch/review/review_tally.py
+++ b/python/larch/review/review_tally.py
@@ -23,15 +23,22 @@ from larch.review import findings_ledger
 from larch.core import logging_util
 from larch.review import tally_engine
 from larch.review import voting
-from larch.review.review_types import JudgeSeverity, ReviewVote, is_canonical_heading, is_security_block_text, parse_blocks
+from larch.review.review_types import (
+    JudgeSeverity,
+    ReviewVote,
+    code_review_classification_header,
+    is_canonical_heading,
+    is_security_block_text,
+    parse_blocks,
+)
 
 _PLUGIN_ROOT = Path(__file__).resolve().parents[3]
 _THREE_SLOT_COUNT = 3
 # Issue #4880: smallest effective panel for which a per-item valid-vote count below quorum is a
 # meaningful degradation signal (a 1-voter panel can never drop "below quorum").
 _MIN_DEGRADABLE_PANEL = 2
-_CLASSIFICATION_HEADER = (
-    "finding_id\treviewer_slots\tvoting_result\tv1_vote\tv1_correctness\tv1_severity\tv1_quality\tv1_uncertain\tv2_vote\tv2_correctness\tv2_severity\tv2_quality\tv2_uncertain\tv3_vote\tv3_correctness\tv3_severity\tv3_quality\tv3_uncertain\tscope"
+_CLASSIFICATION_HEADER = code_review_classification_header(
+    include_tools=False, include_scope=True
 )
 _OOS_AGGREGATE_POOL = "oos-aggregate-pool.md"
 

--- a/python/larch/review/review_types.py
+++ b/python/larch/review/review_types.py
@@ -38,6 +38,47 @@ FINDING_SCOPE_VALUES = tuple(member.value for member in FindingScope)
 FINDING_SCOPE_SET = frozenset(FINDING_SCOPE_VALUES)
 """Immutable membership projection for parsing reviewer input."""
 
+_CODE_REVIEW_CLASSIFICATION_PREFIX = (
+    "finding_id",
+    "reviewer_slots",
+    "voting_result",
+)
+_CODE_REVIEW_CLASSIFICATION_VOTER_FIELDS = (
+    "vote",
+    "correctness",
+    "severity",
+    "quality",
+    "uncertain",
+    "tool",
+)
+
+
+def code_review_classification_header(
+    *, include_tools: bool, include_scope: bool
+) -> str:
+    """Return the canonical code-review classification TSV header variant."""
+    columns: list[str] = list(_CODE_REVIEW_CLASSIFICATION_PREFIX)
+    for voter in range(1, 4):
+        columns.extend(
+            f"v{voter}_{field}"
+            for field in _CODE_REVIEW_CLASSIFICATION_VOTER_FIELDS
+            if include_tools or field != "tool"
+        )
+    if include_scope:
+        columns.append("scope")
+    return "\t".join(columns)
+
+
+def code_review_classification_required_fields(
+    *, include_tools: bool, include_scope: bool
+) -> frozenset[str]:
+    """Return the required-column projection for one canonical header variant."""
+    return frozenset(
+        code_review_classification_header(
+            include_tools=include_tools, include_scope=include_scope
+        ).split("\t")
+    )
+
 
 def render_wire_values(values: tuple[str, ...], *, delimiter: str = "/", quoted: bool = False) -> str:
     """Render a canonical wire-value projection without creating another list."""

--- a/python/larch/review/voting.py
+++ b/python/larch/review/voting.py
@@ -29,6 +29,7 @@ from larch.review.review_types import (
     JudgeSeverity,
     ParsedBlock,
     ReviewVote,
+    code_review_classification_header as _code_review_classification_header,
     is_security_block_text,
     parse_blocks,
 )
@@ -120,8 +121,8 @@ FINDINGS_CLASSIFICATION_HEADER = (
     "finding_id\tfinding_reviewers\tvoting_result\tv1_vote\tv1_correctness\tv1_severity\tv1_quality\tv1_uncertain\tv1_tool\tv2_vote\tv2_correctness\tv2_severity\tv2_quality\tv2_uncertain\tv2_tool\tv3_vote\tv3_correctness\tv3_severity\tv3_quality\tv3_uncertain\tv3_tool\tbody_severity\tscope"
 )
 
-CODE_REVIEW_FINDINGS_CLASSIFICATION_HEADER = (
-    "finding_id\treviewer_slots\tvoting_result\tv1_vote\tv1_correctness\tv1_severity\tv1_quality\tv1_uncertain\tv1_tool\tv2_vote\tv2_correctness\tv2_severity\tv2_quality\tv2_uncertain\tv2_tool\tv3_vote\tv3_correctness\tv3_severity\tv3_quality\tv3_uncertain\tv3_tool\tscope"
+CODE_REVIEW_FINDINGS_CLASSIFICATION_HEADER = _code_review_classification_header(
+    include_tools=True, include_scope=True
 )
 
 # Re-exports from sibling module — preserves `voting.X` access for callers and tests.

--- a/python/layering-baseline.json
+++ b/python/layering-baseline.json
@@ -1,19 +1,5 @@
 [
   {
-    "file": "larch/core/architectural_guidelines.py",
-    "qualified_symbol": "<module>",
-    "imported_package": "larch.issue",
-    "occurrence": 1,
-    "reason": "grandfathered upward import pre-layering-ratchet"
-  },
-  {
-    "file": "larch/core/architectural_guidelines.py",
-    "qualified_symbol": "<module>",
-    "imported_package": "larch.state",
-    "occurrence": 1,
-    "reason": "grandfathered upward import pre-layering-ratchet"
-  },
-  {
     "file": "larch/core/coder_delta_guards.py",
     "qualified_symbol": "<module>",
     "imported_package": "larch.git",

--- a/python/tests/design/test_clarify.py
+++ b/python/tests/design/test_clarify.py
@@ -963,11 +963,13 @@ def test_design_clarify_write_result_env_trust_boundaries(tmp_path: Path) -> Non
     link = tmp_path / "link.env"
     link.symlink_to(target)
     with pytest.raises(clarify._ClarifyValidationError):  # pyright: ignore[reportPrivateUsage]
-        clarify._write_result_env(path=link, rows=[("A", "1")])  # pyright: ignore[reportPrivateUsage]
+        clarify._write_result_env(path=link, rows=[("REQUEST_ID", "1")])  # pyright: ignore[reportPrivateUsage]
     with pytest.raises(clarify._ClarifyValidationError):  # pyright: ignore[reportPrivateUsage]
-        clarify._write_result_env(path=target, rows=[("A", "bad\nvalue")])  # pyright: ignore[reportPrivateUsage]
-    clarify._write_result_env(path=target, rows=[("A", "1"), ("B", "2")])  # pyright: ignore[reportPrivateUsage]
-    assert target.read_text(encoding="utf-8") == "A=1\nB=2\n"
+        clarify._write_result_env(path=target, rows=[("REQUEST_ID", "bad\nvalue")])  # pyright: ignore[reportPrivateUsage]
+    with pytest.raises(clarify._ClarifyValidationError):  # pyright: ignore[reportPrivateUsage]
+        clarify._write_result_env(path=target, rows=[("UNEXPECTED", "1")])  # pyright: ignore[reportPrivateUsage]
+    clarify._write_result_env(path=target, rows=[("REQUEST_ID", "1"), ("PLAN_FILE", "2")])  # pyright: ignore[reportPrivateUsage]
+    assert target.read_text(encoding="utf-8") == "REQUEST_ID=1\nPLAN_FILE=2\n"
     assert not list(tmp_path.glob(".result.env.*"))
 
 

--- a/python/tests/review/test_voting.py
+++ b/python/tests/review/test_voting.py
@@ -14,7 +14,12 @@ import pytest
 
 from larch.review import voting
 from larch.core import config
-from larch.review.review_types import JudgeSeverity, ReviewVote
+from larch.review.review_types import (
+    JudgeSeverity,
+    ReviewVote,
+    code_review_classification_header,
+    code_review_classification_required_fields,
+)
 from tests.support.review_wire import vote_lines
 
 CLI = Path(__file__).resolve().parents[2] / "cli.py"
@@ -812,6 +817,19 @@ def test_classification_tsv_schema_supported() -> None:
         "finding_id\tfinding_reviewers\tvoting_result\n",
         panel_kind="design",
     )
+
+
+def test_code_review_classification_header_variants_share_one_schema() -> None:
+    full = code_review_classification_header(include_tools=True, include_scope=True)
+    compact = code_review_classification_header(include_tools=False, include_scope=False)
+    tally = code_review_classification_header(include_tools=False, include_scope=True)
+
+    assert full == voting.CODE_REVIEW_FINDINGS_CLASSIFICATION_HEADER
+    assert compact + "\tscope" == tally
+    assert "v1_tool" not in tally
+    assert code_review_classification_required_fields(
+        include_tools=True, include_scope=True
+    ) == frozenset(full.split("\t"))
 
 
 def test_parse_rate_retry_classify_only_dispatch_shaped_argv(tmp_path: Path) -> None:


### PR DESCRIPTION
Fixes #7541

## Summary

- Derive review classification schema variants and result-env writes from shared owners.
- Share preterminal outcome parsing and clarify failure-stage construction.
- Remove the two stale layering-baseline entries.

## Verification

- `pre-commit run --files …`
- Focused pytest suite: 961 passed
- `python3 python/cli.py lint layering`
- `python3 python/cli.py lint result-env-key-parity`
- `python3 python/cli.py lint duplicate-code`

## Architecture

Consulted `ARCHITECTURAL_INVARIANTS.md` and `ARCHITECTURAL_GUIDELINES.md`; no deviations identified.

The triage marker replacement remains local because it is strict, in-memory validation, while `replace_markdown_block` is a recovery-oriented file upsert API. The skill-closure writer is already centralized in `larch.lint.engine` on current main.