### PR TITLE
Fixes #7660: add canonical larch command dispatcher

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -42,6 +42,18 @@ this file and to the `layering` repository rule in the same change.
 - Cut migrated commands directly to Rust. Do not add Python, `gh`, `gcloud`, or
   Git fallbacks outside the approved compatibility boundaries.
 
+## Command dispatch
+
+The executable parses `larch <domain> <verb> [arguments]` with Clap. Domains
+and verbs are closed enums. An unknown command is an error and never delegates
+to Python or another executable. The `example echo` command is non-production;
+it proves that the composition root dispatches into `larch-core` while command
+ports migrate incrementally.
+
+The workspace package version is the compiled binary version. The CLI test
+suite checks it against `.claude-plugin/plugin.json`, which is the plugin
+release version selected by the release and installation decision in #7670.
+
 ## Dependency policy
 
 `Cargo.toml` at the workspace root owns every crate version, feature set, and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1424,7 +1424,9 @@ dependencies = [
  "assert_cmd",
  "clap",
  "larch-adapters",
+ "larch-core",
  "predicates",
+ "serde_json",
 ]
 
 [[package]]

--- a/crates/larch-cli/Cargo.toml
+++ b/crates/larch-cli/Cargo.toml
@@ -15,10 +15,12 @@ path = "src/main.rs"
 [dependencies]
 clap.workspace = true
 larch-adapters.workspace = true
+larch-core.workspace = true
 
 [dev-dependencies]
 assert_cmd.workspace = true
 predicates.workspace = true
+serde_json.workspace = true
 
 [lints]
 workspace = true

--- a/crates/larch-cli/src/main.rs
+++ b/crates/larch-cli/src/main.rs
@@ -1,10 +1,51 @@
-use clap::{CommandFactory, Parser};
+use std::process::ExitCode;
+
+use clap::{Args, CommandFactory, FromArgMatches, Parser, Subcommand};
 
 #[derive(Parser)]
-#[command(name = "larch", about = "Larch workflow automation")]
-struct Cli;
+#[command(
+    name = "larch",
+    about = "Larch workflow automation",
+    arg_required_else_help = true,
+    subcommand_required = true
+)]
+struct Cli {
+    #[command(subcommand)]
+    domain: Domain,
+}
 
-fn main() {
+#[derive(Subcommand)]
+enum Domain {
+    /// Non-production commands that exercise dispatcher wiring.
+    #[command(subcommand)]
+    Example(ExampleCommand),
+}
+
+#[derive(Subcommand)]
+enum ExampleCommand {
+    /// Print a message through the core library.
+    Echo(EchoArguments),
+}
+
+#[derive(Args)]
+struct EchoArguments {
+    /// Message to print.
+    message: String,
+}
+
+fn run(cli: Cli) {
+    match cli.domain {
+        Domain::Example(ExampleCommand::Echo(arguments)) => {
+            println!("{}", larch_core::example::echo(&arguments.message));
+        }
+    }
+}
+
+fn main() -> ExitCode {
     let metadata = larch_adapters::build_metadata();
-    Cli::command().version(metadata.version()).get_matches();
+    let matches = Cli::command().version(metadata.version()).get_matches();
+    let cli = Cli::from_arg_matches(&matches)
+        .expect("arguments already validated by the generated Clap command");
+    run(cli);
+    ExitCode::SUCCESS
 }

--- a/crates/larch-cli/tests/cli.rs
+++ b/crates/larch-cli/tests/cli.rs
@@ -1,15 +1,129 @@
+use std::{fs, path::Path};
+
 use assert_cmd::Command;
 use predicates::prelude::*;
 
+const ROOT_HELP: &str = "\
+Larch workflow automation
+
+Usage: larch <COMMAND>
+
+Commands:
+  example  Non-production commands that exercise dispatcher wiring
+  help     Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help     Print help
+  -V, --version  Print version
+";
+
+const EXAMPLE_HELP: &str = "\
+Non-production commands that exercise dispatcher wiring
+
+Usage: larch example <COMMAND>
+
+Commands:
+  echo  Print a message through the core library
+  help  Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help  Print help
+";
+
+fn larch() -> Command {
+    Command::cargo_bin("larch").expect("larch binary should build")
+}
+
+#[test]
+fn help_has_pinned_output_and_success_exit() {
+    larch()
+        .arg("--help")
+        .assert()
+        .code(0)
+        .stdout(ROOT_HELP)
+        .stderr("");
+}
+
 #[test]
 fn version_reports_the_workspace_version() {
-    Command::cargo_bin("larch")
-        .expect("larch binary should build")
+    larch()
         .arg("--version")
         .assert()
         .success()
+        .stderr("")
         .stdout(predicate::eq(format!(
             "larch {}\n",
             env!("CARGO_PKG_VERSION")
         )));
+}
+
+#[test]
+fn compiled_version_matches_the_plugin_release_version() {
+    let plugin_manifest_path =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("../../.claude-plugin/plugin.json");
+    let plugin_manifest =
+        fs::read_to_string(&plugin_manifest_path).expect("plugin manifest should be readable");
+    let plugin_manifest: serde_json::Value =
+        serde_json::from_str(&plugin_manifest).expect("plugin manifest should contain valid JSON");
+
+    assert_eq!(
+        plugin_manifest["version"].as_str(),
+        Some(env!("CARGO_PKG_VERSION")),
+        "workspace package version must match .claude-plugin/plugin.json"
+    );
+}
+
+#[test]
+fn example_echo_dispatches_through_the_core_library() {
+    larch()
+        .args(["example", "echo", "library wiring"])
+        .assert()
+        .success()
+        .stdout("library wiring\n")
+        .stderr("");
+}
+
+#[test]
+fn missing_domain_has_pinned_help_and_usage_exit() {
+    larch().assert().code(2).stdout("").stderr(ROOT_HELP);
+}
+
+#[test]
+fn unknown_domain_has_pinned_error_and_does_not_fallback() {
+    larch()
+        .arg("python-command")
+        .assert()
+        .code(2)
+        .stdout("")
+        .stderr("error: unrecognized subcommand\n");
+}
+
+#[test]
+fn missing_verb_has_pinned_help_and_usage_exit() {
+    larch()
+        .arg("example")
+        .assert()
+        .code(2)
+        .stdout("")
+        .stderr(EXAMPLE_HELP);
+}
+
+#[test]
+fn unknown_verb_has_pinned_error_and_does_not_fallback() {
+    larch()
+        .args(["example", "python-verb"])
+        .assert()
+        .code(2)
+        .stdout("")
+        .stderr("error: unrecognized subcommand\n");
+}
+
+#[test]
+fn missing_argument_has_pinned_error_and_usage_exit() {
+    larch()
+        .args(["example", "echo"])
+        .assert()
+        .code(2)
+        .stdout("")
+        .stderr("error: one or more required arguments were not provided\n");
 }

--- a/crates/larch-core/src/lib.rs
+++ b/crates/larch-core/src/lib.rs
@@ -20,14 +20,28 @@ impl BuildMetadata {
     }
 }
 
+/// Non-production use cases that prove command dispatch and library wiring.
+pub mod example {
+    /// Return a caller-owned message unchanged.
+    #[must_use]
+    pub const fn echo(message: &str) -> &str {
+        message
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::BuildMetadata;
+    use super::{BuildMetadata, example};
 
     #[test]
     fn build_metadata_preserves_the_version() {
         let metadata = BuildMetadata::new("1.2.3");
 
         assert_eq!(metadata.version(), "1.2.3");
+    }
+
+    #[test]
+    fn example_echo_preserves_the_message() {
+        assert_eq!(example::echo("library wiring"), "library wiring");
     }
 }


### PR DESCRIPTION
## Summary

- add closed Clap dispatch for `larch <domain> <verb> [arguments]`
- add the non-production `example echo` command through `larch-core`
- pin help, version, usage-error, and unknown-command process contracts
- enforce compiled version parity with `.claude-plugin/plugin.json` under the #7670 release decision
- document that unknown commands never fall back to Python or another executable

## Validation

- `cargo test --locked --package larch-cli --package larch-core`
- `cargo clippy --locked --package larch-cli --package larch-core --all-targets --all-features -- -D warnings`
- `cargo build --locked --package larch-cli --package larch-core --all-targets --all-features`
- `cargo run --quiet --locked --package larch-lint -- all`
- `make rust-deny`
- scoped pre-commit hooks for all changed files

## Self-review

A fresh requirements and failure-mode review found no correctness, fallback, dependency-direction, or architectural issues. The implementation adds 177 Rust lines, below the 1,500-line cap.

Closes #7660