### PR TITLE
Fixes #7669: establish Rust test support and coverage

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -438,11 +438,45 @@ jobs:
       - name: Test Rust workspace
         run: make rust-test
 
+  # Whole-workspace coverage stays separate from test sharding so its measured
+  # baseline and exclusions remain stable.
+  rust-coverage:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            /*
+            !/larch-logs/
+          sparse-checkout-cone-mode: false
+      - name: Cache Cargo inputs and coverage build outputs
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/bin/cargo-llvm-cov
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-${{ runner.os }}-${{ github.job }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml', 'Makefile') }}
+          restore-keys: |
+            cargo-${{ runner.os }}-${{ github.job }}-
+      - name: Install pinned coverage tools
+        run: make rust-coverage-install
+      - name: Test Rust workspace with coverage
+        run: make rust-coverage
+      - name: Upload Rust coverage report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: rust-coverage-lcov
+          path: target/llvm-cov/lcov.info
+          if-no-files-found: error
+
   # Aggregate gate keeps one branch-protection name if the internal Rust job
   # shape changes. `if: always()` prevents a skipped dependency from passing.
   rust-gate:
     name: rust-gate
-    needs: [rust-lint, rust-clippy, rust-build-test]
+    needs: [rust-lint, rust-clippy, rust-build-test, rust-coverage]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -451,9 +485,11 @@ jobs:
           lint_result="${{ needs.rust-lint.result }}"
           clippy_result="${{ needs.rust-clippy.result }}"
           build_test_result="${{ needs.rust-build-test.result }}"
+          coverage_result="${{ needs.rust-coverage.result }}"
           [ "$lint_result" = success ] || { echo "::error::rust-lint result=$lint_result"; exit 1; }
           [ "$clippy_result" = success ] || { echo "::error::rust-clippy result=$clippy_result"; exit 1; }
           [ "$build_test_result" = success ] || { echo "::error::rust-build-test result=$build_test_result"; exit 1; }
+          [ "$coverage_result" = success ] || { echo "::error::rust-coverage result=$coverage_result"; exit 1; }
 
   contains-pins:
     runs-on: ubuntu-latest

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -12,6 +12,7 @@ until each command moves directly to its Rust owner.
 | `larch-adapters` | Concrete implementations of core ports. This includes filesystem and process boundaries, `gix`, Git CLI exceptions, GitHub and Google clients, and other external I/O. | `larch-core`. |
 | `larch-cli` | The composition root and the only released binary. It parses arguments, constructs adapters, and invokes core use cases. Its binary target is named `larch`. | `larch-core`, `larch-adapters`. |
 | `larch-lint` | Repository-only policy tooling. It is not linked into the product. | None of the product crates. |
+| `larch-test-support` | Workspace-only fixture builders for files, environments, clocks, processes, and HTTP responses. Product crates may use it only as a dev-dependency. | `larch-core`. |
 
 The product dependency direction is:
 
@@ -23,11 +24,14 @@ larch-cli -> larch-adapters -> larch-core
 Dependency direction applies to normal and build dependencies. Tests may use
 dev-dependencies across layers when an integration test needs them. Product
 crates must not depend on `larch-lint`.
+`larch-test-support` also stays outside the product graph and release binary.
 
 Add modules inside these crates. A new crate needs an independent ownership
 boundary, dependency set, and test surface, plus updates to this file and the
 `layering` rule. The [shared async model](docs/rust-async-runtime.md) defines
 cancellation, task ownership, signals, and child shutdown.
+The [Rust testing guide](docs/rust-testing.md) defines fixture ownership,
+test boundaries, coverage, external access, and CI partitioning.
 
 ## Boundary rules
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1439,6 +1439,7 @@ version = "53.1.23"
 dependencies = [
  "gix",
  "larch-core",
+ "larch-test-support",
  "nix",
  "serde_json",
  "tempfile",
@@ -1491,6 +1492,14 @@ dependencies = [
  "tree-sitter",
  "tree-sitter-bash",
  "uuid",
+]
+
+[[package]]
+name = "larch-test-support"
+version = "53.1.23"
+dependencies = [
+ "larch-core",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/larch-cli",
     "crates/larch-core",
     "crates/larch-lint",
+    "crates/larch-test-support",
 ]
 resolver = "3"
 
@@ -25,6 +26,7 @@ gix = { version = "=0.85.0", default-features = false, features = ["revision", "
 inventory = { version = "0.3.24", default-features = false }
 larch-adapters = { version = "=53.1.23", path = "crates/larch-adapters" }
 larch-core = { version = "=53.1.23", path = "crates/larch-core" }
+larch-test-support = { version = "=53.1.23", path = "crates/larch-test-support" }
 nix = { version = "0.31.3", default-features = false, features = ["process", "signal"] }
 predicates = { version = "3.1.4", default-features = false }
 pulldown-cmark = { version = "0.13.4", default-features = false }

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@
 PYTHON ?= python3
 PYLINT_JOBS ?= $(shell $(PYTHON) -c 'import os; print(0 if os.sysconf("SC_SEM_NSEMS_MAX") >= 0 else 1)' 2>/dev/null || printf '1')
 CARGO_DENY_VERSION ?= 0.20.2
+CARGO_LLVM_COV_VERSION := 0.8.7
+RUST_COVERAGE_MIN_LINES := 87.377
+RUST_COVERAGE_IGNORE_REGEX := (^|/)(crates/larch-test-support|tests|fixtures)(/|$$)|/build\.rs$$
 
 .PHONY: py-lint py-lint-main py-lint-checks-fast py-lint-shard py-typecheck py-lint-duplicate-code py-test lint lint-only lint-run-log-walkers test-harnesses test-harnesses-1 test-harnesses-2 test-harnesses-3 test-harnesses-4 test-harnesses-5 shellcheck markdownlint jsonlint actionlint agent-lint agnix gitleaks trufflehog setup test-pipe-sigpipe-safety test-redact test-scrub-log-secrets test-redact-tmpdir-paths test-append-tool-failure test-flush-vendor-failure-diagnostics test-append-execution-issue test-validate-research-output test-render-final-summary-bash32 test-collect-agent-results test-blocker test-issue-query test-anti-improvised-wakeup test-audit-runs test-sessionstart test-sweep-design-logs test-cleanup-sessionstart test-check-clean-tree test-check-main-sync test-check-scope-reduction-marker test-plan-review-scope-anchor test-persist-retally-step3-env test-lib-scope-anchor-handoff test-clarify-comment test-clarify-state test-check-stale-plugin test-preflight-args test-cache-root-validation test-cache-key-discipline test-finalize-sanity-check test-audit-edit-write test-block-submodule test-deny-edit-write test-verify-skill-called test-hook-anti-read-poll test-extinct-notification-stack test-sessionstart-statusline test-hook-stop-fail-close test-classify-bump test-git-push test-lint-codex-exec-auth test-lint-no-raw-stderr-after-quiet-init test-lint-readability-preamble test-anti-halt test-orchestrator-scope-sync test-alias-structure test-design-structure test-decompose-panel-dispatch test-decompose-aggregator test-decompose-file-issues test-design-driver test-design-clarify test-design-publish test-design-postplan-emit test-invoke-plan-validator test-file-design-oos test-emit-plan test-gate-b-dedup-plan test-trailer-helpers test-emit-design-plan-preview test-check-plan-size test-parse-plan-commands test-validate-plan-commands test-step3-review-cap test-run-step3-review test-plan-review-loop test-tally-plan-review test-finalize-plan test-step0b-router-flag-recovery test-brainstorm-prompts test-scout-plan-archetypes-wrapper test-dispatch-plan-review-panel test-render-final-summary test-implement-rebase-macro test-phantom-probe-with-warn test-implement-step2-routing test-implement-structure test-implement-step8-exit3-first-fixer test-oos-disposition-gate test-step-8-oos-checkpoint test-plan-adequacy-audit test-implement-preflight test-implement-positional-issue test-implement-fence-shape test-architectural-guidelines-step test-implement-timing-rehydration test-implement-cleanup-roundtrip test-implement-relevant-checks-anti-halt test-implement-anti-halt test-step2-dispatch test-cursor-implementer test-codex-implementer test-refresh-run-logs test-launch-cursor-ci test-launch-claude-ci test-launch-codex-ci test-run-negotiation-round test-launch-claude-subprocess test-launch-claude-review test-dispatch-with-waterfall test-run-external-agent test-run-external-agent-args test-quick-mode-docs-sync test-implement-bootstrap test-implement-bootstrap-invoke test-implement-finalize test-flush-execution-issues test-post-tracking-issue test-commit-implementation test-review-and-fix-commit-fixes test-generate-code-flow-diagram test-refresh-execution-issues test-review-and-fix-write-rejected test-slack-issue-announce test-step-16-17 test-write-final-report write-final-report-py-harness write-final-report-bash-harness test-step-18b-final-report test-token-cost test-render-cost-line test-implement-cleanup-script test-harness-shards-coverage test-harness-timer test-references-headers test-research-structure test-review-structure test-gather-context test-gather-branch-context test-review-core test-dispatch-panel-core test-dispatch-panel-core-dynamic test-dispatch-panel-reuse test-dispatch-panel-limits test-scout-dynamic-archetypes test-dispatch-plan-voters test-collect-findings test-aggregate-findings test-prune-nit-findings test-tally-code-votes test-check-reviewer-failure-threshold test-dispatch-code-voters-happy test-dispatch-code-voters-edge-and-r3-claude test-dispatch-code-voters-regressions-r1-r2 test-dispatch-code-voters-regressions-r3-codex test-emit-tally test-log-phase test-review-and-fix test-review-and-fix-dispatch test-review-and-fix-convergence test-review-and-fix-parsers test-render-findings-batch test-synthesis-subagent test-research-angle-prompts test-subskill-anchors test-tracking-issue-write test-larch-log test-capture-session-transcript test-larch-logs-manifest test-larch-logs-batches test-compose-plan-goals-test test-compose-collector-failure-log test-tracking-issue-summary test-tracking-issue-read-sentinel test-compose-review-findings test-token-tally test-token-ledger test-token-report test-timing-ledger test-timing-report test-parse-codex-usage test-token-vendor-scrapers test-token-claude-source test-review-and-fix-check-changes test-check-mid-run-dirty-tree test-check-phantom-dirty test-check-reviewers test-degraded-tools-gate test-external-tool-registry test-agent-model-args test-effort-prose test-launch-review test-lib-design-tmpdir test-implement-fork-env test-get-issue-context eval-research test-eval-set-structure test-eval-research-baseline-flag test-oos-file-conflict-deps test-oos-issue-cap test-wait-for-reviewers test-classify-diff-mode test-analyze test-compute-pr-line-counts test-review-and-fix-step5 test-run-step1-plan-log test-run-step2-dispatch test-prompt-template-invariants test-verify-run-log-completeness test-design-log-publish test-fetch-combinable-issues-filter test-legacy-title-prefix-literals-scope test-implement-admission test-pause-skill test-fluff-analysis test-rejected-analysis
 
@@ -206,7 +209,7 @@ py-test:
 	# PYTEST_SHARD_COUNT, see python/conftest.py) can be rebalanced by wall time.
 	cd python && $(PYTHON) -m pytest --durations=0
 
-.PHONY: rust-check rust-fmt rust-clippy rust-build rust-test rust-deny rust-lint
+.PHONY: rust-check rust-fmt rust-clippy rust-build rust-test rust-deny rust-lint rust-coverage rust-coverage-install
 
 rust-check: rust-fmt rust-clippy rust-build rust-test rust-deny rust-lint
 
@@ -229,6 +232,18 @@ rust-deny:
 	@test "$$(cargo deny --version)" = "cargo-deny $(CARGO_DENY_VERSION)" \
 		|| (printf '%s\n' "ERROR: make rust-deny requires cargo-deny $(CARGO_DENY_VERSION)" >&2; exit 1)
 	cargo deny --locked --all-features check
+
+rust-coverage-install:
+	rustup component add llvm-tools-preview
+	@test "$$(cargo llvm-cov --version 2>/dev/null)" = "cargo-llvm-cov $(CARGO_LLVM_COV_VERSION)" \
+		|| cargo install cargo-llvm-cov --version $(CARGO_LLVM_COV_VERSION) --locked --force
+
+rust-coverage:
+	@test "$$(cargo llvm-cov --version 2>/dev/null)" = "cargo-llvm-cov $(CARGO_LLVM_COV_VERSION)" \
+		|| (printf '%s\n' "ERROR: make rust-coverage requires cargo-llvm-cov $(CARGO_LLVM_COV_VERSION); run make rust-coverage-install" >&2; exit 1)
+	cargo llvm-cov --workspace --all-features --locked --ignore-filename-regex '$(RUST_COVERAGE_IGNORE_REGEX)' --summary-only --fail-under-lines $(RUST_COVERAGE_MIN_LINES)
+	mkdir -p target/llvm-cov
+	cargo llvm-cov report --ignore-filename-regex '$(RUST_COVERAGE_IGNORE_REGEX)' --lcov --output-path target/llvm-cov/lcov.info
 
 lint-only:
 	pre-commit run --all-files

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Larch is a Claude Code workflow automation framework that orchestrates multi-age
   - [Rust Architecture](ARCHITECTURE.md) — crate ownership, dependency direction, external boundaries, and release constraints
   - [Rust Async Runtime](docs/rust-async-runtime.md) — cancellation, timeouts, bounded tasks, signals, and child shutdown
   - [Rust Parity Harness](docs/rust-parity-harness.md) — isolated Python-to-Rust command comparison and reviewed goldens
+  - [Rust Testing](docs/rust-testing.md) — shared fixtures, test boundaries, coverage, and CI partitioning
   - [Workflow Lifecycle](docs/workflow-lifecycle.md) — how skills compose end-to-end
   - [Agent System](docs/agents.md) — parallel subagent orchestration
   - [Design Flow](docs/collaborative-sketches.md) — direct plan drafting and plan review

--- a/crates/larch-adapters/Cargo.toml
+++ b/crates/larch-adapters/Cargo.toml
@@ -19,5 +19,8 @@ tokio-util.workspace = true
 [target.'cfg(unix)'.dependencies]
 nix.workspace = true
 
+[dev-dependencies]
+larch-test-support.workspace = true
+
 [lints]
 workspace = true

--- a/crates/larch-adapters/src/process.rs
+++ b/crates/larch-adapters/src/process.rs
@@ -538,6 +538,7 @@ mod tests {
     use larch_core::{
         ExternalProgram, GitCliOperation, ProcessRequest, ProcessRequestError, VendorProgram,
     };
+    use larch_test_support::TestClock;
     use std::{
         num::NonZeroUsize,
         sync::Mutex,
@@ -637,20 +638,12 @@ mod tests {
         assert!(!inherited.contains(&"OPENAI_API_KEY"));
     }
 
-    struct FixedClock;
-
-    impl BusinessClock for FixedClock {
-        fn now(&self) -> SystemTime {
-            SystemTime::UNIX_EPOCH
-        }
-    }
-
     #[test]
     fn process_journal_records_only_closed_fields_and_counts() {
         let observer = ProcessJournalObserver::new(
             Vec::new(),
             RunId::parse("run-process").expect("run ID"),
-            FixedClock,
+            TestClock::new(SystemTime::UNIX_EPOCH),
         );
         observer.observe(ProcessEvent::new(
             ProcessEventKind::Exited,

--- a/crates/larch-lint/src/rules/package_and_test_architecture.rs
+++ b/crates/larch-lint/src/rules/package_and_test_architecture.rs
@@ -267,14 +267,18 @@ crate::register_rule!(RENDERER_GOLDEN_TESTS_METADATA, RENDERER_GOLDEN_TESTS_RULE
 fn known_workspace_package(name: &str) -> bool {
     matches!(
         name,
-        "larch-core" | "larch-adapters" | "larch-cli" | "larch-lint"
+        "larch-core"
+            | "larch-adapters"
+            | "larch-cli"
+            | "larch-lint"
+            | "larch-test-support"
     )
 }
 
 fn workspace_dependency_allowed(importer: &str, dependency: &str) -> bool {
     matches!(
         (importer, dependency),
-        ("larch-adapters", "larch-core")
+        ("larch-adapters" | "larch-test-support", "larch-core")
             | ("larch-cli", "larch-core" | "larch-adapters")
     )
 }
@@ -584,6 +588,7 @@ mod tests {
         assert!(known_workspace_package("larch-adapters"));
         assert!(known_workspace_package("larch-cli"));
         assert!(known_workspace_package("larch-lint"));
+        assert!(known_workspace_package("larch-test-support"));
         assert!(!known_workspace_package("larch-report"));
         assert!(workspace_dependency_allowed(
             "larch-adapters",
@@ -592,6 +597,10 @@ mod tests {
         assert!(workspace_dependency_allowed(
             "larch-cli",
             "larch-adapters"
+        ));
+        assert!(workspace_dependency_allowed(
+            "larch-test-support",
+            "larch-core"
         ));
         assert!(!workspace_dependency_allowed(
             "larch-core",

--- a/crates/larch-test-support/Cargo.toml
+++ b/crates/larch-test-support/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "larch-test-support"
+version.workspace = true
+description = "Shared test fixtures for the larch Rust workspace"
+publish = false
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+larch-core.workspace = true
+tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/larch-test-support/src/clock.rs
+++ b/crates/larch-test-support/src/clock.rs
@@ -1,0 +1,101 @@
+use std::{
+    sync::Mutex,
+    time::{Duration, SystemTime},
+};
+
+use larch_core::{AsyncClock, BusinessClock, MonotonicClock, MonotonicTime, Sleep};
+
+#[derive(Clone, Copy, Debug)]
+struct ClockState {
+    wall: SystemTime,
+    elapsed: Duration,
+}
+
+/// A thread-safe clock advanced only by the test.
+#[derive(Debug)]
+pub struct TestClock {
+    state: Mutex<ClockState>,
+}
+
+impl TestClock {
+    /// Start at a fixed wall time and zero monotonic time.
+    #[must_use]
+    pub const fn new(wall: SystemTime) -> Self {
+        Self {
+            state: Mutex::new(ClockState {
+                wall,
+                elapsed: Duration::ZERO,
+            }),
+        }
+    }
+
+    /// Advance wall and monotonic time together.
+    ///
+    /// # Panics
+    /// Panics if the fixture lock is poisoned or wall time overflows.
+    pub fn advance(&self, duration: Duration) {
+        let mut state = self.state.lock().expect("test clock lock poisoned");
+        state.wall = state
+            .wall
+            .checked_add(duration)
+            .expect("test clock wall time overflow");
+        state.elapsed = state.elapsed.saturating_add(duration);
+    }
+}
+
+impl BusinessClock for TestClock {
+    fn now(&self) -> SystemTime {
+        self.state.lock().expect("test clock lock poisoned").wall
+    }
+}
+
+impl MonotonicClock for TestClock {
+    fn now(&self) -> MonotonicTime {
+        MonotonicTime::from_elapsed(self.state.lock().expect("test clock lock poisoned").elapsed)
+    }
+}
+
+impl AsyncClock for TestClock {
+    fn sleep(&self, duration: Duration) -> Sleep<'_> {
+        Box::pin(async move { self.advance(duration) })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{future::Future, time::Duration, time::SystemTime};
+
+    use larch_core::{AsyncClock, BusinessClock, MonotonicClock};
+
+    use super::TestClock;
+
+    #[test]
+    fn manual_advance_updates_both_clock_domains() {
+        let clock = TestClock::new(SystemTime::UNIX_EPOCH);
+
+        clock.advance(Duration::from_secs(4));
+
+        assert_eq!(
+            BusinessClock::now(&clock),
+            SystemTime::UNIX_EPOCH + Duration::from_secs(4)
+        );
+        assert_eq!(
+            MonotonicClock::now(&clock).elapsed(),
+            Duration::from_secs(4)
+        );
+    }
+
+    #[test]
+    fn async_sleep_completes_without_real_time() {
+        let clock = TestClock::new(SystemTime::UNIX_EPOCH);
+        let mut future = Box::pin(clock.sleep(Duration::from_secs(30)));
+        let waker = std::task::Waker::noop();
+        let mut context = std::task::Context::from_waker(waker);
+
+        assert!(future.as_mut().poll(&mut context).is_ready());
+        assert_eq!(
+            MonotonicClock::now(&clock).elapsed(),
+            Duration::from_secs(30)
+        );
+    }
+}

--- a/crates/larch-test-support/src/environment.rs
+++ b/crates/larch-test-support/src/environment.rs
@@ -1,0 +1,88 @@
+use std::{
+    collections::BTreeMap,
+    ffi::{OsStr, OsString},
+};
+
+use crate::TestWorkspace;
+
+/// A complete child environment that never mutates the test process.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct TestEnvironment {
+    values: BTreeMap<OsString, OsString>,
+}
+
+impl TestEnvironment {
+    /// Build a minimal offline environment rooted in an owned workspace.
+    ///
+    /// # Errors
+    /// Returns fixture-path creation errors.
+    pub fn isolated(workspace: &TestWorkspace) -> std::io::Result<Self> {
+        let home = workspace.create_dir("home")?;
+        let temp = workspace.create_dir("tmp")?;
+        let bin = workspace.create_dir("bin")?;
+        Ok(Self::default()
+            .set("HOME", home)
+            .set("TMPDIR", &temp)
+            .set("TEMP", &temp)
+            .set("TMP", temp)
+            .set("PATH", bin)
+            .set("LANG", "C")
+            .set("NO_PROXY", "")
+            .set("LARCH_LIVE_SERVICES", "disabled"))
+    }
+
+    /// Set or replace one owned value.
+    #[must_use]
+    pub fn set(mut self, key: impl Into<OsString>, value: impl Into<OsString>) -> Self {
+        self.values.insert(key.into(), value.into());
+        self
+    }
+
+    /// Return one value without consulting the ambient environment.
+    #[must_use]
+    pub fn get(&self, key: impl AsRef<OsStr>) -> Option<&OsStr> {
+        self.values.get(key.as_ref()).map(OsString::as_os_str)
+    }
+
+    /// Iterate over the complete environment for `Command::envs` after `env_clear`.
+    pub fn iter(&self) -> impl Iterator<Item = (&OsStr, &OsStr)> {
+        self.values
+            .iter()
+            .map(|(key, value)| (key.as_os_str(), value.as_os_str()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TestEnvironment;
+    use crate::TestWorkspace;
+
+    #[test]
+    fn isolated_environment_is_owned_and_credential_free() {
+        let workspace = TestWorkspace::new().expect("test workspace");
+        let environment = TestEnvironment::isolated(&workspace).expect("test environment");
+
+        assert_eq!(environment.get("LANG"), Some(std::ffi::OsStr::new("C")));
+        assert_eq!(environment.get("GH_TOKEN"), None);
+        assert!(
+            environment
+                .get("HOME")
+                .is_some_and(|home| workspace.root().join("home") == home)
+        );
+    }
+
+    #[test]
+    fn setting_a_key_replaces_its_prior_value() {
+        let environment = TestEnvironment::default()
+            .set("FIXTURE", "first")
+            .set("FIXTURE", "second");
+
+        assert_eq!(
+            environment.iter().collect::<Vec<_>>(),
+            [(
+                std::ffi::OsStr::new("FIXTURE"),
+                std::ffi::OsStr::new("second")
+            )]
+        );
+    }
+}

--- a/crates/larch-test-support/src/filesystem.rs
+++ b/crates/larch-test-support/src/filesystem.rs
@@ -1,0 +1,175 @@
+use std::{
+    fs, io,
+    path::{Component, Path, PathBuf},
+};
+
+use tempfile::TempDir;
+
+/// An owned temporary directory with confined fixture paths.
+#[derive(Debug)]
+pub struct TestWorkspace {
+    directory: TempDir,
+}
+
+impl TestWorkspace {
+    /// Create an empty workspace that is removed when dropped.
+    ///
+    /// # Errors
+    /// Returns the temporary-directory creation error.
+    pub fn new() -> io::Result<Self> {
+        tempfile::Builder::new()
+            .prefix("larch-test-")
+            .tempdir()
+            .map(|directory| Self { directory })
+    }
+
+    /// Return the absolute fixture root.
+    #[must_use]
+    pub fn root(&self) -> &Path {
+        self.directory.path()
+    }
+
+    /// Resolve a non-empty confined relative path.
+    ///
+    /// # Errors
+    /// Rejects absolute paths, empty paths, and `.` or `..` components.
+    pub fn path(&self, relative: impl AsRef<Path>) -> io::Result<PathBuf> {
+        let relative = relative.as_ref();
+        validate_relative(relative)?;
+        reject_symlink_components(self.root(), relative)?;
+        Ok(self.root().join(relative))
+    }
+
+    /// Create a confined directory and its parents.
+    ///
+    /// # Errors
+    /// Returns path validation or filesystem errors.
+    pub fn create_dir(&self, relative: impl AsRef<Path>) -> io::Result<PathBuf> {
+        let path = self.path(relative)?;
+        fs::create_dir_all(&path)?;
+        Ok(path)
+    }
+
+    /// Write bytes to a confined path, creating parent directories.
+    ///
+    /// # Errors
+    /// Returns path validation or filesystem errors.
+    pub fn write(
+        &self,
+        relative: impl AsRef<Path>,
+        contents: impl AsRef<[u8]>,
+    ) -> io::Result<PathBuf> {
+        let path = self.path(relative)?;
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(&path, contents)?;
+        Ok(path)
+    }
+
+    /// Read bytes from a confined path.
+    ///
+    /// # Errors
+    /// Returns path validation or filesystem errors.
+    pub fn read(&self, relative: impl AsRef<Path>) -> io::Result<Vec<u8>> {
+        fs::read(self.path(relative)?)
+    }
+}
+
+fn validate_relative(path: &Path) -> io::Result<()> {
+    if path.as_os_str().is_empty()
+        || path
+            .components()
+            .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "test fixture path must be a confined relative path: {}",
+                path.display()
+            ),
+        ));
+    }
+    Ok(())
+}
+
+fn reject_symlink_components(root: &Path, relative: &Path) -> io::Result<()> {
+    let mut candidate = root.to_path_buf();
+    for component in relative.components() {
+        candidate.push(component);
+        match fs::symlink_metadata(&candidate) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!(
+                        "test fixture path crosses a symlink: {}",
+                        candidate.display()
+                    ),
+                ));
+            }
+            Ok(_) => {}
+            Err(error) if error.kind() == io::ErrorKind::NotFound => break,
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{io::ErrorKind, path::Path};
+
+    use super::TestWorkspace;
+
+    #[test]
+    fn workspace_builds_files_without_changing_process_state() {
+        let original = std::env::current_dir().expect("current directory");
+        let workspace = TestWorkspace::new().expect("test workspace");
+
+        workspace
+            .write("nested/input.txt", b"fixture\n")
+            .expect("write fixture");
+
+        assert_eq!(
+            workspace.read("nested/input.txt").expect("read fixture"),
+            b"fixture\n"
+        );
+        assert_eq!(
+            std::env::current_dir().expect("current directory"),
+            original
+        );
+    }
+
+    #[test]
+    fn workspace_rejects_escape_and_absolute_paths() {
+        let workspace = TestWorkspace::new().expect("test workspace");
+        for path in [Path::new("../escape"), workspace.root()] {
+            assert_eq!(
+                workspace
+                    .path(path)
+                    .expect_err("unsafe path must fail")
+                    .kind(),
+                ErrorKind::InvalidInput
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn workspace_rejects_symlinked_ancestors() {
+        use std::os::unix::fs::symlink;
+
+        let workspace = TestWorkspace::new().expect("test workspace");
+        let outside = tempfile::tempdir().expect("outside workspace");
+        symlink(outside.path(), workspace.root().join("linked")).expect("fixture symlink");
+
+        assert_eq!(
+            workspace
+                .write("linked/escape.txt", b"escape")
+                .expect_err("symlink escape must fail")
+                .kind(),
+            ErrorKind::InvalidInput
+        );
+        assert!(!outside.path().join("escape.txt").exists());
+    }
+}

--- a/crates/larch-test-support/src/http.rs
+++ b/crates/larch-test-support/src/http.rs
@@ -1,0 +1,161 @@
+use std::{collections::BTreeMap, error::Error, fmt};
+
+/// A complete in-memory HTTP response for an injected client or loopback stub.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HttpResponse {
+    status: u16,
+    headers: BTreeMap<String, String>,
+    body: Vec<u8>,
+}
+
+impl HttpResponse {
+    #[must_use]
+    pub const fn status(&self) -> u16 {
+        self.status
+    }
+
+    #[must_use]
+    pub const fn headers(&self) -> &BTreeMap<String, String> {
+        &self.headers
+    }
+
+    #[must_use]
+    pub fn body(&self) -> &[u8] {
+        &self.body
+    }
+}
+
+/// Builder for deterministic HTTP response fixtures.
+#[derive(Clone, Debug)]
+pub struct HttpResponseBuilder {
+    status: u16,
+    headers: BTreeMap<String, String>,
+    body: Vec<u8>,
+}
+
+impl HttpResponseBuilder {
+    #[must_use]
+    pub const fn new(status: u16) -> Self {
+        Self {
+            status,
+            headers: BTreeMap::new(),
+            body: Vec::new(),
+        }
+    }
+
+    /// Add or replace a case-normalized header.
+    ///
+    /// # Errors
+    /// Rejects invalid HTTP token names and line-breaking values.
+    pub fn header(mut self, name: &str, value: &str) -> Result<Self, HttpResponseError> {
+        if !valid_header_name(name) {
+            return Err(HttpResponseError::InvalidHeaderName);
+        }
+        if value.contains(['\r', '\n']) {
+            return Err(HttpResponseError::InvalidHeaderValue);
+        }
+        self.headers
+            .insert(name.to_ascii_lowercase(), value.to_owned());
+        Ok(self)
+    }
+
+    /// Set raw response body bytes.
+    #[must_use]
+    pub fn body(mut self, body: impl Into<Vec<u8>>) -> Self {
+        self.body = body.into();
+        self
+    }
+
+    /// Validate and build the response.
+    ///
+    /// # Errors
+    /// Rejects status codes outside the HTTP three-digit range.
+    pub fn build(self) -> Result<HttpResponse, HttpResponseError> {
+        if !(100..=599).contains(&self.status) {
+            return Err(HttpResponseError::InvalidStatus);
+        }
+        Ok(HttpResponse {
+            status: self.status,
+            headers: self.headers,
+            body: self.body,
+        })
+    }
+}
+
+fn valid_header_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.bytes().all(|byte| {
+            byte.is_ascii_alphanumeric()
+                || matches!(
+                    byte,
+                    b'!' | b'#'
+                        | b'$'
+                        | b'%'
+                        | b'&'
+                        | b'\''
+                        | b'*'
+                        | b'+'
+                        | b'-'
+                        | b'.'
+                        | b'^'
+                        | b'_'
+                        | b'`'
+                        | b'|'
+                        | b'~'
+                )
+        })
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum HttpResponseError {
+    InvalidStatus,
+    InvalidHeaderName,
+    InvalidHeaderValue,
+}
+
+impl fmt::Display for HttpResponseError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::InvalidStatus => "HTTP fixture status must be between 100 and 599",
+            Self::InvalidHeaderName => "HTTP fixture header name is invalid",
+            Self::InvalidHeaderValue => "HTTP fixture header value contains a line break",
+        })
+    }
+}
+
+impl Error for HttpResponseError {}
+
+#[cfg(test)]
+mod tests {
+    use super::{HttpResponseBuilder, HttpResponseError};
+
+    #[test]
+    fn response_builder_normalizes_headers_and_preserves_body_bytes() {
+        let response = HttpResponseBuilder::new(429)
+            .header("Retry-After", "3")
+            .expect("valid header")
+            .body(vec![0, 255])
+            .build()
+            .expect("valid response");
+
+        assert_eq!(response.status(), 429);
+        assert_eq!(response.headers()["retry-after"], "3");
+        assert_eq!(response.body(), [0, 255]);
+    }
+
+    #[test]
+    fn response_builder_rejects_forged_headers_and_invalid_status() {
+        assert_eq!(
+            HttpResponseBuilder::new(200)
+                .header("X-Test", "ok\r\nforged: yes")
+                .expect_err("line break must fail"),
+            HttpResponseError::InvalidHeaderValue
+        );
+        assert_eq!(
+            HttpResponseBuilder::new(99)
+                .build()
+                .expect_err("invalid status must fail"),
+            HttpResponseError::InvalidStatus
+        );
+    }
+}

--- a/crates/larch-test-support/src/lib.rs
+++ b/crates/larch-test-support/src/lib.rs
@@ -1,0 +1,13 @@
+//! Shared, deterministic fixtures for Rust tests in the larch workspace.
+
+mod clock;
+mod environment;
+mod filesystem;
+mod http;
+mod process;
+
+pub use clock::TestClock;
+pub use environment::TestEnvironment;
+pub use filesystem::TestWorkspace;
+pub use http::{HttpResponse, HttpResponseBuilder, HttpResponseError};
+pub use process::{FakeProcessRunner, NeverCancelled, ProcessOutputBuilder};

--- a/crates/larch-test-support/src/process.rs
+++ b/crates/larch-test-support/src/process.rs
@@ -1,0 +1,227 @@
+use std::{collections::VecDeque, future, sync::Mutex};
+
+use larch_core::{
+    ExternalProcessRunner, ProcessCancellation, ProcessError, ProcessErrorKind, ProcessFuture,
+    ProcessOutput, ProcessRequest, ProcessStatus,
+};
+
+/// Builder for captured process results.
+#[derive(Clone, Debug)]
+pub struct ProcessOutputBuilder {
+    code: Option<i32>,
+    success: bool,
+    stdout: Vec<u8>,
+    stderr: Vec<u8>,
+    stdout_truncated: bool,
+    stderr_truncated: bool,
+}
+
+impl ProcessOutputBuilder {
+    /// Start with a successful empty exit.
+    #[must_use]
+    pub const fn success() -> Self {
+        Self {
+            code: Some(0),
+            success: true,
+            stdout: Vec::new(),
+            stderr: Vec::new(),
+            stdout_truncated: false,
+            stderr_truncated: false,
+        }
+    }
+
+    /// Start with a failed empty exit.
+    #[must_use]
+    pub const fn failure(code: i32) -> Self {
+        Self {
+            code: Some(code),
+            success: false,
+            stdout: Vec::new(),
+            stderr: Vec::new(),
+            stdout_truncated: false,
+            stderr_truncated: false,
+        }
+    }
+
+    /// Set stdout bytes.
+    #[must_use]
+    pub fn stdout(mut self, stdout: impl Into<Vec<u8>>) -> Self {
+        self.stdout = stdout.into();
+        self
+    }
+
+    /// Set stderr bytes.
+    #[must_use]
+    pub fn stderr(mut self, stderr: impl Into<Vec<u8>>) -> Self {
+        self.stderr = stderr.into();
+        self
+    }
+
+    /// Mark either captured stream as truncated.
+    #[must_use]
+    pub const fn truncated(mut self, stdout: bool, stderr: bool) -> Self {
+        self.stdout_truncated = stdout;
+        self.stderr_truncated = stderr;
+        self
+    }
+
+    /// Build the typed output.
+    #[must_use]
+    pub fn build(self) -> ProcessOutput {
+        ProcessOutput::new(
+            ProcessStatus::new(self.success, self.code),
+            self.stdout,
+            self.stderr,
+            self.stdout_truncated,
+            self.stderr_truncated,
+        )
+    }
+}
+
+/// A queued fake that records requests and never starts a process.
+#[derive(Debug, Default)]
+pub struct FakeProcessRunner {
+    responses: Mutex<VecDeque<Result<ProcessOutput, ProcessError>>>,
+    requests: Mutex<Vec<ProcessRequest>>,
+}
+
+impl FakeProcessRunner {
+    /// Queue responses in call order.
+    #[must_use]
+    pub fn new(responses: impl IntoIterator<Item = Result<ProcessOutput, ProcessError>>) -> Self {
+        Self {
+            responses: Mutex::new(responses.into_iter().collect()),
+            requests: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Return a snapshot of all received requests.
+    ///
+    /// # Panics
+    /// Panics if another test thread poisoned the fixture lock.
+    #[must_use]
+    pub fn requests(&self) -> Vec<ProcessRequest> {
+        self.requests
+            .lock()
+            .expect("fake process request lock poisoned")
+            .clone()
+    }
+}
+
+impl ExternalProcessRunner for FakeProcessRunner {
+    fn run<'a>(
+        &'a self,
+        request: ProcessRequest,
+        cancellation: &'a dyn ProcessCancellation,
+    ) -> ProcessFuture<'a> {
+        self.requests
+            .lock()
+            .expect("fake process request lock poisoned")
+            .push(request);
+        Box::pin(async move {
+            if cancellation.is_cancelled() {
+                return Err(ProcessError::new(
+                    ProcessErrorKind::Cancelled,
+                    "fake process cancelled",
+                    None,
+                ));
+            }
+            self.responses
+                .lock()
+                .expect("fake process response lock poisoned")
+                .pop_front()
+                .unwrap_or_else(|| {
+                    Err(ProcessError::new(
+                        ProcessErrorKind::Wait,
+                        "fake process response queue exhausted",
+                        None,
+                    ))
+                })
+        })
+    }
+}
+
+/// Cancellation fixture that remains pending.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct NeverCancelled;
+
+impl ProcessCancellation for NeverCancelled {
+    fn is_cancelled(&self) -> bool {
+        false
+    }
+
+    fn cancelled(&self) -> std::pin::Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        Box::pin(future::pending())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{future::Future, num::NonZeroUsize, time::Duration};
+
+    use larch_core::{
+        ExternalProcessRunner, ExternalProgram, ProcessErrorKind, ProcessStatus, VendorProgram,
+    };
+
+    use super::{FakeProcessRunner, NeverCancelled, ProcessOutputBuilder};
+    use crate::TestWorkspace;
+
+    fn request(workspace: &TestWorkspace, vendor: VendorProgram) -> larch_core::ProcessRequest {
+        larch_core::ProcessRequest::new(
+            ExternalProgram::Vendor(vendor),
+            ["exec"],
+            workspace.root().to_path_buf(),
+            Duration::from_secs(1),
+            Duration::from_millis(100),
+            NonZeroUsize::new(1024).expect("non-zero output limit"),
+        )
+        .expect("process request")
+    }
+
+    #[test]
+    fn fake_records_requests_and_returns_queued_bytes() {
+        let workspace = TestWorkspace::new().expect("test workspace");
+        let runner = FakeProcessRunner::new([Ok(ProcessOutputBuilder::success()
+            .stdout(b"ok\n".to_vec())
+            .build())]);
+        let mut future =
+            Box::pin(runner.run(request(&workspace, VendorProgram::Codex), &NeverCancelled));
+        let waker = std::task::Waker::noop();
+        let mut context = std::task::Context::from_waker(waker);
+        let std::task::Poll::Ready(result) = future.as_mut().poll(&mut context) else {
+            panic!("fake response should be ready");
+        };
+
+        assert_eq!(result.expect("fake output").stdout(), b"ok\n");
+        assert_eq!(runner.requests().len(), 1);
+    }
+
+    #[test]
+    fn output_builder_preserves_failures_and_truncation() {
+        let output = ProcessOutputBuilder::failure(17)
+            .stderr(b"failed".to_vec())
+            .truncated(false, true)
+            .build();
+
+        assert_eq!(output.status(), ProcessStatus::new(false, Some(17)));
+        assert!(output.stderr_truncated());
+    }
+
+    #[test]
+    fn exhausted_queue_fails_loudly() {
+        let workspace = TestWorkspace::new().expect("test workspace");
+        let runner = FakeProcessRunner::default();
+        let mut future =
+            Box::pin(runner.run(request(&workspace, VendorProgram::Claude), &NeverCancelled));
+        let waker = std::task::Waker::noop();
+        let mut context = std::task::Context::from_waker(waker);
+        let std::task::Poll::Ready(result) = future.as_mut().poll(&mut context) else {
+            panic!("fake error should be ready");
+        };
+
+        assert_eq!(
+            result.expect_err("empty queue must fail").kind(),
+            ProcessErrorKind::Wait
+        );
+    }
+}

--- a/docs/linting.md
+++ b/docs/linting.md
@@ -62,6 +62,10 @@ components. Install the dependency-policy tool with
 formatting, Clippy, build, test, and dependency policy. CI runs the same checks
 through parallel lint and build/test lanes behind the stable `rust-gate`. See
 [`docs/rust-dependency-survey.md`](rust-dependency-survey.md) for crate choices.
+Run `make rust-coverage-install` once, then `make rust-coverage` to enforce the
+measured line baseline and write `target/llvm-cov/lcov.info`. CI uploads the
+same report and includes coverage in `rust-gate`. See
+[`docs/rust-testing.md`](rust-testing.md) for exclusions and test boundaries.
 
 ### Python complexity ratchet
 

--- a/docs/rust-testing.md
+++ b/docs/rust-testing.md
@@ -1,0 +1,72 @@
+# Rust Testing
+
+Rust tests must be deterministic, offline by default, and safe under Cargo's
+parallel test runner. Use `larch-test-support` from integration tests and from
+crate-local tests where the dependency graph permits it.
+
+## Shared fixtures
+
+- `TestWorkspace` owns a temporary root. It rejects absolute paths and dot
+  segments, rejects symlink traversal, creates parents, and removes the root
+  on drop.
+- `TestEnvironment` builds a complete child environment without changing the
+  test process. Call `env_clear` before applying its iterator to a command.
+- `TestClock` implements the core wall, monotonic, and async clock ports.
+  Sleeps advance injected time without waiting.
+- `FakeProcessRunner` records typed requests and returns queued outcomes.
+  `ProcessOutputBuilder` creates byte-exact success and failure results.
+- `HttpResponseBuilder` creates in-memory responses and rejects invalid status
+  codes, header names, and header line injection.
+
+Never call `set_current_dir`, `set_var`, or `remove_var` in a test. Do not use a
+shared fixed path, port, clock, response queue, or mutable static. Give each
+test its own fixture and let Cargo run it in parallel.
+
+## Test boundaries
+
+- Unit tests live in a crate-local `#[cfg(test)]` module. They cover private
+  logic through injected ports. Use an owned workspace if filesystem state is
+  part of the behavior; never use the ambient working directory.
+- Integration tests live directly under a crate's `tests/` directory. They
+  cover the public crate boundary and may use owned filesystem fixtures.
+- Golden tests compare complete user-facing or wire-format bytes under
+  `fixtures/`. Update goldens only for an intentional, reviewed contract
+  change. Keep the update switch opt-in and disabled in CI.
+- Property tests cover parsers, codecs, path rules, and other broad input
+  spaces. Fix the generator seed in failure output and keep shrinking enabled.
+  A property test complements named boundary examples; it does not replace
+  them.
+- Live-smoke tests exercise a real remote service or vendor executable. Mark
+  them ignored by default, require an explicit opt-in, and never run them in
+  normal pull-request CI.
+
+Normal unit, integration, golden, property, and coverage runs cannot access an
+external network. Use injected HTTP responses. A transport adapter test may
+bind an ephemeral loopback port when it must exercise socket framing; it cannot
+resolve DNS or contact a non-loopback address.
+
+Do not depend on an installed executable unless the test covers an approved
+executable compatibility boundary. The process adapter may invoke Git, and the
+parity harness may invoke its documented Python and Rust fixture programs.
+Everything else uses `FakeProcessRunner`. Real Claude, Codex, Cursor, service
+credentials, and remote endpoints belong only in explicit live-smoke runs.
+
+## Coverage and CI
+
+Install the pinned tool with `make rust-coverage-install`. Run
+`make rust-coverage` to print the workspace summary, enforce the measured line
+baseline, and write `target/llvm-cov/lcov.info`.
+
+The baseline is 87.377% lines. This was the measured unrounded floor when the
+policy was introduced. It is a no-regression floor, not a chosen repository
+target. Raise it when coverage
+improves. Lower it only with a documented reason and issue. Coverage excludes
+the shared test-support crate, `tests/` and `fixtures/` trees, and build scripts.
+Keep that exclusion expression in the Makefile so local and CI reports match.
+
+The Rust suite remains one workspace test lane while it is fast. When it needs
+partitioning, shard by Cargo package rather than test-name or source-file
+globs. Assign every package to exactly one test shard, keep `--all-features`
+and `--locked` on each shard, and retain one unsharded workspace coverage run.
+Use recorded CI duration to balance package groups. Keep `rust-gate` as the
+stable aggregate check when the internal shard count changes.

--- a/python/tests/implement/test_checks.py
+++ b/python/tests/implement/test_checks.py
@@ -3986,12 +3986,14 @@ def test_local_relevant_checks_ci_superset_guard() -> None:
     assert "rust-lint:" in workflow
     assert "rust-build-test:" in workflow
     assert "rust-clippy:" in workflow
+    assert "rust-coverage:" in workflow
     assert "rust-gate:" in workflow
-    assert "needs: [rust-lint, rust-clippy, rust-build-test]" in workflow
+    assert "needs: [rust-lint, rust-clippy, rust-build-test, rust-coverage]" in workflow
     assert "make rust-fmt" in workflow
     assert "make rust-clippy" in workflow
     assert "make rust-build" in workflow
     assert "make rust-test" in workflow
+    assert "make rust-coverage" in workflow
     assert "cargo-deny-action@" in workflow
 
 def test_existing_regular_files_includes_symlink_to_file(tmp_path: Path) -> None:


### PR DESCRIPTION
Fixes #7669

## Summary

- add a workspace-only Rust test-support crate for confined files, owned environments, deterministic clocks, queued processes, and validated HTTP responses
- add a measured cargo-llvm-cov line-coverage ratchet with stable exclusions and an uploaded CI artifact
- document unit, integration, golden, property, live-smoke, external-access, parallel-safety, and future package-sharding rules

## Self-review

A fresh acceptance and architecture review found and fixed three issues: coverage-tool caching happened after installation, no consumer exercised the shared crate, and the filesystem fixture could follow a symlink outside its root. The revision reorders the cache, uses TestClock from the adapter tests, rejects symlink traversal, and adds regression coverage.

## Validation

- changed-file pre-commit hooks
- focused Clippy for larch-test-support, larch-adapters, and larch-lint
- focused larch-test-support, adapter, and architecture-rule tests
- make rust-coverage at the measured 87.377% line floor
- cargo run --quiet --locked --package larch-lint -- all
- git diff --check

The implementation adds 778 non-generated Rust lines, including tests.