### PR TITLE
Release v53.1.22

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "53.1.21",
+  "version": "53.1.22",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## Added
- Add a harness session-env lint and an automated-PR merge backstop guideline. (#7564)

## Changed
- Export shared lint-engine helpers and generate per-rule wiring (contract unification). (#7559)
- Adopt shared test builders across git builders, lint conftest, and wire factories (contract unification). (#7566)
- Upgrade pinned CI versions of agnix and agent-lint to latest. (#7567)

## Fixed
- Fix a main-health ship-gate bug: the 53.1.21 skip fix was unreachable, so `/implement --merge` could stall on CI-on-PR-only repos. (#7572)
