### PR TITLE
Build typed GitHub Actions operations

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -6,6 +6,7 @@ useDefault = true
 [allowlist]
 paths = [
     '''^\.gitleaks\.toml$''',
+    '''^target/''',
     '''^scripts/redact-secrets\.sh$''',
     '''^scripts/scrub-log-secrets\.sh$''',
     '''^scripts/test-redact-secrets\.sh$''',

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2184,9 +2184,13 @@ dependencies = [
 name = "larch-adapters"
 version = "53.1.24"
 dependencies = [
+ "bytes",
+ "chrono",
  "gix",
  "google-cloud-auth",
  "http",
+ "http-body",
+ "http-body-util",
  "larch-core",
  "larch-test-support",
  "nix",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2200,6 +2200,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-util",
+ "tower",
  "url",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ version = "53.1.24"
 [workspace.dependencies]
 assert_cmd = { version = "2.2.2", default-features = false }
 automod = { version = "1.0.17", default-features = false }
+bytes = { version = "1.11.1", default-features = false, features = ["std"] }
+chrono = { version = "0.4.44", default-features = false, features = ["serde", "std"] }
 csv = { version = "1.4.0", default-features = false }
 cargo_metadata = { version = "0.23.1", default-features = false }
 clap = { version = "4.6.2", default-features = false, features = ["derive", "help", "std", "usage"] }
@@ -25,6 +27,8 @@ globset = { version = "0.4.19", default-features = false }
 gix = { version = "=0.85.0", default-features = false, features = ["revision", "sha1", "sha256", "status"] }
 google-cloud-auth = { version = "=1.14.0", default-features = false, features = ["default-rustls-provider"] }
 http = { version = "1.4.2", default-features = false, features = ["std"] }
+http-body = { version = "1.0.1", default-features = false }
+http-body-util = { version = "0.1.3", default-features = false }
 inventory = { version = "0.3.24", default-features = false }
 larch-adapters = { version = "=53.1.24", path = "crates/larch-adapters" }
 larch-core = { version = "=53.1.24", path = "crates/larch-core" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ tempfile = { version = "3.27.0", default-features = false }
 tokio = { version = "1.53.0", default-features = false, features = ["io-util", "macros", "process", "rt-multi-thread", "signal", "sync", "test-util", "time"] }
 tokio-util = { version = "0.7.18", default-features = false, features = ["rt"] }
 toml = { version = "1.1.3", default-features = false, features = ["parse", "serde", "std"] }
+tower = { version = "0.5.3", default-features = false, features = ["util"] }
 tree-sitter = { version = "0.26.7", default-features = false, features = ["std"] }
 tree-sitter-bash = { version = "0.25.1", default-features = false }
 url = { version = "2.5.8", default-features = false, features = ["std"] }

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -139,6 +139,24 @@ paths, config values, and remote URLs as bytes. Errors use fixed classes and do
 not include repository paths, config values, remote credentials, or upstream
 library diagnostics.
 
+## Rust GitHub Actions Operation Boundary
+
+The Actions operation port builds repository, workflow, run, job, and check
+paths only from validated typed inputs. Reads retry a bounded transient set
+within the overall deadline and cap pages, items, body bytes, strings, and JSON
+nesting. Rerun and dispatch mutations are serialized. They honor numeric
+`Retry-After` pacing before read-back and report an ambiguous outcome when the
+read-back cannot prove the mutation happened.
+
+Workflow log archives have a 64 MiB and 60 second limit. The adapter follows at
+most three redirects, rejects loops, URL credentials, fragments, plaintext,
+unexpected content types, and oversize or incomplete streams. Redirect hosts
+are limited to the documented `*.actions.githubusercontent.com` suffix and the
+`productionresultssa<digits>.blob.core.windows.net` storage family. Octocrab
+adds authorization only for `api.github.com`, so cross-origin log requests do
+not carry `Authorization`. Expired download URLs and every other non-success
+response fail with a typed, redacted error.
+
 ## Scoped Live-Mutation Authorization Boundary
 
 Scoped GitHub issue create, comment, close, and label operations require explicit live-run authorization. The guarded boundary covers `python3 python/cli.py issue create-one`, the cross-repository stall-report filing helper (`scripts/file-failure-report-cross-repo.sh`), Tier-A dedup before terminal reporter filing, `/design` salvage reconciliation comment and close operations, OOS blocker probes, label provisioning and edits, issue filing and cleanup, and `audit-runs close-priors`.
@@ -437,6 +455,10 @@ fixtures such as `python/tests/core/test_redact.py` and session-local Python cac
 directories under `python/`. Those entries are blind spots for gitleaks pattern
 matching in those paths, so test fixtures must stay obviously fake and live
 credential coverage continues to rely on the independent TruffleHog CI job.
+
+The ignored `target/` build directory is excluded because compiled dependency
+metadata can contain dependency-owned key fixtures. Authored source and
+committed artifacts remain in the working-tree and history scan scopes.
 
 `.gitleaks.toml` maintains a narrow path-based allowlist: the config's self-allowlist (`^\.gitleaks\.toml$`), redaction/scrubber source (`python/larch/core/redact.py`, reached via `python/cli.py redact secrets` / `redact scrub-log-secrets`), redaction-scanner test fixtures (`python/tests/core/test_redact.py`), and the tracking-issue Python module (`python/larch/issue/tracking_issue.py`, `python/tests/issue/test_tracking_issue.py`). These paths legitimately carry token-shaped strings throughout — regex literals, token-family tables, and synthetic test inputs — so per-line allowlisting would churn without adding signal. **The committed run-log tree (`larch-logs/`) is intentionally NOT allowlisted**: gitleaks Layers 1–2 scan it like any other path. The UUID-shaped `LARCH_TOKEN_SESSION_ID` `generic-api-key` false positive that originally motivated a blanket `larch-logs/` exclusion does not fire under the pinned engine, so the exclusion was removed. The primary run-log leak defense is `python/cli.py redact scrub-log-secrets`, a larch-owned pre-flush secret gate invoked right before every flush (`run-log commit`, `design-log-publish.sh`, and the `python/` `ship-pr` rework's `run_logs._scrub_run_tree`): it scrubs secret-shaped values — including Cursor `crsr_` / `key_` keys, which gitleaks does NOT cover — from the entire staged run tree in place so the flush still proceeds, while emitting a very loud warning so the operator can rotate the exposed credential. Consumer repos therefore need no third-party scanner installed for covered secret-shaped token families, but run logs remain sensitive documents: secrets or PII outside the scrubber patterns, including non-standard tokens, private hostnames, and domain-specific sensitive data, still require operator discipline before publication. Publishable `*.stderr-tail` sidecars copied into `larch-logs/` are scrubbed by the same gate; treat run logs as sensitive regardless. **High-churn documentation is NOT allowlisted** (#375): `README.md`, `CHANGELOG.md`, `SECURITY.md` itself, `skills/issue/SKILL.md`, and the issue creation CLI surface are scanned by gitleaks in both Layer 1 (pre-commit, working tree) and Layer 2 (CI, full history). The layer responsibilities remain distinct: gitleaks Layers 1–2 catch regex-matched patterns including synthetic token-shaped literals in docs; trufflehog Layer 3 (`--only-verified`) catches ONLY live, authenticable credentials and is non-redundant with gitleaks for that reason, NOT a replacement for it — an accidental paste of a revoked token or a covered-family token in an unusual format is caught by gitleaks Layers 1–2, not by the verified-only scan. Tokens whose format falls outside gitleaks' covered rule families (see the "Outbound shell-layer redaction" subsection below for the covered families) may slip both Layer 1–2 (no matching regex rule) and Layer 3 (nothing to authenticate against a live API) — contributors must not rely on scanner layers as a substitute for editorial discipline in docs. Contributors adding new token-shaped examples to docs should use non-detector-matching forms: short prefixes without the high-entropy suffix (e.g., `ghp_` as a prefix mention rather than a full 40-character token) or an explicit placeholder like `<REDACTED-TOKEN>`.
 

--- a/agent-lint.toml
+++ b/agent-lint.toml
@@ -1362,10 +1362,10 @@ conditional-sources = [
 root-max-lines = 879
 root-max-tokens = 35383
 root-max-content-tokens = 35301
-# Issues #7731/#7725/#7733 add trust boundaries to imported SECURITY.md.
-closure-max-lines = 3662
-closure-max-tokens = 141922
-closure-max-content-tokens = 141624
+# Issues #7731/#7725/#7733/#7726 add trust boundaries to imported SECURITY.md.
+closure-max-lines = 3684
+closure-max-tokens = 142244
+closure-max-content-tokens = 141944
 conditional-max-lines = 589
 conditional-max-tokens = 18764
 conditional-max-content-tokens = 18717
@@ -1412,7 +1412,7 @@ roots = [
   "skills/shared/reviewer-templates.md",
   "skills/shared/voting-protocol.md",
 ]
-# Issues #7731/#7725/#7733 add trust boundaries to imported SECURITY.md.
-closure-max-lines = 5950
-closure-max-tokens = 167394
-closure-max-content-tokens = 166934
+# Issues #7731/#7725/#7733/#7726 add trust boundaries to imported SECURITY.md.
+closure-max-lines = 5972
+closure-max-tokens = 167716
+closure-max-content-tokens = 167254

--- a/crates/larch-adapters/Cargo.toml
+++ b/crates/larch-adapters/Cargo.toml
@@ -31,6 +31,7 @@ nix.workspace = true
 [dev-dependencies]
 http.workspace = true
 larch-test-support.workspace = true
+tower.workspace = true
 
 [lints]
 workspace = true

--- a/crates/larch-adapters/Cargo.toml
+++ b/crates/larch-adapters/Cargo.toml
@@ -9,9 +9,13 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+bytes.workspace = true
+chrono.workspace = true
 gix.workspace = true
 google-cloud-auth.workspace = true
 http.workspace = true
+http-body.workspace = true
+http-body-util.workspace = true
 larch-core.workspace = true
 octocrab.workspace = true
 serde.workspace = true

--- a/crates/larch-adapters/src/github.rs
+++ b/crates/larch-adapters/src/github.rs
@@ -4,6 +4,7 @@ use http::header::HeaderName;
 use larch_core::{GitHubTransportPolicy, ProcessCancellation, RuntimeRedactor, SafeText, env};
 use octocrab::Octocrab;
 use std::{error::Error, ffi::OsString, fmt, future::Future};
+use tokio::sync::Mutex;
 use url::Url;
 
 const API_BASE: &str = "https://api.github.com/";
@@ -162,6 +163,7 @@ pub struct OctocrabGitHubService {
     pub(crate) client: Octocrab,
     pub(crate) policy: GitHubTransportPolicy,
     redactor: RuntimeRedactor,
+    pub(crate) mutation_lock: Mutex<()>,
 }
 
 impl OctocrabGitHubService {
@@ -171,6 +173,7 @@ impl OctocrabGitHubService {
             client,
             policy: GitHubTransportPolicy::github_com(),
             redactor: RuntimeRedactor::default(),
+            mutation_lock: Mutex::new(()),
         }
     }
 
@@ -201,7 +204,22 @@ impl OctocrabGitHubService {
             client,
             policy,
             redactor,
+            mutation_lock: Mutex::new(()),
         })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_test_token(token: &str) -> Self {
+        struct TestEnvironment(OsString);
+
+        impl EnvironmentSource for TestEnvironment {
+            fn read(&self, name: &'static str) -> Option<OsString> {
+                (name == env::LARCH_GH_TOKEN).then(|| self.0.clone())
+            }
+        }
+
+        Self::from_source(&TestEnvironment(OsString::from(token)))
+            .expect("test token and active runtime must construct the client")
     }
 
     /// Fixed request headers applied to every GitHub API request.
@@ -218,6 +236,10 @@ impl OctocrabGitHubService {
     #[must_use]
     pub fn redact_diagnostic(&self, text: impl AsRef<str>) -> SafeText {
         self.redactor.safe_text(text)
+    }
+
+    pub(crate) const fn client(&self) -> &Octocrab {
+        &self.client
     }
 
     /// Resolve a response-supplied pagination or redirect continuation and

--- a/crates/larch-adapters/src/github_actions.rs
+++ b/crates/larch-adapters/src/github_actions.rs
@@ -508,7 +508,7 @@ impl OctocrabGitHubService {
                     response.headers(),
                     &["application/zip", "application/octet-stream"],
                 )?;
-                let expected_length = content_length(response.headers());
+                let expected_length = content_length(response.headers())?;
                 if expected_length.is_some_and(|length| length > LOG_BYTES) {
                     return Err(self.error(
                         GitHubActionsErrorKind::LogLimit,
@@ -859,13 +859,22 @@ fn require_content_type(
     }
 }
 
-fn content_length(headers: &http::HeaderMap) -> Option<usize> {
+fn content_length(headers: &http::HeaderMap) -> Result<Option<usize>, GitHubActionsError> {
     headers
-        .get(header::CONTENT_LENGTH)?
-        .to_str()
-        .ok()?
-        .parse()
-        .ok()
+        .get(header::CONTENT_LENGTH)
+        .map(|value| {
+            value
+                .to_str()
+                .ok()
+                .and_then(|value| value.parse().ok())
+                .ok_or_else(|| {
+                    GitHubActionsError::new(
+                        GitHubActionsErrorKind::Response,
+                        "GitHub workflow log Content-Length is invalid",
+                    )
+                })
+        })
+        .transpose()
 }
 
 fn validate_log_redirect(
@@ -919,9 +928,100 @@ fn approved_log_host(host: &str) -> bool {
 mod tests {
     use super::*;
     use http_body_util::Full;
+    use std::collections::VecDeque;
+    use std::convert::Infallible;
+    use std::sync::{Arc, Mutex as StdMutex};
+    use tower::service_fn;
 
     fn repository() -> GitHubRepositoryRef {
         GitHubRepositoryRef::new("octo-org", "octo-repo").expect("repository")
+    }
+
+    fn queued_service(responses: Vec<Response<Full<bytes::Bytes>>>) -> OctocrabGitHubService {
+        let responses = Arc::new(StdMutex::new(VecDeque::from(responses)));
+        let client = octocrab::OctocrabBuilder::new_empty()
+            .with_service(service_fn(
+                move |_request: http::Request<octocrab::OctoBody>| {
+                    let response = responses.lock().expect("response queue").pop_front();
+                    std::future::ready(Ok::<_, Infallible>(response.expect("queued response")))
+                },
+            ))
+            .with_auth(octocrab::AuthState::None)
+            .build()
+            .expect("test client");
+        OctocrabGitHubService::with_test_client(client)
+    }
+
+    fn response(
+        status: u16,
+        content_type: &str,
+        body: &'static str,
+    ) -> Response<Full<bytes::Bytes>> {
+        Response::builder()
+            .status(status)
+            .header(header::CONTENT_TYPE, content_type)
+            .body(Full::new(bytes::Bytes::from_static(body.as_bytes())))
+            .expect("response")
+    }
+
+    #[test]
+    fn actions_port_exercises_successful_offline_operations() {
+        const RUN: &str = r#"{"id":1,"status":"completed","conclusion":"success","head_sha":"abc","event":"push","run_attempt":1}"#;
+        const RUNS: &str = r#"{"workflow_runs":[{"id":1,"status":"completed","conclusion":"success","head_sha":"abc","event":"push","run_attempt":1}]}"#;
+        let json = "application/json";
+        let responses = vec![
+            response(200, json, RUNS),
+            response(200, json, RUN),
+            response(
+                200,
+                json,
+                r#"{"jobs":[{"name":"job","status":"completed","conclusion":"success","started_at":null,"completed_at":null}]}"#,
+            ),
+            response(
+                200,
+                json,
+                r#"{"check_runs":[{"name":"check","status":"completed","conclusion":"success"}]}"#,
+            ),
+            response(200, json, RUN),
+            response(201, json, ""),
+            response(200, json, RUNS),
+            response(204, json, ""),
+            response(200, "application/zip", "ZIP"),
+        ];
+        let runtime = crate::runtime::LarchRuntime::new().expect("runtime");
+        runtime.block_on(async move {
+            let s = queued_service(responses);
+            let r = repository();
+            let c = crate::runtime::Cancellation::new();
+            let f = WorkflowRunFilters::default();
+            assert_eq!(
+                s.list_workflow_runs(&r, &f, &c).await.expect("runs").len(),
+                1
+            );
+            assert_eq!(s.workflow_run(&r, 1, &c).await.expect("run").database_id, 1);
+            assert_eq!(s.workflow_jobs(&r, 1, &c).await.expect("jobs").len(), 1);
+            assert_eq!(s.check_runs(&r, "abc", &c).await.expect("checks").len(), 1);
+            assert_eq!(
+                s.rerun_workflow(&r, 1, false, &c).await.expect("rerun"),
+                GitHubMutationOutcome::Accepted
+            );
+            let dispatch = WorkflowDispatchRequest {
+                repository: r.clone(),
+                workflow: String::from("ci.yml"),
+                git_reference: String::from("main"),
+            };
+            assert_eq!(
+                s.dispatch_workflow(&dispatch, &c).await.expect("dispatch"),
+                GitHubMutationOutcome::Accepted
+            );
+            assert_eq!(
+                s.download_workflow_logs(&r, 1, &c)
+                    .await
+                    .expect("logs")
+                    .as_bytes(),
+                b"ZIP"
+            );
+        });
     }
 
     #[test]
@@ -943,6 +1043,8 @@ mod tests {
             route,
             "/repos/octo-org/octo-repo/actions/workflows/ci+check.yml/runs?per_page=100&page=2&branch=topic%2Fname&event=pull_request&status=in_progress&head_sha=abc123"
         );
+        assert!(validate_selector("", "workflow").is_err());
+        assert!(require_positive_id(0).is_err());
     }
 
     #[test]
@@ -1036,6 +1138,17 @@ mod tests {
                 .await
                 .expect("at limit"),
             b"12345"
+        );
+
+        let headers = Response::builder()
+            .header(header::CONTENT_LENGTH, "invalid")
+            .body(())
+            .expect("response");
+        assert_eq!(
+            content_length(headers.headers())
+                .expect_err("malformed content length")
+                .kind(),
+            GitHubActionsErrorKind::Response
         );
     }
 

--- a/crates/larch-adapters/src/github_actions.rs
+++ b/crates/larch-adapters/src/github_actions.rs
@@ -1,0 +1,1112 @@
+//! Typed GitHub Actions operations over the shared authenticated transport.
+
+use crate::github::{GitHubCompletionError, OctocrabGitHubService};
+use bytes::Buf;
+use chrono::{DateTime, Utc};
+use http::{Response, StatusCode, header};
+use http_body::Body;
+use http_body_util::BodyExt;
+use larch_core::{
+    CheckBucket, CheckRun, GitHubActionsError, GitHubActionsErrorKind, GitHubActionsFuture,
+    GitHubActionsService, GitHubMutationOutcome, GitHubRepositoryRef, GitHubService,
+    ProcessCancellation, WorkflowDispatchRequest, WorkflowJob, WorkflowLogArchive, WorkflowRun,
+    WorkflowRunFilters,
+};
+use serde::Deserialize;
+use serde::de::DeserializeOwned;
+use std::collections::BTreeSet;
+use std::future::Future;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use url::{Url, form_urlencoded};
+
+const PAGE_SIZE: usize = 100;
+const LOG_BYTES: usize = 64 * 1024 * 1024;
+const LOG_TIMEOUT: Duration = Duration::from_secs(60);
+const LOG_REDIRECTS: usize = 3;
+const READ_ATTEMPTS: u32 = 3;
+
+#[derive(Deserialize)]
+struct RunsResponse {
+    workflow_runs: Vec<RunDto>,
+}
+
+#[derive(Clone, Deserialize)]
+struct RunDto {
+    id: u64,
+    status: String,
+    conclusion: Option<String>,
+    #[serde(default)]
+    head_sha: String,
+    #[serde(default)]
+    event: String,
+    #[serde(default = "default_attempt")]
+    run_attempt: u32,
+}
+
+const fn default_attempt() -> u32 {
+    1
+}
+
+impl RunDto {
+    fn into_core(self) -> WorkflowRun {
+        WorkflowRun {
+            database_id: self.id,
+            status: self.status,
+            conclusion: self.conclusion,
+            head_sha: self.head_sha,
+            event: self.event,
+            attempt: self.run_attempt,
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct JobsResponse {
+    jobs: Vec<JobDto>,
+}
+
+#[derive(Deserialize)]
+struct JobDto {
+    name: String,
+    status: String,
+    conclusion: Option<String>,
+    started_at: Option<DateTime<Utc>>,
+    completed_at: Option<DateTime<Utc>>,
+}
+
+impl JobDto {
+    fn into_core(self) -> WorkflowJob {
+        let wall_clock_seconds =
+            self.started_at
+                .zip(self.completed_at)
+                .and_then(|(started, completed)| {
+                    (completed - started)
+                        .to_std()
+                        .ok()
+                        .filter(|duration| !duration.is_zero())
+                        .map(|duration| duration.as_secs_f64())
+                });
+        WorkflowJob {
+            name: self.name,
+            status: self.status,
+            conclusion: self.conclusion,
+            wall_clock_seconds,
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct ChecksResponse {
+    check_runs: Vec<CheckDto>,
+}
+
+#[derive(Deserialize)]
+struct CheckDto {
+    name: String,
+    status: String,
+    conclusion: Option<String>,
+}
+
+impl CheckDto {
+    fn into_core(self) -> CheckRun {
+        let bucket = check_bucket(&self.status, self.conclusion.as_deref());
+        CheckRun {
+            name: self.name,
+            status: self.status,
+            conclusion: self.conclusion,
+            bucket,
+        }
+    }
+}
+
+fn check_bucket(status: &str, conclusion: Option<&str>) -> CheckBucket {
+    if status != "completed" {
+        return CheckBucket::Pending;
+    }
+    match conclusion {
+        Some("success") => CheckBucket::Pass,
+        Some("cancelled") => CheckBucket::Cancel,
+        Some("failure" | "timed_out" | "action_required" | "startup_failure") => CheckBucket::Fail,
+        Some("skipped" | "neutral") => CheckBucket::Skipping,
+        _ => CheckBucket::Pending,
+    }
+}
+
+impl GitHubActionsService for OctocrabGitHubService {
+    fn list_workflow_runs<'service>(
+        &'service self,
+        repository: &'service GitHubRepositoryRef,
+        filters: &'service WorkflowRunFilters,
+        cancellation: &'service dyn ProcessCancellation,
+    ) -> GitHubActionsFuture<'service, Vec<WorkflowRun>> {
+        Box::pin(async move {
+            self.with_cancellation(cancellation, self.list_runs(repository, filters))
+                .await
+        })
+    }
+
+    fn workflow_run<'service>(
+        &'service self,
+        repository: &'service GitHubRepositoryRef,
+        run_id: u64,
+        cancellation: &'service dyn ProcessCancellation,
+    ) -> GitHubActionsFuture<'service, WorkflowRun> {
+        Box::pin(self.with_cancellation(cancellation, async move {
+            require_positive_id(run_id)?;
+            let route = format!("{}/actions/runs/{run_id}", repository_route(repository));
+            let run: RunDto = self.read_json(&route).await?;
+            validate_run(self, &run)?;
+            Ok(run.into_core())
+        }))
+    }
+
+    fn workflow_jobs<'service>(
+        &'service self,
+        repository: &'service GitHubRepositoryRef,
+        run_id: u64,
+        cancellation: &'service dyn ProcessCancellation,
+    ) -> GitHubActionsFuture<'service, Vec<WorkflowJob>> {
+        Box::pin(async move {
+            self.with_cancellation(cancellation, self.list_jobs(repository, run_id))
+                .await
+        })
+    }
+
+    fn check_runs<'service>(
+        &'service self,
+        repository: &'service GitHubRepositoryRef,
+        git_reference: &'service str,
+        cancellation: &'service dyn ProcessCancellation,
+    ) -> GitHubActionsFuture<'service, Vec<CheckRun>> {
+        Box::pin(async move {
+            self.with_cancellation(cancellation, self.list_checks(repository, git_reference))
+                .await
+        })
+    }
+
+    fn rerun_workflow<'service>(
+        &'service self,
+        repository: &'service GitHubRepositoryRef,
+        run_id: u64,
+        failed_only: bool,
+        cancellation: &'service dyn ProcessCancellation,
+    ) -> GitHubActionsFuture<'service, GitHubMutationOutcome> {
+        Box::pin(self.with_cancellation(cancellation, async move {
+            require_positive_id(run_id)?;
+            let _guard = self.mutation_lock.lock().await;
+            let before =
+                GitHubActionsService::workflow_run(self, repository, run_id, cancellation).await?;
+            let suffix = if failed_only {
+                "rerun-failed-jobs"
+            } else {
+                "rerun"
+            };
+            let route = format!(
+                "{}/actions/runs/{run_id}/{suffix}",
+                repository_route(repository)
+            );
+            match self.post_mutation(&route, StatusCode::CREATED).await? {
+                MutationAttempt::Accepted => Ok(GitHubMutationOutcome::Accepted),
+                MutationAttempt::Uncertain(delay) => {
+                    wait_for_rate_limit(delay).await;
+                    let after =
+                        GitHubActionsService::workflow_run(self, repository, run_id, cancellation)
+                            .await?;
+                    Ok(if after.attempt > before.attempt {
+                        GitHubMutationOutcome::Reconciled
+                    } else {
+                        GitHubMutationOutcome::Ambiguous
+                    })
+                }
+            }
+        }))
+    }
+
+    fn dispatch_workflow<'service>(
+        &'service self,
+        request: &'service WorkflowDispatchRequest,
+        cancellation: &'service dyn ProcessCancellation,
+    ) -> GitHubActionsFuture<'service, GitHubMutationOutcome> {
+        Box::pin(self.with_cancellation(cancellation, async move {
+            let repository = &request.repository;
+            let workflow = &request.workflow;
+            let git_reference = &request.git_reference;
+            validate_selector(workflow, "workflow")?;
+            validate_selector(git_reference, "Git reference")?;
+            let _guard = self.mutation_lock.lock().await;
+            let filters = WorkflowRunFilters {
+                branch: Some(git_reference.to_owned()),
+                workflow: Some(workflow.to_owned()),
+                event: Some(String::from("workflow_dispatch")),
+                limit: 1,
+                ..WorkflowRunFilters::default()
+            };
+            let before = self.list_runs(repository, &filters).await?;
+            let route = format!(
+                "{}/actions/workflows/{}/dispatches",
+                repository_route(repository),
+                encode_path_segment(workflow)
+            );
+            let body = serde_json::json!({"ref": git_reference});
+            match self
+                .post_json_mutation(&route, &body, StatusCode::NO_CONTENT)
+                .await?
+            {
+                MutationAttempt::Accepted => Ok(GitHubMutationOutcome::Accepted),
+                MutationAttempt::Uncertain(delay) => {
+                    wait_for_rate_limit(delay).await;
+                    let after = self.list_runs(repository, &filters).await?;
+                    Ok(if latest_run_id(&after) == latest_run_id(&before) {
+                        GitHubMutationOutcome::Ambiguous
+                    } else {
+                        GitHubMutationOutcome::Reconciled
+                    })
+                }
+            }
+        }))
+    }
+
+    fn download_workflow_logs<'service>(
+        &'service self,
+        repository: &'service GitHubRepositoryRef,
+        run_id: u64,
+        cancellation: &'service dyn ProcessCancellation,
+    ) -> GitHubActionsFuture<'service, WorkflowLogArchive> {
+        Box::pin(self.with_cancellation(cancellation, async move {
+            require_positive_id(run_id)?;
+            tokio::time::timeout(LOG_TIMEOUT, self.download_logs(repository, run_id))
+                .await
+                .map_err(|_| {
+                    self.error(
+                        GitHubActionsErrorKind::DeadlineExceeded,
+                        "GitHub workflow log download exceeded its time limit",
+                    )
+                })?
+        }))
+    }
+}
+
+impl OctocrabGitHubService {
+    async fn with_cancellation<T, F>(
+        &self,
+        cancellation: &dyn ProcessCancellation,
+        operation: F,
+    ) -> Result<T, GitHubActionsError>
+    where
+        F: Future<Output = Result<T, GitHubActionsError>> + Send,
+        T: Send,
+    {
+        match self.guard_operation(cancellation, operation).await {
+            Ok(result) => result,
+            Err(GitHubCompletionError::Cancelled) => Err(self.error(
+                GitHubActionsErrorKind::Cancelled,
+                "GitHub Actions operation cancelled",
+            )),
+            Err(GitHubCompletionError::DeadlineExceeded) => Err(self.error(
+                GitHubActionsErrorKind::DeadlineExceeded,
+                "GitHub Actions operation exceeded its time limit",
+            )),
+        }
+    }
+
+    async fn list_runs(
+        &self,
+        repository: &GitHubRepositoryRef,
+        filters: &WorkflowRunFilters,
+    ) -> Result<Vec<WorkflowRun>, GitHubActionsError> {
+        validate_filters(filters)?;
+        let requested = filters
+            .effective_limit()
+            .min(self.transport_policy().limits().items());
+        let mut runs = Vec::with_capacity(requested.min(PAGE_SIZE));
+        for page in 1..=self.transport_policy().limits().pages() {
+            let route = runs_route(repository, filters, page, requested - runs.len());
+            let response: RunsResponse = self.read_json(&route).await?;
+            let count = response.workflow_runs.len();
+            for run in response.workflow_runs {
+                validate_run(self, &run)?;
+                runs.push(run.into_core());
+                if runs.len() == requested {
+                    return Ok(runs);
+                }
+            }
+            if count < PAGE_SIZE {
+                return Ok(runs);
+            }
+        }
+        if runs.len() < requested {
+            return Err(self.error(
+                GitHubActionsErrorKind::Response,
+                "GitHub workflow run pagination exceeded its page limit",
+            ));
+        }
+        Ok(runs)
+    }
+
+    async fn list_jobs(
+        &self,
+        repository: &GitHubRepositoryRef,
+        run_id: u64,
+    ) -> Result<Vec<WorkflowJob>, GitHubActionsError> {
+        require_positive_id(run_id)?;
+        let mut jobs = Vec::new();
+        for page in 1..=self.transport_policy().limits().pages() {
+            let route = format!(
+                "{}/actions/runs/{run_id}/jobs?filter=latest&per_page={PAGE_SIZE}&page={page}",
+                repository_route(repository)
+            );
+            let response: JobsResponse = self.read_json(&route).await?;
+            let count = response.jobs.len();
+            for job in response.jobs {
+                validate_string(self, &job.name, "workflow job name")?;
+                validate_string(self, &job.status, "workflow job status")?;
+                validate_optional_string(
+                    self,
+                    job.conclusion.as_deref(),
+                    "workflow job conclusion",
+                )?;
+                jobs.push(job.into_core());
+                if jobs.len() == self.transport_policy().limits().items() {
+                    return Ok(jobs);
+                }
+            }
+            if count < PAGE_SIZE {
+                return Ok(jobs);
+            }
+        }
+        Err(self.error(
+            GitHubActionsErrorKind::Response,
+            "GitHub workflow job pagination exceeded its page limit",
+        ))
+    }
+
+    async fn list_checks(
+        &self,
+        repository: &GitHubRepositoryRef,
+        git_reference: &str,
+    ) -> Result<Vec<CheckRun>, GitHubActionsError> {
+        validate_selector(git_reference, "Git reference")?;
+        let mut checks = Vec::new();
+        for page in 1..=self.transport_policy().limits().pages() {
+            let route = format!(
+                "{}/commits/{}/check-runs?filter=latest&per_page={PAGE_SIZE}&page={page}",
+                repository_route(repository),
+                encode_path_segment(git_reference)
+            );
+            let response: ChecksResponse = self.read_json(&route).await?;
+            let count = response.check_runs.len();
+            for check in response.check_runs {
+                validate_string(self, &check.name, "check run name")?;
+                validate_string(self, &check.status, "check run status")?;
+                validate_optional_string(
+                    self,
+                    check.conclusion.as_deref(),
+                    "check run conclusion",
+                )?;
+                checks.push(check.into_core());
+                if checks.len() == self.transport_policy().limits().items() {
+                    return Ok(checks);
+                }
+            }
+            if count < PAGE_SIZE {
+                return Ok(checks);
+            }
+        }
+        Err(self.error(
+            GitHubActionsErrorKind::Response,
+            "GitHub check run pagination exceeded its page limit",
+        ))
+    }
+
+    async fn read_json<T: DeserializeOwned>(&self, route: &str) -> Result<T, GitHubActionsError> {
+        for attempt in 1..=READ_ATTEMPTS {
+            let response = match self.client()._get(route).await {
+                Ok(response) => response,
+                Err(error) if attempt == READ_ATTEMPTS => {
+                    return Err(self.error(GitHubActionsErrorKind::Transport, error.to_string()));
+                }
+                Err(_) => {
+                    tokio::time::sleep(read_backoff(attempt, None)).await;
+                    continue;
+                }
+            };
+            let status = response.status();
+            if transient_read_status(status, response.headers()) && attempt < READ_ATTEMPTS {
+                let delay = retry_delay(response.headers());
+                drop(response);
+                tokio::time::sleep(read_backoff(attempt, delay)).await;
+                continue;
+            }
+            if !status.is_success() {
+                return Err(self.status_error(status, response.headers()));
+            }
+            require_content_type(self, response.headers(), &["application/json"])?;
+            let bytes = collect_bounded(
+                response.into_body(),
+                self.transport_policy().limits().body_bytes(),
+                GitHubActionsErrorKind::Response,
+            )
+            .await?;
+            if !json_depth_within(&bytes, self.transport_policy().limits().nesting_depth()) {
+                return Err(self.error(
+                    GitHubActionsErrorKind::Response,
+                    "GitHub JSON response exceeds its nesting limit",
+                ));
+            }
+            return serde_json::from_slice(&bytes)
+                .map_err(|error| self.error(GitHubActionsErrorKind::Response, error.to_string()));
+        }
+        unreachable!("bounded read retry loop returns on every terminal state")
+    }
+
+    async fn post_mutation(
+        &self,
+        route: &str,
+        expected: StatusCode,
+    ) -> Result<MutationAttempt, GitHubActionsError> {
+        let Ok(response) = self.client()._post(route, None::<&()>).await else {
+            return Ok(MutationAttempt::Uncertain(None));
+        };
+        mutation_response(self, &response, expected)
+    }
+
+    async fn post_json_mutation<T: serde::Serialize + Sync + ?Sized>(
+        &self,
+        route: &str,
+        body: &T,
+        expected: StatusCode,
+    ) -> Result<MutationAttempt, GitHubActionsError> {
+        let Ok(response) = self.client()._post(route, Some(body)).await else {
+            return Ok(MutationAttempt::Uncertain(None));
+        };
+        mutation_response(self, &response, expected)
+    }
+
+    async fn download_logs(
+        &self,
+        repository: &GitHubRepositoryRef,
+        run_id: u64,
+    ) -> Result<WorkflowLogArchive, GitHubActionsError> {
+        let route = format!(
+            "{}/actions/runs/{run_id}/logs",
+            repository_route(repository)
+        );
+        let mut response =
+            self.client()._get(&route).await.map_err(|error| {
+                self.error(GitHubActionsErrorKind::Transport, error.to_string())
+            })?;
+        let mut current = Url::parse(&format!("https://api.github.com{route}"))
+            .expect("repository route is a valid fixed API URL");
+        let mut visited = BTreeSet::from([current.as_str().to_owned()]);
+        for redirects in 0..=LOG_REDIRECTS {
+            if !response.status().is_redirection() {
+                if !response.status().is_success() {
+                    return Err(self.status_error(response.status(), response.headers()));
+                }
+                require_content_type(
+                    self,
+                    response.headers(),
+                    &["application/zip", "application/octet-stream"],
+                )?;
+                let expected_length = content_length(response.headers());
+                if expected_length.is_some_and(|length| length > LOG_BYTES) {
+                    return Err(self.error(
+                        GitHubActionsErrorKind::LogLimit,
+                        "GitHub workflow log archive exceeds its byte limit",
+                    ));
+                }
+                let bytes = collect_bounded(
+                    response.into_body(),
+                    LOG_BYTES,
+                    GitHubActionsErrorKind::LogLimit,
+                )
+                .await?;
+                if expected_length.is_some_and(|length| length != bytes.len()) {
+                    return Err(self.error(
+                        GitHubActionsErrorKind::LogLimit,
+                        "GitHub workflow log archive ended before its declared length",
+                    ));
+                }
+                return Ok(WorkflowLogArchive::new(bytes));
+            }
+            if redirects == LOG_REDIRECTS {
+                return Err(self.error(
+                    GitHubActionsErrorKind::Redirect,
+                    "GitHub workflow log redirect limit exceeded",
+                ));
+            }
+            let location = response
+                .headers()
+                .get(header::LOCATION)
+                .ok_or_else(|| {
+                    self.error(
+                        GitHubActionsErrorKind::Redirect,
+                        "GitHub workflow log redirect omitted Location",
+                    )
+                })?
+                .to_str()
+                .map_err(|_| {
+                    self.error(
+                        GitHubActionsErrorKind::Redirect,
+                        "GitHub workflow log redirect Location is invalid",
+                    )
+                })?;
+            let next = validate_log_redirect(&current, location, &visited)?;
+            visited.insert(next.as_str().to_owned());
+            current = next;
+            response = self
+                .client()
+                ._get(current.as_str())
+                .await
+                .map_err(|error| {
+                    self.error(GitHubActionsErrorKind::Transport, error.to_string())
+                })?;
+        }
+        unreachable!("bounded redirect loop returns on every terminal state")
+    }
+
+    fn status_error(&self, status: StatusCode, headers: &http::HeaderMap) -> GitHubActionsError {
+        let kind = match status {
+            StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN if !rate_limited(status, headers) => {
+                GitHubActionsErrorKind::Authorization
+            }
+            StatusCode::TOO_MANY_REQUESTS | StatusCode::FORBIDDEN => {
+                GitHubActionsErrorKind::RateLimited
+            }
+            _ => GitHubActionsErrorKind::Response,
+        };
+        let retry_after = retry_delay(headers)
+            .map_or_else(|| String::from("none"), |delay| delay.as_secs().to_string());
+        self.error(
+            kind,
+            format!("GitHub returned HTTP {status}; retry-after={retry_after}"),
+        )
+    }
+
+    fn error(&self, kind: GitHubActionsErrorKind, detail: impl AsRef<str>) -> GitHubActionsError {
+        let safe = self.redact_diagnostic(detail);
+        GitHubActionsError::new(kind, safe.as_str())
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum MutationAttempt {
+    Accepted,
+    Uncertain(Option<Duration>),
+}
+
+fn mutation_response<B>(
+    service: &OctocrabGitHubService,
+    response: &Response<B>,
+    expected: StatusCode,
+) -> Result<MutationAttempt, GitHubActionsError> {
+    if response.status() == expected {
+        return Ok(MutationAttempt::Accepted);
+    }
+    if matches!(
+        response.status(),
+        StatusCode::REQUEST_TIMEOUT
+            | StatusCode::TOO_MANY_REQUESTS
+            | StatusCode::INTERNAL_SERVER_ERROR
+            | StatusCode::BAD_GATEWAY
+            | StatusCode::SERVICE_UNAVAILABLE
+            | StatusCode::GATEWAY_TIMEOUT
+    ) || rate_limited(response.status(), response.headers())
+    {
+        return Ok(MutationAttempt::Uncertain(retry_delay(response.headers())));
+    }
+    Err(service.status_error(response.status(), response.headers()))
+}
+
+fn rate_limited(status: StatusCode, headers: &http::HeaderMap) -> bool {
+    status == StatusCode::TOO_MANY_REQUESTS
+        || headers.contains_key(header::RETRY_AFTER)
+        || headers
+            .get("x-ratelimit-remaining")
+            .is_some_and(|value| value == "0")
+}
+
+fn transient_read_status(status: StatusCode, headers: &http::HeaderMap) -> bool {
+    matches!(
+        status,
+        StatusCode::REQUEST_TIMEOUT
+            | StatusCode::TOO_MANY_REQUESTS
+            | StatusCode::INTERNAL_SERVER_ERROR
+            | StatusCode::BAD_GATEWAY
+            | StatusCode::SERVICE_UNAVAILABLE
+            | StatusCode::GATEWAY_TIMEOUT
+    ) || rate_limited(status, headers)
+}
+
+fn retry_delay(headers: &http::HeaderMap) -> Option<Duration> {
+    let retry_after = headers
+        .get(header::RETRY_AFTER)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse::<u64>().ok())
+        .map(Duration::from_secs);
+    if retry_after.is_some() {
+        return retry_after;
+    }
+    let reset = headers
+        .get("x-ratelimit-reset")?
+        .to_str()
+        .ok()?
+        .parse::<u64>()
+        .ok()?;
+    let now = SystemTime::now().duration_since(UNIX_EPOCH).ok()?.as_secs();
+    Some(Duration::from_secs(reset.saturating_sub(now)))
+}
+
+fn read_backoff(attempt: u32, requested: Option<Duration>) -> Duration {
+    requested
+        .unwrap_or_else(|| Duration::from_millis(u64::from(attempt) * 100))
+        .min(LOG_TIMEOUT)
+}
+
+async fn wait_for_rate_limit(delay: Option<Duration>) {
+    if let Some(delay) = delay {
+        tokio::time::sleep(delay.min(LOG_TIMEOUT)).await;
+    }
+}
+
+async fn collect_bounded<B>(
+    mut body: B,
+    limit: usize,
+    kind: GitHubActionsErrorKind,
+) -> Result<Vec<u8>, GitHubActionsError>
+where
+    B: Body + Unpin,
+    B::Data: Buf,
+{
+    let mut output = Vec::new();
+    while let Some(frame) = body.frame().await {
+        let frame = frame
+            .map_err(|_| GitHubActionsError::new(kind, "GitHub response body stream failed"))?;
+        let Ok(mut data) = frame.into_data() else {
+            continue;
+        };
+        if data.remaining() > limit.saturating_sub(output.len()) {
+            return Err(GitHubActionsError::new(
+                kind,
+                "GitHub response exceeded its byte limit",
+            ));
+        }
+        let length = data.remaining();
+        output.extend_from_slice(&data.copy_to_bytes(length));
+    }
+    Ok(output)
+}
+
+fn json_depth_within(bytes: &[u8], limit: usize) -> bool {
+    let mut depth = 0_usize;
+    let mut in_string = false;
+    let mut escaped = false;
+    for byte in bytes {
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if *byte == b'\\' {
+                escaped = true;
+            } else if *byte == b'"' {
+                in_string = false;
+            }
+            continue;
+        }
+        match byte {
+            b'"' => in_string = true,
+            b'{' | b'[' => {
+                depth += 1;
+                if depth > limit {
+                    return false;
+                }
+            }
+            b'}' | b']' => depth = depth.saturating_sub(1),
+            _ => {}
+        }
+    }
+    true
+}
+
+fn runs_route(
+    repository: &GitHubRepositoryRef,
+    filters: &WorkflowRunFilters,
+    page: usize,
+    remaining: usize,
+) -> String {
+    let workflow = filters
+        .workflow
+        .as_ref()
+        .map(|value| format!("/workflows/{}", encode_path_segment(value)))
+        .unwrap_or_default();
+    let mut query = form_urlencoded::Serializer::new(String::new());
+    query.append_pair("per_page", &remaining.min(PAGE_SIZE).to_string());
+    query.append_pair("page", &page.to_string());
+    for (name, value) in [
+        ("branch", filters.branch.as_deref()),
+        ("event", filters.event.as_deref()),
+        ("status", filters.status.as_deref()),
+        ("head_sha", filters.commit.as_deref()),
+    ] {
+        if let Some(value) = value {
+            query.append_pair(name, value);
+        }
+    }
+    format!(
+        "{}/actions{workflow}/runs?{}",
+        repository_route(repository),
+        query.finish()
+    )
+}
+
+fn repository_route(repository: &GitHubRepositoryRef) -> String {
+    format!("/repos/{}/{}", repository.owner(), repository.name())
+}
+
+fn encode_path_segment(value: &str) -> String {
+    form_urlencoded::byte_serialize(value.as_bytes()).collect()
+}
+
+fn validate_selector(value: &str, label: &str) -> Result<(), GitHubActionsError> {
+    if value.is_empty() || value.len() > 255 || value.bytes().any(|byte| byte.is_ascii_control()) {
+        return Err(GitHubActionsError::new(
+            GitHubActionsErrorKind::InvalidInput,
+            format!("GitHub {label} is invalid"),
+        ));
+    }
+    Ok(())
+}
+
+fn require_positive_id(value: u64) -> Result<(), GitHubActionsError> {
+    if value == 0 {
+        Err(GitHubActionsError::new(
+            GitHubActionsErrorKind::InvalidInput,
+            "GitHub numeric identifier must be positive",
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+fn validate_run(service: &OctocrabGitHubService, run: &RunDto) -> Result<(), GitHubActionsError> {
+    validate_string(service, &run.status, "workflow run status")?;
+    validate_optional_string(
+        service,
+        run.conclusion.as_deref(),
+        "workflow run conclusion",
+    )?;
+    validate_string(service, &run.head_sha, "workflow run head SHA")?;
+    validate_string(service, &run.event, "workflow run event")
+}
+
+fn validate_optional_string(
+    service: &OctocrabGitHubService,
+    value: Option<&str>,
+    label: &str,
+) -> Result<(), GitHubActionsError> {
+    value.map_or(Ok(()), |value| validate_string(service, value, label))
+}
+
+fn validate_filters(filters: &WorkflowRunFilters) -> Result<(), GitHubActionsError> {
+    for (label, value) in [
+        ("branch", filters.branch.as_deref()),
+        ("workflow", filters.workflow.as_deref()),
+        ("event", filters.event.as_deref()),
+        ("status", filters.status.as_deref()),
+        ("commit", filters.commit.as_deref()),
+    ] {
+        if let Some(value) = value {
+            validate_selector(value, label)?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_string(
+    service: &OctocrabGitHubService,
+    value: &str,
+    label: &str,
+) -> Result<(), GitHubActionsError> {
+    if value.len() > service.transport_policy().limits().string_bytes() {
+        return Err(service.error(
+            GitHubActionsErrorKind::Response,
+            format!("GitHub {label} exceeds its byte limit"),
+        ));
+    }
+    Ok(())
+}
+
+fn latest_run_id(runs: &[WorkflowRun]) -> Option<u64> {
+    runs.first().map(|run| run.database_id)
+}
+
+fn require_content_type(
+    service: &OctocrabGitHubService,
+    headers: &http::HeaderMap,
+    allowed: &[&str],
+) -> Result<(), GitHubActionsError> {
+    let content_type = headers
+        .get(header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.split(';').next())
+        .map(str::trim);
+    if content_type.is_some_and(|value| allowed.contains(&value)) {
+        Ok(())
+    } else {
+        Err(service.error(
+            GitHubActionsErrorKind::Response,
+            "GitHub response content type is not allowed for this operation",
+        ))
+    }
+}
+
+fn content_length(headers: &http::HeaderMap) -> Option<usize> {
+    headers
+        .get(header::CONTENT_LENGTH)?
+        .to_str()
+        .ok()?
+        .parse()
+        .ok()
+}
+
+fn validate_log_redirect(
+    current: &Url,
+    location: &str,
+    visited: &BTreeSet<String>,
+) -> Result<Url, GitHubActionsError> {
+    let next = current.join(location).map_err(|_| {
+        GitHubActionsError::new(
+            GitHubActionsErrorKind::Redirect,
+            "GitHub workflow log redirect URL is invalid",
+        )
+    })?;
+    let host = next.host_str().unwrap_or_default();
+    let approved = next.scheme() == "https"
+        && next.port_or_known_default() == Some(443)
+        && next.username().is_empty()
+        && next.password().is_none()
+        && next.fragment().is_none()
+        && approved_log_host(host);
+    if !approved {
+        return Err(GitHubActionsError::new(
+            GitHubActionsErrorKind::Redirect,
+            "GitHub workflow log redirect origin is not approved",
+        ));
+    }
+    if visited.contains(next.as_str()) {
+        return Err(GitHubActionsError::new(
+            GitHubActionsErrorKind::Redirect,
+            "GitHub workflow log redirect loop detected",
+        ));
+    }
+    Ok(next)
+}
+
+fn approved_log_host(host: &str) -> bool {
+    if host
+        .strip_suffix(".actions.githubusercontent.com")
+        .is_some_and(|prefix| !prefix.is_empty())
+    {
+        return true;
+    }
+    host.strip_suffix(".blob.core.windows.net")
+        .and_then(|prefix| prefix.strip_prefix("productionresultssa"))
+        .is_some_and(|suffix| {
+            !suffix.is_empty() && suffix.bytes().all(|byte| byte.is_ascii_digit())
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use http_body_util::Full;
+
+    fn repository() -> GitHubRepositoryRef {
+        GitHubRepositoryRef::new("octo-org", "octo-repo").expect("repository")
+    }
+
+    #[test]
+    fn run_filters_preserve_every_current_filter_and_bound_page_size() {
+        let route = runs_route(
+            &repository(),
+            &WorkflowRunFilters {
+                branch: Some(String::from("topic/name")),
+                workflow: Some(String::from("ci check.yml")),
+                event: Some(String::from("pull_request")),
+                status: Some(String::from("in_progress")),
+                commit: Some(String::from("abc123")),
+                limit: 500,
+            },
+            2,
+            400,
+        );
+        assert_eq!(
+            route,
+            "/repos/octo-org/octo-repo/actions/workflows/ci+check.yml/runs?per_page=100&page=2&branch=topic%2Fname&event=pull_request&status=in_progress&head_sha=abc123"
+        );
+    }
+
+    #[test]
+    fn check_classification_retains_blocking_and_nonblocking_buckets() {
+        assert_eq!(check_bucket("queued", None), CheckBucket::Pending);
+        assert_eq!(
+            check_bucket("completed", Some("failure")),
+            CheckBucket::Fail
+        );
+        assert_eq!(
+            check_bucket("completed", Some("timed_out")),
+            CheckBucket::Fail
+        );
+        assert_eq!(
+            check_bucket("completed", Some("skipped")),
+            CheckBucket::Skipping
+        );
+        assert_eq!(
+            check_bucket("completed", Some("success")),
+            CheckBucket::Pass
+        );
+        assert_eq!(
+            check_bucket("completed", Some("cancelled")),
+            CheckBucket::Cancel
+        );
+        assert_eq!(
+            check_bucket("completed", Some("stale")),
+            CheckBucket::Pending
+        );
+    }
+
+    #[test]
+    fn jobs_preserve_failure_and_positive_wall_clock_classification() {
+        let failed: JobDto = serde_json::from_str(
+            r#"{"name":"test-harnesses (3)","status":"completed","conclusion":"failure","started_at":"2026-07-18T01:00:00Z","completed_at":"2026-07-18T01:00:02.500Z"}"#,
+        )
+        .expect("job");
+        let job = failed.into_core();
+        assert!(job.is_failed());
+        assert_eq!(job.harness_shard(), Some(3));
+        assert_eq!(job.wall_clock_seconds, Some(2.5));
+
+        let zero: JobDto = serde_json::from_str(
+            r#"{"name":"test-harnesses (4)","status":"completed","conclusion":"success","started_at":"2026-07-18T01:00:02Z","completed_at":"2026-07-18T01:00:02Z"}"#,
+        )
+        .expect("job");
+        assert_eq!(zero.into_core().wall_clock_seconds, None);
+    }
+
+    #[test]
+    fn log_redirect_policy_rejects_downgrade_credentials_loops_and_broad_blob_hosts() {
+        let start =
+            Url::parse("https://api.github.com/repos/o/r/actions/runs/1/logs").expect("URL");
+        let approved = validate_log_redirect(
+            &start,
+            "https://productionresultssa12.blob.core.windows.net/actions-results/log.zip",
+            &BTreeSet::new(),
+        )
+        .expect("approved GitHub Actions storage host");
+        assert_eq!(approved.scheme(), "https");
+
+        for location in [
+            "http://productionresultssa12.blob.core.windows.net/log.zip",
+            "https://user@productionresultssa12.blob.core.windows.net/log.zip",
+            "https://attacker.blob.core.windows.net/log.zip",
+            "https://results-receiver.actions.githubusercontent.com.evil.example/log.zip",
+        ] {
+            assert!(
+                validate_log_redirect(&start, location, &BTreeSet::new()).is_err(),
+                "redirect {location}"
+            );
+        }
+        let loop_url = "https://results-receiver.actions.githubusercontent.com/log.zip";
+        assert!(
+            validate_log_redirect(&start, loop_url, &BTreeSet::from([loop_url.to_owned()]))
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn bounded_stream_fails_instead_of_returning_truncated_bytes() {
+        let body = Full::new(bytes::Bytes::from_static(b"12345"));
+        let error = collect_bounded(body, 4, GitHubActionsErrorKind::LogLimit)
+            .await
+            .expect_err("oversize body");
+        assert_eq!(error.kind(), GitHubActionsErrorKind::LogLimit);
+
+        let body = Full::new(bytes::Bytes::from_static(b"12345"));
+        assert_eq!(
+            collect_bounded(body, 5, GitHubActionsErrorKind::LogLimit)
+                .await
+                .expect("at limit"),
+            b"12345"
+        );
+    }
+
+    #[test]
+    fn actions_port_maps_cooperative_cancellation_to_its_closed_error() {
+        let runtime = crate::runtime::LarchRuntime::paused_current_thread().expect("runtime");
+        let service = runtime.block_on(async {
+            super::OctocrabGitHubService::from_test_token("test-token-for-cancellation")
+        });
+        let cancellation = crate::runtime::Cancellation::new();
+        cancellation.cancel();
+        let result = runtime.block_on(service.with_cancellation(
+            &cancellation,
+            std::future::pending::<Result<(), GitHubActionsError>>(),
+        ));
+        assert_eq!(
+            result.expect_err("cancelled operation").kind(),
+            GitHubActionsErrorKind::Cancelled
+        );
+    }
+
+    #[test]
+    fn mutation_statuses_distinguish_acceptance_uncertainty_and_denial() {
+        let runtime = crate::runtime::LarchRuntime::new().expect("runtime");
+        let service = runtime.block_on(async {
+            super::OctocrabGitHubService::from_test_token("test-token-for-status")
+        });
+        let accepted = Response::builder().status(201).body(()).expect("response");
+        assert_eq!(
+            mutation_response(&service, &accepted, StatusCode::CREATED).expect("accepted"),
+            MutationAttempt::Accepted
+        );
+        let uncertain = Response::builder().status(503).body(()).expect("response");
+        assert_eq!(
+            mutation_response(&service, &uncertain, StatusCode::CREATED).expect("uncertain"),
+            MutationAttempt::Uncertain(None)
+        );
+        let denied = Response::builder().status(401).body(()).expect("response");
+        assert_eq!(
+            mutation_response(&service, &denied, StatusCode::CREATED)
+                .expect_err("authorization")
+                .kind(),
+            GitHubActionsErrorKind::Authorization
+        );
+    }
+
+    #[test]
+    fn response_nesting_counts_structures_but_not_string_punctuation() {
+        assert!(json_depth_within(br#"{"value":"[[[","rows":[{}]}"#, 3));
+        assert!(!json_depth_within(br#"{"rows":[[{"deep":true}]]}"#, 3));
+    }
+
+    #[test]
+    fn retry_after_is_bounded_and_attached_to_uncertain_mutations() {
+        let runtime = crate::runtime::LarchRuntime::new().expect("runtime");
+        let service = runtime.block_on(async {
+            super::OctocrabGitHubService::from_test_token("test-token-for-rate-limit")
+        });
+        let response = Response::builder()
+            .status(429)
+            .header(header::RETRY_AFTER, "120")
+            .body(())
+            .expect("response");
+        assert_eq!(
+            mutation_response(&service, &response, StatusCode::CREATED)
+                .expect("uncertain mutation"),
+            MutationAttempt::Uncertain(Some(Duration::from_secs(120)))
+        );
+        assert_eq!(
+            read_backoff(1, retry_delay(response.headers())),
+            LOG_TIMEOUT
+        );
+    }
+}

--- a/crates/larch-adapters/src/github_rest.rs
+++ b/crates/larch-adapters/src/github_rest.rs
@@ -1137,6 +1137,7 @@ mod tests {
         );
         let policy = GitHubTransportPolicy::github_com();
         assert!(GitHubRepositoryRef::new("../owner", "repo").is_err());
+        assert!(GitHubRepositoryRef::new("o".repeat(101), "repo").is_err());
         assert_eq!(
             error_kind(validate_limit(policy.limits().items() + 1, policy)),
             LimitExceeded

--- a/crates/larch-adapters/src/lib.rs
+++ b/crates/larch-adapters/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod clock;
 pub mod git;
 pub mod github;
+mod github_actions;
 mod github_rest;
 pub mod google_auth;
 pub mod logging;

--- a/crates/larch-core/src/github.rs
+++ b/crates/larch-core/src/github.rs
@@ -226,6 +226,7 @@ impl GitHubRepositoryRef {
 
 fn valid_repository_part(value: &str) -> bool {
     !value.is_empty()
+        && value.len() <= 100
         && value != "."
         && value != ".."
         && value
@@ -814,5 +815,11 @@ mod tests {
             ),
             GitHubRetryAction::Stop(StopReason::Authorization)
         );
+    }
+
+    #[test]
+    fn actions_errors_render_their_safe_detail() {
+        let error = GitHubActionsError::new(GitHubActionsErrorKind::Transport, "request failed");
+        assert_eq!(error.to_string(), "request failed");
     }
 }

--- a/crates/larch-core/src/github.rs
+++ b/crates/larch-core/src/github.rs
@@ -328,6 +328,204 @@ pub struct GitHubLabelCreate {
     pub description: String,
 }
 
+/// Owned future returned by the object-safe GitHub Actions port.
+pub type GitHubActionsFuture<'service, T> =
+    Pin<Box<dyn Future<Output = Result<T, GitHubActionsError>> + Send + 'service>>;
+
+/// Typed workflow, job, check, control, and log operations.
+pub trait GitHubActionsService: GitHubService {
+    fn list_workflow_runs<'service>(
+        &'service self,
+        repository: &'service GitHubRepositoryRef,
+        filters: &'service WorkflowRunFilters,
+        cancellation: &'service dyn ProcessCancellation,
+    ) -> GitHubActionsFuture<'service, Vec<WorkflowRun>>;
+
+    fn workflow_run<'service>(
+        &'service self,
+        repository: &'service GitHubRepositoryRef,
+        run_id: u64,
+        cancellation: &'service dyn ProcessCancellation,
+    ) -> GitHubActionsFuture<'service, WorkflowRun>;
+
+    fn workflow_jobs<'service>(
+        &'service self,
+        repository: &'service GitHubRepositoryRef,
+        run_id: u64,
+        cancellation: &'service dyn ProcessCancellation,
+    ) -> GitHubActionsFuture<'service, Vec<WorkflowJob>>;
+
+    fn check_runs<'service>(
+        &'service self,
+        repository: &'service GitHubRepositoryRef,
+        git_reference: &'service str,
+        cancellation: &'service dyn ProcessCancellation,
+    ) -> GitHubActionsFuture<'service, Vec<CheckRun>>;
+
+    fn rerun_workflow<'service>(
+        &'service self,
+        repository: &'service GitHubRepositoryRef,
+        run_id: u64,
+        failed_only: bool,
+        cancellation: &'service dyn ProcessCancellation,
+    ) -> GitHubActionsFuture<'service, GitHubMutationOutcome>;
+
+    fn dispatch_workflow<'service>(
+        &'service self,
+        request: &'service WorkflowDispatchRequest,
+        cancellation: &'service dyn ProcessCancellation,
+    ) -> GitHubActionsFuture<'service, GitHubMutationOutcome>;
+
+    fn download_workflow_logs<'service>(
+        &'service self,
+        repository: &'service GitHubRepositoryRef,
+        run_id: u64,
+        cancellation: &'service dyn ProcessCancellation,
+    ) -> GitHubActionsFuture<'service, WorkflowLogArchive>;
+}
+
+/// Additive filters for listing workflow runs.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct WorkflowRunFilters {
+    pub branch: Option<String>,
+    pub workflow: Option<String>,
+    pub event: Option<String>,
+    pub status: Option<String>,
+    pub commit: Option<String>,
+    pub limit: usize,
+}
+
+impl WorkflowRunFilters {
+    #[must_use]
+    pub const fn effective_limit(&self) -> usize {
+        if self.limit == 0 { 5 } else { self.limit }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WorkflowRun {
+    pub database_id: u64,
+    pub status: String,
+    pub conclusion: Option<String>,
+    pub head_sha: String,
+    pub event: String,
+    pub attempt: u32,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WorkflowDispatchRequest {
+    pub repository: GitHubRepositoryRef,
+    pub workflow: String,
+    pub git_reference: String,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct WorkflowJob {
+    pub name: String,
+    pub status: String,
+    pub conclusion: Option<String>,
+    pub wall_clock_seconds: Option<f64>,
+}
+
+impl WorkflowJob {
+    #[must_use]
+    pub fn is_failed(&self) -> bool {
+        self.conclusion.as_deref() == Some("failure")
+    }
+
+    #[must_use]
+    pub fn harness_shard(&self) -> Option<u32> {
+        let shard = self
+            .name
+            .strip_prefix("test-harnesses (")?
+            .strip_suffix(')')?;
+        shard.parse().ok()
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CheckBucket {
+    Pass,
+    Fail,
+    Pending,
+    Skipping,
+    Cancel,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CheckRun {
+    pub name: String,
+    pub status: String,
+    pub conclusion: Option<String>,
+    pub bucket: CheckBucket,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GitHubMutationOutcome {
+    Accepted,
+    Reconciled,
+    Ambiguous,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WorkflowLogArchive {
+    bytes: Vec<u8>,
+}
+
+impl WorkflowLogArchive {
+    #[must_use]
+    pub const fn new(bytes: Vec<u8>) -> Self {
+        Self { bytes }
+    }
+
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GitHubActionsErrorKind {
+    InvalidInput,
+    Authorization,
+    RateLimited,
+    Transport,
+    Response,
+    Redirect,
+    LogLimit,
+    Cancelled,
+    DeadlineExceeded,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GitHubActionsError {
+    kind: GitHubActionsErrorKind,
+    detail: SafeText,
+}
+
+impl GitHubActionsError {
+    #[must_use]
+    pub fn new(kind: GitHubActionsErrorKind, detail: impl AsRef<str>) -> Self {
+        Self {
+            kind,
+            detail: SafeText::from_untrusted(detail),
+        }
+    }
+
+    #[must_use]
+    pub const fn kind(&self) -> GitHubActionsErrorKind {
+        self.kind
+    }
+}
+
+impl std::fmt::Display for GitHubActionsError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.detail.fmt(formatter)
+    }
+}
+
+impl std::error::Error for GitHubActionsError {}
+
 /// Fixed per-response and continuation bounds.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct GitHubResponseLimits {

--- a/crates/larch-core/src/lib.rs
+++ b/crates/larch-core/src/lib.rs
@@ -30,12 +30,14 @@ pub use git::{
     Worktree,
 };
 pub use github::{
-    GitHubCloseReason, GitHubComment, GitHubFailureInput, GitHubFuture, GitHubIssue,
-    GitHubIssueCreate, GitHubIssueEdit, GitHubIssueList, GitHubIssueSearch, GitHubIssueState,
-    GitHubLabel, GitHubLabelCreate, GitHubOperationError, GitHubOperationErrorKind,
-    GitHubRateLimitInputs, GitHubRepository, GitHubRepositoryRef, GitHubRequestKind,
-    GitHubResponseLimits, GitHubRetryAction, GitHubService, GitHubTransportPolicy,
-    classify_github_retry,
+    CheckBucket, CheckRun, GitHubActionsError, GitHubActionsErrorKind, GitHubActionsFuture,
+    GitHubActionsService, GitHubCloseReason, GitHubComment, GitHubFailureInput, GitHubFuture,
+    GitHubIssue, GitHubIssueCreate, GitHubIssueEdit, GitHubIssueList, GitHubIssueSearch,
+    GitHubIssueState, GitHubLabel, GitHubLabelCreate, GitHubMutationOutcome, GitHubOperationError,
+    GitHubOperationErrorKind, GitHubRateLimitInputs, GitHubRepository, GitHubRepositoryRef,
+    GitHubRequestKind, GitHubResponseLimits, GitHubRetryAction, GitHubService,
+    GitHubTransportPolicy, WorkflowDispatchRequest, WorkflowJob, WorkflowLogArchive, WorkflowRun,
+    WorkflowRunFilters, classify_github_retry,
 };
 pub use outcome::{ExitCode, WorkflowOutcome};
 pub use process::{


### PR DESCRIPTION
Closes #7726

## Summary

- Add an object-safe typed GitHub Actions service for workflow runs, jobs, checks, reruns, dispatches, and log archives.
- Enforce cancellation, bounded retries and responses, mutation read-back, and a hardened cross-origin log redirect policy.
- Add offline parity, limit, redirect, cancellation, rate-limit, and mutation tests.

## Migration state

- Implementation parity: complete for the typed GitHub Actions operation boundary.
- Consumer cutover: pending in downstream domain umbrellas.
- Python removal: pending; this PR does not claim or perform it.

## Validation

- `make rust-check`
- Changed-file relevant-checks gate with full coverage
