### PR TITLE
Fix Rust release asset Python runtime

### DIFF
--- a/.github/workflows/rust-release-assets.yaml
+++ b/.github/workflows/rust-release-assets.yaml
@@ -29,6 +29,10 @@ jobs:
         with:
           fetch-depth: 1
           persist-credentials: false
+      - name: Install Python 3.11
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.11"
       - name: Validate release identity
         id: identity
         shell: bash
@@ -91,6 +95,10 @@ jobs:
         with:
           fetch-depth: 1
           persist-credentials: false
+      - name: Install Python 3.11
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.11"
       - name: Verify checkout identity
         shell: bash
         env:
@@ -218,6 +226,10 @@ jobs:
         with:
           fetch-depth: 1
           persist-credentials: false
+      - name: Install Python 3.11
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.11"
       - name: Download every matrix output
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/python/tests/release/test_assets.py
+++ b/python/tests/release/test_assets.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import hashlib
+import re
 import shutil
 import tarfile
 from pathlib import Path
@@ -17,6 +18,9 @@ VERSION = "1.2.3"
 TAG = f"v{VERSION}"
 SOURCE_COMMIT = "a" * 40
 IDENTITY = assets.ReleaseIdentity(VERSION, TAG, SOURCE_COMMIT)
+REPO_ROOT = Path(__file__).parents[3]
+RELEASE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "rust-release-assets.yaml"
+SETUP_PYTHON = "actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6"
 
 
 def _write_license(root: Path) -> Path:
@@ -72,6 +76,19 @@ def _json_object(path: Path) -> dict[str, object]:
 
 def _rewrite_json(path: Path, value: dict[str, object]) -> None:
     _ = path.write_text(json.dumps(value, indent=2) + "\n", encoding="utf-8")
+
+
+def test_release_workflow_installs_supported_python_before_cli_in_every_job() -> None:
+    workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+    jobs = workflow.split("\njobs:\n", maxsplit=1)[1]
+    job_sections = re.split(r"(?m)^  (?=[a-z][a-z0-9_-]*:\n)", jobs)[1:]
+    cli_jobs = [job for job in job_sections if "python3 python/cli.py" in job]
+
+    assert len(cli_jobs) == 3
+    assert workflow.count(SETUP_PYTHON) == len(cli_jobs)
+    for job in cli_jobs:
+        assert job.index(SETUP_PYTHON) < job.index("python3 python/cli.py")
+        assert 'python-version: "3.11"' in job
 
 
 def test_validate_candidate_requires_matching_plugin_and_workspace_versions(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- install Python 3.11 before every release-workflow call to `python/cli.py`
- pin `actions/setup-python` to the official `v6` commit
- enforce the runtime setup for every CLI-using workflow job with an offline regression test

## Root cause

The `v53.1.23` asset workflow used Ubuntu 22.04's default `python3`. It is older than larch's Python 3.11 minimum, so candidate validation stopped before any Rust builds ran.

## Verification

- `python3 -m pytest python/tests/release/test_assets.py -q` (14 passed)
- changed-file pre-commit suite, including Ruff, Pyright, actionlint, agent-lint, gitleaks, and repository policy lint
- official `actions/setup-python` `v6` tag resolves to `ece7cb06caefa5fff74198d8649806c4678c61a1`
- setup-python source confirms an omitted architecture input uses each runner's native architecture

## Architecture review

No invariant violations or guideline deviations. The existing release workflow remains the single behavior owner, and the regression test mechanically covers every job that invokes the larch CLI.
