### PR TITLE
Build hardened Rust GitHub transport

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -123,8 +123,9 @@ work:
   graph and require reason-bearing lint suppressions.
 - GitHub code uses a larch-owned core service port. Its adapter uses a pinned
   Octocrab client with native TLS disabled and `rustls` enabled. It accepts only
-  a non-empty `GH_TOKEN`, never reads GitHub CLI state, and does not expose an
-  arbitrary REST URL or GraphQL document to domain callers.
+  a non-empty `LARCH_GH_TOKEN`, never reads `GH_TOKEN`, `GITHUB_TOKEN`, or
+  GitHub CLI state, and does not expose an arbitrary REST URL or GraphQL
+  document to domain callers.
 - Google code uses larch-owned core ports and official Rust clients with
   Application Default Credentials. `google-cloud-auth` is pinned centrally,
   uses rustls, and owns token caching and refresh. Larch validates external

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,6 +97,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
 dependencies = [
  "aws-lc-sys",
+ "untrusted 0.7.1",
  "zeroize",
 ]
 
@@ -225,9 +226,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.67"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
+checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -255,7 +256,7 @@ checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "rand_core",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -265,8 +266,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link",
 ]
 
@@ -664,12 +667,13 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -678,9 +682,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -688,9 +692,20 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -700,9 +715,9 @@ checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -717,20 +732,23 @@ checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-macro",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -768,7 +786,7 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi",
- "rand_core",
+ "rand_core 0.10.1",
  "wasm-bindgen",
 ]
 
@@ -1738,6 +1756,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-serde"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f056c8559e3757392c8d091e796416e4649d8e49e88b8d76df6c002f05027fd"
+dependencies = [
+ "http",
+ "serde",
+]
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1781,9 +1809,24 @@ dependencies = [
  "http",
  "hyper",
  "hyper-util",
+ "log",
  "rustls",
+ "rustls-native-certs",
  "tokio",
  "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
  "tower-service",
 ]
 
@@ -1989,11 +2032,12 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.32"
+version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "961d16382652bfdd8c6f68b223b26a8c93e0d475c672f414411db31c6c5c900e"
+checksum = "dc43d6fb25860892c78ef7ce2ffed572087a6853ecb60f587f499329717ed7da"
 dependencies = [
  "defmt",
+ "jiff-core",
  "jiff-static",
  "jiff-tzdb-platform",
  "log",
@@ -2004,11 +2048,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "jiff-static"
-version = "0.2.32"
+name = "jiff-core"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0879bd39df99c4c5e2c6615ccc026391a423dde10532c573e6086eb94a802cc"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
 dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96fb828bff41eeb269a9665f950cb359e8018f7288b8f34db24937ff54ed8fc5"
+dependencies = [
+ "jiff-core",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -2100,6 +2154,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "10.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
+dependencies = [
+ "aws-lc-rs",
+ "base64",
+ "getrandom 0.2.17",
+ "js-sys",
+ "pem",
+ "serde",
+ "serde_json",
+ "signature",
+ "simple_asn1",
+ "zeroize",
+]
+
+[[package]]
 name = "kstring"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2118,6 +2190,7 @@ dependencies = [
  "larch-core",
  "larch-test-support",
  "nix",
+ "octocrab",
  "serde_json",
  "tempfile",
  "tokio",
@@ -2275,10 +2348,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9737e026353e5cd0736f98eddae28665118eb6f6600902a7f50db585621fecb6"
 
 [[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -2287,6 +2379,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "octocrab"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27be39870c558e1fbc5a5f8d4a29aa916268c1dbcb9d467f2a9bbab35598060e"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "base64",
+ "bytes",
+ "cargo_metadata",
+ "cfg-if",
+ "chrono",
+ "futures",
+ "getrandom 0.2.17",
+ "http",
+ "http-body",
+ "http-body-util",
+ "http-serde",
+ "hyper",
+ "hyper-rustls",
+ "hyper-timeout",
+ "hyper-util",
+ "jsonwebtoken",
+ "percent-encoding",
+ "pin-project",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "snafu",
+ "tokio",
+ "tower",
+ "tower-http",
+ "url",
+ "web-time",
 ]
 
 [[package]]
@@ -2322,6 +2453,16 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
 ]
 
 [[package]]
@@ -2421,9 +2562,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -2507,9 +2648,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -2528,7 +2669,16 @@ checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "getrandom 0.4.3",
- "rand_core",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -2543,7 +2693,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
- "rand_core",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2652,7 +2802,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -2693,6 +2843,7 @@ dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -2757,7 +2908,7 @@ dependencies = [
  "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -2821,6 +2972,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2855,9 +3015,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -2865,22 +3025,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.0",
 ]
 
 [[package]]
@@ -2895,6 +3055,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -3005,6 +3176,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd_cesu8"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3021,6 +3201,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror",
+ "time",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3031,6 +3223,27 @@ name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "snafu"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e84b3f4eacbf3a1ce05eac6763b4d629d60cbc94d632e4092c54ade71f1e1a2"
+dependencies = [
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "socket2"
@@ -3135,22 +3348,22 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.0",
 ]
 
 [[package]]
@@ -3226,9 +3439,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3309,8 +3522,10 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3328,6 +3543,7 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
  "url",
 ]
 
@@ -3433,6 +3649,12 @@ dependencies = [
 
 [[package]]
 name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
@@ -3447,6 +3669,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -3577,6 +3800,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
+ "serde",
  "wasm-bindgen",
 ]
 
@@ -3800,6 +4024,20 @@ name = "zeroize"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2843,7 +2843,6 @@ dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ larch-adapters = { version = "=53.1.24", path = "crates/larch-adapters" }
 larch-core = { version = "=53.1.24", path = "crates/larch-core" }
 larch-test-support = { version = "=53.1.24", path = "crates/larch-test-support" }
 nix = { version = "0.31.3", default-features = false, features = ["process", "signal"] }
-octocrab = { version = "=0.54.0", default-features = false, features = ["default-client", "jwt-aws-lc-rs", "rustls", "rustls-ring", "timeout"] }
+octocrab = { version = "=0.54.0", default-features = false, features = ["default-client", "jwt-aws-lc-rs", "rustls", "rustls-aws-lc-rs", "timeout"] }
 predicates = { version = "3.1.4", default-features = false }
 pulldown-cmark = { version = "0.13.4", default-features = false }
 proc-macro2 = { version = "1.0.106", default-features = false, features = ["span-locations"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ larch-adapters = { version = "=53.1.24", path = "crates/larch-adapters" }
 larch-core = { version = "=53.1.24", path = "crates/larch-core" }
 larch-test-support = { version = "=53.1.24", path = "crates/larch-test-support" }
 nix = { version = "0.31.3", default-features = false, features = ["process", "signal"] }
+octocrab = { version = "=0.54.0", default-features = false, features = ["default-client", "jwt-aws-lc-rs", "rustls", "rustls-ring", "timeout"] }
 predicates = { version = "3.1.4", default-features = false }
 pulldown-cmark = { version = "0.13.4", default-features = false }
 proc-macro2 = { version = "1.0.106", default-features = false, features = ["span-locations"] }

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -72,6 +72,40 @@ explicit least-privilege scopes and IAM permissions. Offline tests use local
 fixtures. Live ADC tests are ignored by default, require explicit opt-in, and do
 not render credential headers.
 
+## Rust GitHub Credential and Transport Boundary
+
+The Rust GitHub service reads exactly one non-empty `LARCH_GH_TOKEN` from the
+environment. It never falls back to `GH_TOKEN`, `GITHUB_TOKEN`, GitHub CLI
+configuration, keychain state, argv, stdin, repository content, issue text, or
+session files. Missing, whitespace-only, and non-Unicode values fail before
+network access. The credential is held by a non-`Debug` wrapper, registered by
+exact value with an invocation-owned redactor, and omitted from the typed child
+environment allowlist. Authorization diagnostics pass through that redactor;
+the Octocrab build excludes its tracing feature.
+
+The adapter constructs one private Octocrab client inside the larch Tokio
+runtime. Octocrab is pinned with default features disabled and only its
+rustls-ring client, timeout, and required JWT support enabled. Octocrab 0.54
+requires a JWT backend even though this adapter exposes token authentication
+only; larch selects AWS-LC because the alternative RustCrypto RSA graph carries
+an unpatched advisory. `aws-lc-sys` builds its bundled C and assembly with CMake
+and a platform C compiler; it adds no dynamic system-library requirement and
+is built by the existing four-target release matrix. Automatic redirects and
+retries are disabled. Requests use fixed `User-Agent`, GitHub JSON `Accept`,
+and API-version headers. The API and upload bases are both pinned to
+`https://api.github.com/`; response-supplied
+continuations must remain HTTPS on the same approved origin. The host policy
+also recognizes `https://github.com` for later typed download boundaries but
+does not permit a continuation to cross between the two origins.
+
+Connect, read, write, and overall deadlines are fixed. Overall execution is
+cooperatively cancellable, response bodies and pagination are bounded, and
+only reviewed transient failures from idempotent reads are retry inputs.
+Uncertain mutations route to typed reconciliation instead of automatic retry.
+The core service port exposes policy and typed transport classifications, not
+raw URLs, arbitrary GraphQL documents, or the concrete client. Operation
+leaves must add typed paths and DTOs behind this same adapter.
+
 ## Scoped Live-Mutation Authorization Boundary
 
 Scoped GitHub issue create, comment, close, and label operations require explicit live-run authorization. The guarded boundary covers `python3 python/cli.py issue create-one`, the cross-repository stall-report filing helper (`scripts/file-failure-report-cross-repo.sh`), Tier-A dedup before terminal reporter filing, `/design` salvage reconciliation comment and close operations, OOS blocker probes, label provisioning and edits, issue filing and cleanup, and `audit-runs close-priors`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -85,7 +85,7 @@ the Octocrab build excludes its tracing feature.
 
 The adapter constructs one private Octocrab client inside the larch Tokio
 runtime. Octocrab is pinned with default features disabled and only its
-rustls-ring client, timeout, and required JWT support enabled. Octocrab 0.54
+rustls AWS-LC client, timeout, and required JWT support enabled. Octocrab 0.54
 requires a JWT backend even though this adapter exposes token authentication
 only; larch selects AWS-LC because the alternative RustCrypto RSA graph carries
 an unpatched advisory. `aws-lc-sys` builds its bundled C and assembly with CMake

--- a/agent-lint.toml
+++ b/agent-lint.toml
@@ -1362,9 +1362,9 @@ conditional-sources = [
 root-max-lines = 879
 root-max-tokens = 35383
 root-max-content-tokens = 35301
-closure-max-lines = 3593
-closure-max-tokens = 140651
-closure-max-content-tokens = 140355
+closure-max-lines = 3600
+closure-max-tokens = 140787
+closure-max-content-tokens = 140491
 conditional-max-lines = 589
 conditional-max-tokens = 18764
 conditional-max-content-tokens = 18717
@@ -1411,6 +1411,6 @@ roots = [
   "skills/shared/reviewer-templates.md",
   "skills/shared/voting-protocol.md",
 ]
-closure-max-lines = 5881
-closure-max-tokens = 166123
-closure-max-content-tokens = 165665
+closure-max-lines = 5888
+closure-max-tokens = 166259
+closure-max-content-tokens = 165801

--- a/agent-lint.toml
+++ b/agent-lint.toml
@@ -1362,9 +1362,9 @@ conditional-sources = [
 root-max-lines = 879
 root-max-tokens = 35383
 root-max-content-tokens = 35301
-closure-max-lines = 3600
-closure-max-tokens = 140787
-closure-max-content-tokens = 140491
+closure-max-lines = 3627
+closure-max-tokens = 141210
+closure-max-content-tokens = 140913
 conditional-max-lines = 589
 conditional-max-tokens = 18764
 conditional-max-content-tokens = 18717
@@ -1411,6 +1411,6 @@ roots = [
   "skills/shared/reviewer-templates.md",
   "skills/shared/voting-protocol.md",
 ]
-closure-max-lines = 5888
-closure-max-tokens = 166259
-closure-max-content-tokens = 165801
+closure-max-lines = 5915
+closure-max-tokens = 166682
+closure-max-content-tokens = 166223

--- a/crates/larch-adapters/Cargo.toml
+++ b/crates/larch-adapters/Cargo.toml
@@ -11,7 +11,9 @@ rust-version.workspace = true
 [dependencies]
 gix.workspace = true
 google-cloud-auth.workspace = true
+http.workspace = true
 larch-core.workspace = true
+octocrab.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true
 tokio.workspace = true

--- a/crates/larch-adapters/src/github.rs
+++ b/crates/larch-adapters/src/github.rs
@@ -1,0 +1,482 @@
+//! Authenticated, policy-bound GitHub transport foundation.
+
+use http::header::HeaderName;
+use larch_core::{
+    GitHubService, GitHubTransportPolicy, ProcessCancellation, RuntimeRedactor, SafeText, env,
+};
+use octocrab::Octocrab;
+use std::{error::Error, ffi::OsString, fmt, future::Future};
+use url::Url;
+
+const API_BASE: &str = "https://api.github.com/";
+const API_VERSION_HEADER: &str = "x-github-api-version";
+const API_VERSION: &str = "2022-11-28";
+const ACCEPT_VALUE: &str = "application/vnd.github+json";
+const USER_AGENT_VALUE: &str = "larch";
+
+/// Reason GitHub credential setup failed before any request was attempted.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GitHubCredentialErrorKind {
+    Missing,
+    Empty,
+    NonUnicode,
+}
+
+/// Secret-free GitHub credential setup error.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct GitHubCredentialError {
+    kind: GitHubCredentialErrorKind,
+}
+
+impl GitHubCredentialError {
+    #[must_use]
+    pub const fn kind(self) -> GitHubCredentialErrorKind {
+        self.kind
+    }
+}
+
+impl fmt::Display for GitHubCredentialError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self.kind {
+            GitHubCredentialErrorKind::Missing => {
+                "LARCH_GH_TOKEN is required; export a non-empty GitHub token before starting larch"
+            }
+            GitHubCredentialErrorKind::Empty => {
+                "LARCH_GH_TOKEN must not be empty or whitespace-only"
+            }
+            GitHubCredentialErrorKind::NonUnicode => {
+                "LARCH_GH_TOKEN must be valid Unicode environment text"
+            }
+        })
+    }
+}
+
+impl Error for GitHubCredentialError {}
+
+/// Failure to construct the hardened GitHub service.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum GitHubClientError {
+    Credential(GitHubCredentialError),
+    Configuration(SafeText),
+}
+
+impl fmt::Display for GitHubClientError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Credential(error) => error.fmt(formatter),
+            Self::Configuration(detail) => {
+                write!(formatter, "cannot configure GitHub transport: {detail}")
+            }
+        }
+    }
+}
+
+impl Error for GitHubClientError {}
+
+impl From<GitHubCredentialError> for GitHubClientError {
+    fn from(error: GitHubCredentialError) -> Self {
+        Self::Credential(error)
+    }
+}
+
+/// Host or continuation policy rejection.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GitHubHostError {
+    InvalidUrl,
+    UnapprovedOrigin,
+    CrossOriginContinuation,
+}
+
+impl fmt::Display for GitHubHostError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::InvalidUrl => "GitHub URL is invalid",
+            Self::UnapprovedOrigin => "GitHub URL origin is not approved",
+            Self::CrossOriginContinuation => "GitHub continuation changed origin",
+        })
+    }
+}
+
+impl Error for GitHubHostError {}
+
+/// Why an operation wrapper completed without an API result.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GitHubCompletionError {
+    Cancelled,
+    DeadlineExceeded,
+}
+
+impl fmt::Display for GitHubCompletionError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Cancelled => "GitHub operation cancelled",
+            Self::DeadlineExceeded => "GitHub operation deadline exceeded",
+        })
+    }
+}
+
+impl Error for GitHubCompletionError {}
+
+trait EnvironmentSource {
+    fn read(&self, name: &'static str) -> Option<OsString>;
+}
+
+struct ProcessEnvironment;
+
+impl EnvironmentSource for ProcessEnvironment {
+    fn read(&self, name: &'static str) -> Option<OsString> {
+        std::env::var_os(name)
+    }
+}
+
+// Deliberately non-Debug: a credential must not enter derived diagnostics.
+struct GitHubCredential(String);
+
+impl GitHubCredential {
+    fn load(source: &dyn EnvironmentSource) -> Result<Self, GitHubCredentialError> {
+        let raw = source
+            .read(env::LARCH_GH_TOKEN)
+            .ok_or(GitHubCredentialError {
+                kind: GitHubCredentialErrorKind::Missing,
+            })?;
+        let value = raw.into_string().map_err(|_| GitHubCredentialError {
+            kind: GitHubCredentialErrorKind::NonUnicode,
+        })?;
+        if value.trim().is_empty() {
+            return Err(GitHubCredentialError {
+                kind: GitHubCredentialErrorKind::Empty,
+            });
+        }
+        Ok(Self(value))
+    }
+
+    fn expose(&self) -> &str {
+        &self.0
+    }
+}
+
+/// One Octocrab client and exact-secret registry for a runtime context.
+///
+/// The client is intentionally private. Operation adapters in this crate add
+/// typed paths and DTOs instead of exposing Octocrab, raw REST URLs, or
+/// arbitrary GraphQL documents to domain callers.
+pub struct OctocrabGitHubService {
+    _client: Octocrab,
+    policy: GitHubTransportPolicy,
+    redactor: RuntimeRedactor,
+}
+
+impl OctocrabGitHubService {
+    /// Load the sole supported credential and construct one hardened client.
+    ///
+    /// # Errors
+    /// Fails before network access when `LARCH_GH_TOKEN` is missing, blank, or
+    /// invalid, or when fixed client configuration cannot be constructed.
+    pub fn from_environment() -> Result<Self, GitHubClientError> {
+        Self::from_source(&ProcessEnvironment)
+    }
+
+    fn from_source(source: &dyn EnvironmentSource) -> Result<Self, GitHubClientError> {
+        let credential = GitHubCredential::load(source)?;
+        let policy = GitHubTransportPolicy::github_com();
+        let mut redactor = RuntimeRedactor::default();
+        let registered = redactor.register_exact_secret(credential.expose().to_owned());
+        debug_assert!(registered, "validated GitHub credential must register");
+        if tokio::runtime::Handle::try_current().is_err() {
+            return Err(GitHubClientError::Configuration(redactor.safe_text(
+                "GitHub transport must be constructed inside the larch Tokio runtime",
+            )));
+        }
+        let client = build_client(&credential, policy).map_err(|error| {
+            GitHubClientError::Configuration(redactor.safe_text(error.to_string()))
+        })?;
+        Ok(Self {
+            _client: client,
+            policy,
+            redactor,
+        })
+    }
+
+    /// Fixed request headers applied to every GitHub API request.
+    #[must_use]
+    pub const fn required_headers() -> [(&'static str, &'static str); 3] {
+        [
+            ("user-agent", USER_AGENT_VALUE),
+            ("accept", ACCEPT_VALUE),
+            (API_VERSION_HEADER, API_VERSION),
+        ]
+    }
+
+    /// Remove the exact runtime credential and standard secret families.
+    #[must_use]
+    pub fn redact_diagnostic(&self, text: impl AsRef<str>) -> SafeText {
+        self.redactor.safe_text(text)
+    }
+
+    /// Resolve a response-supplied pagination or redirect continuation and
+    /// require it to stay on the approved starting origin.
+    ///
+    /// # Errors
+    /// Rejects malformed, non-HTTPS, credential-bearing, unapproved, or
+    /// cross-origin URLs.
+    pub fn continuation_url(base: &str, continuation: &str) -> Result<Url, GitHubHostError> {
+        let base = parse_approved_url(base)?;
+        let next = base
+            .join(continuation)
+            .map_err(|_| GitHubHostError::InvalidUrl)?;
+        validate_approved_url(&next)?;
+        if base.origin() != next.origin() {
+            return Err(GitHubHostError::CrossOriginContinuation);
+        }
+        Ok(next)
+    }
+
+    /// Enforce the overall deadline and cooperative cancellation around one
+    /// typed operation future. Cancellation wins when both signals are ready.
+    ///
+    /// # Errors
+    /// Returns a closed cancellation or deadline outcome.
+    pub async fn guard_operation<T, F>(
+        &self,
+        cancellation: &dyn ProcessCancellation,
+        operation: F,
+    ) -> Result<T, GitHubCompletionError>
+    where
+        F: Future<Output = T> + Send,
+        T: Send,
+    {
+        tokio::select! {
+            biased;
+            () = cancellation.cancelled() => Err(GitHubCompletionError::Cancelled),
+            result = tokio::time::timeout(self.policy.overall_timeout(), operation) => {
+                result.map_err(|_| GitHubCompletionError::DeadlineExceeded)
+            }
+        }
+    }
+}
+
+impl GitHubService for OctocrabGitHubService {
+    fn transport_policy(&self) -> GitHubTransportPolicy {
+        self.policy
+    }
+}
+
+fn build_client(
+    credential: &GitHubCredential,
+    policy: GitHubTransportPolicy,
+) -> octocrab::Result<Octocrab> {
+    let mut builder = Octocrab::builder()
+        .personal_token(credential.expose().to_owned())
+        .set_connect_timeout(Some(policy.connect_timeout()))
+        .set_read_timeout(Some(policy.read_timeout()))
+        .set_write_timeout(Some(policy.write_timeout()))
+        .base_uri(API_BASE)?
+        .upload_uri(API_BASE)?;
+    for (name, value) in OctocrabGitHubService::required_headers() {
+        builder = builder.add_header(HeaderName::from_static(name), value.to_owned());
+    }
+    builder.build()
+}
+
+fn parse_approved_url(value: &str) -> Result<Url, GitHubHostError> {
+    let url = Url::parse(value).map_err(|_| GitHubHostError::InvalidUrl)?;
+    validate_approved_url(&url)?;
+    Ok(url)
+}
+
+fn validate_approved_url(url: &Url) -> Result<(), GitHubHostError> {
+    let host = url.host_str();
+    let approved_host = matches!(host, Some("api.github.com" | "github.com"));
+    let approved = url.scheme() == "https"
+        && approved_host
+        && url.port_or_known_default() == Some(443)
+        && url.username().is_empty()
+        && url.password().is_none();
+    if approved {
+        Ok(())
+    } else {
+        Err(GitHubHostError::UnapprovedOrigin)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::{Cancellation, LarchRuntime};
+    use larch_core::GitHubResponseLimits;
+    use std::{collections::BTreeMap, sync::Mutex};
+
+    struct FakeEnvironment {
+        values: BTreeMap<&'static str, OsString>,
+        reads: Mutex<Vec<&'static str>>,
+    }
+
+    impl FakeEnvironment {
+        fn new(values: impl IntoIterator<Item = (&'static str, &'static str)>) -> Self {
+            Self {
+                values: values
+                    .into_iter()
+                    .map(|(key, value)| (key, OsString::from(value)))
+                    .collect(),
+                reads: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    impl EnvironmentSource for FakeEnvironment {
+        fn read(&self, name: &'static str) -> Option<OsString> {
+            self.reads.lock().expect("read log lock").push(name);
+            self.values.get(name).cloned()
+        }
+    }
+
+    fn configured_service(runtime: &LarchRuntime) -> OctocrabGitHubService {
+        runtime.block_on(async {
+            OctocrabGitHubService::from_source(&FakeEnvironment::new([(
+                env::LARCH_GH_TOKEN,
+                "opaque test credential",
+            )]))
+            .expect("fixed client should build")
+        })
+    }
+
+    #[test]
+    fn credential_loader_reads_only_larch_token_without_fallbacks() {
+        let source = FakeEnvironment::new([
+            (env::GH_TOKEN, "legacy-token"),
+            (env::GITHUB_TOKEN, "actions-token"),
+        ]);
+
+        let error = GitHubCredential::load(&source)
+            .err()
+            .expect("fallbacks must be ignored");
+
+        assert_eq!(error.kind(), GitHubCredentialErrorKind::Missing);
+        assert_eq!(
+            source.reads.into_inner().expect("read log"),
+            [env::LARCH_GH_TOKEN]
+        );
+    }
+
+    #[test]
+    fn credential_loader_rejects_empty_and_whitespace_values() {
+        for value in ["", " \t\n"] {
+            let error =
+                GitHubCredential::load(&FakeEnvironment::new([(env::LARCH_GH_TOKEN, value)]))
+                    .err()
+                    .expect("blank token must fail");
+            assert_eq!(error.kind(), GitHubCredentialErrorKind::Empty);
+            assert_eq!(
+                error.to_string(),
+                "LARCH_GH_TOKEN must not be empty or whitespace-only"
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn credential_loader_rejects_non_unicode_without_echoing_bytes() {
+        use std::os::unix::ffi::OsStringExt;
+
+        let source = FakeEnvironment {
+            values: BTreeMap::from([(env::LARCH_GH_TOKEN, OsString::from_vec(vec![0xff]))]),
+            reads: Mutex::new(Vec::new()),
+        };
+        let error = GitHubCredential::load(&source)
+            .err()
+            .expect("non-Unicode token must fail");
+
+        assert_eq!(error.kind(), GitHubCredentialErrorKind::NonUnicode);
+        assert_eq!(
+            error.to_string(),
+            "LARCH_GH_TOKEN must be valid Unicode environment text"
+        );
+    }
+
+    #[test]
+    fn client_construction_outside_runtime_fails_without_secret_diagnostics() {
+        let error = OctocrabGitHubService::from_source(&FakeEnvironment::new([(
+            env::LARCH_GH_TOKEN,
+            "unusual exact secret",
+        )]))
+        .err()
+        .expect("runtime-less construction must fail");
+
+        assert!(error.to_string().contains("inside the larch Tokio runtime"));
+        assert!(!error.to_string().contains("unusual exact secret"));
+    }
+
+    #[test]
+    fn client_uses_fixed_headers_policy_and_exact_secret_redaction() {
+        let runtime = LarchRuntime::new().expect("runtime");
+        let service = configured_service(&runtime);
+        assert_eq!(
+            OctocrabGitHubService::required_headers(),
+            [
+                ("user-agent", "larch"),
+                ("accept", "application/vnd.github+json"),
+                ("x-github-api-version", "2022-11-28"),
+            ]
+        );
+        let safe = service.redact_diagnostic(
+            "Authorization: Bearer opaque test credential; body=opaque test credential",
+        );
+        assert_eq!(
+            safe.as_str(),
+            "Authorization: Bearer <REDACTED-TOKEN>; body=<REDACTED-TOKEN>"
+        );
+        let limits: GitHubResponseLimits = service.transport_policy().limits();
+        assert_eq!(limits.body_bytes(), 2 * 1024 * 1024);
+        assert_eq!(limits.pages(), 20);
+    }
+
+    #[test]
+    fn continuation_policy_rejects_unapproved_and_cross_origin_urls() {
+        let relative = OctocrabGitHubService::continuation_url(
+            "https://api.github.com/repos/example/repo/issues",
+            "?page=2",
+        )
+        .expect("same-origin relative continuation");
+        assert_eq!(
+            relative.as_str(),
+            "https://api.github.com/repos/example/repo/issues?page=2"
+        );
+
+        for continuation in [
+            "https://github.com/page/2",
+            "https://evil.example/page/2",
+            "http://api.github.com/page/2",
+            "https://user@api.github.com/page/2",
+            "https://api.github.com:444/page/2",
+        ] {
+            assert!(
+                OctocrabGitHubService::continuation_url(API_BASE, continuation).is_err(),
+                "continuation {continuation}"
+            );
+        }
+    }
+
+    #[test]
+    fn operation_guard_prioritizes_cancellation() {
+        let runtime = LarchRuntime::paused_current_thread().expect("runtime");
+        let service = configured_service(&runtime);
+        let cancellation = Cancellation::new();
+        cancellation.cancel();
+
+        let result =
+            runtime.block_on(service.guard_operation(&cancellation, std::future::pending::<()>()));
+
+        assert_eq!(result, Err(GitHubCompletionError::Cancelled));
+    }
+
+    #[test]
+    fn operation_guard_enforces_overall_deadline() {
+        let runtime = LarchRuntime::paused_current_thread().expect("runtime");
+        let service = configured_service(&runtime);
+
+        let result = runtime
+            .block_on(service.guard_operation(&Cancellation::new(), std::future::pending::<()>()));
+
+        assert_eq!(result, Err(GitHubCompletionError::DeadlineExceeded));
+    }
+}

--- a/crates/larch-adapters/src/lib.rs
+++ b/crates/larch-adapters/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod clock;
 pub mod google_auth;
+pub mod github;
 pub mod logging;
 pub mod process;
 pub mod retry;

--- a/crates/larch-adapters/src/lib.rs
+++ b/crates/larch-adapters/src/lib.rs
@@ -1,8 +1,8 @@
 //! Concrete adapters for filesystem, process, Git, time, and service boundaries.
 
 pub mod clock;
-pub mod google_auth;
 pub mod github;
+pub mod google_auth;
 pub mod logging;
 pub mod process;
 pub mod retry;

--- a/crates/larch-adapters/src/process.rs
+++ b/crates/larch-adapters/src/process.rs
@@ -2,6 +2,8 @@
 
 use crate::logging::JsonlJournal;
 use crate::runtime::{Cancellation, ChildProcess, ChildWait, shutdown_child};
+#[cfg(test)]
+use larch_core::env as larch_env;
 use larch_core::{
     BusinessClock, ChildEnvironment, ExternalProcessRunner, JournalRecord, ProcessCancellation,
     ProcessError, ProcessErrorKind, ProcessEvent, ProcessEventKind, ProcessFuture, ProcessObserver,
@@ -633,7 +635,9 @@ mod tests {
         let inherited: Vec<&str> = ChildEnvironment::production()
             .map(ChildEnvironment::name)
             .collect();
-        assert!(!inherited.contains(&"GH_TOKEN"));
+        assert!(!inherited.contains(&larch_env::LARCH_GH_TOKEN));
+        assert!(!inherited.contains(&larch_env::GH_TOKEN));
+        assert!(!inherited.contains(&larch_env::GITHUB_TOKEN));
         assert!(!inherited.contains(&"GOOGLE_APPLICATION_CREDENTIALS"));
         assert!(!inherited.contains(&"OPENAI_API_KEY"));
     }

--- a/crates/larch-core/src/config.rs
+++ b/crates/larch-core/src/config.rs
@@ -19,8 +19,10 @@ pub mod env {
     pub const CURSOR_API_KEY: &str = "CURSOR_API_KEY";
     /// Temporary directory for an active design run.
     pub const DESIGN_TMPDIR: &str = "DESIGN_TMPDIR";
-    /// GitHub service credential. Larch does not fall back to `GITHUB_TOKEN`.
+    /// Legacy GitHub CLI credential, never read by the Rust GitHub service.
     pub const GH_TOKEN: &str = "GH_TOKEN";
+    /// GitHub Actions credential, never read by the Rust GitHub service.
+    pub const GITHUB_TOKEN: &str = "GITHUB_TOKEN";
     /// Optional Google Application Default Credentials file.
     pub const GOOGLE_APPLICATION_CREDENTIALS: &str = "GOOGLE_APPLICATION_CREDENTIALS";
     /// Current user's home directory.
@@ -41,6 +43,8 @@ pub mod env {
     pub const LARCH_CODEX_VOTE_MODEL: &str = "LARCH_CODEX_VOTE_MODEL";
     /// Optional Cursor model override.
     pub const LARCH_CURSOR_MODEL: &str = "LARCH_CURSOR_MODEL";
+    /// Sole credential read by the Rust GitHub service.
+    pub const LARCH_GH_TOKEN: &str = "LARCH_GH_TOKEN";
     /// Disable run-log commits for the current workflow.
     pub const LARCH_NO_LOGS_COMMIT: &str = "LARCH_NO_LOGS_COMMIT";
     /// Canonical run identifier.
@@ -63,7 +67,7 @@ pub mod env {
     pub const USER: &str = "USER";
 
     /// Shared names maintained by this module.
-    pub const ALL: [&str; 28] = [
+    pub const ALL: [&str; 30] = [
         ANTHROPIC_API_KEY,
         CLAUDE_PLUGIN_OPTION_CODEX_EFFORT,
         CLAUDE_PLUGIN_OPTION_CODEX_MODEL,
@@ -72,6 +76,7 @@ pub mod env {
         CURSOR_API_KEY,
         DESIGN_TMPDIR,
         GH_TOKEN,
+        GITHUB_TOKEN,
         GOOGLE_APPLICATION_CREDENTIALS,
         HOME,
         IMPLEMENT_TMPDIR,
@@ -82,6 +87,7 @@ pub mod env {
         LARCH_CODEX_REVIEW_MODEL,
         LARCH_CODEX_VOTE_MODEL,
         LARCH_CURSOR_MODEL,
+        LARCH_GH_TOKEN,
         LARCH_NO_LOGS_COMMIT,
         LARCH_RUN_ID,
         LOGNAME,
@@ -103,6 +109,8 @@ mod tests {
     #[test]
     fn environment_names_preserve_live_public_strings() {
         assert_eq!(env::GH_TOKEN, "GH_TOKEN");
+        assert_eq!(env::GITHUB_TOKEN, "GITHUB_TOKEN");
+        assert_eq!(env::LARCH_GH_TOKEN, "LARCH_GH_TOKEN");
         assert_eq!(
             env::GOOGLE_APPLICATION_CREDENTIALS,
             "GOOGLE_APPLICATION_CREDENTIALS"

--- a/crates/larch-core/src/github.rs
+++ b/crates/larch-core/src/github.rs
@@ -1,0 +1,304 @@
+//! Narrow GitHub service port and shared hostile-transport policy.
+
+use crate::{RetryClass, StopReason};
+use std::time::Duration;
+
+/// Injectable GitHub boundary used by domain code.
+///
+/// Operation leaves extend this boundary with typed DTOs. The foundation does
+/// not expose raw URLs, arbitrary GraphQL documents, or a concrete HTTP client.
+pub trait GitHubService: Send + Sync {
+    /// Return the immutable transport policy enforced by this service.
+    fn transport_policy(&self) -> GitHubTransportPolicy;
+}
+
+/// Fixed per-response and continuation bounds.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct GitHubResponseLimits {
+    body_bytes: usize,
+    pages: usize,
+    items: usize,
+    string_bytes: usize,
+    nesting_depth: usize,
+}
+
+impl GitHubResponseLimits {
+    /// Maximum bytes accepted for one non-streaming response body.
+    #[must_use]
+    pub const fn body_bytes(self) -> usize {
+        self.body_bytes
+    }
+
+    /// Maximum pagination continuations followed for one operation.
+    #[must_use]
+    pub const fn pages(self) -> usize {
+        self.pages
+    }
+
+    /// Maximum aggregate items accepted for one operation.
+    #[must_use]
+    pub const fn items(self) -> usize {
+        self.items
+    }
+
+    /// Maximum bytes accepted for one untrusted API string.
+    #[must_use]
+    pub const fn string_bytes(self) -> usize {
+        self.string_bytes
+    }
+
+    /// Maximum accepted JSON nesting depth.
+    #[must_use]
+    pub const fn nesting_depth(self) -> usize {
+        self.nesting_depth
+    }
+}
+
+/// Immutable policy shared by every GitHub operation adapter.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct GitHubTransportPolicy {
+    connect_timeout: Duration,
+    read_timeout: Duration,
+    write_timeout: Duration,
+    overall_timeout: Duration,
+    limits: GitHubResponseLimits,
+}
+
+impl GitHubTransportPolicy {
+    /// Reviewed policy for the public GitHub API.
+    #[must_use]
+    pub const fn github_com() -> Self {
+        Self {
+            connect_timeout: Duration::from_secs(10),
+            read_timeout: Duration::from_secs(30),
+            write_timeout: Duration::from_secs(30),
+            overall_timeout: Duration::from_secs(60),
+            limits: GitHubResponseLimits {
+                body_bytes: 2 * 1024 * 1024,
+                pages: 20,
+                items: 2_000,
+                string_bytes: 64 * 1024,
+                nesting_depth: 64,
+            },
+        }
+    }
+
+    #[must_use]
+    pub const fn connect_timeout(self) -> Duration {
+        self.connect_timeout
+    }
+
+    #[must_use]
+    pub const fn read_timeout(self) -> Duration {
+        self.read_timeout
+    }
+
+    #[must_use]
+    pub const fn write_timeout(self) -> Duration {
+        self.write_timeout
+    }
+
+    #[must_use]
+    pub const fn overall_timeout(self) -> Duration {
+        self.overall_timeout
+    }
+
+    #[must_use]
+    pub const fn limits(self) -> GitHubResponseLimits {
+        self.limits
+    }
+}
+
+/// Whether an operation is safe to repeat without reconciliation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GitHubRequestKind {
+    IdempotentRead,
+    Mutation,
+}
+
+/// Closed transport input used to classify retries without logging payloads.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GitHubFailureInput {
+    Transport,
+    HttpStatus(u16),
+}
+
+/// Transport action selected before the shared retry executor runs.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GitHubRetryAction {
+    Retry(RetryClass),
+    Stop(StopReason),
+    /// A mutation may have committed; its typed operation must read back state.
+    ReconcileMutation,
+}
+
+/// Inputs parsed from rate-limit headers without retaining response text.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct GitHubRateLimitInputs {
+    retry_after: Option<Duration>,
+    reset_epoch_seconds: Option<u64>,
+    remaining: Option<u64>,
+}
+
+impl GitHubRateLimitInputs {
+    /// No rate-limit headers were present or valid.
+    pub const NONE: Self = Self::new(None, None, None);
+
+    #[must_use]
+    pub const fn new(
+        retry_after: Option<Duration>,
+        reset_epoch_seconds: Option<u64>,
+        remaining: Option<u64>,
+    ) -> Self {
+        Self {
+            retry_after,
+            reset_epoch_seconds,
+            remaining,
+        }
+    }
+
+    #[must_use]
+    pub const fn retry_after(self) -> Option<Duration> {
+        self.retry_after
+    }
+
+    #[must_use]
+    pub const fn reset_epoch_seconds(self) -> Option<u64> {
+        self.reset_epoch_seconds
+    }
+
+    #[must_use]
+    pub const fn remaining(self) -> Option<u64> {
+        self.remaining
+    }
+
+    /// Return whether parsed headers prove GitHub is throttling this request.
+    #[must_use]
+    pub const fn is_limited(self) -> bool {
+        self.retry_after.is_some() || matches!(self.remaining, Some(0))
+    }
+}
+
+/// Classify only reviewed transient inputs. Mutations are never blindly retried.
+#[must_use]
+pub const fn classify_github_retry(
+    request: GitHubRequestKind,
+    failure: GitHubFailureInput,
+    rate_limit: GitHubRateLimitInputs,
+) -> GitHubRetryAction {
+    let retry_class = match failure {
+        GitHubFailureInput::Transport | GitHubFailureInput::HttpStatus(408) => {
+            Some(RetryClass::Transient)
+        }
+        GitHubFailureInput::HttpStatus(429) => Some(RetryClass::Throttled),
+        GitHubFailureInput::HttpStatus(500 | 502 | 503 | 504) => Some(RetryClass::Transient),
+        GitHubFailureInput::HttpStatus(403) if rate_limit.is_limited() => {
+            Some(RetryClass::Throttled)
+        }
+        GitHubFailureInput::HttpStatus(401 | 403) => {
+            return GitHubRetryAction::Stop(StopReason::Authorization);
+        }
+        GitHubFailureInput::HttpStatus(_) => None,
+    };
+    match (request, retry_class) {
+        (GitHubRequestKind::IdempotentRead, Some(class)) => GitHubRetryAction::Retry(class),
+        (GitHubRequestKind::Mutation, Some(_)) => GitHubRetryAction::ReconcileMutation,
+        (_, None) => GitHubRetryAction::Stop(StopReason::Permanent),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reviewed_policy_has_nonzero_deadlines_and_limits() {
+        let policy = GitHubTransportPolicy::github_com();
+        assert!(policy.connect_timeout() < policy.overall_timeout());
+        assert!(policy.read_timeout() < policy.overall_timeout());
+        assert!(policy.write_timeout() < policy.overall_timeout());
+        assert!(policy.limits().body_bytes() > 0);
+        assert!(policy.limits().pages() > 0);
+        assert!(policy.limits().items() > 0);
+        assert!(policy.limits().string_bytes() > 0);
+        assert!(policy.limits().nesting_depth() > 0);
+    }
+
+    #[test]
+    fn retries_only_bounded_idempotent_read_inputs() {
+        assert_eq!(
+            classify_github_retry(
+                GitHubRequestKind::IdempotentRead,
+                GitHubFailureInput::HttpStatus(503),
+                GitHubRateLimitInputs::NONE,
+            ),
+            GitHubRetryAction::Retry(RetryClass::Transient)
+        );
+        assert_eq!(
+            classify_github_retry(
+                GitHubRequestKind::IdempotentRead,
+                GitHubFailureInput::HttpStatus(429),
+                GitHubRateLimitInputs::NONE,
+            ),
+            GitHubRetryAction::Retry(RetryClass::Throttled)
+        );
+        assert_eq!(
+            classify_github_retry(
+                GitHubRequestKind::IdempotentRead,
+                GitHubFailureInput::HttpStatus(401),
+                GitHubRateLimitInputs::NONE,
+            ),
+            GitHubRetryAction::Stop(StopReason::Authorization)
+        );
+    }
+
+    #[test]
+    fn uncertain_mutations_require_reconciliation() {
+        for failure in [
+            GitHubFailureInput::Transport,
+            GitHubFailureInput::HttpStatus(408),
+            GitHubFailureInput::HttpStatus(429),
+            GitHubFailureInput::HttpStatus(500),
+        ] {
+            assert_eq!(
+                classify_github_retry(
+                    GitHubRequestKind::Mutation,
+                    failure,
+                    GitHubRateLimitInputs::NONE,
+                ),
+                GitHubRetryAction::ReconcileMutation
+            );
+        }
+    }
+
+    #[test]
+    fn rate_limit_inputs_are_typed_and_payload_free() {
+        let inputs = GitHubRateLimitInputs::new(Some(Duration::from_secs(3)), Some(99), Some(0));
+        assert_eq!(inputs.retry_after(), Some(Duration::from_secs(3)));
+        assert_eq!(inputs.reset_epoch_seconds(), Some(99));
+        assert_eq!(inputs.remaining(), Some(0));
+        assert!(inputs.is_limited());
+        assert!(!GitHubRateLimitInputs::NONE.is_limited());
+    }
+
+    #[test]
+    fn rate_limited_forbidden_reads_are_throttled_not_authorization_failures() {
+        let limited = GitHubRateLimitInputs::new(Some(Duration::from_secs(3)), None, Some(0));
+        assert_eq!(
+            classify_github_retry(
+                GitHubRequestKind::IdempotentRead,
+                GitHubFailureInput::HttpStatus(403),
+                limited,
+            ),
+            GitHubRetryAction::Retry(RetryClass::Throttled)
+        );
+        assert_eq!(
+            classify_github_retry(
+                GitHubRequestKind::IdempotentRead,
+                GitHubFailureInput::HttpStatus(403),
+                GitHubRateLimitInputs::NONE,
+            ),
+            GitHubRetryAction::Stop(StopReason::Authorization)
+        );
+    }
+}

--- a/crates/larch-core/src/lib.rs
+++ b/crates/larch-core/src/lib.rs
@@ -4,6 +4,7 @@ mod config;
 mod context;
 mod env_file;
 mod error;
+mod github;
 mod outcome;
 mod process;
 mod redaction;
@@ -21,6 +22,10 @@ pub use env_file::{
 pub use error::{
     EnvironmentalFailure, ErrorCategory, FailureKind, InternalDefect, LarchError, OperatorError,
 };
+pub use github::{
+    GitHubFailureInput, GitHubRateLimitInputs, GitHubRequestKind, GitHubResponseLimits,
+    GitHubRetryAction, GitHubService, GitHubTransportPolicy, classify_github_retry,
+};
 pub use outcome::{ExitCode, WorkflowOutcome};
 pub use process::{
     ChildEnvironment, ExternalProcessRunner, ExternalProgram, GitCliOperation, ProcessCancellation,
@@ -28,7 +33,7 @@ pub use process::{
     ProcessOutput, ProcessRequest, ProcessRequestError, ProcessRequestErrorKind, ProcessStatus,
     VendorProgram,
 };
-pub use redaction::{RedactionResult, SafeText, redact, redact_sensitive_paths};
+pub use redaction::{RedactionResult, RuntimeRedactor, SafeText, redact, redact_sensitive_paths};
 pub use retry::{
     AttemptOutcome, DeterministicJitter, Jitter, RetryClass, RetryDecision, RetryObservation,
     RetryPolicy, RetryPolicyError, StopReason,

--- a/crates/larch-core/src/redaction.rs
+++ b/crates/larch-core/src/redaction.rs
@@ -204,6 +204,64 @@ impl fmt::Display for SafeText {
     }
 }
 
+/// Invocation-owned exact-secret registry layered over family redaction.
+///
+/// This type intentionally has no `Debug` implementation. Registering the
+/// exact runtime credential covers tokens whose format matches no known
+/// prefix without introducing global mutable state between concurrent runs.
+#[derive(Default)]
+pub struct RuntimeRedactor {
+    exact_secrets: Vec<Box<str>>,
+}
+
+impl RuntimeRedactor {
+    /// Register one non-empty exact value. Returns false for an empty value.
+    pub fn register_exact_secret(&mut self, secret: impl Into<String>) -> bool {
+        let secret = secret.into();
+        if secret.is_empty() {
+            return false;
+        }
+        if !self
+            .exact_secrets
+            .iter()
+            .any(|known| known.as_ref() == secret)
+        {
+            self.exact_secrets.push(secret.into_boxed_str());
+            self.exact_secrets
+                .sort_unstable_by_key(|value| std::cmp::Reverse(value.len()));
+        }
+        true
+    }
+
+    /// Redact registered exact values, sensitive paths, and known families.
+    #[must_use]
+    pub fn redact(&self, text: &str) -> RedactionResult {
+        let mut exact_count = 0_usize;
+        let mut scrubbed = String::from(text);
+        for secret in &self.exact_secrets {
+            exact_count += scrubbed.matches(secret.as_ref()).count();
+            scrubbed = scrubbed.replace(secret.as_ref(), REDACTED_TOKEN);
+        }
+        let mut result = redact(&scrubbed);
+        if exact_count != 0 {
+            result.findings.insert("runtime-exact", exact_count);
+        }
+        result
+    }
+
+    /// Produce display-safe text with exact runtime values removed first.
+    #[must_use]
+    pub fn safe_text(&self, text: impl AsRef<str>) -> SafeText {
+        let candidate = self.redact(text.as_ref()).text;
+        let verified = self.redact(&candidate);
+        if verified.findings.is_empty() {
+            SafeText(candidate)
+        } else {
+            SafeText(String::from(REDACTION_FAILURE))
+        }
+    }
+}
+
 /// Redact every supported secret family while preserving newline intent.
 #[must_use]
 pub fn redact_secrets(text: &str) -> RedactionResult {
@@ -367,5 +425,29 @@ mod tests {
         let safe = SafeText::diagnostic("bad\u{1b}[31m\nforged\u{7f}");
 
         assert_eq!(safe.as_str(), "bad[31mforged");
+    }
+
+    #[test]
+    fn runtime_redactor_scrubs_exact_unknown_token_formats() {
+        let mut redactor = RuntimeRedactor::default();
+        assert!(redactor.register_exact_secret("short opaque credential"));
+
+        let result = redactor.redact("Authorization: Bearer short opaque credential");
+
+        assert_eq!(result.findings().get("runtime-exact"), Some(&1));
+        assert_eq!(result.text(), "Authorization: Bearer <REDACTED-TOKEN>");
+        assert!(
+            !redactor
+                .safe_text(result.text())
+                .as_str()
+                .contains("credential")
+        );
+    }
+
+    #[test]
+    fn runtime_redactor_rejects_empty_registration() {
+        let mut redactor = RuntimeRedactor::default();
+        assert!(!redactor.register_exact_secret(String::new()));
+        assert_eq!(redactor.redact("ordinary text").text(), "ordinary text");
     }
 }

--- a/deny.toml
+++ b/deny.toml
@@ -27,14 +27,20 @@ external-default-features = "allow"
 # google-cloud-auth 1.14.0 uses async-trait's syn 3 parser while larch and the
 # rest of the workspace remain on syn 2. Keep this exact exception until the
 # workspace can converge without changing the reviewed authentication release.
+# Octocrab's
+# rustls and mandatory JWT graphs use adjacent generations of getrandom, syn,
+# untrusted, and windows-sys; the older generation is listed where applicable.
 skip = [
     { name = "block-buffer", version = "=0.10.4" },
     { name = "cpufeatures", version = "=0.2.17" },
     { name = "crypto-common", version = "=0.1.7" },
     { name = "digest", version = "=0.10.7" },
+    { name = "getrandom", version = "=0.2.17" },
     { name = "hashbrown", version = "=0.14.5" },
     { name = "hashbrown", version = "=0.16.1" },
     { name = "syn", version = "=3.0.0" },
+    { name = "untrusted", version = "=0.7.1" },
+    { name = "windows-sys", version = "=0.52.0" },
 ]
 
 [sources]

--- a/deny.toml
+++ b/deny.toml
@@ -40,7 +40,6 @@ skip = [
     { name = "hashbrown", version = "=0.16.1" },
     { name = "syn", version = "=3.0.0" },
     { name = "untrusted", version = "=0.7.1" },
-    { name = "windows-sys", version = "=0.52.0" },
 ]
 
 [sources]

--- a/docs/configuration-and-permissions.md
+++ b/docs/configuration-and-permissions.md
@@ -190,6 +190,19 @@ universe domains are not supported. Larch requests operation-specific scopes,
 keeps tokens inside the official authentication layer, and does not persist
 them.
 
+### `LARCH_GH_TOKEN`
+
+`LARCH_GH_TOKEN` is the sole credential input for Rust GitHub service calls.
+Set it in the environment before starting larch. Missing, empty, and
+whitespace-only values fail before any network request with setup guidance.
+
+Larch does not consult `GH_TOKEN`, `GITHUB_TOKEN`, `gh` configuration,
+keychain state, argv, stdin, repository configuration, issue text, or session
+files as fallbacks. The value stays in a non-`Debug` secret wrapper, is
+registered exactly with the runtime redactor, and is excluded from child
+process environments. The initial transport supports only GitHub.com over
+HTTPS; GitHub Enterprise needs a separate reviewed host policy.
+
 ### `LARCH_BINARY`
 
 `LARCH_BINARY` selects an explicit local Rust executable for `scripts/larch.sh`.

--- a/docs/installation-and-setup.md
+++ b/docs/installation-and-setup.md
@@ -7,13 +7,14 @@
 ### Authentication
 
 Set up GitHub and Google credentials before starting larch. Installing `gh` is
-separate from supplying the `GH_TOKEN` that larch uses for authenticated GitHub
-requests.
+separate from supplying the `LARCH_GH_TOKEN` that larch uses for authenticated
+GitHub requests.
 
 #### GitHub
 
-Larch requires a non-empty `GH_TOKEN` in its environment. It does not fall
-back to `GITHUB_TOKEN`.
+Larch requires a non-empty `LARCH_GH_TOKEN` in its environment. It does not
+fall back to `GH_TOKEN`, `GITHUB_TOKEN`, GitHub CLI configuration, or keychain
+state.
 
 Choose one source for the token:
 
@@ -21,13 +22,13 @@ Choose one source for the token:
   shell:
 
   ```bash
-  export GH_TOKEN="$(gh auth token)"
+  export LARCH_GH_TOKEN="$(gh auth token)"
   ```
 
   To provide the value for one Claude session only, run:
 
   ```bash
-  GH_TOKEN="$(gh auth token)" claude
+  LARCH_GH_TOKEN="$(gh auth token)" claude
   ```
 
   Larch does not run `gh auth token` during normal service calls.
@@ -38,18 +39,20 @@ Choose one source for the token:
   when its [repository permissions and API coverage](https://docs.github.com/en/rest/authentication/permissions-required-for-fine-grained-personal-access-tokens)
   are sufficient. Current larch operations can require a classic PAT when a
   required GitHub API operation is not available to a fine-grained PAT. Export
-  the selected token as `GH_TOKEN`. Keep the value in a password manager or
-  secret manager; never commit it to a repository or a `.env` file.
+  the selected token as `LARCH_GH_TOKEN`. Keep the value in a password manager
+  or secret manager; never commit it to a repository or a `.env` file.
 
 Verify the setup without printing the token:
 
 ```bash
-test -n "$GH_TOKEN"
-gh api user >/dev/null
+test -n "$LARCH_GH_TOKEN"
+GH_TOKEN="$LARCH_GH_TOKEN" gh api user >/dev/null
 ```
 
-The commands succeed silently when `GH_TOKEN` is non-empty and authenticates
-to GitHub.
+The commands succeed silently when `LARCH_GH_TOKEN` is non-empty and
+authenticates to GitHub. The explicit `GH_TOKEN=` assignment is only for this
+manual GitHub CLI verification command. Larch does not make that conversion or
+invoke `gh auth token` during service calls.
 
 #### Google Application Default Credentials
 

--- a/plugin/docs/configuration-and-permissions.md
+++ b/plugin/docs/configuration-and-permissions.md
@@ -190,6 +190,19 @@ universe domains are not supported. Larch requests operation-specific scopes,
 keeps tokens inside the official authentication layer, and does not persist
 them.
 
+### `LARCH_GH_TOKEN`
+
+`LARCH_GH_TOKEN` is the sole credential input for Rust GitHub service calls.
+Set it in the environment before starting larch. Missing, empty, and
+whitespace-only values fail before any network request with setup guidance.
+
+Larch does not consult `GH_TOKEN`, `GITHUB_TOKEN`, `gh` configuration,
+keychain state, argv, stdin, repository configuration, issue text, or session
+files as fallbacks. The value stays in a non-`Debug` secret wrapper, is
+registered exactly with the runtime redactor, and is excluded from child
+process environments. The initial transport supports only GitHub.com over
+HTTPS; GitHub Enterprise needs a separate reviewed host policy.
+
 ### `LARCH_BINARY`
 
 `LARCH_BINARY` selects an explicit local Rust executable for `scripts/larch.sh`.

--- a/plugin/docs/installation-and-setup.md
+++ b/plugin/docs/installation-and-setup.md
@@ -7,13 +7,14 @@
 ### Authentication
 
 Set up GitHub and Google credentials before starting larch. Installing `gh` is
-separate from supplying the `GH_TOKEN` that larch uses for authenticated GitHub
-requests.
+separate from supplying the `LARCH_GH_TOKEN` that larch uses for authenticated
+GitHub requests.
 
 #### GitHub
 
-Larch requires a non-empty `GH_TOKEN` in its environment. It does not fall
-back to `GITHUB_TOKEN`.
+Larch requires a non-empty `LARCH_GH_TOKEN` in its environment. It does not
+fall back to `GH_TOKEN`, `GITHUB_TOKEN`, GitHub CLI configuration, or keychain
+state.
 
 Choose one source for the token:
 
@@ -21,13 +22,13 @@ Choose one source for the token:
   shell:
 
   ```bash
-  export GH_TOKEN="$(gh auth token)"
+  export LARCH_GH_TOKEN="$(gh auth token)"
   ```
 
   To provide the value for one Claude session only, run:
 
   ```bash
-  GH_TOKEN="$(gh auth token)" claude
+  LARCH_GH_TOKEN="$(gh auth token)" claude
   ```
 
   Larch does not run `gh auth token` during normal service calls.
@@ -38,18 +39,20 @@ Choose one source for the token:
   when its [repository permissions and API coverage](https://docs.github.com/en/rest/authentication/permissions-required-for-fine-grained-personal-access-tokens)
   are sufficient. Current larch operations can require a classic PAT when a
   required GitHub API operation is not available to a fine-grained PAT. Export
-  the selected token as `GH_TOKEN`. Keep the value in a password manager or
-  secret manager; never commit it to a repository or a `.env` file.
+  the selected token as `LARCH_GH_TOKEN`. Keep the value in a password manager
+  or secret manager; never commit it to a repository or a `.env` file.
 
 Verify the setup without printing the token:
 
 ```bash
-test -n "$GH_TOKEN"
-gh api user >/dev/null
+test -n "$LARCH_GH_TOKEN"
+GH_TOKEN="$LARCH_GH_TOKEN" gh api user >/dev/null
 ```
 
-The commands succeed silently when `GH_TOKEN` is non-empty and authenticates
-to GitHub.
+The commands succeed silently when `LARCH_GH_TOKEN` is non-empty and
+authenticates to GitHub. The explicit `GH_TOKEN=` assignment is only for this
+manual GitHub CLI verification command. Larch does not make that conversion or
+invoke `gh auth token` during service calls.
 
 #### Google Application Default Credentials
 


### PR DESCRIPTION
## Summary

- add the injectable core GitHub service policy and a private, rustls-only Octocrab 0.54 adapter
- require only `LARCH_GH_TOKEN`, register its exact value for redaction, and keep service credentials out of child environments
- enforce fixed GitHub.com origins and headers, deadlines, limits, cancellation, rate-limit-aware read retries, and mutation reconciliation
- document the credential and transport trust boundary

## Validation

- `cargo test --locked --package larch-core --package larch-adapters`
- `cargo clippy --locked --all-features --all-targets --package larch-core --package larch-adapters -- -D warnings`
- `cargo deny --locked --all-features check`
- targeted larch-lint rules for dependency policy, layering, environment constants, subprocess ownership, duplicate code, readability, and output style
- release build on `aarch64-apple-darwin` (`829728` bytes)

Fixes #7724
