### PR TITLE
Fixes #7569: skip absent main push CI at ship gate

### DIFF
--- a/python/larch/implement/main_health.py
+++ b/python/larch/implement/main_health.py
@@ -76,6 +76,39 @@ def _read_failure_detail(result: CommandResult) -> str:
     return f"gh command failed ({result.returncode}): {' '.join(result.argv)}"
 
 
+def _read_error_status(
+    result: CommandResult,
+    *,
+    workflow: str,
+) -> MainHealthStatus | None:
+    if result.returncode == 0:
+        return None
+    if (
+        workflow == config.MAIN_HEALTH_DEFAULT_WORKFLOW
+        and gh.is_missing_named_workflow(result, workflow=workflow)
+    ):
+        detail = f"configured main-health workflow {workflow} not present in repo"
+        return MainHealthStatus(status="skip", detail=_bounded_detail(detail))
+    return MainHealthStatus(status="error", detail=_bounded_detail(_read_failure_detail(result)))
+
+
+def _workflow_run_filters(
+    query: MainHealthQuery,
+    *,
+    repo: str,
+    commit: str | None,
+) -> gh.WorkflowRunListFilters:
+    return gh.WorkflowRunListFilters(
+        repo=repo,
+        branch=query.base_branch,
+        workflow=query.workflow,
+        event="push",
+        commit=commit,
+        limit=query.limit,
+        cwd=query.cwd,
+    )
+
+
 def _has_named_repository_failure(
     runner: Runner,
     run: gh.WorkflowRun,
@@ -196,26 +229,25 @@ def read_main_health(
     query: MainHealthQuery,
 ) -> MainHealthStatus:
     query_repo = query.upstream_repo or query.repo
-    filters = gh.WorkflowRunListFilters(
-        repo=query_repo,
-        branch=query.base_branch,
-        workflow=query.workflow,
-        event="push",
-        commit=query.head_sha,
-        limit=query.limit,
-        cwd=query.cwd,
-    )
+    filters = _workflow_run_filters(query, repo=query_repo, commit=query.head_sha)
     try:
         result = gh.run_list_filtered_read(runner, filters)
-        if result.returncode != 0:
-            if (
-                query.workflow == config.MAIN_HEALTH_DEFAULT_WORKFLOW
-                and gh.is_missing_named_workflow(result, workflow=query.workflow)
-            ):
-                detail = f"configured main-health workflow {query.workflow} not present in repo"
-                return MainHealthStatus(status="skip", detail=_bounded_detail(detail))
-            return MainHealthStatus(status="error", detail=_bounded_detail(_read_failure_detail(result)))
+        read_error = _read_error_status(result, workflow=query.workflow)
+        if read_error is not None:
+            return read_error
         runs = gh.parse_run_list_filtered_result(result)
+        if query.head_sha and not runs:
+            history_filters = _workflow_run_filters(query, repo=query_repo, commit=None)
+            history_result = gh.run_list_filtered_read(runner, history_filters)
+            history_error = _read_error_status(history_result, workflow=query.workflow)
+            if history_error is not None:
+                return history_error
+            history = gh.parse_run_list_filtered_result(history_result)
+            if not history:
+                return MainHealthStatus(
+                    status="skip",
+                    detail=_bounded_detail("no default-branch push workflow runs found"),
+                )
         return _classify_runs(
             runner,
             runs,

--- a/python/tests/implement/test_main_health.py
+++ b/python/tests/implement/test_main_health.py
@@ -94,9 +94,10 @@ def test_empty_run_list_without_requested_sha_returns_skip() -> None:
     assert result.detail == "no default-branch push workflow runs found"
 
 
-def test_no_sha_match_and_malformed_json_return_error() -> None:
+def test_no_sha_match_returns_error_when_push_history_exists() -> None:
     no_match = RecordingRunner(
         responses=[
+            _res("[]"),
             _res('[{"databaseId":4,"status":"completed","conclusion":"success","headSha":"old","event":"push"}]'),
         ],
     )
@@ -104,6 +105,20 @@ def test_no_sha_match_and_malformed_json_return_error() -> None:
         main_health.read_main_health(no_match, _query("abc")).status
         == "error"
     )
+
+
+def test_no_push_history_for_requested_sha_returns_skip() -> None:
+    runner = RecordingRunner(responses=[_res("[]"), _res("[]")])
+
+    result = main_health.read_main_health(runner, _query("abc"))
+
+    assert result.status == "skip"
+    assert result.detail == "no default-branch push workflow runs found"
+    assert runner.calls[0][runner.calls[0].index("--commit") + 1] == "abc"
+    assert "--commit" not in runner.calls[1]
+
+
+def test_no_sha_match_and_malformed_json_return_error() -> None:
     malformed = RecordingRunner(responses=[_res("{")])
     assert (
         main_health.read_main_health(malformed, _query()).status
@@ -112,7 +127,7 @@ def test_no_sha_match_and_malformed_json_return_error() -> None:
 
 
 def test_filtered_argv_uses_repo_bare_branch_event_workflow_limit_and_commit() -> None:
-    runner = RecordingRunner(responses=[_res("[]")])
+    runner = RecordingRunner(responses=[_res("[]"), _res("[]")])
 
     _ = main_health.read_main_health(
         runner,
@@ -133,6 +148,8 @@ def test_filtered_argv_uses_repo_bare_branch_event_workflow_limit_and_commit() -
     assert call[call.index("--workflow") + 1] == "CI"
     assert call[call.index("--limit") + 1] == "17"
     assert call[call.index("--commit") + 1] == "abc"
+    history_call = runner.calls[1]
+    assert "--commit" not in history_call
 
 
 def test_missing_default_workflow_returns_skip() -> None:


### PR DESCRIPTION
Fixes #7569

## Summary

- Re-query default-branch push history without a commit filter when the requested SHA has no matching run.
- Skip the gate only when that workflow has no push history.
- Preserve the error for a missing requested SHA when push history exists.

## Validation

- `python3 -m pytest python/tests/implement/test_main_health.py`
- `python3 -m ruff check python/larch/implement/main_health.py python/tests/implement/test_main_health.py`
- `pyright larch/implement/main_health.py tests/implement/test_main_health.py`
- `pylint larch/implement/main_health.py tests/implement/test_main_health.py`