### PR TITLE
Fixes #7668: build Python-to-Rust parity harness

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -63,6 +63,12 @@ inventories production callers, and blocks ownership or caller drift. Product
 crates do not depend on this repository-only migration ledger. See
 `docs/rust-command-registry.md` for the update workflow.
 
+Before a command advances to implementation parity, exercise its Python and
+Rust owners through the repository's [black-box parity
+harness](docs/rust-parity-harness.md). Cases run in isolated roots with live
+service credentials and endpoints disabled. They compare exit status, output,
+files, and declared side-effect records against reviewed goldens.
+
 ## Dependency policy
 
 `Cargo.toml` at the workspace root owns every crate version, feature set, and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1455,7 +1455,10 @@ dependencies = [
  "larch-adapters",
  "larch-core",
  "predicates",
+ "regex",
  "serde_json",
+ "tempfile",
+ "wait-timeout",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ toml = { version = "1.1.3", default-features = false, features = ["parse", "serd
 tree-sitter = { version = "0.26.7", default-features = false, features = ["std"] }
 tree-sitter-bash = { version = "0.25.1", default-features = false }
 uuid = { version = "1.24.0", default-features = false, features = ["std"] }
+wait-timeout = { version = "0.2.1", default-features = false }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Larch is a Claude Code workflow automation framework that orchestrates multi-age
 - **Architecture and workflow**
   - [Rust Architecture](ARCHITECTURE.md) — crate ownership, dependency direction, external boundaries, and release constraints
   - [Rust Async Runtime](docs/rust-async-runtime.md) — cancellation, timeouts, bounded tasks, signals, and child shutdown
+  - [Rust Parity Harness](docs/rust-parity-harness.md) — isolated Python-to-Rust command comparison and reviewed goldens
   - [Workflow Lifecycle](docs/workflow-lifecycle.md) — how skills compose end-to-end
   - [Agent System](docs/agents.md) — parallel subagent orchestration
   - [Design Flow](docs/collaborative-sketches.md) — direct plan drafting and plan review

--- a/crates/larch-cli/Cargo.toml
+++ b/crates/larch-cli/Cargo.toml
@@ -20,7 +20,10 @@ larch-core.workspace = true
 [dev-dependencies]
 assert_cmd.workspace = true
 predicates.workspace = true
+regex.workspace = true
 serde_json.workspace = true
+tempfile.workspace = true
+wait-timeout.workspace = true
 
 [lints]
 workspace = true

--- a/crates/larch-cli/tests/parity.rs
+++ b/crates/larch-cli/tests/parity.rs
@@ -1,0 +1,150 @@
+#[path = "support/parity.rs"]
+mod parity_support;
+
+use std::{
+    env,
+    path::{Path, PathBuf},
+    process::Command,
+    time::Duration,
+};
+
+use parity_support::{NormalizationRule, ParityCase, Program, SeedFile, assert_case};
+use tempfile::TempDir;
+
+#[test]
+fn representative_python_and_rust_commands_have_reviewed_parity() {
+    let fixture_directory = fixture_directory();
+    let python = find_executable("python3");
+    let compiled_rust_fixture = compile_rust_fixture(&fixture_directory);
+    let rust_fixture = compiled_rust_fixture.path().join("reference-command");
+    let python_fixture = fixture_directory.join("reference_command.py");
+    let golden_directory = fixture_directory.join("goldens");
+
+    let cases = [
+        ParityCase {
+            name: "clean",
+            python: Program::new(&python)
+                .args([path_text(&python_fixture), "clean", "{sandbox}"])
+                .env("FIXTURE_TIMESTAMP", "2026-07-18T20:00:00.123Z"),
+            rust: Program::new(&rust_fixture)
+                .args(["clean", "{sandbox}"])
+                .env("FIXTURE_TIMESTAMP", "2026-07-18T20:00:01Z"),
+            seed_files: vec![SeedFile::text("input/seed.txt", "fixture\n")],
+            side_effect_records: vec![PathBuf::from("effects.ndjson")],
+            normalization: vec![
+                NormalizationRule::SandboxRoot,
+                NormalizationRule::Rfc3339Utc,
+            ],
+        },
+        ParityCase {
+            name: "usage-error",
+            python: Program::new(&python).args([path_text(&python_fixture)]),
+            rust: Program::new(&rust_fixture),
+            seed_files: Vec::new(),
+            side_effect_records: Vec::new(),
+            normalization: Vec::new(),
+        },
+        ParityCase {
+            name: "malformed-input",
+            python: Program::new(&python).args([
+                path_text(&python_fixture),
+                "malformed",
+                "{sandbox}",
+            ]),
+            rust: Program::new(&rust_fixture).args(["malformed", "{sandbox}"]),
+            seed_files: Vec::new(),
+            side_effect_records: Vec::new(),
+            normalization: Vec::new(),
+        },
+        ParityCase {
+            name: "environmental-failure",
+            python: Program::new(&python).args([
+                path_text(&python_fixture),
+                "environment",
+                "{sandbox}",
+            ]),
+            rust: Program::new(&rust_fixture).args(["environment", "{sandbox}"]),
+            seed_files: Vec::new(),
+            side_effect_records: Vec::new(),
+            normalization: Vec::new(),
+        },
+        ParityCase {
+            name: "service-isolation",
+            python: Program::new(&python).args([
+                path_text(&python_fixture),
+                "isolation",
+                "{sandbox}",
+            ]),
+            rust: Program::new(&rust_fixture).args(["isolation", "{sandbox}"]),
+            seed_files: Vec::new(),
+            side_effect_records: Vec::new(),
+            normalization: vec![NormalizationRule::SandboxRoot],
+        },
+    ];
+
+    for case in cases {
+        let golden = golden_directory.join(format!("{}.golden.json", case.name));
+        assert_case(&case, &golden).unwrap_or_else(|error| panic!("{error}"));
+    }
+}
+
+#[test]
+fn hung_command_fails_at_the_case_boundary() {
+    let fixture_directory = fixture_directory();
+    let python = find_executable("python3");
+    let compiled_rust_fixture = compile_rust_fixture(&fixture_directory);
+    let case = ParityCase {
+        name: "timeout",
+        python: Program::new(&python)
+            .args(["-c", "import time; time.sleep(2)"])
+            .timeout(Duration::from_millis(50)),
+        rust: Program::new(compiled_rust_fixture.path().join("reference-command")),
+        seed_files: Vec::new(),
+        side_effect_records: Vec::new(),
+        normalization: Vec::new(),
+    };
+
+    let error = assert_case(&case, Path::new("unused.golden.json"))
+        .expect_err("hung command should fail the harness");
+
+    assert!(error.contains("timed out after 50ms"));
+}
+
+fn fixture_directory() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../../fixtures/rust-parity")
+}
+
+fn compile_rust_fixture(fixture_directory: &Path) -> TempDir {
+    let output = tempfile::tempdir().expect("compiled Rust fixture tempdir");
+    let executable = output.path().join("reference-command");
+    let rustc = env::var_os("RUSTC").map_or_else(|| find_executable("rustc"), PathBuf::from);
+    let status = Command::new(&rustc)
+        .args(["--edition=2024", "-o"])
+        .arg(&executable)
+        .arg(fixture_directory.join("reference_command.rs"))
+        .status()
+        .unwrap_or_else(|error| panic!("launch {}: {error}", rustc.display()));
+    assert!(status.success(), "Rust parity fixture failed to compile");
+    output
+}
+
+fn find_executable(name: &str) -> PathBuf {
+    let path = env::var_os("PATH").expect("test process should have PATH");
+    env::split_paths(&path)
+        .map(|directory| {
+            if directory.is_absolute() {
+                directory.join(name)
+            } else {
+                env::current_dir()
+                    .expect("test process should have a current directory")
+                    .join(directory)
+                    .join(name)
+            }
+        })
+        .find(|candidate| candidate.is_file())
+        .unwrap_or_else(|| panic!("required executable not found on PATH: {name}"))
+}
+
+fn path_text(path: &Path) -> &str {
+    path.to_str().expect("fixture path should be UTF-8")
+}

--- a/crates/larch-cli/tests/support/parity.rs
+++ b/crates/larch-cli/tests/support/parity.rs
@@ -1,0 +1,660 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    env, fs,
+    io::{self, Read},
+    path::{Component, Path, PathBuf},
+    process::{Command, Output, Stdio},
+    sync::OnceLock,
+    thread,
+    time::Duration,
+};
+
+use regex::Regex;
+use serde_json::{Value, json};
+use tempfile::TempDir;
+use wait_timeout::ChildExt;
+
+const UPDATE_GOLDENS_ENV: &str = "LARCH_UPDATE_PARITY_GOLDENS";
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+const DIAGNOSTIC_PATH_LIMIT: usize = 8;
+static RFC3339_UTC: OnceLock<Regex> = OnceLock::new();
+const BLOCKED_ENVIRONMENT_KEYS: &[&str] = &[
+    "ALL_PROXY",
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "CLOUDSDK_CONFIG",
+    "GH_ENTERPRISE_TOKEN",
+    "GH_HOST",
+    "GH_TOKEN",
+    "GITHUB_API_URL",
+    "GITHUB_GRAPHQL_URL",
+    "GITHUB_TOKEN",
+    "GOOGLE_APPLICATION_CREDENTIALS",
+    "HTTPS_PROXY",
+    "HTTP_PROXY",
+    "NO_PROXY",
+];
+
+#[derive(Clone, Debug)]
+pub struct Program {
+    executable: PathBuf,
+    arguments: Vec<String>,
+    environment: BTreeMap<String, String>,
+    timeout: Duration,
+}
+
+impl Program {
+    pub fn new(executable: impl Into<PathBuf>) -> Self {
+        Self {
+            executable: executable.into(),
+            arguments: Vec::new(),
+            environment: BTreeMap::new(),
+            timeout: DEFAULT_TIMEOUT,
+        }
+    }
+
+    pub fn args<const N: usize>(mut self, arguments: [&str; N]) -> Self {
+        self.arguments
+            .extend(arguments.into_iter().map(ToOwned::to_owned));
+        self
+    }
+
+    pub fn env(mut self, key: &str, value: &str) -> Self {
+        self.environment.insert(key.to_owned(), value.to_owned());
+        self
+    }
+
+    pub const fn timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct SeedFile {
+    relative_path: PathBuf,
+    contents: Vec<u8>,
+}
+
+impl SeedFile {
+    pub fn text(relative_path: &str, contents: &str) -> Self {
+        Self {
+            relative_path: PathBuf::from(relative_path),
+            contents: contents.as_bytes().to_vec(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum NormalizationRule {
+    SandboxRoot,
+    Rfc3339Utc,
+}
+
+#[derive(Clone, Debug)]
+pub struct ParityCase {
+    pub name: &'static str,
+    pub python: Program,
+    pub rust: Program,
+    pub seed_files: Vec<SeedFile>,
+    pub side_effect_records: Vec<PathBuf>,
+    pub normalization: Vec<NormalizationRule>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum CapturedContent {
+    Text(String),
+    Binary(Vec<u8>),
+}
+
+type FileSnapshot = BTreeMap<String, CapturedContent>;
+type SideEffectSnapshot = BTreeMap<String, String>;
+type TreeSnapshot = (FileSnapshot, SideEffectSnapshot);
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct Capture {
+    exit_code: Option<i32>,
+    stdout: CapturedContent,
+    stderr: CapturedContent,
+    files: FileSnapshot,
+    side_effects: SideEffectSnapshot,
+}
+
+struct Sandbox {
+    directory: TempDir,
+}
+
+impl Sandbox {
+    fn new(seed_files: &[SeedFile]) -> Result<Self, String> {
+        let directory = tempfile::Builder::new()
+            .prefix("larch-parity-")
+            .tempdir()
+            .map_err(|error| format!("create parity sandbox: {error}"))?;
+        for relative in [".home", ".tmp", ".bin"] {
+            fs::create_dir(directory.path().join(relative))
+                .map_err(|error| format!("create sandbox directory {relative}: {error}"))?;
+        }
+        let sandbox = Self { directory };
+        for seed in seed_files {
+            let path = sandbox.safe_path(&seed.relative_path)?;
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent)
+                    .map_err(|error| format!("create seed parent {}: {error}", parent.display()))?;
+            }
+            fs::write(&path, &seed.contents)
+                .map_err(|error| format!("write seed {}: {error}", path.display()))?;
+        }
+        Ok(sandbox)
+    }
+
+    fn root(&self) -> &Path {
+        self.directory.path()
+    }
+
+    fn safe_path(&self, relative: &Path) -> Result<PathBuf, String> {
+        validate_relative_path(relative)?;
+        Ok(self.root().join(relative))
+    }
+}
+
+pub fn assert_case(case: &ParityCase, golden_path: &Path) -> Result<(), String> {
+    validate_program(&case.python, "python")?;
+    validate_program(&case.rust, "rust")?;
+    let python_sandbox = Sandbox::new(&case.seed_files)?;
+    let rust_sandbox = Sandbox::new(&case.seed_files)?;
+    let record_paths: BTreeSet<PathBuf> = case.side_effect_records.iter().cloned().collect();
+    for path in &record_paths {
+        validate_relative_path(path)?;
+    }
+
+    let python = run_program(&case.python, &python_sandbox, &record_paths)?;
+    let rust = run_program(&case.rust, &rust_sandbox, &record_paths)?;
+    let python = normalize_capture(python, python_sandbox.root(), &case.normalization);
+    let rust = normalize_capture(rust, rust_sandbox.root(), &case.normalization);
+    if python != rust {
+        return Err(mismatch_diagnostic(case.name, &python, &rust));
+    }
+    assert_golden(case.name, &python, golden_path)
+}
+
+fn validate_program(program: &Program, label: &str) -> Result<(), String> {
+    if !program.executable.is_absolute() {
+        return Err(format!(
+            "{label} executable must be an absolute path: {}",
+            program.executable.display()
+        ));
+    }
+    for key in program.environment.keys() {
+        if BLOCKED_ENVIRONMENT_KEYS.contains(&key.as_str()) {
+            return Err(format!(
+                "{label} environment override {key} is blocked; use a fixture service"
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_relative_path(path: &Path) -> Result<(), String> {
+    if path.as_os_str().is_empty()
+        || path
+            .components()
+            .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        return Err(format!(
+            "parity fixture path must be a confined relative path: {}",
+            path.display()
+        ));
+    }
+    Ok(())
+}
+
+fn run_program(
+    program: &Program,
+    sandbox: &Sandbox,
+    record_paths: &BTreeSet<PathBuf>,
+) -> Result<Capture, String> {
+    let mut command = Command::new(&program.executable);
+    command
+        .current_dir(sandbox.root())
+        .env_clear()
+        .env("ALL_PROXY", "http://127.0.0.1:9")
+        .env("AWS_EC2_METADATA_DISABLED", "true")
+        .env("CLOUDSDK_CONFIG", sandbox.root().join(".cloud-disabled"))
+        .env("GH_HOST", "127.0.0.1:9")
+        .env("GITHUB_API_URL", "http://127.0.0.1:9")
+        .env("GITHUB_GRAPHQL_URL", "http://127.0.0.1:9/graphql")
+        .env("HOME", sandbox.root().join(".home"))
+        .env("HTTPS_PROXY", "http://127.0.0.1:9")
+        .env("HTTP_PROXY", "http://127.0.0.1:9")
+        .env("LANG", "C")
+        .env("LARCH_PARITY_LIVE_SERVICES", "disabled")
+        .env("NO_OPEN_BROWSER", "1")
+        .env("NO_PROXY", "")
+        .env("PATH", sandbox.root().join(".bin"))
+        .env("PYTHONDONTWRITEBYTECODE", "1")
+        .env("TMPDIR", sandbox.root().join(".tmp"));
+    for argument in &program.arguments {
+        command.arg(expand_sandbox(argument, sandbox.root()));
+    }
+    for (key, value) in &program.environment {
+        command.env(key, expand_sandbox(value, sandbox.root()));
+    }
+    let output = output_with_timeout(command, &program.executable, program.timeout)?;
+    let (files, side_effects) = capture_tree(sandbox.root(), record_paths)?;
+    Ok(Capture {
+        exit_code: output.status.code(),
+        stdout: captured_content(output.stdout),
+        stderr: captured_content(output.stderr),
+        files,
+        side_effects,
+    })
+}
+
+fn output_with_timeout(
+    mut command: Command,
+    executable: &Path,
+    timeout: Duration,
+) -> Result<Output, String> {
+    command.stdout(Stdio::piped()).stderr(Stdio::piped());
+    let mut child = command
+        .spawn()
+        .map_err(|error| format!("launch parity command {}: {error}", executable.display()))?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| "capture parity command stdout: pipe unavailable".to_owned())?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| "capture parity command stderr: pipe unavailable".to_owned())?;
+    let stdout_reader = thread::spawn(move || read_stream(stdout));
+    let stderr_reader = thread::spawn(move || read_stream(stderr));
+    let status = match child.wait_timeout(timeout) {
+        Ok(Some(status)) => status,
+        Ok(None) => {
+            let _ = child.kill();
+            let _ = child.wait();
+            join_reader(stdout_reader, "stdout")?;
+            join_reader(stderr_reader, "stderr")?;
+            return Err(format!(
+                "parity command {} timed out after {timeout:?}",
+                executable.display()
+            ));
+        }
+        Err(error) => {
+            let _ = child.kill();
+            let _ = child.wait();
+            join_reader(stdout_reader, "stdout")?;
+            join_reader(stderr_reader, "stderr")?;
+            return Err(format!(
+                "wait for parity command {}: {error}",
+                executable.display()
+            ));
+        }
+    };
+    Ok(Output {
+        status,
+        stdout: join_reader(stdout_reader, "stdout")?,
+        stderr: join_reader(stderr_reader, "stderr")?,
+    })
+}
+
+fn read_stream(mut stream: impl Read) -> io::Result<Vec<u8>> {
+    let mut bytes = Vec::new();
+    stream.read_to_end(&mut bytes)?;
+    Ok(bytes)
+}
+
+fn join_reader(
+    reader: thread::JoinHandle<io::Result<Vec<u8>>>,
+    label: &str,
+) -> Result<Vec<u8>, String> {
+    reader
+        .join()
+        .map_err(|_| format!("capture parity command {label}: reader thread panicked"))?
+        .map_err(|error| format!("capture parity command {label}: {error}"))
+}
+
+fn captured_content(bytes: Vec<u8>) -> CapturedContent {
+    match String::from_utf8(bytes) {
+        Ok(text) => CapturedContent::Text(text),
+        Err(error) => CapturedContent::Binary(error.into_bytes()),
+    }
+}
+
+fn expand_sandbox(value: &str, root: &Path) -> String {
+    value.replace("{sandbox}", &root.to_string_lossy())
+}
+
+fn capture_tree(root: &Path, record_paths: &BTreeSet<PathBuf>) -> Result<TreeSnapshot, String> {
+    let mut files = BTreeMap::new();
+    let mut side_effects = BTreeMap::new();
+    capture_directory(root, root, record_paths, &mut files, &mut side_effects)?;
+    for relative in record_paths {
+        let key = path_key(relative)?;
+        side_effects.entry(key).or_default();
+    }
+    Ok((files, side_effects))
+}
+
+fn capture_directory(
+    root: &Path,
+    directory: &Path,
+    record_paths: &BTreeSet<PathBuf>,
+    files: &mut BTreeMap<String, CapturedContent>,
+    side_effects: &mut BTreeMap<String, String>,
+) -> Result<(), String> {
+    let mut entries: Vec<_> = fs::read_dir(directory)
+        .map_err(|error| format!("read sandbox directory {}: {error}", directory.display()))?
+        .collect::<Result<_, _>>()
+        .map_err(|error| format!("read sandbox entry: {error}"))?;
+    entries.sort_by_key(fs::DirEntry::file_name);
+    for entry in entries {
+        let path = entry.path();
+        let metadata = fs::symlink_metadata(&path)
+            .map_err(|error| format!("inspect sandbox path {}: {error}", path.display()))?;
+        if metadata.file_type().is_symlink() {
+            return Err(format!(
+                "parity command created a forbidden symlink: {}",
+                path.display()
+            ));
+        }
+        if metadata.is_dir() {
+            capture_directory(root, &path, record_paths, files, side_effects)?;
+            continue;
+        }
+        if !metadata.is_file() {
+            return Err(format!(
+                "parity command created a non-file artifact: {}",
+                path.display()
+            ));
+        }
+        let relative = path
+            .strip_prefix(root)
+            .map_err(|error| format!("derive sandbox-relative path: {error}"))?;
+        let key = path_key(relative)?;
+        let bytes = fs::read(&path)
+            .map_err(|error| format!("read sandbox file {}: {error}", path.display()))?;
+        if record_paths.contains(relative) {
+            let text = String::from_utf8(bytes)
+                .map_err(|error| format!("side-effect record {key} is not UTF-8: {error}"))?;
+            side_effects.insert(key, text);
+        } else {
+            files.insert(key, captured_content(bytes));
+        }
+    }
+    Ok(())
+}
+
+fn path_key(path: &Path) -> Result<String, String> {
+    path.to_str()
+        .map(str::to_owned)
+        .ok_or_else(|| format!("parity fixture path is not UTF-8: {}", path.display()))
+}
+
+fn normalize_capture(
+    mut capture: Capture,
+    sandbox_root: &Path,
+    rules: &[NormalizationRule],
+) -> Capture {
+    normalize_content(&mut capture.stdout, sandbox_root, rules);
+    normalize_content(&mut capture.stderr, sandbox_root, rules);
+    for contents in capture.files.values_mut() {
+        normalize_content(contents, sandbox_root, rules);
+    }
+    for record in capture.side_effects.values_mut() {
+        *record = normalize_text(record, sandbox_root, rules);
+    }
+    capture
+}
+
+fn normalize_content(
+    content: &mut CapturedContent,
+    sandbox_root: &Path,
+    rules: &[NormalizationRule],
+) {
+    if let CapturedContent::Text(text) = content {
+        *text = normalize_text(text, sandbox_root, rules);
+    }
+}
+
+fn normalize_text(text: &str, sandbox_root: &Path, rules: &[NormalizationRule]) -> String {
+    let mut normalized = text.to_owned();
+    for rule in rules {
+        normalized = match rule {
+            NormalizationRule::SandboxRoot => {
+                normalized.replace(sandbox_root.to_string_lossy().as_ref(), "<SANDBOX>")
+            }
+            NormalizationRule::Rfc3339Utc => rfc3339_utc_pattern()
+                .replace_all(&normalized, "<TIMESTAMP>")
+                .into_owned(),
+        };
+    }
+    normalized
+}
+
+fn rfc3339_utc_pattern() -> &'static Regex {
+    RFC3339_UTC.get_or_init(|| {
+        Regex::new(r"\b\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\b")
+            .expect("RFC 3339 normalization regex should compile")
+    })
+}
+
+fn mismatch_diagnostic(case_name: &str, python: &Capture, rust: &Capture) -> String {
+    let mut differences = Vec::new();
+    if python.exit_code != rust.exit_code {
+        differences.push(format!(
+            "exit code: python={:?}, rust={:?}",
+            python.exit_code, rust.exit_code
+        ));
+    }
+    push_value_difference(&mut differences, "stdout", &python.stdout, &rust.stdout);
+    push_value_difference(&mut differences, "stderr", &python.stderr, &rust.stderr);
+    push_map_differences(&mut differences, "file", &python.files, &rust.files);
+    push_map_differences(
+        &mut differences,
+        "side effect",
+        &python.side_effects,
+        &rust.side_effects,
+    );
+    format!(
+        "parity mismatch in {case_name}:\n  {}",
+        differences.join("\n  ")
+    )
+}
+
+fn push_value_difference<T: std::fmt::Debug + PartialEq>(
+    differences: &mut Vec<String>,
+    label: &str,
+    python: &T,
+    rust: &T,
+) {
+    if python != rust {
+        differences.push(format!(
+            "{label}: python={}, rust={}",
+            concise_debug(python),
+            concise_debug(rust)
+        ));
+    }
+}
+
+fn push_map_differences<T: std::fmt::Debug + PartialEq>(
+    differences: &mut Vec<String>,
+    label: &str,
+    python: &BTreeMap<String, T>,
+    rust: &BTreeMap<String, T>,
+) {
+    let keys: BTreeSet<_> = python.keys().chain(rust.keys()).collect();
+    let mismatches: Vec<_> = keys
+        .into_iter()
+        .filter(|key| python.get(*key) != rust.get(*key))
+        .collect();
+    for path in mismatches.iter().take(DIAGNOSTIC_PATH_LIMIT) {
+        differences.push(format!(
+            "{label} {path}: python={}, rust={}",
+            concise_debug(&python.get(*path)),
+            concise_debug(&rust.get(*path))
+        ));
+    }
+    if mismatches.len() > DIAGNOSTIC_PATH_LIMIT {
+        differences.push(format!(
+            "{label}s: {} more mismatched paths omitted",
+            mismatches.len() - DIAGNOSTIC_PATH_LIMIT
+        ));
+    }
+}
+
+fn concise(value: &str) -> String {
+    const LIMIT: usize = 240;
+    let escaped = format!("{value:?}");
+    if escaped.chars().count() <= LIMIT {
+        return escaped;
+    }
+    let prefix: String = escaped.chars().take(LIMIT).collect();
+    format!("{prefix}...[truncated]")
+}
+
+fn concise_debug(value: &impl std::fmt::Debug) -> String {
+    concise(&format!("{value:?}"))
+}
+
+fn assert_golden(case_name: &str, capture: &Capture, path: &Path) -> Result<(), String> {
+    let rendered = format!(
+        "{}\n",
+        serde_json::to_string_pretty(&capture_json(capture))
+            .map_err(|error| format!("render parity golden: {error}"))?
+    );
+    if env::var(UPDATE_GOLDENS_ENV).as_deref() == Ok("1") {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).map_err(|error| {
+                format!(
+                    "create parity golden directory {}: {error}",
+                    parent.display()
+                )
+            })?;
+        }
+        fs::write(path, rendered)
+            .map_err(|error| format!("update parity golden {}: {error}", path.display()))?;
+        return Ok(());
+    }
+    let expected = fs::read_to_string(path)
+        .map_err(|error| format!("read parity golden {}: {error}", path.display()))?;
+    if expected == rendered {
+        Ok(())
+    } else {
+        Err(format!(
+            "golden mismatch in {case_name}: {}; review the parity result, then rerun with {UPDATE_GOLDENS_ENV}=1",
+            path.display()
+        ))
+    }
+}
+
+fn capture_json(capture: &Capture) -> Value {
+    let files: BTreeMap<_, _> = capture
+        .files
+        .iter()
+        .map(|(path, contents)| (path, content_json(contents)))
+        .collect();
+    json!({
+        "exit_code": capture.exit_code,
+        "stdout": content_json(&capture.stdout),
+        "stderr": content_json(&capture.stderr),
+        "files": files,
+        "side_effects": capture.side_effects,
+    })
+}
+
+fn content_json(content: &CapturedContent) -> Value {
+    match content {
+        CapturedContent::Text(text) => json!({"text": text}),
+        CapturedContent::Binary(bytes) => json!({"hex": encode_hex(bytes)}),
+    }
+}
+
+fn encode_hex(bytes: &[u8]) -> String {
+    use std::fmt::Write as _;
+
+    let mut encoded = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        write!(encoded, "{byte:02x}").expect("writing to a string cannot fail");
+    }
+    encoded
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        Capture, CapturedContent, NormalizationRule, Program, mismatch_diagnostic, normalize_text,
+        validate_program,
+    };
+    use std::{collections::BTreeMap, path::Path};
+
+    #[test]
+    fn normalization_replaces_only_named_nondeterminism() {
+        let normalized = normalize_text(
+            "/tmp/case/out at 2026-07-18T21:05:07.123Z; keep 2026-07-18",
+            Path::new("/tmp/case"),
+            &[
+                NormalizationRule::SandboxRoot,
+                NormalizationRule::Rfc3339Utc,
+            ],
+        );
+
+        assert_eq!(normalized, "<SANDBOX>/out at <TIMESTAMP>; keep 2026-07-18");
+    }
+
+    #[test]
+    fn live_service_credentials_cannot_be_reintroduced() {
+        let program = Program::new("/bin/fixture").env("GH_TOKEN", "secret");
+        let error = validate_program(&program, "python").expect_err("credential must be blocked");
+
+        assert!(error.contains("GH_TOKEN"));
+        assert!(error.contains("fixture service"));
+    }
+
+    #[test]
+    fn mismatch_diagnostic_names_channels_and_bounds_values() {
+        let python = Capture {
+            exit_code: Some(2),
+            stdout: CapturedContent::Text("p".repeat(300)),
+            stderr: CapturedContent::Text(String::new()),
+            files: (0..10)
+                .map(|index| {
+                    (
+                        format!("result-{index}.txt"),
+                        CapturedContent::Text("python".to_owned()),
+                    )
+                })
+                .collect(),
+            side_effects: BTreeMap::new(),
+        };
+        let rust = Capture {
+            exit_code: Some(65),
+            stdout: CapturedContent::Text("r".repeat(300)),
+            stderr: CapturedContent::Text("malformed".to_owned()),
+            files: BTreeMap::new(),
+            side_effects: BTreeMap::new(),
+        };
+
+        let diagnostic = mismatch_diagnostic("fixture", &python, &rust);
+
+        assert!(diagnostic.starts_with("parity mismatch in fixture:"));
+        assert!(diagnostic.contains("exit code:"));
+        assert!(diagnostic.contains("stdout:"));
+        assert!(diagnostic.contains("stderr:"));
+        assert!(diagnostic.contains("file result-0.txt:"));
+        assert!(diagnostic.contains("files: 2 more mismatched paths omitted"));
+        assert!(diagnostic.contains("[truncated]"));
+    }
+
+    #[test]
+    fn non_utf8_streams_stay_byte_exact() {
+        let content = super::captured_content(vec![0, 255]);
+
+        assert_eq!(content, CapturedContent::Binary(vec![0, 255]));
+        assert_eq!(
+            super::content_json(&content),
+            serde_json::json!({"hex": "00ff"})
+        );
+    }
+}

--- a/docs/rust-parity-harness.md
+++ b/docs/rust-parity-harness.md
@@ -1,0 +1,64 @@
+# Rust Parity Harness
+
+The black-box parity harness lives in
+`crates/larch-cli/tests/support/parity.rs`. It runs a Python command and its
+Rust replacement in separate temporary roots. Both roots start with the same
+seed files. The harness compares:
+
+- exit code, stdout, and stderr;
+- every regular file, including binary files and non-UTF-8 output streams;
+- declared UTF-8 side-effect records, such as fake service call logs.
+
+A mismatch reports only the differing channels and truncates large values.
+It reports mismatched file paths as whole units and names how many paths it
+omitted when the bounded diagnostic fills. Each child has a 30-second default
+timeout. A case may select a shorter or longer explicit timeout.
+The harness rejects symlinks, special files, absolute fixture paths, and path
+traversal.
+
+## Service isolation
+
+Children start with a cleared environment. The harness supplies isolated
+home, temporary, cloud-config, and executable directories. It removes inherited
+credentials and points standard GitHub and proxy variables at a closed
+loopback endpoint. A case cannot override credential, service-host, or proxy
+variables. Commands that need GitHub or cloud behavior must use a fixture
+executable or local fixture service and record each permitted call.
+
+This boundary prevents accidental live access through normal clients. It is
+not a security sandbox for hostile test code that opens a hard-coded socket.
+Parity cases must not use direct network APIs.
+
+## Normalization
+
+Normalization is opt-in per case. The harness supports only these rules:
+
+- `SandboxRoot` replaces that command's temporary root with `<SANDBOX>`.
+- `Rfc3339Utc` replaces complete UTC timestamps such as
+  `2026-07-18T20:00:00.123Z` with `<TIMESTAMP>`.
+
+Rules apply to stdout, stderr, text files, and side-effect records. Binary
+files remain byte-exact. Add a new rule only for documented nondeterminism and
+cover its exact match boundary with a test. Do not normalize semantic values.
+
+## Add a parity case
+
+Add a `ParityCase` to a `larch-cli` integration test. Supply absolute Python
+and Rust executable paths, arguments, environment values, seed files, declared
+side-effect record paths, and the smallest needed normalization rule set. Use
+`{sandbox}` in an argument or environment value when the command needs its
+isolated root. Call `assert_case` with a checked-in golden path.
+
+`fixtures/rust-parity/` demonstrates clean, usage-error, malformed-input,
+environmental-failure, and service-isolation cases. The clean case also covers
+text and binary files, side-effect records, temporary paths, and timestamps.
+
+Review a contract change before updating its golden. After Python and Rust
+match, refresh goldens with:
+
+```bash
+LARCH_UPDATE_PARITY_GOLDENS=1 cargo test --locked --package larch-cli --test parity
+```
+
+Inspect and commit the resulting `*.golden.json` diff. CI never sets the
+update variable, so an unreviewed contract change fails.

--- a/fixtures/rust-parity/goldens/clean.golden.json
+++ b/fixtures/rust-parity/goldens/clean.golden.json
@@ -1,0 +1,23 @@
+{
+  "exit_code": 0,
+  "files": {
+    "input/seed.txt": {
+      "text": "fixture\n"
+    },
+    "output/data.bin": {
+      "hex": "00ff"
+    },
+    "output/result.txt": {
+      "text": "root=<SANDBOX>\ntimestamp=<TIMESTAMP>\nseed=fixture\n"
+    }
+  },
+  "side_effects": {
+    "effects.ndjson": "{\"action\":\"write\",\"root\":\"<SANDBOX>\",\"at\":\"<TIMESTAMP>\"}\n"
+  },
+  "stderr": {
+    "text": ""
+  },
+  "stdout": {
+    "text": "wrote <SANDBOX>/output/result.txt at <TIMESTAMP>\n"
+  }
+}

--- a/fixtures/rust-parity/goldens/environmental-failure.golden.json
+++ b/fixtures/rust-parity/goldens/environmental-failure.golden.json
@@ -1,0 +1,11 @@
+{
+  "exit_code": 69,
+  "files": {},
+  "side_effects": {},
+  "stderr": {
+    "text": "required environment value is unavailable\n"
+  },
+  "stdout": {
+    "text": ""
+  }
+}

--- a/fixtures/rust-parity/goldens/malformed-input.golden.json
+++ b/fixtures/rust-parity/goldens/malformed-input.golden.json
@@ -1,0 +1,11 @@
+{
+  "exit_code": 65,
+  "files": {},
+  "side_effects": {},
+  "stderr": {
+    "text": "malformed input\n"
+  },
+  "stdout": {
+    "text": ""
+  }
+}

--- a/fixtures/rust-parity/goldens/service-isolation.golden.json
+++ b/fixtures/rust-parity/goldens/service-isolation.golden.json
@@ -1,0 +1,11 @@
+{
+  "exit_code": 0,
+  "files": {},
+  "side_effects": {},
+  "stderr": {
+    "text": ""
+  },
+  "stdout": {
+    "text": "GH_TOKEN=absent\nGITHUB_API_URL=http://127.0.0.1:9\nCLOUDSDK_CONFIG=<SANDBOX>/.cloud-disabled\nPATH=<SANDBOX>/.bin\nLARCH_PARITY_LIVE_SERVICES=disabled\n"
+  }
+}

--- a/fixtures/rust-parity/goldens/usage-error.golden.json
+++ b/fixtures/rust-parity/goldens/usage-error.golden.json
@@ -1,0 +1,11 @@
+{
+  "exit_code": 2,
+  "files": {},
+  "side_effects": {},
+  "stderr": {
+    "text": "usage: reference-command <mode> <root>\n"
+  },
+  "stdout": {
+    "text": ""
+  }
+}

--- a/fixtures/rust-parity/reference_command.py
+++ b/fixtures/rust-parity/reference_command.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Reference program used to prove the Rust parity harness contract."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import sys
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print("usage: reference-command <mode> <root>", file=sys.stderr)
+        return 2
+
+    mode = sys.argv[1]
+    root = Path(sys.argv[2])
+    if mode == "malformed":
+        print("malformed input", file=sys.stderr)
+        return 65
+    if mode == "environment":
+        if "FIXTURE_REQUIRED" not in os.environ:
+            print("required environment value is unavailable", file=sys.stderr)
+            return 69
+        return 0
+    if mode == "isolation":
+        print(f"GH_TOKEN={'present' if 'GH_TOKEN' in os.environ else 'absent'}")
+        for key in (
+            "GITHUB_API_URL",
+            "CLOUDSDK_CONFIG",
+            "PATH",
+            "LARCH_PARITY_LIVE_SERVICES",
+        ):
+            print(f"{key}={os.environ[key]}")
+        return 0
+    if mode != "clean":
+        print(f"unknown mode: {mode}", file=sys.stderr)
+        return 64
+
+    timestamp = os.environ["FIXTURE_TIMESTAMP"]
+    seed = (root / "input" / "seed.txt").read_text(encoding="utf-8").strip()
+    output = root / "output"
+    output.mkdir()
+    rendered = f"root={root}\ntimestamp={timestamp}\nseed={seed}\n"
+    (output / "result.txt").write_text(rendered, encoding="utf-8")
+    (output / "data.bin").write_bytes(bytes((0, 255)))
+    (root / "effects.ndjson").write_text(
+        f'{{"action":"write","root":"{root}","at":"{timestamp}"}}\n',
+        encoding="utf-8",
+    )
+    print(f"wrote {root / 'output' / 'result.txt'} at {timestamp}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/fixtures/rust-parity/reference_command.rs
+++ b/fixtures/rust-parity/reference_command.rs
@@ -1,0 +1,77 @@
+use std::{env, fs, path::Path, process::ExitCode};
+
+fn main() -> ExitCode {
+    let arguments: Vec<String> = env::args().collect();
+    if arguments.len() != 3 {
+        eprintln!("usage: reference-command <mode> <root>");
+        return ExitCode::from(2);
+    }
+
+    let mode = &arguments[1];
+    let root = Path::new(&arguments[2]);
+    match mode.as_str() {
+        "malformed" => {
+            eprintln!("malformed input");
+            return ExitCode::from(65);
+        }
+        "environment" => {
+            if env::var_os("FIXTURE_REQUIRED").is_none() {
+                eprintln!("required environment value is unavailable");
+                return ExitCode::from(69);
+            }
+            return ExitCode::SUCCESS;
+        }
+        "isolation" => {
+            let token_state = if env::var_os("GH_TOKEN").is_some() {
+                "present"
+            } else {
+                "absent"
+            };
+            println!("GH_TOKEN={token_state}");
+            for key in [
+                "GITHUB_API_URL",
+                "CLOUDSDK_CONFIG",
+                "PATH",
+                "LARCH_PARITY_LIVE_SERVICES",
+            ] {
+                println!(
+                    "{key}={}",
+                    env::var(key).expect("isolation environment should be set")
+                );
+            }
+            return ExitCode::SUCCESS;
+        }
+        "clean" => {}
+        _ => {
+            eprintln!("unknown mode: {mode}");
+            return ExitCode::from(64);
+        }
+    }
+
+    let timestamp = env::var("FIXTURE_TIMESTAMP").expect("fixture timestamp should be set");
+    let seed = fs::read_to_string(root.join("input/seed.txt"))
+        .expect("seed should be readable")
+        .trim()
+        .to_owned();
+    let output = root.join("output");
+    fs::create_dir(&output).expect("output directory should be created");
+    let rendered = format!(
+        "root={}\ntimestamp={timestamp}\nseed={seed}\n",
+        root.display()
+    );
+    fs::write(output.join("result.txt"), rendered).expect("result should be written");
+    fs::write(output.join("data.bin"), [0, 255]).expect("binary result should be written");
+    fs::write(
+        root.join("effects.ndjson"),
+        format!(
+            "{{\"action\":\"write\",\"root\":\"{}\",\"at\":\"{timestamp}\"}}\n",
+            root.display()
+        ),
+    )
+    .expect("side effect should be recorded");
+    println!(
+        "wrote {} at {timestamp}",
+        output.join("result.txt").display()
+    );
+    ExitCode::SUCCESS
+}


### PR DESCRIPTION
Fixes #7668

## Summary

- add a reusable test-only harness that runs Python and Rust commands in separate seeded roots
- compare exit status, byte-exact streams, files, and declared side-effect records
- disable inherited credentials and live service endpoints, bound child runtime, and keep normalization limited to named path and timestamp rules
- add reviewed goldens for clean, usage-error, malformed-input, environmental-failure, and service-isolation cases
- document the extension and intentional golden-update workflow

The implementation adds 887 non-generated Rust lines, including tests. `wait-timeout` provides the standard-library timeout gap and was already present in the audited lockfile as a transitive dependency.

## Self-review

A fresh acceptance and architecture review found three issues in the first pass: whole-map diagnostic truncation, rejection of non-UTF-8 streams, and unbounded child execution. This revision fixes all three and adds regression coverage.

## Checks

- `cargo fmt --all -- --check`
- `cargo clippy --package larch-cli --all-targets --all-features --locked -- -D warnings`
- `cargo test --locked --package larch-cli --all-features`
- `cargo deny --locked --all-features check`
- `cargo run --quiet --locked --package larch-lint -- all`
- changed-file `pre-commit run --files ...`
- `git diff --check`
- `python3 -m py_compile fixtures/rust-parity/reference_command.py`