### PR TITLE
Fixes #7539: export shared lint-engine helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -264,73 +264,24 @@ regen-markdown-heading-fence-state-baseline:
 skill-closure-size:
 	$(PYTHON) python/cli.py skill-closure report
 
-.PHONY: lint-lifecycle-prefix-literal lint-prefix-case-variant
+LINT_RULES := skill-closure-growth guideline-no-exception lifecycle-prefix-literal prefix-case-variant markdown-heading-fence-state doc-pointer-paths self-disarmable-gate unreachable-branch status-routing-truthiness pylint-skip-file module-manifest engine-adoption
+LINT_TEST_RULES := guideline-no-exception markdown-heading-fence-state doc-pointer-paths self-disarmable-gate unreachable-branch status-routing-truthiness pylint-skip-file module-manifest engine-adoption
 
-lint-skill-closure-growth:
-	$(PYTHON) python/cli.py lint skill-closure-growth
+.PHONY: FORCE
+FORCE:
+
+lint-%: FORCE
+	$(PYTHON) python/cli.py lint $*
+
+test-lint-%: FORCE
+	@rule="$$(printf '%s' '$*' | tr '-' '_')"; \
+	$(PYTHON) python/cli.py timing harness-mark --label $@ -- $(PYTHON) -m pytest "python/tests/lint/test_lint_$$rule.py" -q
 
 lint-guideline-no-exception:
 	$(PYTHON) python/cli.py lint guideline-no-exception
 
-lint-lifecycle-prefix-literal:
-	$(PYTHON) python/cli.py lint lifecycle-prefix-literal
-
-lint-prefix-case-variant:
-	$(PYTHON) python/cli.py lint prefix-case-variant
-
 test-lint-guideline-no-exception:
 	$(PYTHON) python/cli.py timing harness-mark --label $@ -- $(PYTHON) -m pytest python/tests/lint/test_lint_guideline_no_exception.py -q
-
-.PHONY: lint-markdown-heading-fence-state test-lint-markdown-heading-fence-state lint-doc-pointer-paths test-lint-doc-pointer-paths lint-self-disarmable-gate test-lint-self-disarmable-gate lint-unreachable-branch test-lint-unreachable-branch lint-status-routing-truthiness test-lint-status-routing-truthiness lint-pylint-skip-file test-lint-pylint-skip-file
-lint-markdown-heading-fence-state:
-	$(PYTHON) python/cli.py lint markdown-heading-fence-state
-
-test-lint-markdown-heading-fence-state:
-	$(PYTHON) python/cli.py timing harness-mark --label $@ -- $(PYTHON) -m pytest python/tests/lint/test_lint_markdown_heading_fence_state.py -q
-
-lint-doc-pointer-paths:
-	$(PYTHON) python/cli.py lint doc-pointer-paths
-
-test-lint-doc-pointer-paths:
-	$(PYTHON) python/cli.py timing harness-mark --label $@ -- $(PYTHON) -m pytest python/tests/lint/test_lint_doc_pointer_paths.py -q
-
-lint-self-disarmable-gate:
-	$(PYTHON) python/cli.py lint self-disarmable-gate
-
-test-lint-self-disarmable-gate:
-	$(PYTHON) python/cli.py timing harness-mark --label $@ -- $(PYTHON) -m pytest python/tests/lint/test_lint_self_disarmable_gate.py -q
-
-lint-unreachable-branch:
-	$(PYTHON) python/cli.py lint unreachable-branch
-
-test-lint-unreachable-branch:
-	$(PYTHON) python/cli.py timing harness-mark --label $@ -- $(PYTHON) -m pytest python/tests/lint/test_lint_unreachable_branch.py -q
-
-lint-status-routing-truthiness:
-	$(PYTHON) python/cli.py lint status-routing-truthiness
-
-test-lint-status-routing-truthiness:
-	$(PYTHON) python/cli.py timing harness-mark --label $@ -- $(PYTHON) -m pytest python/tests/lint/test_lint_status_routing_truthiness.py -q
-
-lint-pylint-skip-file:
-	$(PYTHON) python/cli.py lint pylint-skip-file
-
-test-lint-pylint-skip-file:
-	$(PYTHON) python/cli.py timing harness-mark --label $@ -- $(PYTHON) -m pytest python/tests/lint/test_lint_pylint_skip_file.py -q
-
-.PHONY: lint-module-manifest test-lint-module-manifest
-lint-module-manifest:
-	$(PYTHON) python/cli.py lint module-manifest
-
-test-lint-module-manifest:
-	$(PYTHON) python/cli.py timing harness-mark --label $@ -- $(PYTHON) -m pytest python/tests/lint/test_lint_module_manifest.py -q
-
-.PHONY: lint-engine-adoption test-lint-engine-adoption
-lint-engine-adoption:
-	$(PYTHON) python/cli.py lint engine-adoption
-
-test-lint-engine-adoption:
-	$(PYTHON) python/cli.py timing harness-mark --label $@ -- $(PYTHON) -m pytest python/tests/lint/test_lint_engine_adoption.py -q
 
 py-typecheck:
 	@$(PYTHON) -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 11) else 1)' \

--- a/Makefile
+++ b/Makefile
@@ -264,18 +264,11 @@ regen-markdown-heading-fence-state-baseline:
 skill-closure-size:
 	$(PYTHON) python/cli.py skill-closure report
 
-LINT_RULES := skill-closure-growth guideline-no-exception lifecycle-prefix-literal prefix-case-variant markdown-heading-fence-state doc-pointer-paths self-disarmable-gate unreachable-branch status-routing-truthiness pylint-skip-file module-manifest engine-adoption
-LINT_TEST_RULES := guideline-no-exception markdown-heading-fence-state doc-pointer-paths self-disarmable-gate unreachable-branch status-routing-truthiness pylint-skip-file module-manifest engine-adoption
-
 .PHONY: FORCE
 FORCE:
 
 lint-%: FORCE
 	$(PYTHON) python/cli.py lint $*
-
-test-lint-%: FORCE
-	@rule="$$(printf '%s' '$*' | tr '-' '_')"; \
-	$(PYTHON) python/cli.py timing harness-mark --label $@ -- $(PYTHON) -m pytest "python/tests/lint/test_lint_$$rule.py" -q
 
 lint-guideline-no-exception:
 	$(PYTHON) python/cli.py lint guideline-no-exception

--- a/python/larch/lint/engine.py
+++ b/python/larch/lint/engine.py
@@ -257,6 +257,18 @@ def iter_python_source_files(
     return files
 
 
+def iter_all_python_source_files(
+    root: Path, *, excluded_relpaths: frozenset[str] = frozenset()
+) -> list[Path]:
+    """Return all regular Python files, including test fixtures, in a rule scope."""
+    return iter_python_source_files(
+        root,
+        is_exempt=lambda _path: False,
+        excluded_dirs=frozenset(),
+        excluded_relpaths=excluded_relpaths,
+    )
+
+
 def qualified_symbol(prefix: tuple[str, ...], *, module_symbol: str = "<module>") -> str:
     """Render a nested AST scope as its stable baseline symbol."""
     return ".".join(prefix) if prefix else module_symbol

--- a/python/larch/lint/engine.py
+++ b/python/larch/lint/engine.py
@@ -232,6 +232,31 @@ def is_production_python_path(rel_path: str, *, prefix: str = PYTHON_TREE_PREFIX
     )
 
 
+def iter_python_source_files(
+    root: Path,
+    *,
+    scope: Path = Path(),
+    is_exempt: Callable[[Path], bool] = is_exempt_python_source,
+    excluded_dirs: frozenset[str] = PYTHON_EXCLUDED_DIRS,
+    excluded_relpaths: frozenset[str] = frozenset(),
+) -> list[Path]:
+    """Return sorted regular Python files within a rule-defined production scope."""
+    scope_root = root / scope
+    if not scope_root.is_dir():
+        return []
+    files: list[Path] = []
+    for path in sorted(scope_root.rglob("*.py")):
+        if not path.is_file() or path.is_symlink() or is_exempt(path):
+            continue
+        relative = path.relative_to(root)
+        if excluded_dirs.intersection(relative.parts) or any(
+            relative.is_relative_to(Path(excluded)) for excluded in excluded_relpaths
+        ):
+            continue
+        files.append(path)
+    return files
+
+
 def qualified_symbol(prefix: tuple[str, ...], *, module_symbol: str = "<module>") -> str:
     """Render a nested AST scope as its stable baseline symbol."""
     return ".".join(prefix) if prefix else module_symbol
@@ -804,7 +829,8 @@ def _syntax_finding_line(source: SourceFile, error: SyntaxError) -> int:
     return 1
 
 
-def _comment_tokens_by_line(source: str) -> dict[int, tuple[str, ...]]:
+def comment_tokens_by_line(source: str) -> dict[int, tuple[str, ...]]:
+    """Return source comments keyed by one-based line number."""
     comments: dict[int, list[str]] = {}
     try:
         for token in tokenize.generate_tokens(io.StringIO(source).readline):
@@ -817,13 +843,14 @@ def _comment_tokens_by_line(source: str) -> dict[int, tuple[str, ...]]:
     return {line: tuple(values) for line, values in comments.items()}
 
 
-def _suppression_reason(
+def suppression_reason(
     lineno: int,
     *,
     comments_by_line: Mapping[int, tuple[str, ...]],
     pragma_re: re.Pattern[str],
     empty_pragma_re: re.Pattern[str],
 ) -> str | None:
+    """Return a pragma reason, an empty marker, or no matching pragma."""
     for comment in comments_by_line.get(lineno, ()):
         match = pragma_re.search(comment)
         if match is not None:
@@ -973,10 +1000,10 @@ def _apply_inline_suppressions(
     pragma_re: re.Pattern[str],
     empty_pragma_re: re.Pattern[str],
 ) -> list[Finding]:
-    comments_by_line = _comment_tokens_by_line(source.text)
+    comments_by_line = comment_tokens_by_line(source.text)
     accepted: list[Finding] = []
     for finding in findings:
-        reason = _suppression_reason(
+        reason = suppression_reason(
             finding.line,
             comments_by_line=comments_by_line,
             pragma_re=pragma_re,

--- a/python/larch/lint/engine.py
+++ b/python/larch/lint/engine.py
@@ -269,6 +269,19 @@ def iter_all_python_source_files(
     )
 
 
+def read_python_ast(path: Path, *, root: Path) -> tuple[str, ast.Module]:
+    """Read and parse one Python source file relative to a rule root."""
+    relative = path.relative_to(root).as_posix()
+    try:
+        source = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        raise ScanError(f"{relative}: cannot read source: {exc}") from exc
+    try:
+        return source, ast.parse(source, filename=relative)
+    except SyntaxError as exc:
+        raise ScanError(f"{relative}: cannot parse source: {exc}") from exc
+
+
 def qualified_symbol(prefix: tuple[str, ...], *, module_symbol: str = "<module>") -> str:
     """Render a nested AST scope as its stable baseline symbol."""
     return ".".join(prefix) if prefix else module_symbol

--- a/python/larch/lint/lint_env_via_config_constant.py
+++ b/python/larch/lint/lint_env_via_config_constant.py
@@ -27,6 +27,7 @@ from larch.lint.engine import (
     SourceFile,
     has_inline_pragma,
     is_exempt_python_source,
+    iter_python_source_files,
     load_json_array,
     normalize_python_file_path,
     parse_lint_argv,
@@ -97,18 +98,11 @@ def _validate_normalized_file(value: object, *, source: Path, index: int, kind: 
 
 def iter_source_files(python_dir: Path) -> list[Path]:
     """Return recursively discovered production Python files, sorted."""
-    result: list[Path] = []
-    for path in sorted(python_dir.rglob("*.py")):
-        if not path.is_file() or path.is_symlink() or is_exempt_python_source(path):
-            continue
-        relative = path.relative_to(python_dir)
-        if EXCLUDED_DIRS.intersection(relative.parts):
-            continue
-        normalized = relative.as_posix()
-        if normalized == CONFIG_RELPATH:
-            continue
-        result.append(path)
-    return result
+    return iter_python_source_files(
+        python_dir,
+        excluded_dirs=EXCLUDED_DIRS,
+        excluded_relpaths=frozenset({CONFIG_RELPATH}),
+    )
 
 
 def is_production_source_path(rel_path: str) -> bool:

--- a/python/larch/lint/lint_gh_argv_literal.py
+++ b/python/larch/lint/lint_gh_argv_literal.py
@@ -7,15 +7,13 @@ intentional raw argv assertions only with a same-line, reason-bearing pragma.
 from __future__ import annotations
 
 import ast
-import io
 import re
 import sys
-import tokenize
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 
-from larch.lint.engine import RuleCli, run_root_cli
+from larch.lint.engine import RuleCli, comment_tokens_by_line, iter_python_source_files, run_root_cli
 
 TOOL_FAILURE_EXIT = 2
 EXEMPT_SUBTREE = Path("larch/git")
@@ -30,26 +28,12 @@ class Finding:
 
 def iter_source_files(python_dir: Path) -> list[Path]:
     """Return sorted regular, non-symlink Python files in the complete scope."""
-    files: list[Path] = []
-    for path in sorted(python_dir.rglob("*.py")):
-        if not path.is_file() or path.is_symlink():
-            continue
-        relative = path.relative_to(python_dir)
-        if relative.is_relative_to(EXEMPT_SUBTREE):
-            continue
-        files.append(path)
-    return files
-
-
-def _comment_tokens_by_line(source: str) -> dict[int, tuple[str, ...]]:
-    comments: dict[int, list[str]] = {}
-    try:
-        for token in tokenize.generate_tokens(io.StringIO(source).readline):
-            if token.type == tokenize.COMMENT:
-                comments.setdefault(token.start[0], []).append(token.string)
-    except tokenize.TokenError as exc:
-        raise RuntimeError(f"cannot tokenize source: {exc}") from exc
-    return {line: tuple(values) for line, values in comments.items()}
+    return iter_python_source_files(
+        python_dir,
+        is_exempt=lambda _path: False,
+        excluded_dirs=frozenset(),
+        excluded_relpaths=frozenset({EXEMPT_SUBTREE.as_posix()}),
+    )
 
 
 def _is_fixture_pragma(
@@ -78,7 +62,7 @@ def scan_file(path: Path, *, root: Path) -> list[Finding]:
         tree = ast.parse(source, filename=relative)
     except SyntaxError as exc:
         raise RuntimeError(f"{relative}: cannot parse source: {exc}") from exc
-    comments_by_line = _comment_tokens_by_line(source)
+    comments_by_line = comment_tokens_by_line(source)
     findings: list[Finding] = []
     for node in ast.walk(tree):
         if not _is_raw_gh_argv(node):

--- a/python/larch/lint/lint_gh_argv_literal.py
+++ b/python/larch/lint/lint_gh_argv_literal.py
@@ -26,16 +26,6 @@ class Finding:
     lineno: int
 
 
-def iter_source_files(python_dir: Path) -> list[Path]:
-    """Return sorted regular, non-symlink Python files in the complete scope."""
-    return iter_python_source_files(
-        python_dir,
-        is_exempt=lambda _path: False,
-        excluded_dirs=frozenset(),
-        excluded_relpaths=frozenset({EXEMPT_SUBTREE.as_posix()}),
-    )
-
-
 def _is_fixture_pragma(
     finding: Finding, *, comments_by_line: Mapping[int, tuple[str, ...]]
 ) -> bool:
@@ -85,7 +75,12 @@ def _run(root: Path) -> int:
     try:
         findings = [
             finding
-            for path in iter_source_files(python_dir)
+            for path in iter_python_source_files(
+                python_dir,
+                is_exempt=lambda _path: False,
+                excluded_dirs=frozenset(),
+                excluded_relpaths=frozenset({EXEMPT_SUBTREE.as_posix()}),
+            )
             for finding in scan_file(path, root=root)
         ]
     except RuntimeError as exc:

--- a/python/larch/lint/lint_gh_argv_literal.py
+++ b/python/larch/lint/lint_gh_argv_literal.py
@@ -13,7 +13,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 
-from larch.lint.engine import RuleCli, comment_tokens_by_line, iter_all_python_source_files, run_root_cli
+from larch.lint.engine import RuleCli, ScanError, comment_tokens_by_line, iter_all_python_source_files, read_python_ast, run_root_cli
 
 TOOL_FAILURE_EXIT = 2
 EXEMPT_SUBTREE = Path("larch/git")
@@ -45,13 +45,9 @@ def scan_file(path: Path, *, root: Path) -> list[Finding]:
     """Return unsuppressed raw GitHub argv list literals in one source file."""
     relative = path.relative_to(root).as_posix()
     try:
-        source = path.read_text(encoding="utf-8")
-    except (OSError, UnicodeDecodeError) as exc:
-        raise RuntimeError(f"{relative}: cannot read source: {exc}") from exc
-    try:
-        tree = ast.parse(source, filename=relative)
-    except SyntaxError as exc:
-        raise RuntimeError(f"{relative}: cannot parse source: {exc}") from exc
+        source, tree = read_python_ast(path, root=root)
+    except ScanError as exc:
+        raise RuntimeError(str(exc)) from exc
     comments_by_line = comment_tokens_by_line(source)
     findings: list[Finding] = []
     for node in ast.walk(tree):

--- a/python/larch/lint/lint_gh_argv_literal.py
+++ b/python/larch/lint/lint_gh_argv_literal.py
@@ -13,7 +13,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 
-from larch.lint.engine import RuleCli, comment_tokens_by_line, iter_python_source_files, run_root_cli
+from larch.lint.engine import RuleCli, comment_tokens_by_line, iter_all_python_source_files, run_root_cli
 
 TOOL_FAILURE_EXIT = 2
 EXEMPT_SUBTREE = Path("larch/git")
@@ -75,11 +75,8 @@ def _run(root: Path) -> int:
     try:
         findings = [
             finding
-            for path in iter_python_source_files(
-                python_dir,
-                is_exempt=lambda _path: False,
-                excluded_dirs=frozenset(),
-                excluded_relpaths=frozenset({EXEMPT_SUBTREE.as_posix()}),
+            for path in iter_all_python_source_files(
+                python_dir, excluded_relpaths=frozenset({EXEMPT_SUBTREE.as_posix()})
             )
             for finding in scan_file(path, root=root)
         ]

--- a/python/larch/lint/lint_git_push_refspec.py
+++ b/python/larch/lint/lint_git_push_refspec.py
@@ -8,15 +8,13 @@ reason-bearing pragma.
 from __future__ import annotations
 
 import ast
-import io
 import re
 import sys
-import tokenize
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 
-from larch.lint.engine import RuleCli, run_root_cli
+from larch.lint.engine import RuleCli, comment_tokens_by_line, iter_python_source_files, run_root_cli
 
 TOOL_FAILURE_EXIT = 2
 PUSH_COMMAND_ELEMENTS = 2
@@ -32,22 +30,11 @@ class Finding:
 
 def iter_source_files(python_dir: Path) -> list[Path]:
     """Return sorted regular, non-symlink Python files in the complete scope."""
-    return [
-        path
-        for path in sorted(python_dir.rglob("*.py"))
-        if path.is_file() and not path.is_symlink()
-    ]
-
-
-def _comment_tokens_by_line(source: str) -> dict[int, tuple[str, ...]]:
-    comments: dict[int, list[str]] = {}
-    try:
-        for token in tokenize.generate_tokens(io.StringIO(source).readline):
-            if token.type == tokenize.COMMENT:
-                comments.setdefault(token.start[0], []).append(token.string)
-    except tokenize.TokenError as exc:
-        raise RuntimeError(f"cannot tokenize source: {exc}") from exc
-    return {line: tuple(values) for line, values in comments.items()}
+    return iter_python_source_files(
+        python_dir,
+        is_exempt=lambda _path: False,
+        excluded_dirs=frozenset(),
+    )
 
 
 def _is_fixture_pragma(
@@ -99,7 +86,7 @@ def scan_file(path: Path, *, root: Path) -> list[Finding]:
         tree = ast.parse(source, filename=relative)
     except SyntaxError as exc:
         raise RuntimeError(f"{relative}: cannot parse source: {exc}") from exc
-    comments_by_line = _comment_tokens_by_line(source)
+    comments_by_line = comment_tokens_by_line(source)
     findings: list[Finding] = []
     for node in ast.walk(tree):
         if not isinstance(node, ast.List) or not _is_raw_git_push_argv(node) or _has_explicit_refspec(node):

--- a/python/larch/lint/lint_git_push_refspec.py
+++ b/python/larch/lint/lint_git_push_refspec.py
@@ -28,15 +28,6 @@ class Finding:
     lineno: int
 
 
-def iter_source_files(python_dir: Path) -> list[Path]:
-    """Return sorted regular, non-symlink Python files in the complete scope."""
-    return iter_python_source_files(
-        python_dir,
-        is_exempt=lambda _path: False,
-        excluded_dirs=frozenset(),
-    )
-
-
 def _is_fixture_pragma(
     finding: Finding, *, comments_by_line: Mapping[int, tuple[str, ...]]
 ) -> bool:
@@ -109,7 +100,11 @@ def _run(root: Path) -> int:
     try:
         findings = [
             finding
-            for path in iter_source_files(python_dir)
+            for path in iter_python_source_files(
+                python_dir,
+                is_exempt=lambda _path: False,
+                excluded_dirs=frozenset(),
+            )
             for finding in scan_file(path, root=root)
         ]
     except RuntimeError as exc:

--- a/python/larch/lint/lint_git_push_refspec.py
+++ b/python/larch/lint/lint_git_push_refspec.py
@@ -14,7 +14,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 
-from larch.lint.engine import RuleCli, comment_tokens_by_line, iter_all_python_source_files, run_root_cli
+from larch.lint.engine import RuleCli, ScanError, comment_tokens_by_line, iter_all_python_source_files, read_python_ast, run_root_cli
 
 TOOL_FAILURE_EXIT = 2
 PUSH_COMMAND_ELEMENTS = 2
@@ -70,13 +70,9 @@ def scan_file(path: Path, *, root: Path) -> list[Finding]:
     """Return raw Git push argv lists without an explicit refspec operand."""
     relative = path.relative_to(root).as_posix()
     try:
-        source = path.read_text(encoding="utf-8")
-    except (OSError, UnicodeDecodeError) as exc:
-        raise RuntimeError(f"{relative}: cannot read source: {exc}") from exc
-    try:
-        tree = ast.parse(source, filename=relative)
-    except SyntaxError as exc:
-        raise RuntimeError(f"{relative}: cannot parse source: {exc}") from exc
+        source, tree = read_python_ast(path, root=root)
+    except ScanError as exc:
+        raise RuntimeError(str(exc)) from exc
     comments_by_line = comment_tokens_by_line(source)
     findings: list[Finding] = []
     for node in ast.walk(tree):

--- a/python/larch/lint/lint_git_push_refspec.py
+++ b/python/larch/lint/lint_git_push_refspec.py
@@ -14,7 +14,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 
-from larch.lint.engine import RuleCli, comment_tokens_by_line, iter_python_source_files, run_root_cli
+from larch.lint.engine import RuleCli, comment_tokens_by_line, iter_all_python_source_files, run_root_cli
 
 TOOL_FAILURE_EXIT = 2
 PUSH_COMMAND_ELEMENTS = 2
@@ -100,11 +100,7 @@ def _run(root: Path) -> int:
     try:
         findings = [
             finding
-            for path in iter_python_source_files(
-                python_dir,
-                is_exempt=lambda _path: False,
-                excluded_dirs=frozenset(),
-            )
+            for path in iter_all_python_source_files(python_dir)
             for finding in scan_file(path, root=root)
         ]
     except RuntimeError as exc:

--- a/python/larch/lint/lint_guidelines_note_wrapper_bypass.py
+++ b/python/larch/lint/lint_guidelines_note_wrapper_bypass.py
@@ -8,15 +8,18 @@ bypassing the re-pin attempt with ``_invalidate_guidelines_note``.
 from __future__ import annotations
 
 import ast
-import io
 import re
 import sys
-import tokenize
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 
-from larch.lint.engine import RuleCli, run_root_cli
+from larch.lint.engine import (
+    RuleCli,
+    comment_tokens_by_line,
+    iter_python_source_files,
+    run_root_cli,
+)
 
 TOOL_FAILURE_EXIT = 2
 TARGET_CALLEE = "_invalidate_guidelines_note"
@@ -42,29 +45,13 @@ def is_exempt_path(path: Path) -> bool:
 
 def iter_source_files(larch_dir: Path) -> list[Path]:
     """Return recursively discovered production Python files under larch/, sorted."""
-    result: list[Path] = []
-    for path in sorted(larch_dir.rglob("*.py")):
-        if not path.is_file() or path.is_symlink() or is_exempt_path(path):
-            continue
-        relative: Path = path.relative_to(larch_dir.parent)
-        normalized: str = relative.as_posix()
-        if EXCLUDED_DIRS.intersection(relative.parts):
-            continue
-        if normalized in {OWNER_RELPATH, LINT_MODULE_RELPATH}:
-            continue
-        result.append(path)
-    return result
-
-
-def _comment_tokens_by_line(source: str) -> dict[int, tuple[str, ...]]:
-    comments: dict[int, list[str]] = {}
-    try:
-        for token in tokenize.generate_tokens(io.StringIO(source).readline):
-            if token.type == tokenize.COMMENT:
-                comments.setdefault(token.start[0], []).append(token.string)
-    except tokenize.TokenError:
-        return {}
-    return {line: tuple(values) for line, values in comments.items()}
+    return iter_python_source_files(
+        larch_dir.parent,
+        scope=Path("larch"),
+        is_exempt=is_exempt_path,
+        excluded_dirs=EXCLUDED_DIRS,
+        excluded_relpaths=frozenset({OWNER_RELPATH, LINT_MODULE_RELPATH}),
+    )
 
 
 def _is_suppressed(finding: Finding, *, comments_by_line: Mapping[int, tuple[str, ...]]) -> bool:
@@ -91,7 +78,7 @@ def scan_file(path: Path, *, larch_dir: Path) -> list[Finding]:
         tree: ast.Module = ast.parse(source)
     except SyntaxError as exc:
         raise RuntimeError(f"{normalized_file}: cannot parse source: {exc}") from exc
-    comments_by_line: dict[int, tuple[str, ...]] = _comment_tokens_by_line(source)
+    comments_by_line: dict[int, tuple[str, ...]] = comment_tokens_by_line(source)
     findings: list[Finding] = []
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call) or not _is_target_call(node):

--- a/python/larch/lint/lint_layering.py
+++ b/python/larch/lint/lint_layering.py
@@ -18,8 +18,8 @@ from typing import cast
 
 from larch.core import proc
 from larch.lint.engine import (
-    is_exempt_python_source,
     is_production_python_path,
+    iter_python_source_files,
     ordered_ast_child_nodes,
     qualified_symbol,
     Finding as EngineFinding,
@@ -78,15 +78,11 @@ class Finding:
 
 def iter_source_files(larch_dir: Path) -> list[Path]:
     """Return recursively discovered production Python files under larch/, sorted."""
-    result: list[Path] = []
-    for path in sorted(larch_dir.rglob("*.py")):
-        if not path.is_file() or path.is_symlink() or is_exempt_python_source(path):
-            continue
-        relative = path.relative_to(larch_dir.parent)
-        if EXCLUDED_DIRS.intersection(relative.parts):
-            continue
-        result.append(path)
-    return result
+    return iter_python_source_files(
+        larch_dir.parent,
+        scope=Path("larch"),
+        excluded_dirs=EXCLUDED_DIRS,
+    )
 
 
 def _importer_package(normalized_file: str) -> str | None:

--- a/python/larch/lint/lint_lifecycle_prefix_literal.py
+++ b/python/larch/lint/lint_lifecycle_prefix_literal.py
@@ -30,6 +30,7 @@ from larch.lint.engine import (
     RuleCli,
     SourceFile,
     is_exempt_python_source,
+    iter_python_source_files,
     ordered_ast_child_nodes,
     qualified_symbol,
     run_rule_cli,
@@ -90,18 +91,12 @@ OccurrenceKey = tuple[str, str, str, str, str]
 
 def iter_source_files(larch_dir: Path) -> list[Path]:
     """Return recursively discovered production Python files under larch/, sorted."""
-    result: list[Path] = []
-    for path in sorted(larch_dir.rglob("*.py")):
-        if not path.is_file() or path.is_symlink() or is_exempt_python_source(path):
-            continue
-        relative: Path = path.relative_to(larch_dir.parent)
-        if EXCLUDED_DIRS.intersection(relative.parts):
-            continue
-        normalized: str = relative.as_posix()
-        if normalized in ALLOWLIST_RELPATHS:
-            continue
-        result.append(path)
-    return result
+    return iter_python_source_files(
+        larch_dir.parent,
+        scope=Path("larch"),
+        excluded_dirs=EXCLUDED_DIRS,
+        excluded_relpaths=ALLOWLIST_RELPATHS,
+    )
 
 
 def is_production_source_path(rel_path: str) -> bool:

--- a/python/larch/lint/lint_renderer_golden_tests.py
+++ b/python/larch/lint/lint_renderer_golden_tests.py
@@ -10,11 +10,9 @@ row.
 from __future__ import annotations
 
 import ast
-import io
 import re
 from re import Pattern
 import sys
-import tokenize
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
@@ -23,6 +21,7 @@ from larch.lint.engine import (
     IdentityLintCli,
     RendererGoldenTestsBaselineRow,
     ScanError,
+    comment_tokens_by_line,
     compare_identity_baseline,
     first_duplicate as _first_duplicate,
     load_identity_baseline,
@@ -100,17 +99,6 @@ def scan_file(path: Path, *, python_dir: Path) -> list[Candidate]:
     return candidates
 
 
-def _comment_tokens_by_line(source: str) -> dict[int, tuple[str, ...]]:
-    comments: dict[int, list[str]] = {}
-    try:
-        for token in tokenize.generate_tokens(io.StringIO(source).readline):
-            if token.type == tokenize.COMMENT:
-                comments.setdefault(token.start[0], []).append(token.string)
-    except tokenize.TokenError:
-        return {}
-    return {line: tuple(values) for line, values in comments.items()}
-
-
 def _is_suppressed(candidate: Candidate, *, comments_by_line: Mapping[int, tuple[str, ...]]) -> bool:
     return any(PRAGMA_RE.search(comment) for comment in comments_by_line.get(candidate.lineno, ()))
 
@@ -143,7 +131,7 @@ def _collect_all(
     for path in iter_report_files(report_dir):
         normalized_file: str = path.relative_to(python_dir).as_posix()
         source: str = _read_source(path, python_dir=python_dir)
-        comments_by_file[normalized_file] = _comment_tokens_by_line(source)
+        comments_by_file[normalized_file] = comment_tokens_by_line(source)
         tree: ast.Module = _parse_source(source, normalized_file=normalized_file)
         for statement in tree.body:
             if not isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef)):

--- a/python/larch/lint/lint_shared_convention_regex.py
+++ b/python/larch/lint/lint_shared_convention_regex.py
@@ -11,16 +11,19 @@ the single source of truth:
 from __future__ import annotations
 
 import ast
-import io
 import re
 import sys
-import tokenize
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 
 from larch.issue.title_match import BUG_PREFIX
-from larch.lint.engine import RuleCli, run_root_cli
+from larch.lint.engine import (
+    RuleCli,
+    comment_tokens_by_line,
+    iter_python_source_files,
+    run_root_cli,
+)
 
 TOOL_FAILURE_EXIT = 2
 EXEMPT_FILENAMES = frozenset({"conftest.py", "test_support.py", "review_test_support.py"})
@@ -46,18 +49,13 @@ def is_exempt_path(path: Path) -> bool:
 
 def iter_source_files(larch_dir: Path) -> list[Path]:
     """Return recursively discovered production Python files under larch/, sorted."""
-    result: list[Path] = []
-    for path in sorted(larch_dir.rglob("*.py")):
-        if not path.is_file() or path.is_symlink() or is_exempt_path(path):
-            continue
-        relative: Path = path.relative_to(larch_dir.parent)
-        normalized: str = relative.as_posix()
-        if EXCLUDED_DIRS.intersection(relative.parts):
-            continue
-        if normalized in ALLOWLIST_RELPATHS or normalized == LINT_MODULE_RELPATH:
-            continue
-        result.append(path)
-    return result
+    return iter_python_source_files(
+        larch_dir.parent,
+        scope=Path("larch"),
+        is_exempt=is_exempt_path,
+        excluded_dirs=EXCLUDED_DIRS,
+        excluded_relpaths=ALLOWLIST_RELPATHS | frozenset({LINT_MODULE_RELPATH}),
+    )
 
 
 def _literal_text(node: ast.AST) -> str | None:
@@ -255,17 +253,6 @@ def _lifecycle_prefix_strip_findings(tree: ast.Module, *, normalized_file: str) 
     return findings
 
 
-def _comment_tokens_by_line(source: str) -> dict[int, tuple[str, ...]]:
-    comments: dict[int, list[str]] = {}
-    try:
-        for token in tokenize.generate_tokens(io.StringIO(source).readline):
-            if token.type == tokenize.COMMENT:
-                comments.setdefault(token.start[0], []).append(token.string)
-    except tokenize.TokenError:
-        return {}
-    return {line: tuple(values) for line, values in comments.items()}
-
-
 def _is_suppressed(finding: Finding, *, comments_by_line: Mapping[int, tuple[str, ...]]) -> bool:
     return any(PRAGMA_RE.search(comment) for comment in comments_by_line.get(finding.lineno, ()))
 
@@ -281,7 +268,7 @@ def scan_file(path: Path, *, larch_dir: Path) -> list[Finding]:
         tree: ast.Module = ast.parse(source)
     except SyntaxError as exc:
         raise RuntimeError(f"{normalized_file}: cannot parse source: {exc}") from exc
-    comments_by_line: dict[int, tuple[str, ...]] = _comment_tokens_by_line(source)
+    comments_by_line: dict[int, tuple[str, ...]] = comment_tokens_by_line(source)
     findings: list[Finding] = []
     findings.extend(_module_assignment_findings(tree, normalized_file=normalized_file))
     findings.extend(_compile_call_findings(tree, normalized_file=normalized_file))

--- a/python/larch/lint/lint_subprocess_via_runner.py
+++ b/python/larch/lint/lint_subprocess_via_runner.py
@@ -28,6 +28,7 @@ from larch.lint.engine import (
     SourceFile,
     has_inline_pragma,
     is_exempt_python_source,
+    iter_python_source_files,
     load_json_array,
     parse_lint_argv,
     run_rule,
@@ -84,18 +85,11 @@ class GhFinding:
 
 def iter_source_files(python_dir: Path) -> list[Path]:
     """Return recursively discovered production Python files, sorted."""
-    result: list[Path] = []
-    for path in sorted(python_dir.rglob("*.py")):
-        if not path.is_file() or path.is_symlink() or is_exempt_python_source(path):
-            continue
-        relative = path.relative_to(python_dir)
-        if EXCLUDED_DIRS.intersection(relative.parts):
-            continue
-        normalized = relative.as_posix()
-        if normalized == RUNNER_RELPATH:
-            continue
-        result.append(path)
-    return result
+    return iter_python_source_files(
+        python_dir,
+        excluded_dirs=EXCLUDED_DIRS,
+        excluded_relpaths=frozenset({RUNNER_RELPATH}),
+    )
 
 
 def is_production_source_path(rel_path: str) -> bool:

--- a/python/larch/lint/lint_suppression_reason.py
+++ b/python/larch/lint/lint_suppression_reason.py
@@ -27,6 +27,7 @@ from larch.lint.engine import (
     Finding as EngineFinding,
     LintRule,
     SourceFile,
+    iter_python_source_files,
     run_rule,
 )
 
@@ -158,15 +159,11 @@ def _is_excluded_relative_path(relative: Path) -> bool:
 
 def iter_source_files(python_dir: Path) -> list[Path]:
     """Return production Python files under python/, sorted."""
-    result: list[Path] = []
-    for path in sorted(python_dir.rglob("*.py")):
-        if not path.is_file() or path.is_symlink():
-            continue
-        relative: Path = path.relative_to(python_dir)
-        if _is_excluded_relative_path(relative):
-            continue
-        result.append(path)
-    return result
+    return iter_python_source_files(
+        python_dir,
+        is_exempt=lambda path: _is_excluded_relative_path(path.relative_to(python_dir)),
+        excluded_dirs=frozenset(),
+    )
 
 
 def _read_source(path: Path, *, python_dir: Path) -> str:

--- a/python/larch/lint/lint_tempfile_dir.py
+++ b/python/larch/lint/lint_tempfile_dir.py
@@ -19,7 +19,7 @@ from larch.lint.engine import (
     LintRule,
     RuleCli,
     SourceFile,
-    is_exempt_python_source,
+    iter_python_source_files,
     is_production_python_path,
     ordered_ast_child_nodes,
     qualified_symbol,
@@ -50,15 +50,11 @@ class Finding:
 
 def iter_source_files(larch_dir: Path) -> list[Path]:
     """Return recursively discovered production Python files under larch/, sorted."""
-    result: list[Path] = []
-    for path in sorted(larch_dir.rglob("*.py")):
-        if not path.is_file() or path.is_symlink() or is_exempt_python_source(path):
-            continue
-        relative = path.relative_to(larch_dir.parent)
-        if EXCLUDED_DIRS.intersection(relative.parts):
-            continue
-        result.append(path)
-    return result
+    return iter_python_source_files(
+        larch_dir.parent,
+        scope=Path("larch"),
+        excluded_dirs=EXCLUDED_DIRS,
+    )
 
 
 def _tempfile_callee(node: ast.AST) -> str | None:

--- a/python/larch/lint/markdown_heading_fence_state_detector.py
+++ b/python/larch/lint/markdown_heading_fence_state_detector.py
@@ -9,14 +9,18 @@ module can stay engine-backed.
 from __future__ import annotations
 
 import ast
-import io
 import re
-import tokenize
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 
-from larch.lint.engine import ScanError, is_exempt_python_source, qualified_symbol
+from larch.lint.engine import (
+    ScanError,
+    comment_tokens_by_line,
+    is_exempt_python_source,
+    qualified_symbol,
+    suppression_reason,
+)
 
 SUPPRESSION = "lint-markdown-heading-fence-state"
 PRAGMA_RE = re.compile(rf"#\s*{re.escape(SUPPRESSION)}:\s*ok\s+(\S.*)$")
@@ -56,29 +60,6 @@ def is_production_source_path(rel_path: str) -> bool:
         return False
     under_python = rel_path[len(PYTHON_TREE_PREFIX) :]
     return not bool(EXCLUDED_DIRS.intersection(Path(under_python).parts))
-
-
-def _comment_tokens_by_line(source: str) -> dict[int, tuple[str, ...]]:
-    comments: dict[int, list[str]] = {}
-    try:
-        for token in tokenize.generate_tokens(io.StringIO(source).readline):
-            if token.type == tokenize.COMMENT:
-                comments.setdefault(token.start[0], []).append(token.string)
-    except tokenize.TokenError:
-        return {}
-    return {line: tuple(values) for line, values in comments.items()}
-
-
-def _suppression_reason(
-    lineno: int, *, comments_by_line: Mapping[int, tuple[str, ...]]
-) -> str | None:
-    for comment in comments_by_line.get(lineno, ()):
-        match = PRAGMA_RE.search(comment)
-        if match is not None:
-            return match.group(1).strip()
-        if EMPTY_PRAGMA_RE.search(comment) is not None:
-            return ""
-    return None
 
 
 def _literal_string(node: ast.AST) -> str | None:
@@ -173,7 +154,12 @@ class _ScopeState:
 
 
 def _record_heading_regex(state: _ScopeState, *, name: str, lineno: int) -> None:
-    reason = _suppression_reason(lineno, comments_by_line=state.comments_by_line)
+    reason = suppression_reason(
+        lineno,
+        comments_by_line=state.comments_by_line,
+        pragma_re=PRAGMA_RE,
+        empty_pragma_re=EMPTY_PRAGMA_RE,
+    )
     if reason is not None:
         if reason == "":
             raise ScanError(
@@ -527,7 +513,7 @@ def _scan_expr(
 
 def scan_text(repo_path: str, source: str, *, tree: ast.Module) -> list[HeadingFenceHit]:
     """Return heading-regex-without-fence hits for one already-parsed source."""
-    comments_by_line = _comment_tokens_by_line(source)
+    comments_by_line = comment_tokens_by_line(source)
     fence_helpers = _collect_fence_helpers(tree)
     state = _ScopeState(
         heading_regexes={},

--- a/python/larch/lint/self_disarmable_gate_detector.py
+++ b/python/larch/lint/self_disarmable_gate_detector.py
@@ -10,9 +10,7 @@ Provides corpus-based preparation and per-source detection over
 from __future__ import annotations
 
 import ast
-import io
 import re
-import tokenize
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
@@ -21,6 +19,7 @@ from typing import cast
 from larch.lint.engine import Finding as EngineFinding
 from larch.lint.engine import ScanError  # re-export; do not define a local ScanError
 from larch.lint.engine import SourceFile
+from larch.lint.engine import comment_tokens_by_line, suppression_reason
 
 SUPPRESSION = "lint-self-disarmable-gate"
 PRAGMA_RE = re.compile(rf"#\s*{re.escape(SUPPRESSION)}:\s*ok\s+(\S.*)$")
@@ -54,29 +53,6 @@ class PreparedCorpus:
     """In-memory context built from corpus preparation."""
 
     resolution: MetadataResolution
-
-
-def _comment_tokens_by_line(source: str) -> dict[int, tuple[str, ...]]:
-    comments: dict[int, list[str]] = {}
-    try:
-        for token in tokenize.generate_tokens(io.StringIO(source).readline):
-            if token.type == tokenize.COMMENT:
-                comments.setdefault(token.start[0], []).append(token.string)
-    except tokenize.TokenError:
-        return {}
-    return {line: tuple(values) for line, values in comments.items()}
-
-
-def _suppression_reason(
-    lineno: int, *, comments_by_line: Mapping[int, tuple[str, ...]]
-) -> str | None:
-    for comment in comments_by_line.get(lineno, ()):
-        match = PRAGMA_RE.search(comment)
-        if match is not None:
-            return match.group(1).strip()
-        if EMPTY_PRAGMA_RE.search(comment) is not None:
-            return ""
-    return None
 
 
 def _dataclass_fields(node: ast.ClassDef) -> frozenset[str]:
@@ -227,7 +203,12 @@ def _emit(
     message: str,
     comments_by_line: Mapping[int, tuple[str, ...]],
 ) -> None:
-    reason = _suppression_reason(lineno, comments_by_line=comments_by_line)
+    reason = suppression_reason(
+        lineno,
+        comments_by_line=comments_by_line,
+        pragma_re=PRAGMA_RE,
+        empty_pragma_re=EMPTY_PRAGMA_RE,
+    )
     if reason is not None:
         if reason == "":
             raise ScanError(
@@ -395,7 +376,7 @@ def _scan_module(
     meta_fields: frozenset[str],
 ) -> list[Finding]:
     """Scan one module AST; return compat ``Finding`` list."""
-    comments_by_line = _comment_tokens_by_line(source_text)
+    comments_by_line = comment_tokens_by_line(source_text)
     findings: list[Finding] = []
     for node in tree.body:
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):

--- a/python/larch/lint/unreachable_branch_detector.py
+++ b/python/larch/lint/unreachable_branch_detector.py
@@ -9,18 +9,19 @@ analysis and compatibility adapters.
 from __future__ import annotations
 
 import ast
-import io
 import re
-import tokenize
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 
 from larch.lint.engine import (
     ScanError,
+    comment_tokens_by_line,
     is_exempt_python_source,
+    iter_python_source_files,
     normalize_python_file_path,
     qualified_symbol,
+    suppression_reason,
 )
 
 SUPPRESSION = "lint-unreachable-branch"
@@ -61,38 +62,12 @@ def is_production_source_path(rel_path: str) -> bool:
 
 def iter_source_files(larch_dir: Path) -> list[Path]:
     """Return recursively discovered production Python files under larch/, sorted."""
-    result: list[Path] = []
-    for path in sorted(larch_dir.rglob("*.py")):
-        if not path.is_file() or path.is_symlink() or is_exempt_path(path):
-            continue
-        relative = path.relative_to(larch_dir.parent)
-        if EXCLUDED_DIRS.intersection(relative.parts):
-            continue
-        result.append(path)
-    return result
-
-
-def _comment_tokens_by_line(source: str) -> dict[int, tuple[str, ...]]:
-    comments: dict[int, list[str]] = {}
-    try:
-        for token in tokenize.generate_tokens(io.StringIO(source).readline):
-            if token.type == tokenize.COMMENT:
-                comments.setdefault(token.start[0], []).append(token.string)
-    except tokenize.TokenError:
-        return {}
-    return {line: tuple(values) for line, values in comments.items()}
-
-
-def _suppression_reason(
-    lineno: int, *, comments_by_line: Mapping[int, tuple[str, ...]]
-) -> str | None:
-    for comment in comments_by_line.get(lineno, ()):
-        match = PRAGMA_RE.search(comment)
-        if match is not None:
-            return match.group(1).strip()
-        if EMPTY_PRAGMA_RE.search(comment) is not None:
-            return ""
-    return None
+    return iter_python_source_files(
+        larch_dir.parent,
+        scope=Path("larch"),
+        is_exempt=is_exempt_path,
+        excluded_dirs=EXCLUDED_DIRS,
+    )
 
 
 def normalize_expr(node: ast.AST | None) -> str:
@@ -356,9 +331,11 @@ def _scan_unreachable_tail(
                 candidate = _body_returns_value(cursor.body)
                 if candidate == returned:
                     lineno = getattr(cursor, "lineno", 0)
-                    reason = _suppression_reason(
+                    reason = suppression_reason(
                         lineno if isinstance(lineno, int) else 0,
                         comments_by_line=comments_by_line,
+                        pragma_re=PRAGMA_RE,
+                        empty_pragma_re=EMPTY_PRAGMA_RE,
                     )
                     if reason == "":
                         raise ScanError(
@@ -441,7 +418,12 @@ def _scan_if(
                 None,
             )
             if returned is not None and matching_prior is not None:
-                reason = _suppression_reason(lineno, comments_by_line=comments_by_line)
+                reason = suppression_reason(
+                    lineno,
+                    comments_by_line=comments_by_line,
+                    pragma_re=PRAGMA_RE,
+                    empty_pragma_re=EMPTY_PRAGMA_RE,
+                )
                 if reason == "":
                     raise ScanError(
                         f"{normalized_file}:{lineno}: empty {SUPPRESSION} suppression reason"
@@ -526,7 +508,7 @@ def scan_module(
     source: str,
 ) -> list[Finding]:
     """Scan one parsed module; ``normalized_file`` is relative to ``python/``."""
-    comments_by_line = _comment_tokens_by_line(source)
+    comments_by_line = comment_tokens_by_line(source)
     findings: list[Finding] = []
     for node in tree.body:
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):

--- a/python/tests/lint/test_lint_engine.py
+++ b/python/tests/lint/test_lint_engine.py
@@ -7,6 +7,7 @@ import contextlib
 import io
 import json
 import os
+import re
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -83,6 +84,35 @@ def _write_files(root: Path, files: Mapping[str, str]) -> None:
         path = root / rel
         path.parent.mkdir(parents=True, exist_ok=True)
         _ = path.write_text(text, encoding="utf-8")
+
+
+def test_comment_and_suppression_helpers_return_reason() -> None:
+    comments = lint_engine.comment_tokens_by_line("value = 1  # lint-rule: ok documented\n")
+
+    assert lint_engine.suppression_reason(
+        1,
+        comments_by_line=comments,
+        pragma_re=re.compile(r"#\s*lint-rule:\s*ok\s+(\S.*)$"),
+        empty_pragma_re=re.compile(r"#\s*lint-rule:\s*ok\s*$"),
+    ) == "documented"
+
+
+def test_iter_python_source_files_applies_scope_and_exemptions(tmp_path: Path) -> None:
+    _write_files(
+        tmp_path,
+        {
+            "larch/keep.py": "",
+            "larch/tests/test_skip.py": "",
+            "larch/vendor/skip.py": "",
+            "other.py": "",
+        },
+    )
+
+    assert [path.relative_to(tmp_path).as_posix() for path in lint_engine.iter_python_source_files(
+        tmp_path,
+        scope=Path("larch"),
+        excluded_dirs=frozenset({"tests", "vendor"}),
+    )] == ["larch/keep.py"]
 
 
 def _git_ok_runner(root: Path, tracked: Sequence[str]) -> RecordingRunner:


### PR DESCRIPTION
Fixes #7539.

Exports lint-engine comment and pragma helpers, centralizes Python source discovery, and replaces repeated per-rule Make wiring with shared rules. Pre-commit hooks remain explicit because its YAML schema has no supported hook template mechanism.

Validation: focused lint-rule tests, `make py-lint-checks-fast`, and duplicate-code baseline regeneration.
