### PR TITLE
Fixes #7594: Upgrade agent-lint to v3.0.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -289,15 +289,15 @@ jobs:
         uses: actions/cache@v5
         with:
           path: /usr/local/bin/agent-lint
-          key: agent-lint-bin-${{ runner.os }}-2.7.0
-      - name: Install agent-lint v2.7.0
+          key: agent-lint-bin-${{ runner.os }}-3.0.0
+      - name: Install agent-lint v3.0.0
         if: steps.cache-agent-lint.outputs.cache-hit != 'true'
         run: |
           set -euo pipefail
           tmp=$(mktemp -d)
           curl -sSfL --retry 5 --retry-max-time 120 --retry-all-errors --connect-timeout 10 \
             -o "$tmp/agent-lint.tgz" \
-            https://github.com/zhupanov/agent-lint/releases/download/v2.7.0/agent-lint-v2.7.0-x86_64-unknown-linux-musl.tar.gz
+            https://github.com/zhupanov/agent-lint/releases/download/v3.0.0/agent-lint-v3.0.0-x86_64-unknown-linux-musl.tar.gz
           tar -xzf "$tmp/agent-lint.tgz" -C "$tmp"
           sudo install -m 0755 "$tmp/agent-lint" /usr/local/bin/agent-lint
           rm -rf "$tmp"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -213,7 +213,7 @@ repos:
         always_run: true
 
   - repo: https://github.com/zhupanov/agent-lint
-    rev: v2.6.0
+    rev: v3.0.0
     hooks:
       - id: agent-lint
         args: [--pedantic]


### PR DESCRIPTION
Closes #7594

## Summary
- upgrade the pre-commit agent-lint pin to v3.0.0
- upgrade the CI binary, release URL, and cache key to v3.0.0

## Validation
- agent-lint v3.0.0 --pedantic .
- pre-commit run --files .pre-commit-config.yaml .github/workflows/ci.yaml (all relevant hooks passed except the repository-wide gitleaks scan, which reports existing larch-logs artifacts)
- make agent-lint