### PR TITLE
Require clean-install and issue-registry parity

### DIFF
--- a/ARCHITECTURAL_INVARIANTS.md
+++ b/ARCHITECTURAL_INVARIANTS.md
@@ -72,6 +72,10 @@ so a clean plugin cache could reach a missing `bin/larch`. Mechanical backing:
 outside the bootstrap and upgrade allowlist; the command-registry caller
 inventory recognizes `scripts/larch.sh`; clean-install tests prove first use.
 
+### I-Cutover-1: A command changes owner atomically
+
+A command becomes Rust-owned only in the change that proves Rust implementation parity, switches every production caller, removes the Python registration and superseded Python entrypoint, and proves clean-install execution through the verified runtime entrypoint. Until every condition holds, the command remains Python-owned even when a Rust parity implementation exists. No dual-owner, bridge, shim, selector fallback, or pending-removal Rust state is valid. Mechanical backing: the command registry state machine, expanded caller inventory, Python entrypoint retirement checks, and clean-install coverage ledger.
+
 ## Run-log integrity
 
 ### I-Flush-1: A missing required run-log artifact is a recorded execution issue, never a silent status string

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -46,6 +46,12 @@ require an explicit matching `LARCH_BINARY`. These controls do not defend
 against a hostile same-UID process that can rewrite plugin cache or data files.
 Runtime lints reject production Cargo, `bin/larch`, and
 `target/{debug,release}/larch`; only verified bootstrap owners may execute them.
+The command registry also requires each live Rust-owned selector to name a
+unique shared clean-install fixture. Those fixtures start without `bin/larch`,
+verify version and target before dispatch, and invoke the selector only through
+`scripts/larch.sh`. Issue-registry audit input is typed JSON derived from the
+canonical owner and plan parsers. It is validation evidence, not executable
+input.
 The `service-ownership` rule also rejects runtime `gcloud` execution and keeps
 this clean-install `gh` in `scripts/larch.sh` separate from runtime service
 access: bootstrap use of `gh` does not authorize a runtime adapter to shell out.

--- a/agent-lint.toml
+++ b/agent-lint.toml
@@ -1333,9 +1333,10 @@ root-max-content-tokens = 26286
 # Issue #7780 documents the executable-plan / force-admission contract in
 # docs/issue-anchored-plan.md (always-imported design closure).
 # Issue #7783 adds the shared-owner implementation-lease invariant.
-closure-max-lines = 1675
-closure-max-tokens = 50235
-closure-max-content-tokens = 50109
+# Issue #7785 adds the atomic command-cutover invariant.
+closure-max-lines = 1679
+closure-max-tokens = 50403
+closure-max-content-tokens = 50276
 conditional-max-lines = 661
 conditional-max-tokens = 18524
 conditional-max-content-tokens = 18465
@@ -1369,9 +1370,10 @@ root-max-content-tokens = 35301
 # issue #7728 adds the service-ownership CLI-independence trust boundary;
 # issue #7783 adds shared-owner implementation-lease enforcement.
 # issue #7736 adds the final Git ownership boundary.
-closure-max-lines = 3844
-closure-max-tokens = 145879
-closure-max-content-tokens = 145572
+# issue #7785 adds clean-install and issue-registry audit boundaries.
+closure-max-lines = 3854
+closure-max-tokens = 146145
+closure-max-content-tokens = 145838
 conditional-max-lines = 591
 conditional-max-tokens = 18803
 conditional-max-content-tokens = 18756
@@ -1429,6 +1431,7 @@ roots = [
 # issue #7728 adds the service-ownership CLI-independence trust boundary;
 # issue #7783 adds shared-owner implementation-lease enforcement.
 # issue #7736 adds the final Git ownership boundary.
-closure-max-lines = 6132
-closure-max-tokens = 171330
-closure-max-content-tokens = 170861
+# issue #7785 adds clean-install and issue-registry audit boundaries.
+closure-max-lines = 6142
+closure-max-tokens = 171595
+closure-max-content-tokens = 171125

--- a/crates/larch-cli/tests/parity.rs
+++ b/crates/larch-cli/tests/parity.rs
@@ -2,14 +2,135 @@
 mod parity_support;
 
 use std::{
-    env,
+    env, fs,
     path::{Path, PathBuf},
     process::Command,
     time::Duration,
 };
 
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt as _;
+
 use parity_support::{NormalizationRule, ParityCase, Program, SeedFile, assert_case};
 use tempfile::TempDir;
+
+#[derive(Clone, Copy)]
+struct CleanInstallCase {
+    id: &'static str,
+    domain: &'static str,
+    verb: &'static str,
+}
+
+impl CleanInstallCase {
+    const fn new(id: &'static str, domain: &'static str, verb: &'static str) -> Self {
+        Self { id, domain, verb }
+    }
+}
+
+const CLEAN_INSTALL_CASES: &[CleanInstallCase] = &[
+    CleanInstallCase::new("clean-install-gh-remote-repo", "gh", "remote-repo"),
+    CleanInstallCase::new("clean-install-gh-resolve-repo", "gh", "resolve-repo"),
+    CleanInstallCase::new("clean-install-gh-run-logs", "gh", "run-logs"),
+    CleanInstallCase::new("clean-install-gh-workflow-path", "gh", "workflow-path"),
+    CleanInstallCase::new("clean-install-git-amend-add", "git", "amend-add"),
+    CleanInstallCase::new("clean-install-git-branch-info", "git", "branch-info"),
+    CleanInstallCase::new(
+        "clean-install-git-check-main-sync",
+        "git",
+        "check-main-sync",
+    ),
+    CleanInstallCase::new(
+        "clean-install-git-check-phantom-dirty",
+        "git",
+        "check-phantom-dirty",
+    ),
+    CleanInstallCase::new(
+        "clean-install-git-check-remote-branch",
+        "git",
+        "check-remote-branch",
+    ),
+    CleanInstallCase::new("clean-install-git-checkout-ours", "git", "checkout-ours"),
+    CleanInstallCase::new("clean-install-git-clean-tree", "git", "clean-tree"),
+    CleanInstallCase::new("clean-install-git-commit", "git", "commit"),
+    CleanInstallCase::new("clean-install-git-conflict-files", "git", "conflict-files"),
+    CleanInstallCase::new("clean-install-git-count-commits", "git", "count-commits"),
+    CleanInstallCase::new("clean-install-git-current-branch", "git", "current-branch"),
+    CleanInstallCase::new("clean-install-git-phantom-probe", "git", "phantom-probe"),
+    CleanInstallCase::new("clean-install-git-rebase-abort", "git", "rebase-abort"),
+    CleanInstallCase::new("clean-install-git-rebase-skip", "git", "rebase-skip"),
+    CleanInstallCase::new("clean-install-git-show-stage", "git", "show-stage"),
+    CleanInstallCase::new(
+        "clean-install-git-snapshot-untracked",
+        "git",
+        "snapshot-untracked",
+    ),
+    CleanInstallCase::new("clean-install-git-stage", "git", "stage"),
+    CleanInstallCase::new(
+        "clean-install-git-sync-local-main",
+        "git",
+        "sync-local-main",
+    ),
+    CleanInstallCase::new(
+        "clean-install-plugin-read-version",
+        "plugin",
+        "read-version",
+    ),
+    CleanInstallCase::new("clean-install-push-branch", "push", "branch"),
+    CleanInstallCase::new(
+        "clean-install-push-checkpoint-probe",
+        "push",
+        "checkpoint-probe",
+    ),
+    CleanInstallCase::new("clean-install-push-force", "push", "force"),
+    CleanInstallCase::new("clean-install-push-rebase", "push", "rebase"),
+    CleanInstallCase::new(
+        "clean-install-release-asset-candidate",
+        "release",
+        "asset-candidate",
+    ),
+    CleanInstallCase::new(
+        "clean-install-release-classify-bump",
+        "release",
+        "classify-bump",
+    ),
+    CleanInstallCase::new(
+        "clean-install-release-collect-assets",
+        "release",
+        "collect-assets",
+    ),
+    CleanInstallCase::new(
+        "clean-install-release-package-asset",
+        "release",
+        "package-asset",
+    ),
+    CleanInstallCase::new(
+        "clean-install-release-plugin-runtime",
+        "release",
+        "plugin-runtime",
+    ),
+    CleanInstallCase::new("clean-install-release-prepare", "release", "prepare"),
+    CleanInstallCase::new(
+        "clean-install-release-set-version",
+        "release",
+        "set-version",
+    ),
+    CleanInstallCase::new(
+        "clean-install-release-validate-assets",
+        "release",
+        "validate-assets",
+    ),
+    CleanInstallCase::new(
+        "clean-install-upgrade-larch-release-step7-root",
+        "upgrade-larch",
+        "release-step7-root",
+    ),
+    CleanInstallCase::new("clean-install-upgrade-larch-run", "upgrade-larch", "run"),
+    CleanInstallCase::new(
+        "clean-install-upgrade-larch-sparse-dirs",
+        "upgrade-larch",
+        "sparse-dirs",
+    ),
+];
 
 #[test]
 fn representative_python_and_rust_commands_have_reviewed_parity() {
@@ -108,6 +229,145 @@ fn hung_command_fails_at_the_case_boundary() {
         .expect_err("hung command should fail the harness");
 
     assert!(error.contains("timed out after 50ms"));
+}
+
+#[test]
+fn rust_owned_selector_matrix_enters_through_verified_clean_install_script() {
+    let fixture = clean_install_fixture();
+    for case in CLEAN_INSTALL_CASES {
+        fs::write(&fixture.events, b"").expect("clear clean-install event log");
+        let output = run_clean_install_case(&fixture, *case, None);
+        assert!(
+            output.status.success(),
+            "{} failed: {}",
+            case.id,
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let events = fs::read_to_string(&fixture.events).expect("read clean-install events");
+        let lines: Vec<&str> = events.lines().collect();
+        assert_eq!(lines.first(), Some(&"--version"), "{}", case.id);
+        assert_eq!(lines.get(1), Some(&"bootstrap self-check"), "{}", case.id);
+        assert_eq!(
+            lines.get(2),
+            Some(&format!("{} {} --help", case.domain, case.verb).as_str()),
+            "{}",
+            case.id
+        );
+        assert_eq!(lines.len(), 3, "{}", case.id);
+        assert!(!fixture.root.join("bin/larch").exists(), "{}", case.id);
+    }
+}
+
+#[test]
+fn clean_install_validation_failures_precede_selector_dispatch() {
+    let fixture = clean_install_fixture();
+    let case = CLEAN_INSTALL_CASES[0];
+    for failure in ["version", "target", "bootstrap"] {
+        fs::write(&fixture.events, b"").expect("clear clean-install event log");
+        let output = run_clean_install_case(&fixture, case, Some(failure));
+        assert!(
+            !output.status.success(),
+            "{failure} unexpectedly dispatched"
+        );
+        let events = fs::read_to_string(&fixture.events).expect("read clean-install events");
+        assert!(
+            !events
+                .lines()
+                .any(|line| line == format!("{} {} --help", case.domain, case.verb)),
+            "{failure} reached selector dispatch"
+        );
+    }
+}
+
+struct CleanInstallFixture {
+    _temporary: TempDir,
+    root: PathBuf,
+    wrapper: PathBuf,
+    events: PathBuf,
+    binary: PathBuf,
+}
+
+fn clean_install_fixture() -> CleanInstallFixture {
+    let temporary = tempfile::tempdir().expect("clean-install tempdir");
+    let temporary_root = fs::canonicalize(temporary.path()).expect("canonical clean-install root");
+    let root = temporary_root.join("plugin");
+    let scripts = root.join("scripts");
+    let manifest_directory = root.join(".claude-plugin");
+    fs::create_dir_all(&scripts).expect("create clean-install scripts directory");
+    fs::create_dir_all(&manifest_directory).expect("create clean-install manifest directory");
+    fs::copy(
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("../../scripts/larch.sh"),
+        scripts.join("larch.sh"),
+    )
+    .expect("copy verified bootstrap script");
+    fs::write(
+        manifest_directory.join("plugin.json"),
+        format!(
+            "{{\n  \"name\": \"larch\",\n  \"version\": \"{}\"\n}}\n",
+            env!("CARGO_PKG_VERSION")
+        ),
+    )
+    .expect("write clean-install plugin manifest");
+    let wrapper = temporary_root.join("verified-larch");
+    fs::write(
+        &wrapper,
+        r#"#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> "$CLEAN_INSTALL_EVENTS"
+case "$CLEAN_INSTALL_FAILURE" in
+  version)
+    if [ "$1" = --version ]; then printf '%s\n' 'larch 0.0.0'; exit 0; fi
+    ;;
+  target)
+    if [ "$1" = bootstrap ]; then
+      if [ "$2" = self-check ]; then
+        "$REAL_LARCH" "$@" | sed 's/"target":"[^"]*"/"target":"wrong-target"/'
+        exit "$?"
+      fi
+    fi
+    ;;
+  bootstrap)
+    if [ "$1" = bootstrap ]; then
+      if [ "$2" = self-check ]; then exit 9; fi
+    fi
+    ;;
+esac
+exec "$REAL_LARCH" "$@"
+"#,
+    )
+    .expect("write verified binary wrapper");
+    #[cfg(unix)]
+    {
+        let mut permissions = fs::metadata(&wrapper)
+            .expect("read wrapper metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&wrapper, permissions).expect("make wrapper executable");
+    }
+    CleanInstallFixture {
+        events: temporary_root.join("events.log"),
+        binary: PathBuf::from(env!("CARGO_BIN_EXE_larch")),
+        _temporary: temporary,
+        root,
+        wrapper,
+    }
+}
+
+fn run_clean_install_case(
+    fixture: &CleanInstallFixture,
+    case: CleanInstallCase,
+    failure: Option<&str>,
+) -> std::process::Output {
+    let mut command = Command::new("/bin/bash");
+    command
+        .arg(fixture.root.join("scripts/larch.sh"))
+        .args([case.domain, case.verb, "--help"])
+        .env("CLAUDE_PLUGIN_ROOT", &fixture.root)
+        .env("LARCH_BINARY", &fixture.wrapper)
+        .env("REAL_LARCH", &fixture.binary)
+        .env("CLEAN_INSTALL_EVENTS", &fixture.events)
+        .env("CLEAN_INSTALL_FAILURE", failure.unwrap_or_default());
+    command.output().expect("run clean-install selector")
 }
 
 fn fixture_directory() -> PathBuf {

--- a/crates/larch-lint/data/command-registry.toml
+++ b/crates/larch-lint/data/command-registry.toml
@@ -2711,6 +2711,7 @@ implementation_parity = "complete"
 consumer_cutover = "complete"
 python_removal = "complete"
 migration_issue = 7764
+clean_install_test = "clean-install-gh-remote-repo"
 
 [[commands]]
 domain = "gh"
@@ -2723,6 +2724,7 @@ implementation_parity = "complete"
 consumer_cutover = "complete"
 python_removal = "complete"
 migration_issue = 7764
+clean_install_test = "clean-install-gh-resolve-repo"
 
 [[commands]]
 domain = "gh"
@@ -2735,6 +2737,7 @@ implementation_parity = "complete"
 consumer_cutover = "complete"
 python_removal = "complete"
 migration_issue = 7765
+clean_install_test = "clean-install-gh-run-logs"
 
 [[commands]]
 domain = "gh"
@@ -2747,6 +2750,7 @@ implementation_parity = "complete"
 consumer_cutover = "complete"
 python_removal = "complete"
 migration_issue = 7765
+clean_install_test = "clean-install-gh-workflow-path"
 
 [[commands]]
 domain = "git"
@@ -2759,6 +2763,7 @@ implementation_parity = "complete"
 consumer_cutover = "complete"
 python_removal = "complete"
 migration_issue = 7735
+clean_install_test = "clean-install-git-amend-add"
 
 [[commands]]
 domain = "git"
@@ -2771,6 +2776,7 @@ implementation_parity = "complete"
 consumer_cutover = "complete"
 python_removal = "complete"
 migration_issue = 7734
+clean_install_test = "clean-install-git-branch-info"
 
 [[commands]]
 domain = "git"
@@ -2783,6 +2789,7 @@ implementation_parity = "complete"
 consumer_cutover = "complete"
 python_removal = "complete"
 migration_issue = 7758
+clean_install_test = "clean-install-git-check-main-sync"
 
 [[commands]]
 domain = "git"
@@ -2795,6 +2802,7 @@ implementation_parity = "complete"
 consumer_cutover = "complete"
 python_removal = "complete"
 migration_issue = 7757
+clean_install_test = "clean-install-git-check-phantom-dirty"
 
 [[commands]]
 domain = "git"
@@ -2807,6 +2815,7 @@ implementation_parity = "complete"
 consumer_cutover = "complete"
 python_removal = "complete"
 migration_issue = 7734
+clean_install_test = "clean-install-git-check-remote-branch"
 
 [[commands]]
 domain = "git"
@@ -2819,6 +2828,7 @@ implementation_parity = "complete"
 consumer_cutover = "complete"
 python_removal = "complete"
 migration_issue = 7759
+clean_install_test = "clean-install-git-checkout-ours"
 
 [[commands]]
 domain = "git"
@@ -2831,6 +2841,7 @@ implementation_parity = "complete"
 consumer_cutover = "complete"
 python_removal = "complete"
 migration_issue = 7756
+clean_install_test = "clean-install-git-clean-tree"
 
 [[commands]]
 domain = "git"
@@ -2843,6 +2854,7 @@ implementation_parity = "complete"
 consumer_cutover = "complete"
 python_removal = "complete"
 migration_issue = 7735
+clean_install_test = "clean-install-git-commit"
 
 [[commands]]
 domain = "git"
@@ -2855,6 +2867,7 @@ implementation_parity = "complete"
 consumer_cutover = "complete"
 python_removal = "complete"
 migration_issue = 7756
+clean_install_test = "clean-install-git-conflict-files"
 
 [[commands]]
 domain = "git"
@@ -2867,6 +2880,7 @@ implementation_parity = "complete"
 consumer_cutover = "complete"
 python_removal = "complete"
 migration_issue = 7734
+clean_install_test = "clean-install-git-count-commits"
 
 [[commands]]
 domain = "git"
@@ -2879,6 +2893,7 @@ implementation_parity = "complete"
 consumer_cutover = "complete"
 python_removal = "complete"
 migration_issue = 7734
+clean_install_test = "clean-install-git-current-branch"
 
 [[commands]]
 domain = "git"
@@ -2891,6 +2906,7 @@ implementation_parity = "complete"
 consumer_cutover = "complete"
 python_removal = "complete"
 migration_issue = 7757
+clean_install_test = "clean-install-git-phantom-probe"
 
 [[commands]]
 domain = "git"
@@ -2903,6 +2919,7 @@ implementation_parity = "complete"
 consumer_cutover = "complete"
 python_removal = "complete"
 migration_issue = 7759
+clean_install_test = "clean-install-git-rebase-abort"
 
 [[commands]]
 domain = "git"
@@ -2915,6 +2932,7 @@ implementation_parity = "complete"
 consumer_cutover = "complete"
 python_removal = "complete"
 migration_issue = 7759
+clean_install_test = "clean-install-git-rebase-skip"
 
 [[commands]]
 domain = "git"
@@ -2927,6 +2945,7 @@ implementation_parity = "complete"
 consumer_cutover = "complete"
 python_removal = "complete"
 migration_issue = 7734
+clean_install_test = "clean-install-git-show-stage"
 
 [[commands]]
 domain = "git"
@@ -2939,6 +2958,7 @@ implementation_parity = "complete"
 consumer_cutover = "complete"
 python_removal = "complete"
 migration_issue = 7756
+clean_install_test = "clean-install-git-snapshot-untracked"
 
 [[commands]]
 domain = "git"
@@ -2951,6 +2971,7 @@ implementation_parity = "complete"
 consumer_cutover = "complete"
 python_removal = "complete"
 migration_issue = 7735
+clean_install_test = "clean-install-git-stage"
 
 [[commands]]
 domain = "git"
@@ -2963,6 +2984,7 @@ implementation_parity = "complete"
 consumer_cutover = "complete"
 python_removal = "complete"
 migration_issue = 7758
+clean_install_test = "clean-install-git-sync-local-main"
 
 [[commands]]
 domain = "hook"
@@ -4847,6 +4869,7 @@ implementation_parity = "complete"
 consumer_cutover = "complete"
 python_removal = "complete"
 migration_issue = 7749
+clean_install_test = "clean-install-plugin-read-version"
 
 [[commands]]
 domain = "pr"
@@ -5051,6 +5074,7 @@ implementation_parity = "complete"
 consumer_cutover = "complete"
 python_removal = "complete"
 migration_issue = 7760
+clean_install_test = "clean-install-push-branch"
 
 [[commands]]
 domain = "push"
@@ -5063,6 +5087,7 @@ implementation_parity = "complete"
 consumer_cutover = "complete"
 python_removal = "complete"
 migration_issue = 7762
+clean_install_test = "clean-install-push-checkpoint-probe"
 
 [[commands]]
 domain = "push"
@@ -5075,6 +5100,7 @@ implementation_parity = "complete"
 consumer_cutover = "complete"
 python_removal = "complete"
 migration_issue = 7760
+clean_install_test = "clean-install-push-force"
 
 [[commands]]
 domain = "push"
@@ -5087,6 +5113,7 @@ implementation_parity = "complete"
 consumer_cutover = "complete"
 python_removal = "complete"
 migration_issue = 7762
+clean_install_test = "clean-install-push-rebase"
 
 [[commands]]
 domain = "redact"
@@ -5195,6 +5222,7 @@ implementation_parity = "complete"
 consumer_cutover = "complete"
 python_removal = "complete"
 migration_issue = 7747
+clean_install_test = "clean-install-release-asset-candidate"
 
 [[commands]]
 domain = "release"
@@ -5219,6 +5247,7 @@ implementation_parity = "complete"
 consumer_cutover = "complete"
 python_removal = "complete"
 migration_issue = 7749
+clean_install_test = "clean-install-release-classify-bump"
 
 [[commands]]
 domain = "release"
@@ -5231,6 +5260,7 @@ implementation_parity = "complete"
 consumer_cutover = "complete"
 python_removal = "complete"
 migration_issue = 7747
+clean_install_test = "clean-install-release-collect-assets"
 
 [[commands]]
 domain = "release"
@@ -5267,6 +5297,7 @@ implementation_parity = "complete"
 consumer_cutover = "complete"
 python_removal = "complete"
 migration_issue = 7747
+clean_install_test = "clean-install-release-package-asset"
 
 [[commands]]
 domain = "release"
@@ -5279,6 +5310,7 @@ implementation_parity = "complete"
 consumer_cutover = "complete"
 python_removal = "complete"
 migration_issue = 7748
+clean_install_test = "clean-install-release-plugin-runtime"
 
 [[commands]]
 domain = "release"
@@ -5291,6 +5323,7 @@ implementation_parity = "complete"
 consumer_cutover = "complete"
 python_removal = "complete"
 migration_issue = 7749
+clean_install_test = "clean-install-release-prepare"
 
 [[commands]]
 domain = "release"
@@ -5327,6 +5360,7 @@ implementation_parity = "complete"
 consumer_cutover = "complete"
 python_removal = "complete"
 migration_issue = 7750
+clean_install_test = "clean-install-release-set-version"
 
 [[commands]]
 domain = "release"
@@ -5351,6 +5385,7 @@ implementation_parity = "complete"
 consumer_cutover = "complete"
 python_removal = "complete"
 migration_issue = 7747
+clean_install_test = "clean-install-release-validate-assets"
 
 [[commands]]
 domain = "release"
@@ -7259,6 +7294,7 @@ implementation_parity = "complete"
 consumer_cutover = "complete"
 python_removal = "complete"
 migration_issue = 7753
+clean_install_test = "clean-install-upgrade-larch-release-step7-root"
 
 [[commands]]
 domain = "upgrade-larch"
@@ -7271,6 +7307,7 @@ implementation_parity = "complete"
 consumer_cutover = "complete"
 python_removal = "complete"
 migration_issue = 7753
+clean_install_test = "clean-install-upgrade-larch-run"
 
 [[commands]]
 domain = "upgrade-larch"
@@ -7283,6 +7320,7 @@ implementation_parity = "complete"
 consumer_cutover = "complete"
 python_removal = "complete"
 migration_issue = 7753
+clean_install_test = "clean-install-upgrade-larch-sparse-dirs"
 
 [[commands]]
 domain = "validate-merged"

--- a/crates/larch-lint/src/cli.rs
+++ b/crates/larch-lint/src/cli.rs
@@ -38,7 +38,7 @@ enum Command {
     Registry(CommandRegistryCommand),
 }
 
-#[derive(Clone, Copy, Debug, Subcommand)]
+#[derive(Clone, Debug, Subcommand)]
 enum CommandRegistryCommand {
     /// Refresh Python command metadata and production caller inventory.
     Sync {
@@ -48,6 +48,12 @@ enum CommandRegistryCommand {
     },
     /// Render migration progress for the Chief migration issue.
     Report,
+    /// Compare issue command evidence with registry migration ownership.
+    Audit {
+        /// JSON input produced from canonical issue owner and plan parsers.
+        #[arg(long, value_name = "PATH")]
+        input: PathBuf,
+    },
 }
 
 /// Run the production command-line interface.
@@ -83,6 +89,17 @@ fn execute_command_registry(command: CommandRegistryCommand, root: Option<&Path>
             crate::render_command_progress(&repository).map(|report| {
                 print!("{report}");
             })
+        }
+        CommandRegistryCommand::Audit { input } => {
+            match crate::audit_migration_issue_commands(&repository, &input) {
+                Ok(output) => {
+                    if let Err(error) = render_findings(output.findings(), &mut std::io::stdout()) {
+                        return render_error(&error, &mut std::io::stderr()).as_i32();
+                    }
+                    return crate::finding_exit_code(output.findings()).as_i32();
+                }
+                Err(error) => Err(error),
+            }
         }
     };
     match result {

--- a/crates/larch-lint/src/command_registry.rs
+++ b/crates/larch-lint/src/command_registry.rs
@@ -20,6 +20,7 @@ const NAME: &str = "command-registry";
 const DESCRIPTION: &str =
     "Validate command ownership, migration state, and production caller inventory";
 const LEDGER_PATH: &str = "crates/larch-lint/data/command-registry.toml";
+const CLEAN_INSTALL_CASES_PATH: &str = "crates/larch-cli/tests/parity.rs";
 const PYTHON_REGISTRY_PATH: &str = "python/larch/cli.py";
 const HOOKS_PATH: &str = "hooks/hooks.json";
 const SCHEMA_VERSION: u32 = 1;
@@ -37,6 +38,12 @@ static PYTHON_KEY: LazyLock<Regex> = LazyLock::new(|| {
 static HOOK_PATH: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r#"\$\{CLAUDE_PLUGIN_ROOT\}/(?P<path>[^\"\s]+)"#)
         .expect("hook command path expression is valid")
+});
+static CLEAN_INSTALL_CASE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r#"CleanInstallCase::new\(\s*\"(?P<id>[a-z0-9-]+)\"\s*,\s*\"(?P<domain>[a-z0-9-]+)\"\s*,\s*\"(?P<verb>[a-z0-9-]+)\"\s*,?\s*\)"#,
+    )
+    .expect("clean-install parity case expression is valid")
 });
 
 pub static METADATA: RuleMetadata = RuleMetadata::new(
@@ -65,7 +72,14 @@ impl Rule for CommandRegistryRule {
         let known = ledger.commands.iter().map(CommandRecord::key).collect();
         let python_sources = read_python_sources(repository, &ledger)?;
         let callers = discover_callers(repository, &known, Some(&python_sources))?;
-        validate_ledger(&ledger, &python, &callers, &python_sources)
+        let clean_install_cases = read_clean_install_cases(repository)?;
+        validate_ledger(
+            &ledger,
+            &python,
+            &callers,
+            &python_sources,
+            &clean_install_cases,
+        )
     }
 }
 
@@ -111,6 +125,8 @@ struct CommandRecord {
     consumer_cutover: Completion,
     python_removal: Completion,
     migration_issue: u64,
+    #[serde(default)]
+    clean_install_test: Option<String>,
 }
 
 impl CommandRecord {
@@ -213,6 +229,46 @@ struct PythonCommand {
     machine_stdout: bool,
 }
 
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[serde(deny_unknown_fields)]
+struct MigrationIssueAuditInput {
+    schema_version: u32,
+    rollout_enabled: bool,
+    #[serde(default)]
+    issues: Vec<MigrationIssueRecord>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[serde(deny_unknown_fields)]
+struct MigrationIssueRecord {
+    number: u64,
+    state: IssueState,
+    executable_leaf: bool,
+    command: Option<CommandKeyRecord>,
+    #[serde(default)]
+    plan_commands: Vec<CommandKeyRecord>,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "lowercase")]
+enum IssueState {
+    Open,
+    Closed,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd)]
+#[serde(deny_unknown_fields)]
+struct CommandKeyRecord {
+    domain: String,
+    verb: String,
+}
+
+impl CommandKeyRecord {
+    fn key(&self) -> CommandKey {
+        CommandKey::new(&self.domain, &self.verb)
+    }
+}
+
 fn read_ledger(repository: &Repository) -> Result<Ledger, LintError> {
     let content = required_utf8(repository, LEDGER_PATH)?;
     parse_ledger(&content)
@@ -228,6 +284,54 @@ fn parse_ledger(content: &str) -> Result<Ledger, LintError> {
         )));
     }
     Ok(ledger)
+}
+
+fn read_clean_install_cases(
+    repository: &Repository,
+) -> Result<BTreeMap<String, CommandKey>, LintError> {
+    let source = required_utf8(repository, CLEAN_INSTALL_CASES_PATH)?;
+    let table_start = source.find("const CLEAN_INSTALL_CASES:").ok_or_else(|| {
+        LintError::new(format!(
+            "{CLEAN_INSTALL_CASES_PATH}: missing CLEAN_INSTALL_CASES table"
+        ))
+    })?;
+    let table_tail = &source[table_start..];
+    let table_end = table_tail.find("];").ok_or_else(|| {
+        LintError::new(format!(
+            "{CLEAN_INSTALL_CASES_PATH}: unterminated CLEAN_INSTALL_CASES table"
+        ))
+    })?;
+    let table = &table_tail[..table_end + 2];
+    let mut by_id = BTreeMap::new();
+    let mut by_selector = BTreeMap::new();
+    for captures in CLEAN_INSTALL_CASE.captures_iter(table) {
+        let id = captures["id"].to_owned();
+        let key = CommandKey::new(&captures["domain"], &captures["verb"]);
+        if by_id.insert(id.clone(), key.clone()).is_some() {
+            return Err(LintError::new(format!(
+                "{CLEAN_INSTALL_CASES_PATH}: duplicate clean-install fixture id {id}"
+            )));
+        }
+        if let Some(previous) = by_selector.insert(key.clone(), id.clone()) {
+            return Err(LintError::new(format!(
+                "{CLEAN_INSTALL_CASES_PATH}: duplicate clean-install selector {} in {previous} and {id}",
+                key.selector()
+            )));
+        }
+    }
+    let syntactic_rows = table.matches("CleanInstallCase::new(").count();
+    if syntactic_rows != by_id.len() {
+        return Err(LintError::new(format!(
+            "{CLEAN_INSTALL_CASES_PATH}: parsed {} of {syntactic_rows} clean-install fixture rows",
+            by_id.len()
+        )));
+    }
+    if by_id.is_empty() {
+        return Err(LintError::new(format!(
+            "{CLEAN_INSTALL_CASES_PATH}: clean-install fixture table is empty"
+        )));
+    }
+    Ok(by_id)
 }
 
 fn read_python_registry(
@@ -293,8 +397,10 @@ fn validate_ledger(
     python: &BTreeMap<CommandKey, PythonCommand>,
     live_callers: &[CallerRecord],
     python_sources: &[PythonSource],
+    clean_install_cases: &BTreeMap<String, CommandKey>,
 ) -> Result<RuleOutput, LintError> {
     let commands = command_map(ledger)?;
+    validate_clean_install_references(&commands, clean_install_cases)?;
     let callers = caller_map(&ledger.callers)?;
     validate_caller_selectors(&callers, &commands)?;
     let live_callers = caller_map(live_callers)?;
@@ -310,6 +416,13 @@ fn validate_ledger(
     }
     for (key, record) in &commands {
         validate_command_state(key, record, python.get(key), &callers, &mut findings);
+        validate_clean_install_coverage(
+            key,
+            record,
+            &live_callers,
+            clean_install_cases,
+            &mut findings,
+        );
         if record.python_removal == Completion::Complete {
             validate_python_retirement(key, record, python.get(key), python_sources, &mut findings);
         }
@@ -335,6 +448,9 @@ fn command_map(ledger: &Ledger) -> Result<BTreeMap<CommandKey, &CommandRecord>, 
                 command.key().selector()
             )));
         }
+        if let Some(fixture) = &command.clean_install_test {
+            validate_token("clean_install_test", fixture)?;
+        }
         let key = command.key();
         if commands.insert(key.clone(), command).is_some() {
             return Err(LintError::new(format!(
@@ -344,6 +460,55 @@ fn command_map(ledger: &Ledger) -> Result<BTreeMap<CommandKey, &CommandRecord>, 
         }
     }
     Ok(commands)
+}
+
+fn validate_clean_install_references(
+    commands: &BTreeMap<CommandKey, &CommandRecord>,
+    cases: &BTreeMap<String, CommandKey>,
+) -> Result<(), LintError> {
+    let mut claimed = BTreeMap::new();
+    for (key, command) in commands {
+        let Some(fixture) = &command.clean_install_test else {
+            continue;
+        };
+        if let Some(previous) = claimed.insert(fixture, key) {
+            return Err(LintError::new(format!(
+                "{LEDGER_PATH}: duplicate clean_install_test {fixture:?} for {} and {}",
+                previous.selector(),
+                key.selector()
+            )));
+        }
+        if !cases.contains_key(fixture) {
+            return Err(LintError::new(format!(
+                "{LEDGER_PATH}: {} references unknown clean_install_test {fixture:?}",
+                key.selector()
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_clean_install_coverage(
+    key: &CommandKey,
+    record: &CommandRecord,
+    callers: &BTreeMap<String, &CallerRecord>,
+    cases: &BTreeMap<String, CommandKey>,
+    findings: &mut Vec<Finding>,
+) {
+    if record.owner != Owner::Rust || matching_callers(key, callers, Runtime::Rust).is_empty() {
+        return;
+    }
+    let covered = record
+        .clean_install_test
+        .as_ref()
+        .and_then(|fixture| cases.get(fixture))
+        .is_some_and(|fixture_key| fixture_key == key);
+    if !covered {
+        findings.push(finding(format!(
+            "clean-install-coverage-missing {}",
+            key.selector()
+        )));
+    }
 }
 
 fn caller_map(callers: &[CallerRecord]) -> Result<BTreeMap<String, &CallerRecord>, LintError> {
@@ -1386,6 +1551,7 @@ pub fn sync_command_registry(
                 consumer_cutover: Completion::Pending,
                 python_removal: Completion::Pending,
                 migration_issue,
+                clean_install_test: None,
             });
         record.python_module.clone_from(&source.module);
         record.python_function.clone_from(&source.function);
@@ -1463,6 +1629,9 @@ fn render_ledger(ledger: &Ledger) -> String {
             command.python_removal.as_str()
         );
         let _ = writeln!(output, "migration_issue = {}", command.migration_issue);
+        if let Some(fixture) = &command.clean_install_test {
+            let _ = writeln!(output, "clean_install_test = {fixture:?}");
+        }
     }
     for caller in &ledger.callers {
         output.push_str("\n[[callers]]\n");
@@ -1485,6 +1654,99 @@ fn render_array(values: &[String]) -> String {
     )
 }
 
+/// Compare canonical issue command evidence with registry migration ownership.
+///
+/// # Errors
+///
+/// Returns an error when the audit input or command registry is malformed.
+pub fn audit_migration_issue_commands(
+    repository: &Repository,
+    input_path: &Path,
+) -> Result<RuleOutput, LintError> {
+    let content = fs::read_to_string(input_path).map_err(|error| {
+        LintError::new(format!(
+            "{}: cannot read migration issue audit input: {error}",
+            input_path.display()
+        ))
+    })?;
+    let input: MigrationIssueAuditInput = serde_json::from_str(&content).map_err(|error| {
+        LintError::new(format!(
+            "{}: invalid migration issue audit JSON: {error}",
+            input_path.display()
+        ))
+    })?;
+    if input.schema_version != 1 {
+        return Err(LintError::new(format!(
+            "{}: unsupported schema_version {}; expected 1",
+            input_path.display(),
+            input.schema_version
+        )));
+    }
+    let ledger = read_ledger(repository)?;
+    let commands = command_map(&ledger)?;
+    let mut issues = BTreeMap::new();
+    for issue in &input.issues {
+        if issue.number == 0 || issues.insert(issue.number, issue).is_some() {
+            return Err(LintError::new(format!(
+                "{}: issue numbers must be positive and unique",
+                input_path.display()
+            )));
+        }
+        if let Some(command) = &issue.command {
+            validate_token("audit command domain", &command.domain)?;
+            validate_token("audit command verb", &command.verb)?;
+        }
+        let mut previous = None;
+        for command in &issue.plan_commands {
+            validate_token("plan command domain", &command.domain)?;
+            validate_token("plan command verb", &command.verb)?;
+            if previous.is_some_and(|value| value >= command) {
+                return Err(LintError::new(format!(
+                    "{}: issue #{} plan_commands must be sorted and unique",
+                    input_path.display(),
+                    issue.number
+                )));
+            }
+            previous = Some(command);
+        }
+    }
+
+    let mut findings = BTreeSet::new();
+    for issue in &input.issues {
+        if let Some(command) = &issue.command {
+            let key = command.key();
+            let registry_matches = commands
+                .get(&key)
+                .is_some_and(|record| record.migration_issue == issue.number);
+            let plan_mentions = issue.plan_commands.binary_search(command).is_ok();
+            if !registry_matches || !plan_mentions {
+                let _ = findings.insert(migration_issue_drift(issue.number, &key));
+            }
+        }
+    }
+    if input.rollout_enabled {
+        for (key, record) in &commands {
+            let Some(issue) = issues.get(&record.migration_issue) else {
+                continue;
+            };
+            if issue.state != IssueState::Open || !issue.executable_leaf {
+                continue;
+            }
+            if issue.command.as_ref().map(CommandKeyRecord::key).as_ref() != Some(key) {
+                let _ = findings.insert(migration_issue_drift(issue.number, key));
+            }
+        }
+    }
+    Ok(RuleOutput::from_findings(findings.into_iter().collect()))
+}
+
+fn migration_issue_drift(issue: u64, key: &CommandKey) -> Finding {
+    finding(format!(
+        "migration-issue-command-drift issue=#{issue} command={}",
+        key.selector()
+    ))
+}
+
 /// Render deterministic Markdown progress data for the Chief migration issue.
 ///
 /// # Errors
@@ -1496,7 +1758,14 @@ pub fn render_command_progress(repository: &Repository) -> Result<String, LintEr
     let known = ledger.commands.iter().map(CommandRecord::key).collect();
     let python_sources = read_python_sources(repository, &ledger)?;
     let live_callers = discover_callers(repository, &known, Some(&python_sources))?;
-    let validation = validate_ledger(&ledger, &python, &live_callers, &python_sources)?;
+    let clean_install_cases = read_clean_install_cases(repository)?;
+    let validation = validate_ledger(
+        &ledger,
+        &python,
+        &live_callers,
+        &python_sources,
+        &clean_install_cases,
+    )?;
     if let Some(finding) = validation.findings().first() {
         return Err(LintError::new(format!(
             "cannot render progress from an invalid command registry: {finding}"

--- a/crates/larch-lint/src/lib.rs
+++ b/crates/larch-lint/src/lib.rs
@@ -18,7 +18,9 @@ mod rules {
 }
 
 pub use cli::run_cli;
-pub use command_registry::{render_command_progress, sync_command_registry};
+pub use command_registry::{
+    audit_migration_issue_commands, render_command_progress, sync_command_registry,
+};
 pub use metadata::{
     RuleMetadata, RuleRegistration, registered_rule_registry, validate_migration_ledger,
 };

--- a/crates/larch-lint/tests/command_registry.rs
+++ b/crates/larch-lint/tests/command_registry.rs
@@ -432,3 +432,209 @@ fn completed_python_removal_rejects_registration_definition_imports_and_calls() 
         .stdout(predicate::str::contains("false_positive.py").not())
         .stderr("");
 }
+
+#[test]
+fn live_rust_command_requires_a_matching_clean_install_fixture() {
+    let repository = TempRepo::new();
+    prepare(
+        &repository,
+        &command_row("rust", "complete", "complete", "complete"),
+    );
+    repository.write(
+        "skills/example/SKILL.md",
+        b"\"${CLAUDE_PLUGIN_ROOT}/scripts/larch.sh\" fixture run\n",
+    );
+    repository.commit_all();
+
+    TempRepo::command_from(repository.path())
+        .args(["rule", "command-registry"])
+        .assert()
+        .code(1)
+        .stdout(predicate::str::contains(
+            "clean-install-coverage-missing fixture run",
+        ))
+        .stderr("");
+}
+
+#[test]
+fn clean_install_fixture_references_reject_unknown_duplicate_and_malformed_ids() {
+    let unknown = TempRepo::new();
+    prepare(
+        &unknown,
+        &format!(
+            "{}clean_install_test = \"missing-fixture\"\n",
+            command_row("python", "pending", "pending", "pending")
+        ),
+    );
+    unknown.commit_all();
+    TempRepo::command_from(unknown.path())
+        .args(["rule", "command-registry"])
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains(
+            "references unknown clean_install_test \"missing-fixture\"",
+        ));
+
+    let malformed = TempRepo::new();
+    prepare(
+        &malformed,
+        &format!(
+            "{}clean_install_test = \"Bad Fixture\"\n",
+            command_row("python", "pending", "pending", "pending")
+        ),
+    );
+    malformed.commit_all();
+    TempRepo::command_from(malformed.path())
+        .args(["rule", "command-registry"])
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("invalid clean_install_test token"));
+
+    let duplicate = TempRepo::new();
+    let mut duplicate_ledger = format!(
+        "{}clean_install_test = \"clean-install-fixture-run\"\n",
+        command_row("python", "pending", "pending", "pending")
+    );
+    let second = format!(
+        "{}clean_install_test = \"clean-install-fixture-run\"\n",
+        command_row_for(
+            "fixture", "other", "fixture", "other", "python", "pending", "pending", "pending",
+        )
+    );
+    append_command(&mut duplicate_ledger, &second);
+    prepare(&duplicate, &duplicate_ledger);
+    duplicate.commit_all();
+    TempRepo::command_from(duplicate.path())
+        .args(["rule", "command-registry"])
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains(
+            "duplicate clean_install_test \"clean-install-fixture-run\"",
+        ));
+}
+
+#[test]
+fn clean_install_fixture_table_rejects_duplicate_selectors_and_malformed_rows() {
+    let duplicate = TempRepo::new();
+    duplicate.write(
+        "crates/larch-cli/tests/parity.rs",
+        b"const CLEAN_INSTALL_CASES: &[CleanInstallCase] = &[\nCleanInstallCase::new(\"first\", \"fixture\", \"run\"),\nCleanInstallCase::new(\"second\", \"fixture\", \"run\"),\n];\n",
+    );
+    duplicate.commit_all();
+    TempRepo::command_from(duplicate.path())
+        .args(["rule", "command-registry"])
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains(
+            "duplicate clean-install selector fixture run",
+        ));
+
+    let malformed = TempRepo::new();
+    malformed.write(
+        "crates/larch-cli/tests/parity.rs",
+        b"const CLEAN_INSTALL_CASES: &[CleanInstallCase] = &[CleanInstallCase::new(\"Bad Fixture\", \"fixture\", \"run\")];\n",
+    );
+    malformed.commit_all();
+    TempRepo::command_from(malformed.path())
+        .args(["rule", "command-registry"])
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains(
+            "parsed 0 of 1 clean-install fixture rows",
+        ));
+}
+
+#[test]
+fn migration_issue_audit_checks_both_directions_and_plan_mentions() {
+    let repository = TempRepo::new();
+    repository.commit_all();
+    let input = repository.path().join("audit.json");
+    fs::write(
+        &input,
+        r#"{"schema_version":1,"rollout_enabled":true,"issues":[{"number":7661,"state":"open","executable_leaf":true,"command":{"domain":"fixture","verb":"run"},"plan_commands":[{"domain":"fixture","verb":"run"}]}]}"#,
+    )
+    .expect("write audit input");
+    TempRepo::command_from(repository.path())
+        .args([
+            "command-registry",
+            "audit",
+            "--input",
+            input.to_str().expect("UTF-8 input path"),
+        ])
+        .assert()
+        .success()
+        .stdout("")
+        .stderr("");
+
+    fs::write(
+        &input,
+        r#"{"schema_version":1,"rollout_enabled":true,"issues":[{"number":7661,"state":"open","executable_leaf":true,"command":{"domain":"fixture","verb":"run"},"plan_commands":[]}]}"#,
+    )
+    .expect("write missing-plan audit input");
+    TempRepo::command_from(repository.path())
+        .args([
+            "command-registry",
+            "audit",
+            "--input",
+            input.to_str().expect("UTF-8 input path"),
+        ])
+        .assert()
+        .code(1)
+        .stdout(predicate::str::contains(
+            "migration-issue-command-drift issue=#7661 command=fixture run",
+        ));
+
+    fs::write(
+        &input,
+        r#"{"schema_version":1,"rollout_enabled":true,"issues":[{"number":7661,"state":"open","executable_leaf":true,"command":null,"plan_commands":[]}]}"#,
+    )
+    .expect("write stale-registry audit input");
+    TempRepo::command_from(repository.path())
+        .args([
+            "command-registry",
+            "audit",
+            "--input",
+            input.to_str().expect("UTF-8 input path"),
+        ])
+        .assert()
+        .code(1)
+        .stdout(predicate::str::contains(
+            "migration-issue-command-drift issue=#7661 command=fixture run",
+        ));
+
+    fs::write(
+        &input,
+        r#"{"schema_version":1,"rollout_enabled":false,"issues":[{"number":7661,"state":"open","executable_leaf":true,"command":{"domain":"fixture","verb":"missing"},"plan_commands":[{"domain":"fixture","verb":"missing"}]}]}"#,
+    )
+    .expect("write missing-selector audit input");
+    TempRepo::command_from(repository.path())
+        .args([
+            "command-registry",
+            "audit",
+            "--input",
+            input.to_str().expect("UTF-8 input path"),
+        ])
+        .assert()
+        .code(1)
+        .stdout(predicate::str::contains(
+            "migration-issue-command-drift issue=#7661 command=fixture missing",
+        ));
+
+    fs::write(
+        &input,
+        r#"{"schema_version":1,"rollout_enabled":false,"issues":[{"number":9999,"state":"open","executable_leaf":true,"command":{"domain":"fixture","verb":"run"},"plan_commands":[{"domain":"fixture","verb":"run"}]}]}"#,
+    )
+    .expect("write wrong-issue audit input");
+    TempRepo::command_from(repository.path())
+        .args([
+            "command-registry",
+            "audit",
+            "--input",
+            input.to_str().expect("UTF-8 input path"),
+        ])
+        .assert()
+        .code(1)
+        .stdout(predicate::str::contains(
+            "migration-issue-command-drift issue=#9999 command=fixture run",
+        ));
+}

--- a/crates/larch-lint/tests/support/mod.rs
+++ b/crates/larch-lint/tests/support/mod.rs
@@ -106,6 +106,10 @@ fn seed_tracked_tree(repository: &TempRepo) {
     );
     repository.write("hooks/hooks.json", b"{\"hooks\": {}}\n");
     repository.write(
+        "crates/larch-cli/tests/parity.rs",
+        b"const CLEAN_INSTALL_CASES: &[CleanInstallCase] = &[CleanInstallCase::new(\"clean-install-fixture-run\", \"fixture\", \"run\")];\n",
+    );
+    repository.write(
         "crates/larch-lint/data/command-registry.toml",
         b"schema_version = 1\n\n[[commands]]\ndomain = \"fixture\"\nverb = \"run\"\npython_module = \"fixture\"\npython_function = \"main\"\nmachine_stdout = false\nowner = \"python\"\nimplementation_parity = \"pending\"\nconsumer_cutover = \"pending\"\npython_removal = \"pending\"\nmigration_issue = 7661\n",
     );

--- a/docs/issue-anchored-plan.md
+++ b/docs/issue-anchored-plan.md
@@ -163,6 +163,16 @@ Independent pieces remain independent. A child issue still requires its own
 `/design` and Gate C approval before it is `[DESIGNED]` or ready for
 `/implement`.
 
+### Command migration evidence
+
+A command-migration leaf uses its canonical `larch:owners` block to carry one
+`COMMAND<TAB><domain><TAB><verb>` row. Its plan names the same selector as
+`<domain> <verb>`. `migration_governance.build_command_audit_issue` reads the
+owner row through `issue_wire.parse_owner_block`, extracts exact registry
+selector mentions from the `larch:plan` block, and emits typed evidence for
+the Rust command-registry audit. The audit requires the selector's
+`migration_issue` to equal the issue number in both directions after rollout.
+
 ## Design Pause Block Format
 
 `/design` pause/resume uses a second paired issue-body marker:

--- a/docs/linting.md
+++ b/docs/linting.md
@@ -77,8 +77,13 @@ validation:
 
 ```bash
 cargo test --locked --package larch-lint --test command_registry
+cargo test --locked --package larch-cli --test parity
 cargo run --quiet --locked --package larch-lint -- rule command-registry
 ```
+
+The focused lint validates `clean_install_test` references against the shared
+parity matrix. Use `command-registry audit --input INPUT.json` for typed
+issue-to-registry parity evidence.
 
 ### Python complexity ratchet
 

--- a/docs/rust-command-registry.md
+++ b/docs/rust-command-registry.md
@@ -3,7 +3,8 @@
 `crates/larch-lint/data/command-registry.toml` is the migration source of
 truth for larch commands and production callers. Each command pair appears
 once. Its row records the current owner, machine-stdout contract, responsible
-migration issue, implementation parity, consumer cutover, and Python removal.
+migration issue, implementation parity, consumer cutover, Python removal, and
+an optional `clean_install_test` fixture ID.
 
 ## Update workflow
 
@@ -28,6 +29,14 @@ Use one workflow for registry or caller changes:
    cargo run --quiet --locked --package larch-lint -- command-registry report
    ```
 
+5. For issue-registry parity audits, build schema-v1 JSON with
+   `migration_governance.build_command_audit_issue` and
+   `render_command_audit_input`, then run:
+
+   ```bash
+   cargo run --quiet --locked --package larch-lint -- command-registry audit --input INPUT.json
+   ```
+
 The caller ledger inventories `skill`, `hook`, `script`, `ci`, `agent`, and
 `python-runtime` paths. Python modules that build a command with the shared
 `larch.core.repo_roots.larch_entrypoint` resolver are Rust callers because the
@@ -37,7 +46,19 @@ unexecuted string literals.
 
 The rule fails for missing or duplicate command rows, stale Python target or
 machine-stdout metadata, invalid status combinations, caller drift, unknown
-caller selectors, and incomplete Python retirement evidence.
+caller selectors, incomplete Python retirement evidence, and missing
+clean-install coverage. Every Rust-owned command with a production caller must
+name one unique fixture from `CLEAN_INSTALL_CASES` in
+`crates/larch-cli/tests/parity.rs`. The shared matrix starts without
+`bin/larch`, validates the local binary version and target through
+`scripts/larch.sh`, and reaches the named Rust selector.
+
+The clean-install diagnostic is
+`clean-install-coverage-missing <domain> <verb>`. The issue audit reports
+`migration-issue-command-drift issue=#N command=<domain> <verb>` when a
+canonical issue `COMMAND` row, its plan mention, or the registry's
+`migration_issue` disagrees. Registry-to-issue checks apply only to open
+executable leaves after the audit input enables rollout.
 
 ## State transitions
 

--- a/plugin/docs/issue-anchored-plan.md
+++ b/plugin/docs/issue-anchored-plan.md
@@ -163,6 +163,16 @@ Independent pieces remain independent. A child issue still requires its own
 `/design` and Gate C approval before it is `[DESIGNED]` or ready for
 `/implement`.
 
+### Command migration evidence
+
+A command-migration leaf uses its canonical `larch:owners` block to carry one
+`COMMAND<TAB><domain><TAB><verb>` row. Its plan names the same selector as
+`<domain> <verb>`. `migration_governance.build_command_audit_issue` reads the
+owner row through `issue_wire.parse_owner_block`, extracts exact registry
+selector mentions from the `larch:plan` block, and emits typed evidence for
+the Rust command-registry audit. The audit requires the selector's
+`migration_issue` to equal the issue number in both directions after rollout.
+
 ## Design Pause Block Format
 
 `/design` pause/resume uses a second paired issue-body marker:

--- a/plugin/docs/linting.md
+++ b/plugin/docs/linting.md
@@ -77,8 +77,13 @@ validation:
 
 ```bash
 cargo test --locked --package larch-lint --test command_registry
+cargo test --locked --package larch-cli --test parity
 cargo run --quiet --locked --package larch-lint -- rule command-registry
 ```
+
+The focused lint validates `clean_install_test` references against the shared
+parity matrix. Use `command-registry audit --input INPUT.json` for typed
+issue-to-registry parity evidence.
 
 ### Python complexity ratchet
 

--- a/plugin/python/larch/issue/migration_governance.py
+++ b/plugin/python/larch/issue/migration_governance.py
@@ -162,6 +162,25 @@ class LeaseAuditFinding:
     cleanup_command: str
 
 
+@dataclass(frozen=True, order=True)
+class CommandAuditKey:
+    """One normalized command selector passed to the Rust registry audit."""
+
+    domain: str
+    verb: str
+
+
+@dataclass(frozen=True)
+class CommandAuditIssue:
+    """Canonical issue evidence for migration-issue command parity."""
+
+    number: int
+    state: str
+    executable_leaf: bool
+    command: CommandAuditKey | None
+    plan_commands: tuple[CommandAuditKey, ...]
+
+
 @dataclass(frozen=True)
 class GovernanceGateVerdict:
     """Combined blocker-parity and receipt-freshness gate used at all four sites."""
@@ -215,6 +234,85 @@ def parse_native_blocker_refs(*, body: str) -> tuple[int, ...]:
 def parse_owner_rows(*, body: str) -> tuple[str, ...]:
     """Return exact owner rows through the canonical wire parser."""
     return issue_wire.parse_owner_block(body=body).raw_rows
+
+
+def build_command_audit_issue(
+    *,
+    number: int,
+    state: str,
+    executable_leaf: bool,
+    body: str,
+    registry_commands: Sequence[CommandAuditKey],
+) -> CommandAuditIssue:
+    """Build typed Rust audit evidence through canonical issue parsers."""
+    normalized_state = _normalize_state(state)
+    if number <= 0 or normalized_state not in {"open", "closed"}:
+        raise ShipError("invalid-command-audit-issue")
+    parsed_owner = issue_wire.parse_owner_block(body=body)
+    command = (
+        CommandAuditKey(parsed_owner.block.domain, parsed_owner.block.verb)
+        if parsed_owner.block is not None
+        else None
+    )
+    plan_inner, malformed = parse_named_block(body=body, marker="plan")
+    plan_commands: tuple[CommandAuditKey, ...] = ()
+    if not malformed and plan_inner is not None:
+        plan_commands = tuple(
+            sorted(
+                {
+                    selector
+                    for selector in registry_commands
+                    if _plan_mentions_command(plan_inner=plan_inner, selector=selector)
+                }
+            )
+        )
+    return CommandAuditIssue(
+        number=number,
+        state=normalized_state,
+        executable_leaf=executable_leaf,
+        command=command,
+        plan_commands=plan_commands,
+    )
+
+
+def _plan_mentions_command(*, plan_inner: str, selector: CommandAuditKey) -> bool:
+    expression = re.compile(
+        rf"(?<![a-z0-9-]){re.escape(selector.domain)}[ \t]+{re.escape(selector.verb)}(?![a-z0-9-])"
+    )
+    return expression.search(plan_inner) is not None
+
+
+def render_command_audit_input(
+    *, rows: Sequence[CommandAuditIssue], rollout_enabled: bool
+) -> str:
+    """Render stable schema-v1 JSON for ``command-registry audit``."""
+    by_number: dict[int, CommandAuditIssue] = {}
+    for row in rows:
+        if row.number in by_number:
+            raise ShipError("duplicate-command-audit-issue")
+        by_number[row.number] = row
+    payload: dict[str, object] = {
+        "schema_version": 1,
+        "rollout_enabled": rollout_enabled,
+        "issues": [
+            {
+                "number": row.number,
+                "state": row.state,
+                "executable_leaf": row.executable_leaf,
+                "command": (
+                    {"domain": row.command.domain, "verb": row.command.verb}
+                    if row.command is not None
+                    else None
+                ),
+                "plan_commands": [
+                    {"domain": command.domain, "verb": command.verb}
+                    for command in row.plan_commands
+                ],
+            }
+            for row in sorted(by_number.values(), key=lambda item: item.number)
+        ],
+    }
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")) + "\n"
 
 
 def owner_keys_from_rows(*, rows: Sequence[str]) -> tuple[str, ...]:
@@ -1023,6 +1121,8 @@ __all__ = [
     "REASON_UNDOCUMENTED_NATIVE",
     "RECEIPT_STALE_REASONS",
     "BlockerSnapshotRow",
+    "CommandAuditIssue",
+    "CommandAuditKey",
     "CommandResult",
     "FreshnessVerdict",
     "GovernanceGateVerdict",
@@ -1031,6 +1131,7 @@ __all__ = [
     "ParityVerdict",
     "PlanReceipt",
     "audit_stale_implementation_leases",
+    "build_command_audit_issue",
     "build_receipt_for_body",
     "compare_blocker_parity",
     "compute_base_scope_fingerprint",
@@ -1049,6 +1150,7 @@ __all__ = [
     "parse_receipt",
     "persist_plan_receipt",
     "read_issue_body",
+    "render_command_audit_input",
     "render_receipt",
     "strip_adjacent_plan_receipts",
     "strip_plan_receipt_lines",

--- a/python/larch/issue/migration_governance.py
+++ b/python/larch/issue/migration_governance.py
@@ -162,6 +162,25 @@ class LeaseAuditFinding:
     cleanup_command: str
 
 
+@dataclass(frozen=True, order=True)
+class CommandAuditKey:
+    """One normalized command selector passed to the Rust registry audit."""
+
+    domain: str
+    verb: str
+
+
+@dataclass(frozen=True)
+class CommandAuditIssue:
+    """Canonical issue evidence for migration-issue command parity."""
+
+    number: int
+    state: str
+    executable_leaf: bool
+    command: CommandAuditKey | None
+    plan_commands: tuple[CommandAuditKey, ...]
+
+
 @dataclass(frozen=True)
 class GovernanceGateVerdict:
     """Combined blocker-parity and receipt-freshness gate used at all four sites."""
@@ -215,6 +234,85 @@ def parse_native_blocker_refs(*, body: str) -> tuple[int, ...]:
 def parse_owner_rows(*, body: str) -> tuple[str, ...]:
     """Return exact owner rows through the canonical wire parser."""
     return issue_wire.parse_owner_block(body=body).raw_rows
+
+
+def build_command_audit_issue(
+    *,
+    number: int,
+    state: str,
+    executable_leaf: bool,
+    body: str,
+    registry_commands: Sequence[CommandAuditKey],
+) -> CommandAuditIssue:
+    """Build typed Rust audit evidence through canonical issue parsers."""
+    normalized_state = _normalize_state(state)
+    if number <= 0 or normalized_state not in {"open", "closed"}:
+        raise ShipError("invalid-command-audit-issue")
+    parsed_owner = issue_wire.parse_owner_block(body=body)
+    command = (
+        CommandAuditKey(parsed_owner.block.domain, parsed_owner.block.verb)
+        if parsed_owner.block is not None
+        else None
+    )
+    plan_inner, malformed = parse_named_block(body=body, marker="plan")
+    plan_commands: tuple[CommandAuditKey, ...] = ()
+    if not malformed and plan_inner is not None:
+        plan_commands = tuple(
+            sorted(
+                {
+                    selector
+                    for selector in registry_commands
+                    if _plan_mentions_command(plan_inner=plan_inner, selector=selector)
+                }
+            )
+        )
+    return CommandAuditIssue(
+        number=number,
+        state=normalized_state,
+        executable_leaf=executable_leaf,
+        command=command,
+        plan_commands=plan_commands,
+    )
+
+
+def _plan_mentions_command(*, plan_inner: str, selector: CommandAuditKey) -> bool:
+    expression = re.compile(
+        rf"(?<![a-z0-9-]){re.escape(selector.domain)}[ \t]+{re.escape(selector.verb)}(?![a-z0-9-])"
+    )
+    return expression.search(plan_inner) is not None
+
+
+def render_command_audit_input(
+    *, rows: Sequence[CommandAuditIssue], rollout_enabled: bool
+) -> str:
+    """Render stable schema-v1 JSON for ``command-registry audit``."""
+    by_number: dict[int, CommandAuditIssue] = {}
+    for row in rows:
+        if row.number in by_number:
+            raise ShipError("duplicate-command-audit-issue")
+        by_number[row.number] = row
+    payload: dict[str, object] = {
+        "schema_version": 1,
+        "rollout_enabled": rollout_enabled,
+        "issues": [
+            {
+                "number": row.number,
+                "state": row.state,
+                "executable_leaf": row.executable_leaf,
+                "command": (
+                    {"domain": row.command.domain, "verb": row.command.verb}
+                    if row.command is not None
+                    else None
+                ),
+                "plan_commands": [
+                    {"domain": command.domain, "verb": command.verb}
+                    for command in row.plan_commands
+                ],
+            }
+            for row in sorted(by_number.values(), key=lambda item: item.number)
+        ],
+    }
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")) + "\n"
 
 
 def owner_keys_from_rows(*, rows: Sequence[str]) -> tuple[str, ...]:
@@ -1023,6 +1121,8 @@ __all__ = [
     "REASON_UNDOCUMENTED_NATIVE",
     "RECEIPT_STALE_REASONS",
     "BlockerSnapshotRow",
+    "CommandAuditIssue",
+    "CommandAuditKey",
     "CommandResult",
     "FreshnessVerdict",
     "GovernanceGateVerdict",
@@ -1031,6 +1131,7 @@ __all__ = [
     "ParityVerdict",
     "PlanReceipt",
     "audit_stale_implementation_leases",
+    "build_command_audit_issue",
     "build_receipt_for_body",
     "compare_blocker_parity",
     "compute_base_scope_fingerprint",
@@ -1049,6 +1150,7 @@ __all__ = [
     "parse_receipt",
     "persist_plan_receipt",
     "read_issue_body",
+    "render_command_audit_input",
     "render_receipt",
     "strip_adjacent_plan_receipts",
     "strip_plan_receipt_lines",

--- a/python/tests/issue/test_migration_governance.py
+++ b/python/tests/issue/test_migration_governance.py
@@ -69,6 +69,73 @@ def test_parse_owner_rows_exact_block() -> None:
     assert mg.owner_keys_from_rows(rows=rows) == ("bar", "foo")
 
 
+def test_command_audit_input_uses_canonical_owner_and_plan_parsers() -> None:
+    registry = (
+        mg.CommandAuditKey("git", "commit"),
+        mg.CommandAuditKey("git", "stage"),
+    )
+    body = (
+        _owner_block(
+            "COMMAND\tgit\tcommit",
+            "REUSE\tgit-owner\t#7735\tcrates/larch-cli/src/git_commands.rs",
+        )
+        + compose_named_block(
+            marker="plan",
+            inner=_plan_inner().replace(
+                "1. Apply the change.",
+                "1. Move `git commit` through the verified entrypoint.\n"
+                "2. Do not treat `git stage-extra` as a selector mention.",
+            ),
+        )
+    )
+
+    row = mg.build_command_audit_issue(
+        number=7735,
+        state="OPEN",
+        executable_leaf=True,
+        body=body,
+        registry_commands=registry,
+    )
+
+    assert row.command == mg.CommandAuditKey("git", "commit")
+    assert row.plan_commands == (mg.CommandAuditKey("git", "commit"),)
+    payload = json.loads(
+        mg.render_command_audit_input(rows=(row,), rollout_enabled=True)
+    )
+    assert payload == {
+        "schema_version": 1,
+        "rollout_enabled": True,
+        "issues": [
+            {
+                "number": 7735,
+                "state": "open",
+                "executable_leaf": True,
+                "command": {"domain": "git", "verb": "commit"},
+                "plan_commands": [{"domain": "git", "verb": "commit"}],
+            }
+        ],
+    }
+
+
+def test_command_audit_input_is_stable_and_rejects_duplicate_issues() -> None:
+    first = mg.CommandAuditIssue(
+        number=8, state="closed", executable_leaf=False, command=None, plan_commands=()
+    )
+    second = mg.CommandAuditIssue(
+        number=7, state="open", executable_leaf=True, command=None, plan_commands=()
+    )
+    rendered = mg.render_command_audit_input(
+        rows=(first, second), rollout_enabled=False
+    )
+    assert rendered == mg.render_command_audit_input(
+        rows=(second, first), rollout_enabled=False
+    )
+    with pytest.raises(mg.ShipError, match="duplicate-command-audit-issue"):
+        _ = mg.render_command_audit_input(
+            rows=(first, first), rollout_enabled=False
+        )
+
+
 def test_blocker_parity_directions_and_closed_report_only() -> None:
     missing = mg.compare_blocker_parity(
         body_rows=(mg.BlockerSnapshotRow(10, "open", "t1"),),


### PR DESCRIPTION
## Summary

- Extend the command registry with clean-install fixture identities and validate every live Rust-owned selector against the shared parity matrix.
- Add typed issue-to-registry audit input and bidirectional migration-issue checks.
- Add the exact I-Cutover-1 invariant, security boundary notes, and supporting documentation.

## Self-review

An independent pass found that fixture coverage initially trusted persisted caller rows. That could let stale caller metadata suppress a missing-fixture finding. The implementation now derives coverage from freshly discovered production callers and adds regression coverage for malformed and duplicate fixture table rows.

## Validation

- cargo test --locked --package larch-lint --test command_registry
- cargo test --locked --package larch-cli --test parity
- python3 -m pytest python/tests/issue/test_migration_governance.py
- cargo run --quiet --locked --package larch-lint -- rule command-registry
- cargo run --quiet --locked --package larch-cli -- release plugin-runtime --check
- changed-file pre-commit suite
- focused Clippy and full package tests
- cargo deny check

Closes #7785