### PR TITLE
Fixes #7842: Enforce Rust GitHub credential boundary

### DIFF
--- a/crates/larch-cli/tests/cli.rs
+++ b/crates/larch-cli/tests/cli.rs
@@ -289,16 +289,19 @@ fn workflow_path_preserves_its_legacy_stdout_contract() {
 
 #[test]
 fn run_logs_reports_missing_rust_credential_without_fallback() {
-    larch()
-        .env_remove("LARCH_GH_TOKEN")
-        .args(["gh", "run-logs", "--run-id", "7", "--repo", "owner/repo"])
-        .assert()
-        .code(1)
-        .stdout(predicate::str::contains(
-            "--- CI log (run 7, repo owner/repo): failed-job log shown.",
-        ))
-        .stdout(predicate::str::contains("LARCH_GH_TOKEN is required"))
-        .stderr("");
+    for generic_credential in ["GH_TOKEN", "GITHUB_TOKEN"] {
+        larch()
+            .env_remove("LARCH_GH_TOKEN")
+            .env(generic_credential, "generic-token-must-not-authenticate")
+            .args(["gh", "run-logs", "--run-id", "7", "--repo", "owner/repo"])
+            .assert()
+            .code(1)
+            .stdout(predicate::str::contains(
+                "--- CI log (run 7, repo owner/repo): failed-job log shown.",
+            ))
+            .stdout(predicate::str::contains("LARCH_GH_TOKEN is required"))
+            .stderr("");
+    }
 }
 
 #[test]

--- a/crates/larch-lint/src/rules/service_ownership.rs
+++ b/crates/larch-lint/src/rules/service_ownership.rs
@@ -41,7 +41,8 @@ const SERVICE_HOSTS: [&str; 4] = [
     "googleapis.com",
 ];
 /// Service credentials that must never enter a spawned child environment.
-const CHILD_CREDENTIALS: [&str; 4] = [
+const CHILD_CREDENTIALS: [&str; 5] = [
+    "LARCH_GH_TOKEN",
     "GH_TOKEN",
     "GITHUB_TOKEN",
     "GOOGLE_APPLICATION_CREDENTIALS",

--- a/crates/larch-lint/tests/service_ownership.rs
+++ b/crates/larch-lint/tests/service_ownership.rs
@@ -191,7 +191,7 @@ fn rejects_gcloud_and_credential_child_environments_in_production_shell() {
     let repository = TempRepo::new();
     repository.write(
         "scripts/deploy.sh",
-        b"#!/usr/bin/env bash\ngcloud auth login\nGH_TOKEN=\"$SECRET\" ./do-thing\nsudo gcloud components update\ncommand gcloud storage ls\nenv FOO=bar gcloud auth print-access-token\n",
+        b"#!/usr/bin/env bash\ngcloud auth login\nLARCH_GH_TOKEN=\"$SECRET\" ./do-thing\nGH_TOKEN=\"$SECRET\" ./do-thing\nsudo gcloud components update\ncommand gcloud storage ls\nenv FOO=bar gcloud auth print-access-token\n",
     );
     repository.write(
         "skills/example/SKILL.md",
@@ -207,16 +207,19 @@ fn rejects_gcloud_and_credential_child_environments_in_production_shell() {
             "scripts/deploy.sh:2: production runtime must not invoke the gcloud CLI; use the Rust Google adapter",
         ))
         .stdout(predicate::str::contains(
-            "scripts/deploy.sh:3: service credential GH_TOKEN must not enter a child environment",
+            "scripts/deploy.sh:3: service credential LARCH_GH_TOKEN must not enter a child environment",
         ))
         .stdout(predicate::str::contains(
-            "scripts/deploy.sh:4: production runtime must not invoke the gcloud CLI; use the Rust Google adapter",
+            "scripts/deploy.sh:4: service credential GH_TOKEN must not enter a child environment",
         ))
         .stdout(predicate::str::contains(
             "scripts/deploy.sh:5: production runtime must not invoke the gcloud CLI; use the Rust Google adapter",
         ))
         .stdout(predicate::str::contains(
             "scripts/deploy.sh:6: production runtime must not invoke the gcloud CLI; use the Rust Google adapter",
+        ))
+        .stdout(predicate::str::contains(
+            "scripts/deploy.sh:7: production runtime must not invoke the gcloud CLI; use the Rust Google adapter",
         ))
         .stdout(predicate::str::contains(
             "skills/example/SKILL.md:2: production runtime must not invoke the gcloud CLI; use the Rust Google adapter",


### PR DESCRIPTION
## Summary

- block forwarding `LARCH_GH_TOKEN` into child processes
- prove `GH_TOKEN` and `GITHUB_TOKEN` cannot authenticate Rust GitHub commands

## Verification

- `cargo test --locked -p larch-lint --test service_ownership`
- `cargo test --locked -p larch-cli --test cli run_logs_reports_missing_rust_credential_without_fallback`
- `cargo clippy --locked -p larch-lint --test service_ownership -- -D warnings`

Fixes #7842