### PR TITLE
Fixes #7568: resume postmerge cleanup

### DIFF
--- a/python/larch/implement/ship.py
+++ b/python/larch/implement/ship.py
@@ -1244,14 +1244,27 @@ def _resume_done_result(
     repo_root: str,
 ) -> ShipResult:
     done_ctx = _hydrate_resume_context(ctx=ctx, resume=resume).with_(pr_closed=True)
-    _write_terminal_finalize_if_terminal(ctx=done_ctx, result=Outcome.OK, step="done")
-    return reconcile_committed_stalled_summary_if_recovered(
+    reconciled: ShipResult | None = reconcile_committed_stalled_summary_if_recovered(
         runner=runner,
         ctx=done_ctx,
         cwd=repo_root,
         counters=_resume_reconciliation_counters(resume),
         allow_post_merge_skip=True,
-    ) or ShipResult(
+    )
+    if reconciled is not None:
+        return reconciled
+    if done_ctx.merge and not done_ctx.draft:
+        postmerge: ShipResult = run_postmerge_phase(runner=runner, ctx=done_ctx, cwd=repo_root)
+        if postmerge.outcome is not Outcome.OK:
+            return ShipResult(
+                postmerge.outcome,
+                pr_number=resume.pr_number,
+                pr_url=resume.pr_url,
+                merge_result=resume.merge_result,
+                detail=postmerge.detail,
+            )
+    _write_terminal_finalize_if_terminal(ctx=done_ctx, result=Outcome.OK, step="done")
+    return ShipResult(
         Outcome.OK,
         pr_number=resume.pr_number,
         pr_url=resume.pr_url,

--- a/python/tests/implement/test_ship.py
+++ b/python/tests/implement/test_ship.py
@@ -3707,7 +3707,7 @@ def test_fresh_fallback_hydrates_modes_and_preserves_counters(
     assert "PR_URL=\n" in state
 
 
-def test_done_merged_resume_is_idempotent_without_manifest_status(
+def test_done_merged_resume_runs_idempotent_postmerge_cleanup(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -3722,13 +3722,47 @@ def test_done_merged_resume_is_idempotent_without_manifest_status(
         "pr_view",
         lambda *_a, **_k: type("PR", (), {"number": 7, "url": "https://example.test/pr/7", "state": "MERGED", "head_ref": "feat"})(),
     )
-    monkeypatch.setattr(ship.finalize, "postmerge", lambda *_a, **_k: (_ for _ in ()).throw(AssertionError("postmerge forbidden")))
+    postmerge_calls: list[bool] = []
+    monkeypatch.setattr(  # lint-monkeypatch-binding: ok _resume_done_result resolves ship's imported binding
+        ship,
+        "run_postmerge_phase",
+        lambda *_a, **_k: postmerge_calls.append(True) or ship.ShipResult(Outcome.OK),
+    )
     monkeypatch.setattr(ship.finalize, "write_finalize_state", lambda *_a, **_k: None)
 
     result = ship.run_ship(_ctx(tmp_path, state_file=str(state_file)), runner=RecordingRunner(), cwd=str(tmp_path))
 
     assert result.outcome is Outcome.OK
     assert result.detail == "already done"
+    assert postmerge_calls == [True]
+
+
+def test_done_merged_resume_preserves_postmerge_cleanup_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    state_file = tmp_path / "ship-pr-state.sh"
+    _ = state_file.write_text(
+        "PHASE=done\nBRANCH_NAME=feat\nPR_NUMBER=7\nREPO=o/r\nMERGE=true\nDRAFT=false\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(ship.git, "current_branch", lambda *_a, **_k: "feat")
+    monkeypatch.setattr(ship.gh, "pr_view", lambda *_a, **_k: _merged_pr_view())
+    monkeypatch.setattr(  # lint-monkeypatch-binding: ok _resume_done_result resolves ship's imported binding
+        ship,
+        "run_postmerge_phase",
+        lambda *_a, **_k: ship.ShipResult(Outcome.STALLED, detail="local cleanup failed"),
+    )
+    monkeypatch.setattr(  # lint-monkeypatch-binding: ok _resume_done_result resolves ship's imported binding
+        ship,
+        "reconcile_committed_stalled_summary_if_recovered",
+        lambda *_a, **_k: None,
+    )
+
+    result = ship.run_ship(_ctx(tmp_path, state_file=str(state_file)), runner=RecordingRunner(), cwd=str(tmp_path))
+
+    assert result.outcome is Outcome.STALLED
+    assert result.detail == "local cleanup failed"
 
 
 def _force_recovered_reconciliation_post_merge_skip(monkeypatch: pytest.MonkeyPatch) -> list[bool]:
@@ -3783,10 +3817,11 @@ def test_done_resume_post_merge_reconciliation_skip_falls_through_to_done(
         "pr_view",
         lambda *_a, **_k: _merged_pr_view(),
     )
-    monkeypatch.setattr(
-        ship.finalize,
-        "postmerge",
-        lambda *_a, **_k: (_ for _ in ()).throw(AssertionError("postmerge forbidden")),
+    postmerge_calls: list[bool] = []
+    monkeypatch.setattr(  # lint-monkeypatch-binding: ok _resume_done_result resolves ship's imported binding
+        ship,
+        "run_postmerge_phase",
+        lambda *_a, **_k: postmerge_calls.append(True) or ship.ShipResult(Outcome.OK),
     )
     flush_calls = _force_recovered_reconciliation_post_merge_skip(monkeypatch)
 
@@ -3800,6 +3835,7 @@ def test_done_resume_post_merge_reconciliation_skip_falls_through_to_done(
     assert result.outcome is Outcome.OK
     assert result.detail == "already done"
     assert flush_calls == [True]
+    assert postmerge_calls == [True]
     assert "PHASE=done\n" in state
     assert "PHASE=stalled\n" not in state
     assert "STALL_STEP=run-log-reconciliation\n" not in state


### PR DESCRIPTION
## Summary

- Resume idempotent post-merge cleanup when a merged run is already marked done.
- Preserve a cleanup failure as a stalled run.

## Verification

- `cd python && python3 -m pytest -q tests/implement/test_ship.py`
- `cd python && ruff check larch/implement/ship.py tests/implement/test_ship.py`
- `cd python && pyright larch/implement/ship.py tests/implement/test_ship.py`
- `cd python && pylint larch/implement/ship.py tests/implement/test_ship.py`

Closes #7568