### PR TITLE
Release v53.1.23

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "53.1.22",
+  "version": "53.1.23",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1435,7 +1435,7 @@ dependencies = [
 
 [[package]]
 name = "larch-adapters"
-version = "53.1.22"
+version = "53.1.23"
 dependencies = [
  "gix",
  "larch-core",
@@ -1448,7 +1448,7 @@ dependencies = [
 
 [[package]]
 name = "larch-cli"
-version = "53.1.22"
+version = "53.1.23"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1463,14 +1463,14 @@ dependencies = [
 
 [[package]]
 name = "larch-core"
-version = "53.1.22"
+version = "53.1.23"
 dependencies = [
  "regex",
 ]
 
 [[package]]
 name = "larch-lint"
-version = "53.1.22"
+version = "53.1.23"
 dependencies = [
  "assert_cmd",
  "automod",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2024"
 license = "MIT"
 repository = "https://github.com/character-ai/larch"
 rust-version = "1.94.1"
-version = "53.1.22"
+version = "53.1.23"
 
 [workspace.dependencies]
 assert_cmd = { version = "2.2.2", default-features = false }
@@ -23,8 +23,8 @@ clap = { version = "4.6.2", default-features = false, features = ["derive", "hel
 globset = { version = "0.4.19", default-features = false }
 gix = { version = "=0.85.0", default-features = false, features = ["revision", "sha1", "sha256", "status"] }
 inventory = { version = "0.3.24", default-features = false }
-larch-adapters = { version = "=53.1.22", path = "crates/larch-adapters" }
-larch-core = { version = "=53.1.22", path = "crates/larch-core" }
+larch-adapters = { version = "=53.1.23", path = "crates/larch-adapters" }
+larch-core = { version = "=53.1.23", path = "crates/larch-core" }
 nix = { version = "0.31.3", default-features = false, features = ["process", "signal"] }
 predicates = { version = "3.1.4", default-features = false }
 pulldown-cmark = { version = "0.13.4", default-features = false }


### PR DESCRIPTION
## Added

- Added the Rust workspace architecture and dependency policy ([#7694](https://github.com/character-ai/larch/pull/7694)), shared runtime foundations ([#7696](https://github.com/character-ai/larch/pull/7696), [#7698](https://github.com/character-ai/larch/pull/7698), [#7699](https://github.com/character-ai/larch/pull/7699), [#7700](https://github.com/character-ai/larch/pull/7700), [#7701](https://github.com/character-ai/larch/pull/7701), [#7703](https://github.com/character-ai/larch/pull/7703), [#7705](https://github.com/character-ai/larch/pull/7705)), the canonical executable ([#7697](https://github.com/character-ai/larch/pull/7697)), and the command ownership registry ([#7702](https://github.com/character-ai/larch/pull/7702)).
- Added deterministic, attested Rust release assets for four initial targets ([#7704](https://github.com/character-ai/larch/pull/7704)), a Python-to-Rust black-box parity harness ([#7709](https://github.com/character-ai/larch/pull/7709)), and atomic clean-install binary bootstrap ([#7710](https://github.com/character-ai/larch/pull/7710)).
- Added the Rust lint runner, syntax support, test harness, and policy rules for KV parity, explicit Git destinations, scratch paths, environment ownership, process boundaries, conventions, gates, Markdown, architecture, duplicate code, lifecycle prefixes, skill prose, topology, residual shell, output text, Codex dispatch, and timing markers ([#7633](https://github.com/character-ai/larch/pull/7633), [#7634](https://github.com/character-ai/larch/pull/7634), [#7635](https://github.com/character-ai/larch/pull/7635), [#7636](https://github.com/character-ai/larch/pull/7636), [#7637](https://github.com/character-ai/larch/pull/7637), [#7638](https://github.com/character-ai/larch/pull/7638), [#7639](https://github.com/character-ai/larch/pull/7639), [#7640](https://github.com/character-ai/larch/pull/7640), [#7641](https://github.com/character-ai/larch/pull/7641), [#7642](https://github.com/character-ai/larch/pull/7642), [#7643](https://github.com/character-ai/larch/pull/7643), [#7644](https://github.com/character-ai/larch/pull/7644), [#7645](https://github.com/character-ai/larch/pull/7645), [#7646](https://github.com/character-ai/larch/pull/7646), [#7647](https://github.com/character-ai/larch/pull/7647), [#7648](https://github.com/character-ai/larch/pull/7648), [#7649](https://github.com/character-ai/larch/pull/7649), [#7650](https://github.com/character-ai/larch/pull/7650), [#7651](https://github.com/character-ai/larch/pull/7651), [#7652](https://github.com/character-ai/larch/pull/7652), [#7653](https://github.com/character-ai/larch/pull/7653), [#7654](https://github.com/character-ai/larch/pull/7654), [#7655](https://github.com/character-ai/larch/pull/7655), [#7656](https://github.com/character-ai/larch/pull/7656), [#7657](https://github.com/character-ai/larch/pull/7657)).
- Added lint coverage for the skill catalog ([#7590](https://github.com/character-ai/larch/pull/7590)) and documented required GitHub token and Google ADC setup ([#7693](https://github.com/character-ai/larch/pull/7693)).

## Changed

- Consolidated contract ownership and lint target behavior ([#7581](https://github.com/character-ai/larch/pull/7581), [#7582](https://github.com/character-ai/larch/pull/7582), [#7584](https://github.com/character-ai/larch/pull/7584)).
- Centralized repository-root probing ([#7583](https://github.com/character-ai/larch/pull/7583)).
- Updated agent-lint integration, pins, suppressions, and local rule ownership ([#7585](https://github.com/character-ai/larch/pull/7585), [#7587](https://github.com/character-ai/larch/pull/7587), [#7592](https://github.com/character-ai/larch/pull/7592), [#7593](https://github.com/character-ai/larch/pull/7593), [#7595](https://github.com/character-ai/larch/pull/7595), [#7600](https://github.com/character-ai/larch/pull/7600), [#7601](https://github.com/character-ai/larch/pull/7601)).
- Updated learn-from-bugs state handling ([#7574](https://github.com/character-ai/larch/pull/7574)).

## Fixed

- Fixed stall report step rendering for main CI and post-merge push watch states ([#7576](https://github.com/character-ai/larch/pull/7576)).
- Fixed disagreement between local and CI secret scans for tracked run logs ([#7598](https://github.com/character-ai/larch/pull/7598)).
- Fixed release synchronization across plugin, Cargo workspace, path dependency, and lockfile versions ([#7711](https://github.com/character-ai/larch/pull/7711)).
