### PR TITLE
Fix release Cargo version synchronization

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -162,7 +162,7 @@ NOTES_DIR="$(dirname "$PR_LIST_FILE")"
 REDACTED_NOTES_FILE="$NOTES_DIR/notes.redacted.md"
 git checkout -b "release/v${NEW_VERSION}"
 python3 "$PWD/python/cli.py" release set-version "${NEW_VERSION}"
-git add .claude-plugin/plugin.json
+git add .claude-plugin/plugin.json Cargo.toml Cargo.lock
 git commit -m "Release v${NEW_VERSION}"
 python3 "$PWD/python/cli.py" pr create --title "Release v${NEW_VERSION}" --body-file "$REDACTED_NOTES_FILE" --repo "$REPO"
 ```
@@ -346,7 +346,7 @@ If `NEW_VERSION_INSTALLED=true`, `CONE_RECONCILED=true`, or `RESTART_REQUIRED=tr
 Runtime helpers:
 
 - `python3 "$PWD/python/cli.py" release prepare`: baseline, PR list (larch-logs housekeeping PRs excluded; count reported as `IGNORED_LARCHLOG_PR_COUNT`), aggregate bump KV
-- `python3 "$PWD/python/cli.py" release set-version`: atomic `plugin.json` version write
+- `python3 "$PWD/python/cli.py" release set-version`: synchronized plugin, Cargo workspace, internal path dependency, and lockfile version write
 - `python3 "$PWD/python/cli.py" release finish`: tag, GitHub Release, promote tail
 - `python3 "$PWD/python/cli.py" release promote`: promote a specific release after `finish`, or during promote-only recovery
 - `python3 "$PWD/python/cli.py" release promote-latest`: one-off Latest promotion for the most recently published non-draft release

--- a/python/larch/release/version_bump.py
+++ b/python/larch/release/version_bump.py
@@ -57,6 +57,13 @@ class ApplyResult:
     error: str = ""
 
 
+@dataclass(frozen=True)
+class ReleaseVersionUpdate:
+    root: Path
+    current: str
+    new: str
+
+
 
 
 _redact_outbound = redact.redact_outbound
@@ -851,52 +858,35 @@ def _set_release_version(root: Path, *, current: str, new: str) -> None:
         raise ShipError(f"release version update failed: {exc}{detail}") from exc
 
 
-def set_version_main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(prog="cli.py release set-version")
-    parser.add_argument("version")
-    args = parser.parse_args(argv)
-    new_version = args.version
+def _release_version_update(new_version: str) -> ReleaseVersionUpdate:
     if not re.fullmatch(config.SEMVER_RE, new_version):
-        print(f"ERROR=invalid semver: {new_version}", file=sys.stderr)
-        return 1
+        raise ShipError(f"invalid semver: {new_version}")
     root_env = os.environ.get("LARCH_RELEASE_SET_VERSION_REPO_ROOT", "")
     plugin_env = os.environ.get("LARCH_RELEASE_SET_VERSION_PLUGIN_JSON", "")
     root = Path(root_env) if root_env else _repo_root_from_cli_file()
     plugin_json = Path(plugin_env) if plugin_env else root / config.PLUGIN_JSON_PATH
     if plugin_env and not root_env:
         root = plugin_json.parent.parent
-    if not plugin_json.is_file():
-        print(f"ERROR={plugin_json} not found", file=sys.stderr)
-        return 1
-    try:
-        plugin_value: object = json.loads(plugin_json.read_text(encoding="utf-8"))
-    except json.JSONDecodeError:
-        print(f"ERROR={plugin_json} is not valid JSON", file=sys.stderr)
-        return 1
-    if not isinstance(plugin_value, dict):
-        print(f"ERROR={plugin_json} does not contain an object", file=sys.stderr)
-        return 1
-    data = cast("dict[str, object]", plugin_value)
-    current = data.get("version")
-    if not isinstance(current, str) or not current:
-        print(f"ERROR={plugin_json} missing .version", file=sys.stderr)
-        return 1
-    if not re.fullmatch(config.SEMVER_RE, current):
-        print(f"ERROR=current version is not semver: {current}", file=sys.stderr)
-        return 1
+    current = _read_plugin_version(plugin_json)
     if new_version == current:
-        print(f"ERROR=no-op: version already {current}", file=sys.stderr)
-        return 1
+        raise ShipError(f"no-op: version already {current}")
     if _semver_parts(new_version) < _semver_parts(current):
-        print(f"ERROR=downgrade refused: {new_version} < {current}", file=sys.stderr)
-        return 1
+        raise ShipError(f"downgrade refused: {new_version} < {current}")
+    return ReleaseVersionUpdate(root=root, current=current, new=new_version)
+
+
+def set_version_main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="cli.py release set-version")
+    parser.add_argument("version")
+    args = parser.parse_args(argv)
     try:
-        _set_release_version(root, current=current, new=new_version)
+        update = _release_version_update(args.version)
+        _set_release_version(update.root, current=update.current, new=update.new)
     except (OSError, ShipError, json.JSONDecodeError) as exc:
         print(f"ERROR={exc}", file=sys.stderr)
         return 1
-    print(f"PREVIOUS_VERSION={current}")
-    print(f"NEW_VERSION={new_version}")
+    print(f"PREVIOUS_VERSION={update.current}")
+    print(f"NEW_VERSION={update.new}")
     return 0
 
 

--- a/python/larch/release/version_bump.py
+++ b/python/larch/release/version_bump.py
@@ -11,9 +11,10 @@ import re
 import shutil
 import sys
 import tempfile
+import tomllib
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 from larch.core import config
 from larch.git import git
@@ -34,6 +35,8 @@ _PORCELAIN_STATUS_PREFIX_LEN = 2
 _NAME_STATUS_RENAME_PATH_INDEX = 2
 _TRANSPARENT_CHANGELOG_SUBJECT_PREFIX = "Update CHANGELOG for "
 _CHANGELOG_DEFAULT_PATH = "CHANGELOG.md"
+_CARGO_MANIFEST_PATH = "Cargo.toml"
+_CARGO_LOCK_PATH = "Cargo.lock"
 
 
 @dataclass(frozen=True)
@@ -592,6 +595,262 @@ def classify_bump_main(argv: list[str] | None = None) -> int:
     return 0
 
 
+def _require_release_file(path: Path) -> bytes:
+    if path.is_symlink() or not path.is_file():
+        msg = f"required release version file is missing or unsafe: {path.name}"
+        raise ShipError(msg)
+    return path.read_bytes()
+
+
+def _toml_data(raw: bytes, *, path: Path) -> dict[str, object]:
+    try:
+        parsed = tomllib.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, tomllib.TOMLDecodeError) as exc:
+        msg = f"{path.name} is not valid UTF-8 TOML"
+        raise ShipError(msg) from exc
+    return cast("dict[str, object]", parsed)
+
+
+def _workspace_members(root: Path, cargo_data: dict[str, object]) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    workspace = cargo_data.get("workspace")
+    if not isinstance(workspace, dict):
+        raise ShipError("Cargo.toml is missing [workspace]")
+    members = workspace.get("members")
+    if not isinstance(members, list) or not members or not all(isinstance(item, str) for item in members):
+        raise ShipError("Cargo.toml workspace members are invalid")
+    member_paths = tuple(cast("str", item) for item in members)
+    names: list[str] = []
+    for member_path in member_paths:
+        member_manifest = root / member_path / _CARGO_MANIFEST_PATH
+        member_data = _toml_data(_require_release_file(member_manifest), path=member_manifest)
+        package = member_data.get("package")
+        name = package.get("name") if isinstance(package, dict) else None
+        version = package.get("version") if isinstance(package, dict) else None
+        if not isinstance(name, str) or version != {"workspace": True}:
+            raise ShipError(f"workspace member version ownership is invalid: {member_path}")
+        names.append(name)
+    if len(set(names)) != len(names):
+        raise ShipError("Cargo workspace member names are not unique")
+    return member_paths, tuple(names)
+
+
+def _workspace_version(cargo_data: dict[str, object]) -> str:
+    workspace = cargo_data.get("workspace")
+    package = workspace.get("package") if isinstance(workspace, dict) else None
+    version = package.get("version") if isinstance(package, dict) else None
+    if not isinstance(version, str) or not re.fullmatch(config.SEMVER_RE, version):
+        raise ShipError("Cargo.toml has no valid workspace package version")
+    return version
+
+
+def _internal_dependency_names(
+    cargo_data: dict[str, object],
+    *,
+    member_paths: tuple[str, ...],
+    member_names: tuple[str, ...],
+    current_version: str,
+) -> tuple[str, ...]:
+    workspace = cargo_data.get("workspace")
+    dependencies = workspace.get("dependencies") if isinstance(workspace, dict) else None
+    if not isinstance(dependencies, dict):
+        raise ShipError("Cargo.toml is missing [workspace.dependencies]")
+    path_to_name = dict(zip(member_paths, member_names, strict=True))
+    internal: list[str] = []
+    for dependency_name, specification in dependencies.items():
+        if not isinstance(specification, dict):
+            continue
+        dependency_path = specification.get("path")
+        if dependency_path not in path_to_name:
+            continue
+        if dependency_name != path_to_name[cast("str", dependency_path)]:
+            raise ShipError(f"workspace path dependency name mismatch: {dependency_name}")
+        if specification.get("version") != f"={current_version}":
+            raise ShipError(f"workspace path dependency version mismatch: {dependency_name}")
+        internal.append(cast("str", dependency_name))
+    return tuple(sorted(internal))
+
+
+def _validate_lock_versions(
+    lock_data: dict[str, object],
+    *,
+    member_names: tuple[str, ...],
+    current_version: str,
+) -> None:
+    packages = lock_data.get("package")
+    if not isinstance(packages, list):
+        raise ShipError("Cargo.lock has no package records")
+    found: dict[str, list[str]] = {name: [] for name in member_names}
+    for package in packages:
+        if not isinstance(package, dict):
+            raise ShipError("Cargo.lock contains an invalid package record")
+        name = package.get("name")
+        version = package.get("version")
+        if name in found and isinstance(version, str):
+            found[cast("str", name)].append(version)
+    for name, versions in found.items():
+        if versions != [current_version]:
+            raise ShipError(f"Cargo.lock workspace package version mismatch: {name}")
+
+
+def _replace_workspace_version(text: str, *, current: str, new: str) -> str:
+    header = "[workspace.package]"
+    start = text.find(header)
+    if start < 0:
+        raise ShipError("Cargo.toml is missing [workspace.package]")
+    end = text.find("\n[", start + len(header))
+    end = len(text) if end < 0 else end
+    section = text[start:end]
+    old_line = f'version = "{current}"'
+    if section.count(old_line) != 1:
+        raise ShipError("Cargo.toml workspace version line is not canonical")
+    return text[:start] + section.replace(old_line, f'version = "{new}"') + text[end:]
+
+
+def _replace_dependency_versions(
+    text: str,
+    *,
+    dependency_names: tuple[str, ...],
+    current: str,
+    new: str,
+) -> str:
+    lines = text.splitlines(keepends=True)
+    for name in dependency_names:
+        matching = [index for index, line in enumerate(lines) if line.startswith(f"{name} = ")]
+        if len(matching) != 1:
+            raise ShipError(f"Cargo.toml dependency line is not canonical: {name}")
+        index = matching[0]
+        old = f'version = "={current}"'
+        if lines[index].count(old) != 1:
+            raise ShipError(f"Cargo.toml dependency version is not canonical: {name}")
+        lines[index] = lines[index].replace(old, f'version = "={new}"')
+    return "".join(lines)
+
+
+def _replace_lock_versions(
+    text: str,
+    *,
+    member_names: tuple[str, ...],
+    current: str,
+    new: str,
+) -> str:
+    blocks = text.split("[[package]]")
+    for name in member_names:
+        name_line = f'\nname = "{name}"\n'
+        matching = [index for index, block in enumerate(blocks) if name_line in block]
+        if len(matching) != 1:
+            raise ShipError(f"Cargo.lock package record is not canonical: {name}")
+        index = matching[0]
+        old = f'\nversion = "{current}"\n'
+        if blocks[index].count(old) != 1:
+            raise ShipError(f"Cargo.lock package version is not canonical: {name}")
+        blocks[index] = blocks[index].replace(old, f'\nversion = "{new}"\n')
+    return "[[package]]".join(blocks)
+
+
+def _atomic_replace(path: Path, content: bytes) -> None:
+    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        temporary.chmod(path.stat(follow_symlinks=False).st_mode & 0o777)
+        temporary.replace(path)
+    except OSError:
+        temporary.unlink(missing_ok=True)
+        raise
+
+
+def _verify_release_version(root: Path, expected: str) -> None:
+    plugin_path = root / config.PLUGIN_JSON_PATH
+    if _read_plugin_version(plugin_path) != expected:
+        raise ShipError("plugin version postcondition failed")
+    cargo_path = root / _CARGO_MANIFEST_PATH
+    cargo_data = _toml_data(_require_release_file(cargo_path), path=cargo_path)
+    if _workspace_version(cargo_data) != expected:
+        raise ShipError("Cargo workspace version postcondition failed")
+    member_paths, member_names = _workspace_members(root, cargo_data)
+    _ = _internal_dependency_names(
+        cargo_data,
+        member_paths=member_paths,
+        member_names=member_names,
+        current_version=expected,
+    )
+    lock_path = root / _CARGO_LOCK_PATH
+    _validate_lock_versions(
+        _toml_data(_require_release_file(lock_path), path=lock_path),
+        member_names=member_names,
+        current_version=expected,
+    )
+
+
+def _set_release_version(root: Path, *, current: str, new: str) -> None:
+    plugin_path = root / config.PLUGIN_JSON_PATH
+    cargo_path = root / _CARGO_MANIFEST_PATH
+    lock_path = root / _CARGO_LOCK_PATH
+    originals = {
+        plugin_path: _require_release_file(plugin_path),
+        cargo_path: _require_release_file(cargo_path),
+        lock_path: _require_release_file(lock_path),
+    }
+    cargo_data = _toml_data(originals[cargo_path], path=cargo_path)
+    if _workspace_version(cargo_data) != current:
+        raise ShipError("Cargo workspace version does not match plugin version")
+    member_paths, member_names = _workspace_members(root, cargo_data)
+    dependency_names = _internal_dependency_names(
+        cargo_data,
+        member_paths=member_paths,
+        member_names=member_names,
+        current_version=current,
+    )
+    lock_data = _toml_data(originals[lock_path], path=lock_path)
+    _validate_lock_versions(
+        lock_data,
+        member_names=member_names,
+        current_version=current,
+    )
+    plugin_value: object = json.loads(originals[plugin_path])
+    if not isinstance(plugin_value, dict):
+        raise ShipError(".claude-plugin/plugin.json does not contain an object")
+    plugin_data = cast("dict[str, object]", plugin_value)
+    plugin_data["version"] = new
+    cargo_text = originals[cargo_path].decode("utf-8")
+    cargo_text = _replace_workspace_version(cargo_text, current=current, new=new)
+    cargo_text = _replace_dependency_versions(
+        cargo_text,
+        dependency_names=dependency_names,
+        current=current,
+        new=new,
+    )
+    lock_text = _replace_lock_versions(
+        originals[lock_path].decode("utf-8"),
+        member_names=member_names,
+        current=current,
+        new=new,
+    )
+    rendered = {
+        plugin_path: (json.dumps(plugin_data, indent=2) + "\n").encode(),
+        cargo_path: cargo_text.encode(),
+        lock_path: lock_text.encode(),
+    }
+    replaced: list[Path] = []
+    try:
+        for path, content in rendered.items():
+            _atomic_replace(path, content)
+            replaced.append(path)
+        _verify_release_version(root, new)
+    except (OSError, ShipError) as exc:
+        rollback_errors: list[str] = []
+        for path in reversed(replaced):
+            try:
+                _atomic_replace(path, originals[path])
+            except OSError:
+                rollback_errors.append(path.name)
+        detail = f"; rollback failed for {','.join(rollback_errors)}" if rollback_errors else ""
+        raise ShipError(f"release version update failed: {exc}{detail}") from exc
+
+
 def set_version_main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="cli.py release set-version")
     parser.add_argument("version")
@@ -600,16 +859,24 @@ def set_version_main(argv: list[str] | None = None) -> int:
     if not re.fullmatch(config.SEMVER_RE, new_version):
         print(f"ERROR=invalid semver: {new_version}", file=sys.stderr)
         return 1
+    root_env = os.environ.get("LARCH_RELEASE_SET_VERSION_REPO_ROOT", "")
     plugin_env = os.environ.get("LARCH_RELEASE_SET_VERSION_PLUGIN_JSON", "")
-    plugin_json = Path(plugin_env) if plugin_env else _repo_root_from_cli_file() / config.PLUGIN_JSON_PATH
+    root = Path(root_env) if root_env else _repo_root_from_cli_file()
+    plugin_json = Path(plugin_env) if plugin_env else root / config.PLUGIN_JSON_PATH
+    if plugin_env and not root_env:
+        root = plugin_json.parent.parent
     if not plugin_json.is_file():
         print(f"ERROR={plugin_json} not found", file=sys.stderr)
         return 1
     try:
-        data: Any = json.loads(plugin_json.read_text(encoding="utf-8"))
+        plugin_value: object = json.loads(plugin_json.read_text(encoding="utf-8"))
     except json.JSONDecodeError:
         print(f"ERROR={plugin_json} is not valid JSON", file=sys.stderr)
         return 1
+    if not isinstance(plugin_value, dict):
+        print(f"ERROR={plugin_json} does not contain an object", file=sys.stderr)
+        return 1
+    data = cast("dict[str, object]", plugin_value)
     current = data.get("version")
     if not isinstance(current, str) or not current:
         print(f"ERROR={plugin_json} missing .version", file=sys.stderr)
@@ -623,13 +890,9 @@ def set_version_main(argv: list[str] | None = None) -> int:
     if _semver_parts(new_version) < _semver_parts(current):
         print(f"ERROR=downgrade refused: {new_version} < {current}", file=sys.stderr)
         return 1
-    data["version"] = new_version
-    tmp_path = plugin_json.with_name(plugin_json.name + f".tmp.{os.getpid()}")
     try:
-        tmp_path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
-        tmp_path.replace(plugin_json)
-    except OSError as exc:
-        tmp_path.unlink(missing_ok=True)
+        _set_release_version(root, current=current, new=new_version)
+    except (OSError, ShipError, json.JSONDecodeError) as exc:
         print(f"ERROR={exc}", file=sys.stderr)
         return 1
     print(f"PREVIOUS_VERSION={current}")

--- a/python/tests/release/test_release.py
+++ b/python/tests/release/test_release.py
@@ -182,6 +182,111 @@ def test_plugin_read_version_cli_captures_stdout_with_inherited_quiet(tmp_path: 
     assert res.stdout == "LARCH_PLUGIN_VERSION=9.8.7\n"
 
 
+def _write_release_version_repo(tmp_path: Path, *, cargo_version: str = "1.2.3") -> Path:
+    root = tmp_path / "repo"
+    (root / ".claude-plugin").mkdir(parents=True)
+    (root / ".claude-plugin/plugin.json").write_text(
+        json.dumps({"name": "larch", "version": "1.2.3"}) + "\n",
+        encoding="utf-8",
+    )
+    (root / "Cargo.toml").write_text(
+        f"""[workspace]
+members = ["crates/larch-cli", "crates/larch-core"]
+
+[workspace.package]
+version = "{cargo_version}"
+
+[workspace.dependencies]
+larch-core = {{ version = "={cargo_version}", path = "crates/larch-core" }}
+""",
+        encoding="utf-8",
+    )
+    for name in ("larch-cli", "larch-core"):
+        member = root / "crates" / name
+        member.mkdir(parents=True)
+        (member / "Cargo.toml").write_text(
+            f'[package]\nname = "{name}"\nversion.workspace = true\n',
+            encoding="utf-8",
+        )
+    (root / "Cargo.lock").write_text(
+        f"""version = 4
+
+[[package]]
+name = "larch-cli"
+version = "{cargo_version}"
+dependencies = ["larch-core"]
+
+[[package]]
+name = "larch-core"
+version = "{cargo_version}"
+""",
+        encoding="utf-8",
+    )
+    return root
+
+
+def test_set_version_synchronizes_plugin_workspace_dependencies_and_lock(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    root = _write_release_version_repo(tmp_path)
+    monkeypatch.setenv("LARCH_RELEASE_SET_VERSION_REPO_ROOT", str(root))
+
+    assert version_bump.set_version_main(["1.2.4"]) == 0
+
+    assert json.loads((root / ".claude-plugin/plugin.json").read_text())["version"] == "1.2.4"
+    cargo = (root / "Cargo.toml").read_text(encoding="utf-8")
+    assert 'version = "1.2.4"' in cargo
+    assert 'larch-core = { version = "=1.2.4"' in cargo
+    lock = (root / "Cargo.lock").read_text(encoding="utf-8")
+    assert lock.count('version = "1.2.4"') == 2
+    assert capsys.readouterr().out == "PREVIOUS_VERSION=1.2.3\nNEW_VERSION=1.2.4\n"
+
+
+def test_set_version_rejects_mismatched_cargo_without_writes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    root = _write_release_version_repo(tmp_path, cargo_version="1.2.2")
+    paths = (root / ".claude-plugin/plugin.json", root / "Cargo.toml", root / "Cargo.lock")
+    originals = {path: path.read_bytes() for path in paths}
+    monkeypatch.setenv("LARCH_RELEASE_SET_VERSION_REPO_ROOT", str(root))
+
+    assert version_bump.set_version_main(["1.2.4"]) == 1
+
+    assert "Cargo workspace version does not match" in capsys.readouterr().err
+    assert all(path.read_bytes() == originals[path] for path in paths)
+
+
+def test_set_version_rolls_back_a_partial_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    root = _write_release_version_repo(tmp_path)
+    paths = (root / ".claude-plugin/plugin.json", root / "Cargo.toml", root / "Cargo.lock")
+    originals = {path: path.read_bytes() for path in paths}
+    real_atomic_replace = version_bump._atomic_replace
+    calls = 0
+
+    def fail_second_write(path: Path, content: bytes) -> None:
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise OSError("injected write failure")
+        real_atomic_replace(path, content)
+
+    monkeypatch.setattr(version_bump, "_atomic_replace", fail_second_write)
+    monkeypatch.setenv("LARCH_RELEASE_SET_VERSION_REPO_ROOT", str(root))
+
+    assert version_bump.set_version_main(["1.2.4"]) == 1
+
+    assert "release version update failed" in capsys.readouterr().err
+    assert all(path.read_bytes() == originals[path] for path in paths)
+
+
 def test_set_version_rejects_downgrade(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
     plugin = tmp_path / "plugin.json"
     plugin.write_text(json.dumps({"version": "2.0.0"}), encoding="utf-8")


### PR DESCRIPTION
## Summary

- synchronize plugin, Cargo workspace, internal path-dependency, and lockfile versions in the release owner
- fail closed on pre-existing drift and re-verify the multi-file postcondition
- restore original files after an interrupted update and stage all release version files

## Reproduction

The first v53.1.23 candidate failed `compiled_version_matches_the_plugin_release_version`: `.claude-plugin/plugin.json` was 53.1.23 while the workspace remained 53.1.22.

## Verification

- 70 release tests passed
- real workspace copy passed `cargo metadata --locked` after the synchronized bump
- release asset candidate validation accepted the synchronized version
- complete changed-file pre-commit suite passed

## Architecture

This extends the existing release-version owner. No architectural invariant violation or guideline deviation was found after self-review.