### PR TITLE
Fixes #7761: Remove duplicate Rust CI hooks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,7 +71,7 @@ jobs:
         # `lint-local`. If a dedicated job is removed, drop its hook
         # name from SKIP to restore CI coverage. Issue #1034.
         env:
-          SKIP: agnix,shellcheck,gitleaks,ruff,pyright,agent-lint,larch-lint,lint-no-raw-stderr-after-quiet-init,bash-syntax-check,check-topology-rule-paths,lint-codex-exec-auth
+          SKIP: agnix,shellcheck,gitleaks,ruff,pyright,agent-lint,cargo-fmt,cargo-clippy,larch-lint,lint-run-log-run-id,lint-no-raw-stderr-after-quiet-init,bash-syntax-check,check-topology-rule-paths,lint-em-dash-output,lint-codex-exec-auth,lint-retired-scripts
         run: |
           set -euo pipefail
           log="$(mktemp)"
@@ -127,9 +127,10 @@ jobs:
       - name: Run pre-commit linters (local)
         # Runs only local bash/python linters. External tools (markdownlint,
         # jsonlint, actionlint) run in `lint`. Dedicated-job hooks
-        # (gitleaks, agnix, shellcheck, agent-lint, ruff, pyright) are skipped here.
+        # (gitleaks, agnix, shellcheck, agent-lint, ruff, pyright, and Rust
+        # hooks covered by rust-gate) are skipped here.
         env:
-          SKIP: agnix,shellcheck,gitleaks,ruff,pyright,markdownlint,jsonlint,agent-lint,actionlint,larch-lint
+          SKIP: agnix,shellcheck,gitleaks,ruff,pyright,markdownlint,jsonlint,agent-lint,actionlint,cargo-fmt,cargo-clippy,larch-lint,lint-run-log-run-id,check-topology-rule-paths,lint-em-dash-output,lint-codex-exec-auth,lint-retired-scripts
         run: make lint-only
       - name: Pipe SIGPIPE safety lint
         run: bash scripts/test-pipe-sigpipe-safety.sh

--- a/Makefile
+++ b/Makefile
@@ -44,22 +44,39 @@ lint: test-harnesses lint-em-dash-output lint-codex-exec-auth rust-lint lint-lif
 
 py-lint: py-lint-main py-typecheck
 
-# Fast Python lints (ruff + custom AST ratchets): a few seconds total. Shared by
-# the local full lint (py-lint-main) and CI shard 1 (py-lint-shard) so the check
-# set is defined once.
+# Fast Python lints (ruff + custom AST ratchets). Shared by the local full lint
+# (py-lint-main) and the Python CI shards so the check set is defined once.
+#
+# Timed locally under the same concurrent process shape as CI, then LPT-packed
+# into three 110–111-second groups. Keep every check in the master list and in
+# exactly one three-way group. One-way mode remains the local default.
+PY_LINT_FAST_CHECKS := ruff complexity-baseline keyword-only subprocess-via-runner gh-argv-literal git-push-refspec wire-artifact-pairing tempfile-dir result-env-key-parity tmpdir-arg-env-fallback markdown-heading-fence-state self-disarmable-gate unreachable-branch status-routing-truthiness monkeypatch-facade-binding env-via-config-constant root-resolution kv-codec lifecycle-prefix-literal shared-convention-regex renderer-golden-tests suppression-reason pylint-skip-file guidelines-note-wrapper-bypass layering flat-tests run-log-walkers module-manifest engine-adoption
+PY_LINT_FAST_CHECKS_SHARD_1 := ruff subprocess-via-runner layering result-env-key-parity env-via-config-constant kv-codec shared-convention-regex tmpdir-arg-env-fallback self-disarmable-gate
+PY_LINT_FAST_CHECKS_SHARD_2 := monkeypatch-facade-binding git-push-refspec wire-artifact-pairing gh-argv-literal suppression-reason root-resolution run-log-walkers complexity-baseline renderer-golden-tests module-manifest keyword-only
+PY_LINT_FAST_CHECKS_SHARD_3 := status-routing-truthiness lifecycle-prefix-literal tempfile-dir pylint-skip-file unreachable-branch guidelines-note-wrapper-bypass flat-tests engine-adoption markdown-heading-fence-state
+PY_LINT_FAST_SHARD_ID ?= 1
+PY_LINT_FAST_SHARD_COUNT ?= 1
+
 py-lint-checks-fast:
 	@$(PYTHON) -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 11) else 1)' \
 		|| (printf '%s\n' "ERROR: make py-lint-checks-fast requires Python 3.11 or newer (PYTHON=$(PYTHON))" >&2; exit 1)
 	@# ruff + the AST ratchet checks are independent read-only checks. Run them
 	@# concurrently (each to its own log) and aggregate exit codes so wall time is
-	@# the slowest single check, not the ~90s serial sum that dominated CI
-	@# python-lint shard 1. Logs replay in deterministic order after all finish,
+	@# the slowest single check, not the serial sum. CI distributes the checks
+	@# across its three pylint shards. Logs replay in deterministic order after all finish,
 	@# so parallelism never muddies which check failed. POSIX sh only (CI /bin/sh
 	@# is dash): no pipefail, no arrays.
-	@tmp=$$(mktemp -d); rc=0; pids=""; \
-	( cd python && ruff check . ) >"$$tmp/ruff.log" 2>&1 & pids="$$pids $$!:ruff"; \
-	for chk in complexity-baseline keyword-only subprocess-via-runner gh-argv-literal git-push-refspec wire-artifact-pairing tempfile-dir result-env-key-parity tmpdir-arg-env-fallback markdown-heading-fence-state self-disarmable-gate unreachable-branch status-routing-truthiness monkeypatch-facade-binding env-via-config-constant root-resolution kv-codec lifecycle-prefix-literal shared-convention-regex renderer-golden-tests suppression-reason pylint-skip-file guidelines-note-wrapper-bypass layering flat-tests run-log-walkers module-manifest engine-adoption; do \
-		$(PYTHON) python/cli.py lint "$$chk" >"$$tmp/$$chk.log" 2>&1 & pids="$$pids $$!:$$chk"; \
+	@case "$(PY_LINT_FAST_SHARD_COUNT):$(PY_LINT_FAST_SHARD_ID)" in \
+		1:1) checks="$(PY_LINT_FAST_CHECKS)" ;; \
+		3:1) checks="$(PY_LINT_FAST_CHECKS_SHARD_1)" ;; \
+		3:2) checks="$(PY_LINT_FAST_CHECKS_SHARD_2)" ;; \
+		3:3) checks="$(PY_LINT_FAST_CHECKS_SHARD_3)" ;; \
+		*) printf '%s\n' "ERROR: unsupported PY_LINT_FAST_SHARD_COUNT:PY_LINT_FAST_SHARD_ID=$(PY_LINT_FAST_SHARD_COUNT):$(PY_LINT_FAST_SHARD_ID)" >&2; exit 2 ;; \
+	esac; \
+	tmp=$$(mktemp -d); rc=0; pids=""; \
+	for chk in $$checks; do \
+		if [ "$$chk" = ruff ]; then ( cd python && ruff check . ) >"$$tmp/ruff.log" 2>&1; else $(PYTHON) python/cli.py lint "$$chk" >"$$tmp/$$chk.log" 2>&1; fi & \
+		pids="$$pids $$!:$$chk"; \
 	done; \
 	for entry in $$pids; do \
 		p=$${entry%%:*}; name=$${entry#*:}; \
@@ -76,16 +93,15 @@ py-lint-checks-fast:
 py-lint-main: py-lint-checks-fast
 	cd python && pylint -j $(PYLINT_JOBS) .
 
-# CI per-shard Python lint (matrix PYLINT_SHARD_ID of PYLINT_SHARD_COUNT). The
-# ruff + AST ratchet fast checks (~10s on CI) run once, on shard 1; pylint runs
-# on this shard's basename subset (python/pylint_sharding.py). Shard 1 holds the
-# a..o source, the lightest pylint shard on CI, so it absorbs the fast-check lump
-# with the least imbalance. A python-lint-gate job aggregates the matrix so the
-# required status check name stays stable across resharding.
+# CI per-shard Python lint (matrix PYLINT_SHARD_ID of PYLINT_SHARD_COUNT). Fast
+# checks and pylint both run on each shard. The fast checks are an exact three-way
+# partition; pylint runs on its basename subset (python/pylint_sharding.py). A
+# python-lint-gate job aggregates the matrix so the required status check name
+# stays stable across resharding.
 py-lint-shard:
 	@$(PYTHON) -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 11) else 1)' \
 		|| (printf '%s\n' "ERROR: make py-lint-shard requires Python 3.11 or newer (PYTHON=$(PYTHON))" >&2; exit 1)
-	@if [ "$(PYLINT_SHARD_ID)" = "1" ]; then $(MAKE) py-lint-checks-fast; fi
+	@$(MAKE) py-lint-checks-fast PY_LINT_FAST_SHARD_ID=$(PYLINT_SHARD_ID) PY_LINT_FAST_SHARD_COUNT=$(PYLINT_SHARD_COUNT)
 	cd python && $(PYTHON) cli.py lint pylint-shard --shard-id $(PYLINT_SHARD_ID) --shard-count $(PYLINT_SHARD_COUNT) --jobs $(PYLINT_JOBS)
 
 .PHONY: regen-complexity-baseline lint-complexity-debt regen-keyword-only-baseline regen-kv-codec-baseline

--- a/python/tests/implement/test_checks.py
+++ b/python/tests/implement/test_checks.py
@@ -3974,6 +3974,10 @@ def test_local_relevant_checks_ci_superset_guard() -> None:
     precommit = (repo_root / ".pre-commit-config.yaml").read_text(encoding="utf-8")
     workflow = (repo_root / ".github" / "workflows" / "ci.yaml").read_text(encoding="utf-8")
     rust_lint = workflow.split("\n  rust-lint:", 1)[1].split("\n  rust-build-test:", 1)[0]
+    lint = workflow.split("\n  lint:", 1)[1].split("\n  lint-local:", 1)[0]
+    lint_local = workflow.split("\n  lint-local:", 1)[1].split("\n  # Python duplicate-code", 1)[0]
+    lint_skip = lint.split("SKIP: ", 1)[1].split("\n", 1)[0].split(",")
+    lint_local_skip = lint_local.split("SKIP: ", 1)[1].split("\n", 1)[0].split(",")
 
     assert "id: ruff" in precommit
     assert "ruff check --fix" in precommit
@@ -3996,6 +4000,18 @@ def test_local_relevant_checks_ci_superset_guard() -> None:
     assert "make rust-test" in workflow
     assert "make rust-coverage" in workflow
     assert "cargo-deny-action@" in workflow
+    for hook in (
+        "cargo-fmt",
+        "cargo-clippy",
+        "larch-lint",
+        "lint-run-log-run-id",
+        "check-topology-rule-paths",
+        "lint-em-dash-output",
+        "lint-codex-exec-auth",
+        "lint-retired-scripts",
+    ):
+        assert hook in lint_skip
+        assert hook in lint_local_skip
 
 def test_existing_regular_files_includes_symlink_to_file(tmp_path: Path) -> None:
     repo = tmp_path / "repo"

--- a/python/tests/lint/test_pylint_sharding.py
+++ b/python/tests/lint/test_pylint_sharding.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -89,3 +90,22 @@ def test_real_tree_three_way_split_is_total_disjoint_nonempty() -> None:
 
     assert sorted(covered) == sorted(all_files)  # no file dropped
     assert len(covered) == len(set(covered))  # no file double-linted
+
+
+def test_fast_checks_are_a_three_way_partition() -> None:
+    makefile = (_repo_root() / "Makefile").read_text(encoding="utf-8")
+
+    def checks_for(variable: str) -> list[str]:
+        match = re.search(rf"^{variable} := (.+)$", makefile, flags=re.MULTILINE)
+        assert match, f"missing {variable}"
+        return match.group(1).split()
+
+    all_checks = checks_for("PY_LINT_FAST_CHECKS")
+    shard_checks = [
+        check
+        for shard in range(1, 4)
+        for check in checks_for(f"PY_LINT_FAST_CHECKS_SHARD_{shard}")
+    ]
+
+    assert sorted(shard_checks) == sorted(all_checks)
+    assert len(shard_checks) == len(set(shard_checks))


### PR DESCRIPTION
## Summary

- Skip duplicated Rust pre-commit hooks in the `lint` and `lint-local` CI jobs.
- Keep Rust validation in `rust-lint`, which feeds the required `rust-gate` check.
- Add a regression guard for the two CI skip lists.
- Distribute the one-time Python fast-lint checks across all three `python-lint` shards.
- Keep the Python fast-check partition exact with a regression test.

## Test plan

- [x] `python3 -m pytest python/tests/implement/test_checks.py -q -k local_relevant_checks_ci_superset_guard`
- [x] `python3 -m ruff check python/tests/implement/test_checks.py`
- [x] `actionlint .github/workflows/ci.yaml`
- [x] `python3 -m pytest python/tests/lint/test_pylint_sharding.py -q`
- [x] `make py-lint-checks-fast PY_LINT_FAST_SHARD_ID=N PY_LINT_FAST_SHARD_COUNT=3` for `N=1,2,3`
- [x] `git diff --check`

Closes #7761
