### PR TITLE
Fix draft release discovery

### DIFF
--- a/python/larch/release/release_finish.py
+++ b/python/larch/release/release_finish.py
@@ -30,7 +30,6 @@ _TAG_RE: Final = re.compile(
 )
 _SHA_RE: Final = re.compile(r"[0-9a-f]{40}")
 _DIGEST_RE: Final = re.compile(r"sha256:([0-9a-f]{64})")
-_NOT_FOUND_RE: Final = re.compile(r"\(HTTP 404\)\s*$")
 _LS_REMOTE_FIELD_COUNT: Final = 2
 
 JsonObject = dict[str, object]
@@ -251,6 +250,19 @@ def _asset_from_json(value: object) -> RemoteAsset:
     return RemoteAsset(name=name, size=size, digest=digest, state="uploaded")
 
 
+def _release_data_for_tag(releases: list[object], *, tag: str) -> JsonObject | None:
+    matches: list[JsonObject] = []
+    for value in releases:
+        if not isinstance(value, dict):
+            raise ReleaseError("release list contains a non-object entry")
+        typed_value = cast("JsonObject", value)
+        if typed_value.get("tag_name") == tag:
+            matches.append(typed_value)
+    if len(matches) > 1:
+        raise ReleaseError(f"multiple releases found for tag {tag}")
+    return matches[0] if matches else None
+
+
 def _release_state(
     runner: proc.Runner,
     *,
@@ -259,21 +271,26 @@ def _release_state(
     cwd: Path,
     missing_ok: bool = False,
 ) -> ReleaseState | None:
-    result = _gh(
-        runner,
-        [
-            "api",
-            "-H",
-            f"X-GitHub-Api-Version: {_API_VERSION}",
-            f"repos/{repo}/releases/tags/{tag}",
-        ],
-        cwd=cwd,
+    # The active candidate is newly created. One bounded page includes it and any
+    # duplicate drafts without rescanning the repository's full release history.
+    releases = _json_array(
+        _gh(
+            runner,
+            [
+                "api",
+                "-H",
+                f"X-GitHub-Api-Version: {_API_VERSION}",
+                f"repos/{repo}/releases?per_page=100",
+            ],
+            cwd=cwd,
+        ),
+        "release list read",
     )
-    if result.returncode != 0 and missing_ok:
-        if _NOT_FOUND_RE.search(result.stderr):
+    data = _release_data_for_tag(releases, tag=tag)
+    if data is None:
+        if missing_ok:
             return None
-        _ = _require_success(result, "release read")
-    data = _json_object(result, "release read")
+        raise ReleaseError(f"release {tag} was not found")
     database_id = data.get("id")
     tag_name = data.get("tag_name")
     draft = data.get("draft")

--- a/python/tests/release/test_release.py
+++ b/python/tests/release/test_release.py
@@ -82,10 +82,8 @@ def test_release_ensure_policy_mutates_then_reverifies(tmp_path: Path) -> None:
     assert runner.calls[3][-1] == "repos/o/r/immutable-releases"
 
 
-def test_release_missing_probe_accepts_only_http_404(tmp_path: Path) -> None:
-    missing_runner = QueueRunner(
-        [cr(["gh"], stderr="gh: Not Found (HTTP 404)\n", rc=1)]  # lint-gh-argv-literal: ok fixture assertion
-    )
+def test_release_list_probe_handles_missing_and_access_failure(tmp_path: Path) -> None:
+    missing_runner = QueueRunner([cr(["gh"], "[]")])  # lint-gh-argv-literal: ok fixture assertion
     assert (
         release_finish._release_state(
             missing_runner,
@@ -100,9 +98,31 @@ def test_release_missing_probe_accepts_only_http_404(tmp_path: Path) -> None:
     denied_runner = QueueRunner(
         [cr(["gh"], stderr="gh: Resource not accessible (HTTP 403)\n", rc=1)]  # lint-gh-argv-literal: ok fixture assertion
     )
-    with pytest.raises(release_finish.ReleaseError, match="release read failed"):
+    with pytest.raises(release_finish.ReleaseError, match="release list read failed"):
         _ = release_finish._release_state(
             denied_runner,
+            repo="o/r",
+            tag="v1.2.3",
+            cwd=tmp_path,
+            missing_ok=True,
+        )
+
+
+def test_release_list_rejects_duplicate_drafts_for_same_tag(tmp_path: Path) -> None:
+    draft = {
+        "id": 7,
+        "tag_name": "v1.2.3",
+        "draft": True,
+        "immutable": False,
+        "assets": [],
+    }
+    runner = QueueRunner(
+        [cr(["gh"], json.dumps([draft, {**draft, "id": 8}]))]  # lint-gh-argv-literal: ok fixture assertion
+    )
+
+    with pytest.raises(release_finish.ReleaseError, match="multiple releases found"):
+        _ = release_finish._release_state(
+            runner,
             repo="o/r",
             tag="v1.2.3",
             cwd=tmp_path,
@@ -127,14 +147,23 @@ def test_release_stage_resume_reuses_same_draft(
         release_finish, "_plugin_version_at", lambda *_args, **_kwargs: "1.2.3"
     )
     monkeypatch.setattr(release_finish, "_stage_tag", lambda *_args, **_kwargs: None)
-    monkeypatch.setattr(
-        release_finish,
-        "_release_state",
-        lambda *_args, **_kwargs: _release_state(draft=True, immutable=False),
-    )
     notes = tmp_path / "notes.md"
     notes.write_text("notes\n", encoding="utf-8")
-    runner = ReleaseStateRunner()
+    draft = {
+        "id": 7,
+        "tag_name": "v1.2.3",
+        "draft": True,
+        "immutable": False,
+        "assets": [],
+    }
+    draft_page = json.dumps([draft])
+    runner = QueueRunner(
+        [
+            cr(["gh"], draft_page),  # lint-gh-argv-literal: ok fixture assertion
+            cr(["gh"]),  # lint-gh-argv-literal: ok fixture assertion
+            cr(["gh"], draft_page),  # lint-gh-argv-literal: ok fixture assertion
+        ]
+    )
     assert (
         release_finish.stage_candidate(
             runner=runner,
@@ -144,6 +173,9 @@ def test_release_stage_resume_reuses_same_draft(
         == SOURCE_COMMIT
     )
     assert not any(call[:3] == ["gh", "release", "create"] for call in runner.calls)  # lint-gh-argv-literal: ok fixture assertion
+    list_calls = [call for call in runner.calls if "repos/o/r/releases?per_page=100" in call]
+    assert len(list_calls) == 2
+    assert all("--paginate" not in call for call in list_calls)
 
 
 def test_release_validate_draft_rejects_incomplete_allowlist(


### PR DESCRIPTION
## Summary

- discover current draft Releases through the bounded releases collection instead of the published-only tag endpoint
- fail closed when more than one Release has the candidate tag
- exercise draft resume, missing state, access failure, and duplicate rejection offline

## Root cause

The GitHub REST `releases/tags/{tag}` endpoint returns 404 for draft Releases. The staging helper interpreted that as absence and could create duplicate drafts on retry. This incomplete behavior was introduced by PR #7712 and blocked the first `v53.1.24` candidate before publication.

## Recovery evidence

- the failed candidate remained unmerged and unpublished
- both exact duplicate draft IDs and the unpublished tag were removed and verified absent
- `python3 -m pytest python/tests/release/test_release.py -q` (46 passed)
- live release-state read of `v53.1.23` through the corrected endpoint
- changed-file pre-commit suite, including Ruff, Pyright, agent-lint, gitleaks, and repository policy lint

## Architecture review

No invariant violations or guideline deviations. The release state machine remains the single owner. The fix preserves fail-closed postconditions and adds an executable recovery-path reproduction.
