### PR TITLE
Release v53.1.24

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "53.1.23",
+  "version": "53.1.24",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1435,7 +1435,7 @@ dependencies = [
 
 [[package]]
 name = "larch-adapters"
-version = "53.1.23"
+version = "53.1.24"
 dependencies = [
  "gix",
  "larch-core",
@@ -1448,7 +1448,7 @@ dependencies = [
 
 [[package]]
 name = "larch-cli"
-version = "53.1.23"
+version = "53.1.24"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1463,14 +1463,14 @@ dependencies = [
 
 [[package]]
 name = "larch-core"
-version = "53.1.23"
+version = "53.1.24"
 dependencies = [
  "regex",
 ]
 
 [[package]]
 name = "larch-lint"
-version = "53.1.23"
+version = "53.1.24"
 dependencies = [
  "assert_cmd",
  "automod",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2024"
 license = "MIT"
 repository = "https://github.com/character-ai/larch"
 rust-version = "1.94.1"
-version = "53.1.23"
+version = "53.1.24"
 
 [workspace.dependencies]
 assert_cmd = { version = "2.2.2", default-features = false }
@@ -23,8 +23,8 @@ clap = { version = "4.6.2", default-features = false, features = ["derive", "hel
 globset = { version = "0.4.19", default-features = false }
 gix = { version = "=0.85.0", default-features = false, features = ["revision", "sha1", "sha256", "status"] }
 inventory = { version = "0.3.24", default-features = false }
-larch-adapters = { version = "=53.1.23", path = "crates/larch-adapters" }
-larch-core = { version = "=53.1.23", path = "crates/larch-core" }
+larch-adapters = { version = "=53.1.24", path = "crates/larch-adapters" }
+larch-core = { version = "=53.1.24", path = "crates/larch-core" }
 nix = { version = "0.31.3", default-features = false, features = ["process", "signal"] }
 predicates = { version = "3.1.4", default-features = false }
 pulldown-cmark = { version = "0.13.4", default-features = false }


### PR DESCRIPTION
## Changed

- Gate release publication on a validated immutable draft ([#7712](https://github.com/character-ai/larch/pull/7712)).
- Refine Rust lint CI execution ([#7714](https://github.com/character-ai/larch/pull/7714)).

## Fixed

- Install a supported Python runtime for Rust release asset jobs ([#7715](https://github.com/character-ai/larch/pull/7715)).
