### PR TITLE
Fixes #7816: Define deterministic run archive format

### DIFF
--- a/crates/larch-cli/src/release_plugin_runtime.rs
+++ b/crates/larch-cli/src/release_plugin_runtime.rs
@@ -19,6 +19,7 @@ const DIRECT_FILES: &[&str] = &[
     "docs/linting.md",
     "docs/python-migration.md",
     "docs/review-agents.md",
+    "docs/run-log-archive.md",
     "docs/run-log-batches.md",
     "docs/run-log-cli.md",
     "docs/run-logs-required-files.tsv",

--- a/crates/larch-lint/data/command-registry.toml
+++ b/crates/larch-lint/data/command-registry.toml
@@ -5869,6 +5869,18 @@ migration_issue = 7687
 
 [[commands]]
 domain = "run-log"
+verb = "archive"
+python_module = "larch.report.run_log_archive"
+python_function = "main"
+machine_stdout = false
+owner = "python"
+implementation_parity = "pending"
+consumer_cutover = "pending"
+python_removal = "pending"
+migration_issue = 7687
+
+[[commands]]
+domain = "run-log"
 verb = "append"
 python_module = "larch.report.run_logs"
 python_function = "larch_log_append_main"

--- a/docs/run-log-archive.md
+++ b/docs/run-log-archive.md
@@ -1,0 +1,21 @@
+# Run-log archive format
+
+`python3 python/cli.py run-log archive` packages one completed, sanitized
+staging tree as `<run-id>.tar.gz`. The source tree is not changed.
+
+The archive is a POSIX PAX tar stream inside gzip. Every member has a
+normalized slash-separated NFC path. Members are ordered by that normalized
+path, use timestamp `0`, owner and group `0`, empty owner/group names, and
+normalized modes: `0644` for non-executable files and `0755` for directories
+and executable files. Gzip metadata uses timestamp `0` and no filename.
+
+Only regular files and directories are accepted. Symlinks, devices, FIFOs,
+sockets, reserved paths, and Unicode-normalization collisions fail closed.
+
+Each archive has a root `archive-manifest.json` member. It is UTF-8 canonical
+JSON with schema version `1`, the skill and run ID, and one entry per source
+tree member. File entries include their byte size and SHA-256 digest; directory
+entries record size `0` and no digest. The manifest does not describe itself,
+avoiding a recursive digest. The command emits SHA-256 digests for both the
+complete archive and its manifest so later publication can use the archive
+digest for idempotence.

--- a/docs/run-logs.md
+++ b/docs/run-logs.md
@@ -4,6 +4,9 @@ On a default `/implement --merge` run, a directory of structured log files is co
 
 Exceptions: `repo_unavailable=true` produces no committed log at all (`$IMPLEMENT_TMPDIR/execution-issues.md` is the only audit trail and is removed at cleanup). Fork dry-run mode (`--forked`) does not create a tracking issue. In all cases, session-derived content in `larch-logs/` passes through secrets and tmpdir-path redaction, but redaction is best-effort — operators should avoid pasting sensitive content into `/implement` prompts.
 
+The deterministic, versioned archive representation of one sanitized run tree is
+defined in [Run-log archive format](run-log-archive.md).
+
 ## Plan scope and committed logs
 
 Issue-anchored `larch:plan` blocks list the files that a `/implement` run is expected to touch. Retroactive maintenance across many runs under `larch-logs/design/` or `larch-logs/implement/` — for example URL normalization, typo fixes, or redaction-policy updates in historical committed logs — is not implied by plans that only target the **runtime plugin authority surface** defined in `AGENTS.md` (`skills/`, `agents/`, `hooks/`, `scripts/`, `.claude-plugin/`). Everything else in the repo (including `docs/`, `larch-logs/`, CI config, and `.claude/skills/`) is supplementary unless the tracking issue's `larch:plan` file list names it. Prefer a log-only PR for bulk `larch-logs/` edits so plan-to-diff review stays traceable; if bulk log edits ship on the same branch as changes under that runtime surface (or other paths not already listed in the plan), disclose the split in the PR title or body so reviewers can separate log churn from substantive work, and extend the issue `larch:plan` file list (or split the PR) when you add normative doc edits such as this file alongside unrelated implementation work.

--- a/plugin/docs/run-log-archive.md
+++ b/plugin/docs/run-log-archive.md
@@ -1,0 +1,21 @@
+# Run-log archive format
+
+`python3 python/cli.py run-log archive` packages one completed, sanitized
+staging tree as `<run-id>.tar.gz`. The source tree is not changed.
+
+The archive is a POSIX PAX tar stream inside gzip. Every member has a
+normalized slash-separated NFC path. Members are ordered by that normalized
+path, use timestamp `0`, owner and group `0`, empty owner/group names, and
+normalized modes: `0644` for non-executable files and `0755` for directories
+and executable files. Gzip metadata uses timestamp `0` and no filename.
+
+Only regular files and directories are accepted. Symlinks, devices, FIFOs,
+sockets, reserved paths, and Unicode-normalization collisions fail closed.
+
+Each archive has a root `archive-manifest.json` member. It is UTF-8 canonical
+JSON with schema version `1`, the skill and run ID, and one entry per source
+tree member. File entries include their byte size and SHA-256 digest; directory
+entries record size `0` and no digest. The manifest does not describe itself,
+avoiding a recursive digest. The command emits SHA-256 digests for both the
+complete archive and its manifest so later publication can use the archive
+digest for idempotence.

--- a/plugin/docs/run-logs.md
+++ b/plugin/docs/run-logs.md
@@ -4,6 +4,9 @@ On a default `/implement --merge` run, a directory of structured log files is co
 
 Exceptions: `repo_unavailable=true` produces no committed log at all (`$IMPLEMENT_TMPDIR/execution-issues.md` is the only audit trail and is removed at cleanup). Fork dry-run mode (`--forked`) does not create a tracking issue. In all cases, session-derived content in `larch-logs/` passes through secrets and tmpdir-path redaction, but redaction is best-effort — operators should avoid pasting sensitive content into `/implement` prompts.
 
+The deterministic, versioned archive representation of one sanitized run tree is
+defined in [Run-log archive format](run-log-archive.md).
+
 ## Plan scope and committed logs
 
 Issue-anchored `larch:plan` blocks list the files that a `/implement` run is expected to touch. Retroactive maintenance across many runs under `larch-logs/design/` or `larch-logs/implement/` — for example URL normalization, typo fixes, or redaction-policy updates in historical committed logs — is not implied by plans that only target the **runtime plugin authority surface** defined in `AGENTS.md` (`skills/`, `agents/`, `hooks/`, `scripts/`, `.claude-plugin/`). Everything else in the repo (including `docs/`, `larch-logs/`, CI config, and `.claude/skills/`) is supplementary unless the tracking issue's `larch:plan` file list names it. Prefer a log-only PR for bulk `larch-logs/` edits so plan-to-diff review stays traceable; if bulk log edits ship on the same branch as changes under that runtime surface (or other paths not already listed in the plan), disclose the split in the PR title or body so reviewers can separate log churn from substantive work, and extend the issue `larch:plan` file list (or split the PR) when you add normative doc edits such as this file alongside unrelated implementation work.

--- a/plugin/python/larch/cli.py
+++ b/plugin/python/larch/cli.py
@@ -649,6 +649,7 @@ _REGISTRY: dict[tuple[str, str], tuple[str, str, bool]] = {
     ("run-log", "flush"): ("larch.report.run_log_flush", "larch_log_flush_main", False),
     ("run-log", "refresh"): ("larch.report.run_log_flush", "refresh_run_logs_main", False),
     ("run-log", "storage-preflight"): ("larch.report.storage_config", "storage_preflight_main", True),
+    ("run-log", "archive"): ("larch.report.run_log_archive", "main", False),
     ("run-log", "validate-run-id"): ("larch.report.run_logs", "larch_log_validate_run_id_main", True),
     ("run-log", "capture-transcript"): ("larch.report.run_log_flush", "capture_transcript_main", False),
     ("run-log", "render-session-transcript"): ("larch.rendering.render_session_transcript", "main", False),

--- a/plugin/python/larch/report/run_log_archive.py
+++ b/plugin/python/larch/report/run_log_archive.py
@@ -1,0 +1,373 @@
+"""Deterministic, versioned archive format for one sanitized run-log tree.
+
+The archive contains regular files and explicit directories from a completed
+staging tree plus ``archive-manifest.json``.  The manifest is canonical JSON
+and records the normalized path, type, size, and SHA-256 digest of every
+source-tree member.  It deliberately excludes itself, avoiding a recursive
+digest while preserving an independently verifiable description of the run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import hashlib
+import json
+import os
+import stat
+import tarfile
+import tempfile
+import unicodedata
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import BinaryIO
+
+from larch import io as larch_io
+from larch.report.run_log_batch import validate_run_id_slug
+
+
+ARCHIVE_FORMAT: str = "larch-run-archive"
+ARCHIVE_MANIFEST_NAME: str = "archive-manifest.json"
+ARCHIVE_SCHEMA_VERSION: int = 1
+_CHUNK_SIZE: int = 1024 * 1024
+_RESERVED_MEMBER_NAMES: frozenset[str] = frozenset({ARCHIVE_MANIFEST_NAME})
+
+
+@dataclass(frozen=True)
+class ArchiveMember:
+    """One normalized source-tree member represented in the archive."""
+
+    path: str
+    kind: str
+    size: int
+    sha256: str | None
+    source: Path
+    mode: int
+
+    def manifest_record(self) -> dict[str, int | str | None]:
+        return {
+            "kind": self.kind,
+            "path": self.path,
+            "sha256": self.sha256,
+            "size": self.size,
+        }
+
+
+@dataclass(frozen=True)
+class RunArchiveManifest:
+    """Versioned, canonical description of archived source-tree members."""
+
+    skill: str
+    run_id: str
+    members: tuple[ArchiveMember, ...]
+
+    def to_bytes(self) -> bytes:
+        payload: dict[str, object] = {
+            "archive_format": ARCHIVE_FORMAT,
+            "member_count": len(self.members),
+            "members": [member.manifest_record() for member in self.members],
+            "run_id": self.run_id,
+            "schema_version": ARCHIVE_SCHEMA_VERSION,
+            "skill": self.skill,
+        }
+        return (json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")) + "\n").encode("utf-8")
+
+
+@dataclass(frozen=True)
+class RunArchiveResult:
+    """Paths and digests emitted by :func:`create_run_archive`."""
+
+    archive_path: Path
+    archive_sha256: str
+    manifest_sha256: str
+    member_count: int
+
+
+class _HashingReader:
+    """Binary reader wrapper that records exactly the bytes tarfile consumes."""
+
+    def __init__(self, handle: BinaryIO) -> None:
+        self._handle = handle
+        self._digest = hashlib.sha256()
+
+    def read(self, size: int = -1) -> bytes:
+        chunk: bytes = self._handle.read(size)
+        self._digest.update(chunk)
+        return chunk
+
+    def hexdigest(self) -> str:
+        return self._digest.hexdigest()
+
+
+def _normalized_member_path(relative: Path) -> str:
+    raw_parts: tuple[str, ...] = relative.parts
+    if not raw_parts:
+        raise ValueError("archive member path is empty")
+    normalized_parts: list[str] = []
+    for part in raw_parts:
+        normalized: str = unicodedata.normalize("NFC", part)
+        if not normalized or normalized in {".", ".."} or "/" in normalized or "\\" in normalized:
+            raise ValueError(f"ambiguous archive member path: {relative}")
+        try:
+            _ = normalized.encode("utf-8", "strict")
+        except UnicodeError as exc:
+            raise ValueError(f"archive member path is not UTF-8 encodable: {relative}") from exc
+        normalized_parts.append(normalized)
+    name: str = str(PurePosixPath(*normalized_parts))
+    if name in _RESERVED_MEMBER_NAMES:
+        raise ValueError(f"archive member path is reserved: {name}")
+    return name
+
+
+def _normalized_file_mode(mode: int) -> int:
+    return 0o755 if mode & 0o111 else 0o644
+
+
+def _digest_regular_file(path: Path, *, root: Path, expected: os.stat_result) -> str:
+    with _open_regular_member(path, root=root, expected=expected) as handle:
+        digest = hashlib.sha256()
+        while chunk := handle.read(_CHUNK_SIZE):
+            digest.update(chunk)
+    _assert_unchanged(path, expected=expected)
+    return digest.hexdigest()
+
+
+def _assert_unchanged(path: Path, *, expected: os.stat_result) -> None:
+    current: os.stat_result = path.stat(follow_symlinks=False)
+    if (
+        current.st_dev,
+        current.st_ino,
+        current.st_size,
+        current.st_mtime_ns,
+    ) != (
+        expected.st_dev,
+        expected.st_ino,
+        expected.st_size,
+        expected.st_mtime_ns,
+    ):
+        raise OSError(f"archive source changed while reading: {path}")
+
+
+def _open_regular_member(path: Path, *, root: Path, expected: os.stat_result) -> BinaryIO:
+    _ = larch_io.validate_trusted_directory(path.parent, root=root)
+    flags: int = os.O_RDONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    fd: int = os.open(path, flags)
+    try:
+        opened: os.stat_result = os.fstat(fd)
+        if not stat.S_ISREG(opened.st_mode):
+            raise OSError(f"unsupported archive member type: {path}")
+        if (opened.st_dev, opened.st_ino, opened.st_size) != (
+            expected.st_dev,
+            expected.st_ino,
+            expected.st_size,
+        ):
+            raise OSError(f"archive source changed while opening: {path}")
+        return os.fdopen(fd, "rb")
+    except OSError:
+        os.close(fd)
+        raise
+
+
+def _collect_members(staging_root: Path) -> tuple[ArchiveMember, ...]:
+    members: list[ArchiveMember] = []
+    normalized_names: set[str] = set()
+    for directory, child_dirs, child_files in os.walk(staging_root, topdown=True, followlinks=False):
+        directory_path: Path = Path(directory)
+        _ = larch_io.validate_trusted_directory(directory_path, root=staging_root)
+        child_dirs.sort()
+        child_files.sort()
+        for child_name in child_dirs:
+            source: Path = directory_path / child_name
+            entry: os.stat_result = source.stat(follow_symlinks=False)
+            if not stat.S_ISDIR(entry.st_mode):
+                raise OSError(f"unsupported archive member type: {source}")
+            relative: Path = source.relative_to(staging_root)
+            member_path: str = _normalized_member_path(relative)
+            _add_member_name(member_path, normalized_names)
+            members.append(ArchiveMember(member_path, "directory", 0, None, source, 0o755))
+        for child_name in child_files:
+            source = directory_path / child_name
+            entry = source.stat(follow_symlinks=False)
+            if not stat.S_ISREG(entry.st_mode):
+                raise OSError(f"unsupported archive member type: {source}")
+            relative = source.relative_to(staging_root)
+            member_path = _normalized_member_path(relative)
+            _add_member_name(member_path, normalized_names)
+            digest: str = _digest_regular_file(source, root=staging_root, expected=entry)
+            members.append(
+                ArchiveMember(
+                    member_path,
+                    "file",
+                    entry.st_size,
+                    digest,
+                    source,
+                    _normalized_file_mode(entry.st_mode),
+                )
+            )
+    return tuple(sorted(members, key=lambda member: member.path))
+
+
+def _add_member_name(name: str, known_names: set[str]) -> None:
+    if name in known_names:
+        raise ValueError(f"ambiguous archive member path after Unicode normalization: {name}")
+    known_names.add(name)
+
+
+def _tar_info(*, name: str, size: int, mode: int, kind: bytes) -> tarfile.TarInfo:
+    info = tarfile.TarInfo(name)
+    info.type = kind
+    info.size = size
+    info.mode = mode
+    info.mtime = 0
+    info.uid = 0
+    info.gid = 0
+    info.uname = ""
+    info.gname = ""
+    return info
+
+
+def _add_manifest_member(*, archive: tarfile.TarFile, manifest_bytes: bytes) -> None:
+    manifest_info: tarfile.TarInfo = _tar_info(
+        name=ARCHIVE_MANIFEST_NAME,
+        size=len(manifest_bytes),
+        mode=0o644,
+        kind=tarfile.REGTYPE,
+    )
+    archive.addfile(manifest_info, fileobj=_BytesReader(manifest_bytes))
+
+
+def _write_archive(*, archive_path: Path, manifest: RunArchiveManifest, staging_root: Path) -> None:
+    manifest_bytes: bytes = manifest.to_bytes()
+    with tempfile.NamedTemporaryFile(
+        dir=archive_path.parent,
+        prefix=f".{archive_path.name}.",
+        suffix=".tmp",
+        delete=False,
+    ) as temporary:
+        temporary_path: Path = Path(temporary.name)
+        try:
+            with gzip.GzipFile(
+                filename="",
+                mode="wb",
+                fileobj=temporary,
+                mtime=0,
+                compresslevel=9,
+            ) as compressed:
+                with tarfile.open(fileobj=compressed, mode="w", format=tarfile.PAX_FORMAT) as archive:
+                    manifest_written = False
+                    for member in manifest.members:
+                        if not manifest_written and member.path > ARCHIVE_MANIFEST_NAME:
+                            _add_manifest_member(archive=archive, manifest_bytes=manifest_bytes)
+                            manifest_written = True
+                        if member.kind == "directory":
+                            archive.addfile(
+                                _tar_info(name=member.path, size=0, mode=member.mode, kind=tarfile.DIRTYPE)
+                            )
+                            continue
+                        expected: os.stat_result = member.source.stat(follow_symlinks=False)
+                        with _open_regular_member(member.source, root=staging_root, expected=expected) as handle:
+                            reader = _HashingReader(handle)
+                            archive.addfile(
+                                _tar_info(name=member.path, size=member.size, mode=member.mode, kind=tarfile.REGTYPE),
+                                fileobj=reader,
+                            )
+                            if reader.hexdigest() != member.sha256:
+                                raise OSError(f"archive source changed while packaging: {member.source}")
+                        _assert_unchanged(member.source, expected=expected)
+                    if not manifest_written:
+                        _add_manifest_member(archive=archive, manifest_bytes=manifest_bytes)
+            temporary.flush()
+            os.fsync(temporary.fileno())
+            if archive_path.is_symlink():
+                raise OSError(f"refusing symlinked archive destination: {archive_path}")
+            _ = temporary_path.replace(archive_path)
+        finally:
+            temporary_path.unlink(missing_ok=True)
+
+
+class _BytesReader:
+    """Minimal deterministic byte reader for ``tarfile.addfile``."""
+
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+        self._offset = 0
+
+    def read(self, size: int = -1) -> bytes:
+        if size < 0:
+            size = len(self._data) - self._offset
+        chunk = self._data[self._offset : self._offset + size]
+        self._offset += len(chunk)
+        return chunk
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(_CHUNK_SIZE):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def create_run_archive(
+    *,
+    staging_root: Path,
+    output_dir: Path,
+    skill: str,
+    run_id: str,
+) -> RunArchiveResult:
+    """Create ``<run-id>.tar.gz`` from one final, sanitized staging tree.
+
+    The source tree is never modified.  Symlinks and every non-file,
+    non-directory source entry are rejected before an archive is published.
+    """
+    if not validate_run_id_slug(skill):
+        raise ValueError(f"invalid skill: {skill}")
+    if not validate_run_id_slug(run_id):
+        raise ValueError(f"invalid run-id: {run_id}")
+    root: Path = larch_io.validate_trusted_directory(staging_root)
+    requested_destination: Path = output_dir if output_dir.is_absolute() else Path.cwd() / output_dir
+    try:
+        _ = requested_destination.relative_to(root)
+    except ValueError:
+        pass
+    else:
+        raise ValueError("archive output directory must not be inside the staging tree")
+    destination_dir: Path = larch_io.ensure_trusted_directory(output_dir)
+    members: tuple[ArchiveMember, ...] = _collect_members(root)
+    manifest = RunArchiveManifest(skill=skill, run_id=run_id, members=members)
+    archive_path: Path = destination_dir / f"{run_id}.tar.gz"
+    _write_archive(archive_path=archive_path, manifest=manifest, staging_root=root)
+    return RunArchiveResult(
+        archive_path=archive_path,
+        archive_sha256=_sha256_file(archive_path),
+        manifest_sha256=hashlib.sha256(manifest.to_bytes()).hexdigest(),
+        member_count=len(members),
+    )
+
+
+def main(argv: Sequence[str]) -> int:
+    """Create one deterministic run archive and emit its machine envelope."""
+    parser = argparse.ArgumentParser(prog="cli.py run-log archive")
+    _ = parser.add_argument("--staging-root", required=True)
+    _ = parser.add_argument("--output-dir", required=True)
+    _ = parser.add_argument("--skill", required=True)
+    _ = parser.add_argument("--run-id", required=True)
+    args = parser.parse_args(argv)
+    try:
+        result = create_run_archive(
+            staging_root=Path(args.staging_root),
+            output_dir=Path(args.output_dir),
+            skill=args.skill,
+            run_id=args.run_id,
+        )
+    except (OSError, ValueError) as exc:
+        print(f"ERROR={exc}")
+        return 1
+    print(f"ARCHIVE_PATH={result.archive_path}")
+    print(f"ARCHIVE_SHA256={result.archive_sha256}")
+    print(f"MANIFEST_SHA256={result.manifest_sha256}")
+    print(f"MEMBER_COUNT={result.member_count}")
+    return 0

--- a/python/larch/cli.py
+++ b/python/larch/cli.py
@@ -649,6 +649,7 @@ _REGISTRY: dict[tuple[str, str], tuple[str, str, bool]] = {
     ("run-log", "flush"): ("larch.report.run_log_flush", "larch_log_flush_main", False),
     ("run-log", "refresh"): ("larch.report.run_log_flush", "refresh_run_logs_main", False),
     ("run-log", "storage-preflight"): ("larch.report.storage_config", "storage_preflight_main", True),
+    ("run-log", "archive"): ("larch.report.run_log_archive", "main", False),
     ("run-log", "validate-run-id"): ("larch.report.run_logs", "larch_log_validate_run_id_main", True),
     ("run-log", "capture-transcript"): ("larch.report.run_log_flush", "capture_transcript_main", False),
     ("run-log", "render-session-transcript"): ("larch.rendering.render_session_transcript", "main", False),

--- a/python/larch/report/run_log_archive.py
+++ b/python/larch/report/run_log_archive.py
@@ -1,0 +1,373 @@
+"""Deterministic, versioned archive format for one sanitized run-log tree.
+
+The archive contains regular files and explicit directories from a completed
+staging tree plus ``archive-manifest.json``.  The manifest is canonical JSON
+and records the normalized path, type, size, and SHA-256 digest of every
+source-tree member.  It deliberately excludes itself, avoiding a recursive
+digest while preserving an independently verifiable description of the run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import hashlib
+import json
+import os
+import stat
+import tarfile
+import tempfile
+import unicodedata
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import BinaryIO
+
+from larch import io as larch_io
+from larch.report.run_log_batch import validate_run_id_slug
+
+
+ARCHIVE_FORMAT: str = "larch-run-archive"
+ARCHIVE_MANIFEST_NAME: str = "archive-manifest.json"
+ARCHIVE_SCHEMA_VERSION: int = 1
+_CHUNK_SIZE: int = 1024 * 1024
+_RESERVED_MEMBER_NAMES: frozenset[str] = frozenset({ARCHIVE_MANIFEST_NAME})
+
+
+@dataclass(frozen=True)
+class ArchiveMember:
+    """One normalized source-tree member represented in the archive."""
+
+    path: str
+    kind: str
+    size: int
+    sha256: str | None
+    source: Path
+    mode: int
+
+    def manifest_record(self) -> dict[str, int | str | None]:
+        return {
+            "kind": self.kind,
+            "path": self.path,
+            "sha256": self.sha256,
+            "size": self.size,
+        }
+
+
+@dataclass(frozen=True)
+class RunArchiveManifest:
+    """Versioned, canonical description of archived source-tree members."""
+
+    skill: str
+    run_id: str
+    members: tuple[ArchiveMember, ...]
+
+    def to_bytes(self) -> bytes:
+        payload: dict[str, object] = {
+            "archive_format": ARCHIVE_FORMAT,
+            "member_count": len(self.members),
+            "members": [member.manifest_record() for member in self.members],
+            "run_id": self.run_id,
+            "schema_version": ARCHIVE_SCHEMA_VERSION,
+            "skill": self.skill,
+        }
+        return (json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")) + "\n").encode("utf-8")
+
+
+@dataclass(frozen=True)
+class RunArchiveResult:
+    """Paths and digests emitted by :func:`create_run_archive`."""
+
+    archive_path: Path
+    archive_sha256: str
+    manifest_sha256: str
+    member_count: int
+
+
+class _HashingReader:
+    """Binary reader wrapper that records exactly the bytes tarfile consumes."""
+
+    def __init__(self, handle: BinaryIO) -> None:
+        self._handle = handle
+        self._digest = hashlib.sha256()
+
+    def read(self, size: int = -1) -> bytes:
+        chunk: bytes = self._handle.read(size)
+        self._digest.update(chunk)
+        return chunk
+
+    def hexdigest(self) -> str:
+        return self._digest.hexdigest()
+
+
+def _normalized_member_path(relative: Path) -> str:
+    raw_parts: tuple[str, ...] = relative.parts
+    if not raw_parts:
+        raise ValueError("archive member path is empty")
+    normalized_parts: list[str] = []
+    for part in raw_parts:
+        normalized: str = unicodedata.normalize("NFC", part)
+        if not normalized or normalized in {".", ".."} or "/" in normalized or "\\" in normalized:
+            raise ValueError(f"ambiguous archive member path: {relative}")
+        try:
+            _ = normalized.encode("utf-8", "strict")
+        except UnicodeError as exc:
+            raise ValueError(f"archive member path is not UTF-8 encodable: {relative}") from exc
+        normalized_parts.append(normalized)
+    name: str = str(PurePosixPath(*normalized_parts))
+    if name in _RESERVED_MEMBER_NAMES:
+        raise ValueError(f"archive member path is reserved: {name}")
+    return name
+
+
+def _normalized_file_mode(mode: int) -> int:
+    return 0o755 if mode & 0o111 else 0o644
+
+
+def _digest_regular_file(path: Path, *, root: Path, expected: os.stat_result) -> str:
+    with _open_regular_member(path, root=root, expected=expected) as handle:
+        digest = hashlib.sha256()
+        while chunk := handle.read(_CHUNK_SIZE):
+            digest.update(chunk)
+    _assert_unchanged(path, expected=expected)
+    return digest.hexdigest()
+
+
+def _assert_unchanged(path: Path, *, expected: os.stat_result) -> None:
+    current: os.stat_result = path.stat(follow_symlinks=False)
+    if (
+        current.st_dev,
+        current.st_ino,
+        current.st_size,
+        current.st_mtime_ns,
+    ) != (
+        expected.st_dev,
+        expected.st_ino,
+        expected.st_size,
+        expected.st_mtime_ns,
+    ):
+        raise OSError(f"archive source changed while reading: {path}")
+
+
+def _open_regular_member(path: Path, *, root: Path, expected: os.stat_result) -> BinaryIO:
+    _ = larch_io.validate_trusted_directory(path.parent, root=root)
+    flags: int = os.O_RDONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    fd: int = os.open(path, flags)
+    try:
+        opened: os.stat_result = os.fstat(fd)
+        if not stat.S_ISREG(opened.st_mode):
+            raise OSError(f"unsupported archive member type: {path}")
+        if (opened.st_dev, opened.st_ino, opened.st_size) != (
+            expected.st_dev,
+            expected.st_ino,
+            expected.st_size,
+        ):
+            raise OSError(f"archive source changed while opening: {path}")
+        return os.fdopen(fd, "rb")
+    except OSError:
+        os.close(fd)
+        raise
+
+
+def _collect_members(staging_root: Path) -> tuple[ArchiveMember, ...]:
+    members: list[ArchiveMember] = []
+    normalized_names: set[str] = set()
+    for directory, child_dirs, child_files in os.walk(staging_root, topdown=True, followlinks=False):
+        directory_path: Path = Path(directory)
+        _ = larch_io.validate_trusted_directory(directory_path, root=staging_root)
+        child_dirs.sort()
+        child_files.sort()
+        for child_name in child_dirs:
+            source: Path = directory_path / child_name
+            entry: os.stat_result = source.stat(follow_symlinks=False)
+            if not stat.S_ISDIR(entry.st_mode):
+                raise OSError(f"unsupported archive member type: {source}")
+            relative: Path = source.relative_to(staging_root)
+            member_path: str = _normalized_member_path(relative)
+            _add_member_name(member_path, normalized_names)
+            members.append(ArchiveMember(member_path, "directory", 0, None, source, 0o755))
+        for child_name in child_files:
+            source = directory_path / child_name
+            entry = source.stat(follow_symlinks=False)
+            if not stat.S_ISREG(entry.st_mode):
+                raise OSError(f"unsupported archive member type: {source}")
+            relative = source.relative_to(staging_root)
+            member_path = _normalized_member_path(relative)
+            _add_member_name(member_path, normalized_names)
+            digest: str = _digest_regular_file(source, root=staging_root, expected=entry)
+            members.append(
+                ArchiveMember(
+                    member_path,
+                    "file",
+                    entry.st_size,
+                    digest,
+                    source,
+                    _normalized_file_mode(entry.st_mode),
+                )
+            )
+    return tuple(sorted(members, key=lambda member: member.path))
+
+
+def _add_member_name(name: str, known_names: set[str]) -> None:
+    if name in known_names:
+        raise ValueError(f"ambiguous archive member path after Unicode normalization: {name}")
+    known_names.add(name)
+
+
+def _tar_info(*, name: str, size: int, mode: int, kind: bytes) -> tarfile.TarInfo:
+    info = tarfile.TarInfo(name)
+    info.type = kind
+    info.size = size
+    info.mode = mode
+    info.mtime = 0
+    info.uid = 0
+    info.gid = 0
+    info.uname = ""
+    info.gname = ""
+    return info
+
+
+def _add_manifest_member(*, archive: tarfile.TarFile, manifest_bytes: bytes) -> None:
+    manifest_info: tarfile.TarInfo = _tar_info(
+        name=ARCHIVE_MANIFEST_NAME,
+        size=len(manifest_bytes),
+        mode=0o644,
+        kind=tarfile.REGTYPE,
+    )
+    archive.addfile(manifest_info, fileobj=_BytesReader(manifest_bytes))
+
+
+def _write_archive(*, archive_path: Path, manifest: RunArchiveManifest, staging_root: Path) -> None:
+    manifest_bytes: bytes = manifest.to_bytes()
+    with tempfile.NamedTemporaryFile(
+        dir=archive_path.parent,
+        prefix=f".{archive_path.name}.",
+        suffix=".tmp",
+        delete=False,
+    ) as temporary:
+        temporary_path: Path = Path(temporary.name)
+        try:
+            with gzip.GzipFile(
+                filename="",
+                mode="wb",
+                fileobj=temporary,
+                mtime=0,
+                compresslevel=9,
+            ) as compressed:
+                with tarfile.open(fileobj=compressed, mode="w", format=tarfile.PAX_FORMAT) as archive:
+                    manifest_written = False
+                    for member in manifest.members:
+                        if not manifest_written and member.path > ARCHIVE_MANIFEST_NAME:
+                            _add_manifest_member(archive=archive, manifest_bytes=manifest_bytes)
+                            manifest_written = True
+                        if member.kind == "directory":
+                            archive.addfile(
+                                _tar_info(name=member.path, size=0, mode=member.mode, kind=tarfile.DIRTYPE)
+                            )
+                            continue
+                        expected: os.stat_result = member.source.stat(follow_symlinks=False)
+                        with _open_regular_member(member.source, root=staging_root, expected=expected) as handle:
+                            reader = _HashingReader(handle)
+                            archive.addfile(
+                                _tar_info(name=member.path, size=member.size, mode=member.mode, kind=tarfile.REGTYPE),
+                                fileobj=reader,
+                            )
+                            if reader.hexdigest() != member.sha256:
+                                raise OSError(f"archive source changed while packaging: {member.source}")
+                        _assert_unchanged(member.source, expected=expected)
+                    if not manifest_written:
+                        _add_manifest_member(archive=archive, manifest_bytes=manifest_bytes)
+            temporary.flush()
+            os.fsync(temporary.fileno())
+            if archive_path.is_symlink():
+                raise OSError(f"refusing symlinked archive destination: {archive_path}")
+            _ = temporary_path.replace(archive_path)
+        finally:
+            temporary_path.unlink(missing_ok=True)
+
+
+class _BytesReader:
+    """Minimal deterministic byte reader for ``tarfile.addfile``."""
+
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+        self._offset = 0
+
+    def read(self, size: int = -1) -> bytes:
+        if size < 0:
+            size = len(self._data) - self._offset
+        chunk = self._data[self._offset : self._offset + size]
+        self._offset += len(chunk)
+        return chunk
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(_CHUNK_SIZE):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def create_run_archive(
+    *,
+    staging_root: Path,
+    output_dir: Path,
+    skill: str,
+    run_id: str,
+) -> RunArchiveResult:
+    """Create ``<run-id>.tar.gz`` from one final, sanitized staging tree.
+
+    The source tree is never modified.  Symlinks and every non-file,
+    non-directory source entry are rejected before an archive is published.
+    """
+    if not validate_run_id_slug(skill):
+        raise ValueError(f"invalid skill: {skill}")
+    if not validate_run_id_slug(run_id):
+        raise ValueError(f"invalid run-id: {run_id}")
+    root: Path = larch_io.validate_trusted_directory(staging_root)
+    requested_destination: Path = output_dir if output_dir.is_absolute() else Path.cwd() / output_dir
+    try:
+        _ = requested_destination.relative_to(root)
+    except ValueError:
+        pass
+    else:
+        raise ValueError("archive output directory must not be inside the staging tree")
+    destination_dir: Path = larch_io.ensure_trusted_directory(output_dir)
+    members: tuple[ArchiveMember, ...] = _collect_members(root)
+    manifest = RunArchiveManifest(skill=skill, run_id=run_id, members=members)
+    archive_path: Path = destination_dir / f"{run_id}.tar.gz"
+    _write_archive(archive_path=archive_path, manifest=manifest, staging_root=root)
+    return RunArchiveResult(
+        archive_path=archive_path,
+        archive_sha256=_sha256_file(archive_path),
+        manifest_sha256=hashlib.sha256(manifest.to_bytes()).hexdigest(),
+        member_count=len(members),
+    )
+
+
+def main(argv: Sequence[str]) -> int:
+    """Create one deterministic run archive and emit its machine envelope."""
+    parser = argparse.ArgumentParser(prog="cli.py run-log archive")
+    _ = parser.add_argument("--staging-root", required=True)
+    _ = parser.add_argument("--output-dir", required=True)
+    _ = parser.add_argument("--skill", required=True)
+    _ = parser.add_argument("--run-id", required=True)
+    args = parser.parse_args(argv)
+    try:
+        result = create_run_archive(
+            staging_root=Path(args.staging_root),
+            output_dir=Path(args.output_dir),
+            skill=args.skill,
+            run_id=args.run_id,
+        )
+    except (OSError, ValueError) as exc:
+        print(f"ERROR={exc}")
+        return 1
+    print(f"ARCHIVE_PATH={result.archive_path}")
+    print(f"ARCHIVE_SHA256={result.archive_sha256}")
+    print(f"MANIFEST_SHA256={result.manifest_sha256}")
+    print(f"MEMBER_COUNT={result.member_count}")
+    return 0

--- a/python/tests/report/test_run_log_archive.py
+++ b/python/tests/report/test_run_log_archive.py
@@ -1,0 +1,184 @@
+"""Tests for the deterministic run-log archive format."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tarfile
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from larch.report import run_log_archive
+
+
+def _write_tree(root: Path) -> None:
+    nested = root / "nested" / "caf\u00e9"
+    nested.mkdir(parents=True)
+    _ = (root / "empty.txt").write_bytes(b"")
+    executable = root / "run.sh"
+    _ = executable.write_text("#!/bin/sh\necho archive\n", encoding="utf-8")
+    executable.chmod(0o700)
+    _ = (nested / "large.bin").write_bytes((b"archive-data-" * 300_000) + b"end")
+    (root / "empty-dir").mkdir()
+
+
+def _manifest_from_archive(path: Path) -> dict[str, object]:
+    with tarfile.open(path, mode="r:gz") as archive:
+        manifest = archive.extractfile(run_log_archive.ARCHIVE_MANIFEST_NAME)
+        assert manifest is not None
+        decoded: object = json.loads(manifest.read().decode("utf-8"))
+        assert isinstance(decoded, dict)
+        return cast("dict[str, object]", decoded)
+
+
+def test_create_run_archive_is_byte_deterministic_and_preserves_source(tmp_path: Path) -> None:
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    _write_tree(staging)
+    before = {path.relative_to(staging): path.read_bytes() for path in staging.rglob("*") if path.is_file()}
+
+    first = run_log_archive.create_run_archive(
+        staging_root=staging,
+        output_dir=tmp_path / "first",
+        skill="implement",
+        run_id="run-archive-1",
+    )
+    os.utime(staging / "nested" / "caf\u00e9" / "large.bin", (1_700_000_000, 1_700_000_000))
+    (staging / "empty.txt").chmod(0o600)
+    second = run_log_archive.create_run_archive(
+        staging_root=staging,
+        output_dir=tmp_path / "second",
+        skill="implement",
+        run_id="run-archive-1",
+    )
+
+    assert first.archive_path.name == "run-archive-1.tar.gz"
+    assert first.archive_path.read_bytes() == second.archive_path.read_bytes()
+    assert first.archive_sha256 == hashlib.sha256(first.archive_path.read_bytes()).hexdigest()
+    assert {path.relative_to(staging): path.read_bytes() for path in staging.rglob("*") if path.is_file()} == before
+
+    manifest = _manifest_from_archive(first.archive_path)
+    assert manifest["archive_format"] == run_log_archive.ARCHIVE_FORMAT
+    assert manifest["schema_version"] == 1
+    members_value: object = manifest["members"]
+    assert isinstance(members_value, list)
+    members: list[object] = cast("list[object]", members_value)
+    records: list[dict[str, object]] = [cast("dict[str, object]", member) for member in members if isinstance(member, dict)]
+    assert len(records) == len(members)
+    large = next(record for record in records if record["path"] == "nested/caf\u00e9/large.bin")
+    assert large["size"] == (staging / "nested" / "caf\u00e9" / "large.bin").stat().st_size
+    assert large["sha256"] == hashlib.sha256((staging / "nested" / "caf\u00e9" / "large.bin").read_bytes()).hexdigest()
+
+
+def test_archive_members_use_normalized_metadata_and_include_empty_directories(tmp_path: Path) -> None:
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    _write_tree(staging)
+
+    result = run_log_archive.create_run_archive(
+        staging_root=staging,
+        output_dir=tmp_path / "archives",
+        skill="design",
+        run_id="run-archive-2",
+    )
+
+    with tarfile.open(result.archive_path, mode="r:gz") as archive:
+        members = archive.getmembers()
+        names = [member.name for member in members]
+        assert names == sorted(names)
+        assert run_log_archive.ARCHIVE_MANIFEST_NAME in names
+        assert "empty-dir" in names
+        executable = archive.getmember("run.sh")
+        assert executable.mode == 0o755
+        for member in members:
+            assert member.mtime == 0
+            assert member.uid == 0
+            assert member.gid == 0
+            assert member.uname == ""
+            assert member.gname == ""
+
+
+def test_archive_rejects_symlink_and_output_inside_staging(tmp_path: Path) -> None:
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    _ = (staging / "regular.txt").write_text("safe", encoding="utf-8")
+    (staging / "link.txt").symlink_to("regular.txt")
+
+    with pytest.raises(OSError, match="unsupported archive member type"):
+        _ = run_log_archive.create_run_archive(
+            staging_root=staging,
+            output_dir=tmp_path / "archives",
+            skill="review",
+            run_id="run-archive-3",
+        )
+
+    (staging / "link.txt").unlink()
+    with pytest.raises(ValueError, match="must not be inside the staging tree"):
+        _ = run_log_archive.create_run_archive(
+            staging_root=staging,
+            output_dir=staging / "archives",
+            skill="review",
+            run_id="run-archive-3",
+        )
+    assert not (staging / "archives").exists()
+
+
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="named pipes are unavailable on this platform")
+def test_archive_rejects_named_pipe(tmp_path: Path) -> None:
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    os.mkfifo(staging / "events.pipe")
+
+    with pytest.raises(OSError, match="unsupported archive member type"):
+        _ = run_log_archive.create_run_archive(
+            staging_root=staging,
+            output_dir=tmp_path / "archives",
+            skill="review",
+            run_id="run-archive-pipe",
+        )
+
+
+def test_archive_rejects_unicode_normalization_collision(tmp_path: Path) -> None:
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    _ = (staging / "caf\u00e9.txt").write_text("nfc", encoding="utf-8")
+    _ = (staging / "cafe\u0301.txt").write_text("nfd", encoding="utf-8")
+    if len(list(staging.iterdir())) != 2:
+        pytest.skip("filesystem normalizes Unicode filenames")
+
+    with pytest.raises(ValueError, match="Unicode normalization"):
+        _ = run_log_archive.create_run_archive(
+            staging_root=staging,
+            output_dir=tmp_path / "archives",
+            skill="review",
+            run_id="run-archive-4",
+        )
+
+
+def test_archive_main_emits_archive_and_manifest_digests(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    _ = (staging / "result.txt").write_text("completed", encoding="utf-8")
+
+    rc = run_log_archive.main(
+        [
+            "--staging-root",
+            str(staging),
+            "--output-dir",
+            str(tmp_path / "archives"),
+            "--skill",
+            "implement",
+            "--run-id",
+            "run-archive-5",
+        ]
+    )
+
+    output = capsys.readouterr().out
+    assert rc == 0
+    assert f"ARCHIVE_PATH={tmp_path / 'archives' / 'run-archive-5.tar.gz'}\n" in output
+    assert "ARCHIVE_SHA256=" in output
+    assert "MANIFEST_SHA256=" in output
+    assert "MEMBER_COUNT=1\n" in output


### PR DESCRIPTION
## Summary

- Define a versioned, deterministic POSIX PAX `.tar.gz` archive for one sanitized run tree.
- Include canonical `archive-manifest.json` member digests and archive metadata normalization.
- Reject links, named pipes, ambiguous paths, and staging-tree output destinations.

## Validation

- `cd python && python3 -m pytest tests/report/test_run_log_archive.py -q`
- Changed-file pre-commit checks, Pyright, and Pylint.

Fixes #7816
