### PR TITLE
Fixes #7839: Repair authenticated Actions log downloads

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -111,9 +111,9 @@ requires a JWT backend even though this adapter exposes token authentication
 only; larch selects AWS-LC because the alternative RustCrypto RSA graph carries
 an unpatched advisory. `aws-lc-sys` builds its bundled C and assembly with CMake
 and a platform C compiler; it adds no dynamic system-library requirement and
-is built by the existing four-target release matrix. Automatic redirects and
-retries are disabled. Requests use fixed `User-Agent`, GitHub JSON `Accept`,
-and API-version headers. The API and upload bases are both pinned to
+is built by the existing four-target release matrix. Redirects and retries are
+disabled. Larch sets `User-Agent` and `Accept`; pinned Octocrab supplies one
+API-version header. Both bases are pinned to
 `https://api.github.com/`; response-supplied
 continuations must remain HTTPS on the same approved origin. The host policy
 also recognizes `https://github.com` for later typed download boundaries but
@@ -276,8 +276,8 @@ unexpected content types, and oversize or incomplete streams. Redirect hosts
 are limited to the documented `*.actions.githubusercontent.com` suffix and the
 `productionresultssa<digits>.blob.core.windows.net` storage family. Octocrab
 adds authorization only for `api.github.com`, so cross-origin log requests do
-not carry `Authorization`. Expired download URLs and every other non-success
-response fail with a typed, redacted error.
+not carry `Authorization`. They preserve the signed query. A production-auth
+loopback test checks both hops. Failures return redacted errors.
 
 ## Scoped Live-Mutation Authorization Boundary
 

--- a/crates/larch-adapters/src/github/mod.rs
+++ b/crates/larch-adapters/src/github/mod.rs
@@ -187,6 +187,9 @@ impl GitHubCredential {
 pub struct OctocrabGitHubService {
     pub(crate) client: Octocrab,
     pub(crate) policy: GitHubTransportPolicy,
+    pub(crate) api_base: Url,
+    #[cfg(test)]
+    pub(crate) test_log_redirect_origin: Option<url::Origin>,
     redactor: RuntimeRedactor,
     pub(crate) mutation_lock: Mutex<()>,
 }
@@ -197,6 +200,8 @@ impl OctocrabGitHubService {
         Self {
             client,
             policy: GitHubTransportPolicy::github_com(),
+            api_base: Url::parse(API_BASE).expect("fixed API base must be valid"),
+            test_log_redirect_origin: None,
             redactor: RuntimeRedactor::default(),
             mutation_lock: Mutex::new(()),
         }
@@ -222,12 +227,20 @@ impl OctocrabGitHubService {
                 "GitHub transport must be constructed inside the larch Tokio runtime",
             )));
         }
-        let client = build_client(&credential, policy).map_err(|error| {
+        if !octocrab_api_version_is_exact() {
+            return Err(GitHubClientError::Configuration(redactor.safe_text(
+                "Octocrab GitHub API version does not match larch policy",
+            )));
+        }
+        let client = build_client(&credential, policy, API_BASE).map_err(|error| {
             GitHubClientError::Configuration(redactor.safe_text(error.to_string()))
         })?;
         Ok(Self {
             client,
             policy,
+            api_base: Url::parse(API_BASE).expect("fixed API base must be valid"),
+            #[cfg(test)]
+            test_log_redirect_origin: None,
             redactor,
             mutation_lock: Mutex::new(()),
         })
@@ -247,14 +260,35 @@ impl OctocrabGitHubService {
             .expect("test token and active runtime must construct the client")
     }
 
-    /// Fixed request headers applied to every GitHub API request.
+    #[cfg(test)]
+    pub(crate) fn from_test_token_with_base(
+        token: &str,
+        api_base: &Url,
+        log_redirect_origin: url::Origin,
+    ) -> Self {
+        let credential = GitHubCredential(token.to_owned());
+        let policy = GitHubTransportPolicy::github_com();
+        let mut redactor = RuntimeRedactor::default();
+        assert!(
+            redactor.register_exact_secret(credential.expose().to_owned()),
+            "test credential must register"
+        );
+        let client = build_client(&credential, policy, api_base.as_str())
+            .expect("test API base and token must construct the client");
+        Self {
+            client,
+            policy,
+            api_base: api_base.clone(),
+            test_log_redirect_origin: Some(log_redirect_origin),
+            redactor,
+            mutation_lock: Mutex::new(()),
+        }
+    }
+
+    /// Larch-owned headers added beside Octocrab's verified API-version header.
     #[must_use]
-    pub const fn required_headers() -> [(&'static str, &'static str); 3] {
-        [
-            ("user-agent", USER_AGENT_VALUE),
-            ("accept", ACCEPT_VALUE),
-            (API_VERSION_HEADER, API_VERSION),
-        ]
+    pub const fn required_headers() -> [(&'static str, &'static str); 2] {
+        [("user-agent", USER_AGENT_VALUE), ("accept", ACCEPT_VALUE)]
     }
 
     /// Remove the exact runtime credential and standard secret families.
@@ -312,18 +346,27 @@ impl OctocrabGitHubService {
 fn build_client(
     credential: &GitHubCredential,
     policy: GitHubTransportPolicy,
+    api_base: &str,
 ) -> octocrab::Result<Octocrab> {
     let mut builder = Octocrab::builder()
         .personal_token(credential.expose().to_owned())
         .set_connect_timeout(Some(policy.connect_timeout()))
         .set_read_timeout(Some(policy.read_timeout()))
         .set_write_timeout(Some(policy.write_timeout()))
-        .base_uri(API_BASE)?
-        .upload_uri(API_BASE)?;
+        .base_uri(api_base)?
+        .upload_uri(api_base)?;
     for (name, value) in OctocrabGitHubService::required_headers() {
         builder = builder.add_header(HeaderName::from_static(name), value.to_owned());
     }
     builder.build()
+}
+
+fn octocrab_api_version_is_exact() -> bool {
+    let mut versions = octocrab::_SET_HEADERS_MAP
+        .iter()
+        .filter(|(name, _)| name.eq_ignore_ascii_case(API_VERSION_HEADER))
+        .map(|(_, value)| *value);
+    versions.next() == Some(API_VERSION) && versions.next().is_none()
 }
 
 fn parse_approved_url(value: &str) -> Result<Url, GitHubHostError> {
@@ -470,8 +513,11 @@ mod tests {
             [
                 ("user-agent", "larch"),
                 ("accept", "application/vnd.github+json"),
-                ("x-github-api-version", "2022-11-28"),
             ]
+        );
+        assert!(
+            octocrab_api_version_is_exact(),
+            "the pinned Octocrab request header must supply the API version exactly once"
         );
         let safe = service.redact_diagnostic(
             "Authorization: Bearer opaque test credential; body=opaque test credential",

--- a/crates/larch-adapters/src/github_actions.rs
+++ b/crates/larch-adapters/src/github_actions.rs
@@ -494,8 +494,10 @@ impl OctocrabGitHubService {
             self.client()._get(&route).await.map_err(|error| {
                 self.error(GitHubActionsErrorKind::Transport, error.to_string())
             })?;
-        let mut current = Url::parse(&format!("https://api.github.com{route}"))
-            .expect("repository route is a valid fixed API URL");
+        let mut current = self
+            .api_base
+            .join(&route)
+            .expect("repository route is a valid API URL");
         let mut visited = BTreeSet::from([current.as_str().to_owned()]);
         for redirects in 0..=LOG_REDIRECTS {
             if !response.status().is_redirection() {
@@ -550,7 +552,16 @@ impl OctocrabGitHubService {
                         "GitHub workflow log redirect Location is invalid",
                     )
                 })?;
-            let next = validate_log_redirect(&current, location, &visited)?;
+            #[cfg(test)]
+            let redirect_override = self.test_log_redirect_origin.as_ref();
+            #[cfg(not(test))]
+            let redirect_override: Option<&url::Origin> = None;
+            let next = validate_log_redirect_with_override(
+                &current,
+                location,
+                &visited,
+                redirect_override,
+            )?;
             visited.insert(next.as_str().to_owned());
             current = next;
             response = self
@@ -876,10 +887,20 @@ fn content_length(headers: &http::HeaderMap) -> Result<Option<usize>, GitHubActi
         .transpose()
 }
 
+#[cfg(test)]
 fn validate_log_redirect(
     current: &Url,
     location: &str,
     visited: &BTreeSet<String>,
+) -> Result<Url, GitHubActionsError> {
+    validate_log_redirect_with_override(current, location, visited, None)
+}
+
+fn validate_log_redirect_with_override(
+    current: &Url,
+    location: &str,
+    visited: &BTreeSet<String>,
+    test_origin: Option<&url::Origin>,
 ) -> Result<Url, GitHubActionsError> {
     let next = current.join(location).map_err(|_| {
         GitHubActionsError::new(
@@ -888,12 +909,19 @@ fn validate_log_redirect(
         )
     })?;
     let host = next.host_str().unwrap_or_default();
-    let approved = next.scheme() == "https"
+    let production_approved = next.scheme() == "https"
         && next.port_or_known_default() == Some(443)
         && next.username().is_empty()
         && next.password().is_none()
         && next.fragment().is_none()
         && approved_log_host(host);
+    let test_approved = test_origin.is_some_and(|origin| {
+        next.username().is_empty()
+            && next.password().is_none()
+            && next.fragment().is_none()
+            && next.origin() == *origin
+    });
+    let approved = production_approved || test_approved;
     if !approved {
         return Err(GitHubActionsError::new(
             GitHubActionsErrorKind::Redirect,
@@ -929,7 +957,10 @@ mod tests {
     use http_body_util::Full;
     use std::collections::VecDeque;
     use std::convert::Infallible;
+    use std::io::{Read as _, Write as _};
+    use std::net::TcpListener;
     use std::sync::{Arc, Mutex as StdMutex};
+    use std::thread;
     use tower::service_fn;
 
     fn repository() -> GitHubRepositoryRef {
@@ -961,6 +992,40 @@ mod tests {
             .header(header::CONTENT_TYPE, content_type)
             .body(Full::new(bytes::Bytes::from_static(body.as_bytes())))
             .expect("response")
+    }
+
+    fn recording_server(response: String) -> (Url, thread::JoinHandle<Vec<u8>>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback server");
+        let base = Url::parse(&format!(
+            "http://{}/",
+            listener.local_addr().expect("loopback address")
+        ))
+        .expect("loopback URL");
+        let server = thread::spawn(move || {
+            let (mut socket, _) = listener.accept().expect("accept request");
+            let mut request = Vec::with_capacity(1_024);
+            while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+                let mut chunk = [0_u8; 1_024];
+                let bytes_read = socket.read(&mut chunk).expect("read request");
+                assert!(bytes_read > 0, "request headers must be complete");
+                request.extend_from_slice(&chunk[..bytes_read]);
+                assert!(request.len() <= 16_384, "request headers exceed test limit");
+            }
+            socket
+                .write_all(response.as_bytes())
+                .expect("write response");
+            request
+        });
+        (base, server)
+    }
+
+    fn header_values<'request>(request: &'request str, name: &str) -> Vec<&'request str> {
+        request
+            .lines()
+            .filter_map(|line| line.split_once(':'))
+            .filter(|(header_name, _)| header_name.eq_ignore_ascii_case(name))
+            .map(|(_, value)| value.trim())
+            .collect()
     }
 
     #[test]
@@ -1123,6 +1188,62 @@ mod tests {
         );
     }
 
+    #[test]
+    fn production_auth_transport_authenticates_api_only_and_preserves_archive_query() {
+        const TOKEN: &str = "loopback-production-auth-token";
+        let archive_response = concat!(
+            "HTTP/1.1 200 OK\r\n",
+            "Content-Type: application/zip\r\n",
+            "Content-Length: 3\r\n",
+            "Connection: close\r\n\r\n",
+            "ZIP"
+        );
+        let (archive_base, archive_server) = recording_server(String::from(archive_response));
+        let archive_url = archive_base
+            .join("archive?sig=server-supplied")
+            .expect("archive URL");
+        let api_response = format!(
+            "HTTP/1.1 302 Found\r\nLocation: {archive_url}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+        );
+        let (api_base, api_server) = recording_server(api_response);
+
+        let runtime = crate::runtime::LarchRuntime::new().expect("runtime");
+        runtime.block_on(async {
+            let service = OctocrabGitHubService::from_test_token_with_base(
+                TOKEN,
+                &api_base,
+                archive_base.origin(),
+            );
+            let cancellation = crate::runtime::Cancellation::new();
+            let archive = service
+                .download_workflow_logs(&repository(), 1, &cancellation)
+                .await
+                .expect("loopback archive download");
+            assert_eq!(archive.as_bytes(), b"ZIP");
+        });
+
+        let api_request =
+            String::from_utf8(api_server.join().expect("API server")).expect("ASCII API request");
+        let archive_request = String::from_utf8(archive_server.join().expect("archive server"))
+            .expect("ASCII archive request");
+        let expected_authorization = format!("Bearer {TOKEN}");
+        assert_eq!(
+            header_values(&api_request, "authorization"),
+            [expected_authorization.as_str()]
+        );
+        assert_eq!(
+            header_values(&api_request, "x-github-api-version"),
+            ["2022-11-28"]
+        );
+        assert!(
+            header_values(&archive_request, "authorization").is_empty(),
+            "cross-origin archive request must not carry authorization"
+        );
+        let archive_target = archive_request.lines().next().unwrap_or_default();
+        assert_eq!(archive_target, "GET /archive?sig=server-supplied HTTP/1.1");
+        assert!(!archive_target.contains(TOKEN));
+    }
+
     #[tokio::test]
     async fn bounded_stream_fails_instead_of_returning_truncated_bytes() {
         let body = Full::new(bytes::Bytes::from_static(b"12345"));
@@ -1219,6 +1340,32 @@ mod tests {
         assert_eq!(
             read_backoff(1, retry_delay(response.headers())),
             LOG_TIMEOUT
+        );
+    }
+
+    #[test]
+    #[ignore = "requires LARCH_LIVE_GITHUB_ACTIONS=1, LARCH_LIVE_GITHUB_ACTIONS_RUN_ID, and LARCH_GH_TOKEN"]
+    fn live_completed_public_run_logs_succeeds_without_exposing_token() {
+        if std::env::var("LARCH_LIVE_GITHUB_ACTIONS").as_deref() != Ok("1") {
+            return;
+        }
+        let run_id = std::env::var("LARCH_LIVE_GITHUB_ACTIONS_RUN_ID")
+            .expect("set a completed public Actions run ID")
+            .parse::<u64>()
+            .expect("run ID must be an unsigned integer");
+        let runtime = crate::runtime::LarchRuntime::new().expect("runtime");
+        let output = runtime.block_on(async {
+            let service = OctocrabGitHubService::from_environment()
+                .expect("live GitHub service must construct");
+            let cancellation = crate::runtime::Cancellation::new();
+            let repository =
+                GitHubRepositoryRef::new("character-ai", "larch").expect("fixed public repository");
+            larch_core::run_logs(&service, &repository, run_id, &cancellation).await
+        });
+        assert_eq!(
+            output.exit_code(),
+            0,
+            "completed public run must download and render logs"
         );
     }
 }

--- a/docs/github-service-inventory.md
+++ b/docs/github-service-inventory.md
@@ -19,10 +19,10 @@ service request surfaces, and `gcloud` stay inside `crates/larch-adapters`.
 `crates/larch-adapters/src/github/mod.rs` is the single concrete GitHub client
 owner. `OctocrabGitHubService::from_environment` builds the one private Octocrab
 client, reads exactly `LARCH_GH_TOKEN`, and pins the `api.github.com` and
-`github.com` host allowlist. Every other adapter module layers typed operations
-over that one client and exposes no raw REST URL, GraphQL document, or concrete
-client to domain callers. No production code outside `crates/larch-adapters`
-imports Octocrab, names a GitHub service host, or embeds a GraphQL document.
+`github.com` host allowlist. It verifies that pinned Octocrab supplies one API
+version header. Other adapters layer typed operations over that client and hide
+REST URLs, GraphQL documents, and the client. Only
+`crates/larch-adapters` imports Octocrab or names GitHub hosts and GraphQL.
 
 ## Adapter operation ownership
 


### PR DESCRIPTION
## Summary

- stop adding a second `X-GitHub-Api-Version` header to authenticated Octocrab requests
- verify the pinned Octocrab API version before network access
- prove API authentication, cross-origin credential stripping, and signed-query preservation with a loopback transport test
- add an opt-in completed-run smoke test and update the security boundary documentation

## Verification

- `cargo test --locked --package larch-adapters`
- `cargo test --locked --package larch-cli --test parity`
- `cargo test --locked --package larch-cli --test cli`
- `cargo clippy --locked --package larch-adapters --all-targets --all-features -- -D warnings`
- changed-file pre-commit checks
- opt-in live smoke against completed public run `29717964421`

Fixes #7839
