### PR TITLE
Fixes #7617: add Rust kv-codec and result-env-key-parity rules

### DIFF
--- a/crates/larch-lint/migration-ledger/kv-codec.toml
+++ b/crates/larch-lint/migration-ledger/kv-codec.toml
@@ -1,0 +1,1 @@
+rule = "kv-codec"

--- a/crates/larch-lint/migration-ledger/result-env-key-parity.toml
+++ b/crates/larch-lint/migration-ledger/result-env-key-parity.toml
@@ -1,0 +1,1 @@
+rule = "result-env-key-parity"

--- a/crates/larch-lint/src/rules/kv_codec.rs
+++ b/crates/larch-lint/src/rules/kv_codec.rs
@@ -1,0 +1,503 @@
+//! Reject ad-hoc `KEY=value` readers and emitters outside shared owners.
+//!
+//! # Crate survey (issue #7617)
+//!
+//! | Need | Candidates | Selection |
+//! |------|------------|-----------|
+//! | Rust syntax | workspace `syn`, `ra_ap_syntax` | Use `syn` visitors already established by #7604 for call-shape detection. Line numbers come from the source text (no `proc-macro2` `span-locations` feature; leaves must not add workspace dependencies). Custom code encodes only owner paths and prohibited shapes. |
+//! | Shell line shapes | workspace `regex`, `tree-sitter-bash` | This future-state rule targets Rust sources only. Shell KEY=value ratchet remains with the Python `kv-codec` lint until the non-Python cutover leaf retires it. |
+//! | Serialization / baselines | workspace `serde`/`toml` | Not required: the Rust corpus starts at zero findings, so no grandfathering baseline ships. |
+//!
+//! No workspace `Cargo.toml` dependency is added (umbrella concurrency contract).
+
+use std::collections::BTreeSet;
+
+use syn::{
+    Expr, ExprForLoop, ExprMethodCall, ItemFn, Member,
+    visit::{self, Visit},
+};
+
+use crate::{
+    Finding, LintError, PathSelector, RepoPath, Repository, Rule, RuleMetadata, syntax::RustSyntax,
+};
+
+const NAME: &str = "kv-codec";
+const DESCRIPTION: &str =
+    "Reject ad-hoc KEY=value readers and emitters outside shared codec owners";
+
+/// Future-state reader owners (Rust equivalents of `larch.io` / `env_file`).
+const READER_OWNERS: &[&str] = &[
+    "crates/larch-io/src/lib.rs",
+    "crates/larch-io/src/env_file.rs",
+    "crates/larch-core/src/env_file.rs",
+];
+
+/// Future-state emitter owner (Rust equivalent of `logging_util.emit_kv`).
+const EMITTER_OWNER: &str = "crates/larch-core/src/logging_util.rs";
+
+/// Modules where ad-hoc `print!`/`println!` KEY=value wrappers are also gated.
+const EMITTER_GUARDED_PREFIXES: &[&str] = &["crates/larch-issue/"];
+
+const OPTION_ITER_NAMES: &[&str] = &["args", "argv", "options", "tokens"];
+const OPTION_BINDING_NAMES: &[&str] = &["arg", "token", "opt", "option", "argv_item"];
+
+pub static METADATA: RuleMetadata = RuleMetadata::new(
+    NAME,
+    DESCRIPTION,
+    "crates/larch-lint/migration-ledger/kv-codec.toml",
+);
+
+#[derive(Debug)]
+pub struct KvCodecRule;
+
+pub static RULE: KvCodecRule = KvCodecRule;
+
+impl Rule for KvCodecRule {
+    fn name(&self) -> &'static str {
+        NAME
+    }
+
+    fn description(&self) -> &'static str {
+        DESCRIPTION
+    }
+
+    fn check(&self, repository: &Repository) -> Result<Vec<Finding>, LintError> {
+        let selector = PathSelector::new(&["crates/**/*.rs"], &[])?;
+        let mut findings = Vec::new();
+        for path in selector.select(repository) {
+            findings.extend(check_rust_file(repository, path)?);
+        }
+        findings.sort();
+        findings.dedup();
+        Ok(findings)
+    }
+}
+
+crate::register_rule!(METADATA, RULE);
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+enum ViolationKind {
+    Split,
+    EmitterDef,
+    PrintWrapper,
+}
+
+impl ViolationKind {
+    const fn message(self) -> &'static str {
+        match self {
+            Self::Split => "ad-hoc KEY=value split; use the shared KV codec owner",
+            Self::EmitterDef => "ad-hoc KEY=value emitter; use the shared emit_kv owner",
+            Self::PrintWrapper => {
+                "ad-hoc KEY=value print wrapper; use the shared emit_kv owner"
+            }
+        }
+    }
+}
+
+fn check_rust_file(repository: &Repository, path: &RepoPath) -> Result<Vec<Finding>, LintError> {
+    let source = repository.read_utf8(path)?;
+    let syntax = RustSyntax::parse(path.as_str(), &source)?;
+    let mut visitor = KvCodecVisitor {
+        reader_owner: is_reader_owner(path.as_str()),
+        emitter_owner: path.as_str() == EMITTER_OWNER,
+        emitter_guarded: is_emitter_guarded(path.as_str()),
+        option_loop_depth: 0,
+        pending: Vec::new(),
+    };
+    visitor.visit_file(syntax.file());
+    Ok(resolve_findings(path.as_str(), &source, &visitor.pending))
+}
+
+fn is_reader_owner(path: &str) -> bool {
+    READER_OWNERS.contains(&path)
+}
+
+fn is_emitter_guarded(path: &str) -> bool {
+    EMITTER_GUARDED_PREFIXES
+        .iter()
+        .any(|prefix| path.starts_with(prefix))
+}
+
+struct PendingViolation {
+    kind: ViolationKind,
+    needles: &'static [&'static str],
+}
+
+struct KvCodecVisitor {
+    reader_owner: bool,
+    emitter_owner: bool,
+    emitter_guarded: bool,
+    option_loop_depth: usize,
+    pending: Vec<PendingViolation>,
+}
+
+impl<'ast> Visit<'ast> for KvCodecVisitor {
+    fn visit_item_fn(&mut self, node: &'ast ItemFn) {
+        if !self.emitter_owner && node.sig.ident == "emit_kv" {
+            self.pending.push(PendingViolation {
+                kind: ViolationKind::EmitterDef,
+                needles: &["fn emit_kv", "fn emit_kv("],
+            });
+        }
+        visit::visit_item_fn(self, node);
+    }
+
+    fn visit_expr_for_loop(&mut self, node: &'ast ExprForLoop) {
+        let option_loop = is_option_iter_expr(&node.expr);
+        if option_loop {
+            self.option_loop_depth += 1;
+        }
+        visit::visit_expr_for_loop(self, node);
+        if option_loop {
+            self.option_loop_depth -= 1;
+        }
+    }
+
+    fn visit_expr_method_call(&mut self, node: &'ast ExprMethodCall) {
+        if !self.reader_owner
+            && self.option_loop_depth == 0
+            && is_equals_split(node)
+            && !is_option_receiver(&node.receiver)
+        {
+            self.pending.push(PendingViolation {
+                kind: ViolationKind::Split,
+                needles: split_needles(node),
+            });
+        }
+        if self.emitter_guarded && !self.emitter_owner && is_kv_print_method(node) {
+            self.pending.push(PendingViolation {
+                kind: ViolationKind::PrintWrapper,
+                needles: &[".print(", ".println(", ".write(", ".writeln("],
+            });
+        }
+        visit::visit_expr_method_call(self, node);
+    }
+
+    fn visit_expr_macro(&mut self, node: &'ast syn::ExprMacro) {
+        self.maybe_print_macro(node);
+        visit::visit_expr_macro(self, node);
+    }
+
+    fn visit_stmt_macro(&mut self, node: &'ast syn::StmtMacro) {
+        self.maybe_print_macro_path_tokens(&node.mac);
+        visit::visit_stmt_macro(self, node);
+    }
+}
+
+impl KvCodecVisitor {
+    fn maybe_print_macro(&mut self, node: &syn::ExprMacro) {
+        self.maybe_print_macro_path_tokens(&node.mac);
+    }
+
+    fn maybe_print_macro_path_tokens(&mut self, mac: &syn::Macro) {
+        if self.emitter_guarded && !self.emitter_owner && is_kv_print_macro(mac) {
+            self.pending.push(PendingViolation {
+                kind: ViolationKind::PrintWrapper,
+                needles: &[
+                    "print!(",
+                    "println!(",
+                    "eprint!(",
+                    "eprintln!(",
+                    "write!(",
+                    "writeln!(",
+                ],
+            });
+        }
+    }
+}
+
+fn split_needles(call: &ExprMethodCall) -> &'static [&'static str] {
+    match call.method.to_string().as_str() {
+        "split_once" => &[".split_once('=')", ".split_once(\"=\")"],
+        "rsplit_once" => &[".rsplit_once('=')", ".rsplit_once(\"=\")"],
+        "splitn" => &[".splitn(2, '=')", ".splitn(2, \"=\")"],
+        "rsplitn" => &[".rsplitn(2, '=')", ".rsplitn(2, \"=\")"],
+        _ => &[".split_once('=')"],
+    }
+}
+
+fn resolve_findings(path: &str, source: &str, pending: &[PendingViolation]) -> Vec<Finding> {
+    let lines: Vec<(u32, &str)> = source
+        .lines()
+        .enumerate()
+        .map(|(index, line)| (u32::try_from(index + 1).unwrap_or(1), line))
+        .collect();
+    let mut used_lines = BTreeSet::new();
+    let mut findings = Vec::new();
+    for item in pending {
+        let line = take_line(&lines, &mut used_lines, item.needles, item.kind).unwrap_or(1);
+        findings.push(Finding::new(path, line, item.kind.message()));
+    }
+    findings
+}
+
+fn take_line(
+    lines: &[(u32, &str)],
+    used: &mut BTreeSet<u32>,
+    needles: &[&str],
+    kind: ViolationKind,
+) -> Option<u32> {
+    for (number, text) in lines {
+        if used.contains(number) {
+            continue;
+        }
+        let matches = match kind {
+            ViolationKind::Split => needles.iter().any(|needle| text.contains(needle)),
+            ViolationKind::EmitterDef => {
+                text.contains("fn emit_kv") && !text.trim_start().starts_with("//")
+            }
+            ViolationKind::PrintWrapper => {
+                needles.iter().any(|needle| text.contains(needle)) && looks_like_kv_format(text)
+            }
+        };
+        if matches && used.insert(*number) {
+            return Some(*number);
+        }
+    }
+    None
+}
+
+fn is_option_iter_expr(expr: &Expr) -> bool {
+    match expr {
+        Expr::Path(path) => path
+            .path
+            .get_ident()
+            .is_some_and(|ident| OPTION_ITER_NAMES.contains(&ident.to_string().as_str())),
+        Expr::Field(field) => match &field.member {
+            Member::Named(ident) => OPTION_ITER_NAMES.contains(&ident.to_string().as_str()),
+            Member::Unnamed(_) => false,
+        },
+        _ => false,
+    }
+}
+
+fn is_option_receiver(expr: &Expr) -> bool {
+    match expr {
+        Expr::Path(path) => path
+            .path
+            .get_ident()
+            .is_some_and(|ident| OPTION_BINDING_NAMES.contains(&ident.to_string().as_str())),
+        Expr::Reference(reference) => is_option_receiver(&reference.expr),
+        Expr::Paren(paren) => is_option_receiver(&paren.expr),
+        _ => false,
+    }
+}
+
+fn is_equals_split(call: &ExprMethodCall) -> bool {
+    let method = call.method.to_string();
+    match method.as_str() {
+        "split_once" | "rsplit_once" => equals_literal(call.args.first()),
+        "splitn" | "rsplitn" => {
+            is_two_literal(call.args.first()) && equals_literal(call.args.iter().nth(1))
+        }
+        _ => false,
+    }
+}
+
+fn equals_literal(expr: Option<&Expr>) -> bool {
+    match expr {
+        Some(Expr::Lit(lit)) => match &lit.lit {
+            syn::Lit::Char(character) => character.value() == '=',
+            syn::Lit::Str(string) => string.value() == "=",
+            _ => false,
+        },
+        _ => false,
+    }
+}
+
+fn is_two_literal(expr: Option<&Expr>) -> bool {
+    matches!(expr, Some(Expr::Lit(lit)) if matches!(&lit.lit, syn::Lit::Int(value) if value.base10_digits() == "2"))
+}
+
+fn is_kv_print_method(call: &ExprMethodCall) -> bool {
+    let method = call.method.to_string();
+    if method != "print" && method != "println" && method != "write" && method != "writeln" {
+        return false;
+    }
+    call.args.iter().any(expr_contains_equals_format)
+}
+
+fn is_kv_print_macro(mac: &syn::Macro) -> bool {
+    let name = mac
+        .path
+        .segments
+        .last()
+        .map(|segment| segment.ident.to_string())
+        .unwrap_or_default();
+    if !matches!(
+        name.as_str(),
+        "print" | "println" | "eprint" | "eprintln" | "write" | "writeln"
+    ) {
+        return false;
+    }
+    looks_like_kv_format(&mac.tokens.to_string())
+}
+
+fn looks_like_kv_format(tokens: &str) -> bool {
+    let compact: String = tokens.chars().filter(|ch| !ch.is_whitespace()).collect();
+    compact.contains("}={")
+        || compact.contains("{}={}")
+        || compact.contains("\"=\"")
+        || compact.contains("{key}={value}")
+        || compact.contains("{k}={v}")
+}
+
+fn expr_contains_equals_format(expr: &Expr) -> bool {
+    match expr {
+        Expr::Lit(lit) => match &lit.lit {
+            syn::Lit::Str(string) => {
+                let value = string.value();
+                value.contains('=') && (value.contains('{') || value.contains("{}"))
+            }
+            _ => false,
+        },
+        Expr::Reference(reference) => expr_contains_equals_format(&reference.expr),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{EMITTER_OWNER, KvCodecRule, READER_OWNERS};
+    use crate::{Git, LintError, Repository, Rule};
+    use std::path::{Path, PathBuf};
+
+    struct Fixture {
+        _temporary: tempfile::TempDir,
+        repository: Repository,
+    }
+
+    struct FakeGit {
+        root: PathBuf,
+        stream: Vec<u8>,
+    }
+
+    impl Git for FakeGit {
+        fn repository_root(&self, _cwd: &Path) -> Result<PathBuf, LintError> {
+            Ok(self.root.clone())
+        }
+
+        fn tracked_paths(&self, _root: &Path) -> Result<Vec<u8>, LintError> {
+            Ok(self.stream.clone())
+        }
+    }
+
+    fn repository_with(files: &[(&str, &str)]) -> Fixture {
+        let temporary = tempfile::tempdir().expect("tempdir");
+        let mut stream = Vec::new();
+        for (relative, contents) in files {
+            let path = temporary.path().join(relative);
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent).expect("parents");
+            }
+            std::fs::write(&path, contents).expect("write");
+            stream.extend(relative.as_bytes());
+            stream.push(0);
+        }
+        let repository = Repository::discover(
+            &FakeGit {
+                root: temporary.path().to_path_buf(),
+                stream,
+            },
+            temporary.path(),
+        )
+        .expect("repository");
+        Fixture {
+            _temporary: temporary,
+            repository,
+        }
+    }
+
+    #[test]
+    fn detects_split_once_reader_outside_owner() {
+        let fixture = repository_with(&[(
+            "crates/larch-example/src/lib.rs",
+            "fn parse(rows: &[String]) {\n    for line in rows {\n        let _ = line.split_once('=');\n    }\n}\n",
+        )]);
+        let findings = KvCodecRule.check(&fixture.repository).expect("check");
+        assert_eq!(findings.len(), 1);
+        assert!(findings[0].to_string().contains(":3:"));
+        assert!(findings[0].to_string().contains("ad-hoc KEY=value split"));
+    }
+
+    #[test]
+    fn ignores_option_loop_and_reader_owner() {
+        let option = repository_with(&[(
+            "crates/larch-example/src/lib.rs",
+            "fn parse(args: &[String]) {\n    for arg in args {\n        let _ = arg.split_once('=');\n    }\n}\n",
+        )]);
+        assert!(
+            KvCodecRule
+                .check(&option.repository)
+                .expect("check")
+                .is_empty()
+        );
+
+        let owner = repository_with(&[(
+            READER_OWNERS[0],
+            "fn parse(rows: &[String]) {\n    for line in rows {\n        let _ = line.split_once('=');\n    }\n}\n",
+        )]);
+        assert!(
+            KvCodecRule
+                .check(&owner.repository)
+                .expect("check")
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn detects_splitn_and_private_emit_kv() {
+        let fixture = repository_with(&[(
+            "crates/larch-issue/src/create.rs",
+            "fn emit_kv(key: &str, value: &str) {\n    println!(\"{key}={value}\");\n}\nfn read(line: &str) {\n    let _ = line.splitn(2, '=');\n}\n",
+        )]);
+        let findings = KvCodecRule.check(&fixture.repository).expect("check");
+        let messages: Vec<_> = findings.iter().map(ToString::to_string).collect();
+        assert!(
+            messages
+                .iter()
+                .any(|message| message.contains("ad-hoc KEY=value emitter")),
+            "{messages:?}"
+        );
+        assert!(
+            messages
+                .iter()
+                .any(|message| message.contains("ad-hoc KEY=value split")),
+            "{messages:?}"
+        );
+        assert!(
+            messages
+                .iter()
+                .any(|message| message.contains("ad-hoc KEY=value print wrapper")),
+            "{messages:?}"
+        );
+    }
+
+    #[test]
+    fn emitter_owner_may_define_emit_kv() {
+        let fixture = repository_with(&[(
+            EMITTER_OWNER,
+            "pub fn emit_kv(key: &str, value: &str) {\n    println!(\"{key}={value}\");\n}\n",
+        )]);
+        assert!(
+            KvCodecRule
+                .check(&fixture.repository)
+                .expect("check")
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn ignores_non_equals_splits() {
+        let fixture = repository_with(&[(
+            "crates/larch-example/src/lib.rs",
+            "fn parse(rows: &[String]) {\n    for line in rows {\n        let _ = line.split_once(':');\n        let _ = line.splitn(2, ',');\n    }\n}\n",
+        )]);
+        assert!(
+            KvCodecRule
+                .check(&fixture.repository)
+                .expect("check")
+                .is_empty()
+        );
+    }
+}

--- a/crates/larch-lint/src/rules/result_env_key_parity.rs
+++ b/crates/larch-lint/src/rules/result_env_key_parity.rs
@@ -1,0 +1,553 @@
+//! Compare sibling result-env writers and reject divergent key sets.
+//!
+//! # Crate survey (issue #7617)
+//!
+//! | Need | Candidates | Selection |
+//! |------|------------|-----------|
+//! | Rust syntax | workspace `syn` | Use `syn` visitors to collect literal writer calls. Line numbers come from the source text (no new `proc-macro2` feature; leaves must not add workspace dependencies). Custom code owns only writer-name, basename, and key-tuple shapes. |
+//! | Suppression parsing | workspace shared `suppression` module | Reuse the reason-bearing `lint-<rule>: ok <reason>` helper from #7604. |
+//! | Serialization / baselines | workspace `serde`/`toml` | Not required: the Rust corpus starts at zero findings, so no grandfathering baseline ships. |
+//!
+//! No workspace `Cargo.toml` dependency is added (umbrella concurrency contract).
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use syn::{
+    Expr, ExprCall, ExprMethodCall, ExprPath, Lit, Member,
+    visit::{self, Visit},
+};
+
+use crate::{
+    Finding, LintError, PathSelector, RepoPath, Repository, Rule, RuleMetadata, suppression,
+    syntax::RustSyntax,
+};
+
+const NAME: &str = "result-env-key-parity";
+const DESCRIPTION: &str =
+    "Reject divergent key sets across sibling writers of the same result-env basename";
+const SUPPRESSION_TOKEN: &str = "lint-result-env-key-parity";
+const WRITER_EXACT_NAMES: &[&str] = &["phase_driver_write_result_env", "write_result_env"];
+const WRITER_SUFFIX: &str = "_write_result_env";
+const MIN_SIBLING_WRITERS: usize = 2;
+
+/// Per-basename keys a writer may omit without violating parity (G-Cfg-3).
+const OPTIONAL_KEYS: &[(&str, &[&str])] = &[];
+
+pub static METADATA: RuleMetadata = RuleMetadata::new(
+    NAME,
+    DESCRIPTION,
+    "crates/larch-lint/migration-ledger/result-env-key-parity.toml",
+);
+
+#[derive(Debug)]
+pub struct ResultEnvKeyParityRule;
+
+pub static RULE: ResultEnvKeyParityRule = ResultEnvKeyParityRule;
+
+impl Rule for ResultEnvKeyParityRule {
+    fn name(&self) -> &'static str {
+        NAME
+    }
+
+    fn description(&self) -> &'static str {
+        DESCRIPTION
+    }
+
+    fn check(&self, repository: &Repository) -> Result<Vec<Finding>, LintError> {
+        let selector = PathSelector::new(&["crates/**/*.rs"], &[])?;
+        let mut writers = Vec::new();
+        let mut sources: BTreeMap<String, String> = BTreeMap::new();
+        for path in selector.select(repository) {
+            let source = repository.read_utf8(path)?;
+            writers.extend(collect_writers(path, &source)?);
+            sources.insert(path.as_str().to_owned(), source);
+        }
+        for writer in &mut writers {
+            writer.line = resolve_writer_line(
+                sources.get(&writer.path).map_or("", String::as_str),
+                &writer.callee,
+                &writer.basename,
+                writer.occurrence,
+            );
+        }
+        findings_for_writers(&writers, &sources)
+    }
+}
+
+crate::register_rule!(METADATA, RULE);
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct WriterCall {
+    path: String,
+    line: u32,
+    callee: String,
+    basename: String,
+    keys: BTreeSet<String>,
+    occurrence: usize,
+}
+
+fn collect_writers(path: &RepoPath, source: &str) -> Result<Vec<WriterCall>, LintError> {
+    let syntax = RustSyntax::parse(path.as_str(), source)?;
+    let mut visitor = WriterVisitor {
+        path: path.as_str().to_owned(),
+        writers: Vec::new(),
+        occurrence_by_key: BTreeMap::new(),
+    };
+    visitor.visit_file(syntax.file());
+    Ok(visitor.writers)
+}
+
+struct WriterVisitor {
+    path: String,
+    writers: Vec<WriterCall>,
+    occurrence_by_key: BTreeMap<(String, String), usize>,
+}
+
+impl<'ast> Visit<'ast> for WriterVisitor {
+    fn visit_expr_call(&mut self, node: &'ast ExprCall) {
+        if let Some(name) = callee_name(&node.func)
+            && is_writer_name(&name)
+        {
+            self.maybe_record(&name, node.args.iter());
+        }
+        visit::visit_expr_call(self, node);
+    }
+
+    fn visit_expr_method_call(&mut self, node: &'ast ExprMethodCall) {
+        let name = node.method.to_string();
+        if is_writer_name(&name) {
+            self.maybe_record(&name, node.args.iter());
+        }
+        visit::visit_expr_method_call(self, node);
+    }
+}
+
+impl WriterVisitor {
+    fn maybe_record<'a>(&mut self, callee: &str, args: impl Iterator<Item = &'a Expr>) {
+        let args: Vec<&Expr> = args.collect();
+        let Some(basename) = args.iter().find_map(|expr| literal_basename(expr)) else {
+            return;
+        };
+        let Some(keys) = args.iter().find_map(|expr| literal_keys(expr)) else {
+            return;
+        };
+        let occurrence_key = (callee.to_owned(), basename.clone());
+        let occurrence = self.occurrence_by_key.entry(occurrence_key).or_insert(0);
+        *occurrence += 1;
+        self.writers.push(WriterCall {
+            path: self.path.clone(),
+            line: 1,
+            callee: callee.to_owned(),
+            basename,
+            keys,
+            occurrence: *occurrence,
+        });
+    }
+}
+
+fn resolve_writer_line(source: &str, callee: &str, basename: &str, occurrence: usize) -> u32 {
+    let mut seen = 0usize;
+    for (index, line) in source.lines().enumerate() {
+        if line.contains(callee) && line.contains(basename) {
+            seen += 1;
+            if seen == occurrence {
+                return u32::try_from(index + 1).unwrap_or(1);
+            }
+        }
+    }
+    // Multi-line call: basename may be on a later line than the callee.
+    seen = 0;
+    let lines: Vec<&str> = source.lines().collect();
+    for (index, line) in lines.iter().enumerate() {
+        if !line.contains(callee) {
+            continue;
+        }
+        let window = lines[index..].iter().take(6).copied().collect::<Vec<_>>().join("\n");
+        if window.contains(basename) {
+            seen += 1;
+            if seen == occurrence {
+                return u32::try_from(index + 1).unwrap_or(1);
+            }
+        }
+    }
+    1
+}
+
+fn is_writer_name(name: &str) -> bool {
+    WRITER_EXACT_NAMES.contains(&name) || name.ends_with(WRITER_SUFFIX)
+}
+
+fn callee_name(expr: &Expr) -> Option<String> {
+    match expr {
+        Expr::Path(ExprPath { path, .. }) => path.segments.last().map(|s| s.ident.to_string()),
+        Expr::Field(field) => match &field.member {
+            Member::Named(ident) => Some(ident.to_string()),
+            Member::Unnamed(_) => None,
+        },
+        Expr::Paren(paren) => callee_name(&paren.expr),
+        _ => None,
+    }
+}
+
+fn literal_basename(expr: &Expr) -> Option<String> {
+    match expr {
+        Expr::Lit(lit) => match &lit.lit {
+            Lit::Str(string) => basename_from_path(&string.value()),
+            _ => None,
+        },
+        Expr::Reference(reference) => literal_basename(&reference.expr),
+        Expr::Paren(paren) => literal_basename(&paren.expr),
+        Expr::Call(call) => {
+            let name = callee_name(&call.func)?;
+            if matches!(name.as_str(), "new" | "from" | "from_str") {
+                call.args.iter().find_map(literal_basename)
+            } else {
+                None
+            }
+        }
+        Expr::MethodCall(method) => {
+            let name = method.method.to_string();
+            if name == "join" {
+                method.args.iter().find_map(literal_basename)
+            } else {
+                literal_basename(&method.receiver)
+                    .or_else(|| method.args.iter().find_map(literal_basename))
+            }
+        }
+        Expr::Binary(binary) if matches!(binary.op, syn::BinOp::Div(_)) => {
+            literal_basename(&binary.right)
+        }
+        _ => None,
+    }
+}
+
+fn basename_from_path(value: &str) -> Option<String> {
+    let base = value.rsplit('/').next().unwrap_or(value);
+    if base.is_empty() {
+        return None;
+    }
+    // Result-env basenames are lowercase `.env` by convention; keep the exact
+    // suffix check so `Foo.ENV` is not treated as a result-env target.
+    #[allow(clippy::case_sensitive_file_extension_comparisons)] // intentional exact `.env`
+    if base.ends_with(".env") {
+        Some(base.to_owned())
+    } else {
+        None
+    }
+}
+
+fn literal_keys(expr: &Expr) -> Option<BTreeSet<String>> {
+    match expr {
+        Expr::Array(array) => keys_from_elements(array.elems.iter()),
+        Expr::Reference(reference) => literal_keys(&reference.expr),
+        Expr::Paren(paren) => literal_keys(&paren.expr),
+        Expr::Call(call) => call.args.iter().find_map(literal_keys),
+        Expr::Macro(mac) => {
+            let name = mac
+                .mac
+                .path
+                .segments
+                .last()
+                .map(|segment| segment.ident.to_string())
+                .unwrap_or_default();
+            if name == "vec" {
+                parse_vec_macro_keys(&mac.mac.tokens.to_string())
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+fn keys_from_elements<'a>(elements: impl Iterator<Item = &'a Expr>) -> Option<BTreeSet<String>> {
+    let mut keys = BTreeSet::new();
+    for element in elements {
+        let key = match element {
+            Expr::Tuple(tuple) if tuple.elems.len() == 2 => string_literal(tuple.elems.first()?),
+            Expr::Call(call) if call.args.len() == 2 => string_literal(call.args.first()?),
+            _ => None,
+        }?;
+        keys.insert(key);
+    }
+    Some(keys)
+}
+
+fn string_literal(expr: &Expr) -> Option<String> {
+    match expr {
+        Expr::Lit(lit) => match &lit.lit {
+            Lit::Str(string) => Some(string.value()),
+            _ => None,
+        },
+        Expr::Reference(reference) => string_literal(&reference.expr),
+        Expr::Call(call) => call.args.iter().find_map(string_literal),
+        Expr::MethodCall(method) => method.args.iter().find_map(string_literal),
+        _ => None,
+    }
+}
+
+fn parse_vec_macro_keys(tokens: &str) -> Option<BTreeSet<String>> {
+    let mut keys = BTreeSet::new();
+    let mut rest = tokens;
+    while let Some(start) = rest.find("(\"") {
+        rest = &rest[start + 2..];
+        let end = rest.find('"')?;
+        keys.insert(rest[..end].to_owned());
+        rest = &rest[end + 1..];
+        let close = rest.find(')')?;
+        rest = &rest[close + 1..];
+    }
+    if keys.is_empty() { None } else { Some(keys) }
+}
+
+fn optional_keys_for(basename: &str) -> BTreeSet<String> {
+    OPTIONAL_KEYS
+        .iter()
+        .find(|(name, _)| *name == basename)
+        .map(|(_, keys)| keys.iter().map(|key| (*key).to_owned()).collect())
+        .unwrap_or_default()
+}
+
+fn findings_for_writers(
+    writers: &[WriterCall],
+    sources: &BTreeMap<String, String>,
+) -> Result<Vec<Finding>, LintError> {
+    let mut by_basename: BTreeMap<&str, Vec<&WriterCall>> = BTreeMap::new();
+    for writer in writers {
+        by_basename
+            .entry(writer.basename.as_str())
+            .or_default()
+            .push(writer);
+    }
+    let mut required: BTreeMap<&str, BTreeSet<String>> = BTreeMap::new();
+    for (basename, group) in &by_basename {
+        if group.len() < MIN_SIBLING_WRITERS {
+            continue;
+        }
+        let mut union = BTreeSet::new();
+        for writer in group {
+            union.extend(writer.keys.iter().cloned());
+        }
+        for key in optional_keys_for(basename) {
+            union.remove(&key);
+        }
+        required.insert(basename, union);
+    }
+
+    let mut findings = Vec::new();
+    for writer in writers {
+        let Some(needed) = required.get(writer.basename.as_str()) else {
+            continue;
+        };
+        let missing: Vec<&String> = needed.difference(&writer.keys).collect();
+        if missing.is_empty() {
+            continue;
+        }
+        let line_text = sources
+            .get(&writer.path)
+            .and_then(|source| source.lines().nth(usize::try_from(writer.line).ok()?.checked_sub(1)?))
+            .unwrap_or("");
+        if suppression::reason(line_text, SUPPRESSION_TOKEN)?.is_some() {
+            continue;
+        }
+        for key in missing {
+            findings.push(Finding::new(
+                writer.path.clone(),
+                writer.line,
+                format!(
+                    "{} writer missing key {key} present in sibling writers",
+                    writer.basename
+                ),
+            ));
+        }
+    }
+    findings.sort();
+    findings.dedup();
+    Ok(findings)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{OPTIONAL_KEYS, ResultEnvKeyParityRule};
+    use crate::{Git, LintError, Repository, Rule};
+    use std::path::{Path, PathBuf};
+
+    struct Fixture {
+        _temporary: tempfile::TempDir,
+        repository: Repository,
+    }
+
+    struct FakeGit {
+        root: PathBuf,
+        stream: Vec<u8>,
+    }
+
+    impl Git for FakeGit {
+        fn repository_root(&self, _cwd: &Path) -> Result<PathBuf, LintError> {
+            Ok(self.root.clone())
+        }
+
+        fn tracked_paths(&self, _root: &Path) -> Result<Vec<u8>, LintError> {
+            Ok(self.stream.clone())
+        }
+    }
+
+    fn repository_with(files: &[(&str, &str)]) -> Fixture {
+        let temporary = tempfile::tempdir().expect("tempdir");
+        let mut stream = Vec::new();
+        for (relative, contents) in files {
+            let path = temporary.path().join(relative);
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent).expect("parents");
+            }
+            std::fs::write(&path, contents).expect("write");
+            stream.extend(relative.as_bytes());
+            stream.push(0);
+        }
+        let repository = Repository::discover(
+            &FakeGit {
+                root: temporary.path().to_path_buf(),
+                stream,
+            },
+            temporary.path(),
+        )
+        .expect("repository");
+        Fixture {
+            _temporary: temporary,
+            repository,
+        }
+    }
+
+    fn writer_src(basename: &str, keys: &[&str], pragma: bool) -> String {
+        let open = if pragma {
+            "    write_result_env(  // lint-result-env-key-parity: ok fixture divergence\n"
+        } else {
+            "    write_result_env(\n"
+        };
+        let items = keys
+            .iter()
+            .map(|key| format!("(\"{key}\", \"value\")"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!(
+            "fn emit(path: &str) {{\n{open}        \"{basename}\",\n        [{items}],\n    );\n}}\n"
+        )
+    }
+
+    #[test]
+    fn identical_key_sets_are_clean() {
+        let fixture = repository_with(&[
+            (
+                "crates/a/src/lib.rs",
+                &writer_src("slot.env", &["A", "B"], false),
+            ),
+            (
+                "crates/b/src/lib.rs",
+                &writer_src("slot.env", &["A", "B"], false),
+            ),
+        ]);
+        assert!(
+            ResultEnvKeyParityRule
+                .check(&fixture.repository)
+                .expect("check")
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn missing_key_names_basename_and_key() {
+        let fixture = repository_with(&[
+            (
+                "crates/a/src/lib.rs",
+                &writer_src("slot.env", &["A", "B"], false),
+            ),
+            (
+                "crates/b/src/lib.rs",
+                &writer_src("slot.env", &["A"], false),
+            ),
+        ]);
+        let findings = ResultEnvKeyParityRule
+            .check(&fixture.repository)
+            .expect("check");
+        assert_eq!(findings.len(), 1);
+        assert_eq!(
+            findings[0].to_string(),
+            "crates/b/src/lib.rs:2: slot.env writer missing key B present in sibling writers"
+        );
+    }
+
+    #[test]
+    fn single_writer_and_dynamic_keys_are_skipped() {
+        let solo = repository_with(&[(
+            "crates/a/src/lib.rs",
+            &writer_src("solo.env", &["A", "B", "C"], false),
+        )]);
+        assert!(
+            ResultEnvKeyParityRule
+                .check(&solo.repository)
+                .expect("check")
+                .is_empty()
+        );
+
+        let dynamic = repository_with(&[
+            (
+                "crates/a/src/lib.rs",
+                &writer_src("slot.env", &["A", "B"], false),
+            ),
+            (
+                "crates/b/src/lib.rs",
+                "fn emit(rows: &[(&str, &str)]) {\n    write_result_env(\"slot.env\", rows);\n}\n",
+            ),
+        ]);
+        assert!(
+            ResultEnvKeyParityRule
+                .check(&dynamic.repository)
+                .expect("check")
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn pragma_suppresses_divergent_writer() {
+        let fixture = repository_with(&[
+            (
+                "crates/a/src/lib.rs",
+                &writer_src("slot.env", &["A", "B"], false),
+            ),
+            (
+                "crates/b/src/lib.rs",
+                &writer_src("slot.env", &["A"], true),
+            ),
+        ]);
+        assert!(
+            ResultEnvKeyParityRule
+                .check(&fixture.repository)
+                .expect("check")
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn join_basename_and_method_call_are_detected() {
+        let fixture = repository_with(&[
+            (
+                "crates/a/src/lib.rs",
+                "fn emit(dir: &std::path::Path) {\n    write_result_env(dir.join(\"slot.env\"), [(\"A\", \"1\"), (\"B\", \"2\")]);\n}\n",
+            ),
+            (
+                "crates/b/src/lib.rs",
+                "fn emit(helper: Helper) {\n    helper.phase_driver_write_result_env(\"slot.env\", [(\"A\", \"1\")]);\n}\nstruct Helper;\nimpl Helper {\n    fn phase_driver_write_result_env(&self, _path: &str, _kvs: [(&str, &str); 1]) {}\n}\n",
+            ),
+        ]);
+        let findings = ResultEnvKeyParityRule
+            .check(&fixture.repository)
+            .expect("check");
+        assert_eq!(findings.len(), 1);
+        assert!(findings[0].to_string().contains("missing key B"));
+    }
+
+    #[test]
+    fn optional_keys_table_is_the_declared_exception_surface() {
+        assert!(OPTIONAL_KEYS.is_empty());
+    }
+}

--- a/crates/larch-lint/tests/cli.rs
+++ b/crates/larch-lint/tests/cli.rs
@@ -22,13 +22,21 @@ fn all_resolves_root_from_a_nested_working_directory() {
 }
 
 #[test]
-fn rules_lists_the_empty_foundation_registry() {
+fn rules_lists_registered_rules_in_name_order() {
     let repository = TempRepo::new();
     TempRepo::command_from(repository.path())
         .arg("rules")
         .assert()
         .success()
-        .stdout("fixture\tValidate decentralized rule registration\n")
+        .stdout(predicate::str::contains(
+            "fixture\tValidate decentralized rule registration\n",
+        ))
+        .stdout(predicate::str::contains(
+            "kv-codec\tReject ad-hoc KEY=value readers and emitters outside shared codec owners\n",
+        ))
+        .stdout(predicate::str::contains(
+            "result-env-key-parity\tReject divergent key sets across sibling writers of the same result-env basename\n",
+        ))
         .stderr(predicate::str::is_empty());
 }
 
@@ -107,6 +115,64 @@ fn malformed_cli_input_has_the_error_exit() {
         .assert()
         .code(2)
         .stderr("error: unrecognized subcommand\n");
+}
+
+#[test]
+fn kv_codec_and_result_env_rules_are_clean_on_empty_rust_corpus() {
+    let repository = TempRepo::new();
+    repository.write("crates/demo/src/lib.rs", b"pub fn ok() {}\n");
+    repository.commit_all();
+
+    TempRepo::command_from(repository.path())
+        .args(["rule", "kv-codec"])
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+    TempRepo::command_from(repository.path())
+        .args(["rule", "result-env-key-parity"])
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+}
+
+#[test]
+fn kv_codec_reports_ad_hoc_split() {
+    let repository = TempRepo::new();
+    repository.write(
+        "crates/demo/src/lib.rs",
+        b"fn parse(line: &str) {\n    let _ = line.split_once('=');\n}\n",
+    );
+    repository.commit_all();
+
+    TempRepo::command_from(repository.path())
+        .args(["rule", "kv-codec"])
+        .assert()
+        .code(1)
+        .stdout(predicate::str::contains(
+            "crates/demo/src/lib.rs:2: ad-hoc KEY=value split",
+        ));
+}
+
+#[test]
+fn result_env_key_parity_reports_divergent_siblings() {
+    let repository = TempRepo::new();
+    repository.write(
+        "crates/a/src/lib.rs",
+        b"fn emit() {\n    write_result_env(\"slot.env\", [(\"A\", \"1\"), (\"B\", \"2\")]);\n}\n",
+    );
+    repository.write(
+        "crates/b/src/lib.rs",
+        b"fn emit() {\n    write_result_env(\"slot.env\", [(\"A\", \"1\")]);\n}\n",
+    );
+    repository.commit_all();
+
+    TempRepo::command_from(repository.path())
+        .args(["rule", "result-env-key-parity"])
+        .assert()
+        .code(1)
+        .stdout(predicate::str::contains(
+            "slot.env writer missing key B present in sibling writers",
+        ));
 }
 
 #[test]

--- a/crates/larch-lint/tests/support/mod.rs
+++ b/crates/larch-lint/tests/support/mod.rs
@@ -20,6 +20,14 @@ impl TempRepo {
             "crates/larch-lint/migration-ledger/fixture.toml",
             b"rule = \"fixture\"\n",
         );
+        repository.write(
+            "crates/larch-lint/migration-ledger/kv-codec.toml",
+            b"rule = \"kv-codec\"\n",
+        );
+        repository.write(
+            "crates/larch-lint/migration-ledger/result-env-key-parity.toml",
+            b"rule = \"result-env-key-parity\"\n",
+        );
         repository
     }
 


### PR DESCRIPTION
## Summary
- Add future-state `kv-codec` and `result-env-key-parity` rules to `larch-lint` (Rust sources only; Python lints stay active).
- Cover owners, false positives, suppressions, cross-file sibling grouping, and CLI fixtures; migration ledgers start at zero baseline debt.
- Document the crate survey in each rule module; no new workspace dependencies.

## Test plan
- [x] `make rust-check`
- [x] `cargo run --bin larch-lint -- all` on this branch (clean)
- [x] CLI fixtures for clean corpus, split finding, and divergent result-env siblings

Fixes #7617

Made with [Cursor](https://cursor.com)