### PR TITLE
Release v53.1.21

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "53.1.20",
+  "version": "53.1.21",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Changed

- Port logic-bearing implement step scripts into the shared bgjob-wait stem, reducing duplication across the implement pipeline. (#7549)
- Migrate occurrence baselines, identity baseline schemas, complexity history, and skill-closure aggregates to the shared lint engine. (#7550, #7551, #7552, #7554)
- Remove remaining legacy lint argparse entrypoints now that the shared lint engine handles those baselines. (#7555)
- Eliminate remaining runtime keep-in-sync twins to unify contract definitions. (#7556)

## Fixed

- Fix `finalize _rename_issue` silently retitling a tracking issue to the PR title. (#7548)
- Fix `/implement` blocking in repos that have no CI-on-main run. (#7558)
