### PR TITLE
Fixes #7604: add syntax support and decentralized rule registration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "automod"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a273e731a7fb8c2268fd2932c9e9a3469f4fd171d85d070d2687190229653bd3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -48,6 +59,61 @@ dependencies = [
  "regex-automata",
  "serde_core",
 ]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "camino"
+version = "1.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2d30e4173c4026932d51d31d6b0613b1fd3014bf3f9f8943d4ba139c437ba0"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0061da739915fae12ea00e16397555ed4371a6bb285431aab930f61b0aa4ba"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "cc"
+version = "1.2.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
@@ -88,10 +154,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -110,6 +203,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "globset"
 version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -122,20 +245,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
+name = "inventory"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "larch-lint"
 version = "0.1.0"
 dependencies = [
  "assert_cmd",
+ "automod",
+ "cargo_metadata",
  "clap",
+ "csv",
  "globset",
+ "inventory",
  "predicates",
+ "pulldown-cmark",
+ "regex",
+ "serde",
+ "syn",
  "tempfile",
+ "toml",
+ "tree-sitter",
+ "tree-sitter-bash",
+ "uuid",
 ]
 
 [[package]]
@@ -161,6 +338,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "predicates"
@@ -199,12 +382,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
+dependencies = [
+ "bitflags",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "regex"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -238,6 +444,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -256,6 +494,47 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
 
 [[package]]
 name = "syn"
@@ -287,10 +566,115 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
+
+[[package]]
+name = "tree-sitter"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1c71c1c4cc0920b20d6b0f6572e7682cd07a6a2faec71067a31fa394c586df"
+dependencies = [
+ "cc",
+ "regex",
+ "regex-syntax",
+ "serde_json",
+ "streaming-iterator",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-bash"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5ec769279cc91b561d3df0d8a5deb26b0ad40d183127f409494d6d8fc53062"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-language"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "uuid"
+version = "1.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "wait-timeout"
@@ -299,6 +683,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -315,3 +744,15 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,22 @@ rust-version = "1.94.1"
 
 [workspace.dependencies]
 assert_cmd = { version = "2.2.2", default-features = false }
+automod = { version = "1.0.17", default-features = false }
+csv = { version = "1.4.0", default-features = false }
+cargo_metadata = { version = "0.23.1", default-features = false }
 clap = { version = "4.6.2", default-features = false, features = ["derive", "help", "std", "usage"] }
 globset = { version = "0.4.19", default-features = false }
+inventory = { version = "0.3.24", default-features = false }
 predicates = { version = "3.1.4", default-features = false }
+pulldown-cmark = { version = "0.13.4", default-features = false }
+regex = { version = "1.13.1", default-features = false, features = ["std", "perf"] }
+serde = { version = "1.0.228", default-features = false, features = ["derive", "std"] }
+syn = { version = "2.0.119", default-features = false, features = ["full", "parsing", "visit"] }
 tempfile = { version = "3.27.0", default-features = false }
+toml = { version = "1.1.3", default-features = false, features = ["parse", "serde", "std"] }
+tree-sitter = { version = "0.26.7", default-features = false, features = ["std"] }
+tree-sitter-bash = { version = "0.25.1", default-features = false }
+uuid = { version = "1.24.0", default-features = false, features = ["std"] }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/crates/larch-lint/Cargo.toml
+++ b/crates/larch-lint/Cargo.toml
@@ -9,8 +9,20 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+automod.workspace = true
+cargo_metadata.workspace = true
 clap.workspace = true
+csv.workspace = true
 globset.workspace = true
+inventory.workspace = true
+pulldown-cmark.workspace = true
+regex.workspace = true
+serde.workspace = true
+syn.workspace = true
+toml.workspace = true
+tree-sitter.workspace = true
+tree-sitter-bash.workspace = true
+uuid.workspace = true
 
 [dev-dependencies]
 assert_cmd.workspace = true

--- a/crates/larch-lint/migration-ledger/fixture.toml
+++ b/crates/larch-lint/migration-ledger/fixture.toml
@@ -1,0 +1,1 @@
+rule = "fixture"

--- a/crates/larch-lint/src/cli.rs
+++ b/crates/larch-lint/src/cli.rs
@@ -6,8 +6,8 @@ use std::{
 use clap::{Parser, Subcommand};
 
 use crate::{
-    GitCli, Repository,
-    runner::{ExitCode, RuleRegistry, render_error, render_findings, render_rule_list, run},
+    GitCli, Repository, registered_rule_registry,
+    runner::{ExitCode, render_error, render_findings, render_rule_list, run},
 };
 
 /// Check larch repository policy.
@@ -39,52 +39,79 @@ enum Command {
 #[must_use]
 pub fn run_cli() -> i32 {
     let cli = Cli::parse();
-    let rules: [&dyn crate::Rule; 0] = [];
-    let registry = match RuleRegistry::new(&rules) {
-        Ok(registry) => registry,
-        Err(error) => return render_error(&error, &mut std::io::stderr()).as_i32(),
-    };
     match cli.command {
-        Command::Rules => match render_rule_list(&registry, &mut std::io::stdout()) {
-            Ok(()) => ExitCode::Clean.as_i32(),
+        Command::Rules => match registered_rule_registry() {
+            Ok(registry) => match render_rule_list(&registry, &mut std::io::stdout()) {
+                Ok(()) => ExitCode::Clean.as_i32(),
+                Err(error) => render_error(&error, &mut std::io::stderr()).as_i32(),
+            },
             Err(error) => render_error(&error, &mut std::io::stderr()).as_i32(),
         },
-        Command::All => execute(registry.iter(), cli.root.as_deref()),
-        Command::Rule { name } => registry.get(&name).map_or_else(
-            || {
-                render_error(
-                    &crate::runner::LintError::new(format!("unknown rule: {name}")),
-                    &mut std::io::stderr(),
-                )
-                .as_i32()
-            },
-            |rule| execute(std::iter::once(rule), cli.root.as_deref()),
-        ),
+        Command::All => execute_all(cli.root.as_deref()),
+        Command::Rule { name } => execute_named(&name, cli.root.as_deref()),
     }
 }
 
-fn execute<'rule>(
-    rules: impl IntoIterator<Item = &'rule dyn crate::Rule>,
-    root: Option<&Path>,
-) -> i32 {
+fn execute_all(root: Option<&Path>) -> i32 {
+    let repository = match discover_repository(root) {
+        Ok(repository) => repository,
+        Err(exit) => return exit,
+    };
+    let registry = match registered_rule_registry() {
+        Ok(registry) => registry,
+        Err(error) => return render_error(&error, &mut std::io::stderr()).as_i32(),
+    };
+    if let Err(error) = crate::validate_migration_ledger(&repository, &registry) {
+        return render_error(&error, &mut std::io::stderr()).as_i32();
+    }
+    execute(&repository, registry.iter())
+}
+
+fn execute_named(name: &str, root: Option<&Path>) -> i32 {
+    let registry = match registered_rule_registry() {
+        Ok(registry) => registry,
+        Err(error) => return render_error(&error, &mut std::io::stderr()).as_i32(),
+    };
+    let Some(rule) = registry.get(name) else {
+        return render_error(
+            &crate::runner::LintError::new(format!("unknown rule: {name}")),
+            &mut std::io::stderr(),
+        )
+        .as_i32();
+    };
+    let repository = match discover_repository(root) {
+        Ok(repository) => repository,
+        Err(exit) => return exit,
+    };
+    if let Err(error) = crate::validate_migration_ledger(&repository, &registry) {
+        return render_error(&error, &mut std::io::stderr()).as_i32();
+    }
+    execute(&repository, std::iter::once(rule))
+}
+
+fn discover_repository(root: Option<&Path>) -> Result<Repository, i32> {
     let cwd = match root
         .map(Path::to_path_buf)
         .map_or_else(env::current_dir, Ok)
     {
         Ok(cwd) => cwd,
         Err(error) => {
-            return render_error(
+            return Err(render_error(
                 &crate::runner::LintError::new(format!("cannot read current directory: {error}")),
                 &mut std::io::stderr(),
             )
-            .as_i32();
+            .as_i32());
         }
     };
-    let repository = match Repository::discover(&GitCli, &cwd) {
-        Ok(repository) => repository,
-        Err(error) => return render_error(&error, &mut std::io::stderr()).as_i32(),
-    };
-    let findings = match run(&repository, rules) {
+    Repository::discover(&GitCli, &cwd)
+        .map_err(|error| render_error(&error, &mut std::io::stderr()).as_i32())
+}
+
+fn execute<'rule>(
+    repository: &Repository,
+    rules: impl IntoIterator<Item = &'rule dyn crate::Rule>,
+) -> i32 {
+    let findings = match run(repository, rules) {
         Ok(findings) => findings,
         Err(error) => return render_error(&error, &mut std::io::stderr()).as_i32(),
     };

--- a/crates/larch-lint/src/lib.rs
+++ b/crates/larch-lint/src/lib.rs
@@ -1,13 +1,36 @@
 //! Shared execution support for larch repository-policy rules.
 //!
-//! Rules are registered by the next foundation stage. This crate owns the
-//! command contract, tracked-file discovery, repository-relative path
-//! selection, diagnostics, and testable rule execution.
+//! This crate owns the command contract, tracked-file discovery,
+//! repository-relative path selection, shared syntax support, and testable
+//! rule execution. Rules register from their own modules; no central registry
+//! must change when a later rule is added.
 
 mod cli;
+mod metadata;
 mod repository;
 mod runner;
+pub mod suppression;
+pub mod syntax;
+
+mod rules {
+    automod::dir!("src/rules");
+}
 
 pub use cli::run_cli;
+pub use metadata::{
+    RuleMetadata, RuleRegistration, registered_rule_registry, validate_migration_ledger,
+};
 pub use repository::{Git, GitCli, PathSelector, RepoPath, Repository};
 pub use runner::{ExitCode, Finding, LintError, Rule, RuleRegistry, finding_exit_code, run};
+
+/// Register a static rule and its co-located metadata without editing a shared
+/// registry. The matching migration-ledger record is verified before a rule
+/// run can complete.
+#[macro_export]
+macro_rules! register_rule {
+    ($metadata:ident, $rule:ident) => {
+        inventory::submit! {
+            $crate::RuleRegistration::new(&$metadata, &$rule)
+        }
+    };
+}

--- a/crates/larch-lint/src/metadata.rs
+++ b/crates/larch-lint/src/metadata.rs
@@ -1,0 +1,249 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::{LintError, Repository, Rule, RuleRegistry};
+
+const MIGRATION_LEDGER_PREFIX: &str = "crates/larch-lint/migration-ledger/";
+const MIGRATION_LEDGER_SUFFIX: &str = ".toml";
+
+/// Static rule facts owned beside a rule implementation.
+#[derive(Debug)]
+pub struct RuleMetadata {
+    name: &'static str,
+    description: &'static str,
+    migration_ledger: &'static str,
+}
+
+impl RuleMetadata {
+    /// Construct metadata for one independently maintained rule.
+    #[must_use]
+    pub const fn new(
+        name: &'static str,
+        description: &'static str,
+        migration_ledger: &'static str,
+    ) -> Self {
+        Self {
+            name,
+            description,
+            migration_ledger,
+        }
+    }
+
+    /// Return the stable rule name.
+    #[must_use]
+    pub const fn name(&self) -> &'static str {
+        self.name
+    }
+
+    /// Return the stable human-facing description.
+    #[must_use]
+    pub const fn description(&self) -> &'static str {
+        self.description
+    }
+
+    /// Return the tracked per-rule migration-ledger path.
+    #[must_use]
+    pub const fn migration_ledger(&self) -> &'static str {
+        self.migration_ledger
+    }
+}
+
+/// A distributed registration that binds one rule to its metadata.
+pub struct RuleRegistration {
+    metadata: &'static RuleMetadata,
+    rule: &'static dyn Rule,
+}
+
+impl RuleRegistration {
+    /// Construct one inventory entry.
+    #[must_use]
+    pub const fn new(metadata: &'static RuleMetadata, rule: &'static dyn Rule) -> Self {
+        Self { metadata, rule }
+    }
+
+    /// Return the registration's immutable metadata.
+    #[must_use]
+    pub const fn metadata(&self) -> &'static RuleMetadata {
+        self.metadata
+    }
+
+    /// Return the registered rule.
+    #[must_use]
+    pub const fn rule(&self) -> &'static dyn Rule {
+        self.rule
+    }
+}
+
+inventory::collect!(RuleRegistration);
+
+/// Build the deterministic registry from every linked, distributed rule.
+///
+/// # Errors
+///
+/// Returns an error for missing metadata, mismatched rule facts, duplicate
+/// registrations, or invalid rule names.
+pub fn registered_rule_registry() -> Result<RuleRegistry<'static>, LintError> {
+    registry_from_registrations(inventory::iter::<RuleRegistration>)
+}
+
+fn registry_from_registrations(
+    registrations: impl IntoIterator<Item = &'static RuleRegistration>,
+) -> Result<RuleRegistry<'static>, LintError> {
+    let registrations: Vec<&RuleRegistration> = registrations.into_iter().collect();
+    let mut rules = Vec::with_capacity(registrations.len());
+    for registration in registrations {
+        let metadata = registration.metadata();
+        let rule = registration.rule();
+        if metadata.name() != rule.name() {
+            return Err(LintError::new(format!(
+                "registered metadata name {} does not match rule name {}",
+                metadata.name(),
+                rule.name()
+            )));
+        }
+        if metadata.description() != rule.description() {
+            return Err(LintError::new(format!(
+                "registered metadata description for {} does not match the rule",
+                metadata.name()
+            )));
+        }
+        rules.push(rule);
+    }
+    RuleRegistry::from_static(rules)
+}
+
+/// Validate the tracked, one-file-per-rule migration ledger.
+///
+/// # Errors
+///
+/// Returns an error for missing, duplicate, malformed, or stale ledger records.
+pub fn validate_migration_ledger(
+    repository: &Repository,
+    registry: &RuleRegistry<'_>,
+) -> Result<(), LintError> {
+    let expected: BTreeMap<&str, &str> = inventory::iter::<RuleRegistration>
+        .into_iter()
+        .map(|registration| {
+            let metadata = registration.metadata();
+            (metadata.name(), metadata.migration_ledger())
+        })
+        .collect();
+    if expected.len() != registry.iter().count() {
+        return Err(LintError::new(
+            "registered rule metadata does not match the rule registry",
+        ));
+    }
+    let actual_paths: BTreeSet<&str> = repository
+        .paths()
+        .iter()
+        .map(crate::RepoPath::as_str)
+        .filter(|path| {
+            path.starts_with(MIGRATION_LEDGER_PREFIX) && path.ends_with(MIGRATION_LEDGER_SUFFIX)
+        })
+        .collect();
+    let expected_paths: BTreeSet<&str> = expected.values().copied().collect();
+
+    if let Some(path) = expected_paths.difference(&actual_paths).next() {
+        return Err(LintError::new(format!(
+            "missing migration-ledger record: {path}"
+        )));
+    }
+    let mut records = Vec::with_capacity(actual_paths.len());
+    for path in &actual_paths {
+        let content = repository.read_utf8(&crate::RepoPath::from_trusted(path))?;
+        let rule_name = parse_ledger_rule(path, &content)?;
+        records.push((*path, rule_name));
+    }
+
+    let mut recorded = BTreeSet::new();
+    for (_, rule_name) in &records {
+        if !recorded.insert(rule_name) {
+            return Err(LintError::new(format!(
+                "duplicate migration-ledger rule record: {rule_name}"
+            )));
+        }
+    }
+    for (path, rule_name) in records {
+        let expected_path = expected.get(rule_name.as_str()).ok_or_else(|| {
+            LintError::new(format!("stale migration-ledger rule record: {rule_name}"))
+        })?;
+        let canonical_path = ledger_path_for_rule(&rule_name);
+        if *expected_path != canonical_path {
+            return Err(LintError::new(format!(
+                "metadata for {rule_name} must name {canonical_path}"
+            )));
+        }
+        if *expected_path != path {
+            return Err(LintError::new(format!(
+                "migration-ledger record {path} must be named {expected_path}"
+            )));
+        }
+    }
+    if let Some(path) = actual_paths.difference(&expected_paths).next() {
+        return Err(LintError::new(format!(
+            "stale migration-ledger record: {path}"
+        )));
+    }
+    Ok(())
+}
+
+fn ledger_path_for_rule(name: &str) -> String {
+    format!("{MIGRATION_LEDGER_PREFIX}{name}{MIGRATION_LEDGER_SUFFIX}")
+}
+
+fn parse_ledger_rule(path: &str, content: &str) -> Result<String, LintError> {
+    let parsed: toml::Table = toml::from_str(content)
+        .map_err(|error| LintError::new(format!("{path}: invalid TOML: {error}")))?;
+    let rule = parsed
+        .get("rule")
+        .and_then(toml::Value::as_str)
+        .ok_or_else(|| LintError::new(format!("{path}: missing string rule field")))?;
+    if parsed.len() != 1 {
+        return Err(LintError::new(format!(
+            "{path}: migration-ledger records may contain only the rule field"
+        )));
+    }
+    Ok(rule.to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{RuleMetadata, RuleRegistration, registry_from_registrations};
+    use crate::{Finding, LintError, Repository, Rule};
+
+    #[derive(Debug)]
+    struct DriftRule;
+
+    impl Rule for DriftRule {
+        fn name(&self) -> &'static str {
+            "actual-rule"
+        }
+
+        fn description(&self) -> &'static str {
+            "actual rule"
+        }
+
+        fn check(&self, _repository: &Repository) -> Result<Vec<Finding>, LintError> {
+            Ok(Vec::new())
+        }
+    }
+
+    static DRIFT_METADATA: RuleMetadata = RuleMetadata::new(
+        "metadata-rule",
+        "actual rule",
+        "crates/larch-lint/migration-ledger/metadata-rule.toml",
+    );
+    static DRIFT_RULE: DriftRule = DriftRule;
+    static DRIFT_REGISTRATION: RuleRegistration =
+        RuleRegistration::new(&DRIFT_METADATA, &DRIFT_RULE);
+
+    #[test]
+    fn registration_drift_is_rejected_before_rules_run() {
+        let Err(error) = registry_from_registrations([&DRIFT_REGISTRATION]) else {
+            panic!("metadata and rule names unexpectedly agreed");
+        };
+        assert_eq!(
+            error.to_string(),
+            "registered metadata name metadata-rule does not match rule name actual-rule"
+        );
+    }
+}

--- a/crates/larch-lint/src/repository.rs
+++ b/crates/larch-lint/src/repository.rs
@@ -14,6 +14,10 @@ use crate::runner::LintError;
 pub struct RepoPath(String);
 
 impl RepoPath {
+    pub(crate) fn from_trusted(raw: &str) -> Self {
+        Self(raw.to_owned())
+    }
+
     fn parse(raw: &str) -> Result<Self, LintError> {
         let path = Path::new(raw);
         if raw.is_empty()

--- a/crates/larch-lint/src/rules/fixture.rs
+++ b/crates/larch-lint/src/rules/fixture.rs
@@ -1,0 +1,43 @@
+use crate::{Finding, LintError, PathSelector, Repository, Rule, RuleMetadata};
+
+const NAME: &str = "fixture";
+const DESCRIPTION: &str = "Validate decentralized rule registration";
+
+pub static METADATA: RuleMetadata = RuleMetadata::new(
+    NAME,
+    DESCRIPTION,
+    "crates/larch-lint/migration-ledger/fixture.toml",
+);
+
+#[derive(Debug)]
+pub struct FixtureRule;
+
+pub static RULE: FixtureRule = FixtureRule;
+
+impl Rule for FixtureRule {
+    fn name(&self) -> &'static str {
+        NAME
+    }
+
+    fn description(&self) -> &'static str {
+        DESCRIPTION
+    }
+
+    fn check(&self, repository: &Repository) -> Result<Vec<Finding>, LintError> {
+        let selector = PathSelector::new(&["fixtures/**/*.fixture"], &[])?;
+        let mut findings = Vec::new();
+        for path in selector.select(repository) {
+            for (index, line) in repository.read_utf8(path)?.lines().enumerate() {
+                if line == "forbidden" {
+                    let line_number = u32::try_from(index + 1).map_err(|_| {
+                        LintError::new(format!("{}: line number exceeds u32", path.as_str()))
+                    })?;
+                    findings.push(Finding::new(path.as_str(), line_number, "fixture violation"));
+                }
+            }
+        }
+        Ok(findings)
+    }
+}
+
+crate::register_rule!(METADATA, RULE);

--- a/crates/larch-lint/src/runner.rs
+++ b/crates/larch-lint/src/runner.rs
@@ -96,6 +96,10 @@ impl<'rule> RuleRegistry<'rule> {
     ///
     /// Returns an error when a rule name is malformed or duplicated.
     pub fn new(rules: &'rule [&'rule dyn Rule]) -> Result<Self, LintError> {
+        Self::from_rules(rules.iter().copied())
+    }
+
+    fn from_rules(rules: impl IntoIterator<Item = &'rule dyn Rule>) -> Result<Self, LintError> {
         let mut registered = BTreeMap::new();
         for rule in rules {
             let name = rule.name();
@@ -106,7 +110,7 @@ impl<'rule> RuleRegistry<'rule> {
             {
                 return Err(LintError::new(format!("invalid rule name: {name:?}")));
             }
-            if registered.insert(name, *rule).is_some() {
+            if registered.insert(name, rule).is_some() {
                 return Err(LintError::new(format!("duplicate rule name: {name}")));
             }
         }
@@ -122,6 +126,19 @@ impl<'rule> RuleRegistry<'rule> {
     /// Iterate rules in stable name order.
     pub fn iter(&self) -> impl Iterator<Item = &dyn Rule> {
         self.rules.values().copied()
+    }
+}
+
+impl RuleRegistry<'static> {
+    /// Build a registry from distributed static registrations.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when a rule name is malformed or duplicated.
+    pub fn from_static(
+        rules: impl IntoIterator<Item = &'static dyn Rule>,
+    ) -> Result<Self, LintError> {
+        Self::from_rules(rules)
     }
 }
 

--- a/crates/larch-lint/src/suppression.rs
+++ b/crates/larch-lint/src/suppression.rs
@@ -1,0 +1,77 @@
+//! Reason-bearing, same-line lint suppression parsing.
+
+use crate::LintError;
+
+/// A validated inline suppression reason.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct SuppressionReason<'source>(&'source str);
+
+impl<'source> SuppressionReason<'source> {
+    /// Return the non-empty operator-facing reason.
+    #[must_use]
+    pub const fn as_str(self) -> &'source str {
+        self.0
+    }
+}
+
+/// Read a same-line `lint-<rule>: ok <reason>` suppression from a comment.
+///
+/// # Errors
+///
+/// Returns an error when the suppression token is present but its reason is
+/// absent. A missing token returns `Ok(None)`.
+pub fn reason<'source>(
+    line: &'source str,
+    token: &str,
+) -> Result<Option<SuppressionReason<'source>>, LintError> {
+    let Some(offset) = line.find(token) else {
+        return Ok(None);
+    };
+    let before = &line[..offset];
+    if !before.contains('#') && !before.contains("//") && !before.contains("<!--") {
+        return Ok(None);
+    }
+    let tail = &line[offset + token.len()..];
+    let Some(reason) = tail.strip_prefix(": ok") else {
+        return Ok(None);
+    };
+    let reason = reason.trim().trim_end_matches("-->").trim();
+    if reason.is_empty() {
+        return Err(LintError::new(format!(
+            "suppression {token} lacks a reason"
+        )));
+    }
+    Ok(Some(SuppressionReason(reason)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::reason;
+
+    #[test]
+    fn requires_a_reason_in_comment_forms() {
+        assert_eq!(
+            reason("// lint-demo: ok fixture exception", "lint-demo")
+                .expect("valid suppression")
+                .expect("suppressed")
+                .as_str(),
+            "fixture exception"
+        );
+        assert_eq!(
+            reason("<!-- lint-demo: ok documented exception -->", "lint-demo")
+                .expect("valid suppression")
+                .expect("suppressed")
+                .as_str(),
+            "documented exception"
+        );
+        assert!(reason("# lint-demo: ok", "lint-demo").is_err());
+    }
+
+    #[test]
+    fn ignores_tokens_outside_comments() {
+        assert_eq!(
+            reason("let value = lint-demo: ok", "lint-demo").expect("not a comment"),
+            None
+        );
+    }
+}

--- a/crates/larch-lint/src/syntax.rs
+++ b/crates/larch-lint/src/syntax.rs
@@ -1,0 +1,214 @@
+//! Shared Rust and Markdown syntax support for rule implementations.
+
+use pulldown_cmark::Parser;
+
+use crate::LintError;
+
+/// Parse one Rust source file and retain its source identity for diagnostics.
+pub struct RustSyntax {
+    path: String,
+    file: syn::File,
+}
+
+impl RustSyntax {
+    /// Parse Rust source with `syn`'s complete-file grammar.
+    ///
+    /// # Errors
+    ///
+    /// Returns a deterministic diagnostic when the source is not valid Rust.
+    pub fn parse(path: impl Into<String>, source: &str) -> Result<Self, LintError> {
+        let path = path.into();
+        let file = syn::parse_file(source)
+            .map_err(|error| LintError::new(format!("{path}: invalid Rust syntax: {error}")))?;
+        Ok(Self { path, file })
+    }
+
+    /// Return the repository-relative source path.
+    #[must_use]
+    pub fn path(&self) -> &str {
+        &self.path
+    }
+
+    /// Return the parsed syntax tree.
+    #[must_use]
+    pub const fn file(&self) -> &syn::File {
+        &self.file
+    }
+}
+
+/// Whether a Markdown line is outside a fence or inside one with an optional language.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum FenceState<'source> {
+    /// The line is ordinary Markdown.
+    Outside,
+    /// The line belongs to a fenced code block.
+    Inside { language: Option<&'source str> },
+}
+
+/// One source line annotated with its fenced-code state.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct MarkdownLine<'source> {
+    number: usize,
+    text: &'source str,
+    fence_state: FenceState<'source>,
+}
+
+impl<'source> MarkdownLine<'source> {
+    /// Return the one-based source line number.
+    #[must_use]
+    pub const fn number(self) -> usize {
+        self.number
+    }
+
+    /// Return the line without its newline terminator.
+    #[must_use]
+    pub const fn text(self) -> &'source str {
+        self.text
+    }
+
+    /// Return whether this line appears within a fenced code block.
+    #[must_use]
+    pub const fn fence_state(self) -> FenceState<'source> {
+        self.fence_state
+    }
+}
+
+/// A Markdown document with `CommonMark` events and line-oriented fence state.
+#[derive(Debug)]
+pub struct MarkdownDocument<'source> {
+    source: &'source str,
+}
+
+impl<'source> MarkdownDocument<'source> {
+    /// Retain source for structural `CommonMark` parsing and line-level rules.
+    #[must_use]
+    pub const fn new(source: &'source str) -> Self {
+        Self { source }
+    }
+
+    /// Return the maintained `CommonMark` parser for structural rules.
+    #[must_use]
+    pub fn parser(&self) -> Parser<'source> {
+        Parser::new(self.source)
+    }
+
+    /// Iterate source lines with deterministic fenced-code state.
+    #[must_use]
+    pub fn lines(&self) -> MarkdownLines<'source> {
+        MarkdownLines {
+            lines: self.source.lines().enumerate(),
+            open_fence: None,
+        }
+    }
+}
+
+/// Iterator returned by [`MarkdownDocument::lines`].
+pub struct MarkdownLines<'source> {
+    lines: std::iter::Enumerate<std::str::Lines<'source>>,
+    open_fence: Option<OpenFence<'source>>,
+}
+
+impl<'source> Iterator for MarkdownLines<'source> {
+    type Item = MarkdownLine<'source>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let (index, text) = self.lines.next()?;
+        let fence_state = match self.open_fence {
+            Some(open_fence) if open_fence.closes(text) => {
+                let state = FenceState::Inside {
+                    language: open_fence.language,
+                };
+                self.open_fence = None;
+                state
+            }
+            Some(open_fence) => FenceState::Inside {
+                language: open_fence.language,
+            },
+            None => {
+                if let Some(open_fence) = OpenFence::opens(text) {
+                    self.open_fence = Some(open_fence);
+                }
+                FenceState::Outside
+            }
+        };
+        Some(MarkdownLine {
+            number: index + 1,
+            text,
+            fence_state,
+        })
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct OpenFence<'source> {
+    marker: char,
+    width: usize,
+    language: Option<&'source str>,
+}
+
+impl<'source> OpenFence<'source> {
+    fn opens(line: &'source str) -> Option<Self> {
+        let trimmed = line.trim_start_matches([' ', '\t']);
+        let marker = trimmed.chars().next()?;
+        if marker != '`' && marker != '~' {
+            return None;
+        }
+        let width = trimmed
+            .chars()
+            .take_while(|character| *character == marker)
+            .count();
+        if width < 3 {
+            return None;
+        }
+        let info = trimmed[width..].trim();
+        if info.contains(marker) {
+            return None;
+        }
+        Some(Self {
+            marker,
+            width,
+            language: info.split_whitespace().next(),
+        })
+    }
+
+    fn closes(self, line: &str) -> bool {
+        let trimmed = line.trim_start_matches([' ', '\t']);
+        let width = trimmed
+            .chars()
+            .take_while(|character| *character == self.marker)
+            .count();
+        width >= self.width && trimmed[width..].trim().is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{FenceState, MarkdownDocument, RustSyntax};
+
+    #[test]
+    fn rust_syntax_reports_the_source_path() {
+        let Err(error) = RustSyntax::parse("src/bad.rs", "fn {") else {
+            panic!("invalid source unexpectedly parsed");
+        };
+        assert!(
+            error
+                .to_string()
+                .starts_with("src/bad.rs: invalid Rust syntax:")
+        );
+    }
+
+    #[test]
+    fn markdown_lines_track_fence_marker_width_and_language() {
+        let document = MarkdownDocument::new("# heading\n```bash\n# ignored\n````\n# visible");
+        let lines: Vec<_> = document.lines().collect();
+        assert_eq!(lines[0].fence_state(), FenceState::Outside);
+        assert_eq!(
+            lines[2].fence_state(),
+            FenceState::Inside {
+                language: Some("bash")
+            }
+        );
+        assert_eq!(lines[4].fence_state(), FenceState::Outside);
+        assert!(document.parser().next().is_some());
+    }
+}

--- a/crates/larch-lint/tests/cli.rs
+++ b/crates/larch-lint/tests/cli.rs
@@ -28,8 +28,64 @@ fn rules_lists_the_empty_foundation_registry() {
         .arg("rules")
         .assert()
         .success()
-        .stdout(predicate::str::is_empty())
+        .stdout("fixture\tValidate decentralized rule registration\n")
         .stderr(predicate::str::is_empty());
+}
+
+#[test]
+fn fixture_rule_is_discovered_without_a_central_registry_edit() {
+    let repository = TempRepo::new();
+    repository.write("fixtures/demo.fixture", b"allowed\nforbidden\n");
+    repository.commit_all();
+
+    TempRepo::command_from(repository.path())
+        .arg("all")
+        .assert()
+        .code(1)
+        .stdout("fixtures/demo.fixture:2: fixture violation\n")
+        .stderr(predicate::str::is_empty());
+}
+
+#[test]
+fn migration_ledger_rejects_missing_duplicate_and_stale_records() {
+    let missing = TempRepo::new();
+    fs::remove_file(
+        missing
+            .path()
+            .join("crates/larch-lint/migration-ledger/fixture.toml"),
+    )
+    .expect("remove default ledger");
+    missing.write("tracked.md", b"tracked\n");
+    missing.commit_all();
+    TempRepo::command_from(missing.path())
+        .arg("all")
+        .assert()
+        .code(2)
+        .stderr("larch-lint: error: missing migration-ledger record: crates/larch-lint/migration-ledger/fixture.toml\n");
+
+    let duplicate = TempRepo::new();
+    duplicate.write(
+        "crates/larch-lint/migration-ledger/fixture-copy.toml",
+        b"rule = \"fixture\"\n",
+    );
+    duplicate.commit_all();
+    TempRepo::command_from(duplicate.path())
+        .arg("all")
+        .assert()
+        .code(2)
+        .stderr("larch-lint: error: duplicate migration-ledger rule record: fixture\n");
+
+    let stale = TempRepo::new();
+    stale.write(
+        "crates/larch-lint/migration-ledger/obsolete.toml",
+        b"rule = \"obsolete\"\n",
+    );
+    stale.commit_all();
+    TempRepo::command_from(stale.path())
+        .arg("all")
+        .assert()
+        .code(2)
+        .stderr("larch-lint: error: stale migration-ledger rule record: obsolete\n");
 }
 
 #[test]

--- a/crates/larch-lint/tests/support/mod.rs
+++ b/crates/larch-lint/tests/support/mod.rs
@@ -15,7 +15,12 @@ impl TempRepo {
     pub fn new() -> Self {
         let directory = tempfile::tempdir().expect("tempdir");
         run_git(directory.path(), ["init", "--quiet"]);
-        Self { directory }
+        let repository = Self { directory };
+        repository.write(
+            "crates/larch-lint/migration-ledger/fixture.toml",
+            b"rule = \"fixture\"\n",
+        );
+        repository
     }
 
     pub fn path(&self) -> &Path {

--- a/docs/rust-dependency-survey.md
+++ b/docs/rust-dependency-survey.md
@@ -18,3 +18,25 @@ The selected runtime dependencies are `clap` and `globset`. The F2 test harness
 uses `assert_cmd`, `predicates`, and `tempfile`. Deferred selections stay out of
 `Cargo.lock` until code uses them. This keeps the foundation minimal and makes
 future dependency additions explicit review points.
+
+## Shared rule foundation (issue #7604)
+
+Issue #7604 establishes the extension points used by every remaining Rust lint.
+The survey checked current crates.io metadata, repository activity, and license
+metadata on 2026-07-17. All selected crates are active, unarchived, and
+license-compatible with larch's MIT license.
+
+| Need | Candidates | Maintenance and license check | Selection |
+|------|------------|-------------------------------|-----------|
+| Decentralized registration | [`inventory` 0.3.24](https://crates.io/crates/inventory/0.3.24), [`linkme` 0.3](https://crates.io/crates/linkme/0.3) | Both are maintained by dtolnay and MIT OR Apache-2.0. | Use `inventory`. Its typed, distributed registration lets each rule submit metadata and an implementation without editing a central registry. The runner sorts by rule name, so inventory's unspecified iteration order never reaches output. |
+| Module discovery | [`automod` 1.0.17](https://crates.io/crates/automod/1.0.17), manual `mod` declarations | `automod` is maintained by dtolnay and MIT OR Apache-2.0. | Use `automod` for `src/rules/`. A new leaf adds its own co-located rule source without changing `lib.rs` or a shared module list. |
+| Rust syntax | [`syn` 2.0.119](https://crates.io/crates/syn/2.0.119), [`ra_ap_syntax`](https://crates.io/crates/ra_ap_syntax) | Both are maintained and license-compatible; `syn` is MIT OR Apache-2.0. | Use `syn` with full parsing and visiting. It has the small stable AST surface required by the rule set; rust-analyzer internals would add substantially more churn. |
+| Markdown structure | [`pulldown-cmark` 0.13.4](https://crates.io/crates/pulldown-cmark/0.13.4), [`comrak`](https://crates.io/crates/comrak) | Both are maintained and MIT licensed. | Use `pulldown-cmark` for CommonMark events. The shared line iterator deliberately supplements it with fence state because line-oriented lint diagnostics need source-line membership, which event streams do not expose directly. |
+| Metadata and migration records | [`serde` 1.0.228](https://crates.io/crates/serde/1.0.228) with [`toml` 1.1.3](https://crates.io/crates/toml/1.1.3), handwritten parser | Both are maintained and MIT OR Apache-2.0. | Use `toml` for strict per-rule migration records. The one-file-per-rule directory rejects missing, duplicate, malformed, and stale records. |
+| Text, tabular, and identity helpers | [`regex` 1.13.1](https://crates.io/crates/regex/1.13.1), [`csv` 1.4.0](https://crates.io/crates/csv/1.4.0), [`uuid` 1.24.0](https://crates.io/crates/uuid/1.24.0) | All are maintained and permissively licensed (MIT OR Apache-2.0, Unlicense/MIT, and Apache-2.0 OR MIT respectively). | Establish these shared dependencies now for the filed textual-policy, TSV, and run-id leaves. Their rules remain the sole owners of policy semantics. |
+| Shell syntax | [`tree-sitter-bash` 0.25.1](https://crates.io/crates/tree-sitter-bash/0.25.1) with [`tree-sitter`](https://crates.io/crates/tree-sitter), `brush-parser` | Both candidates are maintained and MIT licensed. | Reserve the maintained tree-sitter grammar for the shell-contract leaves. The leaves must still test their required Bash semantics before adopting it; no regex-only parser is introduced by the foundation. |
+| Cargo workspace facts | [`cargo_metadata` 0.23.1](https://crates.io/crates/cargo_metadata/0.23.1), [`guppy`](https://crates.io/crates/guppy) | Both are maintained and license-compatible; `cargo_metadata` is MIT. | Establish `cargo_metadata` for the package-architecture leaf. It exposes Cargo's structured workspace view without guppy's larger graph-analysis surface. |
+
+The F3 workspace dependency set is intentionally complete for the already
+filed leaves. A leaf may not add a root dependency: a newly discovered shared
+need requires a blocked foundation issue and an amended dependency graph.


### PR DESCRIPTION
## Summary

- add auto-discovered, inventory-backed rule metadata and registration
- add shared Rust, Markdown fence, and reason-bearing suppression APIs
- validate one-record-per-rule migration ledgers and document the maintained crate survey

## Validation

- `make rust-check`
- `cargo run --quiet --bin larch-lint -- all`

Fixes #7604