### PR TITLE
Fixes #7690: bootstrap the Rust binary atomically

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,6 +4,7 @@
       "Bash($PWD/.claude/skills/*)",
       "Bash($PWD/.claude/skills/release/scripts/*)",
       "Bash($PWD/scripts/*)",
+      "Bash($PWD/scripts/larch.sh:*)",
       "Bash($PWD/skills/implement/scripts/*)",
       "Bash($PWD/skills/report-tokens/scripts/*)",
       "Bash(./:*)",

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -138,6 +138,8 @@ glibc 2.17 or newer. Windows and musl are not initial targets.
 Release archives contain only `larch` and `LICENSE`. Builds use the pinned Rust
 toolchain and lockfile. Release CI must build and smoke-test the supported
 targets without Python and must not introduce an undeclared native runtime
-library. A thin residual Bash bootstrap may install and execute the verified
-binary as specified by issue #7670. Bootstrap use of `gh` does not authorize
-runtime service adapters to shell out to it.
+library. The thin residual `scripts/larch.sh` bootstrap verifies and atomically
+installs the release-matched binary as specified by issue #7670. Its hidden
+`larch bootstrap self-check` command reports the compiled version and target
+for staged validation. Bootstrap use of `gh` does not authorize runtime service
+adapters to shell out to it.

--- a/README.md
+++ b/README.md
@@ -278,6 +278,12 @@ Dev-only: not shipped with the plugin; runnable only inside the larch source tre
   </thead>
   <tbody>
     <tr>
+      <td><a href="docs/installation-and-setup.md#rust-executable-bootstrap"><code>scripts/larch.sh</code></a></td>
+      <td><code>&lt;larch domain&gt; &lt;verb&gt; [arguments...]</code></td>
+    </tr>
+    <tr><td colspan="2">Verify and install the exact release-matched Rust executable when needed, then replace the shim process with it. Local <code>--plugin-dir</code> checkouts require an explicit <code>LARCH_BINARY</code>.</td></tr>
+    <tr><td colspan="2"><hr></td></tr>
+    <tr>
       <td><a href="docs/skills.md#relevant-checks-script"><code>python/cli.py checks run-relevant</code></a></td>
       <td><code>--site &lt;site&gt; [--tmpdir DIR] [--repo-root DIR] [--allow-skip]</code></td>
     </tr>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,6 +27,24 @@ Each matrix job attests its archive through GitHub artifact attestations. The co
 
 This provenance proves that GitHub Actions built the bytes from the recorded repository commit under the named workflow. It does not make the source, dependencies, runner images, pinned container images, GitHub Actions service, or maintainers intrinsically trustworthy. The checksum file is an integrity index, not an independent trust root. Consumers must verify GitHub attestations and the strict manifest contract before installation. Immutable Release publication and installer-side verification are separate gates owned by the release publication and bootstrap flows.
 
+## Rust Bootstrap and Atomic Installation
+
+`scripts/larch.sh` is the only clean-install exec shim and uses no Python. It
+maps four targets and verifies the exact immutable release, tag commit, asset
+allowlist, build attestations, strict manifest and checksums, sizes, digests,
+platform identity, and raw USTAR layout. It rejects symlinks, special files,
+traversal, extra members, malformed archives, and trailing data before
+extracting only `larch`.
+
+The staged binary must pass `--version` and compact-JSON
+`larch bootstrap self-check`. A same-directory rename installs it atomically;
+an existing regular binary retains a hard-link rollback through post-install
+verification. A bounded `CLAUDE_PLUGIN_DATA/bootstrap.lock` serializes first
+use, reclaims revalidated dead-owner locks, and makes waiters re-check before
+downloading. Cleanup removes only process-owned state. Local `.git` checkouts
+require an explicit matching `LARCH_BINARY`. These controls do not defend
+against a hostile same-UID process that can rewrite plugin cache or data files.
+
 ## Scoped Live-Mutation Authorization Boundary
 
 Scoped GitHub issue create, comment, close, and label operations require explicit live-run authorization. The guarded boundary covers `python3 python/cli.py issue create-one`, the cross-repository stall-report filing helper (`scripts/file-failure-report-cross-repo.sh`), Tier-A dedup before terminal reporter filing, `/design` salvage reconciliation comment and close operations, OOS blocker probes, label provisioning and edits, issue filing and cleanup, and `audit-runs close-priors`.

--- a/agent-lint.toml
+++ b/agent-lint.toml
@@ -1358,9 +1358,9 @@ conditional-sources = [
 root-max-lines = 879
 root-max-tokens = 35383
 root-max-content-tokens = 35301
-closure-max-lines = 3548
-closure-max-tokens = 139997
-closure-max-content-tokens = 139704
+closure-max-lines = 3566
+closure-max-tokens = 140255
+closure-max-content-tokens = 139961
 conditional-max-lines = 589
 conditional-max-tokens = 18764
 conditional-max-content-tokens = 18717
@@ -1407,6 +1407,6 @@ roots = [
   "skills/shared/reviewer-templates.md",
   "skills/shared/voting-protocol.md",
 ]
-closure-max-lines = 5836
-closure-max-tokens = 165469
-closure-max-content-tokens = 165014
+closure-max-lines = 5854
+closure-max-tokens = 165727
+closure-max-content-tokens = 165271

--- a/crates/larch-adapters/build.rs
+++ b/crates/larch-adapters/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    let target = std::env::var("TARGET").expect("Cargo must provide TARGET to build scripts");
+    println!("cargo:rustc-env=LARCH_BUILD_TARGET={target}");
+}

--- a/crates/larch-adapters/src/lib.rs
+++ b/crates/larch-adapters/src/lib.rs
@@ -23,7 +23,7 @@ pub use filesystem::{
 /// Return metadata compiled into the adapter layer.
 #[must_use]
 pub const fn build_metadata() -> BuildMetadata {
-    BuildMetadata::new(env!("CARGO_PKG_VERSION"))
+    BuildMetadata::new(env!("CARGO_PKG_VERSION"), env!("LARCH_BUILD_TARGET"))
 }
 
 #[cfg(test)]
@@ -33,5 +33,6 @@ mod tests {
     #[test]
     fn build_metadata_uses_the_workspace_version() {
         assert_eq!(build_metadata().version(), env!("CARGO_PKG_VERSION"));
+        assert_eq!(build_metadata().target(), env!("LARCH_BUILD_TARGET"));
     }
 }

--- a/crates/larch-cli/src/main.rs
+++ b/crates/larch-cli/src/main.rs
@@ -16,9 +16,18 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Domain {
+    /// Internal bootstrap commands used before installation completes.
+    #[command(subcommand, hide = true)]
+    Bootstrap(BootstrapCommand),
     /// Non-production commands that exercise dispatcher wiring.
     #[command(subcommand)]
     Example(ExampleCommand),
+}
+
+#[derive(Subcommand)]
+enum BootstrapCommand {
+    /// Print the compiled version and target as machine-readable JSON.
+    SelfCheck,
 }
 
 #[derive(Subcommand)]
@@ -33,8 +42,11 @@ struct EchoArguments {
     message: String,
 }
 
-fn run(cli: Cli) {
+fn run(cli: Cli, metadata: larch_core::BuildMetadata) {
     match cli.domain {
+        Domain::Bootstrap(BootstrapCommand::SelfCheck) => {
+            println!("{}", larch_core::bootstrap_self_check(metadata));
+        }
         Domain::Example(ExampleCommand::Echo(arguments)) => {
             println!("{}", larch_core::example::echo(&arguments.message));
         }
@@ -46,6 +58,6 @@ fn main() -> ExitCode {
     let matches = Cli::command().version(metadata.version()).get_matches();
     let cli = Cli::from_arg_matches(&matches)
         .expect("arguments already validated by the generated Clap command");
-    run(cli);
+    run(cli, metadata);
     ExitCode::SUCCESS
 }

--- a/crates/larch-cli/tests/cli.rs
+++ b/crates/larch-cli/tests/cli.rs
@@ -58,6 +58,26 @@ fn version_reports_the_workspace_version() {
 }
 
 #[test]
+fn bootstrap_self_check_reports_machine_readable_build_identity() {
+    let output = larch()
+        .args(["bootstrap", "self-check"])
+        .output()
+        .expect("self-check should run");
+
+    assert!(output.status.success());
+    assert!(output.stderr.is_empty());
+    let payload: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("self-check should emit JSON");
+    assert_eq!(payload["schema_version"], 1);
+    assert_eq!(payload["version"], env!("CARGO_PKG_VERSION"));
+    assert!(
+        payload["target"]
+            .as_str()
+            .is_some_and(|target| !target.is_empty())
+    );
+}
+
+#[test]
 fn compiled_version_matches_the_plugin_release_version() {
     let plugin_manifest_path =
         Path::new(env!("CARGO_MANIFEST_DIR")).join("../../.claude-plugin/plugin.json");

--- a/crates/larch-core/src/context.rs
+++ b/crates/larch-core/src/context.rs
@@ -192,7 +192,7 @@ mod tests {
     #[test]
     fn runtime_context_preserves_validated_immutable_identity() {
         let context = RuntimeContext::new(
-            BuildMetadata::new("53.1.22"),
+            BuildMetadata::new("53.1.22", "aarch64-apple-darwin"),
             RunId::parse("run-abc").expect("fixture run ID should parse"),
             Some("session-123".to_owned()),
         );

--- a/crates/larch-core/src/lib.rs
+++ b/crates/larch-core/src/lib.rs
@@ -40,13 +40,14 @@ pub use time::{AsyncClock, BusinessClock, Deadline, MonotonicClock, MonotonicTim
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct BuildMetadata {
     version: &'static str,
+    target: &'static str,
 }
 
 impl BuildMetadata {
     /// Create metadata for a compile-time version.
     #[must_use]
-    pub const fn new(version: &'static str) -> Self {
-        Self { version }
+    pub const fn new(version: &'static str, target: &'static str) -> Self {
+        Self { version, target }
     }
 
     /// Return the build version.
@@ -54,6 +55,22 @@ impl BuildMetadata {
     pub const fn version(self) -> &'static str {
         self.version
     }
+
+    /// Return the compilation target triple.
+    #[must_use]
+    pub const fn target(self) -> &'static str {
+        self.target
+    }
+}
+
+/// Render the machine-readable identity checked by the installation shim.
+#[must_use]
+pub fn bootstrap_self_check(metadata: BuildMetadata) -> String {
+    format!(
+        "{{\"schema_version\":1,\"version\":\"{}\",\"target\":\"{}\"}}",
+        metadata.version(),
+        metadata.target()
+    )
 }
 
 /// Non-production use cases that prove command dispatch and library wiring.
@@ -67,13 +84,24 @@ pub mod example {
 
 #[cfg(test)]
 mod tests {
-    use super::{BuildMetadata, example};
+    use super::{BuildMetadata, bootstrap_self_check, example};
 
     #[test]
     fn build_metadata_preserves_the_version() {
-        let metadata = BuildMetadata::new("1.2.3");
+        let metadata = BuildMetadata::new("1.2.3", "aarch64-apple-darwin");
 
         assert_eq!(metadata.version(), "1.2.3");
+        assert_eq!(metadata.target(), "aarch64-apple-darwin");
+    }
+
+    #[test]
+    fn bootstrap_self_check_is_compact_machine_readable_json() {
+        let metadata = BuildMetadata::new("1.2.3", "x86_64-unknown-linux-gnu");
+
+        assert_eq!(
+            bootstrap_self_check(metadata),
+            r#"{"schema_version":1,"version":"1.2.3","target":"x86_64-unknown-linux-gnu"}"#
+        );
     }
 
     #[test]

--- a/docs/configuration-and-permissions.md
+++ b/docs/configuration-and-permissions.md
@@ -10,6 +10,11 @@
 
 **Copy-paste settings.allow snippet (Skill entries only).** Add these to your `.claude/settings.json` `permissions.allow` list, maintaining strict ASCII code-point order across the entire list. This snippet covers only the `Skill(...)` authorizations; you will also need `Bash(...)` allowlist patterns for larch's shell helpers — see larch's own [`.claude/settings.json`](../.claude/settings.json) for the full reference.
 
+The documented plugin-cache `Bash(.../scripts/*)` rule also authorizes
+`scripts/larch.sh`. Rust-backed skills and hooks must call that shim by
+absolute path. They must not ask strict-permission consumers to authorize a
+bare `bin/larch` command.
+
 ```json
 "Skill(alias)",
 "Skill(block-issue)",
@@ -167,6 +172,17 @@ The default Step 2 order depends on the implementation difficulty: **TRIVIAL** u
 The legacy `--codex-available true|false` knob is still accepted by the dispatcher for one release with a stderr deprecation warning (`true → coder=codex`, `false → coder=claude`); orchestrator-side, prefer `--coder` directly. Passing both flags together is a parse-time error.
 
 ## Environment Variables
+
+### `LARCH_BINARY`
+
+`LARCH_BINARY` selects an explicit local Rust executable for `scripts/larch.sh`.
+Use it with `claude --plugin-dir` development, where automatic release downloads
+are refused. The value must be an absolute, non-symlinked executable whose
+machine-readable version and target match the active plugin and host.
+
+Marketplace users normally leave it unset. Claude Code supplies
+`CLAUDE_PLUGIN_ROOT` and `CLAUDE_PLUGIN_DATA`; the bootstrap installs under the
+former and keeps its bounded concurrency lock under the latter.
 
 ### Stall Recovery Reports
 

--- a/docs/installation-and-setup.md
+++ b/docs/installation-and-setup.md
@@ -84,7 +84,7 @@ ADC can obtain an access token.
 - **OpenAI / Codex**: `npm install -g @openai/codex`
 - **Cursor / Cursor CLI** (larch uses it only as an agent, but the whole editor package needs to be installed)
 - **git**: version control (used by all skills)
-- **gh**: [GitHub CLI](https://cli.github.com/), authenticated with repo write access (`gh auth login`). Required for PR creation, CI monitoring, and merge automation.
+- **gh**: [GitHub CLI](https://cli.github.com/), authenticated with repo write access (`gh auth login`). The installed version must provide `gh release verify`, `gh attestation verify`, and immutable release metadata. Larch uses these commands for the first Rust binary install, PR creation, CI monitoring, and merge automation.
 - **jq**: [JSON processor](https://jqlang.github.io/jq/).
 - **python3**: Python 3.11 or newer
 
@@ -126,6 +126,38 @@ Larch is distributed as a [Claude Code plugin](https://code.claude.com/docs/en/p
 claude plugin marketplace add character-ai/larch --sparse .claude-plugin agents docs hooks python scripts skills
 claude plugin install larch@larch-local
 ```
+
+### Rust executable bootstrap
+
+Every Rust-backed entrypoint must call
+`${CLAUDE_PLUGIN_ROOT}/scripts/larch.sh`. On first use, the shim installs the
+executable that exactly matches the plugin version.
+It downloads the versioned manifest, checksum file, and host archive from the
+immutable `v<plugin-version>` release. It verifies release and asset
+attestations, the strict manifest, SHA-256 digests, archive members, and the
+staged executable's machine-readable identity before atomically installing
+`${CLAUDE_PLUGIN_ROOT}/bin/larch`.
+
+Claude Code supplies `CLAUDE_PLUGIN_ROOT` and `CLAUDE_PLUGIN_DATA` to plugin
+commands. The latter holds the bounded first-use lock. A failed bootstrap keeps
+an existing executable intact and prints retry guidance. Run the same command
+again after fixing a missing tool, authentication problem, or interrupted
+download.
+
+Local `--plugin-dir` development never downloads into the checkout. Build and
+select the executable explicitly:
+
+```bash
+cargo build --locked --release --package larch-cli
+CLAUDE_PLUGIN_ROOT="$PWD" \
+CLAUDE_PLUGIN_DATA="${TMPDIR:-/tmp}/larch-plugin-data" \
+LARCH_BINARY="$PWD/target/release/larch" \
+"$PWD/scripts/larch.sh" example echo "local build"
+```
+
+`LARCH_BINARY` must be an absolute, regular executable. Its version and target
+self-check must match the active plugin and host.
+
 ### Configure Claude
 Edit `~/.claude/settings.json` and add a `permissions`/`allow` section (if it does not have one yet) with this entry. NOTE: replace `<your-user-name>`!
 

--- a/docs/linting.md
+++ b/docs/linting.md
@@ -496,7 +496,11 @@ Focused harnesses cover the /design auto-reporting port:
 
 Bash-targeting linters use the residual shell manifest instead of broad repo discovery. The shared reader is `python3 python/cli.py residual-bash paths [--root PATH]`; fixture harnesses pass `--root` so they read the fixture manifest.
 
-The residual manifest covers kept hooks, thin wrappers, `scripts/sleep-seconds.sh`, the combine-issues helper, residual harnesses, and any standalone source `.awk` helper. Terminal shared libraries, retired non-thin helpers, and verified-zero-consumer includes are absent.
+The residual manifest covers kept hooks, thin wrappers, the approved
+`scripts/larch.sh` clean-install bootstrap, `scripts/sleep-seconds.sh`, the
+combine-issues helper, residual harnesses, and any standalone source `.awk`
+helper. Terminal shared libraries, retired non-thin helpers, and
+verified-zero-consumer includes are absent.
 
 Agent-lint G010/G011 treat `scripts/agent-lint-script-inventory.txt` as their authoritative explicit scope, even if another rule excludes one of its paths. Add standalone awk helpers to that inventory in the same change; its test enforces complete residual-Bash coverage. CI shellcheck continues to read `scripts/residual-bash-paths.txt`. Test shard rebalance is deferred to `/rebalance-tests`.
 

--- a/python/tests/release/test_bootstrap.py
+++ b/python/tests/release/test_bootstrap.py
@@ -1,0 +1,542 @@
+"""Clean-install bootstrap, verification, locking, and attack coverage."""
+
+from __future__ import annotations
+
+import gzip
+import hashlib
+import io
+import json
+import os
+import shutil
+import subprocess
+import tarfile
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from larch.release import assets
+
+VERSION = "1.2.3"
+TAG = f"v{VERSION}"
+SOURCE_COMMIT = "a" * 40
+SCRIPT = Path(__file__).parents[3] / "scripts" / "larch.sh"
+
+
+@dataclass(frozen=True)
+class BootstrapFixture:
+    root: Path
+    data: Path
+    release: Path
+    tools: Path
+    log: Path
+    target: str
+
+
+def _fake_binary(version: str, target: str) -> bytes:
+    return f"""#!/bin/sh
+case "$1" in
+  --version) printf 'larch {version}\\n' ;;
+  bootstrap)
+    [ "${{2:-}}" = self-check ] || exit 2
+    printf '%s\\n' '{{"schema_version":1,"version":"{version}","target":"{target}"}}'
+    ;;
+  *) printf 'ran:%s\\n' "$*" ;;
+esac
+""".encode()
+
+
+def _archive_bytes(
+    binary: bytes,
+    *,
+    first_name: str = "larch",
+    first_type: bytes = tarfile.REGTYPE,
+    include_extra: bool = False,
+) -> bytes:
+    tar_buffer = io.BytesIO()
+    with tarfile.open(
+        fileobj=tar_buffer, mode="w", format=tarfile.USTAR_FORMAT
+    ) as archive:
+        first = tarfile.TarInfo(first_name)
+        first.mode = 0o755
+        first.mtime = 0
+        first.uid = 0
+        first.gid = 0
+        first.type = first_type
+        if first_type == tarfile.REGTYPE:
+            first.size = len(binary)
+            archive.addfile(first, io.BytesIO(binary))
+        elif first_type == tarfile.SYMTYPE:
+            first.linkname = "LICENSE"
+            archive.addfile(first)
+        else:
+            archive.addfile(first)
+
+        license_info = tarfile.TarInfo("LICENSE")
+        license_bytes = b"test license\n"
+        license_info.mode = 0o644
+        license_info.mtime = 0
+        license_info.uid = 0
+        license_info.gid = 0
+        license_info.size = len(license_bytes)
+        archive.addfile(license_info, io.BytesIO(license_bytes))
+
+        if include_extra:
+            extra = tarfile.TarInfo("unexpected")
+            extra.mode = 0o644
+            extra.mtime = 0
+            extra.uid = 0
+            extra.gid = 0
+            extra.size = 1
+            archive.addfile(extra, io.BytesIO(b"x"))
+
+    gzip_buffer = io.BytesIO()
+    with gzip.GzipFile(filename="", mode="wb", fileobj=gzip_buffer, mtime=0) as output:
+        _ = output.write(tar_buffer.getvalue())
+    return gzip_buffer.getvalue()
+
+
+def _manifest(release: Path) -> dict[str, object]:
+    records: list[dict[str, object]] = []
+    for target in assets.TARGETS:
+        archive_name = f"larch-v{VERSION}-{target}.tar.gz"
+        archive_data = (release / archive_name).read_bytes()
+        records.append(
+            {
+                "target": target,
+                "archive": archive_name,
+                "byte_size": len(archive_data),
+                "sha256": hashlib.sha256(archive_data).hexdigest(),
+                "binary_path": "larch",
+                "minimum_os_or_libc": assets.TARGET_CONTRACTS[target].to_json(),
+            }
+        )
+    return {
+        "schema_version": 1,
+        "plugin_version": VERSION,
+        "tag": TAG,
+        "source_commit": SOURCE_COMMIT,
+        "assets": records,
+    }
+
+
+def _refresh_metadata(release: Path, manifest: dict[str, object] | None = None) -> None:
+    manifest_value = _manifest(release) if manifest is None else manifest
+    manifest_path = release / f"larch-v{VERSION}-manifest.json"
+    _ = manifest_path.write_text(
+        json.dumps(manifest_value, indent=2) + "\n", encoding="utf-8"
+    )
+    names = [f"larch-v{VERSION}-{target}.tar.gz" for target in assets.TARGETS]
+    names.append(manifest_path.name)
+    checksums = "".join(
+        f"{hashlib.sha256((release / name).read_bytes()).hexdigest()}  {name}\n"
+        for name in names
+    )
+    _ = (release / f"larch-v{VERSION}-SHA256SUMS").write_text(
+        checksums, encoding="ascii"
+    )
+
+
+def _write_tool(path: Path, text: str) -> None:
+    _ = path.write_text(text, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _stub_tools(tools: Path) -> None:
+    tools.mkdir()
+    _write_tool(
+        tools / "uname",
+        """#!/bin/sh
+case "$1" in
+  -s) printf '%s\\n' "$TEST_UNAME_S" ;;
+  -m) printf '%s\\n' "$TEST_UNAME_M" ;;
+  *) exit 2 ;;
+esac
+""",
+    )
+    _write_tool(
+        tools / "gh",
+        """#!/bin/sh
+set -eu
+if [ "$1:$2:${3:-}" = "release:verify:--help" ]; then
+  printf 'verify release attestation\\n'
+  exit 0
+fi
+if [ "$1:$2:${3:-}" = "attestation:verify:--help" ]; then
+  printf 'verify artifact attestation\\n'
+  exit 0
+fi
+if [ "$1:$2:${3:-}" = "release:view:--help" ]; then
+  printf 'JSON FIELDS: isImmutable assets\\n'
+  exit 0
+fi
+if [ "$1:$2" = "release:verify" ]; then
+  [ "${GH_FAIL:-}" != release ]
+  exit 0
+fi
+if [ "$1:$2" = "release:view" ]; then
+  [ "${GH_FAIL:-}" != view ]
+  printf '%s\\n' "v$TEST_VERSION" true false false \
+    "larch-v$TEST_VERSION-aarch64-apple-darwin.tar.gz" \
+    "larch-v$TEST_VERSION-x86_64-apple-darwin.tar.gz" \
+    "larch-v$TEST_VERSION-aarch64-unknown-linux-gnu.tar.gz" \
+    "larch-v$TEST_VERSION-x86_64-unknown-linux-gnu.tar.gz" \
+    "larch-v$TEST_VERSION-manifest.json" \
+    "larch-v$TEST_VERSION-SHA256SUMS"
+  exit 0
+fi
+if [ "$1" = api ]; then
+  printf '%s\\n' "$TEST_SOURCE_COMMIT"
+  exit 0
+fi
+if [ "$1:$2" = "release:download" ]; then
+  [ "${GH_FAIL:-}" != download ]
+  printf 'download\\n' >> "$GH_LOG"
+  if [ "${GH_DOWNLOAD_DELAY:-0}" != 0 ]; then sleep "$GH_DOWNLOAD_DELAY"; fi
+  download_dir=""
+  while [ "$#" -gt 0 ]; do
+    if [ "$1" = --dir ]; then
+      download_dir="$2"
+      shift 2
+    else
+      shift
+    fi
+  done
+  cp "$TEST_RELEASE/larch-v$TEST_VERSION-manifest.json" "$download_dir/"
+  cp "$TEST_RELEASE/larch-v$TEST_VERSION-SHA256SUMS" "$download_dir/"
+  cp "$TEST_RELEASE/larch-v$TEST_VERSION-$TEST_TARGET.tar.gz" "$download_dir/"
+  exit 0
+fi
+if [ "$1:$2" = "attestation:verify" ]; then
+  [ "${GH_FAIL:-}" != attestation ]
+  printf 'attestation\\n' >> "$GH_LOG"
+  exit 0
+fi
+exit 2
+""",
+    )
+
+
+def _fixture(
+    tmp_path: Path, target: str = "x86_64-unknown-linux-gnu"
+) -> BootstrapFixture:
+    root = tmp_path / "plugin"
+    data = tmp_path / "data"
+    release = tmp_path / "release"
+    tools = tmp_path / "tools"
+    log = tmp_path / "gh.log"
+    (root / ".claude-plugin").mkdir(parents=True)
+    release.mkdir()
+    _ = (root / ".claude-plugin" / "plugin.json").write_text(
+        json.dumps({"name": "larch", "version": VERSION}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    for release_target in assets.TARGETS:
+        archive_name = f"larch-v{VERSION}-{release_target}.tar.gz"
+        _ = (release / archive_name).write_bytes(
+            _archive_bytes(_fake_binary(VERSION, release_target))
+        )
+    _refresh_metadata(release)
+    _stub_tools(tools)
+    return BootstrapFixture(root, data, release, tools, log, target)
+
+
+def _host_for_target(target: str) -> tuple[str, str]:
+    mapping = {
+        "aarch64-apple-darwin": ("Darwin", "arm64"),
+        "x86_64-apple-darwin": ("Darwin", "x86_64"),
+        "aarch64-unknown-linux-gnu": ("Linux", "aarch64"),
+        "x86_64-unknown-linux-gnu": ("Linux", "x86_64"),
+    }
+    return mapping[target]
+
+
+def _environment(fixture: BootstrapFixture, **updates: str) -> dict[str, str]:
+    os_name, architecture = _host_for_target(fixture.target)
+    environment: dict[str, str] = {
+        **os.environ,
+        "CLAUDE_PLUGIN_ROOT": str(fixture.root),
+        "CLAUDE_PLUGIN_DATA": str(fixture.data),
+        "GH_LOG": str(fixture.log),
+        "PATH": f"{fixture.tools}:{os.environ['PATH']}",
+        "TEST_RELEASE": str(fixture.release),
+        "TEST_SOURCE_COMMIT": SOURCE_COMMIT,
+        "TEST_TARGET": fixture.target,
+        "TEST_UNAME_M": architecture,
+        "TEST_UNAME_S": os_name,
+        "TEST_VERSION": VERSION,
+    }
+    environment.update(updates)
+    return environment
+
+
+def _run(
+    fixture: BootstrapFixture,
+    *arguments: str,
+    environment: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["/bin/bash", str(SCRIPT), *arguments],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=_environment(fixture) if environment is None else environment,
+        timeout=20,
+    )
+
+
+@pytest.mark.parametrize("target", assets.TARGETS)
+def test_clean_install_maps_every_supported_target_and_executes(
+    target: str, tmp_path: Path
+) -> None:
+    fixture = _fixture(tmp_path, target)
+
+    result = _run(fixture, "example", "echo", target)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == f"ran:example echo {target}\n"
+    assert (fixture.root / "bin" / "larch").is_file()
+    assert fixture.log.read_text(encoding="utf-8").splitlines().count("download") == 1
+    assert (
+        fixture.log.read_text(encoding="utf-8").splitlines().count("attestation") == 3
+    )
+
+
+def test_unsupported_target_fails_with_retry_guidance(tmp_path: Path) -> None:
+    fixture = _fixture(tmp_path)
+    environment = _environment(fixture, TEST_UNAME_S="FreeBSD", TEST_UNAME_M="x86_64")
+
+    result = _run(fixture, environment=environment)
+
+    assert result.returncode == 1
+    assert "unsupported operating system or architecture" in result.stderr
+    assert "Retry the command" in result.stderr
+    assert not (fixture.root / "bin" / "larch").exists()
+
+
+def test_missing_required_tool_fails_closed_with_retry_guidance(tmp_path: Path) -> None:
+    fixture = _fixture(tmp_path)
+    isolated_tools = tmp_path / "isolated-tools"
+    isolated_tools.mkdir()
+    required = [
+        "awk",
+        "bash",
+        "chmod",
+        "cmp",
+        "dd",
+        "gzip",
+        "ln",
+        "mkdir",
+        "mktemp",
+        "mv",
+        "rm",
+        "rmdir",
+        "sed",
+        "sleep",
+        "sort",
+        "tar",
+        "tr",
+        "uname",
+        "wc",
+    ]
+    sha_tool = "sha256sum" if shutil.which("sha256sum") is not None else "shasum"
+    required.append(sha_tool)
+    for command in required:
+        source = shutil.which(command)
+        assert source is not None
+        (isolated_tools / command).symlink_to(source)
+    environment = _environment(fixture)
+    environment["PATH"] = str(isolated_tools)
+
+    result = _run(fixture, environment=environment)
+
+    assert result.returncode == 1
+    assert "required tool is missing: gh" in result.stderr
+    assert "Retry the command" in result.stderr
+
+
+@pytest.mark.parametrize("failure", ["release", "view", "download", "attestation"])
+def test_github_and_attestation_failures_leave_existing_binary_untouched(
+    failure: str, tmp_path: Path
+) -> None:
+    fixture = _fixture(tmp_path)
+    binary = fixture.root / "bin" / "larch"
+    binary.parent.mkdir()
+    original = _fake_binary("1.2.2", fixture.target)
+    _ = binary.write_bytes(original)
+    binary.chmod(0o755)
+
+    result = _run(fixture, environment=_environment(fixture, GH_FAIL=failure))
+
+    assert result.returncode != 0
+    assert "Retry the command" in result.stderr
+    assert binary.read_bytes() == original
+    assert list(binary.parent.glob(".larch-bootstrap.*")) == []
+
+
+def test_same_version_wrong_target_is_atomically_replaced(tmp_path: Path) -> None:
+    fixture = _fixture(tmp_path)
+    binary = fixture.root / "bin" / "larch"
+    binary.parent.mkdir()
+    _ = binary.write_bytes(_fake_binary(VERSION, "aarch64-apple-darwin"))
+    binary.chmod(0o755)
+    previous_inode = binary.stat().st_ino
+
+    result = _run(fixture, "example", "echo", "replacement")
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "ran:example echo replacement\n"
+    assert binary.stat().st_ino != previous_inode
+    assert fixture.log.read_text(encoding="utf-8").splitlines().count("download") == 1
+
+
+def test_digest_mismatch_fails_before_replacement(tmp_path: Path) -> None:
+    fixture = _fixture(tmp_path)
+    archive = fixture.release / f"larch-v{VERSION}-{fixture.target}.tar.gz"
+    _ = archive.write_bytes(archive.read_bytes() + b"corrupt")
+
+    result = _run(fixture)
+
+    assert result.returncode == 1
+    assert "archive byte size does not match" in result.stderr
+    assert not (fixture.root / "bin" / "larch").exists()
+
+
+def test_manifest_schema_and_identity_are_strict(tmp_path: Path) -> None:
+    fixture = _fixture(tmp_path)
+    manifest = _manifest(fixture.release)
+    manifest["unexpected"] = True
+    _refresh_metadata(fixture.release, manifest)
+
+    result = _run(fixture)
+
+    assert result.returncode == 1
+    assert "manifest violates the strict schema" in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("first_name", "first_type", "include_extra"),
+    [
+        ("../larch", tarfile.REGTYPE, False),
+        ("larch", tarfile.SYMTYPE, False),
+        ("larch", tarfile.CHRTYPE, False),
+        ("larch", tarfile.REGTYPE, True),
+    ],
+)
+def test_archive_attacks_are_rejected(
+    first_name: str, first_type: bytes, include_extra: bool, tmp_path: Path
+) -> None:
+    fixture = _fixture(tmp_path)
+    archive = fixture.release / f"larch-v{VERSION}-{fixture.target}.tar.gz"
+    _ = archive.write_bytes(
+        _archive_bytes(
+            _fake_binary(VERSION, fixture.target),
+            first_name=first_name,
+            first_type=first_type,
+            include_extra=include_extra,
+        )
+    )
+    _refresh_metadata(fixture.release)
+
+    result = _run(fixture)
+
+    assert result.returncode == 1
+    assert "archive" in result.stderr
+    assert not (fixture.root / "bin" / "larch").exists()
+
+
+def test_staged_version_mismatch_is_rejected(tmp_path: Path) -> None:
+    fixture = _fixture(tmp_path)
+    archive = fixture.release / f"larch-v{VERSION}-{fixture.target}.tar.gz"
+    _ = archive.write_bytes(_archive_bytes(_fake_binary("9.9.9", fixture.target)))
+    _refresh_metadata(fixture.release)
+
+    result = _run(fixture)
+
+    assert result.returncode == 1
+    assert "staged executable reports the wrong version" in result.stderr
+
+
+def test_dead_lock_is_recovered_and_waiter_installs(tmp_path: Path) -> None:
+    fixture = _fixture(tmp_path)
+    lock = fixture.data / "bootstrap.lock"
+    lock.mkdir(parents=True)
+    _ = (lock / "owner").write_text("999999999\n", encoding="ascii")
+
+    result = _run(fixture, "example", "echo", "recovered")
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "ran:example echo recovered\n"
+    assert not lock.exists()
+
+
+def test_concurrent_first_use_downloads_once(tmp_path: Path) -> None:
+    fixture = _fixture(tmp_path)
+    environment = _environment(fixture, GH_DOWNLOAD_DELAY="1")
+    command = ["/bin/bash", str(SCRIPT), "example", "echo", "concurrent"]
+
+    first = subprocess.Popen(
+        command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=environment,
+    )
+    second = subprocess.Popen(
+        command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=environment,
+    )
+    first_stdout, first_stderr = first.communicate(timeout=20)
+    second_stdout, second_stderr = second.communicate(timeout=20)
+
+    assert first.returncode == 0, first_stderr
+    assert second.returncode == 0, second_stderr
+    assert first_stdout == "ran:example echo concurrent\n"
+    assert second_stdout == "ran:example echo concurrent\n"
+    assert fixture.log.read_text(encoding="utf-8").splitlines().count("download") == 1
+
+
+def test_interrupted_staging_is_ignored_and_only_owned_stage_is_cleaned(
+    tmp_path: Path,
+) -> None:
+    fixture = _fixture(tmp_path)
+    interrupted = fixture.root / "bin" / ".larch-bootstrap.interrupted"
+    interrupted.mkdir(parents=True)
+    _ = (interrupted / "partial").write_text(
+        "keep for explicit cleanup\n", encoding="utf-8"
+    )
+
+    result = _run(fixture, "example", "echo", "fresh")
+
+    assert result.returncode == 0, result.stderr
+    assert (interrupted / "partial").is_file()
+    owned_stages = [
+        path
+        for path in interrupted.parent.glob(".larch-bootstrap.*")
+        if path != interrupted
+    ]
+    assert owned_stages == []
+
+
+def test_local_plugin_dir_requires_explicit_matching_override(tmp_path: Path) -> None:
+    fixture = _fixture(tmp_path)
+    (fixture.root / ".git").mkdir()
+
+    refused = _run(fixture)
+
+    assert refused.returncode == 1
+    assert "local --plugin-dir checkout needs an explicit build" in refused.stderr
+    assert not (fixture.root / "bin").exists()
+
+    override = tmp_path / "built-larch"
+    _ = override.write_bytes(_fake_binary(VERSION, fixture.target))
+    override.chmod(0o755)
+    environment = _environment(fixture, LARCH_BINARY=str(override))
+    accepted = _run(fixture, "example", "echo", "override", environment=environment)
+
+    assert accepted.returncode == 0, accepted.stderr
+    assert accepted.stdout == "ran:example echo override\n"
+    assert not (fixture.root / "bin").exists()

--- a/python/tests/release/test_bootstrap.py
+++ b/python/tests/release/test_bootstrap.py
@@ -371,7 +371,7 @@ def test_github_and_attestation_failures_leave_existing_binary_untouched(
     assert result.returncode != 0
     assert "Retry the command" in result.stderr
     assert binary.read_bytes() == original
-    assert list(binary.parent.glob(".larch-bootstrap.*")) == []
+    assert not list(binary.parent.glob(".larch-bootstrap.*"))
 
 
 def test_same_version_wrong_target_is_atomically_replaced(tmp_path: Path) -> None:
@@ -475,22 +475,24 @@ def test_concurrent_first_use_downloads_once(tmp_path: Path) -> None:
     environment = _environment(fixture, GH_DOWNLOAD_DELAY="1")
     command = ["/bin/bash", str(SCRIPT), "example", "echo", "concurrent"]
 
-    first = subprocess.Popen(
-        command,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-        env=environment,
-    )
-    second = subprocess.Popen(
-        command,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-        env=environment,
-    )
-    first_stdout, first_stderr = first.communicate(timeout=20)
-    second_stdout, second_stderr = second.communicate(timeout=20)
+    with (
+        subprocess.Popen(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=environment,
+        ) as first,
+        subprocess.Popen(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=environment,
+        ) as second,
+    ):
+        first_stdout, first_stderr = first.communicate(timeout=20)
+        second_stdout, second_stderr = second.communicate(timeout=20)
 
     assert first.returncode == 0, first_stderr
     assert second.returncode == 0, second_stderr

--- a/python/tests/release/test_rust_bootstrap.py
+++ b/python/tests/release/test_rust_bootstrap.py
@@ -1,4 +1,4 @@
-"""Clean-install bootstrap, verification, locking, and attack coverage."""
+"""Rust clean-install bootstrap, verification, locking, and attack coverage."""
 
 from __future__ import annotations
 

--- a/scripts/agent-lint-script-inventory.txt
+++ b/scripts/agent-lint-script-inventory.txt
@@ -15,6 +15,7 @@ scripts/external-tool-registry.sh
 scripts/file-failure-report-cross-repo.sh
 scripts/flush-vendor-failure-diagnostics.sh
 scripts/hook-anti-read-poll.sh
+scripts/larch.sh
 scripts/sessionstart-statusline.sh
 scripts/pre-commit-bash-syntax.sh
 scripts/pre-commit-shellcheck.sh

--- a/scripts/larch.sh
+++ b/scripts/larch.sh
@@ -1,0 +1,601 @@
+#!/usr/bin/env bash
+# Install the release-matched Rust executable when needed, then replace this
+# process with it. Keep this bootstrap compatible with macOS Bash 3.2.
+set -eEuo pipefail
+
+readonly RELEASE_REPO="character-ai/larch"
+readonly RELEASE_WORKFLOW="character-ai/larch/.github/workflows/rust-release-assets.yaml"
+readonly LOCK_WAIT_SECONDS=120
+
+plugin_root=""
+plugin_data=""
+bin_dir=""
+binary_path=""
+stage_dir=""
+lock_dir=""
+lock_held=false
+sha_command=""
+
+retry_hint() {
+    printf '%s\n' "Retry the command after correcting the reported problem. No existing larch binary was changed before verified installation." >&2
+}
+
+die() {
+    printf 'larch bootstrap: %s\n' "$1" >&2
+    retry_hint
+    exit 1
+}
+
+read_lock_owner() {
+    local owner_path="$1"
+    local owner=""
+    [ -f "$owner_path" ] && [ ! -L "$owner_path" ] || return 1
+    owner="$(awk 'NR == 1 && $0 ~ /^[1-9][0-9]*$/ { value = $0; next } { exit 1 } END { if (NR == 1) print value; else exit 1 }' "$owner_path")" || return 1
+    printf '%s\n' "$owner"
+}
+
+cleanup() {
+    local owner=""
+    if [ "$lock_held" = true ] && [ -n "$lock_dir" ] && [ -d "$lock_dir" ] && [ ! -L "$lock_dir" ]; then
+        owner="$(read_lock_owner "$lock_dir/owner" 2>/dev/null || true)"
+        if [ "$owner" = "$$" ]; then
+            rm -f -- "$lock_dir/owner"
+            rmdir "$lock_dir" 2>/dev/null || true
+        fi
+    fi
+    lock_held=false
+    if [ -n "$stage_dir" ] && [ -n "$bin_dir" ]; then
+        case "$stage_dir" in
+            "$bin_dir"/.larch-bootstrap.*)
+                if [ -d "$stage_dir" ] && [ ! -L "$stage_dir" ]; then
+                    rm -rf -- "$stage_dir"
+                fi
+                ;;
+        esac
+    fi
+    stage_dir=""
+}
+
+unexpected_error() {
+    local status="$1"
+    local line="$2"
+    trap - ERR
+    printf 'larch bootstrap: installation failed at script line %s (exit %s).\n' "$line" "$status" >&2
+    retry_hint
+    exit "$status"
+}
+
+trap cleanup EXIT
+trap 'unexpected_error "$?" "$LINENO"' ERR
+
+validate_absolute_path() {
+    local label="$1"
+    local path="$2"
+    local probe=""
+    case "$path" in
+        /*) ;;
+        *) die "$label must be an absolute path" ;;
+    esac
+    case "$path/" in
+        *$'\n'*|*'/../'*|*'/./'*|*'//'*) die "$label contains an unsafe path component" ;;
+    esac
+    probe="$path"
+    while [ "$probe" != "/" ]; do
+        if [ -L "$probe" ]; then
+            die "$label or one of its existing ancestors is a symlink: $probe"
+        fi
+        probe="${probe%/*}"
+        [ -n "$probe" ] || probe="/"
+    done
+}
+
+read_plugin_version() {
+    local manifest="$1"
+    local version=""
+    [ -f "$manifest" ] && [ ! -L "$manifest" ] || die "plugin manifest is missing or unsafe: $manifest"
+    version="$(awk -F '"' '$2 == "version" { count++; value = $4 } END { if (count == 1) print value; else exit 1 }' "$manifest")" || die "plugin manifest must contain exactly one version string"
+    if ! [[ "$version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+        die "plugin manifest version is not a release semantic version"
+    fi
+    printf '%s\n' "$version"
+}
+
+resolve_target() {
+    local os_name=""
+    local architecture=""
+    os_name="$(uname -s)"
+    architecture="$(uname -m)"
+    case "$os_name:$architecture" in
+        Darwin:arm64|Darwin:aarch64) printf '%s\n' "aarch64-apple-darwin" ;;
+        Darwin:x86_64|Darwin:amd64) printf '%s\n' "x86_64-apple-darwin" ;;
+        Linux:arm64|Linux:aarch64) printf '%s\n' "aarch64-unknown-linux-gnu" ;;
+        Linux:x86_64|Linux:amd64) printf '%s\n' "x86_64-unknown-linux-gnu" ;;
+        *) die "unsupported operating system or architecture: $os_name/$architecture" ;;
+    esac
+}
+
+binary_matches_version() {
+    local candidate="$1"
+    local expected_version="$2"
+    local reported=""
+    [ -f "$candidate" ] && [ ! -L "$candidate" ] && [ -x "$candidate" ] || return 1
+    reported="$("$candidate" --version 2>/dev/null)" || return 1
+    [ "$reported" = "larch $expected_version" ]
+}
+
+binary_passes_self_check() {
+    local candidate="$1"
+    local expected_version="$2"
+    local expected_target="$3"
+    local reported=""
+    local expected=""
+    reported="$("$candidate" bootstrap self-check 2>/dev/null)" || return 1
+    expected="{\"schema_version\":1,\"version\":\"$expected_version\",\"target\":\"$expected_target\"}"
+    [ "$reported" = "$expected" ]
+}
+
+require_commands() {
+    local command_name=""
+    for command_name in awk chmod cmp dd gh gzip kill ln mkdir mktemp mv rm rmdir sed sleep sort tar tr uname wc; do
+        command -v "$command_name" >/dev/null 2>&1 || die "required tool is missing: $command_name"
+    done
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha_command="sha256sum"
+    elif command -v shasum >/dev/null 2>&1; then
+        sha_command="shasum"
+    else
+        die "required SHA-256 tool is missing: install sha256sum or shasum"
+    fi
+    gh release verify --help >/dev/null 2>&1 || die "GitHub CLI is too old: gh release verify is required"
+    gh attestation verify --help >/dev/null 2>&1 || die "GitHub CLI is too old: gh attestation verify is required"
+    gh release view --help 2>/dev/null | awk '/isImmutable/ { found = 1 } END { exit(found ? 0 : 1) }' || die "GitHub CLI is too old: immutable release metadata is required"
+}
+
+sha256_file() {
+    local path="$1"
+    local digest=""
+    if [ "$sha_command" = "sha256sum" ]; then
+        digest="$(sha256sum "$path" | awk '{ print $1 }')"
+    else
+        digest="$(shasum -a 256 "$path" | awk '{ print $1 }')"
+    fi
+    case "$digest" in
+        *[!0-9a-f]*|'') die "SHA-256 tool returned an invalid digest for ${path##*/}" ;;
+    esac
+    [ "${#digest}" -eq 64 ] || die "SHA-256 tool returned an invalid digest length for ${path##*/}"
+    printf '%s\n' "$digest"
+}
+
+acquire_lock() {
+    local attempts=0
+    local observed_owner=""
+    local moved_owner=""
+    local stale_claim=""
+    mkdir -p -- "$plugin_data"
+    [ -d "$plugin_data" ] && [ ! -L "$plugin_data" ] || die "plugin data root is not a real directory"
+    chmod 700 "$plugin_data"
+    lock_dir="$plugin_data/bootstrap.lock"
+    while ! mkdir "$lock_dir" 2>/dev/null; do
+        [ -d "$lock_dir" ] && [ ! -L "$lock_dir" ] || die "bootstrap lock path is unsafe"
+        observed_owner="$(read_lock_owner "$lock_dir/owner" 2>/dev/null || true)"
+        if [ -n "$observed_owner" ] && ! kill -0 "$observed_owner" 2>/dev/null; then
+            stale_claim="$plugin_data/.bootstrap-lock-stale.$$"
+            [ ! -e "$stale_claim" ] && [ ! -L "$stale_claim" ] || die "stale-lock claim path already exists"
+            if mv "$lock_dir" "$stale_claim" 2>/dev/null; then
+                moved_owner="$(read_lock_owner "$stale_claim/owner" 2>/dev/null || true)"
+                if [ "$moved_owner" != "$observed_owner" ]; then
+                    [ -e "$lock_dir" ] || mv "$stale_claim" "$lock_dir"
+                else
+                    rm -f -- "$stale_claim/owner"
+                    if ! rmdir "$stale_claim"; then
+                        [ -e "$lock_dir" ] || mv "$stale_claim" "$lock_dir"
+                        die "stale bootstrap lock contains unexpected files"
+                    fi
+                fi
+            fi
+        elif [ -z "$observed_owner" ] && [ "$attempts" -ge 2 ]; then
+            rmdir "$lock_dir" 2>/dev/null || true
+        fi
+        attempts=$((attempts + 1))
+        [ "$attempts" -lt "$LOCK_WAIT_SECONDS" ] || die "timed out waiting for another larch bootstrap; retry after it exits"
+        sleep 1
+    done
+    lock_held=true
+    umask 077
+    printf '%s\n' "$$" > "$lock_dir/owner"
+    [ "$(read_lock_owner "$lock_dir/owner")" = "$$" ] || die "bootstrap lock ownership could not be verified"
+}
+
+write_expected_release_assets() {
+    local version="$1"
+    local output="$2"
+    printf '%s\n' \
+        "larch-v$version-SHA256SUMS" \
+        "larch-v$version-aarch64-apple-darwin.tar.gz" \
+        "larch-v$version-aarch64-unknown-linux-gnu.tar.gz" \
+        "larch-v$version-manifest.json" \
+        "larch-v$version-x86_64-apple-darwin.tar.gz" \
+        "larch-v$version-x86_64-unknown-linux-gnu.tar.gz" | sort > "$output"
+}
+
+verify_release_surface() {
+    local version="$1"
+    local tag="$2"
+    local release_info="$stage_dir/release-info.txt"
+    local actual_assets="$stage_dir/release-assets.txt"
+    local expected_assets="$stage_dir/expected-assets.txt"
+    gh release verify "$tag" --repo "$RELEASE_REPO" >/dev/null
+    gh release view "$tag" --repo "$RELEASE_REPO" \
+        --json tagName,isImmutable,isDraft,isPrerelease,assets \
+        --jq '.tagName, (.isImmutable | tostring), (.isDraft | tostring), (.isPrerelease | tostring), (.assets[].name)' > "$release_info"
+    [ "$(sed -n '1p' "$release_info")" = "$tag" ] || die "release tag identity mismatch"
+    [ "$(sed -n '2p' "$release_info")" = "true" ] || die "release is not immutable"
+    [ "$(sed -n '3p' "$release_info")" = "false" ] || die "release is still a draft"
+    [ "$(sed -n '4p' "$release_info")" = "false" ] || die "release is a prerelease"
+    sed -n '5,$p' "$release_info" | sort > "$actual_assets"
+    write_expected_release_assets "$version" "$expected_assets"
+    cmp -s "$actual_assets" "$expected_assets" || die "release asset allowlist mismatch"
+}
+
+validate_checksums() {
+    local path="$1"
+    local version="$2"
+    local target="$3"
+    awk -v version="$version" -v selected="$target" '
+        function target_at(asset_index) {
+            if (asset_index == 1) return "aarch64-apple-darwin"
+            if (asset_index == 2) return "x86_64-apple-darwin"
+            if (asset_index == 3) return "aarch64-unknown-linux-gnu"
+            if (asset_index == 4) return "x86_64-unknown-linux-gnu"
+            return ""
+        }
+        function fail() { exit 1 }
+        {
+            if (NR > 5 || length($0) < 67) fail()
+            digest = substr($0, 1, 64)
+            separator = substr($0, 65, 2)
+            name = substr($0, 67)
+            if (digest !~ /^[0-9a-f]+$/ || length(digest) != 64 || separator != "  ") fail()
+            if (NR <= 4) {
+                target = target_at(NR)
+                expected = "larch-v" version "-" target ".tar.gz"
+                if (name != expected) fail()
+                if (target == selected) selected_digest = digest
+            } else {
+                if (name != "larch-v" version "-manifest.json") fail()
+                manifest_digest = digest
+            }
+        }
+        END {
+            if (NR != 5 || selected_digest == "" || manifest_digest == "") exit 1
+            print manifest_digest, selected_digest
+        }
+    ' "$path"
+}
+
+validate_manifest() {
+    local path="$1"
+    local version="$2"
+    local tag="$3"
+    local source_commit="$4"
+    local selected_target="$5"
+    awk -v version="$version" -v tag="$tag" -v commit="$source_commit" -v selected="$selected_target" '
+        function fail() { exit 1 }
+        function target_at(asset_index) {
+            if (asset_index == 1) return "aarch64-apple-darwin"
+            if (asset_index == 2) return "x86_64-apple-darwin"
+            if (asset_index == 3) return "aarch64-unknown-linux-gnu"
+            if (asset_index == 4) return "x86_64-unknown-linux-gnu"
+            return ""
+        }
+        function kind_at(asset_index) { return asset_index <= 2 ? "macos" : "glibc" }
+        function floor_at(asset_index) {
+            if (asset_index == 1) return "11.0"
+            if (asset_index == 2) return "10.12"
+            return "2.17"
+        }
+        function exact(expected) { if ($0 != expected) fail() }
+        NR == 1 { exact("{"); next }
+        NR == 2 { exact("  \"schema_version\": 1,"); next }
+        NR == 3 { exact("  \"plugin_version\": \"" version "\","); next }
+        NR == 4 { exact("  \"tag\": \"" tag "\","); next }
+        NR == 5 { exact("  \"source_commit\": \"" commit "\","); next }
+        NR == 6 { exact("  \"assets\": ["); next }
+        NR >= 7 && NR <= 50 {
+            asset_index = int((NR - 7) / 11) + 1
+            position = (NR - 7) % 11 + 1
+            target = target_at(asset_index)
+            if (position == 1) exact("    {")
+            else if (position == 2) exact("      \"target\": \"" target "\",")
+            else if (position == 3) exact("      \"archive\": \"larch-v" version "-" target ".tar.gz\",")
+            else if (position == 4) {
+                if ($0 !~ /^      "byte_size": [1-9][0-9]*,$/) fail()
+                value = $0
+                sub(/^      "byte_size": /, "", value)
+                sub(/,$/, "", value)
+                if (target == selected) selected_size = value
+            }
+            else if (position == 5) {
+                if ($0 !~ /^      "sha256": "[0-9a-f]+",$/) fail()
+                value = $0
+                sub(/^      "sha256": "/, "", value)
+                sub(/",$/, "", value)
+                if (length(value) != 64) fail()
+                if (target == selected) selected_digest = value
+            }
+            else if (position == 6) exact("      \"binary_path\": \"larch\",")
+            else if (position == 7) exact("      \"minimum_os_or_libc\": {")
+            else if (position == 8) exact("        \"kind\": \"" kind_at(asset_index) "\",")
+            else if (position == 9) exact("        \"version\": \"" floor_at(asset_index) "\"")
+            else if (position == 10) exact("      }")
+            else if (asset_index < 4) exact("    },")
+            else exact("    }")
+            next
+        }
+        NR == 51 { exact("  ]"); next }
+        NR == 52 { exact("}"); next }
+        { fail() }
+        END {
+            if (NR != 52 || selected_size == "" || selected_digest == "") exit 1
+            print selected_size, selected_digest
+        }
+    ' "$path"
+}
+
+header_text() {
+    local tar_path="$1"
+    local offset="$2"
+    local length="$3"
+    dd if="$tar_path" bs=1 skip="$offset" count="$length" 2>/dev/null | tr -d '\000'
+}
+
+header_octal_size() {
+    local tar_path="$1"
+    local header_offset="$2"
+    local raw=""
+    raw="$(dd if="$tar_path" bs=1 skip="$((header_offset + 124))" count=12 2>/dev/null | tr -d '\000 ')"
+    case "$raw" in
+        *[!0-7]*|'') die "archive contains an invalid tar size field" ;;
+    esac
+    printf '%s\n' "$((8#$raw))"
+}
+
+validate_tar_header() {
+    local tar_path="$1"
+    local header_offset="$2"
+    local expected_name="$3"
+    [ "$(header_text "$tar_path" "$header_offset" 100)" = "$expected_name" ] || die "archive member name allowlist mismatch"
+    [ "$(header_text "$tar_path" "$((header_offset + 156))" 1)" = "0" ] || die "archive contains a symlink or special file"
+    [ -z "$(header_text "$tar_path" "$((header_offset + 157))" 100)" ] || die "archive member has an unexpected link target"
+    [ -z "$(header_text "$tar_path" "$((header_offset + 345))" 155)" ] || die "archive member has an unexpected path prefix"
+}
+
+validate_and_extract_archive() {
+    local archive="$1"
+    local output_binary="$2"
+    local tar_path="$stage_dir/archive.tar"
+    local members="$stage_dir/archive-members.txt"
+    local expected_members="$stage_dir/expected-members.txt"
+    local first_size=0
+    local second_offset=0
+    local second_size=0
+    local trailer_offset=0
+    local tar_size=0
+    local nonzero_trailer=0
+    gzip -dc "$archive" > "$tar_path"
+    tar -tzf "$archive" > "$members"
+    printf 'larch\nLICENSE\n' > "$expected_members"
+    cmp -s "$members" "$expected_members" || die "archive member allowlist mismatch"
+    validate_tar_header "$tar_path" 0 "larch"
+    first_size="$(header_octal_size "$tar_path" 0)"
+    [ "$first_size" -gt 0 ] || die "archive executable is empty"
+    second_offset=$((512 + ((first_size + 511) / 512) * 512))
+    validate_tar_header "$tar_path" "$second_offset" "LICENSE"
+    second_size="$(header_octal_size "$tar_path" "$second_offset")"
+    [ "$second_size" -gt 0 ] || die "archive license is empty"
+    trailer_offset=$((second_offset + 512 + ((second_size + 511) / 512) * 512))
+    tar_size="$(wc -c < "$tar_path" | tr -d '[:space:]')"
+    [ "$tar_size" -ge $((trailer_offset + 1024)) ] || die "archive is missing the tar end marker"
+    [ $((tar_size % 512)) -eq 0 ] || die "archive tar size is not block aligned"
+    nonzero_trailer="$(dd if="$tar_path" bs=1 skip="$trailer_offset" 2>/dev/null | tr -d '\000' | wc -c | tr -d '[:space:]')"
+    [ "$nonzero_trailer" -eq 0 ] || die "archive contains unexpected trailing data"
+    umask 077
+    tar -xOzf "$archive" larch > "$output_binary"
+    chmod 755 "$output_binary"
+    [ -f "$output_binary" ] && [ ! -L "$output_binary" ] && [ -x "$output_binary" ] || die "staged executable is not a regular executable file"
+}
+
+verify_download_set() {
+    local download_dir="$1"
+    local manifest_name="$2"
+    local checksums_name="$3"
+    local archive_name="$4"
+    local entry=""
+    local name=""
+    local count=0
+    for entry in "$download_dir"/* "$download_dir"/.[!.]* "$download_dir"/..?*; do
+        if [ ! -e "$entry" ] && [ ! -L "$entry" ]; then
+            continue
+        fi
+        count=$((count + 1))
+        [ -f "$entry" ] && [ ! -L "$entry" ] || die "download staging contains a non-regular entry"
+        name="${entry##*/}"
+        case "$name" in
+            "$manifest_name"|"$checksums_name"|"$archive_name") ;;
+            *) die "download staging contains an unexpected asset: $name" ;;
+        esac
+    done
+    [ "$count" -eq 3 ] || die "download staging does not contain exactly three requested assets"
+}
+
+install_release_binary() {
+    local version="$1"
+    local target="$2"
+    local tag="v$version"
+    local source_commit=""
+    local download_dir=""
+    local manifest_name="larch-v$version-manifest.json"
+    local checksums_name="larch-v$version-SHA256SUMS"
+    local archive_name="larch-v$version-$target.tar.gz"
+    local manifest_path=""
+    local checksums_path=""
+    local archive_path=""
+    local checksum_record=""
+    local manifest_record=""
+    local manifest_checksum=""
+    local archive_checksum=""
+    local archive_size=""
+    local archive_manifest_digest=""
+    local actual_size=""
+    local actual_digest=""
+    local staged_binary=""
+    local previous_binary=""
+
+    verify_release_surface "$version" "$tag"
+    source_commit="$(gh api "repos/$RELEASE_REPO/commits/$tag" --jq '.sha')"
+    case "$source_commit" in
+        *[!0-9a-f]*|'') die "release source commit is invalid" ;;
+    esac
+    [ "${#source_commit}" -eq 40 ] || die "release source commit has an invalid length"
+
+    download_dir="$stage_dir/download"
+    mkdir "$download_dir"
+    gh release download "$tag" --repo "$RELEASE_REPO" --dir "$download_dir" \
+        --pattern "$manifest_name" --pattern "$checksums_name" --pattern "$archive_name"
+    verify_download_set "$download_dir" "$manifest_name" "$checksums_name" "$archive_name"
+    manifest_path="$download_dir/$manifest_name"
+    checksums_path="$download_dir/$checksums_name"
+    archive_path="$download_dir/$archive_name"
+
+    gh attestation verify "$manifest_path" --repo "$RELEASE_REPO" --signer-workflow "$RELEASE_WORKFLOW" \
+        --source-ref "refs/tags/$tag" --source-digest "$source_commit" --deny-self-hosted-runners >/dev/null
+    gh attestation verify "$checksums_path" --repo "$RELEASE_REPO" --signer-workflow "$RELEASE_WORKFLOW" \
+        --source-ref "refs/tags/$tag" --source-digest "$source_commit" --deny-self-hosted-runners >/dev/null
+    gh attestation verify "$archive_path" --repo "$RELEASE_REPO" --signer-workflow "$RELEASE_WORKFLOW" \
+        --source-ref "refs/tags/$tag" --source-digest "$source_commit" --deny-self-hosted-runners >/dev/null
+
+    if ! checksum_record="$(validate_checksums "$checksums_path" "$version" "$target")"; then
+        die "checksum file violates the release schema"
+    fi
+    case "$checksum_record" in
+        *' '*) ;;
+        *) die "checksum parser returned malformed data" ;;
+    esac
+    manifest_checksum="${checksum_record%% *}"
+    archive_checksum="${checksum_record#* }"
+    case "$archive_checksum" in
+        *' '*) die "checksum parser returned malformed data" ;;
+    esac
+    [ "$(sha256_file "$manifest_path")" = "$manifest_checksum" ] || die "manifest SHA-256 digest mismatch"
+
+    if ! manifest_record="$(validate_manifest "$manifest_path" "$version" "$tag" "$source_commit" "$target")"; then
+        die "manifest violates the strict schema or release identity"
+    fi
+    case "$manifest_record" in
+        *' '*) ;;
+        *) die "manifest parser returned malformed data" ;;
+    esac
+    archive_size="${manifest_record%% *}"
+    archive_manifest_digest="${manifest_record#* }"
+    case "$archive_manifest_digest" in
+        *' '*) die "manifest parser returned malformed data" ;;
+    esac
+    [ "$archive_manifest_digest" = "$archive_checksum" ] || die "archive digest differs between manifest and checksum file"
+    actual_size="$(wc -c < "$archive_path" | tr -d '[:space:]')"
+    [ "$actual_size" = "$archive_size" ] || die "archive byte size does not match the manifest"
+    actual_digest="$(sha256_file "$archive_path")"
+    [ "$actual_digest" = "$archive_manifest_digest" ] || die "archive SHA-256 digest mismatch"
+
+    staged_binary="$stage_dir/larch.staged"
+    validate_and_extract_archive "$archive_path" "$staged_binary"
+    binary_matches_version "$staged_binary" "$version" || die "staged executable reports the wrong version"
+    binary_passes_self_check "$staged_binary" "$version" "$target" || die "staged executable failed its machine-readable self-check"
+
+    if [ -e "$binary_path" ] || [ -L "$binary_path" ]; then
+        [ -f "$binary_path" ] && [ ! -L "$binary_path" ] || die "existing larch binary is not a regular file"
+        previous_binary="$stage_dir/larch.previous"
+        ln "$binary_path" "$previous_binary"
+    fi
+    mv -f "$staged_binary" "$binary_path"
+    if ! binary_matches_version "$binary_path" "$version" || ! binary_passes_self_check "$binary_path" "$version" "$target"; then
+        if [ -n "$previous_binary" ] && [ -f "$previous_binary" ]; then
+            mv -f "$previous_binary" "$binary_path"
+        fi
+        die "installed executable failed post-install verification"
+    fi
+}
+
+run_binary() {
+    local candidate="$1"
+    shift
+    cleanup
+    trap - EXIT ERR
+    exec "$candidate" "$@"
+    die "verified larch executable could not be started"
+}
+
+main() {
+    local version=""
+    local target=""
+    local override="${LARCH_BINARY:-}"
+
+    plugin_root="${CLAUDE_PLUGIN_ROOT:-}"
+    [ -n "$plugin_root" ] || die "CLAUDE_PLUGIN_ROOT is required"
+    while [ "$plugin_root" != "/" ] && [ "${plugin_root%/}" != "$plugin_root" ]; do
+        plugin_root="${plugin_root%/}"
+    done
+    validate_absolute_path "CLAUDE_PLUGIN_ROOT" "$plugin_root"
+    [ -d "$plugin_root" ] && [ ! -L "$plugin_root" ] || die "CLAUDE_PLUGIN_ROOT is not a real directory"
+    version="$(read_plugin_version "$plugin_root/.claude-plugin/plugin.json")"
+    target="$(resolve_target)"
+
+    if [ -n "$override" ]; then
+        validate_absolute_path "LARCH_BINARY" "$override"
+        binary_matches_version "$override" "$version" || die "LARCH_BINARY is not an executable for plugin version $version"
+        binary_passes_self_check "$override" "$version" "$target" || die "LARCH_BINARY self-check does not match $version for $target"
+        run_binary "$override" "$@"
+    fi
+
+    bin_dir="$plugin_root/bin"
+    binary_path="$bin_dir/larch"
+    if [ -e "$binary_path" ] || [ -L "$binary_path" ]; then
+        [ -f "$binary_path" ] && [ ! -L "$binary_path" ] || die "existing larch binary is not a regular file"
+        if binary_matches_version "$binary_path" "$version" && binary_passes_self_check "$binary_path" "$version" "$target"; then
+            run_binary "$binary_path" "$@"
+        fi
+    fi
+
+    if [ -e "$plugin_root/.git" ] || [ -L "$plugin_root/.git" ]; then
+        die "local --plugin-dir checkout needs an explicit build: run 'cargo build --locked --release --package larch-cli' and set LARCH_BINARY to target/release/larch"
+    fi
+
+    plugin_data="${CLAUDE_PLUGIN_DATA:-}"
+    [ -n "$plugin_data" ] || die "CLAUDE_PLUGIN_DATA is required for the bounded bootstrap lock"
+    while [ "$plugin_data" != "/" ] && [ "${plugin_data%/}" != "$plugin_data" ]; do
+        plugin_data="${plugin_data%/}"
+    done
+    validate_absolute_path "CLAUDE_PLUGIN_DATA" "$plugin_data"
+    require_commands
+    acquire_lock
+
+    if [ -e "$binary_path" ] || [ -L "$binary_path" ]; then
+        [ -f "$binary_path" ] && [ ! -L "$binary_path" ] || die "existing larch binary is not a regular file"
+        if binary_matches_version "$binary_path" "$version" && binary_passes_self_check "$binary_path" "$version" "$target"; then
+            run_binary "$binary_path" "$@"
+        fi
+    fi
+
+    mkdir -p -- "$bin_dir"
+    [ -d "$bin_dir" ] && [ ! -L "$bin_dir" ] || die "plugin bin path is not a real directory"
+    chmod 700 "$bin_dir"
+    stage_dir="$(mktemp -d "$bin_dir/.larch-bootstrap.XXXXXX")"
+    case "$stage_dir" in
+        "$bin_dir"/.larch-bootstrap.*) ;;
+        *) die "mktemp returned a staging path outside the plugin bin directory" ;;
+    esac
+    [ -d "$stage_dir" ] && [ ! -L "$stage_dir" ] || die "bootstrap staging path is unsafe"
+    install_release_binary "$version" "$target"
+    run_binary "$binary_path" "$@"
+}
+
+main "$@"

--- a/scripts/residual-bash-paths.txt
+++ b/scripts/residual-bash-paths.txt
@@ -13,6 +13,7 @@ scripts/external-tool-registry.sh
 scripts/file-failure-report-cross-repo.sh
 scripts/flush-vendor-failure-diagnostics.sh
 scripts/hook-anti-read-poll.sh
+scripts/larch.sh
 scripts/sessionstart-statusline.sh
 scripts/pre-commit-bash-syntax.sh
 scripts/pre-commit-shellcheck.sh


### PR DESCRIPTION
Closes #7690

## Summary

- add the Bash 3.2-compatible bootstrap/exec shim decided in #7670
- verify immutable release provenance, strict metadata, archives, target identity, and staged binary health before atomic install
- serialize concurrent first use, recover dead locks, preserve existing binaries on failure, and require explicit local-development overrides
- document installation, permissions, residual Bash policy, architecture, and the security boundary

## Verification

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- cargo test --locked --package larch-core --package larch-adapters --package larch-cli
- cargo build --locked --release --package larch-cli
- PYTHONPATH=python python3 -m pytest -q python/tests/release/test_rust_bootstrap.py python/tests/core/test_residual_bash.py
- full pytest collection, exact CI Pylint shard 2, Ruff, Pyright, ShellCheck, Bash 3.2 syntax, Markdown, JSON, agent-lint, and larch-lint checks

## Review

An independent self-review corrected the no-consumer documentation, reduced prompt-closure growth, and required target self-checks on the installed-binary fast path. No architectural invariant violation or guideline deviation remains.