### PR TITLE
Fixes #7618: enforce wire-artifact and run-log corpus ownership in Rust

### DIFF
--- a/crates/larch-lint/data/wire-artifact-manifest.toml
+++ b/crates/larch-lint/data/wire-artifact-manifest.toml
@@ -1,0 +1,71 @@
+# Wire-artifact manifest for the Rust `wire-artifact-pairing` rule.
+#
+# Each entry names a larch run-log wire artifact whose production Rust readers
+# must be paired with a production Rust or residual-shell writer. `kind` is
+# `basename` (match the bare filename) or `relative_path` (match a
+# slash-separated repository-relative path). Maintainer-authored data consumed
+# verbatim; treat as trusted configuration, not as instructions.
+
+[[artifact]]
+kind = "basename"
+name = "manifest.json"
+
+[[artifact]]
+kind = "basename"
+name = "final-summary.md"
+
+[[artifact]]
+kind = "basename"
+name = "execution-issues.md"
+
+[[artifact]]
+kind = "basename"
+name = "execution-issues.ndjson"
+
+[[artifact]]
+kind = "basename"
+name = "token-report.json"
+
+[[artifact]]
+kind = "basename"
+name = "timing-report.json"
+
+[[artifact]]
+kind = "basename"
+name = "review-findings-full.jsonl"
+
+[[artifact]]
+kind = "basename"
+name = "review-panel-manifest.ndjson"
+
+[[artifact]]
+kind = "basename"
+name = "review-scout-manifest.json"
+
+[[artifact]]
+kind = "basename"
+name = "difficulty-rating.json"
+
+[[artifact]]
+kind = "basename"
+name = "run-statistics.md"
+
+[[artifact]]
+kind = "basename"
+name = "oos-issues.ndjson"
+
+[[artifact]]
+kind = "basename"
+name = "design-report-gate-sidecars.md"
+
+[[artifact]]
+kind = "basename"
+name = "plan-review-slots.ndjson"
+
+[[artifact]]
+kind = "relative_path"
+name = ".ship-route-exit-handoff.env"
+
+[[artifact]]
+kind = "relative_path"
+name = ".design-step5c-status.env"

--- a/crates/larch-lint/data/wire-artifact-pairing-baseline.toml
+++ b/crates/larch-lint/data/wire-artifact-pairing-baseline.toml
@@ -1,0 +1,8 @@
+# Grandfathered one-sided wire artifacts for the `wire-artifact-pairing` rule.
+#
+# Starts empty: the future-state Rust runtime has no readers yet, so the rule
+# reports zero findings. Each row that is added must carry a `side`
+# (`external-writer`, `external-reader`, or `intentionally-one-sided`) and a
+# non-empty `reason`. This baseline is a ratchet that only shrinks.
+
+grandfathered = []

--- a/crates/larch-lint/migration-ledger/run-log-corpus-walkers.toml
+++ b/crates/larch-lint/migration-ledger/run-log-corpus-walkers.toml
@@ -1,0 +1,1 @@
+rule = "run-log-corpus-walkers"

--- a/crates/larch-lint/migration-ledger/wire-artifact-pairing.toml
+++ b/crates/larch-lint/migration-ledger/wire-artifact-pairing.toml
@@ -1,0 +1,1 @@
+rule = "wire-artifact-pairing"

--- a/crates/larch-lint/src/rules/run_log_corpus_walkers.rs
+++ b/crates/larch-lint/src/rules/run_log_corpus_walkers.rs
@@ -1,0 +1,560 @@
+//! Reject raw committed run-log corpus walkers outside the shared owner.
+//!
+//! This is the future-state Rust equivalent of the Python `run-log-walkers`
+//! lint. It scans production Rust sources for directory-walking calls
+//! (`read_dir`, `glob`, `WalkDir::new`, `scandir`, `walk_dir`) whose argument
+//! references a committed-corpus root, and for classification-glob families,
+//! and reports any that appear outside the shared `run_log_corpus` owner
+//! module. Validated per-run recursion must route through that owner.
+//!
+//! Line anchoring: the shared `syn` parser retains no source line numbers in
+//! this build (the `proc-macro2` `span-locations` feature is not enabled, and a
+//! leaf rule may not add a workspace dependency feature), so this rule matches
+//! over source lines to report the exact offending line. Each line is first run
+//! through a lexer that blanks comment, string, and char-literal spans, so a
+//! walker token only matches a real call, never one quoted inside a string or a
+//! comment. The corpus/session marker check is scoped to the parenthesized call
+//! argument, so a marker on an adjacent statement does not bleed in. The
+//! residual limitation is single-line: a call whose argument or corpus marker
+//! spans multiple physical lines, or a multi-line raw string, is not tracked;
+//! such cases can carry an inline suppression when intentional.
+//!
+//! Scope note: the larch-lint crate is excluded from the scanned surface, like
+//! the sibling `wire-artifact-pairing` rule. It is tooling that names walker
+//! vocabulary in rule definitions and test fixtures rather than run-time larch
+//! code, so scanning it would report those meta-references. The runtime
+//! migration lands larch runtime code in its own crate, which this rule scans.
+//!
+//! Deviation from the Python rule: within a scanned runtime crate, inline
+//! `#[cfg(test)]` modules are scanned (integration `tests/` trees are already
+//! outside the `src` scope). Test code that must walk a corpus root should
+//! route through the owner or carry an inline suppression.
+//!
+//! Crate survey: comment and literal lexing and marker matching reuse the
+//! workspace `regex` crate for the call pattern; inline suppression reuses the
+//! crate [`crate::suppression`] helper; path selection reuses the
+//! `globset`-backed [`PathSelector`]. The bespoke code expresses only the larch
+//! corpus-ownership grammar (walker families, corpus and session markers,
+//! classification patterns) and the line lexer, which no general crate owns
+//! without pulling a full parser that this build cannot line-anchor.
+
+use regex::Regex;
+
+use crate::suppression;
+use crate::{Finding, LintError, PathSelector, RepoPath, Repository, Rule, RuleMetadata, RuleOutput};
+
+const NAME: &str = "run-log-corpus-walkers";
+const DESCRIPTION: &str = "Reject raw committed run-log corpus walkers outside the shared owner";
+const RUST_SCOPE_INCLUDE: &str = "crates/*/src/**/*.rs";
+const LINTER_CRATE_EXCLUDE: &str = "crates/larch-lint/**";
+const OWNER_SUFFIX: &str = "report/run_log_corpus.rs";
+const SUPPRESSION_TOKEN: &str = "lint-run-log-corpus-walkers";
+const CLASSIFICATION_MARKER: &str = "findings-classification";
+const CLASSIFICATION_ROOTS: [&str; 3] = ["design/", "implement/", "review/"];
+
+const CORPUS_MARKERS: [&str; 9] = [
+    "larch-logs",
+    "log_root",
+    "log_base",
+    "logs_root",
+    "impl_root",
+    "design_root",
+    "implement_root",
+    "skill_dir",
+    "skill_root",
+];
+const SESSION_MARKERS: [&str; 6] = [
+    "tmpdir",
+    "implement_tmpdir",
+    "design_tmpdir",
+    "canonical_tmp",
+    "session_tmpdir",
+    "session_env",
+];
+
+pub static METADATA: RuleMetadata = RuleMetadata::new(
+    NAME,
+    DESCRIPTION,
+    "crates/larch-lint/migration-ledger/run-log-corpus-walkers.toml",
+);
+
+#[derive(Debug)]
+pub struct RunLogCorpusWalkersRule;
+
+pub static RULE: RunLogCorpusWalkersRule = RunLogCorpusWalkersRule;
+
+impl Rule for RunLogCorpusWalkersRule {
+    fn name(&self) -> &'static str {
+        NAME
+    }
+
+    fn description(&self) -> &'static str {
+        DESCRIPTION
+    }
+
+    fn check(&self, repository: &Repository) -> Result<RuleOutput, LintError> {
+        let walker = walker_regex()?;
+        let selector = PathSelector::new(&[RUST_SCOPE_INCLUDE], &[LINTER_CRATE_EXCLUDE])?;
+        let mut findings = Vec::new();
+        for path in selector.select(repository) {
+            if is_owner(path) {
+                continue;
+            }
+            let source = repository.read_utf8(path)?;
+            findings.extend(scan_source(path.as_str(), &source, &walker)?);
+        }
+        Ok(RuleOutput::from_findings(findings))
+    }
+}
+
+fn is_owner(path: &RepoPath) -> bool {
+    path.as_str().ends_with(OWNER_SUFFIX)
+}
+
+fn walker_regex() -> Result<Regex, LintError> {
+    // A directory-walking call: a family token followed by `(`, or `WalkDir::new(`.
+    Regex::new(
+        r"(?:^|[^A-Za-z0-9_])(read_dir|scandir|walk_dir|iglob|rglob|glob)\s*\(|(WalkDir)::new\s*\(",
+    )
+    .map_err(|error| LintError::new(format!("invalid walker pattern: {error}")))
+}
+
+fn scan_source(path: &str, source: &str, walker: &Regex) -> Result<Vec<Finding>, LintError> {
+    let mut findings = Vec::new();
+    let mut block_depth = 0usize;
+    for (index, raw) in source.lines().enumerate() {
+        let view = clean_line(raw, &mut block_depth);
+        let Some(detection) = classify(&view, walker) else {
+            continue;
+        };
+        if suppression::reason(raw, SUPPRESSION_TOKEN)?.is_some() {
+            continue;
+        }
+        let line = u32::try_from(index + 1)
+            .map_err(|_| LintError::new(format!("{path}: line number exceeds u32")))?;
+        findings.push(Finding::new(path, line, detection.message()));
+    }
+    Ok(findings)
+}
+
+/// A classified corpus-walker violation and its remediation family.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Detection {
+    Classification,
+    Walk,
+    Glob,
+    ReadDir,
+}
+
+impl Detection {
+    fn message(self) -> String {
+        let remediation =
+            "route through the run_log_corpus owner (safe_child_run_dirs / validated-run helpers)";
+        match self {
+            Self::Classification => "raw classification-glob outside run_log_corpus: use its \
+                 classification discovery helpers"
+                .to_owned(),
+            Self::Walk => format!("raw corpus directory walk outside run_log_corpus: {remediation}"),
+            Self::Glob => format!("raw corpus glob outside run_log_corpus: {remediation}"),
+            Self::ReadDir => {
+                format!("raw corpus directory read outside run_log_corpus: {remediation}")
+            }
+        }
+    }
+}
+
+/// Classify a lexed line: match a real walker call, then judge its argument.
+fn classify(view: &LineView, walker: &Regex) -> Option<Detection> {
+    for captures in walker.captures_iter(&view.code) {
+        let whole = captures.get(0)?;
+        let argument = argument_slice(&view.code, &view.markers, whole.end());
+        if is_classification(argument) {
+            return Some(Detection::Classification);
+        }
+        if has_marker(argument, &CORPUS_MARKERS) && !has_marker(argument, &SESSION_MARKERS) {
+            return Some(family(&captures));
+        }
+    }
+    None
+}
+
+fn family(captures: &regex::Captures<'_>) -> Detection {
+    if captures.get(2).is_some() {
+        return Detection::Walk;
+    }
+    match captures.get(1).map(|token| token.as_str()) {
+        Some("walk_dir") => Detection::Walk,
+        Some("glob" | "iglob" | "rglob") => Detection::Glob,
+        _ => Detection::ReadDir,
+    }
+}
+
+/// Return the marker view of the call argument that begins at `arg_start`,
+/// bounded by the matching close paren in the (literal-blanked) code view.
+fn argument_slice<'markers>(code: &str, markers: &'markers str, arg_start: usize) -> &'markers str {
+    let bytes = code.as_bytes();
+    let mut depth = 1i32;
+    let mut index = arg_start;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'(' => depth += 1,
+            b')' => {
+                depth -= 1;
+                if depth == 0 {
+                    return &markers[arg_start..index];
+                }
+            }
+            _ => {}
+        }
+        index += 1;
+    }
+    &markers[arg_start..]
+}
+
+fn is_classification(argument: &str) -> bool {
+    argument.contains(CLASSIFICATION_MARKER)
+        && CLASSIFICATION_ROOTS
+            .iter()
+            .any(|root| argument.contains(root))
+}
+
+fn has_marker(text: &str, markers: &[&str]) -> bool {
+    markers.iter().any(|marker| text.contains(marker))
+}
+
+/// A lexed source line, byte-aligned with the original. `code` blanks comment,
+/// string, and char-literal spans so a walker token matches only real calls and
+/// paren matching ignores literal parens; `markers` blanks comments but keeps
+/// string and identifier text so a literal corpus path stays visible.
+struct LineView {
+    code: String,
+    markers: String,
+}
+
+impl LineView {
+    fn with_capacity(capacity: usize) -> Self {
+        Self {
+            code: String::with_capacity(capacity),
+            markers: String::with_capacity(capacity),
+        }
+    }
+
+    fn push_code(&mut self, character: char) {
+        self.code.push(character);
+        self.markers.push(character);
+    }
+
+    fn push_literal(&mut self, character: char) {
+        blank(&mut self.code, character);
+        self.markers.push(character);
+    }
+
+    fn push_comment(&mut self, character: char) {
+        blank(&mut self.code, character);
+        blank(&mut self.markers, character);
+    }
+}
+
+fn blank(target: &mut String, character: char) {
+    for _ in 0..character.len_utf8() {
+        target.push(' ');
+    }
+}
+
+fn is_ident_continue(character: char) -> bool {
+    character.is_alphanumeric() || character == '_'
+}
+
+/// Lex one line into its code and marker views, carrying block-comment depth.
+fn clean_line(line: &str, block_depth: &mut usize) -> LineView {
+    let chars: Vec<char> = line.chars().collect();
+    let mut view = LineView::with_capacity(line.len());
+    let mut index = 0;
+    while index < chars.len() {
+        index = if *block_depth > 0 {
+            consume_block(&chars, index, block_depth, &mut view)
+        } else {
+            consume_token(&chars, index, block_depth, &mut view)
+        };
+    }
+    view
+}
+
+fn consume_block(
+    chars: &[char],
+    index: usize,
+    block_depth: &mut usize,
+    view: &mut LineView,
+) -> usize {
+    if chars[index] == '*' && chars.get(index + 1) == Some(&'/') {
+        *block_depth -= 1;
+        view.push_comment(chars[index]);
+        view.push_comment(chars[index + 1]);
+        return index + 2;
+    }
+    if chars[index] == '/' && chars.get(index + 1) == Some(&'*') {
+        *block_depth += 1;
+        view.push_comment(chars[index]);
+        view.push_comment(chars[index + 1]);
+        return index + 2;
+    }
+    view.push_comment(chars[index]);
+    index + 1
+}
+
+fn consume_token(
+    chars: &[char],
+    index: usize,
+    block_depth: &mut usize,
+    view: &mut LineView,
+) -> usize {
+    let current = chars[index];
+    let next = chars.get(index + 1).copied();
+    match (current, next) {
+        ('/', Some('/')) => consume_line_comment(chars, index, view),
+        ('/', Some('*')) => {
+            *block_depth += 1;
+            view.push_comment(current);
+            view.push_comment('*');
+            index + 2
+        }
+        _ if is_raw_string_start(chars, index) => consume_raw_string(chars, index, view),
+        ('"', _) => consume_string(chars, index, view),
+        ('\'', _) => consume_char(chars, index, view),
+        _ => {
+            view.push_code(current);
+            index + 1
+        }
+    }
+}
+
+fn consume_line_comment(chars: &[char], start: usize, view: &mut LineView) -> usize {
+    for &character in &chars[start..] {
+        view.push_comment(character);
+    }
+    chars.len()
+}
+
+fn consume_string(chars: &[char], start: usize, view: &mut LineView) -> usize {
+    view.push_literal(chars[start]);
+    let mut index = start + 1;
+    while index < chars.len() {
+        let character = chars[index];
+        if character == '\\' {
+            view.push_literal(character);
+            if let Some(&escaped) = chars.get(index + 1) {
+                view.push_literal(escaped);
+                index += 2;
+                continue;
+            }
+            return index + 1;
+        }
+        view.push_literal(character);
+        index += 1;
+        if character == '"' {
+            return index;
+        }
+    }
+    index
+}
+
+fn consume_char(chars: &[char], start: usize, view: &mut LineView) -> usize {
+    // A simple char literal `'x'` (covers `'"'`), keeping any interior quote out
+    // of string state.
+    if chars.get(start + 1) != Some(&'\\') && chars.get(start + 2) == Some(&'\'') {
+        for &character in &chars[start..start + 3] {
+            view.push_literal(character);
+        }
+        return start + 3;
+    }
+    // An escaped char literal `'\n'`, `'\''`, `'\u{1F}'`.
+    if chars.get(start + 1) == Some(&'\\') {
+        let mut index = start + 2;
+        while index < chars.len() && chars[index] != '\'' {
+            index += 1;
+        }
+        if index < chars.len() {
+            for &character in &chars[start..=index] {
+                view.push_literal(character);
+            }
+            return index + 1;
+        }
+    }
+    // A lifetime (`'a`) or stray apostrophe: emit as code and move on.
+    view.push_code(chars[start]);
+    start + 1
+}
+
+fn is_raw_string_start(chars: &[char], index: usize) -> bool {
+    if index > 0 && is_ident_continue(chars[index - 1]) {
+        return false;
+    }
+    let mut cursor = index;
+    if chars.get(cursor) == Some(&'b') {
+        cursor += 1;
+    }
+    if chars.get(cursor) != Some(&'r') {
+        return false;
+    }
+    cursor += 1;
+    while chars.get(cursor) == Some(&'#') {
+        cursor += 1;
+    }
+    chars.get(cursor) == Some(&'"')
+}
+
+fn consume_raw_string(chars: &[char], start: usize, view: &mut LineView) -> usize {
+    let mut index = start;
+    if chars[index] == 'b' {
+        view.push_literal(chars[index]);
+        index += 1;
+    }
+    view.push_literal(chars[index]); // 'r'
+    index += 1;
+    let mut hashes = 0usize;
+    while chars.get(index) == Some(&'#') {
+        view.push_literal(chars[index]);
+        index += 1;
+        hashes += 1;
+    }
+    if chars.get(index) == Some(&'"') {
+        view.push_literal(chars[index]);
+        index += 1;
+    }
+    while index < chars.len() {
+        if chars[index] == '"' && raw_closes(chars, index + 1, hashes) {
+            view.push_literal(chars[index]);
+            index += 1;
+            for _ in 0..hashes {
+                view.push_literal(chars[index]);
+                index += 1;
+            }
+            return index;
+        }
+        view.push_literal(chars[index]);
+        index += 1;
+    }
+    index
+}
+
+fn raw_closes(chars: &[char], from: usize, hashes: usize) -> bool {
+    (0..hashes).all(|offset| chars.get(from + offset) == Some(&'#'))
+}
+
+crate::register_rule!(METADATA, RULE);
+
+#[cfg(test)]
+mod tests {
+    use super::{Detection, LineView, classify, clean_line, walker_regex};
+
+    fn lex(line: &str) -> LineView {
+        let mut depth = 0usize;
+        clean_line(line, &mut depth)
+    }
+
+    fn classify_line(line: &str) -> Option<Detection> {
+        let walker = walker_regex().expect("walker regex");
+        classify(&lex(line), &walker)
+    }
+
+    #[test]
+    fn classifies_each_walker_family_over_corpus_arguments() {
+        assert_eq!(
+            classify_line("let e = std::fs::read_dir(log_root)?;"),
+            Some(Detection::ReadDir)
+        );
+        assert_eq!(
+            classify_line("for p in glob::glob(log_base)? {"),
+            Some(Detection::Glob)
+        );
+        assert_eq!(
+            classify_line("let w = WalkDir::new(impl_root);"),
+            Some(Detection::Walk)
+        );
+        assert_eq!(
+            classify_line("read_dir(\"larch-logs/run\")"),
+            Some(Detection::ReadDir)
+        );
+    }
+
+    #[test]
+    fn ignores_session_roots_and_non_corpus_arguments() {
+        assert_eq!(classify_line("read_dir(session_tmpdir)"), None);
+        // A corpus marker paired with a session marker in the argument is a
+        // session read.
+        assert_eq!(classify_line("read_dir(log_root_tmpdir)"), None);
+        assert_eq!(classify_line("read_dir(some_local_dir)"), None);
+        // A bare mention that is not a call is never flagged.
+        assert_eq!(classify_line("let handler = read_dir_for(log_root);"), None);
+    }
+
+    #[test]
+    fn classification_globs_require_a_corpus_root_segment() {
+        assert_eq!(
+            classify_line("glob(\"design/x/plan-review/round-1/findings-classification.tsv\")"),
+            Some(Detection::Classification)
+        );
+        // The classification token alone, without a design/implement/review
+        // root, is not a classification glob.
+        assert_ne!(
+            classify_line("glob(log_root_findings_classification)"),
+            Some(Detection::Classification)
+        );
+    }
+
+    #[test]
+    fn walker_token_inside_a_string_literal_is_not_a_call() {
+        // 2a: a walker token quoted inside a log or error string is data.
+        assert_eq!(
+            classify_line("return Err(format!(\"failed read_dir(log_root): {e}\"));"),
+            None
+        );
+    }
+
+    #[test]
+    fn corpus_marker_does_not_bleed_from_an_adjacent_statement() {
+        // 2b: the marker on a following statement is outside the call argument.
+        assert_eq!(
+            classify_line("let _ = std::fs::read_dir(scratch); let _k = log_root;"),
+            None
+        );
+    }
+
+    #[test]
+    fn nested_block_comment_hides_an_inner_walker() {
+        // 2c: Rust block comments nest.
+        let mut depth = 0usize;
+        let view = clean_line("/* outer /* inner */ read_dir(log_root); */", &mut depth);
+        let walker = walker_regex().expect("walker regex");
+        assert_eq!(classify(&view, &walker), None);
+        assert_eq!(depth, 0);
+    }
+
+    #[test]
+    fn char_literal_quote_does_not_open_a_string() {
+        // 2d: `'"'` must not swallow the following real comment.
+        assert_eq!(
+            classify_line("let _q = '\"'; // read_dir(log_root) note"),
+            None
+        );
+    }
+
+    #[test]
+    fn literal_corpus_path_argument_is_still_detected() {
+        // A real call over a literal corpus path survives lexing.
+        assert_eq!(
+            classify_line("let _ = std::fs::read_dir(\"larch-logs/x\");"),
+            Some(Detection::ReadDir)
+        );
+    }
+
+    #[test]
+    fn raw_string_argument_is_preserved_for_markers() {
+        assert_eq!(
+            classify_line("let _ = glob::glob(r\"larch-logs/**\");"),
+            Some(Detection::Glob)
+        );
+        // A walker token inside a raw string is data, not a call.
+        assert_eq!(classify_line("let _m = r#\"read_dir(log_root)\"#;"), None);
+    }
+}

--- a/crates/larch-lint/src/rules/wire_artifact_pairing.rs
+++ b/crates/larch-lint/src/rules/wire_artifact_pairing.rs
@@ -1,0 +1,699 @@
+//! Require a production Rust or shell writer for every wire-artifact reader.
+//!
+//! This is the future-state Rust equivalent of the Python
+//! `wire-artifact-pairing` lint. It scans production Rust sources and residual
+//! shell writers for a curated manifest of larch wire artifacts and reports any
+//! artifact that has reader evidence but no paired production writer. Existing
+//! one-sided artifacts are grandfathered in a reason-bearing baseline that only
+//! shrinks.
+//!
+//! Scope note: the larch-lint crate is excluded from the scanned surface. It
+//! names wire artifacts as lint configuration, not as run-time reads or writes,
+//! so including it would report meta-references as one-sided artifacts. The
+//! runtime migration lands larch runtime code in its own crate, which this rule
+//! scans.
+//!
+//! Crate survey: manifest and baseline parsing reuse the workspace `toml` and
+//! `serde` crates; Rust reader and writer evidence reuses the shared `syn`
+//! parser behind [`crate::syntax::RustSyntax`]; path selection reuses the
+//! `globset`-backed [`PathSelector`]. The bespoke code expresses only the larch
+//! artifact manifest schema, the artifact-token matching (basename boundary and
+//! relative-path membership), and the shell writer grammar, none of which a
+//! general crate owns.
+
+use std::collections::BTreeSet;
+
+use serde::Deserialize;
+use syn::visit::{self, Visit};
+
+use crate::syntax::RustSyntax;
+use crate::{Finding, LintError, PathSelector, RepoPath, Repository, Rule, RuleMetadata, RuleOutput};
+
+const NAME: &str = "wire-artifact-pairing";
+const DESCRIPTION: &str = "Require a production writer for every wire-artifact reader";
+const MANIFEST_PATH: &str = "crates/larch-lint/data/wire-artifact-manifest.toml";
+const BASELINE_PATH: &str = "crates/larch-lint/data/wire-artifact-pairing-baseline.toml";
+const RUST_SCOPE_INCLUDE: &str = "crates/*/src/**/*.rs";
+const LINTER_CRATE_EXCLUDE: &str = "crates/larch-lint/**";
+const SHELL_SCOPES: [&str; 2] = ["scripts/**", "skills/*/scripts/**"];
+const SHELL_TEST_PREFIX: &str = "test-";
+const VALID_SIDES: [&str; 3] = ["external-writer", "external-reader", "intentionally-one-sided"];
+
+pub static METADATA: RuleMetadata = RuleMetadata::new(
+    NAME,
+    DESCRIPTION,
+    "crates/larch-lint/migration-ledger/wire-artifact-pairing.toml",
+);
+
+#[derive(Debug)]
+pub struct WireArtifactPairingRule;
+
+pub static RULE: WireArtifactPairingRule = WireArtifactPairingRule;
+
+/// How a manifest artifact token is matched against source evidence.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+enum Kind {
+    /// Match the bare filename on non-word boundaries.
+    Basename,
+    /// Match a slash-separated repository-relative path.
+    RelativePath,
+}
+
+impl Kind {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Basename => "basename",
+            Self::RelativePath => "relative_path",
+        }
+    }
+}
+
+/// One validated manifest artifact.
+#[derive(Debug)]
+struct ManifestRow {
+    kind: Kind,
+    artifact: String,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ManifestFile {
+    #[serde(default)]
+    artifact: Vec<RawManifestRow>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawManifestRow {
+    kind: String,
+    name: String,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct BaselineFile {
+    #[serde(default)]
+    grandfathered: Vec<RawBaselineRow>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawBaselineRow {
+    artifact: String,
+    side: String,
+    reason: String,
+}
+
+/// Reader and writer evidence collected once from the production Rust surface.
+#[derive(Default)]
+struct RustEvidence {
+    reader_texts: Vec<String>,
+    writer_scopes: Vec<String>,
+}
+
+impl Rule for WireArtifactPairingRule {
+    fn name(&self) -> &'static str {
+        NAME
+    }
+
+    fn description(&self) -> &'static str {
+        DESCRIPTION
+    }
+
+    fn check(&self, repository: &Repository) -> Result<RuleOutput, LintError> {
+        let Some(manifest_text) = read_optional(repository, MANIFEST_PATH)? else {
+            return Ok(RuleOutput::clean());
+        };
+        let manifest = parse_manifest(&manifest_text)?;
+        if manifest.is_empty() {
+            return Ok(RuleOutput::clean());
+        }
+        let grandfathered = load_baseline(repository)?;
+        let evidence = scan_rust(repository)?;
+        let shell_lines = scan_shell(repository)?;
+        let matcher = ShellMatcher::new()?;
+        let mut findings = Vec::new();
+        for row in &manifest {
+            if grandfathered.contains(&row.artifact) {
+                continue;
+            }
+            if !evidence.reader_texts.iter().any(|text| mentions(text, row)) {
+                continue;
+            }
+            let has_writer = evidence.writer_scopes.iter().any(|text| mentions(text, row))
+                || shell_lines
+                    .iter()
+                    .any(|line| matcher.writes(line, row));
+            if !has_writer {
+                findings.push(Finding::new(
+                    MANIFEST_PATH,
+                    manifest_line(&manifest_text, &row.artifact),
+                    format!(
+                        "wire artifact {}:{} has reader evidence but no production writer; \
+                         add a writer or baseline a one-sided artifact",
+                        row.kind.label(),
+                        row.artifact
+                    ),
+                ));
+            }
+        }
+        Ok(RuleOutput::from_findings(findings))
+    }
+}
+
+/// Read a tracked file when present, returning `None` when it is not tracked.
+fn read_optional(repository: &Repository, path: &str) -> Result<Option<String>, LintError> {
+    let selector = PathSelector::new(&[path], &[])?;
+    match selector.select(repository).first() {
+        Some(repo_path) => Ok(Some(repository.read_utf8(repo_path)?)),
+        None => Ok(None),
+    }
+}
+
+fn parse_manifest(text: &str) -> Result<Vec<ManifestRow>, LintError> {
+    let parsed: ManifestFile = toml::from_str(text)
+        .map_err(|error| LintError::new(format!("{MANIFEST_PATH}: invalid manifest TOML: {error}")))?;
+    let mut rows = Vec::with_capacity(parsed.artifact.len());
+    let mut seen = BTreeSet::new();
+    for raw in parsed.artifact {
+        let row = validate_manifest_row(raw)?;
+        if !seen.insert((row.kind, row.artifact.clone())) {
+            return Err(LintError::new(format!(
+                "{MANIFEST_PATH}: duplicate manifest artifact {}:{}",
+                row.kind.label(),
+                row.artifact
+            )));
+        }
+        rows.push(row);
+    }
+    Ok(rows)
+}
+
+fn validate_manifest_row(raw: RawManifestRow) -> Result<ManifestRow, LintError> {
+    let kind = match raw.kind.as_str() {
+        "basename" => Kind::Basename,
+        "relative_path" => Kind::RelativePath,
+        other => {
+            return Err(LintError::new(format!(
+                "{MANIFEST_PATH}: invalid manifest kind {other:?}"
+            )));
+        }
+    };
+    if raw.name.is_empty() {
+        return Err(LintError::new(format!(
+            "{MANIFEST_PATH}: manifest artifact name must be non-empty"
+        )));
+    }
+    match kind {
+        Kind::Basename if raw.name.contains('/') || raw.name == "." || raw.name == ".." => {
+            Err(LintError::new(format!(
+                "{MANIFEST_PATH}: invalid basename artifact {:?}",
+                raw.name
+            )))
+        }
+        Kind::RelativePath if !valid_relative_path(&raw.name) => Err(LintError::new(format!(
+            "{MANIFEST_PATH}: invalid relative_path artifact {:?}",
+            raw.name
+        ))),
+        _ => Ok(ManifestRow {
+            kind,
+            artifact: raw.name,
+        }),
+    }
+}
+
+fn valid_relative_path(value: &str) -> bool {
+    !value.is_empty()
+        && !value.starts_with('/')
+        && value
+            .split('/')
+            .all(|part| !part.is_empty() && part != "." && part != "..")
+}
+
+fn load_baseline(repository: &Repository) -> Result<BTreeSet<String>, LintError> {
+    read_optional(repository, BASELINE_PATH)?
+        .map_or_else(|| Ok(BTreeSet::new()), |text| parse_baseline(&text))
+}
+
+fn parse_baseline(text: &str) -> Result<BTreeSet<String>, LintError> {
+    let parsed: BaselineFile = toml::from_str(text)
+        .map_err(|error| LintError::new(format!("{BASELINE_PATH}: invalid baseline TOML: {error}")))?;
+    let mut grandfathered = BTreeSet::new();
+    for row in parsed.grandfathered {
+        if !VALID_SIDES.contains(&row.side.as_str()) {
+            return Err(LintError::new(format!(
+                "{BASELINE_PATH}: invalid baseline side {:?}",
+                row.side
+            )));
+        }
+        if row.reason.trim().is_empty() {
+            return Err(LintError::new(format!(
+                "{BASELINE_PATH}: baseline artifact {:?} needs a non-empty reason",
+                row.artifact
+            )));
+        }
+        if !grandfathered.insert(row.artifact.clone()) {
+            return Err(LintError::new(format!(
+                "{BASELINE_PATH}: duplicate baseline artifact {:?}",
+                row.artifact
+            )));
+        }
+    }
+    Ok(grandfathered)
+}
+
+/// Collect reader literals and writer-bearing function scopes from production
+/// Rust, excluding the linter crate and inline `#[cfg(test)]` code.
+fn scan_rust(repository: &Repository) -> Result<RustEvidence, LintError> {
+    let selector = PathSelector::new(&[RUST_SCOPE_INCLUDE], &[LINTER_CRATE_EXCLUDE])?;
+    let mut evidence = RustEvidence::default();
+    for path in selector.select(repository) {
+        let Ok(source) = repository.read_utf8(path) else {
+            continue; // Skip an unreadable (e.g. non-UTF-8) file, mirroring Python `_read_text`.
+        };
+        let Ok(syntax) = RustSyntax::parse(path.as_str(), &source) else {
+            continue; // Skip a file the shared parser cannot read, mirroring the Python leniency.
+        };
+        let mut scanner = FileScanner::default();
+        scanner.visit_file(syntax.file());
+        evidence.reader_texts.push(scanner.top_level);
+        for scope in scanner.scopes {
+            if scope.has_write {
+                evidence.writer_scopes.push(scope.text.clone());
+            }
+            evidence.reader_texts.push(scope.text);
+        }
+    }
+    Ok(evidence)
+}
+
+/// Collect non-comment lines from residual shell writer files.
+fn scan_shell(repository: &Repository) -> Result<Vec<String>, LintError> {
+    let selector = PathSelector::new(&SHELL_SCOPES, &[])?;
+    let mut lines = Vec::new();
+    for path in selector.select(repository) {
+        if is_shell_test_file(path) {
+            continue;
+        }
+        let Ok(source) = repository.read_utf8(path) else {
+            // A non-UTF-8 file under the shell scope is not a writer; skip it
+            // instead of failing the run, mirroring Python `_read_text`. The
+            // scope reads all file types under these trees, not only scripts.
+            continue;
+        };
+        for line in source.lines() {
+            if !line.trim_start().starts_with('#') {
+                lines.push(line.to_owned());
+            }
+        }
+    }
+    Ok(lines)
+}
+
+fn is_shell_test_file(path: &RepoPath) -> bool {
+    path.as_str()
+        .rsplit('/')
+        .next()
+        .is_some_and(|name| name.starts_with(SHELL_TEST_PREFIX))
+}
+
+/// One collected function scope: its string-literal text and write evidence.
+struct FnScope {
+    text: String,
+    has_write: bool,
+}
+
+/// File-level collector: top-level reader literals plus per-function scopes.
+#[derive(Default)]
+struct FileScanner {
+    top_level: String,
+    scopes: Vec<FnScope>,
+}
+
+impl FileScanner {
+    fn scan_body(block: &syn::Block) -> FnScope {
+        let mut scanner = FnScanner::default();
+        scanner.visit_block(block);
+        FnScope {
+            text: scanner.text,
+            has_write: scanner.has_write,
+        }
+    }
+}
+
+impl<'ast> Visit<'ast> for FileScanner {
+    fn visit_lit_str(&mut self, node: &'ast syn::LitStr) {
+        self.top_level.push_str(&node.value());
+        self.top_level.push('\n');
+    }
+
+    fn visit_item_mod(&mut self, node: &'ast syn::ItemMod) {
+        if has_cfg_test(&node.attrs) {
+            return;
+        }
+        visit::visit_item_mod(self, node);
+    }
+
+    fn visit_item_fn(&mut self, node: &'ast syn::ItemFn) {
+        if has_cfg_test(&node.attrs) {
+            return;
+        }
+        self.scopes.push(Self::scan_body(&node.block));
+    }
+
+    fn visit_impl_item_fn(&mut self, node: &'ast syn::ImplItemFn) {
+        if has_cfg_test(&node.attrs) {
+            return;
+        }
+        self.scopes.push(Self::scan_body(&node.block));
+    }
+
+    fn visit_trait_item_fn(&mut self, node: &'ast syn::TraitItemFn) {
+        if has_cfg_test(&node.attrs) {
+            return;
+        }
+        if let Some(block) = &node.default {
+            self.scopes.push(Self::scan_body(block));
+        }
+    }
+}
+
+/// Function-body collector: string literals and write-call evidence.
+#[derive(Default)]
+struct FnScanner {
+    text: String,
+    has_write: bool,
+}
+
+impl<'ast> Visit<'ast> for FnScanner {
+    fn visit_lit_str(&mut self, node: &'ast syn::LitStr) {
+        self.text.push_str(&node.value());
+        self.text.push('\n');
+    }
+
+    fn visit_expr_method_call(&mut self, node: &'ast syn::ExprMethodCall) {
+        if is_write_name(&node.method.to_string()) {
+            self.has_write = true;
+        }
+        visit::visit_expr_method_call(self, node);
+    }
+
+    fn visit_expr_call(&mut self, node: &'ast syn::ExprCall) {
+        if let syn::Expr::Path(path) = node.func.as_ref()
+            && last_segment(&path.path).is_some_and(|name| is_write_name(&name))
+        {
+            self.has_write = true;
+        }
+        visit::visit_expr_call(self, node);
+    }
+}
+
+fn last_segment(path: &syn::Path) -> Option<String> {
+    path.segments.last().map(|segment| segment.ident.to_string())
+}
+
+/// Whether a call name is generous writer evidence. Over-matching only clears a
+/// finding, never invents one, so a broad set is the safe direction.
+fn is_write_name(name: &str) -> bool {
+    matches!(
+        name,
+        "write" | "write_all" | "write_fmt" | "create" | "create_new" | "touch"
+    ) || name.contains("atomic_write")
+        || name.starts_with("write_")
+        || name.starts_with("_write")
+        || name.ends_with("_atomic")
+}
+
+fn has_cfg_test(attrs: &[syn::Attribute]) -> bool {
+    attrs.iter().any(|attr| {
+        if attr.path().is_ident("test") {
+            return true;
+        }
+        if !attr.path().is_ident("cfg") {
+            return false;
+        }
+        match &attr.meta {
+            syn::Meta::List(list) => list.tokens.to_string().contains("test"),
+            _ => false,
+        }
+    })
+}
+
+/// Whether collected evidence text mentions a manifest artifact.
+fn mentions(text: &str, row: &ManifestRow) -> bool {
+    match row.kind {
+        Kind::Basename => boundary_contains(text, &row.artifact),
+        Kind::RelativePath => {
+            text.contains(&row.artifact)
+                || text.contains(&format!("/{}", row.artifact))
+                || row
+                    .artifact
+                    .split('/')
+                    .filter(|part| !part.is_empty())
+                    .all(|part| text.contains(part))
+        }
+    }
+}
+
+/// Substring match that rejects filename-character neighbours, mirroring the
+/// Python negative-lookaround boundary over `[A-Za-z0-9_.-]`.
+fn boundary_contains(text: &str, needle: &str) -> bool {
+    if needle.is_empty() {
+        return false;
+    }
+    let bytes = text.as_bytes();
+    let mut offset = 0;
+    while let Some(found) = text[offset..].find(needle) {
+        let start = offset + found;
+        let end = start + needle.len();
+        let before_ok = start == 0 || !is_filename_byte(bytes[start - 1]);
+        let after_ok = end >= bytes.len() || !is_filename_byte(bytes[end]);
+        if before_ok && after_ok {
+            return true;
+        }
+        offset = start + 1;
+    }
+    false
+}
+
+const fn is_filename_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'.' || byte == b'-'
+}
+
+fn manifest_line(text: &str, artifact: &str) -> u32 {
+    let needle = format!("\"{artifact}\"");
+    for (index, line) in text.lines().enumerate() {
+        if line.contains(&needle) {
+            return u32::try_from(index + 1).unwrap_or(1);
+        }
+    }
+    1
+}
+
+/// Compiled shell writer detectors reused across every line and artifact.
+struct ShellMatcher {
+    touch: regex::Regex,
+    tee: regex::Regex,
+    mv: regex::Regex,
+}
+
+impl ShellMatcher {
+    fn new() -> Result<Self, LintError> {
+        Ok(Self {
+            touch: compile(r"(^|[;&|[:space:]])touch\b")?,
+            tee: compile(r"(^|[;&|[:space:]])tee\b")?,
+            mv: compile(r"(^|[;&|[:space:]])mv\b")?,
+        })
+    }
+
+    fn writes(&self, line: &str, row: &ManifestRow) -> bool {
+        if self.touch.is_match(line) && shell_mentions(line, row) {
+            return true;
+        }
+        if self.tee.is_match(line) && shell_mentions(line, row) {
+            return true;
+        }
+        if self.mv.is_match(line) && mv_target_writes(line, row) {
+            return true;
+        }
+        redirect_writes(line, row)
+    }
+}
+
+fn compile(pattern: &str) -> Result<regex::Regex, LintError> {
+    regex::Regex::new(pattern)
+        .map_err(|error| LintError::new(format!("invalid shell pattern {pattern:?}: {error}")))
+}
+
+fn mv_target_writes(line: &str, row: &ManifestRow) -> bool {
+    let Some((_, tail)) = line.split_once("mv") else {
+        return false;
+    };
+    let targets: Vec<&str> = tail
+        .split_whitespace()
+        .filter(|token| !token.is_empty() && !token.starts_with('-'))
+        .collect();
+    targets
+        .last()
+        .is_some_and(|target| shell_mentions(target, row))
+}
+
+fn redirect_writes(line: &str, row: &ManifestRow) -> bool {
+    let double = line.rfind(">>");
+    let single = line.rfind('>');
+    let Some(index) = double.max(single) else {
+        return false;
+    };
+    let width = if line[index..].starts_with(">>") { 2 } else { 1 };
+    shell_mentions(&line[index + width..], row)
+}
+
+fn shell_mentions(text: &str, row: &ManifestRow) -> bool {
+    match row.kind {
+        Kind::Basename => boundary_contains(text, &row.artifact),
+        Kind::RelativePath => {
+            text.contains(&row.artifact) || text.contains(&format!("/{}", row.artifact))
+        }
+    }
+}
+
+crate::register_rule!(METADATA, RULE);
+
+#[cfg(test)]
+mod tests {
+    use syn::visit::Visit;
+
+    use super::{
+        FileScanner, Kind, ManifestRow, ShellMatcher, boundary_contains, mentions, parse_baseline,
+        parse_manifest, valid_relative_path,
+    };
+
+    fn basename(artifact: &str) -> ManifestRow {
+        ManifestRow {
+            kind: Kind::Basename,
+            artifact: artifact.to_owned(),
+        }
+    }
+
+    fn relative(artifact: &str) -> ManifestRow {
+        ManifestRow {
+            kind: Kind::RelativePath,
+            artifact: artifact.to_owned(),
+        }
+    }
+
+    #[test]
+    fn basename_boundary_rejects_filename_character_neighbours() {
+        assert!(boundary_contains("logs/final-summary.md here", "final-summary.md"));
+        assert!(boundary_contains("final-summary.md", "final-summary.md"));
+        // A basename must not match when embedded in a longer filename token.
+        assert!(!boundary_contains("run-manifest.json", "manifest.json"));
+        assert!(!boundary_contains("manifest.jsonl", "manifest.json"));
+    }
+
+    #[test]
+    fn relative_path_matches_full_path_and_segment_membership() {
+        assert!(mentions("wrote .ship-route-exit-handoff.env", &relative(".ship-route-exit-handoff.env")));
+        assert!(mentions("dir/.design-step5c-status.env", &relative(".design-step5c-status.env")));
+        assert!(!mentions("unrelated text", &relative(".design-step5c-status.env")));
+    }
+
+    #[test]
+    fn valid_relative_path_rejects_absolute_and_dot_segments() {
+        assert!(valid_relative_path("a/b/c.env"));
+        assert!(!valid_relative_path("/absolute"));
+        assert!(!valid_relative_path("a/../b"));
+        assert!(!valid_relative_path("a//b"));
+    }
+
+    #[test]
+    fn parse_manifest_accepts_valid_rows_and_rejects_malformed() {
+        let manifest = parse_manifest(
+            "[[artifact]]\nkind = \"basename\"\nname = \"final-summary.md\"\n\
+             [[artifact]]\nkind = \"relative_path\"\nname = \"a/b.env\"\n",
+        )
+        .expect("valid manifest");
+        assert_eq!(manifest.len(), 2);
+        assert_eq!(manifest[0].kind, Kind::Basename);
+
+        assert!(parse_manifest("[[artifact]]\nkind = \"other\"\nname = \"x\"\n").is_err());
+        assert!(parse_manifest("[[artifact]]\nkind = \"basename\"\nname = \"a/b\"\n").is_err());
+        assert!(parse_manifest("[[artifact]]\nkind = \"basename\"\nname = \"\"\n").is_err());
+        assert!(
+            parse_manifest("[[artifact]]\nkind = \"basename\"\nname = \"x\"\nextra = 1\n").is_err()
+        );
+    }
+
+    #[test]
+    fn parse_manifest_rejects_duplicate_identity() {
+        let duplicate = "[[artifact]]\nkind = \"basename\"\nname = \"dup.json\"\n\
+             [[artifact]]\nkind = \"basename\"\nname = \"dup.json\"\n";
+        assert!(parse_manifest(duplicate).is_err());
+    }
+
+    #[test]
+    fn parse_baseline_validates_side_reason_and_uniqueness() {
+        let clean = parse_baseline(
+            "[[grandfathered]]\nartifact = \"a.env\"\nside = \"intentionally-one-sided\"\n\
+             reason = \"produced outside the scanned surface\"\n",
+        )
+        .expect("valid baseline");
+        assert!(clean.contains("a.env"));
+
+        assert!(parse_baseline("grandfathered = []\n").expect("empty").is_empty());
+        assert!(
+            parse_baseline(
+                "[[grandfathered]]\nartifact = \"a\"\nside = \"bogus\"\nreason = \"r\"\n"
+            )
+            .is_err()
+        );
+        assert!(
+            parse_baseline(
+                "[[grandfathered]]\nartifact = \"a\"\nside = \"external-writer\"\nreason = \" \"\n"
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn shell_matcher_detects_touch_tee_mv_and_redirect() {
+        let matcher = ShellMatcher::new().expect("shell matcher");
+        let row = basename("final-summary.md");
+        assert!(matcher.writes("  touch \"$dir/final-summary.md\"", &row));
+        assert!(matcher.writes("printf x | tee final-summary.md", &row));
+        assert!(matcher.writes("mv -f tmp final-summary.md", &row));
+        assert!(matcher.writes("printf x >> final-summary.md", &row));
+        assert!(!matcher.writes("cat final-summary.md", &row));
+        // mv reports the destination token, not the source.
+        assert!(!matcher.writes("mv final-summary.md archived", &row));
+    }
+
+    #[test]
+    fn file_scanner_detects_writers_and_skips_cfg_test() {
+        let source = "fn reads() { let _ = std::fs::read_to_string(\"final-summary.md\"); }\n\
+             fn writes() { let _ = std::fs::write(\"token-report.json\", b\"\"); }\n\
+             #[cfg(test)]\nmod tests { fn t() { let _ = std::fs::write(\"hidden.json\", b\"\"); } }\n";
+        let file = syn::parse_file(source).expect("parse fixture");
+        let mut scanner = FileScanner::default();
+        scanner.visit_file(&file);
+
+        assert_eq!(scanner.scopes.len(), 2, "cfg(test) scope must be skipped");
+        let writer_texts: Vec<&str> = scanner
+            .scopes
+            .iter()
+            .filter(|scope| scope.has_write)
+            .map(|scope| scope.text.as_str())
+            .collect();
+        assert_eq!(writer_texts.len(), 1);
+        assert!(mentions(writer_texts[0], &basename("token-report.json")));
+        // The read-only scope references the artifact but carries no write.
+        assert!(
+            scanner
+                .scopes
+                .iter()
+                .any(|scope| !scope.has_write && mentions(&scope.text, &basename("final-summary.md")))
+        );
+        // The cfg(test) literal never reaches reader evidence.
+        assert!(!scanner.scopes.iter().any(|scope| mentions(&scope.text, &basename("hidden.json"))));
+    }
+}

--- a/crates/larch-lint/tests/cli.rs
+++ b/crates/larch-lint/tests/cli.rs
@@ -100,6 +100,12 @@ fn rules_lists_registered_rules_in_name_order() {
         .stdout(predicate::str::contains(
             "skill-documentation\tRequire public, alias, and private skills in both documentation catalogs\n",
         ))
+        .stdout(predicate::str::contains(
+            "run-log-corpus-walkers\tReject raw committed run-log corpus walkers outside the shared owner\n",
+        ))
+        .stdout(predicate::str::contains(
+            "wire-artifact-pairing\tRequire a production writer for every wire-artifact reader\n",
+        ))
         .stderr(predicate::str::is_empty());
 }
 

--- a/crates/larch-lint/tests/run_log_corpus_walkers.rs
+++ b/crates/larch-lint/tests/run_log_corpus_walkers.rs
@@ -1,0 +1,121 @@
+mod support;
+
+use predicates::prelude::*;
+use support::TempRepo;
+
+fn run(repository: &TempRepo) -> assert_cmd::assert::Assert {
+    TempRepo::command_from(repository.path())
+        .args(["rule", "run-log-corpus-walkers"])
+        .assert()
+}
+
+#[test]
+fn raw_read_dir_over_a_corpus_root_is_reported() {
+    let repository = TempRepo::new();
+    repository.write(
+        "crates/app/src/lib.rs",
+        b"pub fn scan(log_root: &std::path::Path) {\n    \
+          let _ = std::fs::read_dir(log_root);\n}\n",
+    );
+    repository.commit_all();
+
+    run(&repository).code(1).stdout(
+        predicate::str::contains("crates/app/src/lib.rs:2:")
+            .and(predicate::str::contains("raw corpus directory read")),
+    );
+}
+
+#[test]
+fn glob_and_walk_families_are_reported() {
+    let repository = TempRepo::new();
+    repository.write(
+        "crates/app/src/lib.rs",
+        b"pub fn a(log_base: &str) {\n    let _ = glob::glob(log_base);\n}\n\
+          pub fn b(impl_root: &std::path::Path) {\n    let _ = walkdir::WalkDir::new(impl_root);\n}\n",
+    );
+    repository.commit_all();
+
+    run(&repository).code(1).stdout(
+        predicate::str::contains("raw corpus glob")
+            .and(predicate::str::contains("raw corpus directory walk")),
+    );
+}
+
+#[test]
+fn owner_module_is_exempt() {
+    let repository = TempRepo::new();
+    repository.write(
+        "crates/app/src/report/run_log_corpus.rs",
+        b"pub fn scan(log_root: &std::path::Path) {\n    \
+          let _ = std::fs::read_dir(log_root);\n}\n",
+    );
+    repository.commit_all();
+
+    run(&repository)
+        .success()
+        .stdout(predicate::str::is_empty());
+}
+
+#[test]
+fn session_scoped_corpus_argument_is_not_flagged() {
+    let repository = TempRepo::new();
+    // The argument carries a corpus marker (`log_root`) and a session marker
+    // (`session_tmpdir`); the session-marker override wins, exercising the real
+    // override branch and nested-paren argument scoping.
+    repository.write(
+        "crates/app/src/lib.rs",
+        b"pub fn scan(session_tmpdir: &std::path::Path, log_root: &str) {\n    \
+          let _ = std::fs::read_dir(session_tmpdir.join(log_root));\n}\n",
+    );
+    repository.commit_all();
+
+    run(&repository)
+        .success()
+        .stdout(predicate::str::is_empty());
+}
+
+#[test]
+fn walker_token_quoted_in_a_string_is_not_flagged() {
+    let repository = TempRepo::new();
+    // A walker token inside an error/log string is data, not a call.
+    repository.write(
+        "crates/app/src/lib.rs",
+        b"pub fn scan(log_root: &str) -> String {\n    \
+          format!(\"failed to read_dir({log_root})\")\n}\n",
+    );
+    repository.commit_all();
+
+    run(&repository)
+        .success()
+        .stdout(predicate::str::is_empty());
+}
+
+#[test]
+fn inline_suppression_with_reason_is_honored() {
+    let repository = TempRepo::new();
+    repository.write(
+        "crates/app/src/lib.rs",
+        b"pub fn scan(log_root: &std::path::Path) {\n    \
+          let _ = std::fs::read_dir(log_root); // lint-run-log-corpus-walkers: ok external tool root\n}\n",
+    );
+    repository.commit_all();
+
+    run(&repository)
+        .success()
+        .stdout(predicate::str::is_empty());
+}
+
+#[test]
+fn inline_suppression_without_reason_is_an_error() {
+    let repository = TempRepo::new();
+    repository.write(
+        "crates/app/src/lib.rs",
+        b"pub fn scan(log_root: &std::path::Path) {\n    \
+          let _ = std::fs::read_dir(log_root); // lint-run-log-corpus-walkers: ok\n}\n",
+    );
+    repository.commit_all();
+
+    run(&repository)
+        .code(2)
+        .stderr(predicate::str::contains("lacks a reason"));
+}

--- a/crates/larch-lint/tests/wire_artifact_pairing.rs
+++ b/crates/larch-lint/tests/wire_artifact_pairing.rs
@@ -1,0 +1,159 @@
+mod support;
+
+use predicates::prelude::*;
+use support::TempRepo;
+
+const MANIFEST: &str = "crates/larch-lint/data/wire-artifact-manifest.toml";
+const BASELINE: &str = "crates/larch-lint/data/wire-artifact-pairing-baseline.toml";
+
+const fn final_summary_manifest() -> &'static [u8] {
+    b"[[artifact]]\nkind = \"basename\"\nname = \"final-summary.md\"\n"
+}
+
+#[test]
+fn reader_without_writer_is_reported() {
+    let repository = TempRepo::new();
+    repository.write(MANIFEST, final_summary_manifest());
+    repository.write(
+        "crates/app/src/lib.rs",
+        b"pub fn load() -> std::io::Result<String> {\n    \
+          std::fs::read_to_string(\"final-summary.md\")\n}\n",
+    );
+    repository.commit_all();
+
+    TempRepo::command_from(repository.path())
+        .args(["rule", "wire-artifact-pairing"])
+        .assert()
+        .code(1)
+        .stdout(
+            predicate::str::contains(MANIFEST)
+                .and(predicate::str::contains("basename:final-summary.md"))
+                .and(predicate::str::contains("no production writer")),
+        );
+}
+
+#[test]
+fn production_writer_clears_the_finding() {
+    let repository = TempRepo::new();
+    repository.write(MANIFEST, final_summary_manifest());
+    repository.write(
+        "crates/app/src/lib.rs",
+        b"pub fn load() -> std::io::Result<String> {\n    \
+          std::fs::read_to_string(\"final-summary.md\")\n}\n\
+          pub fn save(data: &[u8]) -> std::io::Result<()> {\n    \
+          std::fs::write(\"final-summary.md\", data)\n}\n",
+    );
+    repository.commit_all();
+
+    TempRepo::command_from(repository.path())
+        .args(["rule", "wire-artifact-pairing"])
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+}
+
+#[test]
+fn residual_shell_writer_clears_the_finding() {
+    let repository = TempRepo::new();
+    repository.write(MANIFEST, final_summary_manifest());
+    repository.write(
+        "crates/app/src/lib.rs",
+        b"pub fn load() -> std::io::Result<String> {\n    \
+          std::fs::read_to_string(\"final-summary.md\")\n}\n",
+    );
+    repository.write(
+        "scripts/emit.sh",
+        b"#!/usr/bin/env bash\nprintf 'done' > \"$dir/final-summary.md\"\n",
+    );
+    repository.commit_all();
+
+    TempRepo::command_from(repository.path())
+        .args(["rule", "wire-artifact-pairing"])
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+}
+
+#[test]
+fn baseline_grandfathers_a_one_sided_artifact() {
+    let repository = TempRepo::new();
+    repository.write(MANIFEST, final_summary_manifest());
+    repository.write(
+        BASELINE,
+        b"[[grandfathered]]\nartifact = \"final-summary.md\"\n\
+          side = \"intentionally-one-sided\"\n\
+          reason = \"produced outside the scanned Rust surface\"\n",
+    );
+    repository.write(
+        "crates/app/src/lib.rs",
+        b"pub fn load() -> std::io::Result<String> {\n    \
+          std::fs::read_to_string(\"final-summary.md\")\n}\n",
+    );
+    repository.commit_all();
+
+    TempRepo::command_from(repository.path())
+        .args(["rule", "wire-artifact-pairing"])
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+}
+
+#[test]
+fn basename_boundary_does_not_match_a_longer_filename() {
+    let repository = TempRepo::new();
+    repository.write(
+        MANIFEST,
+        b"[[artifact]]\nkind = \"basename\"\nname = \"manifest.json\"\n",
+    );
+    repository.write(
+        "crates/app/src/lib.rs",
+        b"pub fn load() -> std::io::Result<String> {\n    \
+          std::fs::read_to_string(\"run-manifest.json\")\n}\n",
+    );
+    repository.commit_all();
+
+    TempRepo::command_from(repository.path())
+        .args(["rule", "wire-artifact-pairing"])
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+}
+
+#[test]
+fn non_utf8_file_under_shell_scope_is_tolerated() {
+    let repository = TempRepo::new();
+    repository.write(MANIFEST, final_summary_manifest());
+    repository.write(
+        "crates/app/src/lib.rs",
+        b"pub fn load() -> std::io::Result<String> {\n    \
+          std::fs::read_to_string(\"final-summary.md\")\n}\n",
+    );
+    // A non-UTF-8 file lives under the shell scope (which reads every file type,
+    // not just scripts). It must be skipped, not abort the run with exit 2.
+    repository.write("scripts/blob.bin", &[0xff, 0xfe, 0x00, 0xe9]);
+    repository.commit_all();
+
+    // The reader-without-writer finding still surfaces (exit 1), proving the
+    // non-UTF-8 file was tolerated rather than turning the run into a hard error.
+    TempRepo::command_from(repository.path())
+        .args(["rule", "wire-artifact-pairing"])
+        .assert()
+        .code(1)
+        .stdout(predicate::str::contains("basename:final-summary.md"));
+}
+
+#[test]
+fn malformed_manifest_is_a_hard_error() {
+    let repository = TempRepo::new();
+    repository.write(
+        MANIFEST,
+        b"[[artifact]]\nkind = \"unsupported\"\nname = \"final-summary.md\"\n",
+    );
+    repository.commit_all();
+
+    TempRepo::command_from(repository.path())
+        .args(["rule", "wire-artifact-pairing"])
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("invalid manifest kind"));
+}


### PR DESCRIPTION
Fixes #7618

## What

RUST-LINT C6 of the linter migration (#7632): implement Rust equivalents of the Python `wire-artifact-pairing` and `run-log-walkers` linters. Per the umbrella, the Python linters stay active — these enforce the same policy against the **migrating Rust runtime** (plus residual shell), not against Python.

### `wire-artifact-pairing`
Requires a production Rust or residual-shell writer for every wire-artifact reader named in a TOML manifest (`crates/larch-lint/data/wire-artifact-manifest.toml`).
- `syn`-based reader (string-literal) and writer (write-call scope) evidence, plus shell writer grammar (`touch`/`tee`/`mv`/redirect).
- Reason-bearing baseline that only shrinks (`…-baseline.toml`, starts empty).
- Findings anchor to the manifest (the `syn` build carries no line spans).
- The larch-lint crate is out of scope: it names artifacts as lint *configuration*, not run-time reads. The runtime migration lands larch code in its own crate, which this rule scans.

### `run-log-corpus-walkers`
Rejects raw `read_dir`/`glob`/`WalkDir::new`/`scandir`/`walk_dir` over committed-corpus roots outside the `run_log_corpus` owner module.
- A line lexer blanks comment, string, and char-literal spans so a walker token only matches a real call; the corpus/session marker check is scoped to the parenthesized call argument.
- Inline suppression via the shared `suppression` helper.

### Framework
Both rules register through `automod` with per-rule `migration-ledger` records — **no shared-registry, Cargo, CI, Makefile, or docs edits**. They run from `larch-lint all` in CI immediately at **zero findings**.

## Verification
- `make rust-fmt`, `make rust-clippy` (pedantic + nursery, `-D warnings`), `make rust-test`, `make rust-lint` (`larch-lint all`, exit 0), `make rust-deny` — all green. `Cargo.lock` unchanged.
- 101 unit + integration tests pass (mine plus every sibling rule). Coverage spans fixed per-run reads, writer evidence, manifest validation, glob families, baseline grandfathering, inline suppression, the lexer edge cases, and non-UTF-8 tolerance.

## Notes
- An independent review (run against the compiled binary) surfaced a latent non-UTF-8 hard-error under the shell scope and four run-log false positives (walker tokens quoted in strings, marker bleed from adjacent statements, nested block comments, `'"'` char literals); all are fixed with regression tests — the line lexer + argument scoping is that fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HaBKGMdVkbRm5fAytrwnsZ
