### PR TITLE
Release v53.1.24

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "53.1.23",
+  "version": "53.1.24",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/.github/workflows/rust-release-assets.yaml
+++ b/.github/workflows/rust-release-assets.yaml
@@ -137,6 +137,7 @@ jobs:
             '
           })"
           test "$minimum" = "$MACOSX_DEPLOYMENT_TARGET"
+          codesign --force --sign - --timestamp=none "$binary"
           codesign --verify --verbose=2 "$binary"
       - name: Build and smoke-test at the GNU baseline
         if: matrix.family == 'linux'
@@ -166,6 +167,7 @@ jobs:
             --env EXPECTED_ARCHITECTURE="$EXPECTED_ARCHITECTURE" \
             "$CONTAINER_IMAGE" \
             bash -euo pipefail -c '
+              export PATH="/root/.cargo/bin:$PATH"
               cargo test --locked --package larch-cli --target "$TARGET"
               cargo build --locked --release --package larch-cli --target "$TARGET"
               binary="target/$TARGET/release/larch"

--- a/.github/workflows/rust-release-assets.yaml
+++ b/.github/workflows/rust-release-assets.yaml
@@ -167,7 +167,8 @@ jobs:
             --env EXPECTED_ARCHITECTURE="$EXPECTED_ARCHITECTURE" \
             "$CONTAINER_IMAGE" \
             bash -euo pipefail -c '
-              export PATH="/root/.cargo/bin:$PATH"
+              export PATH="/opt/python/cp311-cp311/bin:/root/.cargo/bin:$PATH"
+              python3 --version
               cargo test --locked --package larch-cli --target "$TARGET"
               cargo build --locked --release --package larch-cli --target "$TARGET"
               binary="target/$TARGET/release/larch"

--- a/.github/workflows/rust-release-assets.yaml
+++ b/.github/workflows/rust-release-assets.yaml
@@ -297,7 +297,9 @@ jobs:
           VERSION: ${{ needs.metadata.outputs.version }}
         run: |
           set -euo pipefail
-          release_state="$(gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --json isDraft,isImmutable,tagName)"
+          release_state="$(gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --json databaseId,isDraft,isImmutable,tagName)"
+          release_id="$(jq -r '.databaseId' <<<"$release_state")"
+          [[ "$release_id" =~ ^[1-9][0-9]*$ ]]
           test "$(jq -r '.isDraft' <<<"$release_state")" = "true"
           test "$(jq -r '.isImmutable' <<<"$release_state")" = "false"
           test "$(jq -r '.tagName' <<<"$release_state")" = "$GITHUB_REF_NAME"
@@ -310,7 +312,7 @@ jobs:
             "dist/larch-v$VERSION-SHA256SUMS"
           )
           gh release upload "$GITHUB_REF_NAME" "${release_assets[@]}" --repo "$GITHUB_REPOSITORY" --clobber
-          remote_names="$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$GITHUB_REF_NAME" --jq '.assets | map(select(.state == "uploaded" and (.digest | startswith("sha256:")))) | map(.name) | sort | .[]')"
+          remote_names="$(gh api "repos/$GITHUB_REPOSITORY/releases/$release_id" --jq '.assets | map(select(.state == "uploaded" and (.digest | startswith("sha256:")))) | map(.name) | sort | .[]')"
           local_names="$(printf '%s\n' "${release_assets[@]##*/}" | sort)"
           test "$remote_names" = "$local_names"
       - name: Upload validated release asset set

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1435,7 +1435,7 @@ dependencies = [
 
 [[package]]
 name = "larch-adapters"
-version = "53.1.23"
+version = "53.1.24"
 dependencies = [
  "gix",
  "larch-core",
@@ -1449,7 +1449,7 @@ dependencies = [
 
 [[package]]
 name = "larch-cli"
-version = "53.1.23"
+version = "53.1.24"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1464,14 +1464,14 @@ dependencies = [
 
 [[package]]
 name = "larch-core"
-version = "53.1.23"
+version = "53.1.24"
 dependencies = [
  "regex",
 ]
 
 [[package]]
 name = "larch-lint"
-version = "53.1.23"
+version = "53.1.24"
 dependencies = [
  "assert_cmd",
  "automod",
@@ -1496,7 +1496,7 @@ dependencies = [
 
 [[package]]
 name = "larch-test-support"
-version = "53.1.23"
+version = "53.1.24"
 dependencies = [
  "larch-core",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2024"
 license = "MIT"
 repository = "https://github.com/character-ai/larch"
 rust-version = "1.94.1"
-version = "53.1.23"
+version = "53.1.24"
 
 [workspace.dependencies]
 assert_cmd = { version = "2.2.2", default-features = false }
@@ -24,9 +24,9 @@ clap = { version = "4.6.2", default-features = false, features = ["derive", "hel
 globset = { version = "0.4.19", default-features = false }
 gix = { version = "=0.85.0", default-features = false, features = ["revision", "sha1", "sha256", "status"] }
 inventory = { version = "0.3.24", default-features = false }
-larch-adapters = { version = "=53.1.23", path = "crates/larch-adapters" }
-larch-core = { version = "=53.1.23", path = "crates/larch-core" }
-larch-test-support = { version = "=53.1.23", path = "crates/larch-test-support" }
+larch-adapters = { version = "=53.1.24", path = "crates/larch-adapters" }
+larch-core = { version = "=53.1.24", path = "crates/larch-core" }
+larch-test-support = { version = "=53.1.24", path = "crates/larch-test-support" }
 nix = { version = "0.31.3", default-features = false, features = ["process", "signal"] }
 predicates = { version = "3.1.4", default-features = false }
 pulldown-cmark = { version = "0.13.4", default-features = false }

--- a/python/tests/release/test_assets.py
+++ b/python/tests/release/test_assets.py
@@ -91,6 +91,20 @@ def test_release_workflow_installs_supported_python_before_cli_in_every_job() ->
         assert 'python-version: "3.11"' in job
 
 
+def test_release_workflow_prepares_platform_smoke_test_prerequisites() -> None:
+    workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+    macos_step = workflow.split("- name: Build and smoke-test on macOS", maxsplit=1)[1]
+    macos_step = macos_step.split("- name: Build and smoke-test at the GNU baseline", maxsplit=1)[0]
+    linux_step = workflow.split("- name: Build and smoke-test at the GNU baseline", maxsplit=1)[1]
+    linux_step = linux_step.split("- name: Package deterministic archive", maxsplit=1)[0]
+
+    sign = 'codesign --force --sign - --timestamp=none "$binary"'
+    verify = 'codesign --verify --verbose=2 "$binary"'
+    cargo_test = 'cargo test --locked --package larch-cli --target "$TARGET"'
+    assert macos_step.index(sign) < macos_step.index(verify)
+    assert linux_step.index('export PATH="/root/.cargo/bin:$PATH"') < linux_step.index(cargo_test)
+
+
 def test_validate_candidate_requires_matching_plugin_and_workspace_versions(tmp_path: Path) -> None:
     (tmp_path / ".claude-plugin").mkdir()
     _ = (tmp_path / ".claude-plugin" / "plugin.json").write_text(

--- a/python/tests/release/test_assets.py
+++ b/python/tests/release/test_assets.py
@@ -101,8 +101,10 @@ def test_release_workflow_prepares_platform_smoke_test_prerequisites() -> None:
     sign = 'codesign --force --sign - --timestamp=none "$binary"'
     verify = 'codesign --verify --verbose=2 "$binary"'
     cargo_test = 'cargo test --locked --package larch-cli --target "$TARGET"'
+    linux_path = 'export PATH="/opt/python/cp311-cp311/bin:/root/.cargo/bin:$PATH"'
     assert macos_step.index(sign) < macos_step.index(verify)
-    assert linux_step.index('export PATH="/root/.cargo/bin:$PATH"') < linux_step.index(cargo_test)
+    assert linux_step.index(linux_path) < linux_step.index("python3 --version")
+    assert linux_step.index("python3 --version") < linux_step.index(cargo_test)
 
 
 def test_validate_candidate_requires_matching_plugin_and_workspace_versions(tmp_path: Path) -> None:

--- a/python/tests/release/test_assets.py
+++ b/python/tests/release/test_assets.py
@@ -107,6 +107,20 @@ def test_release_workflow_prepares_platform_smoke_test_prerequisites() -> None:
     assert linux_step.index("python3 --version") < linux_step.index(cargo_test)
 
 
+def test_release_workflow_verifies_draft_assets_by_release_id() -> None:
+    workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+    upload_step = workflow.split("- name: Upload the validated set to the draft Release", maxsplit=1)[1]
+    upload_step = upload_step.split("- name: Upload validated release asset set", maxsplit=1)[0]
+
+    assert "databaseId,isDraft,isImmutable,tagName" in upload_step
+    assert 'release_id="$(jq -r \'.databaseId\' <<<"$release_state")"' in upload_step
+    assert '[[ "$release_id" =~ ^[1-9][0-9]*$ ]]' in upload_step
+    upload = 'gh release upload "$GITHUB_REF_NAME"'
+    verify = 'gh api "repos/$GITHUB_REPOSITORY/releases/$release_id"'
+    assert upload_step.index(upload) < upload_step.index(verify)
+    assert "releases/tags/" not in upload_step
+
+
 def test_validate_candidate_requires_matching_plugin_and_workspace_versions(tmp_path: Path) -> None:
     (tmp_path / ".claude-plugin").mkdir()
     _ = (tmp_path / ".claude-plugin" / "plugin.json").write_text(


### PR DESCRIPTION
## Added

- Establish Rust coverage, fixtures, and test-support conventions ([#7716](https://github.com/character-ai/larch/pull/7716)).

## Changed

- Gate release publication on a validated immutable draft ([#7712](https://github.com/character-ai/larch/pull/7712)).
- Refine Rust lint CI execution ([#7714](https://github.com/character-ai/larch/pull/7714)).

## Fixed

- Install a supported Python runtime for Rust release asset jobs ([#7715](https://github.com/character-ai/larch/pull/7715)).
- Discover and resume draft Releases by exact tag ([#7718](https://github.com/character-ai/larch/pull/7718)).
- Prepare Linux release container tooling and macOS ad-hoc signing for release assets ([#7720](https://github.com/character-ai/larch/issues/7720)).
- Verify draft release assets through their numeric release ID ([#7721](https://github.com/character-ai/larch/issues/7721)).

Fixes #7720
Fixes #7721
