### PR TITLE
Port typed Git status and local changes to gix

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -116,6 +116,11 @@ work:
   It reopens through strict config parsing and ownership checks before reading
   mutable repository state. Callers receive core byte types and cannot select
   `gix` or Git CLI reads.
+- Configured status iteration and tree changes return core-owned change sets.
+  They preserve byte paths, modes, object IDs, conflict stages, ignored-entry
+  safety classes, and the index flags needed to interpret status. Patch text,
+  `--raw`, `--numstat`, textconv, and external-diff bytes remain owned by the
+  typed exact-diff Git CLI method.
 - Git mutations and network operations stay behind a closed, typed Git CLI
   compatibility adapter where installed-Git behavior is part of the contract.
   There is no public arbitrary-argv escape hatch.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -139,6 +139,19 @@ paths, config values, and remote URLs as bytes. Errors use fixed classes and do
 not include repository paths, config values, remote credentials, or upstream
 library diagnostics.
 
+Status and typed tree changes follow the same reopen rule. Status uses the full
+configured `gix` iterator and never writes its optional index-stat refreshes.
+Repository and worktree config that defines an external clean, process,
+textconv, or diff command returns `UnsupportedSemantics` before iteration.
+Callers must route those byte-sensitive cases through the closed exact-diff Git
+CLI operation. User and system filter definitions remain operator-owned config;
+status rejects repository attributes that select them before `gix` can launch a
+filter. Effective conversion attributes are queried through the configured
+attribute stack. Discovery does not follow symlinks and fails closed when the
+worktree traversal exceeds its entry cap.
+Typed results contain paths, modes, IDs, and flags, but no file content or
+upstream diagnostic text.
+
 ## Rust GitHub Actions Operation Boundary
 
 The Actions operation port builds repository, workflow, run, job, and check

--- a/agent-lint.toml
+++ b/agent-lint.toml
@@ -1362,10 +1362,10 @@ conditional-sources = [
 root-max-lines = 879
 root-max-tokens = 35383
 root-max-content-tokens = 35301
-# Issues #7731/#7725/#7733/#7726 add trust boundaries to imported SECURITY.md.
-closure-max-lines = 3684
-closure-max-tokens = 142244
-closure-max-content-tokens = 141944
+# Issues #7731/#7725/#7733/#7726/#7732 add trust boundaries to imported SECURITY.md.
+closure-max-lines = 3697
+closure-max-tokens = 142454
+closure-max-content-tokens = 142154
 conditional-max-lines = 589
 conditional-max-tokens = 18764
 conditional-max-content-tokens = 18717
@@ -1412,7 +1412,7 @@ roots = [
   "skills/shared/reviewer-templates.md",
   "skills/shared/voting-protocol.md",
 ]
-# Issues #7731/#7725/#7733/#7726 add trust boundaries to imported SECURITY.md.
-closure-max-lines = 5972
-closure-max-tokens = 167716
-closure-max-content-tokens = 167254
+# Issues #7731/#7725/#7733/#7726/#7732 add trust boundaries to imported SECURITY.md.
+closure-max-lines = 5985
+closure-max-tokens = 167926
+closure-max-content-tokens = 167464

--- a/crates/larch-adapters/src/git/repository.rs
+++ b/crates/larch-adapters/src/git/repository.rs
@@ -4,10 +4,12 @@ use std::path::{Path, PathBuf};
 
 use gix::bstr::ByteSlice;
 use larch_core::{
-    Commit, ConfigKey, ConfigScope, ConfigValue, GitPath, Head, Object, ObjectHash, ObjectId,
-    ObjectKind, RefFormat, RefName, Reference, ReferenceKind, ReferenceTarget, Remote,
-    RepositoryError, RepositoryErrorKind, RepositoryLocation, RepositoryRead, Revision, Upstream,
-    Worktree,
+    Change, ChangeKind, ChangeSet, Commit, ConfigKey, ConfigScope, ConfigValue, ConflictKind,
+    ConflictStage, GitMode, GitPath, Head, IgnoreKind, IgnoredEntry, IndexFlags, Object,
+    ObjectHash, ObjectId, ObjectKind, RefFormat, RefName, Reference, ReferenceKind,
+    ReferenceTarget, Remote, RepositoryError, RepositoryErrorKind, RepositoryLocation,
+    RepositoryRead, RepositoryStatus, Revision, StatusOptions, TrackedEntry, UnmergedEntry,
+    Upstream, Worktree,
 };
 
 /// The only production repository metadata reader.
@@ -357,6 +359,144 @@ impl RepositoryRead for GixRepository {
         Ok(output)
     }
 
+    fn status(&self, options: &StatusOptions) -> Result<RepositoryStatus, RepositoryError> {
+        let repository = self.local()?;
+        reject_unsupported_status_semantics(&repository)?;
+        let index = repository
+            .index_or_empty()
+            .map_err(|_| error(RepositoryErrorKind::CorruptRepository))?;
+        let untracked = if options.include_untracked || options.include_ignored {
+            gix::status::UntrackedFiles::Files
+        } else {
+            gix::status::UntrackedFiles::None
+        };
+        let mut platform = repository
+            .status(gix::progress::Discard)
+            .map_err(|_| error(RepositoryErrorKind::MalformedConfig))?
+            .index(gix::worktree::IndexPersistedOrInMemory::Persisted(
+                index.clone(),
+            ))
+            .untracked_files(untracked);
+        if options.include_ignored {
+            platform = platform.dirwalk_options(|dirwalk| {
+                dirwalk.emit_ignored(Some(gix::dir::walk::EmissionMode::Matching))
+            });
+        }
+        let patterns = options
+            .pathspecs
+            .iter()
+            .map(|path| path.as_bytes().into())
+            .collect::<Vec<gix::bstr::BString>>();
+        let tracked = tracked_entries(&repository, &index, &patterns)?;
+        let iter = platform
+            .into_iter(patterns)
+            .map_err(|error_value| map_status_init_error(&error_value))?;
+        let mut staged = Vec::new();
+        let mut unstaged = Vec::new();
+        let mut untracked_paths = Vec::new();
+        let mut ignored = Vec::new();
+        let mut unmerged = Vec::new();
+        for item in iter {
+            match item.map_err(|error_value| map_status_item_error(&error_value))? {
+                gix::status::Item::TreeIndex(change) => {
+                    staged.push(index_change(change, &index));
+                }
+                gix::status::Item::IndexWorktree(item) => collect_worktree_item(
+                    item,
+                    &mut unstaged,
+                    &mut untracked_paths,
+                    &mut ignored,
+                    &mut unmerged,
+                ),
+            }
+        }
+        unmerged.sort_by(|left, right| left.path.cmp(&right.path));
+        staged.retain(|change| !unmerged.iter().any(|entry| entry.path == change.path));
+        unstaged.retain(|change| !unmerged.iter().any(|entry| entry.path == change.path));
+        sort_changes(&mut staged);
+        sort_changes(&mut unstaged);
+        untracked_paths.sort();
+        untracked_paths.dedup();
+        if !options.include_untracked {
+            untracked_paths.clear();
+        }
+        ignored.sort_by(|left, right| left.path.cmp(&right.path));
+        ignored.dedup_by(|left, right| left.path == right.path);
+        Ok(RepositoryStatus {
+            tracked,
+            tree_to_index: ChangeSet::new(staged),
+            index_to_worktree: ChangeSet::new(unstaged),
+            untracked: untracked_paths,
+            ignored,
+            unmerged,
+        })
+    }
+
+    fn tree_changes(
+        &self,
+        old_tree: &ObjectId,
+        new_tree: &ObjectId,
+    ) -> Result<ChangeSet, RepositoryError> {
+        let repository = self.local()?;
+        reject_external_diff_drivers(&repository)?;
+        let old = repository
+            .try_find_object(gix_id(old_tree, repository.object_hash())?)
+            .map_err(|_| error(RepositoryErrorKind::CorruptRepository))?
+            .ok_or_else(|| error(RepositoryErrorKind::MissingObject))?
+            .try_into_tree()
+            .map_err(|_| error(RepositoryErrorKind::ObjectType))?;
+        let new = repository
+            .try_find_object(gix_id(new_tree, repository.object_hash())?)
+            .map_err(|_| error(RepositoryErrorKind::CorruptRepository))?
+            .ok_or_else(|| error(RepositoryErrorKind::MissingObject))?
+            .try_into_tree()
+            .map_err(|_| error(RepositoryErrorKind::ObjectType))?;
+        let mut changes = Vec::new();
+        let mut configured = old
+            .changes()
+            .map_err(|_| error(RepositoryErrorKind::MalformedConfig))?;
+        configured
+            .for_each_to_obtain_tree(&new, |change| {
+                changes.push(tree_change(change));
+                Ok::<_, std::convert::Infallible>(std::ops::ControlFlow::Continue(()))
+            })
+            .map_err(|_| error(RepositoryErrorKind::CorruptRepository))?;
+        let copy_sources = changes
+            .iter()
+            .filter(|change| change.kind == ChangeKind::Copied)
+            .filter_map(|change| change.source_path.clone())
+            .collect::<Vec<_>>();
+        if !copy_sources.is_empty() {
+            let mut without_rewrites = old
+                .changes()
+                .map_err(|_| error(RepositoryErrorKind::MalformedConfig))?;
+            without_rewrites.options(|options| {
+                options.track_rewrites(None);
+            });
+            without_rewrites
+                .for_each_to_obtain_tree(&new, |change| {
+                    let change = tree_change(change);
+                    if copy_sources.contains(&change.path)
+                        && !changes.iter().any(|existing| {
+                            existing.path == change.path && existing.kind == change.kind
+                        })
+                        && matches!(
+                            change.kind,
+                            ChangeKind::Modified
+                                | ChangeKind::TypeChanged
+                                | ChangeKind::SubmoduleModified
+                        )
+                    {
+                        changes.push(change);
+                    }
+                    Ok::<_, std::convert::Infallible>(std::ops::ControlFlow::Continue(()))
+                })
+                .map_err(|_| error(RepositoryErrorKind::CorruptRepository))?;
+        }
+        sort_changes(&mut changes);
+        Ok(ChangeSet::new(changes))
+    }
+
     fn validate_ref_name(&self, name: &RefName, format: RefFormat) -> Result<(), RepositoryError> {
         let name = name.as_bytes().as_bstr();
         let valid = match format {
@@ -370,6 +510,588 @@ impl RepositoryRead for GixRepository {
             Err(error(RepositoryErrorKind::InvalidRef))
         }
     }
+}
+
+fn reject_unsupported_status_semantics(
+    repository: &gix::Repository,
+) -> Result<(), RepositoryError> {
+    let config = repository.config_snapshot();
+    let external_filters = config.sections_by_name("filter").is_some_and(|sections| {
+        sections
+            .into_iter()
+            .any(|section| section.value("clean").is_some() || section.value("process").is_some())
+    });
+    let repository_filters = config.sections_by_name("filter").is_some_and(|sections| {
+        sections.into_iter().any(|section| {
+            matches!(
+                section.meta().source,
+                gix::config::Source::Local | gix::config::Source::Worktree
+            ) && (section.value("clean").is_some() || section.value("process").is_some())
+        })
+    });
+    let attributes = attribute_semantics(repository)?;
+    if repository_filters || attributes.conversion || attributes.filter && external_filters {
+        return Err(error(RepositoryErrorKind::UnsupportedSemantics));
+    }
+    Ok(())
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct AttributeSemantics {
+    conversion: bool,
+    filter: bool,
+}
+
+fn attribute_semantics(
+    repository: &gix::Repository,
+) -> Result<AttributeSemantics, RepositoryError> {
+    const ENTRY_MAX: usize = 1_000_000;
+    let index = repository
+        .index_or_empty()
+        .map_err(|_| error(RepositoryErrorKind::CorruptRepository))?;
+    let mut stack = repository
+        .attributes_only(
+            &index,
+            gix::worktree::stack::state::attributes::Source::WorktreeThenIdMapping,
+        )
+        .map_err(|_| error(RepositoryErrorKind::MalformedConfig))?;
+    let mut output = AttributeSemantics::default();
+    for entry in index.entries() {
+        merge_path_attribute_semantics(
+            &mut stack,
+            gix::path::from_bstr(entry.path(&index)),
+            Some(entry.mode),
+            &mut output,
+        )?;
+    }
+    let Some(workdir) = repository.workdir() else {
+        return Ok(output);
+    };
+    let mut pending = vec![workdir.to_owned()];
+    let mut entries_seen = 0_usize;
+    while let Some(directory) = pending.pop() {
+        let entries = std::fs::read_dir(directory).map_err(|_| error(RepositoryErrorKind::Io))?;
+        for entry in entries {
+            let entry = entry.map_err(|_| error(RepositoryErrorKind::Io))?;
+            entries_seen = entries_seen
+                .checked_add(1)
+                .ok_or_else(|| error(RepositoryErrorKind::UnsupportedSemantics))?;
+            if entries_seen > ENTRY_MAX {
+                return Err(error(RepositoryErrorKind::UnsupportedSemantics));
+            }
+            let file_type = entry
+                .file_type()
+                .map_err(|_| error(RepositoryErrorKind::Io))?;
+            if file_type.is_dir() {
+                let name = entry.file_name();
+                let path = entry.path();
+                let is_dot_git = name.to_string_lossy().as_ref().eq_ignore_ascii_case(".git");
+                let is_nested_repository = std::fs::symlink_metadata(path.join(".git")).is_ok();
+                if !is_dot_git && !is_nested_repository {
+                    pending.push(path);
+                }
+                continue;
+            }
+            if !file_type.is_file() {
+                continue;
+            }
+            let relative = entry
+                .path()
+                .strip_prefix(workdir)
+                .map_err(|_| error(RepositoryErrorKind::Io))?
+                .to_owned();
+            merge_path_attribute_semantics(&mut stack, relative, None, &mut output)?;
+        }
+    }
+    Ok(output)
+}
+
+fn merge_path_attribute_semantics(
+    stack: &mut gix::AttributeStack<'_>,
+    path: impl AsRef<Path>,
+    mode: Option<gix::index::entry::Mode>,
+    output: &mut AttributeSemantics,
+) -> Result<(), RepositoryError> {
+    let mut matches = stack.selected_attribute_matches([
+        "text",
+        "eol",
+        "crlf",
+        "ident",
+        "working-tree-encoding",
+        "filter",
+    ]);
+    stack
+        .at_path(path, mode)
+        .map_err(|_| error(RepositoryErrorKind::Io))?
+        .matching_attributes(&mut matches);
+    for match_value in matches.iter_selected() {
+        if matches!(
+            match_value.assignment.state,
+            gix::attrs::StateRef::Unspecified
+        ) {
+            continue;
+        }
+        if match_value.assignment.name.as_str() == "filter" {
+            output.filter = true;
+        } else {
+            output.conversion = true;
+        }
+    }
+    Ok(())
+}
+
+fn reject_external_diff_drivers(repository: &gix::Repository) -> Result<(), RepositoryError> {
+    let config = repository.config_snapshot();
+    if config.sections_by_name("diff").is_some_and(|sections| {
+        sections.into_iter().any(|section| {
+            matches!(
+                section.meta().source,
+                gix::config::Source::Local | gix::config::Source::Worktree
+            ) && section.header().subsection_name().is_some()
+                && (section.value("command").is_some() || section.value("textconv").is_some())
+        })
+    }) {
+        return Err(error(RepositoryErrorKind::UnsupportedSemantics));
+    }
+    Ok(())
+}
+
+fn tracked_entries(
+    repository: &gix::Repository,
+    index: &gix::index::State,
+    patterns: &[gix::bstr::BString],
+) -> Result<Vec<TrackedEntry>, RepositoryError> {
+    let mut pathspec = repository
+        .pathspec(
+            true,
+            patterns,
+            true,
+            index,
+            gix::worktree::stack::state::attributes::Source::WorktreeThenIdMapping,
+        )
+        .map_err(|_| error(RepositoryErrorKind::InvalidInput))?;
+    let mut output = index
+        .entries()
+        .iter()
+        .filter(|entry| entry.stage() == gix::index::entry::Stage::Unconflicted)
+        .filter(|entry| {
+            pathspec.is_included(
+                entry.path(index),
+                Some(entry.mode == gix::index::entry::Mode::DIR),
+            )
+        })
+        .map(|entry| TrackedEntry {
+            path: GitPath::new(entry.path(index).to_vec()),
+            mode: GitMode::new(entry.mode.bits()),
+            id: object_id(&entry.id),
+            flags: index_flags(entry.flags),
+        })
+        .collect::<Vec<_>>();
+    output.sort_by(|left, right| left.path.cmp(&right.path));
+    Ok(output)
+}
+
+const fn map_status_init_error(error_value: &gix::status::into_iter::Error) -> RepositoryError {
+    match error_value {
+        gix::status::into_iter::Error::HeadTreeDiff(
+            gix::status::tree_index::Error::TreeIndexDiff(gix::diff::index::Error::IsSparse),
+        ) => error(RepositoryErrorKind::UnsupportedSemantics),
+        gix::status::into_iter::Error::Pathspec(_) => error(RepositoryErrorKind::InvalidInput),
+        gix::status::into_iter::Error::ConfigSkipHash(_)
+        | gix::status::into_iter::Error::PrepareSubmodules(_) => {
+            error(RepositoryErrorKind::MalformedConfig)
+        }
+        _ => error(RepositoryErrorKind::CorruptRepository),
+    }
+}
+
+const fn map_status_item_error(error_value: &gix::status::iter::Error) -> RepositoryError {
+    match error_value {
+        gix::status::iter::Error::TreeIndex(gix::status::tree_index::Error::TreeIndexDiff(
+            gix::diff::index::Error::IsSparse,
+        )) => error(RepositoryErrorKind::UnsupportedSemantics),
+        _ => error(RepositoryErrorKind::CorruptRepository),
+    }
+}
+
+fn collect_worktree_item(
+    item: gix::status::index_worktree::Item,
+    changes: &mut Vec<Change>,
+    untracked: &mut Vec<GitPath>,
+    ignored: &mut Vec<IgnoredEntry>,
+    unmerged: &mut Vec<UnmergedEntry>,
+) {
+    use gix::status::index_worktree::Item;
+    use gix::status::plumbing::index_as_worktree::{Change as WorktreeChange, EntryStatus};
+    match item {
+        Item::Modification {
+            entry,
+            rela_path,
+            status,
+            ..
+        } => match status {
+            EntryStatus::Conflict { summary, entries } => {
+                let stages = entries
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(index, entry)| {
+                        entry.as_ref().map(|entry| ConflictStage {
+                            stage: u8::try_from(index + 1).expect("three conflict stages"),
+                            mode: GitMode::new(entry.mode.bits()),
+                            id: object_id(&entry.id),
+                            flags: index_flags(entry.flags),
+                        })
+                    })
+                    .collect();
+                unmerged.push(UnmergedEntry {
+                    path: GitPath::new(rela_path.to_vec()),
+                    kind: conflict_kind(summary),
+                    stages,
+                });
+            }
+            EntryStatus::Change(change) => {
+                let old_mode = entry.mode.bits();
+                let (kind, new_mode) = match change {
+                    WorktreeChange::Removed => (ChangeKind::Deleted, None),
+                    WorktreeChange::Type { worktree_mode } => {
+                        (ChangeKind::TypeChanged, Some(worktree_mode.bits()))
+                    }
+                    WorktreeChange::Modification {
+                        executable_bit_changed,
+                        ..
+                    } => {
+                        let mode =
+                            executable_bit_changed.then(|| toggled_executable_mode(old_mode));
+                        (ChangeKind::Modified, mode.or(Some(old_mode)))
+                    }
+                    WorktreeChange::SubmoduleModification(_) => {
+                        (ChangeKind::SubmoduleModified, Some(old_mode))
+                    }
+                };
+                changes.push(Change {
+                    kind,
+                    path: GitPath::new(rela_path.to_vec()),
+                    source_path: None,
+                    old_mode: Some(GitMode::new(old_mode)),
+                    new_mode: new_mode.map(GitMode::new),
+                    old_id: Some(object_id(&entry.id)),
+                    new_id: None,
+                    index_flags: Some(index_flags(entry.flags)),
+                });
+            }
+            EntryStatus::IntentToAdd => changes.push(Change {
+                kind: ChangeKind::Added,
+                path: GitPath::new(rela_path.to_vec()),
+                source_path: None,
+                old_mode: None,
+                new_mode: Some(GitMode::new(entry.mode.bits())),
+                old_id: None,
+                new_id: None,
+                index_flags: Some(index_flags(entry.flags)),
+            }),
+            EntryStatus::NeedsUpdate(_) => {}
+        },
+        Item::DirectoryContents { entry, .. } => {
+            collect_directory_entry(&entry, untracked, ignored);
+        }
+        Item::Rewrite {
+            source,
+            dirwalk_entry,
+            dirwalk_entry_id,
+            copy,
+            ..
+        } => changes.push(worktree_rewrite(
+            &source,
+            &dirwalk_entry,
+            &dirwalk_entry_id,
+            copy,
+        )),
+    }
+}
+
+fn collect_directory_entry(
+    entry: &gix::dir::Entry,
+    untracked: &mut Vec<GitPath>,
+    ignored: &mut Vec<IgnoredEntry>,
+) {
+    match entry.status {
+        gix::dir::entry::Status::Untracked => {
+            untracked.push(GitPath::new(entry.rela_path.to_vec()));
+        }
+        gix::dir::entry::Status::Ignored(kind) => ignored.push(IgnoredEntry {
+            path: GitPath::new(entry.rela_path.to_vec()),
+            kind: match kind {
+                gix::ignore::Kind::Expendable => IgnoreKind::Expendable,
+                gix::ignore::Kind::Precious => IgnoreKind::Precious,
+            },
+        }),
+        gix::dir::entry::Status::Pruned | gix::dir::entry::Status::Tracked => {}
+    }
+}
+
+fn worktree_rewrite(
+    source: &gix::status::index_worktree::RewriteSource,
+    destination: &gix::dir::Entry,
+    destination_id: &gix::hash::ObjectId,
+    copy: bool,
+) -> Change {
+    Change {
+        kind: if copy {
+            ChangeKind::Copied
+        } else {
+            ChangeKind::Renamed
+        },
+        path: GitPath::new(destination.rela_path.to_vec()),
+        source_path: Some(GitPath::new(source.rela_path().to_vec())),
+        old_mode: None,
+        new_mode: None,
+        old_id: None,
+        new_id: (!destination_id.is_null()).then(|| object_id(destination_id)),
+        index_flags: rewrite_source_flags(source),
+    }
+}
+
+fn index_change(change: gix::diff::index::Change, index: &gix::index::State) -> Change {
+    use gix::diff::index::Change;
+    match change {
+        Change::Addition {
+            location,
+            index: entry_index,
+            entry_mode,
+            id,
+            ..
+        } => with_index_flags(
+            typed_change(
+                ChangeKind::Added,
+                location.as_ref(),
+                None,
+                None,
+                Some(entry_mode.bits()),
+                None,
+                Some(id.as_ref()),
+            ),
+            index_flags(index.entries()[entry_index].flags),
+        ),
+        Change::Deletion {
+            location,
+            entry_mode,
+            id,
+            ..
+        } => typed_change(
+            ChangeKind::Deleted,
+            location.as_ref(),
+            None,
+            Some(entry_mode.bits()),
+            None,
+            Some(id.as_ref()),
+            None,
+        ),
+        Change::Modification {
+            location,
+            index: entry_index,
+            previous_entry_mode,
+            previous_id,
+            entry_mode,
+            id,
+            ..
+        } => with_index_flags(
+            typed_change(
+                modified_kind(previous_entry_mode.bits(), entry_mode.bits()),
+                location.as_ref(),
+                None,
+                Some(previous_entry_mode.bits()),
+                Some(entry_mode.bits()),
+                Some(previous_id.as_ref()),
+                Some(id.as_ref()),
+            ),
+            index_flags(index.entries()[entry_index].flags),
+        ),
+        Change::Rewrite {
+            source_location,
+            source_entry_mode,
+            source_id,
+            location,
+            index: entry_index,
+            entry_mode,
+            id,
+            copy,
+            ..
+        } => with_index_flags(
+            typed_change(
+                if copy {
+                    ChangeKind::Copied
+                } else {
+                    ChangeKind::Renamed
+                },
+                location.as_ref(),
+                Some(source_location.as_ref()),
+                Some(source_entry_mode.bits()),
+                Some(entry_mode.bits()),
+                Some(source_id.as_ref()),
+                Some(id.as_ref()),
+            ),
+            index_flags(index.entries()[entry_index].flags),
+        ),
+    }
+}
+
+fn tree_change(change: gix::object::tree::diff::Change<'_, '_, '_>) -> Change {
+    use gix::object::tree::diff::Change;
+    match change {
+        Change::Addition {
+            location,
+            entry_mode,
+            id,
+            ..
+        } => typed_change(
+            ChangeKind::Added,
+            location,
+            None,
+            None,
+            Some(u32::from(entry_mode.value())),
+            None,
+            Some(id.as_ref()),
+        ),
+        Change::Deletion {
+            location,
+            entry_mode,
+            id,
+            ..
+        } => typed_change(
+            ChangeKind::Deleted,
+            location,
+            None,
+            Some(u32::from(entry_mode.value())),
+            None,
+            Some(id.as_ref()),
+            None,
+        ),
+        Change::Modification {
+            location,
+            previous_entry_mode,
+            previous_id,
+            entry_mode,
+            id,
+        } => typed_change(
+            modified_kind(
+                u32::from(previous_entry_mode.value()),
+                u32::from(entry_mode.value()),
+            ),
+            location,
+            None,
+            Some(u32::from(previous_entry_mode.value())),
+            Some(u32::from(entry_mode.value())),
+            Some(previous_id.as_ref()),
+            Some(id.as_ref()),
+        ),
+        Change::Rewrite {
+            source_location,
+            source_entry_mode,
+            source_id,
+            location,
+            entry_mode,
+            id,
+            copy,
+            ..
+        } => typed_change(
+            if copy {
+                ChangeKind::Copied
+            } else {
+                ChangeKind::Renamed
+            },
+            location,
+            Some(source_location),
+            Some(u32::from(source_entry_mode.value())),
+            Some(u32::from(entry_mode.value())),
+            Some(source_id.as_ref()),
+            Some(id.as_ref()),
+        ),
+    }
+}
+
+fn typed_change(
+    kind: ChangeKind,
+    path_value: &[u8],
+    source_path: Option<&[u8]>,
+    old_mode: Option<u32>,
+    new_mode: Option<u32>,
+    old_id: Option<&gix::hash::oid>,
+    new_id: Option<&gix::hash::oid>,
+) -> Change {
+    Change {
+        kind,
+        path: GitPath::new(path_value),
+        source_path: source_path.map(GitPath::new),
+        old_mode: old_mode.map(GitMode::new),
+        new_mode: new_mode.map(GitMode::new),
+        old_id: old_id.map(object_id),
+        new_id: new_id.map(object_id),
+        index_flags: None,
+    }
+}
+
+const fn with_index_flags(mut change: Change, flags: IndexFlags) -> Change {
+    change.index_flags = Some(flags);
+    change
+}
+
+const fn rewrite_source_flags(
+    source: &gix::status::index_worktree::RewriteSource,
+) -> Option<IndexFlags> {
+    use gix::status::index_worktree::RewriteSource;
+    match source {
+        RewriteSource::RewriteFromIndex { source_entry, .. } => {
+            Some(index_flags(source_entry.flags))
+        }
+        RewriteSource::CopyFromDirectoryEntry { .. } => None,
+    }
+}
+
+const fn modified_kind(old_mode: u32, new_mode: u32) -> ChangeKind {
+    if old_mode == 0o160_000 && new_mode == 0o160_000 {
+        ChangeKind::SubmoduleModified
+    } else if old_mode & 0o170_000 != new_mode & 0o170_000 {
+        ChangeKind::TypeChanged
+    } else {
+        ChangeKind::Modified
+    }
+}
+
+const fn toggled_executable_mode(mode: u32) -> u32 {
+    if mode == 0o100_755 {
+        0o100_644
+    } else {
+        0o100_755
+    }
+}
+
+const fn index_flags(flags: gix::index::entry::Flags) -> IndexFlags {
+    IndexFlags {
+        assume_valid: flags.contains(gix::index::entry::Flags::ASSUME_VALID),
+        intent_to_add: flags.contains(gix::index::entry::Flags::INTENT_TO_ADD),
+        skip_worktree: flags.contains(gix::index::entry::Flags::SKIP_WORKTREE),
+    }
+}
+
+const fn conflict_kind(kind: gix::status::plumbing::index_as_worktree::Conflict) -> ConflictKind {
+    use gix::status::plumbing::index_as_worktree::Conflict;
+    match kind {
+        Conflict::BothDeleted => ConflictKind::BothDeleted,
+        Conflict::AddedByUs => ConflictKind::AddedByUs,
+        Conflict::DeletedByThem => ConflictKind::DeletedByThem,
+        Conflict::AddedByThem => ConflictKind::AddedByThem,
+        Conflict::DeletedByUs => ConflictKind::DeletedByUs,
+        Conflict::BothAdded => ConflictKind::BothAdded,
+        Conflict::BothModified => ConflictKind::BothModified,
+    }
+}
+
+fn sort_changes(changes: &mut [Change]) {
+    changes.sort_by(|left, right| {
+        left.path
+            .cmp(&right.path)
+            .then_with(|| left.source_path.cmp(&right.source_path))
+    });
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/crates/larch-adapters/tests/git_repository.rs
+++ b/crates/larch-adapters/tests/git_repository.rs
@@ -5,8 +5,9 @@ use std::os::unix::ffi::OsStringExt;
 
 use larch_adapters::git::GixRepository;
 use larch_core::{
-    ConfigKey, ConfigScope, Head, ObjectHash, ObjectId, ObjectKind, RefFormat, RefName,
-    ReferenceTarget, RepositoryErrorKind, RepositoryRead, Revision,
+    ChangeKind, ConfigKey, ConfigScope, GitPath, Head, IgnoreKind, ObjectHash, ObjectId,
+    ObjectKind, RefFormat, RefName, ReferenceTarget, RepositoryErrorKind, RepositoryRead, Revision,
+    StatusOptions,
 };
 use larch_test_support::{
     ExecutionSnapshot, GitFixture, GitFixtureError, GitObjectFormat, GitRepository,
@@ -360,6 +361,384 @@ fn head_worktrees_sha256_and_errors_have_typed_results() {
     );
 }
 
+#[test]
+fn configured_status_matches_git_for_clean_and_dirty_worktrees() {
+    let Some(clean) = fixture(GitFixture::Refs, GitObjectFormat::Sha1) else {
+        return;
+    };
+    let clean_status = GixRepository::open(clean.root())
+        .unwrap()
+        .status(&StatusOptions::default())
+        .unwrap();
+    assert!(!clean_status.is_dirty());
+
+    let Some(changes) = fixture(GitFixture::Changes, GitObjectFormat::Sha1) else {
+        return;
+    };
+    let reader = GixRepository::open(changes.root()).unwrap();
+    let status = reader
+        .status(&StatusOptions {
+            include_ignored: true,
+            ..StatusOptions::default()
+        })
+        .unwrap();
+    assert!(status.is_dirty(), "untracked files must count as dirty");
+    assert_eq!(
+        status
+            .tree_to_index
+            .paths()
+            .map(|path| path.as_bytes().to_vec())
+            .collect::<Vec<_>>(),
+        git_nul_paths(&changes, ["diff", "--cached", "--name-only", "-z"])
+    );
+    assert_eq!(status.tree_to_index.entries()[0].kind, ChangeKind::Added);
+    assert_eq!(
+        status
+            .index_to_worktree
+            .paths()
+            .map(|path| path.as_bytes().to_vec())
+            .collect::<Vec<_>>(),
+        git_nul_paths(&changes, ["diff", "--name-only", "-z"])
+    );
+    assert_eq!(
+        status
+            .untracked
+            .iter()
+            .map(|path| path.as_bytes().to_vec())
+            .collect::<Vec<_>>(),
+        git_nul_paths(
+            &changes,
+            ["ls-files", "--others", "--exclude-standard", "-z"]
+        )
+    );
+    assert_eq!(status.ignored[0].path, GitPath::new("ignored.txt"));
+    assert_eq!(status.ignored[0].kind, IgnoreKind::Expendable);
+
+    let scoped = reader
+        .status(&StatusOptions {
+            pathspecs: vec![GitPath::new("tracked.txt")],
+            ..StatusOptions::default()
+        })
+        .unwrap();
+    assert_eq!(
+        scoped.index_to_worktree.paths().collect::<Vec<_>>(),
+        vec![&GitPath::new("tracked.txt")]
+    );
+    assert!(scoped.tree_to_index.is_empty());
+    assert!(scoped.untracked.is_empty());
+    assert_eq!(scoped.tracked.len(), 1);
+    assert_eq!(scoped.tracked[0].path, GitPath::new("tracked.txt"));
+
+    git_ok(&changes, ["reset", "--hard", "--quiet"]);
+    std::fs::remove_file(changes.root().join("untracked.txt")).unwrap();
+    git_ok(&changes, ["add", ".gitignore"]);
+    git_ok(&changes, ["commit", "--quiet", "-m", "track ignores"]);
+    let ignored_only = reader
+        .status(&StatusOptions {
+            include_ignored: true,
+            ..StatusOptions::default()
+        })
+        .unwrap();
+    assert_eq!(ignored_only.ignored[0].path, GitPath::new("ignored.txt"));
+    assert!(!ignored_only.is_dirty());
+    let ignored_without_untracked = reader
+        .status(&StatusOptions {
+            include_untracked: false,
+            include_ignored: true,
+            ..StatusOptions::default()
+        })
+        .unwrap();
+    assert!(ignored_without_untracked.untracked.is_empty());
+    assert_eq!(
+        ignored_without_untracked.ignored[0].path,
+        GitPath::new("ignored.txt")
+    );
+    changes.write("only-untracked.txt", b"dirty\n").unwrap();
+    let untracked_only = reader.status(&StatusOptions::default()).unwrap();
+    assert_eq!(
+        untracked_only.untracked,
+        vec![GitPath::new("only-untracked.txt")]
+    );
+    assert!(untracked_only.is_dirty());
+}
+
+#[test]
+fn conflicts_are_only_unmerged_and_preserve_all_index_stages() {
+    let Some(conflict) = fixture(GitFixture::Conflict, GitObjectFormat::Sha1) else {
+        return;
+    };
+    let status = GixRepository::open(conflict.root())
+        .unwrap()
+        .status(&StatusOptions::default())
+        .unwrap();
+    assert!(status.is_dirty());
+    assert_eq!(status.unmerged.len(), 1);
+    let entry = &status.unmerged[0];
+    assert_eq!(entry.path.as_bytes(), b"tracked.txt");
+    assert_eq!(
+        entry
+            .stages
+            .iter()
+            .map(|stage| stage.stage)
+            .collect::<Vec<_>>(),
+        vec![1, 2, 3]
+    );
+    assert!(
+        entry
+            .stages
+            .iter()
+            .all(|stage| stage.mode.raw() == 0o100_644)
+    );
+    assert!(status.tree_to_index.is_empty());
+    assert!(status.index_to_worktree.is_empty());
+}
+
+#[test]
+fn tree_changes_report_names_statuses_modes_and_configured_rewrites() {
+    let Some(repository) = fixture(GitFixture::Refs, GitObjectFormat::Sha1) else {
+        return;
+    };
+    repository
+        .write("rename.txt", b"rename me\nsame line\n")
+        .unwrap();
+    repository.write("copy.txt", b"copy me\n").unwrap();
+    git_ok(&repository, ["add", "--all"]);
+    git_ok(&repository, ["commit", "--quiet", "-m", "sources"]);
+    git_ok(&repository, ["config", "diff.renames", "copies"]);
+    let old_tree = git_id(&repository, ["rev-parse", "HEAD^{tree}"]);
+    git_ok(&repository, ["mv", "rename.txt", "renamed.txt"]);
+    let staged = GixRepository::open(repository.root())
+        .unwrap()
+        .status(&StatusOptions::default())
+        .unwrap();
+    assert!(staged.tree_to_index.entries().iter().any(|change| {
+        change.kind == ChangeKind::Renamed
+            && change.source_path.as_ref().unwrap().as_bytes() == b"rename.txt"
+            && change.path.as_bytes() == b"renamed.txt"
+    }));
+    repository
+        .write("renamed.txt", b"rename me\nsame line\nchanged\n")
+        .unwrap();
+    repository.write("copy.txt", b"copy changed\n").unwrap();
+    repository.write("copy-2.txt", b"copy changed\n").unwrap();
+    git_ok(&repository, ["add", "--all"]);
+    git_ok(&repository, ["commit", "--quiet", "-m", "rewrites"]);
+    let new_tree = git_id(&repository, ["rev-parse", "HEAD^{tree}"]);
+
+    let changes = GixRepository::open(repository.root())
+        .unwrap()
+        .tree_changes(&old_tree, &new_tree)
+        .unwrap();
+    assert_eq!(changes.entries().len(), 3);
+    assert!(changes.entries().iter().any(|change| {
+        change.kind == ChangeKind::Renamed
+            && change.source_path.as_ref().unwrap().as_bytes() == b"rename.txt"
+            && change.path.as_bytes() == b"renamed.txt"
+    }));
+    assert!(changes.entries().iter().any(|change| {
+        change.kind == ChangeKind::Copied
+            && change.source_path.as_ref().unwrap().as_bytes() == b"copy.txt"
+            && change.path.as_bytes() == b"copy-2.txt"
+    }));
+    assert!(changes.entries().iter().any(|change| {
+        change.kind == ChangeKind::Modified && change.path.as_bytes() == b"copy.txt"
+    }));
+    assert!(changes.entries().iter().all(|change| {
+        change.old_mode.unwrap().raw() == 0o100_644
+            && change.new_mode.unwrap().raw() == 0o100_644
+            && change.old_id.is_some()
+            && change.new_id.is_some()
+    }));
+}
+
+#[cfg(unix)]
+#[test]
+fn status_preserves_non_utf8_paths_and_file_type_changes() {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    let Some(repository) = fixture(GitFixture::SpecialFiles, GitObjectFormat::Sha1) else {
+        return;
+    };
+    let old_tree = git_id(&repository, ["rev-parse", "HEAD^{tree}"]);
+    fs::remove_file(repository.root().join("link")).unwrap();
+    repository.write("link", b"regular now\n").unwrap();
+    fs::set_permissions(
+        repository.root().join("executable.sh"),
+        fs::Permissions::from_mode(0o644),
+    )
+    .unwrap();
+    let status = GixRepository::open(repository.root())
+        .unwrap()
+        .status(&StatusOptions::default())
+        .unwrap();
+    assert!(status.index_to_worktree.entries().iter().any(|change| {
+        change.path.as_bytes() == b"link" && change.kind == ChangeKind::TypeChanged
+    }));
+    assert!(status.index_to_worktree.entries().iter().any(|change| {
+        change.path.as_bytes() == b"executable.sh"
+            && change.old_mode.unwrap().raw() == 0o100_755
+            && change.new_mode.unwrap().raw() == 0o100_644
+    }));
+    git_ok(&repository, ["add", "link"]);
+    git_ok(&repository, ["commit", "--quiet", "-m", "replace symlink"]);
+    let new_tree = git_id(&repository, ["rev-parse", "HEAD^{tree}"]);
+    let tree_changes = GixRepository::open(repository.root())
+        .unwrap()
+        .tree_changes(&old_tree, &new_tree)
+        .unwrap();
+    assert_eq!(tree_changes.entries()[0].kind, ChangeKind::TypeChanged);
+    assert_eq!(tree_changes.entries()[0].old_mode.unwrap().raw(), 0o120_000);
+    assert_eq!(tree_changes.entries()[0].new_mode.unwrap().raw(), 0o100_644);
+
+    let raw_name = OsString::from_vec(b"untracked-\xff".to_vec());
+    if let Err(error) = repository.write(std::path::Path::new(&raw_name), b"raw\n") {
+        eprintln!("fixture skipped: raw byte path is unsupported: {error}");
+        return;
+    }
+    let status = GixRepository::open(repository.root())
+        .unwrap()
+        .status(&StatusOptions::default())
+        .unwrap();
+    assert!(
+        status
+            .untracked
+            .iter()
+            .any(|path| path.as_bytes() == b"untracked-\xff")
+    );
+}
+
+#[test]
+fn status_respects_case_configuration_and_reports_submodule_changes() {
+    let Some(changes) = fixture(GitFixture::Changes, GitObjectFormat::Sha1) else {
+        return;
+    };
+    git_ok(&changes, ["config", "core.ignoreCase", "true"]);
+    let scoped = GixRepository::open(changes.root())
+        .unwrap()
+        .status(&StatusOptions {
+            pathspecs: vec![GitPath::new("TRACKED.TXT")],
+            ..StatusOptions::default()
+        })
+        .unwrap();
+    assert_eq!(scoped.index_to_worktree.entries().len(), 1);
+
+    let Some(submodule) = fixture(GitFixture::Submodule, GitObjectFormat::Sha1) else {
+        return;
+    };
+    submodule
+        .write("submodule/child.txt", b"child changed\n")
+        .unwrap();
+    let status = GixRepository::open(submodule.root())
+        .unwrap()
+        .status(&StatusOptions::default())
+        .unwrap();
+    assert!(status.index_to_worktree.entries().iter().any(|change| {
+        change.path.as_bytes() == b"submodule" && change.kind == ChangeKind::SubmoduleModified
+    }));
+}
+
+#[test]
+fn external_filters_and_sparse_indexes_fail_explicitly() {
+    if let Some(filtered) = fixture(GitFixture::AttributesAndFilters, GitObjectFormat::Sha1) {
+        assert_eq!(
+            GixRepository::open(filtered.root())
+                .unwrap()
+                .status(&StatusOptions::default())
+                .unwrap_err()
+                .kind(),
+            RepositoryErrorKind::UnsupportedSemantics
+        );
+    }
+
+    if let Some(sparse) = fixture(GitFixture::SparseCheckout, GitObjectFormat::Sha1) {
+        let converted = sparse.git(["sparse-checkout", "reapply", "--sparse-index"]);
+        if converted.is_ok_and(|output| output.success()) {
+            let result = GixRepository::open(sparse.root())
+                .unwrap()
+                .status(&StatusOptions::default());
+            match result {
+                Ok(status) => assert!(!status.is_dirty()),
+                Err(error) => {
+                    assert_eq!(error.kind(), RepositoryErrorKind::UnsupportedSemantics);
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn crlf_status_difference_routes_to_exact_compatibility() {
+    let Some(repository) = fixture(GitFixture::Unborn, GitObjectFormat::Sha1) else {
+        return;
+    };
+    repository
+        .write(".gitattributes", b"crlf.txt text eol=crlf\n")
+        .unwrap();
+    repository.write("crlf.txt", b"one\r\ntwo\r\n").unwrap();
+    git_ok(&repository, ["add", "--all"]);
+    git_ok(&repository, ["commit", "--quiet", "-m", "crlf"]);
+    repository.write("crlf.txt", b"one\ntwo\n").unwrap();
+    let reader = GixRepository::open(repository.root()).unwrap();
+    assert!(repository.git(["diff", "--quiet"]).unwrap().success());
+    assert_eq!(
+        reader.status(&StatusOptions::default()).unwrap_err().kind(),
+        RepositoryErrorKind::UnsupportedSemantics
+    );
+}
+
+#[test]
+fn tracked_entries_preserve_flags_and_precious_ignore_kind() {
+    let Some(repository) = fixture(GitFixture::Refs, GitObjectFormat::Sha1) else {
+        return;
+    };
+    repository.write("skip.txt", b"skip\n").unwrap();
+    git_ok(&repository, ["add", "skip.txt"]);
+    git_ok(&repository, ["commit", "--quiet", "-m", "add skip entry"]);
+    git_ok(
+        &repository,
+        ["update-index", "--assume-unchanged", "tracked.txt"],
+    );
+    git_ok(&repository, ["update-index", "--skip-worktree", "skip.txt"]);
+    repository.write("intent.txt", b"intent\n").unwrap();
+    git_ok(&repository, ["add", "--intent-to-add", "intent.txt"]);
+    repository.write(".gitignore", b"$precious.txt\n").unwrap();
+    repository.write("precious.txt", b"keep\n").unwrap();
+    git_ok(&repository, ["config", "gitoxide.parsePrecious", "true"]);
+
+    let status = GixRepository::open(repository.root())
+        .unwrap()
+        .status(&StatusOptions {
+            include_ignored: true,
+            ..StatusOptions::default()
+        })
+        .unwrap();
+    let tracked = status
+        .tracked
+        .iter()
+        .find(|entry| entry.path.as_bytes() == b"tracked.txt")
+        .unwrap();
+    assert!(tracked.flags.assume_valid);
+    let skipped = status
+        .tracked
+        .iter()
+        .find(|entry| entry.path.as_bytes() == b"skip.txt")
+        .unwrap();
+    assert!(skipped.flags.skip_worktree);
+    let intent = status
+        .tracked
+        .iter()
+        .find(|entry| entry.path.as_bytes() == b"intent.txt")
+        .unwrap();
+    assert!(intent.flags.intent_to_add);
+    assert!(status.index_to_worktree.entries().iter().any(|change| {
+        change.path.as_bytes() == b"intent.txt" && change.index_flags.unwrap().intent_to_add
+    }));
+    assert!(status.ignored.iter().any(|entry| {
+        entry.path.as_bytes() == b"precious.txt" && entry.kind == IgnoreKind::Precious
+    }));
+}
+
 fn fixture(kind: GitFixture, format: GitObjectFormat) -> Option<GitRepository> {
     match GitRepository::builder(kind).object_format(format).build() {
         Ok(repository) => Some(repository),
@@ -414,6 +793,20 @@ where
         .filter(|line| !line.is_empty())
         .map(<[u8]>::to_vec)
         .collect()
+}
+
+fn git_nul_paths<I, S>(repository: &GitRepository, arguments: I) -> Vec<Vec<u8>>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<std::ffi::OsStr>,
+{
+    let mut paths = git_bytes(repository, arguments)
+        .split(|byte| *byte == 0)
+        .filter(|path| !path.is_empty())
+        .map(<[u8]>::to_vec)
+        .collect::<Vec<_>>();
+    paths.sort();
+    paths
 }
 
 fn git_id<I, S>(repository: &GitRepository, arguments: I) -> ObjectId

--- a/crates/larch-core/src/git.rs
+++ b/crates/larch-core/src/git.rs
@@ -250,6 +250,227 @@ pub struct Worktree {
     pub locked: bool,
 }
 
+/// A raw Git tree or index mode.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct GitMode(u32);
+
+impl GitMode {
+    /// Preserve a mode without interpreting adapter-specific bitflags.
+    #[must_use]
+    pub const fn new(raw: u32) -> Self {
+        Self(raw)
+    }
+
+    /// Return the raw mode bits.
+    #[must_use]
+    pub const fn raw(self) -> u32 {
+        self.0
+    }
+}
+
+/// The semantic kind of a typed repository change.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum ChangeKind {
+    /// A path exists only in the destination.
+    Added,
+    /// A path exists only in the source.
+    Deleted,
+    /// Content or executable permission changed.
+    Modified,
+    /// The tree entry or filesystem kind changed.
+    TypeChanged,
+    /// A source path moved to a destination path.
+    Renamed,
+    /// A destination was copied from a source path.
+    Copied,
+    /// A gitlink target or submodule worktree changed.
+    SubmoduleModified,
+}
+
+/// One byte-oriented tree, index, or worktree change.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Change {
+    /// The semantic name-status kind.
+    pub kind: ChangeKind,
+    /// The destination path, or affected path for non-rewrites.
+    pub path: GitPath,
+    /// The source path for a rename or copy.
+    pub source_path: Option<GitPath>,
+    /// The source mode when available.
+    pub old_mode: Option<GitMode>,
+    /// The destination mode when available.
+    pub new_mode: Option<GitMode>,
+    /// The source object ID when available.
+    pub old_id: Option<ObjectId>,
+    /// The destination object ID when available.
+    pub new_id: Option<ObjectId>,
+    /// Flags from the relevant index entry, when this change crosses the index.
+    pub index_flags: Option<IndexFlags>,
+}
+
+/// A deterministic name-status change set. `paths()` is its name-only view.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct ChangeSet(Vec<Change>);
+
+impl ChangeSet {
+    /// Build a change set whose entries are already in deterministic order.
+    #[must_use]
+    pub const fn new(entries: Vec<Change>) -> Self {
+        Self(entries)
+    }
+
+    /// Return typed name-status entries.
+    #[must_use]
+    pub fn entries(&self) -> &[Change] {
+        &self.0
+    }
+
+    /// Return the destination paths used by name-only callers.
+    pub fn paths(&self) -> impl Iterator<Item = &GitPath> {
+        self.0.iter().map(|entry| &entry.path)
+    }
+
+    /// Report whether the set has no changes.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+/// Persistent index flags callers need to interpret status safely.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct IndexFlags {
+    /// Git may skip stat checks and assume the worktree matches.
+    pub assume_valid: bool,
+    /// The entry promises a future addition without an indexed blob.
+    pub intent_to_add: bool,
+    /// Sparse checkout omits the entry from the worktree.
+    pub skip_worktree: bool,
+}
+
+/// One unconflicted entry currently recorded in the index.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TrackedEntry {
+    /// The repository-relative byte path.
+    pub path: GitPath,
+    /// The raw index mode.
+    pub mode: GitMode,
+    /// The indexed object ID.
+    pub id: ObjectId,
+    /// Persistent caller-relevant index flags.
+    pub flags: IndexFlags,
+}
+
+/// The safety class of one excluded worktree path.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum IgnoreKind {
+    /// The ignored path may be replaced by checkout-like operations.
+    Expendable,
+    /// The ignored path is marked for preservation by gitoxide semantics.
+    Precious,
+}
+
+/// One ignored worktree entry.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct IgnoredEntry {
+    /// The repository-relative byte path.
+    pub path: GitPath,
+    /// Whether the ignored entry is expendable or precious.
+    pub kind: IgnoreKind,
+}
+
+/// One conflict-stage entry from the index.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ConflictStage {
+    /// Index stage 1 (base), 2 (ours), or 3 (theirs).
+    pub stage: u8,
+    /// The stage's raw index mode.
+    pub mode: GitMode,
+    /// The stage's object ID.
+    pub id: ObjectId,
+    /// The stage's persistent caller-relevant flags.
+    pub flags: IndexFlags,
+}
+
+/// Git's stable conflict classification.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ConflictKind {
+    /// Both sides deleted distinct versions.
+    BothDeleted,
+    /// Our side added while their side modified.
+    AddedByUs,
+    /// Their side deleted while our side modified.
+    DeletedByThem,
+    /// Their side added while our side modified.
+    AddedByThem,
+    /// Our side deleted while their side modified.
+    DeletedByUs,
+    /// Both sides added distinct versions.
+    BothAdded,
+    /// Both sides modified the entry differently.
+    BothModified,
+}
+
+/// An unmerged path with every present base, ours, and theirs stage.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct UnmergedEntry {
+    /// The conflicted byte path.
+    pub path: GitPath,
+    /// The conflict classification.
+    pub kind: ConflictKind,
+    /// Every present base, ours, and theirs stage.
+    pub stages: Vec<ConflictStage>,
+}
+
+/// Policy for one configured status iteration.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct StatusOptions {
+    /// Git pathspec patterns, interpreted from repository-relative byte paths.
+    pub pathspecs: Vec<GitPath>,
+    /// Include individual untracked files.
+    pub include_untracked: bool,
+    /// Include individual ignored files.
+    pub include_ignored: bool,
+}
+
+impl Default for StatusOptions {
+    fn default() -> Self {
+        Self {
+            pathspecs: Vec::new(),
+            include_untracked: true,
+            include_ignored: false,
+        }
+    }
+}
+
+/// Typed changes across `HEAD`, the index, and the worktree.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct RepositoryStatus {
+    /// Unconflicted tracked entries selected by the pathspec.
+    pub tracked: Vec<TrackedEntry>,
+    /// Changes from `HEAD`'s tree to the index.
+    pub tree_to_index: ChangeSet,
+    /// Changes from the index to the worktree.
+    pub index_to_worktree: ChangeSet,
+    /// Untracked paths selected by policy and pathspec.
+    pub untracked: Vec<GitPath>,
+    /// Ignored entries selected by policy and pathspec.
+    pub ignored: Vec<IgnoredEntry>,
+    /// Conflicted paths, kept separate from ordinary change sets.
+    pub unmerged: Vec<UnmergedEntry>,
+}
+
+impl RepositoryStatus {
+    /// Match larch's dirty policy. Ignored paths alone do not make a repository dirty.
+    #[must_use]
+    pub const fn is_dirty(&self) -> bool {
+        !self.tree_to_index.is_empty()
+            || !self.index_to_worktree.is_empty()
+            || !self.untracked.is_empty()
+            || !self.unmerged.is_empty()
+    }
+}
+
 /// Validation mode for a candidate ref name.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum RefFormat {
@@ -270,6 +491,7 @@ pub enum RepositoryErrorKind {
     RevisionNotFound,
     AmbiguousRevision,
     UnsupportedRevision,
+    UnsupportedSemantics,
     MissingObject,
     ObjectType,
     CorruptRepository,
@@ -308,6 +530,9 @@ impl fmt::Display for RepositoryError {
             RepositoryErrorKind::RevisionNotFound => "revision was not found",
             RepositoryErrorKind::AmbiguousRevision => "revision is ambiguous",
             RepositoryErrorKind::UnsupportedRevision => "revision syntax is unsupported",
+            RepositoryErrorKind::UnsupportedSemantics => {
+                "repository operation requires exact Git compatibility"
+            }
             RepositoryErrorKind::MissingObject => "required object is missing",
             RepositoryErrorKind::ObjectType => "object has an unexpected type",
             RepositoryErrorKind::CorruptRepository => "repository data is corrupt",
@@ -386,6 +611,20 @@ pub trait RepositoryRead: Send + Sync {
     /// # Errors
     /// Returns a typed I/O or repository read failure.
     fn worktrees(&self) -> Result<Vec<Worktree>, RepositoryError>;
+    /// Return typed staged, unstaged, untracked, ignored, and unmerged state.
+    ///
+    /// # Errors
+    /// Returns a typed failure for corrupt state or semantics that require the exact-diff adapter.
+    fn status(&self, options: &StatusOptions) -> Result<RepositoryStatus, RepositoryError>;
+    /// Compare two tree object IDs with configured rename and copy behavior.
+    ///
+    /// # Errors
+    /// Returns a typed missing-object, object-type, or unsupported-semantics failure.
+    fn tree_changes(
+        &self,
+        old_tree: &ObjectId,
+        new_tree: &ObjectId,
+    ) -> Result<ChangeSet, RepositoryError>;
     /// Validate a name under the requested Git ref format.
     ///
     /// # Errors

--- a/crates/larch-core/src/lib.rs
+++ b/crates/larch-core/src/lib.rs
@@ -24,10 +24,12 @@ pub use error::{
     EnvironmentalFailure, ErrorCategory, FailureKind, InternalDefect, LarchError, OperatorError,
 };
 pub use git::{
-    Commit, ConfigKey, ConfigScope, ConfigValue, GitPath, Head, Object, ObjectHash, ObjectId,
-    ObjectKind, RefFormat, RefName, Reference, ReferenceKind, ReferenceTarget, Remote,
-    RepositoryError, RepositoryErrorKind, RepositoryLocation, RepositoryRead, Revision, Upstream,
-    Worktree,
+    Change, ChangeKind, ChangeSet, Commit, ConfigKey, ConfigScope, ConfigValue, ConflictKind,
+    ConflictStage, GitMode, GitPath, Head, IgnoreKind, IgnoredEntry, IndexFlags, Object,
+    ObjectHash, ObjectId, ObjectKind, RefFormat, RefName, Reference, ReferenceKind,
+    ReferenceTarget, Remote, RepositoryError, RepositoryErrorKind, RepositoryLocation,
+    RepositoryRead, RepositoryStatus, Revision, StatusOptions, TrackedEntry, UnmergedEntry,
+    Upstream, Worktree,
 };
 pub use github::{
     CheckBucket, CheckRun, GitHubActionsError, GitHubActionsErrorKind, GitHubActionsFuture,

--- a/docs/rust-testing.md
+++ b/docs/rust-testing.md
@@ -45,6 +45,11 @@ through `GixRepository`. Compare typed IDs, ref targets, config provenance,
 URLs, worktree records, and error classes with parsed Git oracle results. Path
 comparisons may normalize filesystem aliases such as macOS `/var` and
 `/private/var`, but the adapter result must retain its original path bytes.
+For status and change sets, compare staged, unstaged, untracked, ignored, and
+unmerged paths plus change kinds, modes, IDs, conflict stages, and flags. Cover
+pathspec and case configuration, filters and CRLF, sparse indexes, submodules,
+non-UTF-8 paths, symlinks, executable bits, and configured rewrite behavior.
+An unsupported semantic must return its typed error instead of dropping data.
 
 Use `SemanticSnapshot::capture` after each implementation runs against its own
 equivalent repository. Supply the operation's public result through


### PR DESCRIPTION
Closes #7732

## Summary

- add byte-oriented tracked, staged, unstaged, untracked, ignored, and conflict DTOs with modes, object IDs, stages, flags, and precious-ignore classification
- implement configured gix status and typed tree change sets with rename/copy, submodule, pathspec, sparse-index, case, and exact-diff fallback handling
- add differential fixtures and document the architecture, security boundary, and testing matrix

## Validation

- cargo test -p larch-core -p larch-adapters --all-targets
- cargo clippy -p larch-core -p larch-adapters --all-targets --all-features -- -D warnings
- changed-file pre-commit hooks
- cargo run --locked --package larch-lint -- all

Rust additions: 1,366 (issue ceiling: 1,500).