### PR TITLE
Fixes #7662: add Rust shared runtime types

### DIFF
--- a/crates/larch-core/src/config.rs
+++ b/crates/larch-core/src/config.rs
@@ -1,0 +1,131 @@
+//! Shared configuration names that survive the Python migration.
+
+/// Environment-variable names read at Rust composition boundaries.
+///
+/// Core domain code does not read the process environment. The CLI and adapter
+/// layers use these names to construct typed configuration and runtime context.
+pub mod env {
+    /// Anthropic API credential used by Claude subprocesses.
+    pub const ANTHROPIC_API_KEY: &str = "ANTHROPIC_API_KEY";
+    /// Plugin-provided fallback for the Codex effort setting.
+    pub const CLAUDE_PLUGIN_OPTION_CODEX_EFFORT: &str = "CLAUDE_PLUGIN_OPTION_CODEX_EFFORT";
+    /// Plugin-provided fallback for the Codex model setting.
+    pub const CLAUDE_PLUGIN_OPTION_CODEX_MODEL: &str = "CLAUDE_PLUGIN_OPTION_CODEX_MODEL";
+    /// Plugin-provided fallback for the Cursor model setting.
+    pub const CLAUDE_PLUGIN_OPTION_CURSOR_MODEL: &str = "CLAUDE_PLUGIN_OPTION_CURSOR_MODEL";
+    /// Root of the installed Claude plugin.
+    pub const CLAUDE_PLUGIN_ROOT: &str = "CLAUDE_PLUGIN_ROOT";
+    /// Cursor API credential used by Cursor subprocesses.
+    pub const CURSOR_API_KEY: &str = "CURSOR_API_KEY";
+    /// Temporary directory for an active design run.
+    pub const DESIGN_TMPDIR: &str = "DESIGN_TMPDIR";
+    /// GitHub service credential. Larch does not fall back to `GITHUB_TOKEN`.
+    pub const GH_TOKEN: &str = "GH_TOKEN";
+    /// Optional Google Application Default Credentials file.
+    pub const GOOGLE_APPLICATION_CREDENTIALS: &str = "GOOGLE_APPLICATION_CREDENTIALS";
+    /// Current user's home directory.
+    pub const HOME: &str = "HOME";
+    /// Temporary directory for an active implementation run.
+    pub const IMPLEMENT_TMPDIR: &str = "IMPLEMENT_TMPDIR";
+    /// Issue number associated with the current workflow.
+    pub const ISSUE_NUMBER: &str = "ISSUE_NUMBER";
+    /// Optional Codex effort override.
+    pub const LARCH_CODEX_EFFORT: &str = "LARCH_CODEX_EFFORT";
+    /// Optional Codex fixer model override.
+    pub const LARCH_CODEX_FIX_MODEL: &str = "LARCH_CODEX_FIX_MODEL";
+    /// Optional Codex implementation model override.
+    pub const LARCH_CODEX_MODEL: &str = "LARCH_CODEX_MODEL";
+    /// Optional Codex reviewer model override.
+    pub const LARCH_CODEX_REVIEW_MODEL: &str = "LARCH_CODEX_REVIEW_MODEL";
+    /// Optional Codex voter model override.
+    pub const LARCH_CODEX_VOTE_MODEL: &str = "LARCH_CODEX_VOTE_MODEL";
+    /// Optional Cursor model override.
+    pub const LARCH_CURSOR_MODEL: &str = "LARCH_CURSOR_MODEL";
+    /// Disable run-log commits for the current workflow.
+    pub const LARCH_NO_LOGS_COMMIT: &str = "LARCH_NO_LOGS_COMMIT";
+    /// Canonical run identifier.
+    pub const LARCH_RUN_ID: &str = "LARCH_RUN_ID";
+    /// Current user login name on platforms that provide it.
+    pub const LOGNAME: &str = "LOGNAME";
+    /// `OpenAI` API credential used by Codex subprocesses.
+    pub const OPENAI_API_KEY: &str = "OPENAI_API_KEY";
+    /// Executable search path inherited by approved child processes.
+    pub const PATH: &str = "PATH";
+    /// GitHub `OWNER/REPO` associated with the current workflow.
+    pub const REPO: &str = "REPO";
+    /// Session identifier associated with the current workflow.
+    pub const SESSION_ID: &str = "SESSION_ID";
+    /// Temporary directory for the current session.
+    pub const SESSION_TMPDIR: &str = "SESSION_TMPDIR";
+    /// System temporary directory override.
+    pub const TMPDIR: &str = "TMPDIR";
+    /// Current user name.
+    pub const USER: &str = "USER";
+
+    /// Shared names maintained by this module.
+    pub const ALL: [&str; 28] = [
+        ANTHROPIC_API_KEY,
+        CLAUDE_PLUGIN_OPTION_CODEX_EFFORT,
+        CLAUDE_PLUGIN_OPTION_CODEX_MODEL,
+        CLAUDE_PLUGIN_OPTION_CURSOR_MODEL,
+        CLAUDE_PLUGIN_ROOT,
+        CURSOR_API_KEY,
+        DESIGN_TMPDIR,
+        GH_TOKEN,
+        GOOGLE_APPLICATION_CREDENTIALS,
+        HOME,
+        IMPLEMENT_TMPDIR,
+        ISSUE_NUMBER,
+        LARCH_CODEX_EFFORT,
+        LARCH_CODEX_FIX_MODEL,
+        LARCH_CODEX_MODEL,
+        LARCH_CODEX_REVIEW_MODEL,
+        LARCH_CODEX_VOTE_MODEL,
+        LARCH_CURSOR_MODEL,
+        LARCH_NO_LOGS_COMMIT,
+        LARCH_RUN_ID,
+        LOGNAME,
+        OPENAI_API_KEY,
+        PATH,
+        REPO,
+        SESSION_ID,
+        SESSION_TMPDIR,
+        TMPDIR,
+        USER,
+    ];
+}
+
+#[cfg(test)]
+mod tests {
+    use super::env;
+    use std::collections::BTreeSet;
+
+    #[test]
+    fn environment_names_preserve_live_public_strings() {
+        assert_eq!(env::GH_TOKEN, "GH_TOKEN");
+        assert_eq!(
+            env::GOOGLE_APPLICATION_CREDENTIALS,
+            "GOOGLE_APPLICATION_CREDENTIALS"
+        );
+        assert_eq!(env::LARCH_RUN_ID, "LARCH_RUN_ID");
+        assert_eq!(env::DESIGN_TMPDIR, "DESIGN_TMPDIR");
+        assert_eq!(env::IMPLEMENT_TMPDIR, "IMPLEMENT_TMPDIR");
+        assert_eq!(env::CLAUDE_PLUGIN_ROOT, "CLAUDE_PLUGIN_ROOT");
+        assert_eq!(env::REPO, "REPO");
+        assert_eq!(env::ISSUE_NUMBER, "ISSUE_NUMBER");
+        assert_eq!(env::SESSION_ID, "SESSION_ID");
+        assert_eq!(env::SESSION_TMPDIR, "SESSION_TMPDIR");
+        assert_eq!(
+            env::CLAUDE_PLUGIN_OPTION_CODEX_MODEL,
+            "CLAUDE_PLUGIN_OPTION_CODEX_MODEL"
+        );
+        assert_eq!(env::LARCH_NO_LOGS_COMMIT, "LARCH_NO_LOGS_COMMIT");
+    }
+
+    #[test]
+    fn centralized_environment_names_are_unique() {
+        let unique = env::ALL.into_iter().collect::<BTreeSet<_>>();
+        assert_eq!(unique.len(), env::ALL.len());
+        assert!(unique.iter().all(|name| !name.is_empty()));
+    }
+}

--- a/crates/larch-core/src/context.rs
+++ b/crates/larch-core/src/context.rs
@@ -1,0 +1,206 @@
+//! Validated run identity and immutable runtime context.
+
+use crate::BuildMetadata;
+use std::{error::Error, fmt};
+
+const RUN_ID_MAX_BYTES: usize = 128;
+
+/// A path-safe identifier for one larch run.
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct RunId(Box<str>);
+
+impl RunId {
+    /// Parse a run identifier shared by progress, background-job, and run-log paths.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RunIdError`] when the value is empty, too long, reserved, or
+    /// contains a byte outside the stable ASCII allowlist.
+    pub fn parse(value: impl Into<String>) -> Result<Self, RunIdError> {
+        let value = value.into();
+        validate_run_id(&value)?;
+        Ok(Self(value.into_boxed_str()))
+    }
+
+    /// Return the validated identifier.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for RunId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl TryFrom<String> for RunId {
+    type Error = RunIdError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::parse(value)
+    }
+}
+
+impl TryFrom<&str> for RunId {
+    type Error = RunIdError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::parse(value)
+    }
+}
+
+/// The reason a run identifier was rejected.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum RunIdErrorKind {
+    /// The identifier was empty.
+    Empty,
+    /// The identifier exceeded the shared size bound.
+    TooLong,
+    /// The identifier is reserved by the progress pointer contract.
+    Reserved,
+    /// The identifier contained bytes outside the stable ASCII allowlist.
+    InvalidCharacter,
+}
+
+/// A typed run-identifier validation failure.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RunIdError {
+    kind: RunIdErrorKind,
+}
+
+impl RunIdError {
+    /// Return the validation failure kind.
+    #[must_use]
+    pub const fn kind(&self) -> RunIdErrorKind {
+        self.kind
+    }
+}
+
+impl fmt::Display for RunIdError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self.kind {
+            RunIdErrorKind::Empty => "run ID must be non-empty",
+            RunIdErrorKind::TooLong => "run ID must be at most 128 bytes",
+            RunIdErrorKind::Reserved => "run ID is reserved",
+            RunIdErrorKind::InvalidCharacter => {
+                "run ID must contain only ASCII letters, digits, dot, underscore, or dash"
+            }
+        })
+    }
+}
+
+impl Error for RunIdError {}
+
+fn validate_run_id(value: &str) -> Result<(), RunIdError> {
+    let kind = if value.is_empty() {
+        Some(RunIdErrorKind::Empty)
+    } else if value.len() > RUN_ID_MAX_BYTES {
+        Some(RunIdErrorKind::TooLong)
+    } else if matches!(value, "." | ".." | "current") || value.contains("..") {
+        Some(RunIdErrorKind::Reserved)
+    } else if !value
+        .bytes()
+        .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'))
+    {
+        Some(RunIdErrorKind::InvalidCharacter)
+    } else {
+        None
+    };
+
+    kind.map_or(Ok(()), |kind| Err(RunIdError { kind }))
+}
+
+/// Immutable metadata shared by one larch invocation.
+///
+/// Composition code constructs this value once after parsing untrusted input.
+/// Domain code receives it by shared reference and cannot replace its identity.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RuntimeContext {
+    build: BuildMetadata,
+    run_id: RunId,
+    session_id: Option<Box<str>>,
+}
+
+impl RuntimeContext {
+    /// Create an invocation context from validated identity.
+    #[must_use]
+    pub fn new(build: BuildMetadata, run_id: RunId, session_id: Option<String>) -> Self {
+        Self {
+            build,
+            run_id,
+            session_id: session_id.map(String::into_boxed_str),
+        }
+    }
+
+    /// Return metadata for the running build.
+    #[must_use]
+    pub const fn build(&self) -> BuildMetadata {
+        self.build
+    }
+
+    /// Return the validated run identifier.
+    #[must_use]
+    pub const fn run_id(&self) -> &RunId {
+        &self.run_id
+    }
+
+    /// Return the optional outer-session correlation identifier.
+    #[must_use]
+    pub fn session_id(&self) -> Option<&str> {
+        self.session_id.as_deref()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{RunId, RunIdErrorKind, RuntimeContext};
+    use crate::BuildMetadata;
+
+    #[test]
+    fn run_id_accepts_live_ascii_contract() {
+        for value in ["run-1", "-abc123", "abc.DEF_123", "A", &"a".repeat(128)] {
+            let run_id = RunId::parse(value).expect("valid run ID should parse");
+            assert_eq!(run_id.as_str(), value);
+            assert_eq!(run_id.to_string(), value);
+        }
+    }
+
+    #[test]
+    fn run_id_rejects_unsafe_and_reserved_values() {
+        let invalid = [
+            ("", RunIdErrorKind::Empty),
+            (&"a".repeat(129), RunIdErrorKind::TooLong),
+            (".", RunIdErrorKind::Reserved),
+            ("..", RunIdErrorKind::Reserved),
+            ("current", RunIdErrorKind::Reserved),
+            ("a..b", RunIdErrorKind::Reserved),
+            ("../evil", RunIdErrorKind::Reserved),
+            ("bad/slash", RunIdErrorKind::InvalidCharacter),
+            (r"bad\slash", RunIdErrorKind::InvalidCharacter),
+            ("bad space", RunIdErrorKind::InvalidCharacter),
+            ("café", RunIdErrorKind::InvalidCharacter),
+        ];
+
+        for (value, expected) in invalid {
+            let error = RunId::parse(value).expect_err("unsafe run ID should fail");
+            assert_eq!(error.kind(), expected, "{value:?}");
+        }
+    }
+
+    #[test]
+    fn runtime_context_preserves_validated_immutable_identity() {
+        let context = RuntimeContext::new(
+            BuildMetadata::new("53.1.22"),
+            RunId::parse("run-abc").expect("fixture run ID should parse"),
+            Some("session-123".to_owned()),
+        );
+        let cloned = context.clone();
+
+        assert_eq!(context.build().version(), "53.1.22");
+        assert_eq!(context.run_id().as_str(), "run-abc");
+        assert_eq!(context.session_id(), Some("session-123"));
+        assert_eq!(cloned, context);
+    }
+}

--- a/crates/larch-core/src/error.rs
+++ b/crates/larch-core/src/error.rs
@@ -1,0 +1,210 @@
+//! Categorized failures for domain and composition layers.
+
+use crate::ExitCode;
+use std::{error::Error, fmt};
+
+/// The actor or system responsible for resolving a failure.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum ErrorCategory {
+    /// The operator must correct input, grant authority, or make a decision.
+    Operator,
+    /// An external dependency or runtime precondition failed.
+    Environment,
+    /// Larch violated one of its own contracts.
+    Internal,
+}
+
+/// Operator-resolvable failures.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum OperatorError {
+    /// Command arguments or trusted configuration are invalid.
+    Usage,
+    /// The workflow needs a decision or manual action.
+    NeedsUserInput,
+    /// A live mutation was not authorized.
+    MutationRefused,
+    /// An authored artifact must be revised.
+    ReauthorRequired,
+}
+
+/// Failures caused by external systems or runtime preconditions.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum EnvironmentalFailure {
+    /// A required external precondition is not currently satisfied.
+    Stalled,
+    /// A retryable infrastructure or service failure occurred.
+    Transient,
+    /// An external operation exceeded its deadline.
+    Timeout,
+}
+
+/// Defects caused by larch itself.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum InternalDefect {
+    /// Larch reached a state forbidden by its own contracts.
+    ContractViolation,
+}
+
+/// A typed failure kind with an unambiguous responsibility category.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum FailureKind {
+    /// An operator-resolvable failure.
+    Operator(OperatorError),
+    /// An environmental failure.
+    Environment(EnvironmentalFailure),
+    /// An internal larch defect.
+    Internal(InternalDefect),
+}
+
+impl FailureKind {
+    /// Return the responsible category.
+    #[must_use]
+    pub const fn category(self) -> ErrorCategory {
+        match self {
+            Self::Operator(_) => ErrorCategory::Operator,
+            Self::Environment(_) => ErrorCategory::Environment,
+            Self::Internal(_) => ErrorCategory::Internal,
+        }
+    }
+
+    /// Return the stable process exit code.
+    #[must_use]
+    pub const fn exit_code(self) -> ExitCode {
+        match self {
+            Self::Operator(OperatorError::Usage) => ExitCode::Usage,
+            Self::Operator(OperatorError::NeedsUserInput) => ExitCode::NeedsUserInput,
+            Self::Operator(OperatorError::MutationRefused) => ExitCode::MutationRefused,
+            Self::Operator(OperatorError::ReauthorRequired) => ExitCode::ReauthorRequired,
+            Self::Environment(EnvironmentalFailure::Stalled) => ExitCode::Stalled,
+            Self::Environment(EnvironmentalFailure::Transient) => ExitCode::Transient,
+            Self::Environment(EnvironmentalFailure::Timeout) => ExitCode::Timeout,
+            Self::Internal(InternalDefect::ContractViolation) => ExitCode::InternalError,
+        }
+    }
+}
+
+/// A categorized larch failure with diagnostic context.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LarchError {
+    kind: FailureKind,
+    message: String,
+}
+
+impl LarchError {
+    /// Create a categorized failure.
+    #[must_use]
+    pub fn new(kind: FailureKind, message: impl Into<String>) -> Self {
+        Self {
+            kind,
+            message: message.into(),
+        }
+    }
+
+    /// Return the typed failure kind.
+    #[must_use]
+    pub const fn kind(&self) -> FailureKind {
+        self.kind
+    }
+
+    /// Return the responsible category.
+    #[must_use]
+    pub const fn category(&self) -> ErrorCategory {
+        self.kind.category()
+    }
+
+    /// Return the stable process exit code.
+    #[must_use]
+    pub const fn exit_code(&self) -> ExitCode {
+        self.kind.exit_code()
+    }
+
+    /// Return the diagnostic without adding presentation text.
+    #[must_use]
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+impl fmt::Display for LarchError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl Error for LarchError {}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        EnvironmentalFailure, ErrorCategory, FailureKind, InternalDefect, LarchError, OperatorError,
+    };
+    use crate::ExitCode;
+
+    #[test]
+    fn every_failure_kind_maps_to_one_category_and_stable_exit() {
+        let expected = [
+            (
+                FailureKind::Operator(OperatorError::Usage),
+                ErrorCategory::Operator,
+                ExitCode::Usage,
+            ),
+            (
+                FailureKind::Operator(OperatorError::NeedsUserInput),
+                ErrorCategory::Operator,
+                ExitCode::NeedsUserInput,
+            ),
+            (
+                FailureKind::Operator(OperatorError::MutationRefused),
+                ErrorCategory::Operator,
+                ExitCode::MutationRefused,
+            ),
+            (
+                FailureKind::Operator(OperatorError::ReauthorRequired),
+                ErrorCategory::Operator,
+                ExitCode::ReauthorRequired,
+            ),
+            (
+                FailureKind::Environment(EnvironmentalFailure::Stalled),
+                ErrorCategory::Environment,
+                ExitCode::Stalled,
+            ),
+            (
+                FailureKind::Environment(EnvironmentalFailure::Transient),
+                ErrorCategory::Environment,
+                ExitCode::Transient,
+            ),
+            (
+                FailureKind::Environment(EnvironmentalFailure::Timeout),
+                ErrorCategory::Environment,
+                ExitCode::Timeout,
+            ),
+            (
+                FailureKind::Internal(InternalDefect::ContractViolation),
+                ErrorCategory::Internal,
+                ExitCode::InternalError,
+            ),
+        ];
+
+        for (kind, category, exit) in expected {
+            assert_eq!(kind.category(), category);
+            assert_eq!(kind.exit_code(), exit);
+        }
+    }
+
+    #[test]
+    fn larch_error_preserves_typed_and_display_contracts() {
+        let error = LarchError::new(
+            FailureKind::Environment(EnvironmentalFailure::Transient),
+            "GitHub request failed",
+        );
+
+        assert_eq!(
+            error.kind(),
+            FailureKind::Environment(EnvironmentalFailure::Transient)
+        );
+        assert_eq!(error.category(), ErrorCategory::Environment);
+        assert_eq!(error.exit_code(), ExitCode::Transient);
+        assert_eq!(error.message(), "GitHub request failed");
+        assert_eq!(error.to_string(), "GitHub request failed");
+    }
+}

--- a/crates/larch-core/src/lib.rs
+++ b/crates/larch-core/src/lib.rs
@@ -1,5 +1,17 @@
 //! Domain types, use cases, and effect-free service ports for larch.
 
+mod config;
+mod context;
+mod error;
+mod outcome;
+
+pub use config::env;
+pub use context::{RunId, RunIdError, RunIdErrorKind, RuntimeContext};
+pub use error::{
+    EnvironmentalFailure, ErrorCategory, FailureKind, InternalDefect, LarchError, OperatorError,
+};
+pub use outcome::{ExitCode, WorkflowOutcome};
+
 /// Immutable metadata about the running larch build.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct BuildMetadata {

--- a/crates/larch-core/src/outcome.rs
+++ b/crates/larch-core/src/outcome.rs
@@ -1,0 +1,199 @@
+//! Stable process exits and workflow outcomes.
+
+use std::fmt;
+
+/// Stable process exit codes shared by larch commands.
+///
+/// These values preserve the live Python command contract. Domain-specific
+/// helper exits stay with their owning command instead of expanding this type.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[repr(i32)]
+pub enum ExitCode {
+    /// The command completed successfully.
+    Success = 0,
+    /// Larch encountered an internal defect.
+    InternalError = 1,
+    /// The operator supplied invalid arguments or configuration.
+    Usage = 2,
+    /// Larch needs an operator decision before it can continue.
+    NeedsUserInput = 3,
+    /// An external precondition prevented the workflow from continuing.
+    Stalled = 4,
+    /// A requested live mutation lacked operator authorization.
+    MutationRefused = 5,
+    /// A retryable environmental failure interrupted the workflow.
+    Transient = 6,
+    /// An authored artifact must be revised before it can be accepted.
+    ReauthorRequired = 7,
+    /// An external operation exceeded its deadline.
+    Timeout = 124,
+}
+
+impl ExitCode {
+    /// Every shared exit code, used by composition layers and exhaustive tests.
+    pub const ALL: [Self; 9] = [
+        Self::Success,
+        Self::InternalError,
+        Self::Usage,
+        Self::NeedsUserInput,
+        Self::Stalled,
+        Self::MutationRefused,
+        Self::Transient,
+        Self::ReauthorRequired,
+        Self::Timeout,
+    ];
+
+    /// Return the process exit status.
+    #[must_use]
+    pub const fn value(self) -> i32 {
+        match self {
+            Self::Success => 0,
+            Self::InternalError => 1,
+            Self::Usage => 2,
+            Self::NeedsUserInput => 3,
+            Self::Stalled => 4,
+            Self::MutationRefused => 5,
+            Self::Transient => 6,
+            Self::ReauthorRequired => 7,
+            Self::Timeout => 124,
+        }
+    }
+
+    /// Parse a process status when it is part of the shared contract.
+    #[must_use]
+    pub const fn from_value(value: i32) -> Option<Self> {
+        match value {
+            0 => Some(Self::Success),
+            1 => Some(Self::InternalError),
+            2 => Some(Self::Usage),
+            3 => Some(Self::NeedsUserInput),
+            4 => Some(Self::Stalled),
+            5 => Some(Self::MutationRefused),
+            6 => Some(Self::Transient),
+            7 => Some(Self::ReauthorRequired),
+            124 => Some(Self::Timeout),
+            _ => None,
+        }
+    }
+}
+
+/// Terminal outcomes shared by workflow state machines.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum WorkflowOutcome {
+    /// The workflow completed successfully.
+    Ok,
+    /// The workflow needs an operator decision.
+    NeedsUserInput,
+    /// The workflow stopped on an unmet external precondition.
+    Stalled,
+    /// The workflow stopped on a retryable environmental failure.
+    Transient,
+    /// The workflow stopped because larch violated an internal contract.
+    InternalError,
+}
+
+impl WorkflowOutcome {
+    /// Every shared workflow outcome.
+    pub const ALL: [Self; 5] = [
+        Self::Ok,
+        Self::NeedsUserInput,
+        Self::Stalled,
+        Self::Transient,
+        Self::InternalError,
+    ];
+
+    /// Return the stable machine-readable outcome string.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Ok => "OK",
+            Self::NeedsUserInput => "NEEDS_USER_INPUT",
+            Self::Stalled => "STALLED",
+            Self::Transient => "TRANSIENT",
+            Self::InternalError => "INTERNAL_ERROR",
+        }
+    }
+
+    /// Return the stable process exit code for this outcome.
+    #[must_use]
+    pub const fn exit_code(self) -> ExitCode {
+        match self {
+            Self::Ok => ExitCode::Success,
+            Self::NeedsUserInput => ExitCode::NeedsUserInput,
+            Self::Stalled => ExitCode::Stalled,
+            Self::Transient => ExitCode::Transient,
+            Self::InternalError => ExitCode::InternalError,
+        }
+    }
+}
+
+impl fmt::Display for WorkflowOutcome {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ExitCode, WorkflowOutcome};
+    use std::collections::BTreeSet;
+
+    #[test]
+    fn shared_exit_codes_preserve_the_live_contract() {
+        let expected = [
+            (ExitCode::Success, 0),
+            (ExitCode::InternalError, 1),
+            (ExitCode::Usage, 2),
+            (ExitCode::NeedsUserInput, 3),
+            (ExitCode::Stalled, 4),
+            (ExitCode::MutationRefused, 5),
+            (ExitCode::Transient, 6),
+            (ExitCode::ReauthorRequired, 7),
+            (ExitCode::Timeout, 124),
+        ];
+
+        assert_eq!(ExitCode::ALL.len(), expected.len());
+        for (exit, value) in expected {
+            assert_eq!(exit.value(), value);
+            assert_eq!(ExitCode::from_value(value), Some(exit));
+        }
+    }
+
+    #[test]
+    fn shared_exit_codes_are_unique_and_unknown_values_stay_domain_owned() {
+        let values = ExitCode::ALL.map(ExitCode::value);
+        assert_eq!(
+            values.into_iter().collect::<BTreeSet<_>>().len(),
+            values.len()
+        );
+        assert_eq!(ExitCode::from_value(-1), None);
+        assert_eq!(ExitCode::from_value(8), None);
+        assert_eq!(ExitCode::from_value(125), None);
+    }
+
+    #[test]
+    fn every_workflow_outcome_has_its_stable_string_and_exit() {
+        let expected = [
+            (WorkflowOutcome::Ok, "OK", ExitCode::Success),
+            (
+                WorkflowOutcome::NeedsUserInput,
+                "NEEDS_USER_INPUT",
+                ExitCode::NeedsUserInput,
+            ),
+            (WorkflowOutcome::Stalled, "STALLED", ExitCode::Stalled),
+            (WorkflowOutcome::Transient, "TRANSIENT", ExitCode::Transient),
+            (
+                WorkflowOutcome::InternalError,
+                "INTERNAL_ERROR",
+                ExitCode::InternalError,
+            ),
+        ];
+
+        assert_eq!(WorkflowOutcome::ALL.len(), expected.len());
+        for (outcome, text, exit) in expected {
+            assert_eq!(outcome.as_str(), text);
+            assert_eq!(outcome.to_string(), text);
+            assert_eq!(outcome.exit_code(), exit);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- add typed workflow outcomes and exhaustive stable exit-code mappings
- separate operator errors, environmental failures, and internal defects
- centralize live environment-variable names and add validated immutable run context

## Tests

- `cargo test --locked --package larch-core`
- `cargo clippy --locked --package larch-core --all-targets --all-features -- -D warnings`
- `cargo run --quiet --locked --package larch-lint -- all`

Fixes #7662