### PR TITLE
Build trusted gix repository metadata reads

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -111,6 +111,11 @@ work:
   only `sha1`, `sha256`, `revision`, and `status`. The workspace records that
   exact selection. Do not enable `gix` network, credential, archive, merge, or
   worktree-mutation features without a bounded design and parity evidence.
+- `larch_core::RepositoryRead` owns the repository metadata read contract.
+  `larch_adapters::git::GixRepository` is its sole production implementation.
+  It reopens through strict config parsing and ownership checks before reading
+  mutable repository state. Callers receive core byte types and cannot select
+  `gix` or Git CLI reads.
 - Git mutations and network operations stay behind a closed, typed Git CLI
   compatibility adapter where installed-Git behavior is part of the contract.
   There is no public arbitrary-argv escape hatch.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -106,6 +106,22 @@ The core service port exposes policy and typed transport classifications, not
 raw URLs, arbitrary GraphQL documents, or the concrete client. Operation
 leaves must add typed paths and DTOs behind this same adapter.
 
+## Rust Repository Metadata Read Boundary
+
+`larch_adapters::git::GixRepository` is the sole production implementation of
+the core `RepositoryRead` port. It opens and discovers repositories with `gix`
+ownership checks enabled, rejects reduced-trust ownership, and parses config in
+strict mode. Each mutable-state query reopens through the same checks so later
+ownership or config changes cannot reuse an earlier trusted handle. The
+location method returns the immutable repository identity captured by the
+trusted constructor.
+
+The adapter performs local reads only. It exposes no mutation, network,
+credential, or arbitrary Git command surface. Results preserve object IDs,
+paths, config values, and remote URLs as bytes. Errors use fixed classes and do
+not include repository paths, config values, remote credentials, or upstream
+library diagnostics.
+
 ## Scoped Live-Mutation Authorization Boundary
 
 Scoped GitHub issue create, comment, close, and label operations require explicit live-run authorization. The guarded boundary covers `python3 python/cli.py issue create-one`, the cross-repository stall-report filing helper (`scripts/file-failure-report-cross-repo.sh`), Tier-A dedup before terminal reporter filing, `/design` salvage reconciliation comment and close operations, OOS blocker probes, label provisioning and edits, issue filing and cleanup, and `audit-runs close-priors`.

--- a/agent-lint.toml
+++ b/agent-lint.toml
@@ -1362,9 +1362,10 @@ conditional-sources = [
 root-max-lines = 879
 root-max-tokens = 35383
 root-max-content-tokens = 35301
-closure-max-lines = 3627
-closure-max-tokens = 141210
-closure-max-content-tokens = 140913
+# Issue #7731 adds the repository-read trust boundary to imported SECURITY.md.
+closure-max-lines = 3643
+closure-max-tokens = 141423
+closure-max-content-tokens = 141126
 conditional-max-lines = 589
 conditional-max-tokens = 18764
 conditional-max-content-tokens = 18717
@@ -1411,6 +1412,7 @@ roots = [
   "skills/shared/reviewer-templates.md",
   "skills/shared/voting-protocol.md",
 ]
-closure-max-lines = 5915
-closure-max-tokens = 166682
-closure-max-content-tokens = 166223
+# Issue #7731 adds the repository-read trust boundary to imported SECURITY.md.
+closure-max-lines = 5931
+closure-max-tokens = 166895
+closure-max-content-tokens = 166436

--- a/crates/larch-adapters/src/git.rs
+++ b/crates/larch-adapters/src/git.rs
@@ -1,0 +1,576 @@
+//! Trusted `gix` implementation of the core repository metadata read port.
+
+use std::path::{Path, PathBuf};
+
+use gix::bstr::ByteSlice;
+use larch_core::{
+    Commit, ConfigKey, ConfigScope, ConfigValue, GitPath, Head, Object, ObjectHash, ObjectId,
+    ObjectKind, RefFormat, RefName, Reference, ReferenceKind, ReferenceTarget, Remote,
+    RepositoryError, RepositoryErrorKind, RepositoryLocation, RepositoryRead, Revision, Upstream,
+    Worktree,
+};
+
+/// The only production repository metadata reader.
+#[derive(Debug)]
+pub struct GixRepository {
+    git_dir: PathBuf,
+    location: RepositoryLocation,
+}
+
+impl GixRepository {
+    /// Open a repository at a known path with strict configuration and ownership checks.
+    ///
+    /// # Errors
+    /// Returns a stable, redacted repository error class.
+    pub fn open(path: impl AsRef<Path>) -> Result<Self, RepositoryError> {
+        let repository = gix::ThreadSafeRepository::open_opts(path.as_ref(), read_options())
+            .map_err(|error| map_open_error(&error))?;
+        Ok(Self::from_repository(&repository))
+    }
+
+    /// Discover a repository from `path` or its ancestors with ownership checks enabled.
+    ///
+    /// # Errors
+    /// Returns a stable, redacted repository error class.
+    pub fn discover(path: impl AsRef<Path>) -> Result<Self, RepositoryError> {
+        let options = read_options();
+        let trust = gix::sec::trust::Mapping {
+            full: options.clone(),
+            reduced: options,
+        };
+        let repository = gix::ThreadSafeRepository::discover_opts(
+            path.as_ref(),
+            gix::discover::upwards::Options::default(),
+            trust,
+        )
+        .map_err(|error| map_discover_error(&error))?;
+        Ok(Self::from_repository(&repository))
+    }
+
+    fn from_repository(repository: &gix::ThreadSafeRepository) -> Self {
+        let local = repository.to_thread_local();
+        let location = RepositoryLocation {
+            git_dir: path(local.path()),
+            common_dir: path(local.common_dir()),
+            work_dir: local.workdir().map(path),
+            object_hash: hash_kind(local.object_hash()),
+        };
+        Self {
+            git_dir: repository.path().to_owned(),
+            location,
+        }
+    }
+
+    fn local(&self) -> Result<gix::Repository, RepositoryError> {
+        self.trusted()
+            .map(|repository| repository.to_thread_local())
+    }
+
+    fn trusted(&self) -> Result<gix::ThreadSafeRepository, RepositoryError> {
+        gix::ThreadSafeRepository::open_opts(&self.git_dir, read_options().open_path_as_is(true))
+            .map_err(|error| map_open_error(&error))
+    }
+}
+
+impl RepositoryRead for GixRepository {
+    fn location(&self) -> RepositoryLocation {
+        self.location.clone()
+    }
+
+    fn config_values(&self, key: &ConfigKey) -> Result<Vec<ConfigValue>, RepositoryError> {
+        let repository = self.local()?;
+        let config = repository.config_snapshot();
+        let (section_name, subsection_name, value_name) = config_key_parts(key)?;
+        let mut output = Vec::new();
+        let Some(sections) = config.sections_by_name(section_name) else {
+            return Ok(output);
+        };
+        for section in sections {
+            let subsection = section.header().subsection_name().map(AsRef::as_ref);
+            if subsection != subsection_name.map(str::as_bytes) {
+                continue;
+            }
+            output.extend(
+                section
+                    .values(value_name)
+                    .into_iter()
+                    .map(|value| ConfigValue {
+                        value: value.into_owned().into(),
+                        scope: config_scope(section.meta().source),
+                        include_depth: section.meta().level,
+                    }),
+            );
+        }
+        Ok(output)
+    }
+
+    fn remotes(&self) -> Result<Vec<Remote>, RepositoryError> {
+        let repository = self.local()?;
+        repository
+            .remote_names()
+            .into_iter()
+            .map(|name| {
+                let remote = repository
+                    .find_remote(name.as_ref())
+                    .map_err(|_| error(RepositoryErrorKind::MalformedConfig))?;
+                Ok(Remote {
+                    name: name.as_ref().to_vec(),
+                    fetch_url: remote
+                        .url(gix::remote::Direction::Fetch)
+                        .map(|url| url.to_bstring().into()),
+                    push_url: remote
+                        .url(gix::remote::Direction::Push)
+                        .map(|url| url.to_bstring().into()),
+                })
+            })
+            .collect()
+    }
+
+    fn upstream(&self, branch: &RefName) -> Result<Option<Upstream>, RepositoryError> {
+        let repository = self.local()?;
+        let full_name: &gix::refs::FullNameRef = branch
+            .as_bytes()
+            .as_bstr()
+            .try_into()
+            .map_err(|_| error(RepositoryErrorKind::InvalidRef))?;
+        if full_name.category() != Some(gix::refs::Category::LocalBranch) {
+            return Err(error(RepositoryErrorKind::InvalidRef));
+        }
+        let Some(remote_ref) =
+            repository.branch_remote_ref_name(full_name, gix::remote::Direction::Fetch)
+        else {
+            return Ok(None);
+        };
+        let remote_ref = remote_ref.map_err(|_| error(RepositoryErrorKind::MalformedConfig))?;
+        let remote = repository
+            .branch_remote_name(full_name.shorten(), gix::remote::Direction::Fetch)
+            .ok_or_else(|| error(RepositoryErrorKind::MalformedConfig))?;
+        let tracking_ref = repository
+            .branch_remote_tracking_ref_name(full_name, gix::remote::Direction::Fetch)
+            .transpose()
+            .map_err(|_| error(RepositoryErrorKind::MalformedConfig))?
+            .map(|name| RefName::new(name.as_bstr().to_vec()));
+        Ok(Some(Upstream {
+            remote: remote.as_bstr().to_vec(),
+            remote_ref: RefName::new(remote_ref.as_bstr().to_vec()),
+            tracking_ref,
+        }))
+    }
+
+    fn head(&self) -> Result<Head, RepositoryError> {
+        let repository = self.local()?;
+        let head = repository
+            .head()
+            .map_err(|_| error(RepositoryErrorKind::CorruptRepository))?;
+        let referent = head
+            .referent_name()
+            .map(|name| RefName::new(name.as_bstr().to_vec()));
+        match (head.is_unborn(), head.is_detached(), referent, head.id()) {
+            (true, false, Some(name), None) => Ok(Head::Unborn { name }),
+            (false, true, None, Some(target)) => Ok(Head::Detached {
+                target: object_id(target.as_ref()),
+            }),
+            (false, false, Some(name), Some(target)) => Ok(Head::Symbolic {
+                name,
+                target: object_id(target.as_ref()),
+            }),
+            _ => Err(error(RepositoryErrorKind::CorruptRepository)),
+        }
+    }
+
+    fn resolve_revision(&self, revision: &Revision) -> Result<ObjectId, RepositoryError> {
+        let trusted = self.trusted()?;
+        let objects_dir = trusted.objects_dir().to_owned();
+        let repository = trusted.to_thread_local();
+        let value = revision.as_bytes();
+        if value.is_empty() || value.contains(&0) {
+            return Err(error(RepositoryErrorKind::InvalidInput));
+        }
+        if value.windows(2).any(|pair| pair == b"..")
+            || value.windows(3).any(|window| window == b"^{/")
+            || value.contains(&b':')
+        {
+            return Err(error(RepositoryErrorKind::UnsupportedRevision));
+        }
+        if is_abbreviated_hex(value, repository.object_hash()) {
+            match lookup_prefix(&objects_dir, repository.object_hash(), value)? {
+                PrefixLookup::Missing => return Err(error(RepositoryErrorKind::RevisionNotFound)),
+                PrefixLookup::Ambiguous => {
+                    return Err(error(RepositoryErrorKind::AmbiguousRevision));
+                }
+                PrefixLookup::Unique => {}
+            }
+        }
+        match repository.rev_parse_single(value.as_bstr()) {
+            Ok(id) => Ok(object_id(id.as_ref())),
+            Err(gix::revision::spec::parse::single::Error::RangedRev { .. }) => {
+                Err(error(RepositoryErrorKind::UnsupportedRevision))
+            }
+            Err(gix::revision::spec::parse::single::Error::Parse(_)) => {
+                Err(error(RepositoryErrorKind::RevisionNotFound))
+            }
+        }
+    }
+
+    fn references(&self) -> Result<Vec<Reference>, RepositoryError> {
+        let repository = self.local()?;
+        let platform = repository
+            .references()
+            .map_err(|_| error(RepositoryErrorKind::CorruptRepository))?;
+        let iter = platform
+            .all()
+            .map_err(|_| error(RepositoryErrorKind::CorruptRepository))?;
+        let mut output = Vec::new();
+        for reference in iter {
+            let reference = reference.map_err(|_| error(RepositoryErrorKind::CorruptRepository))?;
+            let name = reference.name().as_bstr();
+            let target = match reference.target() {
+                gix::refs::TargetRef::Object(id) => ReferenceTarget::Object(object_id(id)),
+                gix::refs::TargetRef::Symbolic(name) => {
+                    ReferenceTarget::Symbolic(RefName::new(name.as_bstr().to_vec()))
+                }
+            };
+            output.push(Reference {
+                name: RefName::new(name.to_vec()),
+                kind: reference_kind(name),
+                target,
+            });
+        }
+        output.sort_by(|left, right| left.name.cmp(&right.name));
+        Ok(output)
+    }
+
+    fn object(&self, id: &ObjectId) -> Result<Option<Object>, RepositoryError> {
+        let repository = self.local()?;
+        let id = gix_id(id, repository.object_hash())?;
+        let Some(object) = repository
+            .try_find_object(id)
+            .map_err(|_| error(RepositoryErrorKind::CorruptRepository))?
+        else {
+            return Ok(None);
+        };
+        Ok(Some(Object {
+            id: object_id(&object.id),
+            kind: object_kind(object.kind),
+            data: object.data.clone(),
+        }))
+    }
+
+    fn walk_commits(&self, start: &ObjectId, limit: usize) -> Result<Vec<Commit>, RepositoryError> {
+        let repository = self.local()?;
+        let start = gix_id(start, repository.object_hash())?;
+        let walk = repository
+            .rev_walk([start])
+            .all()
+            .map_err(|_| error(RepositoryErrorKind::CorruptRepository))?;
+        walk.take(limit)
+            .map(|info| {
+                let info = info.map_err(|_| error(RepositoryErrorKind::MissingObject))?;
+                Ok(Commit {
+                    id: object_id(&info.id),
+                    parents: info.parent_ids().map(|id| object_id(id.as_ref())).collect(),
+                })
+            })
+            .collect()
+    }
+
+    fn commit_count(&self, start: &ObjectId) -> Result<u64, RepositoryError> {
+        let repository = self.local()?;
+        let start = gix_id(start, repository.object_hash())?;
+        let walk = repository
+            .rev_walk([start])
+            .all()
+            .map_err(|_| error(RepositoryErrorKind::CorruptRepository))?;
+        let mut count = 0_u64;
+        for info in walk {
+            info.map_err(|_| error(RepositoryErrorKind::MissingObject))?;
+            count = count
+                .checked_add(1)
+                .ok_or_else(|| error(RepositoryErrorKind::CorruptRepository))?;
+        }
+        Ok(count)
+    }
+
+    fn merge_base(&self, left: &ObjectId, right: &ObjectId) -> Result<ObjectId, RepositoryError> {
+        let repository = self.local()?;
+        let left = gix_id(left, repository.object_hash())?;
+        let right = gix_id(right, repository.object_hash())?;
+        repository
+            .merge_base(left, right)
+            .map(|id| object_id(id.as_ref()))
+            .map_err(|_| error(RepositoryErrorKind::RevisionNotFound))
+    }
+
+    fn is_ancestor(
+        &self,
+        ancestor: &ObjectId,
+        descendant: &ObjectId,
+    ) -> Result<bool, RepositoryError> {
+        let repository = self.local()?;
+        let ancestor = gix_id(ancestor, repository.object_hash())?;
+        let descendant = gix_id(descendant, repository.object_hash())?;
+        repository
+            .merge_base(ancestor, descendant)
+            .map(|base| base.as_ref() == ancestor)
+            .map_err(|_| error(RepositoryErrorKind::RevisionNotFound))
+    }
+
+    fn worktrees(&self) -> Result<Vec<Worktree>, RepositoryError> {
+        let repository = self.local()?;
+        let mut output = Vec::new();
+        let mut current_is_linked = false;
+        if let Some(worktree) = repository.worktree() {
+            current_is_linked = worktree.id().is_some();
+            output.push(Worktree {
+                id: worktree.id().map(|id| id.to_vec()),
+                path: path(worktree.base()),
+                git_dir: path(repository.path()),
+                locked: worktree.is_locked(),
+            });
+        }
+        if current_is_linked {
+            let main = repository
+                .main_repo()
+                .map_err(|_| error(RepositoryErrorKind::Io))?;
+            if let Some(worktree) = main.worktree() {
+                output.push(Worktree {
+                    id: None,
+                    path: path(worktree.base()),
+                    git_dir: path(main.path()),
+                    locked: false,
+                });
+            }
+        }
+        for proxy in repository
+            .worktrees()
+            .map_err(|_| error(RepositoryErrorKind::Io))?
+        {
+            output.push(Worktree {
+                id: Some(proxy.id().to_vec()),
+                path: path(&proxy.base().map_err(|_| error(RepositoryErrorKind::Io))?),
+                git_dir: path(proxy.git_dir()),
+                locked: proxy.is_locked(),
+            });
+        }
+        output.sort_by(|left, right| left.path.cmp(&right.path));
+        output.dedup_by(|left, right| left.path == right.path);
+        Ok(output)
+    }
+
+    fn validate_ref_name(&self, name: &RefName, format: RefFormat) -> Result<(), RepositoryError> {
+        let name = name.as_bytes().as_bstr();
+        let valid = match format {
+            RefFormat::Full => gix::validate::reference::name(name).is_ok(),
+            RefFormat::Branch => gix::validate::reference::branch_name(name).is_ok(),
+            RefFormat::Tag => gix::validate::tag::name(name).is_ok(),
+        };
+        if valid {
+            Ok(())
+        } else {
+            Err(error(RepositoryErrorKind::InvalidRef))
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum PrefixLookup {
+    Missing,
+    Unique,
+    Ambiguous,
+}
+
+fn lookup_prefix(
+    objects_dir: &Path,
+    hash: gix::hash::Kind,
+    value: &[u8],
+) -> Result<PrefixLookup, RepositoryError> {
+    let candidate = object_id_from_hex_prefix(value, hash)?;
+    let prefix = gix::hash::Prefix::new(&candidate, value.len())
+        .map_err(|_| error(RepositoryErrorKind::InvalidInput))?;
+    let options = gix::odb::store::init::Options {
+        object_hash: hash,
+        ..Default::default()
+    };
+    let database =
+        gix::odb::at_opts(objects_dir, [], options).map_err(|_| error(RepositoryErrorKind::Io))?;
+    match database
+        .lookup_prefix(prefix, None)
+        .map_err(|_| error(RepositoryErrorKind::CorruptRepository))?
+    {
+        None => Ok(PrefixLookup::Missing),
+        Some(Ok(_)) => Ok(PrefixLookup::Unique),
+        Some(Err(())) => Ok(PrefixLookup::Ambiguous),
+    }
+}
+
+fn read_options() -> gix::open::Options {
+    gix::open::Options::default()
+        .bail_if_untrusted(true)
+        .strict_config(true)
+}
+
+const fn map_open_error(open_error: &gix::open::Error) -> RepositoryError {
+    match open_error {
+        gix::open::Error::UnsafeGitDir { .. } => error(RepositoryErrorKind::UntrustedRepository),
+        gix::open::Error::Config(_) => error(RepositoryErrorKind::MalformedConfig),
+        gix::open::Error::NotARepository { .. } => error(RepositoryErrorKind::NotRepository),
+        gix::open::Error::Io(_) | gix::open::Error::EnvironmentAccessDenied(_) => {
+            error(RepositoryErrorKind::Io)
+        }
+        gix::open::Error::PrefixNotRelative(_) => error(RepositoryErrorKind::InvalidInput),
+    }
+}
+
+const fn map_discover_error(discover_error: &gix::discover::Error) -> RepositoryError {
+    match discover_error {
+        gix::discover::Error::Open(error) => map_open_error(error),
+        gix::discover::Error::Discover(upwards_error) => match upwards_error {
+            gix::discover::upwards::Error::InvalidInput { .. }
+            | gix::discover::upwards::Error::NoMatchingCeilingDir => {
+                error(RepositoryErrorKind::InvalidInput)
+            }
+            gix::discover::upwards::Error::NoTrustedGitRepository { .. } => {
+                error(RepositoryErrorKind::UntrustedRepository)
+            }
+            gix::discover::upwards::Error::NoGitRepository { .. }
+            | gix::discover::upwards::Error::NoGitRepositoryWithinCeiling { .. }
+            | gix::discover::upwards::Error::NoGitRepositoryWithinFs { .. } => {
+                error(RepositoryErrorKind::NotRepository)
+            }
+            gix::discover::upwards::Error::CurrentDir(_)
+            | gix::discover::upwards::Error::InaccessibleDirectory { .. }
+            | gix::discover::upwards::Error::CheckTrust { .. } => error(RepositoryErrorKind::Io),
+        },
+    }
+}
+
+const fn error(kind: RepositoryErrorKind) -> RepositoryError {
+    RepositoryError::new(kind)
+}
+
+fn path(value: &Path) -> GitPath {
+    GitPath::new(gix::path::into_bstr(value).into_owned())
+}
+
+fn hash_kind(kind: gix::hash::Kind) -> ObjectHash {
+    match kind {
+        gix::hash::Kind::Sha1 => ObjectHash::Sha1,
+        gix::hash::Kind::Sha256 => ObjectHash::Sha256,
+        _ => unreachable!("the workspace enables only SHA-1 and SHA-256"),
+    }
+}
+
+fn object_id(id: &gix::hash::oid) -> ObjectId {
+    ObjectId::new(hash_kind(id.kind()), id.as_bytes().to_vec())
+        .expect("gix object IDs have the algorithm's digest length")
+}
+
+fn gix_id(
+    id: &ObjectId,
+    repository_hash: gix::hash::Kind,
+) -> Result<gix::ObjectId, RepositoryError> {
+    if hash_kind(repository_hash) != id.hash() {
+        return Err(error(RepositoryErrorKind::HashMismatch));
+    }
+    let mut output = gix::ObjectId::null(repository_hash);
+    output.as_mut_slice().copy_from_slice(id.digest());
+    Ok(output)
+}
+
+const fn object_kind(kind: gix::objs::Kind) -> ObjectKind {
+    match kind {
+        gix::objs::Kind::Blob => ObjectKind::Blob,
+        gix::objs::Kind::Tree => ObjectKind::Tree,
+        gix::objs::Kind::Commit => ObjectKind::Commit,
+        gix::objs::Kind::Tag => ObjectKind::Tag,
+    }
+}
+
+fn reference_kind(name: &gix::bstr::BStr) -> ReferenceKind {
+    if name.starts_with(b"refs/heads/") {
+        ReferenceKind::LocalBranch
+    } else if name.starts_with(b"refs/remotes/") {
+        ReferenceKind::RemoteBranch
+    } else if name.starts_with(b"refs/tags/") {
+        ReferenceKind::Tag
+    } else {
+        ReferenceKind::Other
+    }
+}
+
+fn is_abbreviated_hex(value: &[u8], hash: gix::hash::Kind) -> bool {
+    let full_len = match hash {
+        gix::hash::Kind::Sha1 => 40,
+        gix::hash::Kind::Sha256 => 64,
+        _ => return false,
+    };
+    value.len() < full_len && value.len() >= 4 && value.iter().all(u8::is_ascii_hexdigit)
+}
+
+fn object_id_from_hex_prefix(
+    value: &[u8],
+    hash: gix::hash::Kind,
+) -> Result<gix::ObjectId, RepositoryError> {
+    let mut id = gix::ObjectId::null(hash);
+    for (index, byte) in value.iter().copied().enumerate() {
+        let nibble = match byte {
+            b'0'..=b'9' => byte - b'0',
+            b'a'..=b'f' => byte - b'a' + 10,
+            b'A'..=b'F' => byte - b'A' + 10,
+            _ => return Err(error(RepositoryErrorKind::InvalidInput)),
+        };
+        if index % 2 == 0 {
+            id.as_mut_slice()[index / 2] = nibble << 4;
+        } else {
+            id.as_mut_slice()[index / 2] |= nibble;
+        }
+    }
+    Ok(id)
+}
+
+fn config_key_parts(key: &ConfigKey) -> Result<(&str, Option<&str>, &str), RepositoryError> {
+    let raw = key.as_str();
+    let first = raw
+        .find('.')
+        .ok_or_else(|| error(RepositoryErrorKind::InvalidInput))?;
+    let last = raw
+        .rfind('.')
+        .ok_or_else(|| error(RepositoryErrorKind::InvalidInput))?;
+    let subsection = (first != last).then(|| &raw[first + 1..last]);
+    Ok((&raw[..first], subsection, &raw[last + 1..]))
+}
+
+const fn config_scope(source: gix::config::Source) -> ConfigScope {
+    match source {
+        gix::config::Source::GitInstallation => ConfigScope::GitInstallation,
+        gix::config::Source::System => ConfigScope::System,
+        gix::config::Source::Git | gix::config::Source::User => ConfigScope::User,
+        gix::config::Source::Local => ConfigScope::Repository,
+        gix::config::Source::Worktree => ConfigScope::Worktree,
+        gix::config::Source::Env | gix::config::Source::EnvOverride => ConfigScope::Environment,
+        gix::config::Source::Cli => ConfigScope::CommandLine,
+        gix::config::Source::Api => ConfigScope::Api,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::map_open_error;
+    use larch_core::RepositoryErrorKind;
+    use std::path::PathBuf;
+
+    #[test]
+    fn unsafe_repository_errors_do_not_render_the_path() {
+        let secret_path = PathBuf::from("/private/credential-bearing/repository");
+        let error = map_open_error(&gix::open::Error::UnsafeGitDir {
+            path: secret_path.clone(),
+        });
+
+        assert_eq!(error.kind(), RepositoryErrorKind::UntrustedRepository);
+        assert!(
+            !error
+                .to_string()
+                .contains(secret_path.to_string_lossy().as_ref())
+        );
+    }
+}

--- a/crates/larch-adapters/src/lib.rs
+++ b/crates/larch-adapters/src/lib.rs
@@ -1,6 +1,7 @@
 //! Concrete adapters for filesystem, process, Git, time, and service boundaries.
 
 pub mod clock;
+pub mod git;
 pub mod github;
 pub mod google_auth;
 pub mod logging;

--- a/crates/larch-adapters/tests/git_repository.rs
+++ b/crates/larch-adapters/tests/git_repository.rs
@@ -1,0 +1,466 @@
+use std::{ffi::OsString, path::PathBuf};
+
+#[cfg(unix)]
+use std::os::unix::ffi::OsStringExt;
+
+use larch_adapters::git::GixRepository;
+use larch_core::{
+    ConfigKey, ConfigScope, Head, ObjectHash, ObjectId, ObjectKind, RefFormat, RefName,
+    ReferenceTarget, RepositoryErrorKind, RepositoryRead, Revision,
+};
+use larch_test_support::{
+    ExecutionSnapshot, GitFixture, GitFixtureError, GitObjectFormat, GitRepository,
+    SemanticSnapshot, TestWorkspace,
+};
+
+#[test]
+fn repository_queries_match_installed_git_semantics() {
+    let Some(fixture) = fixture(GitFixture::Refs, GitObjectFormat::Sha1) else {
+        return;
+    };
+    fixture.write("second.txt", b"second\n").unwrap();
+    git_ok(&fixture, ["add", "second.txt"]);
+    git_ok(&fixture, ["commit", "--quiet", "-m", "second"]);
+    git_ok(&fixture, ["pack-refs", "--all"]);
+    fixture.write("nested/file.txt", b"nested\n").unwrap();
+    fixture.write("ambiguous-a", b"ambiguous-16\n").unwrap();
+    fixture.write("ambiguous-b", b"ambiguous-272\n").unwrap();
+    git_ok(&fixture, ["hash-object", "-w", "ambiguous-a"]);
+    git_ok(&fixture, ["hash-object", "-w", "ambiguous-b"]);
+    let before = SemanticSnapshot::capture(&fixture, ExecutionSnapshot::success()).unwrap();
+
+    let reader = GixRepository::discover(fixture.root().join("nested")).unwrap();
+    let location = reader.location();
+    assert_eq!(
+        canonical_path(location.work_dir.unwrap().as_bytes()),
+        canonical_path(&git_line(&fixture, ["rev-parse", "--show-toplevel"]))
+    );
+    assert_eq!(
+        canonical_path(location.git_dir.as_bytes()),
+        canonical_path(&git_line(&fixture, ["rev-parse", "--absolute-git-dir"]))
+    );
+    assert_eq!(location.object_hash, ObjectHash::Sha1);
+
+    let head = git_id(&fixture, ["rev-parse", "HEAD"]);
+    assert_eq!(
+        reader.resolve_revision(&Revision::new("HEAD")).unwrap(),
+        head
+    );
+    assert_eq!(
+        reader.head().unwrap(),
+        Head::Symbolic {
+            name: RefName::new("refs/heads/main"),
+            target: head.clone(),
+        }
+    );
+
+    assert_ref_and_object_queries(&reader, &fixture, &head);
+    assert_graph_queries(&reader, &fixture, &head);
+    assert_revision_validation(&reader, &fixture);
+
+    let after = SemanticSnapshot::capture(&fixture, ExecutionSnapshot::success()).unwrap();
+    assert_eq!(after, before);
+}
+
+fn assert_ref_and_object_queries(reader: &GixRepository, fixture: &GitRepository, head: &ObjectId) {
+    let references = reader.references().unwrap();
+    for name in [
+        "refs/heads/main",
+        "refs/heads/topic",
+        "refs/remotes/origin/main",
+        "refs/tags/v1",
+    ] {
+        let expected = git_id(fixture, ["show-ref", "--verify", "--hash", name]);
+        let actual = references
+            .iter()
+            .find(|reference| reference.name.as_bytes() == name.as_bytes())
+            .unwrap();
+        assert_eq!(actual.target, ReferenceTarget::Object(expected));
+    }
+
+    let object = reader.object(head).unwrap().unwrap();
+    assert_eq!(object.kind, ObjectKind::Commit);
+    assert_eq!(
+        object.data,
+        git_bytes(fixture, ["cat-file", "commit", "HEAD"])
+    );
+    let missing = ObjectId::new(ObjectHash::Sha1, [0; 20]).unwrap();
+    assert_eq!(reader.object(&missing).unwrap(), None);
+}
+
+fn assert_graph_queries(reader: &GixRepository, fixture: &GitRepository, head: &ObjectId) {
+    let expected_walk: Vec<_> = git_lines(fixture, ["rev-list", "HEAD"])
+        .into_iter()
+        .map(|hex| id_from_hex(&hex))
+        .collect();
+    let walk = reader.walk_commits(head, usize::MAX).unwrap();
+    assert_eq!(
+        walk.iter()
+            .map(|commit| commit.id.clone())
+            .collect::<Vec<_>>(),
+        expected_walk
+    );
+    assert_eq!(
+        reader.commit_count(head).unwrap(),
+        expected_walk.len() as u64
+    );
+    assert_eq!(reader.walk_commits(head, 1).unwrap().len(), 1);
+    let topic = git_id(fixture, ["rev-parse", "topic"]);
+    assert_eq!(
+        reader.merge_base(head, &topic).unwrap(),
+        git_id(fixture, ["merge-base", "HEAD", "topic"])
+    );
+    assert!(reader.is_ancestor(&topic, head).unwrap());
+    assert!(!reader.is_ancestor(head, &topic).unwrap());
+}
+
+fn assert_revision_validation(reader: &GixRepository, fixture: &GitRepository) {
+    for (name, format, git_name) in [
+        ("refs/heads/topic", RefFormat::Full, "refs/heads/topic"),
+        ("refs/heads/topic", RefFormat::Branch, "refs/heads/topic"),
+        ("release/v1", RefFormat::Tag, "refs/tags/release/v1"),
+        ("bad..name", RefFormat::Full, "bad..name"),
+    ] {
+        let git_valid = fixture
+            .git(["check-ref-format", git_name])
+            .unwrap()
+            .success();
+        assert_eq!(
+            reader
+                .validate_ref_name(&RefName::new(name), format)
+                .is_ok(),
+            git_valid
+        );
+    }
+    assert_eq!(
+        reader
+            .resolve_revision(&Revision::new("HEAD..topic"))
+            .unwrap_err()
+            .kind(),
+        RepositoryErrorKind::UnsupportedRevision
+    );
+    assert_eq!(
+        reader
+            .resolve_revision(&Revision::new("HEAD^{/second}"))
+            .unwrap_err()
+            .kind(),
+        RepositoryErrorKind::UnsupportedRevision
+    );
+    assert_eq!(
+        reader
+            .resolve_revision(&Revision::new("missing-name"))
+            .unwrap_err()
+            .kind(),
+        RepositoryErrorKind::RevisionNotFound
+    );
+    assert_eq!(
+        reader
+            .resolve_revision(&Revision::new("5978"))
+            .unwrap_err()
+            .kind(),
+        RepositoryErrorKind::AmbiguousRevision
+    );
+    assert_eq!(
+        reader
+            .resolve_revision(&Revision::new("dead"))
+            .unwrap_err()
+            .kind(),
+        RepositoryErrorKind::RevisionNotFound
+    );
+}
+
+#[test]
+fn config_remotes_and_upstream_match_git() {
+    let Some(fixture) = fixture(GitFixture::HooksSigningAndRemotes, GitObjectFormat::Sha1) else {
+        return;
+    };
+    fixture
+        .write("included.cfg", b"[larch]\nraw = from-include\n")
+        .unwrap();
+    git_ok(&fixture, ["config", "include.path", "../included.cfg"]);
+    git_ok(
+        &fixture,
+        [
+            "config",
+            "url.https://mirror.invalid/.insteadOf",
+            "https://user:secret@example.invalid/",
+        ],
+    );
+    git_ok(
+        &fixture,
+        [
+            "config",
+            "remote.origin.fetch",
+            "+refs/heads/*:refs/remotes/origin/*",
+        ],
+    );
+    git_ok(&fixture, ["config", "branch.main.remote", "origin"]);
+    git_ok(&fixture, ["config", "branch.main.merge", "refs/heads/main"]);
+    git_ok(&fixture, ["update-ref", "refs/remotes/origin/main", "HEAD"]);
+
+    let reader = GixRepository::open(fixture.root()).unwrap();
+    let values = reader
+        .config_values(&ConfigKey::new("larch.raw").unwrap())
+        .unwrap();
+    assert_eq!(values.len(), 1);
+    assert_eq!(values[0].value, b"from-include");
+    assert_eq!(values[0].scope, ConfigScope::Repository);
+    assert_eq!(values[0].include_depth, 1);
+
+    let expected_names = git_lines(&fixture, ["remote"]);
+    let remotes = reader.remotes().unwrap();
+    assert_eq!(
+        remotes
+            .iter()
+            .map(|remote| remote.name.clone())
+            .collect::<Vec<_>>(),
+        expected_names
+    );
+    let origin = remotes
+        .iter()
+        .find(|remote| remote.name == b"origin")
+        .unwrap();
+    assert_eq!(
+        origin.fetch_url.as_deref().unwrap(),
+        git_line(&fixture, ["remote", "get-url", "origin"])
+    );
+    assert_eq!(
+        origin.push_url.as_deref().unwrap(),
+        git_line(&fixture, ["remote", "get-url", "--push", "origin"])
+    );
+
+    let upstream = reader
+        .upstream(&RefName::new("refs/heads/main"))
+        .unwrap()
+        .unwrap();
+    assert_eq!(upstream.remote, b"origin");
+    assert_eq!(upstream.remote_ref.as_bytes(), b"refs/heads/main");
+    assert_eq!(
+        upstream.tracking_ref.unwrap().as_bytes(),
+        b"refs/remotes/origin/main"
+    );
+    let upstream_revision: String = ['@', '{', 'u', 'p', 's', 't', 'r', 'e', 'a', 'm', '}']
+        .into_iter()
+        .collect();
+    assert_eq!(
+        reader
+            .resolve_revision(&Revision::new(upstream_revision.as_str()))
+            .unwrap(),
+        git_id(&fixture, ["rev-parse", upstream_revision.as_str()])
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn non_utf8_config_values_are_preserved() {
+    let Some(fixture) = fixture(GitFixture::Unborn, GitObjectFormat::Sha1) else {
+        return;
+    };
+    let value = OsString::from_vec(b"raw-\xff-value".to_vec());
+    let output = fixture
+        .git([OsString::from("config"), OsString::from("larch.raw"), value])
+        .unwrap();
+    assert!(output.success(), "Git oracle failed");
+    let reader = GixRepository::open(fixture.root()).unwrap();
+    let values = reader
+        .config_values(&ConfigKey::new("larch.raw").unwrap())
+        .unwrap();
+    assert_eq!(values[0].value, b"raw-\xff-value");
+}
+
+#[test]
+fn head_worktrees_sha256_and_errors_have_typed_results() {
+    let Some(unborn) = fixture(GitFixture::Unborn, GitObjectFormat::Sha1) else {
+        return;
+    };
+    let reader = GixRepository::open(unborn.root()).unwrap();
+    assert!(matches!(reader.head().unwrap(), Head::Unborn { .. }));
+    let malformed = unborn.write(".git/config", b"[broken\n").unwrap();
+    assert!(malformed.ends_with("config"));
+    assert_eq!(
+        reader.head().unwrap_err().kind(),
+        RepositoryErrorKind::MalformedConfig
+    );
+    assert_eq!(
+        GixRepository::open(unborn.root()).unwrap_err().kind(),
+        RepositoryErrorKind::MalformedConfig
+    );
+
+    let Some(detached) = fixture(GitFixture::Detached, GitObjectFormat::Sha1) else {
+        return;
+    };
+    assert!(matches!(
+        GixRepository::open(detached.root())
+            .unwrap()
+            .head()
+            .unwrap(),
+        Head::Detached { .. }
+    ));
+
+    if let Some(linked) = fixture(GitFixture::LinkedWorktree, GitObjectFormat::Sha1) {
+        let linked_path = linked.workspace_root().join("linked-worktree");
+        git_ok(&linked, ["config", "extensions.worktreeConfig", "true"]);
+        git_ok(
+            &linked,
+            [
+                OsString::from("-C"),
+                linked_path.as_os_str().to_owned(),
+                OsString::from("config"),
+                OsString::from("--worktree"),
+                OsString::from("larch.scope"),
+                OsString::from("linked"),
+            ],
+        );
+        let reader = GixRepository::open(&linked_path).unwrap();
+        assert!(reader.head().is_ok());
+        let scoped = reader
+            .config_values(&ConfigKey::new("larch.scope").unwrap())
+            .unwrap();
+        assert_eq!(scoped[0].scope, ConfigScope::Worktree);
+        let mut expected: Vec<_> = git_bytes(&linked, ["worktree", "list", "--porcelain", "-z"])
+            .split(|byte| *byte == 0)
+            .filter_map(|line| line.strip_prefix(b"worktree ").map(<[u8]>::to_vec))
+            .collect();
+        expected = expected
+            .into_iter()
+            .map(|value| canonical_path(&value))
+            .collect();
+        expected.sort();
+        let mut actual: Vec<_> = reader
+            .worktrees()
+            .unwrap()
+            .into_iter()
+            .map(|worktree| canonical_path(worktree.path.as_bytes()))
+            .collect();
+        actual.sort();
+        assert_eq!(actual, expected);
+    }
+
+    if let Some(sha256) = fixture(GitFixture::Refs, GitObjectFormat::Sha256) {
+        let reader = GixRepository::open(sha256.root()).unwrap();
+        assert_eq!(reader.location().object_hash, ObjectHash::Sha256);
+        assert_eq!(
+            reader.resolve_revision(&Revision::new("HEAD")).unwrap(),
+            git_id(&sha256, ["rev-parse", "HEAD"])
+        );
+        assert_eq!(
+            reader
+                .object(&ObjectId::new(ObjectHash::Sha1, [0; 20]).unwrap())
+                .unwrap_err()
+                .kind(),
+            RepositoryErrorKind::HashMismatch
+        );
+    }
+
+    let workspace = TestWorkspace::new().unwrap();
+    let plain = workspace.create_dir("plain").unwrap();
+    assert_eq!(
+        GixRepository::discover(plain).unwrap_err().kind(),
+        RepositoryErrorKind::NotRepository
+    );
+}
+
+fn fixture(kind: GitFixture, format: GitObjectFormat) -> Option<GitRepository> {
+    match GitRepository::builder(kind).object_format(format).build() {
+        Ok(repository) => Some(repository),
+        Err(GitFixtureError::Skip(skip)) => {
+            eprintln!("fixture skipped: {skip}");
+            None
+        }
+        Err(error) => panic!("fixture failed: {error}"),
+    }
+}
+
+fn git_ok<I, S>(repository: &GitRepository, arguments: I)
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<std::ffi::OsStr>,
+{
+    assert!(
+        repository.git(arguments).unwrap().success(),
+        "Git oracle failed"
+    );
+}
+
+fn git_bytes<I, S>(repository: &GitRepository, arguments: I) -> Vec<u8>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<std::ffi::OsStr>,
+{
+    let output = repository.git(arguments).unwrap();
+    assert!(output.success(), "Git oracle failed");
+    output.stdout
+}
+
+fn git_line<I, S>(repository: &GitRepository, arguments: I) -> Vec<u8>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<std::ffi::OsStr>,
+{
+    let mut output = git_bytes(repository, arguments);
+    while matches!(output.last(), Some(b'\n' | b'\r')) {
+        output.pop();
+    }
+    output
+}
+
+fn git_lines<I, S>(repository: &GitRepository, arguments: I) -> Vec<Vec<u8>>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<std::ffi::OsStr>,
+{
+    git_bytes(repository, arguments)
+        .split(|byte| *byte == b'\n')
+        .filter(|line| !line.is_empty())
+        .map(<[u8]>::to_vec)
+        .collect()
+}
+
+fn git_id<I, S>(repository: &GitRepository, arguments: I) -> ObjectId
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<std::ffi::OsStr>,
+{
+    id_from_hex(&git_line(repository, arguments))
+}
+
+fn id_from_hex(hex: &[u8]) -> ObjectId {
+    let hash = match hex.len() {
+        40 => ObjectHash::Sha1,
+        64 => ObjectHash::Sha256,
+        _ => panic!("unexpected object ID length"),
+    };
+    let digest = hex
+        .chunks_exact(2)
+        .map(|pair| (nibble(pair[0]) << 4) | nibble(pair[1]))
+        .collect::<Vec<_>>();
+    ObjectId::new(hash, digest).unwrap()
+}
+
+fn nibble(byte: u8) -> u8 {
+    match byte {
+        b'0'..=b'9' => byte - b'0',
+        b'a'..=b'f' => byte - b'a' + 10,
+        _ => panic!("non-hex object ID"),
+    }
+}
+
+#[cfg(unix)]
+fn canonical_path(bytes: &[u8]) -> Vec<u8> {
+    use std::os::unix::ffi::OsStrExt;
+
+    std::fs::canonicalize(PathBuf::from(OsString::from_vec(bytes.to_vec())))
+        .unwrap()
+        .as_os_str()
+        .as_bytes()
+        .to_vec()
+}
+
+#[cfg(not(unix))]
+fn canonical_path(bytes: &[u8]) -> Vec<u8> {
+    std::fs::canonicalize(PathBuf::from(String::from_utf8(bytes.to_vec()).unwrap()))
+        .unwrap()
+        .to_string_lossy()
+        .into_owned()
+        .into_bytes()
+}

--- a/crates/larch-core/src/git.rs
+++ b/crates/larch-core/src/git.rs
@@ -1,0 +1,422 @@
+//! Byte-oriented repository metadata types and the sole read port for Git state.
+
+use std::{error::Error, fmt};
+
+/// The object hash algorithm used by a repository.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum ObjectHash {
+    /// SHA-1 object identifiers contain 20 raw bytes.
+    Sha1,
+    /// SHA-256 object identifiers contain 32 raw bytes.
+    Sha256,
+}
+
+impl ObjectHash {
+    /// Return the required raw digest length.
+    #[must_use]
+    pub const fn digest_len(self) -> usize {
+        match self {
+            Self::Sha1 => 20,
+            Self::Sha256 => 32,
+        }
+    }
+}
+
+/// A raw Git object identifier with its algorithm attached.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct ObjectId {
+    hash: ObjectHash,
+    digest: Vec<u8>,
+}
+
+impl ObjectId {
+    /// Build an object identifier from raw digest bytes.
+    ///
+    /// # Errors
+    /// Returns `InvalidInput` when the digest length does not match the algorithm.
+    pub fn new(hash: ObjectHash, digest: impl Into<Vec<u8>>) -> Result<Self, RepositoryError> {
+        let digest = digest.into();
+        if digest.len() != hash.digest_len() {
+            return Err(RepositoryError::new(RepositoryErrorKind::InvalidInput));
+        }
+        Ok(Self { hash, digest })
+    }
+
+    /// Return the hash algorithm.
+    #[must_use]
+    pub const fn hash(&self) -> ObjectHash {
+        self.hash
+    }
+
+    /// Return the raw digest.
+    #[must_use]
+    pub fn digest(&self) -> &[u8] {
+        &self.digest
+    }
+}
+
+/// A path encoded in the repository platform's native bytes.
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct GitPath(Vec<u8>);
+
+impl GitPath {
+    /// Preserve path bytes without interpreting them as UTF-8.
+    #[must_use]
+    pub fn new(bytes: impl Into<Vec<u8>>) -> Self {
+        Self(bytes.into())
+    }
+
+    /// Return the raw path bytes.
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+/// A Git reference name stored as bytes.
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct RefName(Vec<u8>);
+
+impl RefName {
+    /// Preserve a reference name without validating it for a specific use.
+    #[must_use]
+    pub fn new(bytes: impl Into<Vec<u8>>) -> Self {
+        Self(bytes.into())
+    }
+
+    /// Return the raw reference name.
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+/// A revision expression accepted by the repository reader.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct Revision(Vec<u8>);
+
+impl Revision {
+    /// Preserve revision bytes for parsing at the adapter boundary.
+    #[must_use]
+    pub fn new(bytes: impl Into<Vec<u8>>) -> Self {
+        Self(bytes.into())
+    }
+
+    /// Return the raw revision expression.
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+/// A validated dotted configuration key.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct ConfigKey(String);
+
+impl ConfigKey {
+    /// Create a key with `section.name` or `section.subsection.name` shape.
+    ///
+    /// # Errors
+    /// Returns `InvalidInput` when the section or value name is missing.
+    pub fn new(key: impl Into<String>) -> Result<Self, RepositoryError> {
+        let key = key.into();
+        let Some(first_dot) = key.find('.') else {
+            return Err(RepositoryError::new(RepositoryErrorKind::InvalidInput));
+        };
+        let last_dot = key
+            .rfind('.')
+            .ok_or_else(|| RepositoryError::new(RepositoryErrorKind::InvalidInput))?;
+        if first_dot == 0 || last_dot + 1 == key.len() {
+            return Err(RepositoryError::new(RepositoryErrorKind::InvalidInput));
+        }
+        Ok(Self(key))
+    }
+
+    /// Return the dotted key.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Location and format metadata discovered for a repository.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RepositoryLocation {
+    pub git_dir: GitPath,
+    pub common_dir: GitPath,
+    pub work_dir: Option<GitPath>,
+    pub object_hash: ObjectHash,
+}
+
+/// Source scope for a resolved configuration value.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ConfigScope {
+    GitInstallation,
+    System,
+    User,
+    Repository,
+    Worktree,
+    Environment,
+    CommandLine,
+    Api,
+}
+
+/// One byte-preserving configuration value with provenance.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ConfigValue {
+    pub value: Vec<u8>,
+    pub scope: ConfigScope,
+    pub include_depth: u8,
+}
+
+/// A configured remote after Git URL rewrite rules are applied.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Remote {
+    pub name: Vec<u8>,
+    pub fetch_url: Option<Vec<u8>>,
+    pub push_url: Option<Vec<u8>>,
+}
+
+/// A local branch's configured fetch upstream.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Upstream {
+    pub remote: Vec<u8>,
+    pub remote_ref: RefName,
+    pub tracking_ref: Option<RefName>,
+}
+
+/// The three valid `HEAD` states.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Head {
+    Symbolic { name: RefName, target: ObjectId },
+    Detached { target: ObjectId },
+    Unborn { name: RefName },
+}
+
+/// A reference target without exposing adapter types.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ReferenceTarget {
+    Object(ObjectId),
+    Symbolic(RefName),
+}
+
+/// A local, remote-tracking, tag, or other reference.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ReferenceKind {
+    LocalBranch,
+    RemoteBranch,
+    Tag,
+    Other,
+}
+
+/// One repository reference.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Reference {
+    pub name: RefName,
+    pub kind: ReferenceKind,
+    pub target: ReferenceTarget,
+}
+
+/// A Git object type.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ObjectKind {
+    Blob,
+    Tree,
+    Commit,
+    Tag,
+}
+
+/// A fully loaded object whose bytes retain Git's canonical object payload.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Object {
+    pub id: ObjectId,
+    pub kind: ObjectKind,
+    pub data: Vec<u8>,
+}
+
+/// Commit graph data returned during a walk.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Commit {
+    pub id: ObjectId,
+    pub parents: Vec<ObjectId>,
+}
+
+/// One linked or main worktree.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Worktree {
+    pub id: Option<Vec<u8>>,
+    pub path: GitPath,
+    pub git_dir: GitPath,
+    pub locked: bool,
+}
+
+/// Validation mode for a candidate ref name.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RefFormat {
+    Full,
+    Branch,
+    Tag,
+}
+
+/// Stable repository-read failure classes.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RepositoryErrorKind {
+    NotRepository,
+    UntrustedRepository,
+    MalformedConfig,
+    InvalidInput,
+    InvalidRef,
+    HashMismatch,
+    RevisionNotFound,
+    AmbiguousRevision,
+    UnsupportedRevision,
+    MissingObject,
+    ObjectType,
+    CorruptRepository,
+    Io,
+}
+
+/// A bounded diagnostic that never includes paths, config values, or credentials.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RepositoryError {
+    kind: RepositoryErrorKind,
+}
+
+impl RepositoryError {
+    /// Create a repository error from its stable class.
+    #[must_use]
+    pub const fn new(kind: RepositoryErrorKind) -> Self {
+        Self { kind }
+    }
+
+    /// Return the stable failure class.
+    #[must_use]
+    pub const fn kind(&self) -> RepositoryErrorKind {
+        self.kind
+    }
+}
+
+impl fmt::Display for RepositoryError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self.kind {
+            RepositoryErrorKind::NotRepository => "not a Git repository",
+            RepositoryErrorKind::UntrustedRepository => "repository ownership is not trusted",
+            RepositoryErrorKind::MalformedConfig => "repository configuration is malformed",
+            RepositoryErrorKind::InvalidInput => "repository query input is invalid",
+            RepositoryErrorKind::InvalidRef => "reference name is invalid",
+            RepositoryErrorKind::HashMismatch => "object hash does not match the repository",
+            RepositoryErrorKind::RevisionNotFound => "revision was not found",
+            RepositoryErrorKind::AmbiguousRevision => "revision is ambiguous",
+            RepositoryErrorKind::UnsupportedRevision => "revision syntax is unsupported",
+            RepositoryErrorKind::MissingObject => "required object is missing",
+            RepositoryErrorKind::ObjectType => "object has an unexpected type",
+            RepositoryErrorKind::CorruptRepository => "repository data is corrupt",
+            RepositoryErrorKind::Io => "repository I/O failed",
+        })
+    }
+}
+
+impl Error for RepositoryError {}
+
+/// The sole production interface for repository metadata reads.
+pub trait RepositoryRead: Send + Sync {
+    /// Return immutable repository location and object-format metadata.
+    fn location(&self) -> RepositoryLocation;
+    /// Return all resolved values and scopes for `key`.
+    ///
+    /// # Errors
+    /// Returns a typed config or repository read failure.
+    fn config_values(&self, key: &ConfigKey) -> Result<Vec<ConfigValue>, RepositoryError>;
+    /// Return configured remotes with rewritten fetch and push URLs.
+    ///
+    /// # Errors
+    /// Returns a typed config or repository read failure.
+    fn remotes(&self) -> Result<Vec<Remote>, RepositoryError>;
+    /// Return the configured fetch upstream for a local branch.
+    ///
+    /// # Errors
+    /// Returns a typed invalid-ref, config, or repository read failure.
+    fn upstream(&self, branch: &RefName) -> Result<Option<Upstream>, RepositoryError>;
+    /// Return symbolic, detached, or unborn `HEAD` state.
+    ///
+    /// # Errors
+    /// Returns a typed corrupt-repository or read failure.
+    fn head(&self) -> Result<Head, RepositoryError>;
+    /// Resolve one supported revision expression to an object ID.
+    ///
+    /// # Errors
+    /// Returns a typed input, resolution, or repository read failure.
+    fn resolve_revision(&self, revision: &Revision) -> Result<ObjectId, RepositoryError>;
+    /// Return all references, including packed references.
+    ///
+    /// # Errors
+    /// Returns a typed corrupt-repository or read failure.
+    fn references(&self) -> Result<Vec<Reference>, RepositoryError>;
+    /// Load an object, or return `None` when its ID is absent.
+    ///
+    /// # Errors
+    /// Returns a typed hash or repository read failure.
+    fn object(&self, id: &ObjectId) -> Result<Option<Object>, RepositoryError>;
+    /// Walk at most `limit` commits from `start`.
+    ///
+    /// # Errors
+    /// Returns a typed hash, missing-object, or repository read failure.
+    fn walk_commits(&self, start: &ObjectId, limit: usize) -> Result<Vec<Commit>, RepositoryError>;
+    /// Count every commit reachable from `start`.
+    ///
+    /// # Errors
+    /// Returns a typed hash, missing-object, or repository read failure.
+    fn commit_count(&self, start: &ObjectId) -> Result<u64, RepositoryError>;
+    /// Return the best merge base for two commits.
+    ///
+    /// # Errors
+    /// Returns a typed hash, resolution, or repository read failure.
+    fn merge_base(&self, left: &ObjectId, right: &ObjectId) -> Result<ObjectId, RepositoryError>;
+    /// Report whether `ancestor` is reachable from `descendant`.
+    ///
+    /// # Errors
+    /// Returns a typed hash, resolution, or repository read failure.
+    fn is_ancestor(
+        &self,
+        ancestor: &ObjectId,
+        descendant: &ObjectId,
+    ) -> Result<bool, RepositoryError>;
+    /// Return the main and linked worktree records.
+    ///
+    /// # Errors
+    /// Returns a typed I/O or repository read failure.
+    fn worktrees(&self) -> Result<Vec<Worktree>, RepositoryError>;
+    /// Validate a name under the requested Git ref format.
+    ///
+    /// # Errors
+    /// Returns `InvalidRef` when the name does not satisfy the format.
+    fn validate_ref_name(&self, name: &RefName, format: RefFormat) -> Result<(), RepositoryError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ConfigKey, ObjectHash, ObjectId, RepositoryErrorKind};
+
+    #[test]
+    fn object_ids_require_the_algorithm_digest_length() {
+        assert!(ObjectId::new(ObjectHash::Sha1, [0; 20]).is_ok());
+        assert!(ObjectId::new(ObjectHash::Sha256, [0; 32]).is_ok());
+        assert_eq!(
+            ObjectId::new(ObjectHash::Sha1, [0; 32]).unwrap_err().kind(),
+            RepositoryErrorKind::InvalidInput
+        );
+    }
+
+    #[test]
+    fn config_keys_have_a_bounded_dotted_shape() {
+        assert!(ConfigKey::new("core.bare").is_ok());
+        assert!(ConfigKey::new("remote.origin.url").is_ok());
+        assert!(ConfigKey::new("url.https://example.invalid/.insteadOf").is_ok());
+        for invalid in ["", "core", ".bare", "core."] {
+            assert_eq!(
+                ConfigKey::new(invalid).unwrap_err().kind(),
+                RepositoryErrorKind::InvalidInput
+            );
+        }
+    }
+}

--- a/crates/larch-core/src/lib.rs
+++ b/crates/larch-core/src/lib.rs
@@ -4,6 +4,7 @@ mod config;
 mod context;
 mod env_file;
 mod error;
+mod git;
 mod github;
 mod outcome;
 mod process;
@@ -21,6 +22,12 @@ pub use env_file::{
 };
 pub use error::{
     EnvironmentalFailure, ErrorCategory, FailureKind, InternalDefect, LarchError, OperatorError,
+};
+pub use git::{
+    Commit, ConfigKey, ConfigScope, ConfigValue, GitPath, Head, Object, ObjectHash, ObjectId,
+    ObjectKind, RefFormat, RefName, Reference, ReferenceKind, ReferenceTarget, Remote,
+    RepositoryError, RepositoryErrorKind, RepositoryLocation, RepositoryRead, Revision, Upstream,
+    Worktree,
 };
 pub use github::{
     GitHubFailureInput, GitHubRateLimitInputs, GitHubRequestKind, GitHubResponseLimits,

--- a/docs/rust-testing.md
+++ b/docs/rust-testing.md
@@ -40,6 +40,12 @@ process environment or working directory. Product crates must still use the
 closed Git interfaces described in `ARCHITECTURE.md`; the fixture API does not
 authorize a production arbitrary-argument Git runner.
 
+Repository read differential tests exercise the public `RepositoryRead` port
+through `GixRepository`. Compare typed IDs, ref targets, config provenance,
+URLs, worktree records, and error classes with parsed Git oracle results. Path
+comparisons may normalize filesystem aliases such as macOS `/var` and
+`/private/var`, but the adapter result must retain its original path bytes.
+
 Use `SemanticSnapshot::capture` after each implementation runs against its own
 equivalent repository. Supply the operation's public result through
 `ExecutionSnapshot`. Compare the typed snapshots first. Use


### PR DESCRIPTION
Closes #7731

## Summary

- add the core-owned byte-oriented repository read port and DTOs
- implement the sole production reader with strict, ownership-checked gix opens
- cover repository metadata semantics with installed-Git differential fixtures
- document the architecture, testing, and security boundaries

## Verification

- `cargo clippy --locked --package larch-core --package larch-adapters --all-targets --all-features -- -D warnings`
- `cargo test --locked --package larch-core --package larch-adapters --all-features`
- relevant pre-commit hooks (the full working-tree gitleaks hook also sees unrelated ignored local artifacts; a pinned scan of the nine changed files reports no leaks)