### PR TITLE
Fixes #7575: allow ship stall steps in reports

### DIFF
--- a/python/larch/core/config.py
+++ b/python/larch/core/config.py
@@ -79,6 +79,14 @@ NEEDS_USER_POSTMERGE_MAIN_CI_FAIL: Final = "postmerge-main-ci-fail"
 NEEDS_USER_FLAKY_DEFECT_UNFIXED: Final = "flaky-defect-unfixed"
 NEEDS_USER_SCOPE_DISPOSITION: Final = "scope-disposition"
 NEEDS_USER_ARCHITECTURAL_ASSESSMENTS: Final = "architectural-assessments"
+SHIP_STALL_STEP_MAIN_CI: Final = "main-ci"
+SHIP_STALL_STEP_MERGE: Final = "merge"
+SHIP_STALL_STEP_POSTMERGE_PUSH_WATCH: Final = "postmerge-push-watch"
+SHIP_STALL_STEPS: Final[frozenset[str]] = frozenset({
+    SHIP_STALL_STEP_MAIN_CI,
+    SHIP_STALL_STEP_MERGE,
+    SHIP_STALL_STEP_POSTMERGE_PUSH_WATCH,
+})
 NEEDS_USER_REASON_TOKENS: Final = (
     NEEDS_USER_FIRST_FIXER_NON_HEALTH,
     NEEDS_USER_CI_FIX_EXHAUSTED,

--- a/python/larch/implement/ship.py
+++ b/python/larch/implement/ship.py
@@ -807,8 +807,8 @@ def _postmerge_main_health_gate(
         if not _main_health_sidecar_bootstrapped(working.tmpdir):
             return None
         return _missing_main_health_sidecar_result(
-            ctx=working.with_(stall_tracking=True, stall_step="postmerge-push-watch"),
-            step="postmerge-push-watch",
+            ctx=working.with_(stall_tracking=True, stall_step=config.SHIP_STALL_STEP_POSTMERGE_PUSH_WATCH),
+            step=config.SHIP_STALL_STEP_POSTMERGE_PUSH_WATCH,
             counters=counters,
         )
     _write_ship_state(
@@ -825,9 +825,9 @@ def _postmerge_main_health_gate(
         if fetch.returncode != 0:
             detail = "post-merge push watch could not refresh origin/main"
             _write_terminal_state(
-                ctx=working.with_(stall_tracking=True, stall_step="postmerge-push-watch"),
+                ctx=working.with_(stall_tracking=True, stall_step=config.SHIP_STALL_STEP_POSTMERGE_PUSH_WATCH),
                 result=Outcome.STALLED,
-                step="postmerge-push-watch",
+                step=config.SHIP_STALL_STEP_POSTMERGE_PUSH_WATCH,
                 iteration=counters.iteration,
                 rebase_count=counters.rebase_count,
                 fix_attempts=counters.fix_attempts,
@@ -844,9 +844,9 @@ def _postmerge_main_health_gate(
     if not merged_head:
         detail = "post-merge push watch could not resolve merged main HEAD"
         _write_terminal_state(
-            ctx=working.with_(stall_tracking=True, stall_step="postmerge-push-watch"),
+            ctx=working.with_(stall_tracking=True, stall_step=config.SHIP_STALL_STEP_POSTMERGE_PUSH_WATCH),
             result=Outcome.STALLED,
-            step="postmerge-push-watch",
+            step=config.SHIP_STALL_STEP_POSTMERGE_PUSH_WATCH,
             iteration=counters.iteration,
             rebase_count=counters.rebase_count,
             fix_attempts=counters.fix_attempts,
@@ -956,9 +956,9 @@ def _postmerge_main_health_gate(
             main_repair_head=repair_head,
         )
     _write_terminal_state(
-        ctx=working.with_(stall_tracking=True, stall_step="postmerge-push-watch"),
+        ctx=working.with_(stall_tracking=True, stall_step=config.SHIP_STALL_STEP_POSTMERGE_PUSH_WATCH),
         result=Outcome.STALLED,
-        step="postmerge-push-watch",
+        step=config.SHIP_STALL_STEP_POSTMERGE_PUSH_WATCH,
         iteration=counters.iteration,
         rebase_count=counters.rebase_count,
         fix_attempts=counters.fix_attempts,
@@ -1015,8 +1015,8 @@ def _premerge_main_health_gate(
         if not _main_health_sidecar_bootstrapped(working.tmpdir):
             return None
         return _missing_main_health_sidecar_result(
-            ctx=working.with_(stall_tracking=True, stall_step="main-ci"),
-            step="main-ci",
+            ctx=working.with_(stall_tracking=True, stall_step=config.SHIP_STALL_STEP_MAIN_CI),
+            step=config.SHIP_STALL_STEP_MAIN_CI,
             counters=counters,
         )
     base_head = _resolve_premerge_main_health_sha(
@@ -1027,9 +1027,9 @@ def _premerge_main_health_gate(
     if not base_head:
         detail = f"pre-merge main-health gate could not resolve origin/{base_ref} HEAD"
         _write_terminal_state(
-            ctx=working.with_(stall_tracking=True, stall_step="main-ci"),
+            ctx=working.with_(stall_tracking=True, stall_step=config.SHIP_STALL_STEP_MAIN_CI),
             result=Outcome.STALLED,
-            step="main-ci",
+            step=config.SHIP_STALL_STEP_MAIN_CI,
             iteration=counters.iteration,
             rebase_count=counters.rebase_count,
             fix_attempts=counters.fix_attempts,
@@ -1082,11 +1082,11 @@ def _premerge_main_health_gate(
         _write_terminal_state(
             ctx=working.with_(
                 stall_tracking=True,
-                stall_step="main-ci",
+                stall_step=config.SHIP_STALL_STEP_MAIN_CI,
                 final_bail_reason=config.NEEDS_USER_MAIN_CI_FAIL,
             ),
             result=Outcome.NEEDS_USER_INPUT,
-            step="main-ci",
+            step=config.SHIP_STALL_STEP_MAIN_CI,
             iteration=counters.iteration,
             rebase_count=counters.rebase_count,
             fix_attempts=counters.fix_attempts,
@@ -1103,9 +1103,9 @@ def _premerge_main_health_gate(
             main_health_head_sha=health.head_sha or base_head,
         )
     _write_terminal_state(
-        ctx=working.with_(stall_tracking=True, stall_step="main-ci"),
+        ctx=working.with_(stall_tracking=True, stall_step=config.SHIP_STALL_STEP_MAIN_CI),
         result=Outcome.STALLED,
-        step="main-ci",
+        step=config.SHIP_STALL_STEP_MAIN_CI,
         iteration=counters.iteration,
         rebase_count=counters.rebase_count,
         fix_attempts=counters.fix_attempts,
@@ -1900,11 +1900,11 @@ def run_ship(
                 _write_terminal_state(
                     ctx=working.with_(
                         stall_tracking=True,
-                        stall_step="merge",
+                        stall_step=config.SHIP_STALL_STEP_MERGE,
                         final_bail_reason=config.NEEDS_USER_REVIEW_REQUIRED,
                     ),
                     result=Outcome.NEEDS_USER_INPUT,
-                    step="merge",
+                    step=config.SHIP_STALL_STEP_MERGE,
                     iteration=iteration,
                     rebase_count=rebase_count,
                     fix_attempts=fix_attempts,
@@ -1914,7 +1914,7 @@ def run_ship(
                     runner=runner,
                     ctx=working.with_(
                         stall_tracking=True,
-                        stall_step="merge",
+                        stall_step=config.SHIP_STALL_STEP_MERGE,
                         final_bail_reason=config.NEEDS_USER_REVIEW_REQUIRED,
                     ),
                     cwd=repo_root,
@@ -1946,9 +1946,9 @@ def run_ship(
                     else merged.error or f"merge did not complete: {merged.result}"
                 )
                 _write_terminal_state(
-                    ctx=working.with_(stall_tracking=True, stall_step="merge"),
+                    ctx=working.with_(stall_tracking=True, stall_step=config.SHIP_STALL_STEP_MERGE),
                     result=Outcome.STALLED,
-                    step="merge",
+                    step=config.SHIP_STALL_STEP_MERGE,
                     iteration=iteration,
                     rebase_count=rebase_count,
                     fix_attempts=fix_attempts,

--- a/python/larch/state/_tokens.py
+++ b/python/larch/state/_tokens.py
@@ -260,6 +260,8 @@ def _safe_outcome(value: str) -> bool:
 def _safe_step(value: str, *, generic: bool) -> bool:
     if generic and value in _GENERIC_STEPS:
         return True
+    if value in config.SHIP_STALL_STEPS:
+        return True
     if value in {"bump-branch-guard", "merge-loop-iteration-cap", "rebase-failed"}:
         return True
     if re.fullmatch(r"[2-9]|1[0-5]", value):

--- a/python/tests/state/test_stall_recovery.py
+++ b/python/tests/state/test_stall_recovery.py
@@ -1483,6 +1483,45 @@ def test_compose_report_allows_checks_commit_route_retry_resume_hint() -> None:
     assert stall_recovery._sensitive_value_is_allowlisted("checks-commit-route-retry")  # pyright: ignore[reportPrivateUsage]
 
 
+@pytest.mark.parametrize("stall_step", sorted(config.SHIP_STALL_STEPS))
+def test_compose_report_allows_ship_stall_step_in_sensitive_corpus(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    stall_step: str,
+) -> None:
+    monkeypatch.setenv("LARCH_STALL_RECOVERY_DRY_RUN", "1")
+    signature = "0123456789abcdef" * 4
+    _ = (tmp_path / "stall-recovery-classification.env").write_text(
+        f"FAILURE_CLASS=lint-failure\nFAILURE_SIGNATURE={signature}\n"
+        f"STALL_STEP={stall_step}\nPHASE=review\nEXIT_CODE=1\n",
+        encoding="utf-8",
+    )
+    _ = (tmp_path / "stall-recovery-root-cause.md").write_text(
+        "verdict=larch-defect\nconfidence=high\nsummary=safe summary\n\nProse.\n",
+        encoding="utf-8",
+    )
+    _ = (tmp_path / "stall-recovery-bounded-root-cause.md").write_text(
+        "verdict=larch-defect\nconfidence=high\nsummary=safe summary\n\nBounded.\n",
+        encoding="utf-8",
+    )
+    _ = (tmp_path / "stall-recovery-sensitive-corpus.env").write_text(
+        f"STALL_STEP={stall_step}\n",
+        encoding="utf-8",
+    )
+
+    rc = stall_recovery.compose_report_main([
+        "--implement-tmpdir", str(tmp_path),
+        "--surface", "chat-print",
+        "--report-kind", "terminal-failure",
+    ])
+
+    assert rc == 0
+    assert "STALL_RECOVERY_REPORT_TIER=B" in capsys.readouterr().out
+    report = (tmp_path / "stall-recovery-chat-print.md").read_text(encoding="utf-8")
+    assert f"| Step | `{stall_step}` |" in report
+
+
 def _write_state(tmp_path: Path, step: str, phase: str, bail: str = "", extra: str = "") -> None:
     lines = [
         f"PHASE={phase}",


### PR DESCRIPTION
Fixes #7575

## Summary
- Centralize the three ship stall-step enums.
- Allow those fixed enums in Tier B report validation.
- Cover every enum through compose-report corpus validation.

## Verification
- python3 -m pytest -q python/tests/state/test_stall_recovery.py
- python3 -m pytest -q python/tests/implement/test_ship.py
- ruff, pylint, and pyright for changed files