### PR TITLE
Fixes #7614: require Git push refspecs in Rust lint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,6 +304,7 @@ dependencies = [
  "globset",
  "inventory",
  "predicates",
+ "proc-macro2",
  "pulldown-cmark",
  "regex",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,10 @@ globset = { version = "0.4.19", default-features = false }
 inventory = { version = "0.3.24", default-features = false }
 predicates = { version = "3.1.4", default-features = false }
 pulldown-cmark = { version = "0.13.4", default-features = false }
+proc-macro2 = { version = "1.0.106", default-features = false, features = ["span-locations"] }
 regex = { version = "1.13.1", default-features = false, features = ["std", "perf"] }
 serde = { version = "1.0.228", default-features = false, features = ["derive", "std"] }
-syn = { version = "2.0.119", default-features = false, features = ["full", "parsing", "visit"] }
+syn = { version = "2.0.119", default-features = false, features = ["full", "parsing", "printing", "visit"] }
 tempfile = { version = "3.27.0", default-features = false }
 toml = { version = "1.1.3", default-features = false, features = ["parse", "serde", "std"] }
 tree-sitter = { version = "0.26.7", default-features = false, features = ["std"] }

--- a/crates/larch-lint/Cargo.toml
+++ b/crates/larch-lint/Cargo.toml
@@ -16,6 +16,7 @@ csv.workspace = true
 globset.workspace = true
 inventory.workspace = true
 pulldown-cmark.workspace = true
+proc-macro2.workspace = true
 regex.workspace = true
 serde.workspace = true
 syn.workspace = true

--- a/crates/larch-lint/migration-ledger/git-push-refspec.toml
+++ b/crates/larch-lint/migration-ledger/git-push-refspec.toml
@@ -1,0 +1,1 @@
+rule = "git-push-refspec"

--- a/crates/larch-lint/src/rules/command_arguments.rs
+++ b/crates/larch-lint/src/rules/command_arguments.rs
@@ -1,0 +1,227 @@
+//! `syn`-based resolution for static command arguments used by policy rules.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use proc_macro2::Span;
+use syn::{
+    Expr, ExprArray, ExprCall, ExprMethodCall, ExprPath, File, ItemConst, ItemStatic,
+    PathArguments,
+    spanned::Spanned,
+    visit::{self, Visit},
+};
+
+/// One command argument whose literal value may or may not be statically known.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) enum Argument {
+    /// A literal string or a constant that resolves to one.
+    Static(String),
+    /// A dynamic expression whose eventual value is not known to the linter.
+    Dynamic,
+}
+
+/// A statically recognizable `std::process::Command` builder chain.
+#[derive(Clone, Debug)]
+pub(super) struct BuilderCommand {
+    /// Span of the original `Command::new` construction.
+    pub(super) root_span: Span,
+    /// Arguments accumulated across the builder calls.
+    pub(super) arguments: Vec<Argument>,
+}
+
+/// Constants available for resolving literal command arguments.
+pub(super) struct Constants<'syntax> {
+    values: BTreeMap<String, &'syntax Expr>,
+}
+
+impl<'syntax> Constants<'syntax> {
+    /// Collect `const` and immutable `static` values from one parsed source file.
+    #[must_use]
+    pub(super) fn from_file(file: &'syntax File) -> Self {
+        let mut collector = ConstantCollector {
+            values: BTreeMap::new(),
+        };
+        collector.visit_file(file);
+        Self {
+            values: collector.values,
+        }
+    }
+
+    /// Resolve an expression that represents one ordered argument sequence.
+    #[must_use]
+    pub(super) fn arguments(&self, expression: &'syntax Expr) -> Option<Vec<Argument>> {
+        self.arguments_inner(expression, &mut BTreeSet::new())
+    }
+
+    /// Resolve an expression that supplies exactly one command argument.
+    #[must_use]
+    pub(super) fn argument(&self, expression: &'syntax Expr) -> Argument {
+        self.string_inner(expression, &mut BTreeSet::new())
+            .map_or(Argument::Dynamic, Argument::Static)
+    }
+
+    fn arguments_inner(
+        &self,
+        expression: &'syntax Expr,
+        resolving: &mut BTreeSet<String>,
+    ) -> Option<Vec<Argument>> {
+        match expression {
+            Expr::Array(array) => Some(
+                array
+                    .elems
+                    .iter()
+                    .map(|element| self.string_inner(element, resolving))
+                    .map(|value| value.map_or(Argument::Dynamic, Argument::Static))
+                    .collect(),
+            ),
+            Expr::Reference(reference) => self.arguments_inner(&reference.expr, resolving),
+            Expr::Paren(parenthesized) => self.arguments_inner(&parenthesized.expr, resolving),
+            Expr::Path(path) => {
+                let name = simple_path_name(path)?;
+                let value = self.values.get(&name)?;
+                if !resolving.insert(name.clone()) {
+                    return None;
+                }
+                let arguments = self.arguments_inner(value, resolving);
+                resolving.remove(&name);
+                arguments
+            }
+            _ => None,
+        }
+    }
+
+    fn string_inner(
+        &self,
+        expression: &'syntax Expr,
+        resolving: &mut BTreeSet<String>,
+    ) -> Option<String> {
+        match expression {
+            Expr::Lit(literal) => match &literal.lit {
+                syn::Lit::Str(value) => Some(value.value()),
+                _ => None,
+            },
+            Expr::Reference(reference) => self.string_inner(&reference.expr, resolving),
+            Expr::Paren(parenthesized) => self.string_inner(&parenthesized.expr, resolving),
+            Expr::Path(path) => {
+                let name = simple_path_name(path)?;
+                let value = self.values.get(&name)?;
+                if !resolving.insert(name.clone()) {
+                    return None;
+                }
+                let string = self.string_inner(value, resolving);
+                resolving.remove(&name);
+                string
+            }
+            _ => None,
+        }
+    }
+
+    fn builder_command_inner(&self, expression: &'syntax Expr) -> Option<BuilderCommand> {
+        match expression {
+            Expr::MethodCall(method) => self.extend_builder(method),
+            Expr::Call(call) => self.command_new(call),
+            Expr::Paren(parenthesized) => self.builder_command_inner(&parenthesized.expr),
+            _ => None,
+        }
+    }
+
+    pub(super) fn extend_builder(&self, method: &'syntax ExprMethodCall) -> Option<BuilderCommand> {
+        let mut command = self.builder_command_inner(&method.receiver)?;
+        match method.method.to_string().as_str() {
+            "arg" => {
+                let argument = method.args.first()?;
+                if method.args.len() != 1 {
+                    return None;
+                }
+                command.arguments.push(self.argument(argument));
+            }
+            "args" => {
+                let arguments = method.args.first()?;
+                if method.args.len() != 1 {
+                    return None;
+                }
+                command.arguments.extend(self.arguments(arguments)?);
+            }
+            _ => {}
+        }
+        Some(command)
+    }
+
+    fn command_new(&self, call: &'syntax ExprCall) -> Option<BuilderCommand> {
+        if !is_command_new(&call.func) || call.args.len() != 1 {
+            return None;
+        }
+        let executable = self.argument(call.args.first()?);
+        (executable == Argument::Static("git".to_owned())).then_some(BuilderCommand {
+            root_span: call.func.span(),
+            arguments: vec![Argument::Static("git".to_owned())],
+        })
+    }
+}
+
+struct ConstantCollector<'syntax> {
+    values: BTreeMap<String, &'syntax Expr>,
+}
+
+impl<'ast> Visit<'ast> for ConstantCollector<'ast> {
+    fn visit_item_const(&mut self, item: &'ast ItemConst) {
+        self.values.insert(item.ident.to_string(), &item.expr);
+        visit::visit_item_const(self, item);
+    }
+
+    fn visit_item_static(&mut self, item: &'ast ItemStatic) {
+        if matches!(item.mutability, syn::StaticMutability::None) {
+            self.values.insert(item.ident.to_string(), &item.expr);
+        }
+        visit::visit_item_static(self, item);
+    }
+}
+
+fn simple_path_name(path: &ExprPath) -> Option<String> {
+    (path.qself.is_none() && path.path.segments.len() == 1)
+        .then(|| path.path.segments.first())
+        .flatten()
+        .filter(|segment| matches!(segment.arguments, PathArguments::None))
+        .map(|segment| segment.ident.to_string())
+}
+
+fn is_command_new(function: &Expr) -> bool {
+    let Expr::Path(path) = function else {
+        return false;
+    };
+    if path.qself.is_some() {
+        return false;
+    }
+    let segments: Vec<_> = path.path.segments.iter().collect();
+    if !segments
+        .iter()
+        .all(|segment| matches!(segment.arguments, PathArguments::None))
+    {
+        return false;
+    }
+    match segments.as_slice() {
+        [command, new] => command.ident == "Command" && new.ident == "new",
+        [process, command, new] => {
+            process.ident == "process" && command.ident == "Command" && new.ident == "new"
+        }
+        [standard, process, command, new] => {
+            standard.ident == "std"
+                && process.ident == "process"
+                && command.ident == "Command"
+                && new.ident == "new"
+        }
+        _ => false,
+    }
+}
+
+/// Return the arguments from a direct array expression, if it has one.
+#[must_use]
+pub(super) fn array_arguments<'syntax>(
+    constants: &Constants<'syntax>,
+    array: &'syntax ExprArray,
+) -> Vec<Argument> {
+    array
+        .elems
+        .iter()
+        .map(|element| constants.argument(element))
+        .collect()
+}

--- a/crates/larch-lint/src/rules/git_push_refspec.rs
+++ b/crates/larch-lint/src/rules/git_push_refspec.rs
@@ -1,0 +1,166 @@
+//! Require raw Git push construction to include an explicit destination refspec.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use proc_macro2::LineColumn;
+use syn::{ExprArray, ExprMethodCall, spanned::Spanned, visit::Visit};
+
+use crate::{
+    Finding, LintError, PathSelector, Repository, Rule, RuleMetadata,
+    suppression::reason,
+    syntax::RustSyntax,
+};
+
+use super::command_arguments::{Argument, Constants, array_arguments};
+
+const NAME: &str = "git-push-refspec";
+const DESCRIPTION: &str = "Require Git push commands to name a destination refspec";
+const SUPPRESSION_TOKEN: &str = "lint-git-push-refspec";
+const TEST_PREFIX: &str = "crates/larch-lint/tests/";
+const COMMAND_ELEMENTS: usize = 2;
+const EXPLICIT_OPERANDS: usize = 2;
+
+pub static METADATA: RuleMetadata = RuleMetadata::new(
+    NAME,
+    DESCRIPTION,
+    "crates/larch-lint/migration-ledger/git-push-refspec.toml",
+);
+
+#[derive(Debug)]
+pub struct GitPushRefspecRule;
+
+pub static RULE: GitPushRefspecRule = GitPushRefspecRule;
+
+impl Rule for GitPushRefspecRule {
+    fn name(&self) -> &'static str {
+        NAME
+    }
+
+    fn description(&self) -> &'static str {
+        DESCRIPTION
+    }
+
+    fn check(&self, repository: &Repository) -> Result<Vec<Finding>, LintError> {
+        let selector = PathSelector::new(&["**/*.rs"], &[])?;
+        let mut findings = Vec::new();
+        for path in selector.select(repository) {
+            let source = repository.read_utf8(path)?;
+            let syntax = RustSyntax::parse(path.as_str(), &source)?;
+            let constants = Constants::from_file(syntax.file());
+            let mut visitor = PushVisitor::new(&constants);
+            visitor.visit_file(syntax.file());
+            for line in visitor.finding_lines() {
+                if is_suppressed(path.as_str(), &source, line)? {
+                    continue;
+                }
+                findings.push(Finding::new(
+                    path.as_str(),
+                    line,
+                    "contains git push without an explicit destination refspec",
+                ));
+            }
+        }
+        Ok(findings)
+    }
+}
+
+struct PushVisitor<'syntax> {
+    constants: &'syntax Constants<'syntax>,
+    array_lines: BTreeSet<u32>,
+    builders: BTreeMap<LineColumn, BuilderCandidate>,
+}
+
+impl<'syntax> PushVisitor<'syntax> {
+    const fn new(constants: &'syntax Constants<'syntax>) -> Self {
+        Self {
+            constants,
+            array_lines: BTreeSet::new(),
+            builders: BTreeMap::new(),
+        }
+    }
+
+    fn finding_lines(self) -> BTreeSet<u32> {
+        let mut lines = self.array_lines;
+        lines.extend(
+            self.builders
+                .into_values()
+                .filter(|candidate| lacks_refspec(&candidate.arguments))
+                .map(|candidate| candidate.line),
+        );
+        lines
+    }
+}
+
+impl<'ast> Visit<'ast> for PushVisitor<'ast> {
+    fn visit_expr_array(&mut self, array: &'ast ExprArray) {
+        let arguments = array_arguments(self.constants, array);
+        if lacks_refspec(&arguments)
+            && let Some(line) = array
+                .elems
+                .first()
+                .and_then(|element| line_number(element.span()))
+        {
+            self.array_lines.insert(line);
+        }
+        syn::visit::visit_expr_array(self, array);
+    }
+
+    fn visit_expr_method_call(&mut self, method: &'ast ExprMethodCall) {
+        if let Some(command) = self.constants.extend_builder(method) {
+            let root = command.root_span.start();
+            let candidate = BuilderCandidate {
+                line: u32::try_from(root.line).unwrap_or(u32::MAX),
+                end: method.method.span().end(),
+                arguments: command.arguments,
+            };
+            self.builders
+                .entry(root)
+                .and_modify(|existing| {
+                    if candidate.end > existing.end {
+                        *existing = candidate.clone();
+                    }
+                })
+                .or_insert(candidate);
+        }
+        syn::visit::visit_expr_method_call(self, method);
+    }
+}
+
+#[derive(Clone)]
+struct BuilderCandidate {
+    line: u32,
+    end: LineColumn,
+    arguments: Vec<Argument>,
+}
+
+fn lacks_refspec(arguments: &[Argument]) -> bool {
+    if arguments.len() < COMMAND_ELEMENTS
+        || arguments[0] != Argument::Static("git".to_owned())
+        || arguments[1] != Argument::Static("push".to_owned())
+    {
+        return false;
+    }
+    arguments[COMMAND_ELEMENTS..]
+        .iter()
+        .filter(|argument| !matches!(argument, Argument::Static(value) if value.starts_with('-')))
+        .count()
+        < EXPLICIT_OPERANDS
+}
+
+fn line_number(span: proc_macro2::Span) -> Option<u32> {
+    u32::try_from(span.start().line).ok()
+}
+
+fn is_suppressed(path: &str, source: &str, line: u32) -> Result<bool, LintError> {
+    if !path.starts_with(TEST_PREFIX) {
+        return Ok(false);
+    }
+    let line_index = usize::try_from(line.saturating_sub(1))
+        .map_err(|_| LintError::new(format!("{path}: line number is out of range")))?;
+    let text = source.lines().nth(line_index).ok_or_else(|| {
+        LintError::new(format!("{path}: finding line {line} is outside the source"))
+    })?;
+    Ok(reason(text, SUPPRESSION_TOKEN)?.is_some())
+}
+
+crate::register_rule!(METADATA, RULE);

--- a/crates/larch-lint/tests/cli.rs
+++ b/crates/larch-lint/tests/cli.rs
@@ -32,12 +32,105 @@ fn rules_lists_registered_rules_in_name_order() {
             "fixture\tValidate decentralized rule registration\n",
         ))
         .stdout(predicate::str::contains(
+            "git-push-refspec\tRequire Git push commands to name a destination refspec\n",
+        ))
+        .stdout(predicate::str::contains(
             "kv-codec\tReject ad-hoc KEY=value readers and emitters outside shared codec owners\n",
         ))
         .stdout(predicate::str::contains(
             "result-env-key-parity\tReject divergent key sets across sibling writers of the same result-env basename\n",
         ))
         .stderr(predicate::str::is_empty());
+}
+
+#[test]
+fn git_push_refspec_flags_raw_arrays_slices_constants_and_builders() {
+    let repository = TempRepo::new();
+    repository.write(
+        "src/push.rs",
+        br#"const GIT: &str = "git";
+const PUSH: &str = "push";
+const BARE: [&str; 3] = [GIT, PUSH, "origin"];
+const DESTINATION: &[&str] = &["push", "origin", "HEAD:refs/heads/main"];
+
+fn commands(remote: &str, refspec: &str) {
+    let array = ["git", "push", "origin"];
+    let slice = &["git", "push", "origin"];
+    let accepted = ["git", "push", "origin", "HEAD:refs/heads/main"];
+    std::process::Command::new("git").args(["push", "origin"]);
+    std::process::Command::new("git").args(&["push", "origin"]);
+    std::process::Command::new("git").args(DESTINATION);
+    custom::Command::new("git").args(["push", "origin"]);
+    std::process::Command::new("git").args([
+        "push",
+        "--force-with-lease",
+        "origin",
+        "HEAD:refs/heads/main",
+    ]);
+    std::process::Command::new("git")
+        .arg("push")
+        .arg(remote)
+        .arg(refspec);
+    std::process::Command::new("git").args(["push", "origin", "HEAD:refs/heads/main"]);
+}
+"#,
+    );
+    repository.commit_all();
+
+    TempRepo::command_from(repository.path())
+        .args(["rule", "git-push-refspec"])
+        .assert()
+        .code(1)
+        .stdout(
+            "src/push.rs:3: contains git push without an explicit destination refspec\n\
+             src/push.rs:7: contains git push without an explicit destination refspec\n\
+             src/push.rs:8: contains git push without an explicit destination refspec\n\
+             src/push.rs:10: contains git push without an explicit destination refspec\n\
+             src/push.rs:11: contains git push without an explicit destination refspec\n",
+        )
+        .stderr(predicate::str::is_empty());
+}
+
+#[test]
+fn git_push_refspec_requires_reasoned_test_only_suppressions() {
+    let suppressed = TempRepo::new();
+    suppressed.write(
+        "crates/larch-lint/tests/suppressed.rs",
+        b"fn fixture() { let bare = [\"git\", \"push\", \"origin\"]; // lint-git-push-refspec: ok fixture verifies config resolution\n}\n",
+    );
+    suppressed.commit_all();
+    TempRepo::command_from(suppressed.path())
+        .args(["rule", "git-push-refspec"])
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty())
+        .stderr(predicate::str::is_empty());
+
+    let production = TempRepo::new();
+    production.write(
+        "src/production.rs",
+        b"fn command() { let bare = [\"git\", \"push\", \"origin\"]; // lint-git-push-refspec: ok production exception\n}\n",
+    );
+    production.commit_all();
+    TempRepo::command_from(production.path())
+        .args(["rule", "git-push-refspec"])
+        .assert()
+        .code(1)
+        .stdout("src/production.rs:1: contains git push without an explicit destination refspec\n")
+        .stderr(predicate::str::is_empty());
+
+    let missing_reason = TempRepo::new();
+    missing_reason.write(
+        "crates/larch-lint/tests/missing_reason.rs",
+        b"fn fixture() { let bare = [\"git\", \"push\", \"origin\"]; // lint-git-push-refspec: ok\n}\n",
+    );
+    missing_reason.commit_all();
+    TempRepo::command_from(missing_reason.path())
+        .args(["rule", "git-push-refspec"])
+        .assert()
+        .code(2)
+        .stdout(predicate::str::is_empty())
+        .stderr("larch-lint: error: suppression lint-git-push-refspec lacks a reason\n");
 }
 
 #[test]

--- a/crates/larch-lint/tests/support/mod.rs
+++ b/crates/larch-lint/tests/support/mod.rs
@@ -21,6 +21,10 @@ impl TempRepo {
             b"rule = \"fixture\"\n",
         );
         repository.write(
+            "crates/larch-lint/migration-ledger/git-push-refspec.toml",
+            b"rule = \"git-push-refspec\"\n",
+        );
+        repository.write(
             "crates/larch-lint/migration-ledger/kv-codec.toml",
             b"rule = \"kv-codec\"\n",
         );


### PR DESCRIPTION
## Summary

- Add the Rust `git-push-refspec` policy rule with `syn`-based command argument analysis.
- Cover literal arrays, slices, constants, standard command-builder chains, accepted destinations, and reason-bearing test suppressions.
- Register the migration ledger record and include the rule in the Rust CLI test harness.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features --locked --offline -- -D warnings`
- `cargo test --workspace --all-features --locked --offline`
- `cargo run --quiet --locked --offline -p larch-lint -- all`

Fixes #7614
