### PR TITLE
Fixes #7664: port Rust redaction and logging foundations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1433,6 +1433,7 @@ version = "53.1.22"
 dependencies = [
  "gix",
  "larch-core",
+ "serde_json",
  "tempfile",
  "tokio",
  "tokio-util",
@@ -1453,6 +1454,9 @@ dependencies = [
 [[package]]
 name = "larch-core"
 version = "53.1.22"
+dependencies = [
+ "regex",
+]
 
 [[package]]
 name = "larch-lint"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ larch-core = { version = "=53.1.22", path = "crates/larch-core" }
 predicates = { version = "3.1.4", default-features = false }
 pulldown-cmark = { version = "0.13.4", default-features = false }
 proc-macro2 = { version = "1.0.106", default-features = false, features = ["span-locations"] }
-regex = { version = "1.13.1", default-features = false, features = ["std", "perf"] }
+regex = { version = "1.13.1", default-features = false, features = ["std", "perf", "unicode-perl"] }
 serde = { version = "1.0.228", default-features = false, features = ["derive", "std"] }
 serde_json = { version = "1.0.149", default-features = false, features = ["std"] }
 syn = { version = "2.0.119", default-features = false, features = ["full", "parsing", "printing", "visit"] }

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -482,16 +482,16 @@ through the redaction and publication path described here.
      `.done`, `.status`, `.surfaced`, `.pid`), non-existent race-condition globs,
      non-regular files, and quiet-log candidates outside `larch-quiet-*-*.log`
      basenames.
-5. **Residual sensitive-content risk**: redaction is pattern-based (recognized
-   PEM blocks, common token shapes like `sk-*`, `crsr_` (Cursor API keys),
-   `ghp_`, JWTs, session-tmpdir paths). Reviewer-supplied non-pattern secrets, partial token fragments that
-   fall outside recognized patterns, internal hostnames, PII, and domain-specific
-   sensitive strings can still survive into committed logs. Operational
-   `wait-ci` / `warn` breadcrumb text may still be committed after secrets-family
-   redaction, so CI failure strings, check names, and similar diagnostics should
-   also be treated as public-boundary content. Operators must avoid placing such
-   content in breadcrumb messages; redaction is a backstop, not a comprehensive
-   classifier.
+5. **Rust and Python egress boundaries remain pattern-based**: Python breadcrumb
+   publication uses the pipeline above. Rust uses `larch_core::SafeText` for
+   errors, output, structured breadcrumbs, and journal fields; it redacts paths,
+   token families, and PEM blocks, then re-scans and withholds the whole value if
+   a recognized secret survives. Rust keeps human, machine, and contract writers
+   distinct, and contract rows reject line breaks before writing. Future process
+   and HTTP adapters must use this boundary instead of retaining raw responses in
+   displayable errors. Unknown credentials, partial token fragments, internal
+   hostnames, and PII can still survive. Minimize captured external text and treat
+   redaction as a final egress backstop, not a comprehensive classifier.
 
 See [docs/run-logs.md § breadcrumbs/](docs/run-logs.md#breadcrumbs) for the
 operator-facing directory contract; the same helper applies to every skill

--- a/crates/larch-adapters/Cargo.toml
+++ b/crates/larch-adapters/Cargo.toml
@@ -11,6 +11,7 @@ rust-version.workspace = true
 [dependencies]
 gix.workspace = true
 larch-core.workspace = true
+serde_json.workspace = true
 tempfile.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true

--- a/crates/larch-adapters/src/lib.rs
+++ b/crates/larch-adapters/src/lib.rs
@@ -1,6 +1,7 @@
 //! Concrete adapters for filesystem, process, Git, time, and service boundaries.
 
 pub mod clock;
+pub mod logging;
 pub mod retry;
 pub mod runtime;
 

--- a/crates/larch-adapters/src/logging.rs
+++ b/crates/larch-adapters/src/logging.rs
@@ -1,0 +1,392 @@
+//! JSONL sinks and explicit human, machine, and contract output channels.
+
+use larch_core::{Breadcrumb, JournalRecord, SafeText};
+use serde_json::{Map, Value};
+use std::{error::Error, fmt, io::Write, time::SystemTime};
+
+/// Stable failures from an observability adapter.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum LoggingErrorKind {
+    /// The output sink rejected a write or flush.
+    Io,
+    /// JSON serialization failed before a write.
+    Serialize,
+    /// A timestamp predates the Unix epoch or exceeds the formatter's range.
+    InvalidTimestamp,
+    /// A contract key was empty or contained a line break or equals sign.
+    InvalidContractKey,
+    /// A contract value contained a line break.
+    InvalidContractValue,
+}
+
+/// An output record could not be serialized or written.
+#[derive(Debug)]
+pub struct LoggingError {
+    kind: LoggingErrorKind,
+}
+
+impl LoggingError {
+    const fn new(kind: LoggingErrorKind) -> Self {
+        Self { kind }
+    }
+
+    /// Return the stable failure class.
+    #[must_use]
+    pub const fn kind(&self) -> LoggingErrorKind {
+        self.kind
+    }
+}
+
+impl fmt::Display for LoggingError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self.kind {
+            LoggingErrorKind::Io => "observability sink write failed",
+            LoggingErrorKind::Serialize => "JSONL record serialization failed",
+            LoggingErrorKind::InvalidTimestamp => "record timestamp is outside the supported range",
+            LoggingErrorKind::InvalidContractKey => "contract key must be a single non-empty token",
+            LoggingErrorKind::InvalidContractValue => "contract value must occupy one line",
+        })
+    }
+}
+
+impl Error for LoggingError {}
+
+/// Three non-interchangeable process output channels.
+pub struct OutputChannels<Machine, Human, Contract> {
+    machine: Machine,
+    human: Human,
+    contract: Contract,
+}
+
+impl<Machine, Human, Contract> OutputChannels<Machine, Human, Contract>
+where
+    Machine: Write,
+    Human: Write,
+    Contract: Write,
+{
+    /// Bind machine stdout, human diagnostics, and the contract stream.
+    #[must_use]
+    pub const fn new(machine: Machine, human: Human, contract: Contract) -> Self {
+        Self {
+            machine,
+            human,
+            contract,
+        }
+    }
+
+    /// Write redacted machine output to stdout's logical channel.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LoggingErrorKind::Io`] when the machine sink rejects the line.
+    pub fn machine_line(&mut self, text: impl AsRef<str>) -> Result<(), LoggingError> {
+        write_safe_line(&mut self.machine, &SafeText::from_untrusted(text))
+    }
+
+    /// Write a redacted operator-facing diagnostic to stderr's logical channel.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LoggingErrorKind::Io`] when the human sink rejects the line.
+    pub fn diagnostic(&mut self, text: impl AsRef<str>) -> Result<(), LoggingError> {
+        write_safe_line(&mut self.human, &SafeText::diagnostic(text))
+    }
+
+    /// Write one redacted `KEY=value` row to the contract channel.
+    ///
+    /// # Errors
+    ///
+    /// Rejects keys or values that could forge a second row, and returns an I/O
+    /// error if the contract sink rejects the validated row.
+    pub fn contract_kv(&mut self, key: &str, value: impl AsRef<str>) -> Result<(), LoggingError> {
+        if key.is_empty()
+            || !key
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
+        {
+            return Err(LoggingError::new(LoggingErrorKind::InvalidContractKey));
+        }
+        let value = SafeText::from_untrusted(value);
+        if value.as_str().contains(['\n', '\r']) {
+            return Err(LoggingError::new(LoggingErrorKind::InvalidContractValue));
+        }
+        self.contract
+            .write_all(format!("{key}={}\n", value.as_str()).as_bytes())
+            .and_then(|()| self.contract.flush())
+            .map_err(|_error| LoggingError::new(LoggingErrorKind::Io))
+    }
+
+    /// Return the three bound sinks, primarily for composition and tests.
+    #[must_use]
+    pub fn into_inner(self) -> (Machine, Human, Contract) {
+        (self.machine, self.human, self.contract)
+    }
+}
+
+/// Append-only writer for structured progress breadcrumbs.
+pub struct BreadcrumbWriter<Writer> {
+    writer: Writer,
+}
+
+impl<Writer: Write> BreadcrumbWriter<Writer> {
+    /// Bind a breadcrumb JSONL sink.
+    #[must_use]
+    pub const fn new(writer: Writer) -> Self {
+        Self { writer }
+    }
+
+    /// Append one redacted breadcrumb as a newline-terminated JSON object.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed timestamp, serialization, or sink failure.
+    pub fn append(&mut self, breadcrumb: &Breadcrumb) -> Result<(), LoggingError> {
+        let mut object = Map::new();
+        object.insert(
+            String::from("ts"),
+            Value::String(format_timestamp(breadcrumb.timestamp())?),
+        );
+        if let Some(run_id) = breadcrumb.run_id() {
+            object.insert(String::from("run_id"), Value::String(run_id.to_string()));
+        }
+        object.insert(
+            String::from("component"),
+            Value::String(String::from(breadcrumb.component())),
+        );
+        object.insert(
+            String::from("event"),
+            Value::String(String::from(breadcrumb.event())),
+        );
+        object.insert(
+            String::from("message"),
+            Value::String(String::from(breadcrumb.message().as_str())),
+        );
+        append_json(&mut self.writer, &Value::Object(object))
+    }
+
+    /// Return the bound sink.
+    #[must_use]
+    pub fn into_inner(self) -> Writer {
+        self.writer
+    }
+}
+
+/// Append-only writer for journal JSONL records.
+pub struct JsonlJournal<Writer> {
+    writer: Writer,
+}
+
+impl<Writer: Write> JsonlJournal<Writer> {
+    /// Bind a journal sink.
+    #[must_use]
+    pub const fn new(writer: Writer) -> Self {
+        Self { writer }
+    }
+
+    /// Append one redacted, newline-terminated JSON object.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed timestamp, serialization, or sink failure.
+    pub fn append(&mut self, record: &JournalRecord) -> Result<(), LoggingError> {
+        let mut object = Map::new();
+        object.insert(
+            String::from("ts"),
+            Value::String(format_timestamp(record.timestamp())?),
+        );
+        object.insert(
+            String::from("run_id"),
+            Value::String(record.run_id().to_string()),
+        );
+        object.insert(
+            String::from("event"),
+            Value::String(String::from(record.event())),
+        );
+        for (key, value) in record.fields() {
+            object.insert(
+                String::from(key),
+                Value::String(String::from(value.as_str())),
+            );
+        }
+        append_json(&mut self.writer, &Value::Object(object))
+    }
+
+    /// Return the bound sink.
+    #[must_use]
+    pub fn into_inner(self) -> Writer {
+        self.writer
+    }
+}
+
+fn write_safe_line(writer: &mut impl Write, text: &SafeText) -> Result<(), LoggingError> {
+    writer
+        .write_all(text.as_str().as_bytes())
+        .and_then(|()| {
+            if text.as_str().ends_with('\n') {
+                Ok(())
+            } else {
+                writer.write_all(b"\n")
+            }
+        })
+        .and_then(|()| writer.flush())
+        .map_err(|_error| LoggingError::new(LoggingErrorKind::Io))
+}
+
+fn append_json(writer: &mut impl Write, value: &Value) -> Result<(), LoggingError> {
+    let rendered = serde_json::to_vec(&value)
+        .map_err(|_error| LoggingError::new(LoggingErrorKind::Serialize))?;
+    writer
+        .write_all(&rendered)
+        .and_then(|()| writer.write_all(b"\n"))
+        .and_then(|()| writer.flush())
+        .map_err(|_error| LoggingError::new(LoggingErrorKind::Io))
+}
+
+fn format_timestamp(timestamp: SystemTime) -> Result<String, LoggingError> {
+    let duration = timestamp
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map_err(|_error| LoggingError::new(LoggingErrorKind::InvalidTimestamp))?;
+    let seconds = duration.as_secs();
+    let days = i64::try_from(seconds / 86_400)
+        .map_err(|_error| LoggingError::new(LoggingErrorKind::InvalidTimestamp))?;
+    let seconds_in_day = seconds % 86_400;
+    let hour = seconds_in_day / 3_600;
+    let minute = seconds_in_day % 3_600 / 60;
+    let second = seconds_in_day % 60;
+    let (year, month, day) = civil_date(days);
+    Ok(format!(
+        "{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}.{nanos:09}Z",
+        nanos = duration.subsec_nanos()
+    ))
+}
+
+fn civil_date(days_since_epoch: i64) -> (i64, i64, i64) {
+    let shifted = days_since_epoch + 719_468;
+    let era = shifted / 146_097;
+    let day_of_era = shifted - era * 146_097;
+    let year_of_era =
+        (day_of_era - day_of_era / 1_460 + day_of_era / 36_524 - day_of_era / 146_096) / 365;
+    let mut year = year_of_era + era * 400;
+    let day_of_year = day_of_era - (365 * year_of_era + year_of_era / 4 - year_of_era / 100);
+    let month_prime = (5 * day_of_year + 2) / 153;
+    let day = day_of_year - (153 * month_prime + 2) / 5 + 1;
+    let month = month_prime + if month_prime < 10 { 3 } else { -9 };
+    year += i64::from(month <= 2);
+    (year, month, day)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use larch_core::{RunId, SafeText};
+    use std::time::Duration;
+
+    #[test]
+    fn output_channels_pin_stdout_stderr_and_contract_routing() {
+        let mut channels = OutputChannels::new(Vec::new(), Vec::new(), Vec::new());
+        channels
+            .machine_line("RESULT=machine")
+            .expect("machine should write");
+        channels
+            .diagnostic("human detail")
+            .expect("diagnostic should write");
+        channels
+            .contract_kv("STATUS", "ok")
+            .expect("contract should write");
+
+        let (stdout, stderr, contract) = channels.into_inner();
+        assert_eq!(stdout, b"RESULT=machine\n");
+        assert_eq!(stderr, b"human detail\n");
+        assert_eq!(contract, b"STATUS=ok\n");
+    }
+
+    #[test]
+    fn every_channel_redacts_before_writing() {
+        let token = ["ghp_", "abcdefghijklmnopqrstuvwxyz0123456789AB"].concat();
+        let mut channels = OutputChannels::new(Vec::new(), Vec::new(), Vec::new());
+        channels.machine_line(&token).expect("machine should write");
+        channels
+            .diagnostic(&token)
+            .expect("diagnostic should write");
+        channels
+            .contract_kv("ERROR", &token)
+            .expect("contract should write");
+
+        for bytes in [channels.machine, channels.human, channels.contract] {
+            let rendered = String::from_utf8(bytes).expect("output should be UTF-8");
+            assert!(rendered.contains("<REDACTED-TOKEN>"));
+            assert!(!rendered.contains(&token));
+        }
+    }
+
+    #[test]
+    fn contract_rows_reject_forged_lines_before_writing() {
+        let mut channels = OutputChannels::new(Vec::new(), Vec::new(), Vec::new());
+
+        let error = channels
+            .contract_kv("STATUS", "ok\nFORGED=true")
+            .expect_err("multiline value should fail");
+
+        assert_eq!(error.kind(), LoggingErrorKind::InvalidContractValue);
+        assert!(channels.contract.is_empty());
+    }
+
+    #[test]
+    fn jsonl_journal_matches_the_existing_envelope_and_redacts_fields() {
+        let token = ["crsr_", "1620abcdefghijklmnopqrstuvwxyz0123456789"].concat();
+        let record = JournalRecord::new(
+            SystemTime::UNIX_EPOCH,
+            RunId::parse("run-abc").expect("run ID should parse"),
+            "phase",
+            [("detail", token.as_str()), ("step", "2")],
+        )
+        .expect("record should build");
+        let mut journal = JsonlJournal::new(Vec::new());
+
+        journal.append(&record).expect("record should append");
+
+        let rendered = String::from_utf8(journal.into_inner()).expect("JSONL should be UTF-8");
+        let parsed: Value = serde_json::from_str(rendered.trim()).expect("JSON should parse");
+        assert_eq!(parsed["ts"], "1970-01-01T00:00:00.000000000Z");
+        assert_eq!(parsed["run_id"], "run-abc");
+        assert_eq!(parsed["event"], "phase");
+        assert_eq!(parsed["step"], "2");
+        assert_eq!(parsed["detail"], "<REDACTED-TOKEN>");
+        assert!(!rendered.contains(&token));
+        assert!(rendered.ends_with('\n'));
+    }
+
+    #[test]
+    fn breadcrumb_is_structured_jsonl() {
+        let breadcrumb = Breadcrumb::new(
+            SystemTime::UNIX_EPOCH + Duration::from_secs(86_400),
+            Some(RunId::parse("run-abc").expect("run ID should parse")),
+            "ship",
+            "checks",
+            "running",
+        )
+        .expect("breadcrumb should build");
+        let mut writer = BreadcrumbWriter::new(Vec::new());
+
+        writer
+            .append(&breadcrumb)
+            .expect("breadcrumb should append");
+
+        let rendered = String::from_utf8(writer.into_inner()).expect("JSONL should be UTF-8");
+        let parsed: Value = serde_json::from_str(rendered.trim()).expect("JSON should parse");
+        assert_eq!(parsed["ts"], "1970-01-02T00:00:00.000000000Z");
+        assert_eq!(parsed["component"], "ship");
+        assert_eq!(parsed["event"], "checks");
+        assert_eq!(parsed["message"], "running");
+    }
+
+    #[test]
+    fn safe_text_can_be_written_without_reintroducing_raw_access() {
+        let safe = SafeText::from_untrusted("clean");
+        let mut sink = Vec::new();
+
+        write_safe_line(&mut sink, &safe).expect("line should write");
+
+        assert_eq!(sink, b"clean\n");
+    }
+}

--- a/crates/larch-core/Cargo.toml
+++ b/crates/larch-core/Cargo.toml
@@ -8,5 +8,8 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[dependencies]
+regex.workspace = true
+
 [lints]
 workspace = true

--- a/crates/larch-core/src/error.rs
+++ b/crates/larch-core/src/error.rs
@@ -1,6 +1,6 @@
 //! Categorized failures for domain and composition layers.
 
-use crate::ExitCode;
+use crate::{ExitCode, SafeText};
 use std::{error::Error, fmt};
 
 /// The actor or system responsible for resolving a failure.
@@ -87,7 +87,7 @@ impl FailureKind {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct LarchError {
     kind: FailureKind,
-    message: String,
+    message: SafeText,
 }
 
 impl LarchError {
@@ -96,7 +96,7 @@ impl LarchError {
     pub fn new(kind: FailureKind, message: impl Into<String>) -> Self {
         Self {
             kind,
-            message: message.into(),
+            message: SafeText::from_untrusted(message.into()),
         }
     }
 
@@ -121,13 +121,13 @@ impl LarchError {
     /// Return the diagnostic without adding presentation text.
     #[must_use]
     pub fn message(&self) -> &str {
-        &self.message
+        self.message.as_str()
     }
 }
 
 impl fmt::Display for LarchError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str(&self.message)
+        formatter.write_str(self.message.as_str())
     }
 }
 
@@ -206,5 +206,17 @@ mod tests {
         assert_eq!(error.exit_code(), ExitCode::Transient);
         assert_eq!(error.message(), "GitHub request failed");
         assert_eq!(error.to_string(), "GitHub request failed");
+    }
+
+    #[test]
+    fn larch_error_redacts_external_diagnostics_before_storage() {
+        let token = ["ghp_", "abcdefghijklmnopqrstuvwxyz0123456789AB"].concat();
+        let error = LarchError::new(
+            FailureKind::Environment(EnvironmentalFailure::Transient),
+            format!("GitHub returned {token}"),
+        );
+
+        assert_eq!(error.message(), "GitHub returned <REDACTED-TOKEN>");
+        assert!(!error.to_string().contains(&token));
     }
 }

--- a/crates/larch-core/src/lib.rs
+++ b/crates/larch-core/src/lib.rs
@@ -5,7 +5,9 @@ mod context;
 mod env_file;
 mod error;
 mod outcome;
+mod redaction;
 mod retry;
+mod telemetry;
 mod time;
 
 pub use config::env;
@@ -19,10 +21,12 @@ pub use error::{
     EnvironmentalFailure, ErrorCategory, FailureKind, InternalDefect, LarchError, OperatorError,
 };
 pub use outcome::{ExitCode, WorkflowOutcome};
+pub use redaction::{RedactionResult, SafeText, redact, redact_sensitive_paths};
 pub use retry::{
     AttemptOutcome, DeterministicJitter, Jitter, RetryClass, RetryDecision, RetryObservation,
     RetryPolicy, RetryPolicyError, StopReason,
 };
+pub use telemetry::{Breadcrumb, JournalRecord, RecordError, RecordErrorKind};
 pub use time::{AsyncClock, BusinessClock, Deadline, MonotonicClock, MonotonicTime, Sleep};
 
 /// Immutable metadata about the running larch build.

--- a/crates/larch-core/src/redaction.rs
+++ b/crates/larch-core/src/redaction.rs
@@ -1,0 +1,371 @@
+//! Deterministic redaction for text crossing an observability or error boundary.
+
+use regex::Regex;
+use std::{collections::BTreeMap, fmt, sync::LazyLock};
+
+const REDACTED_TOKEN: &str = "<REDACTED-TOKEN>";
+const REDACTED_PRIVATE_KEY: &str = "<REDACTED-PRIVATE-KEY>";
+const REDACTION_FAILURE: &str = "[content withheld: redaction verification failed]";
+const UNTERMINATED_PEM: &str =
+    "[content truncated: unterminated PEM block; tail of body dropped for safety]";
+
+struct SecretFamily {
+    name: &'static str,
+    pattern: Regex,
+}
+
+impl SecretFamily {
+    fn new(name: &'static str, pattern: &str) -> Self {
+        Self {
+            name,
+            pattern: Regex::new(pattern).expect("static secret regex must compile"),
+        }
+    }
+}
+
+static SECRET_FAMILIES: LazyLock<Vec<SecretFamily>> = LazyLock::new(|| {
+    vec![
+        SecretFamily::new("anthropic-openai-key", r"sk-(?:ant-)?[A-Za-z0-9_-]{20,}"),
+        SecretFamily::new(
+            "github-token",
+            r"(?:ghp|gho|ghu|ghs|ghr|github_pat)_[A-Za-z0-9_]{20,}",
+        ),
+        SecretFamily::new("aws-akia", r"AKIA[0-9A-Z]{16}"),
+        SecretFamily::new(
+            "jwt",
+            r"eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}",
+        ),
+        SecretFamily::new("pem-private-key", r"-----BEGIN [A-Z ]*PRIVATE KEY-----"),
+        SecretFamily::new(
+            "cursor-api-key",
+            r"(?:crsr_[A-Za-z0-9_-]{20,}|key_[A-Za-z0-9]{32,})",
+        ),
+        SecretFamily::new("slack-token", r"xox[baprs]-[A-Za-z0-9-]{10,}"),
+        SecretFamily::new("google-api-key", r"AIza[0-9A-Za-z_-]{35}"),
+        SecretFamily::new("stripe-live-key", r"(?:sk|rk)_live_[0-9A-Za-z]{16,}"),
+        SecretFamily::new("gitlab-pat", r"glpat-[0-9A-Za-z_-]{20,}"),
+    ]
+});
+
+static PEM_BEGIN: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^[\t \x0b\x0c\r>]*-----BEGIN [A-Z ]*PRIVATE KEY-----")
+        .expect("static PEM begin regex must compile")
+});
+static PEM_END: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^[\t \x0b\x0c\r>]*-----END [A-Z ]*PRIVATE KEY-----")
+        .expect("static PEM end regex must compile")
+});
+
+struct PathPattern {
+    pattern: Regex,
+    replacement: &'static str,
+}
+
+impl PathPattern {
+    fn new(pattern: &str, replacement: &'static str) -> Self {
+        Self {
+            pattern: Regex::new(pattern).expect("static path regex must compile"),
+            replacement,
+        }
+    }
+}
+
+static PATH_PATTERNS: LazyLock<Vec<PathPattern>> = LazyLock::new(|| {
+    let session =
+        r"(?:claude|larch)-(?:implement|design|review|research|fix-issue|issue)-[A-Za-z0-9_.-]+";
+    let boundary = r"[^A-Za-z0-9_./-]";
+    let not_path = r#"[^/\s"\\]"#;
+    let mut patterns = vec![
+        PathPattern::new(
+            &format!(
+                r#"(?m)(^|{boundary})/(?:private/)?tmp/+(?:{not_path}+/)*larch-report-tokens[.-][^/\s"\\]+"#
+            ),
+            "$1<TMPDIR>",
+        ),
+        PathPattern::new(
+            &format!(
+                r#"(?m)(^|{boundary})/(?:private/)?var/folders/[^/]+/[^/]+/T/(?:{not_path}+/)*larch-report-tokens[.-][^/\s"\\]+"#
+            ),
+            "$1<TMPDIR>",
+        ),
+        PathPattern::new(
+            &format!(r"(?m)(^|{boundary})/(?:private/)?tmp/+(?:{not_path}+/)*{session}"),
+            "$1<TMPDIR>",
+        ),
+        PathPattern::new(
+            &format!(
+                r"(?m)(^|{boundary})/(?:private/)?var/folders/[^/]+/[^/]+/T/(?:{not_path}+/)*{session}"
+            ),
+            "$1<TMPDIR>",
+        ),
+        PathPattern::new(
+            &format!(r"(?m)(^|{boundary})/(?:{not_path}+/)*larch/sessions/{session}"),
+            "$1<TMPDIR>",
+        ),
+        PathPattern::new(
+            &format!(r"(?m)(\\n)/(?:{not_path}+/)*larch/sessions/{session}"),
+            "$1<TMPDIR>",
+        ),
+        PathPattern::new(
+            &format!(r"(?m)(\\n)/(?:private/)?tmp/+(?:{not_path}+/)*{session}"),
+            "$1<TMPDIR>",
+        ),
+        PathPattern::new(
+            &format!(
+                r"(?m)(\\n)/(?:private/)?var/folders/[^/]+/[^/]+/T/(?:{not_path}+/)*{session}"
+            ),
+            "$1<TMPDIR>",
+        ),
+    ];
+    let operator_specs = [
+        (r#"[^/\s"\\]+/"#, "$1<OPERATOR_REPO_PATH>/"),
+        (r#"[^/\s"\\,]+,"#, "$1<OPERATOR_REPO_PATH>,"),
+        (r#"[^/\s"\\;]+;"#, "$1<OPERATOR_REPO_PATH>;"),
+        (r#"[^/\s"\\:]+:"#, "$1<OPERATOR_REPO_PATH>:"),
+        (r#"[^/\s"\\}]+"\}"#, "$1<OPERATOR_REPO_PATH>\"}"),
+        (r#"[^/\s"\\},]+","#, "$1<OPERATOR_REPO_PATH>\","),
+        (r#"[^/\s"\\]+"$"#, "$1<OPERATOR_REPO_PATH>"),
+        (r#"[^/\s"\\]+$"#, "$1<OPERATOR_REPO_PATH>"),
+    ];
+    for prefix in [format!(r"(?m)(^|{boundary})"), String::from(r"(?m)(\\n)")] {
+        for (repo_and_suffix, replacement) in operator_specs {
+            patterns.push(PathPattern::new(
+                &format!(r#"{prefix}(?:/Users|/home)/[^/\s"\\]+/{repo_and_suffix}"#),
+                replacement,
+            ));
+        }
+    }
+    patterns
+});
+
+/// Redacted text plus deterministic occurrence counts from the original input.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RedactionResult {
+    text: String,
+    findings: BTreeMap<&'static str, usize>,
+}
+
+impl RedactionResult {
+    /// Borrow the redacted text.
+    #[must_use]
+    pub fn text(&self) -> &str {
+        &self.text
+    }
+
+    /// Return secret-family counts from the original input.
+    #[must_use]
+    pub const fn findings(&self) -> &BTreeMap<&'static str, usize> {
+        &self.findings
+    }
+}
+
+/// Text safe to display, persist, or include in an external diagnostic.
+///
+/// The only constructor treats its input as untrusted. If a second scan finds
+/// a secret after scrubbing, the complete value is replaced by a fixed marker.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct SafeText(String);
+
+impl SafeText {
+    /// Redact untrusted process, service, repository, or workflow text.
+    #[must_use]
+    pub fn from_untrusted(text: impl AsRef<str>) -> Self {
+        let first = redact(text.as_ref());
+        let candidate = first.text;
+        let verification = redact_secrets(&candidate);
+        if verification.findings.is_empty() {
+            Self(candidate)
+        } else {
+            Self(String::from(REDACTION_FAILURE))
+        }
+    }
+
+    /// Redact untrusted text and remove terminal control bytes for one diagnostic line.
+    #[must_use]
+    pub fn diagnostic(text: impl AsRef<str>) -> Self {
+        let line: String = text
+            .as_ref()
+            .chars()
+            .filter(|character| *character >= ' ' && *character != '\u{7f}')
+            .collect();
+        Self::from_untrusted(line)
+    }
+
+    /// Borrow the safe text.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for SafeText {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+/// Redact every supported secret family while preserving newline intent.
+#[must_use]
+pub fn redact_secrets(text: &str) -> RedactionResult {
+    let findings = count_secret_families(text);
+    let pem_scrubbed = redact_pem_blocks(text);
+    let mut scrubbed = pem_scrubbed;
+    for family in SECRET_FAMILIES
+        .iter()
+        .filter(|family| family.name != "pem-private-key")
+    {
+        scrubbed = family
+            .pattern
+            .replace_all(&scrubbed, REDACTED_TOKEN)
+            .into_owned();
+    }
+    RedactionResult {
+        text: scrubbed,
+        findings,
+    }
+}
+
+/// Redact session temporary directories and operator repository roots.
+#[must_use]
+pub fn redact_sensitive_paths(text: &str) -> String {
+    let mut scrubbed = String::from(text);
+    for pattern in PATH_PATTERNS.iter() {
+        scrubbed = pattern
+            .pattern
+            .replace_all(&scrubbed, pattern.replacement)
+            .into_owned();
+    }
+    scrubbed
+}
+
+/// Redact sensitive paths first, then all secret families.
+#[must_use]
+pub fn redact(text: &str) -> RedactionResult {
+    let path_scrubbed = redact_sensitive_paths(text);
+    redact_secrets(&path_scrubbed)
+}
+
+fn count_secret_families(text: &str) -> BTreeMap<&'static str, usize> {
+    let mut findings = BTreeMap::new();
+    for family in SECRET_FAMILIES.iter() {
+        let count = family.pattern.find_iter(text).count();
+        if count != 0 {
+            findings.insert(family.name, count);
+        }
+    }
+    findings
+}
+
+fn redact_pem_blocks(text: &str) -> String {
+    let mut output = String::new();
+    let mut in_pem = false;
+    for line in text.split_inclusive('\n') {
+        let logical = line.strip_suffix('\n').unwrap_or(line);
+        if in_pem {
+            if PEM_END.is_match(logical) {
+                in_pem = false;
+            }
+            continue;
+        }
+        if PEM_BEGIN.is_match(logical) {
+            output.push_str(REDACTED_PRIVATE_KEY);
+            if line.ends_with('\n') {
+                output.push('\n');
+            }
+            in_pem = true;
+        } else {
+            output.push_str(line);
+        }
+    }
+    if in_pem {
+        if output.is_empty() || output.ends_with('\n') {
+            output.push_str(UNTERMINATED_PEM);
+            output.push('\n');
+        } else {
+            output.push_str(UNTERMINATED_PEM);
+        }
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_fixture_family_is_counted_and_redacted() {
+        for row in include_str!("../../../fixtures/rust-redaction/secret-families.tsv").lines() {
+            if row.is_empty() || row.starts_with('#') {
+                continue;
+            }
+            let mut columns = row.splitn(3, '\t');
+            let name = columns.next().expect("fixture family should exist");
+            let prefix = columns.next().expect("fixture prefix should exist");
+            let suffix = columns.next().expect("fixture suffix should exist");
+            let secret = format!("{prefix}{suffix}");
+
+            let input = if name == "pem-private-key" {
+                secret.clone()
+            } else {
+                format!("before {secret} after")
+            };
+            let result = redact_secrets(&input);
+
+            assert_eq!(result.findings().get(name), Some(&1), "family {name}");
+            assert!(!result.text().contains(&secret), "family {name}");
+        }
+    }
+
+    #[test]
+    fn path_fixture_matches_python_contract() {
+        for row in include_str!("../../../fixtures/rust-redaction/sensitive-paths.tsv").lines() {
+            if row.is_empty() || row.starts_with('#') {
+                continue;
+            }
+            let (raw, expected) = row
+                .split_once('\t')
+                .expect("fixture should have two columns");
+            let input = raw.replace(r"\n", "\n");
+            let expected = expected.replace(r"\n", "\n");
+
+            assert_eq!(redact_sensitive_paths(&input), expected, "input {raw}");
+        }
+    }
+
+    #[test]
+    fn pem_blocks_are_swallowed_and_unterminated_tails_fail_closed() {
+        let input = "opening\n> -----BEGIN RSA PRIVATE KEY-----\nsecret body\ntail-secret-value";
+        let result = redact_secrets(input);
+
+        assert!(result.text().contains(REDACTED_PRIVATE_KEY));
+        assert!(result.text().contains("content truncated"));
+        assert!(!result.text().contains("secret body"));
+        assert!(!result.text().contains("tail-secret-value"));
+    }
+
+    #[test]
+    fn redaction_is_idempotent_and_paths_run_before_tokens() {
+        let input = "/tmp/claude-implement-sk-ant-abcdefghijklmnopqrstuvwxyz0123456789ABCD/file";
+        let once = redact(input).text().to_owned();
+        let twice = redact(&once).text().to_owned();
+
+        assert_eq!(once, "<TMPDIR>/file");
+        assert_eq!(twice, once);
+    }
+
+    #[test]
+    fn safe_text_scrubs_all_external_text_families() {
+        let raw = ["service returned ", "xox", "b-1234567890-abcdefghijklmnop"].concat();
+        let safe = SafeText::from_untrusted(&raw);
+
+        assert_eq!(safe.as_str(), "service returned <REDACTED-TOKEN>");
+        assert!(!safe.as_str().contains(&raw));
+    }
+
+    #[test]
+    fn diagnostic_text_removes_terminal_controls_and_line_forgery() {
+        let safe = SafeText::diagnostic("bad\u{1b}[31m\nforged\u{7f}");
+
+        assert_eq!(safe.as_str(), "bad[31mforged");
+    }
+}

--- a/crates/larch-core/src/telemetry.rs
+++ b/crates/larch-core/src/telemetry.rs
@@ -1,0 +1,265 @@
+//! Structured, redaction-owning records for breadcrumbs and JSONL journals.
+
+use crate::{RunId, SafeText};
+use std::{collections::BTreeMap, error::Error, fmt, time::SystemTime};
+
+const NAME_MAX_BYTES: usize = 128;
+
+/// Stable validation failures for structured observability records.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RecordErrorKind {
+    /// An event, component, or field name was empty.
+    EmptyName,
+    /// A name exceeded the record schema's size bound.
+    NameTooLong,
+    /// A name contained a byte outside the stable ASCII allowlist.
+    InvalidName,
+    /// A journal attempted to define the same field twice.
+    DuplicateField,
+    /// A custom field attempted to replace a journal envelope key.
+    ReservedField,
+}
+
+/// A record was rejected before it could reach a log sink.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct RecordError {
+    kind: RecordErrorKind,
+}
+
+impl RecordError {
+    /// Return the stable failure class.
+    #[must_use]
+    pub const fn kind(self) -> RecordErrorKind {
+        self.kind
+    }
+}
+
+impl fmt::Display for RecordError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self.kind {
+            RecordErrorKind::EmptyName => "record name must be non-empty",
+            RecordErrorKind::NameTooLong => "record name must be at most 128 bytes",
+            RecordErrorKind::InvalidName => {
+                "record name must contain only ASCII letters, digits, dot, underscore, or dash"
+            }
+            RecordErrorKind::DuplicateField => "journal field names must be unique",
+            RecordErrorKind::ReservedField => {
+                "journal custom field must not replace ts, run_id, or event"
+            }
+        })
+    }
+}
+
+impl Error for RecordError {}
+
+/// One structured progress breadcrumb.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Breadcrumb {
+    timestamp: SystemTime,
+    run_id: Option<RunId>,
+    component: Box<str>,
+    event: Box<str>,
+    message: SafeText,
+}
+
+impl Breadcrumb {
+    /// Build a breadcrumb and redact its untrusted message.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RecordError`] when `component` or `event` is not a valid name.
+    pub fn new(
+        timestamp: SystemTime,
+        run_id: Option<RunId>,
+        component: &str,
+        event: &str,
+        message: impl AsRef<str>,
+    ) -> Result<Self, RecordError> {
+        validate_name(component)?;
+        validate_name(event)?;
+        Ok(Self {
+            timestamp,
+            run_id,
+            component: Box::from(component),
+            event: Box::from(event),
+            message: SafeText::from_untrusted(message),
+        })
+    }
+
+    /// Return the record timestamp.
+    #[must_use]
+    pub const fn timestamp(&self) -> SystemTime {
+        self.timestamp
+    }
+
+    /// Return the optional run identity.
+    #[must_use]
+    pub const fn run_id(&self) -> Option<&RunId> {
+        self.run_id.as_ref()
+    }
+
+    /// Return the emitting component.
+    #[must_use]
+    pub fn component(&self) -> &str {
+        &self.component
+    }
+
+    /// Return the stable event name.
+    #[must_use]
+    pub fn event(&self) -> &str {
+        &self.event
+    }
+
+    /// Return the redacted human-readable detail.
+    #[must_use]
+    pub const fn message(&self) -> &SafeText {
+        &self.message
+    }
+}
+
+/// One append-only JSONL journal record keyed by run identity.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct JournalRecord {
+    timestamp: SystemTime,
+    run_id: RunId,
+    event: Box<str>,
+    fields: BTreeMap<Box<str>, SafeText>,
+}
+
+impl JournalRecord {
+    /// Build a journal record and redact every untrusted field value.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RecordError`] for an invalid event or field name, or a duplicate field.
+    pub fn new<I, K, V>(
+        timestamp: SystemTime,
+        run_id: RunId,
+        event: &str,
+        fields: I,
+    ) -> Result<Self, RecordError>
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: AsRef<str>,
+        V: AsRef<str>,
+    {
+        validate_name(event)?;
+        let mut safe_fields = BTreeMap::new();
+        for (key, value) in fields {
+            let key = key.as_ref();
+            validate_name(key)?;
+            if matches!(key, "ts" | "run_id" | "event") {
+                return Err(RecordError {
+                    kind: RecordErrorKind::ReservedField,
+                });
+            }
+            if safe_fields
+                .insert(Box::from(key), SafeText::from_untrusted(value))
+                .is_some()
+            {
+                return Err(RecordError {
+                    kind: RecordErrorKind::DuplicateField,
+                });
+            }
+        }
+        Ok(Self {
+            timestamp,
+            run_id,
+            event: Box::from(event),
+            fields: safe_fields,
+        })
+    }
+
+    /// Return the record timestamp.
+    #[must_use]
+    pub const fn timestamp(&self) -> SystemTime {
+        self.timestamp
+    }
+
+    /// Return the run identity.
+    #[must_use]
+    pub const fn run_id(&self) -> &RunId {
+        &self.run_id
+    }
+
+    /// Return the stable event name.
+    #[must_use]
+    pub fn event(&self) -> &str {
+        &self.event
+    }
+
+    /// Iterate over sorted, redacted custom fields.
+    pub fn fields(&self) -> impl Iterator<Item = (&str, &SafeText)> {
+        self.fields.iter().map(|(key, value)| (key.as_ref(), value))
+    }
+}
+
+fn validate_name(name: &str) -> Result<(), RecordError> {
+    let kind = if name.is_empty() {
+        Some(RecordErrorKind::EmptyName)
+    } else if name.len() > NAME_MAX_BYTES {
+        Some(RecordErrorKind::NameTooLong)
+    } else if !name
+        .bytes()
+        .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'))
+    {
+        Some(RecordErrorKind::InvalidName)
+    } else {
+        None
+    };
+    kind.map_or(Ok(()), |kind| Err(RecordError { kind }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn records_redact_untrusted_values_at_construction() {
+        let token = ["ghp_", "abcdefghijklmnopqrstuvwxyz0123456789AB"].concat();
+        let record = JournalRecord::new(
+            SystemTime::UNIX_EPOCH,
+            RunId::parse("run-abc").expect("run ID should parse"),
+            "phase",
+            [("detail", token.as_str())],
+        )
+        .expect("record should build");
+
+        assert_eq!(
+            record
+                .fields()
+                .next()
+                .expect("field should exist")
+                .1
+                .as_str(),
+            "<REDACTED-TOKEN>"
+        );
+    }
+
+    #[test]
+    fn duplicate_fields_fail_closed() {
+        let error = JournalRecord::new(
+            SystemTime::UNIX_EPOCH,
+            RunId::parse("run-abc").expect("run ID should parse"),
+            "phase",
+            [("step", "1"), ("step", "2")],
+        )
+        .expect_err("duplicate should fail");
+
+        assert_eq!(error.kind(), RecordErrorKind::DuplicateField);
+    }
+
+    #[test]
+    fn hostile_names_never_enter_the_record() {
+        let error = Breadcrumb::new(
+            SystemTime::UNIX_EPOCH,
+            None,
+            "ship\nforged",
+            "start",
+            "message",
+        )
+        .expect_err("newline should fail");
+
+        assert_eq!(error.kind(), RecordErrorKind::InvalidName);
+    }
+}

--- a/fixtures/rust-redaction/secret-families.tsv
+++ b/fixtures/rust-redaction/secret-families.tsv
@@ -1,0 +1,11 @@
+# family	prefix	suffix (split so fixtures do not contain scanner-shaped values)
+anthropic-openai-key	sk-	ant-abcdefghijklmnopqrstuvwxyz0123456789ABCD
+github-token	ghp_	abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGH
+aws-akia	AKI	AIOSFODNN7EXAMPLE
+jwt	eyJ	hbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c
+pem-private-key	-----BEGIN RSA 	PRIVATE KEY-----
+cursor-api-key	crsr_	1620abcdefghijklmnopqrstuvwxyz0123456789
+slack-token	xox	b-1234567890-abcdefghijklmnop
+google-api-key	AIz	a0123456789abcdefghijklmnopqrstuvwxyz
+stripe-live-key	sk_	live_0123456789abcdefghijklmnop
+gitlab-pat	glpat-	0123456789abcdefghijklmnop

--- a/fixtures/rust-redaction/sensitive-paths.tsv
+++ b/fixtures/rust-redaction/sensitive-paths.tsv
@@ -1,0 +1,11 @@
+# input	expected
+/tmp/claude-implement-AbC123	<TMPDIR>
+/private/tmp/larch-design-run.123/private.txt	<TMPDIR>/private.txt
+/var/folders/aa/bb/T/larch-report-tokens-plot.xyz/x.png	<TMPDIR>/x.png
+/Users/example/larch3/scripts/foo.sh	<OPERATOR_REPO_PATH>/scripts/foo.sh
+/home/example/my.repo/file	<OPERATOR_REPO_PATH>/file
+cwd=/Users/example/foo,bar,	cwd=<OPERATOR_REPO_PATH>,bar,
+cwd=/Users/example/foo;bar;	cwd=<OPERATOR_REPO_PATH>;bar;
+cwd=/Users/example/foo:bar:	cwd=<OPERATOR_REPO_PATH>:bar:
+{"cwd":"/Users/example/my.repo","x":1}	{"cwd":"<OPERATOR_REPO_PATH>","x":1}
+{"cwd":"/Users/example/my}repo"}	{"cwd":"/Users/example/my}repo"}

--- a/python/tests/core/test_rust_redaction_parity.py
+++ b/python/tests/core/test_rust_redaction_parity.py
@@ -1,0 +1,37 @@
+"""Python-side parity pins for the Rust redaction fixtures."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from larch.core import redact
+
+ROOT = Path(__file__).resolve().parents[3]
+FIXTURES = ROOT / "fixtures" / "rust-redaction"
+
+
+def _fixture_rows(name: str, columns: int) -> list[tuple[str, ...]]:
+    rows: list[tuple[str, ...]] = []
+    for line in (FIXTURES / name).read_text(encoding="utf-8").splitlines():
+        if not line or line.startswith("#"):
+            continue
+        row = tuple(line.split("\t", maxsplit=columns - 1))
+        assert len(row) == columns
+        rows.append(row)
+    return rows
+
+
+def test_rust_secret_family_fixtures_match_live_python_contract() -> None:
+    for family, prefix, suffix in _fixture_rows("secret-families.tsv", 3):
+        secret = prefix + suffix
+        text = secret if family == "pem-private-key" else f"before {secret} after"
+
+        result = redact.scrub_log_secrets(text)
+
+        assert result.findings[family] == 1
+        assert secret not in result.scrubbed
+
+
+def test_rust_sensitive_path_fixtures_match_live_python_contract() -> None:
+    for input_text, expected in _fixture_rows("sensitive-paths.tsv", 2):
+        assert redact.redact_tmpdir_paths(input_text) == expected


### PR DESCRIPTION
## Summary

- add deterministic Rust parity for all existing secret families, PEM truncation, and sensitive-path redaction
- add egress-safe error text, structured breadcrumb and journal records, and distinct human, machine, and contract writers
- add shared Rust/Python parity fixtures and document the security boundary

## Self-review

The unbiased review removed a partially redacted public wrapper, added terminal-control sanitization for human diagnostics, and tightened contract-key validation. The final Rust change is 1,045 new lines including tests, below the 1,500-line cap.

## Checks

- `cargo test -p larch-core -p larch-adapters --all-features --locked`
- `cargo clippy -p larch-core -p larch-adapters --all-targets --all-features --locked -- -D warnings`
- `cargo build -p larch-core -p larch-adapters --all-targets --all-features --locked`
- `cargo deny --locked --all-features check`
- focused ruff, pyright, and pytest parity checks
- pre-commit hooks on all changed files

Fixes #7664