### PR TITLE
Fixes #7818: Add durable append-only run publication

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -81,6 +81,17 @@ Extraction avoids `tarfile.extractall`, writes only no-follow regular files in
 a private temporary sibling, verifies before and after atomic promotion, and
 removes failed state. It never merges with or replaces an existing cache.
 
+`python/cli.py run-log publish` persists a deterministic archive and its
+content identity before remote I/O. Final object writes are create-only; an
+already-present key is downloaded to a private local file and accepted only
+after its size and SHA-256 digest match. Larch never replaces or deletes remote
+run objects. Publication and cache promotion share a per-run advisory lock,
+reject symlinked state paths, and verify the cache after atomic promotion.
+Failures retain the archive and identity-pinned retry metadata under the
+operator's XDG state directory. The normal write-through path copies the
+already-sanitized staging tree and does not trust remote bytes; a staging-less
+retry routes the retained archive through the bounded materializer above.
+
 ## Google ADC Trust Boundary
 
 Only trusted operator configuration can select Google ADC. Larch does not shell

--- a/crates/larch-lint/data/command-registry.toml
+++ b/crates/larch-lint/data/command-registry.toml
@@ -5906,6 +5906,18 @@ migration_issue = 7683
 
 [[commands]]
 domain = "run-log"
+verb = "publish"
+python_module = "larch.report.run_log_publish"
+python_function = "main"
+machine_stdout = true
+owner = "python"
+implementation_parity = "pending"
+consumer_cutover = "pending"
+python_removal = "pending"
+migration_issue = 7683
+
+[[commands]]
+domain = "run-log"
 verb = "append"
 python_module = "larch.report.run_logs"
 python_function = "larch_log_append_main"

--- a/docs/run-log-archive.md
+++ b/docs/run-log-archive.md
@@ -28,3 +28,20 @@ malformed contents, and integrity mismatches. Defaults limit archives to
 Materialization writes into a private temporary sibling, verifies the complete
 tree, renames it into place, and verifies it again. Failures remove the staged
 tree. It never merges with or replaces a destination. Cache entries contain ordinary files and the manifest.
+
+`python3 python/cli.py run-log publish --repo-root <root> --skill <skill>
+--run-id <run-id> --staging-root <tree>` persists the archive before attempting
+the create-only upload to `run-logs/<skill>/<run-id>.tar.gz`. Failed attempts
+remain under `${XDG_STATE_HOME:-$HOME/.local/state}/larch/run-log-pending/`
+with content-pinned retry metadata. Repeating the command may omit
+`--staging-root` when that pending state exists.
+
+An existing remote key succeeds only when its downloaded bytes match the
+pending archive; different content fails closed. A new upload is verified by
+remote metadata. The normal success path copies the sanitized staging tree
+directly into
+`${XDG_CACHE_HOME:-$HOME/.cache}/larch/run-logs/<repo>/<skill>/<run-id>/`,
+without downloading or decompressing the archive. Retry without staging safely
+materializes the durable archive instead. A per-run lock covers upload,
+collision verification, cache promotion, and atomic retirement of pending
+state.

--- a/plugin/SECURITY.md
+++ b/plugin/SECURITY.md
@@ -81,6 +81,17 @@ Extraction avoids `tarfile.extractall`, writes only no-follow regular files in
 a private temporary sibling, verifies before and after atomic promotion, and
 removes failed state. It never merges with or replaces an existing cache.
 
+`python/cli.py run-log publish` persists a deterministic archive and its
+content identity before remote I/O. Final object writes are create-only; an
+already-present key is downloaded to a private local file and accepted only
+after its size and SHA-256 digest match. Larch never replaces or deletes remote
+run objects. Publication and cache promotion share a per-run advisory lock,
+reject symlinked state paths, and verify the cache after atomic promotion.
+Failures retain the archive and identity-pinned retry metadata under the
+operator's XDG state directory. The normal write-through path copies the
+already-sanitized staging tree and does not trust remote bytes; a staging-less
+retry routes the retained archive through the bounded materializer above.
+
 ## Google ADC Trust Boundary
 
 Only trusted operator configuration can select Google ADC. Larch does not shell

--- a/plugin/docs/run-log-archive.md
+++ b/plugin/docs/run-log-archive.md
@@ -28,3 +28,20 @@ malformed contents, and integrity mismatches. Defaults limit archives to
 Materialization writes into a private temporary sibling, verifies the complete
 tree, renames it into place, and verifies it again. Failures remove the staged
 tree. It never merges with or replaces a destination. Cache entries contain ordinary files and the manifest.
+
+`python3 python/cli.py run-log publish --repo-root <root> --skill <skill>
+--run-id <run-id> --staging-root <tree>` persists the archive before attempting
+the create-only upload to `run-logs/<skill>/<run-id>.tar.gz`. Failed attempts
+remain under `${XDG_STATE_HOME:-$HOME/.local/state}/larch/run-log-pending/`
+with content-pinned retry metadata. Repeating the command may omit
+`--staging-root` when that pending state exists.
+
+An existing remote key succeeds only when its downloaded bytes match the
+pending archive; different content fails closed. A new upload is verified by
+remote metadata. The normal success path copies the sanitized staging tree
+directly into
+`${XDG_CACHE_HOME:-$HOME/.cache}/larch/run-logs/<repo>/<skill>/<run-id>/`,
+without downloading or decompressing the archive. Retry without staging safely
+materializes the durable archive instead. A per-run lock covers upload,
+collision verification, cache promotion, and atomic retirement of pending
+state.

--- a/plugin/python/larch/cli.py
+++ b/plugin/python/larch/cli.py
@@ -651,6 +651,7 @@ _REGISTRY: dict[tuple[str, str], tuple[str, str, bool]] = {
     ("run-log", "storage-preflight"): ("larch.report.storage_config", "storage_preflight_main", True),
     ("run-log", "archive"): ("larch.report.run_log_archive", "main", False),
     ("run-log", "materialize"): ("larch.report.run_log_archive", "materialize_main", False),
+    ("run-log", "publish"): ("larch.report.run_log_publish", "main", True),
     ("run-log", "validate-run-id"): ("larch.report.run_logs", "larch_log_validate_run_id_main", True),
     ("run-log", "capture-transcript"): ("larch.report.run_log_flush", "capture_transcript_main", False),
     ("run-log", "render-session-transcript"): ("larch.rendering.render_session_transcript", "main", False),

--- a/plugin/python/larch/report/run_log_archive.py
+++ b/plugin/python/larch/report/run_log_archive.py
@@ -657,6 +657,23 @@ def _write_materialized_bytes(path: Path, content: bytes, *, root: Path, mode: i
         os.fsync(handle.fileno())
 
 
+def _fsync_directory(path: Path) -> None:
+    directory: Path = larch_io.validate_trusted_directory(path)
+    flags: int = os.O_RDONLY
+    if hasattr(os, "O_DIRECTORY"):
+        flags |= os.O_DIRECTORY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor: int = os.open(directory, flags)
+    try:
+        opened: os.stat_result = os.fstat(descriptor)
+        if not stat.S_ISDIR(opened.st_mode):
+            raise OSError(f"archive directory changed while opening: {directory}")
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
 def _extract_regular_member(
     archive: tarfile.TarFile,
     tar_member: tarfile.TarInfo,
@@ -813,7 +830,122 @@ def _extract_validated_archive(
             temporary_root=temporary_root,
         )
     for member in sorted(directories, key=lambda item: item.path.count("/"), reverse=True):
-        temporary_root.joinpath(*PurePosixPath(member.path).parts).chmod(0o755)
+        directory: Path = temporary_root.joinpath(*PurePosixPath(member.path).parts)
+        directory.chmod(0o755)
+        _fsync_directory(directory)
+    _fsync_directory(temporary_root)
+
+
+def _copy_staging_members(
+    *,
+    staging_root: Path,
+    temporary_root: Path,
+    manifest: RunArchiveManifest,
+) -> None:
+    directories: list[ArchiveMember] = [
+        member for member in manifest.members if member.kind == "directory"
+    ]
+    for member in sorted(directories, key=lambda item: (item.path.count("/"), item.path)):
+        destination: Path = temporary_root.joinpath(*PurePosixPath(member.path).parts)
+        destination.mkdir(mode=0o700)
+        _ = larch_io.validate_trusted_directory(destination, root=temporary_root)
+    _write_materialized_bytes(
+        temporary_root / ARCHIVE_MANIFEST_NAME,
+        manifest.to_bytes(),
+        root=temporary_root,
+        mode=0o644,
+    )
+    for member in manifest.members:
+        if member.kind == "directory":
+            continue
+        expected: os.stat_result = member.source.stat(follow_symlinks=False)
+        destination = temporary_root.joinpath(*PurePosixPath(member.path).parts)
+        digest = hashlib.sha256()
+        written = 0
+        with (
+            _open_regular_member(member.source, root=staging_root, expected=expected) as source,
+            _new_materialized_file(destination, root=temporary_root, mode=member.mode) as output,
+        ):
+            while chunk := source.read(_CHUNK_SIZE):
+                written += len(chunk)
+                _ = output.write(chunk)
+                digest.update(chunk)
+            output.flush()
+            os.fsync(output.fileno())
+        _assert_unchanged(member.source, expected=expected)
+        if written != member.size or digest.hexdigest() != member.sha256:
+            raise OSError(f"archive source changed while promoting cache: {member.source}")
+    for member in sorted(directories, key=lambda item: item.path.count("/"), reverse=True):
+        directory: Path = temporary_root.joinpath(*PurePosixPath(member.path).parts)
+        directory.chmod(0o755)
+        _fsync_directory(directory)
+    _fsync_directory(temporary_root)
+
+
+def promote_staging_run_directory(
+    *,
+    staging_root: Path,
+    run_dir: Path,
+    expected_skill: str,
+    expected_run_id: str,
+    expected_manifest_sha256: str,
+) -> RunArchiveMaterializationResult:
+    """Copy a sanitized staging tree directly into the unpacked run cache."""
+    if not validate_run_id_slug(expected_skill):
+        raise ValueError(f"invalid expected skill: {expected_skill}")
+    if not validate_run_id_slug(expected_run_id):
+        raise ValueError(f"invalid expected run-id: {expected_run_id}")
+    root: Path = larch_io.validate_trusted_directory(staging_root)
+    requested_run_dir: Path = run_dir if run_dir.is_absolute() else Path.cwd() / run_dir
+    if requested_run_dir.name != expected_run_id:
+        raise ValueError("promoted run directory name must match the expected run-id")
+    try:
+        _ = requested_run_dir.relative_to(root)
+    except ValueError:
+        pass
+    else:
+        raise ValueError("promoted run directory must not be inside the staging tree")
+    parent: Path = larch_io.ensure_trusted_directory(requested_run_dir.parent)
+    destination: Path = parent / requested_run_dir.name
+    if destination.exists() or destination.is_symlink():
+        raise FileExistsError(f"refusing to merge staging tree into existing run directory: {destination}")
+    members: tuple[ArchiveMember, ...] = _collect_members(root)
+    manifest = RunArchiveManifest(skill=expected_skill, run_id=expected_run_id, members=members)
+    manifest_sha256: str = hashlib.sha256(manifest.to_bytes()).hexdigest()
+    if manifest_sha256 != expected_manifest_sha256:
+        raise ValueError("staging tree no longer matches the pending archive manifest")
+    temporary_root: Path | None = None
+    try:
+        temporary_root = Path(
+            tempfile.mkdtemp(dir=parent, prefix=f".{destination.name}.promote-")
+        )
+        temporary_root.chmod(0o700)
+        _copy_staging_members(
+            staging_root=root,
+            temporary_root=temporary_root,
+            manifest=manifest,
+        )
+        _ = verify_materialized_run_directory(
+            run_dir=temporary_root,
+            expected_skill=expected_skill,
+            expected_run_id=expected_run_id,
+        )
+        _ = temporary_root.rename(destination)
+        _fsync_directory(parent)
+        temporary_root = None
+        try:
+            return verify_materialized_run_directory(
+                run_dir=destination,
+                expected_skill=expected_skill,
+                expected_run_id=expected_run_id,
+            )
+        except (OSError, TypeError, ValueError):
+            shutil.rmtree(destination)
+            _fsync_directory(parent)
+            raise
+    finally:
+        if temporary_root is not None:
+            shutil.rmtree(temporary_root)
 
 
 def materialize_run_archive(
@@ -867,6 +999,7 @@ def materialize_run_archive(
             limits=active_limits,
         )
         _ = temporary_root.rename(destination)
+        _fsync_directory(parent)
         temporary_root = None
         try:
             return verify_materialized_run_directory(
@@ -877,6 +1010,7 @@ def materialize_run_archive(
             )
         except (OSError, TypeError, ValueError):
             shutil.rmtree(destination)
+            _fsync_directory(parent)
             raise
     finally:
         if temporary_root is not None:

--- a/plugin/python/larch/report/run_log_publish.py
+++ b/plugin/python/larch/report/run_log_publish.py
@@ -1,0 +1,736 @@
+"""Append-only run archive publication with durable retry and cache promotion."""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import hashlib
+import json
+import os
+import shutil
+import stat
+import sys
+import tarfile
+import tempfile
+from collections.abc import Generator, Mapping, Sequence
+from contextlib import contextmanager, suppress
+from dataclasses import asdict, dataclass, replace
+from enum import StrEnum
+from pathlib import Path
+from typing import Final, Protocol, cast
+
+from larch import io as larch_io
+from larch.core import config
+from larch.core.repo_roots import consumer_repo_root
+from larch.report.object_store import (
+    ObjectStoreError,
+    ObjectStoreErrorKind,
+    RemoteObject,
+    object_store_for,
+)
+from larch.report.run_log_archive import (
+    RunArchiveMaterializationResult,
+    create_run_archive,
+    materialize_run_archive,
+    promote_staging_run_directory,
+    verify_materialized_run_directory,
+)
+from larch.report.run_log_batch import validate_run_id_slug
+from larch.report.storage_config import (
+    StorageConfigurationError,
+    StorageRoot,
+    discover_storage_root,
+)
+
+_PENDING_SCHEMA_VERSION: Final = 1
+_PENDING_ARCHIVE_NAME: Final = "archive.tar.gz"
+_PENDING_METADATA_NAME: Final = "retry.json"
+_ENV_XDG_CACHE_HOME: Final = "XDG_CACHE_HOME"
+_ENV_XDG_STATE_HOME: Final = "XDG_STATE_HOME"
+_CHUNK_SIZE: Final = 1024 * 1024
+_ASCII_CONTROL_BOUND: Final = 32
+_ASCII_DELETE: Final = 127
+_SHA256_HEX_LENGTH: Final = 64
+_PENDING_KEYS: Final = frozenset(
+    {
+        "archive_sha256",
+        "archive_size",
+        "attempts",
+        "last_error",
+        "manifest_sha256",
+        "remote_key",
+        "repo_name",
+        "run_id",
+        "schema_version",
+        "skill",
+        "storage_uri",
+    }
+)
+
+
+class PublicationError(RuntimeError):
+    """A publication or durable retry invariant failed."""
+
+
+class RemotePublicationStatus(StrEnum):
+    """How the immutable remote object reached its postcondition."""
+
+    CREATED = "created"
+    MATCHED = "matched"
+
+
+class CachePublicationStatus(StrEnum):
+    """How the verified unpacked cache reached its postcondition."""
+
+    PROMOTED = "promoted"
+    MATERIALIZED = "materialized"
+    PRESENT = "present"
+
+
+class ObjectStore(Protocol):
+    """Provider-neutral operations required by publication."""
+
+    def upload_create(self, key: str, source: Path) -> RemoteObject: ...
+
+    def download(self, key: str, destination: Path) -> None: ...
+
+    def metadata(self, key: str) -> RemoteObject: ...
+
+
+@dataclass(frozen=True)
+class PublicationPaths:
+    """All local paths owned by one repository/skill/run publication."""
+
+    pending_dir: Path
+    pending_archive: Path
+    pending_metadata: Path
+    cache_dir: Path
+    lock_file: Path
+
+
+@dataclass(frozen=True)
+class PublicationRequest:
+    """Immutable caller inputs for one run publication attempt."""
+
+    repo_root: Path
+    storage_root: StorageRoot
+    skill: str
+    run_id: str
+    staging_root: Path | None
+    cache_home: Path | None = None
+    state_home: Path | None = None
+
+
+@dataclass(frozen=True)
+class PendingPublication:
+    """Content-pinned durable retry record for one immutable object."""
+
+    schema_version: int
+    storage_uri: str
+    repo_name: str
+    skill: str
+    run_id: str
+    remote_key: str
+    archive_sha256: str
+    archive_size: int
+    manifest_sha256: str
+    attempts: int
+    last_error: str
+
+
+@dataclass(frozen=True)
+class PublicationResult:
+    """Verified remote and local postconditions for a published run."""
+
+    remote_key: str
+    archive_sha256: str
+    cache_dir: Path
+    remote_status: RemotePublicationStatus
+    cache_status: CachePublicationStatus
+
+
+def _validated_component(value: str, *, label: str, slug: bool) -> str:
+    invalid_literal: bool = (
+        not value
+        or value in {".", ".."}
+        or "/" in value
+        or "\\" in value
+        or any(
+            ord(character) < _ASCII_CONTROL_BOUND or ord(character) == _ASCII_DELETE
+            for character in value
+        )
+    )
+    if invalid_literal or (slug and not validate_run_id_slug(value)):
+        raise ValueError(f"invalid {label}: {value!r}")
+    return value
+
+
+def _xdg_home(
+    *,
+    environ: Mapping[str, str],
+    variable: str,
+    fallback: Path,
+) -> Path:
+    configured: str = environ.get(variable, "")
+    selected: Path = Path(configured) if configured else fallback
+    if not selected.is_absolute():
+        raise ValueError(f"{variable} must be an absolute path")
+    return selected
+
+
+def publication_paths(
+    *,
+    request: PublicationRequest,
+    environ: Mapping[str, str] | None = None,
+) -> PublicationPaths:
+    """Resolve the literal repository cache path and durable retry path."""
+    root: Path = larch_io.validate_trusted_directory(request.repo_root)
+    repo_name: str = _validated_component(root.name, label="repository name", slug=False)
+    skill_name: str = _validated_component(request.skill, label="skill", slug=True)
+    run_name: str = _validated_component(request.run_id, label="run-id", slug=True)
+    environment: Mapping[str, str] = os.environ if environ is None else environ
+    resolved_cache_home: Path = request.cache_home or _xdg_home(
+        environ=environment,
+        variable=_ENV_XDG_CACHE_HOME,
+        fallback=Path.home() / ".cache",
+    )
+    resolved_state_home: Path = request.state_home or _xdg_home(
+        environ=environment,
+        variable=_ENV_XDG_STATE_HOME,
+        fallback=Path.home() / ".local" / "state",
+    )
+    if not resolved_cache_home.is_absolute() or not resolved_state_home.is_absolute():
+        raise ValueError("publication cache and state homes must be absolute paths")
+    cache_dir: Path = (
+        resolved_cache_home / "larch" / "run-logs" / repo_name / skill_name / run_name
+    )
+    pending_dir: Path = (
+        resolved_state_home
+        / "larch"
+        / "run-log-pending"
+        / repo_name
+        / skill_name
+        / run_name
+    )
+    lock_file: Path = (
+        resolved_state_home
+        / "larch"
+        / "run-log-locks"
+        / repo_name
+        / skill_name
+        / f"{run_name}.lock"
+    )
+    return PublicationPaths(
+        pending_dir=pending_dir,
+        pending_archive=pending_dir / _PENDING_ARCHIVE_NAME,
+        pending_metadata=pending_dir / _PENDING_METADATA_NAME,
+        cache_dir=cache_dir,
+        lock_file=lock_file,
+    )
+
+
+def _ensure_concurrent_directory(path: Path) -> Path:
+    """Create a trusted directory while tolerating a same-path creator race."""
+    directory: Path = path if path.is_absolute() else Path.cwd() / path
+    try:
+        return larch_io.validate_trusted_directory(directory)
+    except OSError:
+        pass
+    if directory == directory.parent:
+        raise OSError(f"cannot create trusted publication directory: {directory}")
+    _ = _ensure_concurrent_directory(directory.parent)
+    with suppress(FileExistsError):
+        directory.mkdir(mode=0o700)
+    return larch_io.validate_trusted_directory(directory)
+
+
+@contextmanager
+def publication_lock(path: Path) -> Generator[None, None, None]:
+    """Hold the blocking advisory lock shared by all operations for one run."""
+    parent: Path = _ensure_concurrent_directory(path.parent)
+    lock_path: Path = parent / path.name
+    if lock_path.is_symlink():
+        raise OSError(f"refusing symlinked publication lock: {lock_path}")
+    flags: int = os.O_RDWR | os.O_CREAT
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor: int = os.open(lock_path, flags, 0o600)
+    try:
+        opened: os.stat_result = os.fstat(descriptor)
+        if not stat.S_ISREG(opened.st_mode):
+            raise OSError(f"publication lock is not a regular file: {lock_path}")
+        os.fchmod(descriptor, 0o600)
+        fcntl.flock(descriptor, fcntl.LOCK_EX)
+        yield
+    finally:
+        with suppress(OSError):
+            fcntl.flock(descriptor, fcntl.LOCK_UN)
+        os.close(descriptor)
+
+
+def _sha256_regular_file(path: Path, *, root: Path) -> tuple[str, int]:
+    trusted_root: Path = larch_io.validate_trusted_directory(root)
+    if path.parent != trusted_root:
+        raise OSError(f"publication archive is outside its trusted directory: {path}")
+    entry: os.stat_result = path.stat(follow_symlinks=False)
+    if not stat.S_ISREG(entry.st_mode):
+        raise OSError(f"publication archive is not a regular file: {path}")
+    flags: int = os.O_RDONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor: int = os.open(path, flags)
+    digest = hashlib.sha256()
+    with os.fdopen(descriptor, "rb") as handle:
+        opened: os.stat_result = os.fstat(handle.fileno())
+        if (opened.st_dev, opened.st_ino, opened.st_size) != (
+            entry.st_dev,
+            entry.st_ino,
+            entry.st_size,
+        ):
+            raise OSError(f"publication archive changed while opening: {path}")
+        while chunk := handle.read(_CHUNK_SIZE):
+            digest.update(chunk)
+    current: os.stat_result = path.stat(follow_symlinks=False)
+    if (current.st_dev, current.st_ino, current.st_size, current.st_mtime_ns) != (
+        entry.st_dev,
+        entry.st_ino,
+        entry.st_size,
+        entry.st_mtime_ns,
+    ):
+        raise OSError(f"publication archive changed while reading: {path}")
+    return digest.hexdigest(), entry.st_size
+
+
+def _fsync_directory(path: Path) -> None:
+    directory: Path = larch_io.validate_trusted_directory(path)
+    flags: int = os.O_RDONLY
+    if hasattr(os, "O_DIRECTORY"):
+        flags |= os.O_DIRECTORY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor: int = os.open(directory, flags)
+    try:
+        opened: os.stat_result = os.fstat(descriptor)
+        if not stat.S_ISDIR(opened.st_mode):
+            raise OSError(f"publication directory changed while opening: {directory}")
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _metadata_text(pending: PendingPublication) -> str:
+    return json.dumps(asdict(pending), ensure_ascii=False, sort_keys=True, separators=(",", ":")) + "\n"
+
+
+def _write_pending_metadata(paths: PublicationPaths, pending: PendingPublication) -> None:
+    larch_io.trusted_atomic_write(
+        paths.pending_metadata,
+        _metadata_text(pending),
+        root=paths.pending_dir,
+    )
+    _fsync_directory(paths.pending_dir)
+
+
+def _parse_pending_metadata(text: str) -> PendingPublication:
+    try:
+        raw: object = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise PublicationError("pending publication metadata is invalid JSON") from exc
+    if not isinstance(raw, dict):
+        raise PublicationError("pending publication metadata has invalid fields")
+    data = cast("dict[str, object]", raw)
+    if frozenset(data) != _PENDING_KEYS:
+        raise PublicationError("pending publication metadata has invalid fields")
+    string_keys: tuple[str, ...] = (
+        "storage_uri",
+        "repo_name",
+        "skill",
+        "run_id",
+        "remote_key",
+        "archive_sha256",
+        "manifest_sha256",
+        "last_error",
+    )
+    if any(not isinstance(data[key], str) for key in string_keys):
+        raise PublicationError("pending publication metadata has invalid string fields")
+    integer_keys: tuple[str, ...] = ("schema_version", "archive_size", "attempts")
+    if any(not isinstance(data[key], int) or isinstance(data[key], bool) for key in integer_keys):
+        raise PublicationError("pending publication metadata has invalid integer fields")
+    return PendingPublication(
+        schema_version=cast("int", data["schema_version"]),
+        storage_uri=cast("str", data["storage_uri"]),
+        repo_name=cast("str", data["repo_name"]),
+        skill=cast("str", data["skill"]),
+        run_id=cast("str", data["run_id"]),
+        remote_key=cast("str", data["remote_key"]),
+        archive_sha256=cast("str", data["archive_sha256"]),
+        archive_size=cast("int", data["archive_size"]),
+        manifest_sha256=cast("str", data["manifest_sha256"]),
+        attempts=cast("int", data["attempts"]),
+        last_error=cast("str", data["last_error"]),
+    )
+
+
+def _validate_pending(
+    *,
+    paths: PublicationPaths,
+    pending: PendingPublication,
+    request: PublicationRequest,
+    repo_name: str,
+) -> PendingPublication:
+    expected_key: str = f"run-logs/{request.skill}/{request.run_id}.tar.gz"
+    identity: tuple[object, ...] = (
+        pending.schema_version,
+        pending.storage_uri,
+        pending.repo_name,
+        pending.skill,
+        pending.run_id,
+        pending.remote_key,
+    )
+    expected_identity: tuple[object, ...] = (
+        _PENDING_SCHEMA_VERSION,
+        request.storage_root.uri,
+        repo_name,
+        request.skill,
+        request.run_id,
+        expected_key,
+    )
+    if identity != expected_identity:
+        raise PublicationError("pending publication identity does not match the live request")
+    if (
+        not _valid_sha256(pending.archive_sha256)
+        or not _valid_sha256(pending.manifest_sha256)
+        or pending.archive_size <= 0
+        or pending.attempts < 0
+    ):
+        raise PublicationError("pending publication metadata has invalid content identity")
+    archive_sha256, archive_size = _sha256_regular_file(
+        paths.pending_archive,
+        root=paths.pending_dir,
+    )
+    if (archive_sha256, archive_size) != (pending.archive_sha256, pending.archive_size):
+        raise PublicationError("pending archive does not match its durable content identity")
+    return pending
+
+
+def _valid_sha256(value: str) -> bool:
+    return len(value) == _SHA256_HEX_LENGTH and all(
+        character in "0123456789abcdef" for character in value
+    )
+
+
+def _load_pending(
+    *,
+    paths: PublicationPaths,
+    request: PublicationRequest,
+    repo_name: str,
+) -> PendingPublication:
+    root: Path = larch_io.validate_trusted_directory(paths.pending_dir)
+    text: str = larch_io.read_trusted_text(
+        paths.pending_metadata,
+        root=root,
+        reject_cr=True,
+    )
+    return _validate_pending(
+        paths=paths,
+        pending=_parse_pending_metadata(text),
+        request=request,
+        repo_name=repo_name,
+    )
+
+
+def _create_pending(
+    *,
+    paths: PublicationPaths,
+    request: PublicationRequest,
+    repo_name: str,
+) -> PendingPublication:
+    parent: Path = _ensure_concurrent_directory(paths.pending_dir.parent)
+    temporary: Path | None = Path(
+        tempfile.mkdtemp(dir=parent, prefix=f".{request.run_id}.pending-")
+    )
+    temporary.chmod(0o700)
+    try:
+        if request.staging_root is None:
+            raise PublicationError("a staging root is required to create a pending archive")
+        created = create_run_archive(
+            staging_root=request.staging_root,
+            output_dir=temporary,
+            skill=request.skill,
+            run_id=request.run_id,
+        )
+        archive_path: Path = temporary / _PENDING_ARCHIVE_NAME
+        _ = created.archive_path.rename(archive_path)
+        pending = PendingPublication(
+            schema_version=_PENDING_SCHEMA_VERSION,
+            storage_uri=request.storage_root.uri,
+            repo_name=repo_name,
+            skill=request.skill,
+            run_id=request.run_id,
+            remote_key=f"run-logs/{request.skill}/{request.run_id}.tar.gz",
+            archive_sha256=created.archive_sha256,
+            archive_size=archive_path.stat(follow_symlinks=False).st_size,
+            manifest_sha256=created.manifest_sha256,
+            attempts=0,
+            last_error="",
+        )
+        temporary_paths = PublicationPaths(
+            pending_dir=temporary,
+            pending_archive=archive_path,
+            pending_metadata=temporary / _PENDING_METADATA_NAME,
+            cache_dir=paths.cache_dir,
+            lock_file=paths.lock_file,
+        )
+        _write_pending_metadata(temporary_paths, pending)
+        _ = temporary.rename(paths.pending_dir)
+        _fsync_directory(parent)
+        temporary = None
+        return _load_pending(
+            paths=paths,
+            request=request,
+            repo_name=repo_name,
+        )
+    finally:
+        if temporary is not None:
+            shutil.rmtree(temporary)
+
+
+def _pending_for_request(
+    *,
+    paths: PublicationPaths,
+    request: PublicationRequest,
+    repo_name: str,
+) -> PendingPublication:
+    if paths.pending_dir.exists() or paths.pending_dir.is_symlink():
+        return _load_pending(
+            paths=paths,
+            request=request,
+            repo_name=repo_name,
+        )
+    if request.staging_root is None:
+        raise PublicationError("no durable pending archive exists and --staging-root was not provided")
+    return _create_pending(
+        paths=paths,
+        request=request,
+        repo_name=repo_name,
+    )
+
+
+def _matching_remote_exists(
+    *,
+    store: ObjectStore,
+    pending: PendingPublication,
+    paths: PublicationPaths,
+) -> bool:
+    remote: RemoteObject = store.metadata(pending.remote_key)
+    if remote.size != pending.archive_size:
+        return False
+    with tempfile.NamedTemporaryFile(
+        dir=paths.pending_dir,
+        prefix=".remote-verify-",
+        delete=False,
+    ) as handle:
+        downloaded: Path = Path(handle.name)
+    try:
+        store.download(pending.remote_key, downloaded)
+        remote_sha256, remote_size = _sha256_regular_file(downloaded, root=paths.pending_dir)
+        return (remote_sha256, remote_size) == (pending.archive_sha256, pending.archive_size)
+    finally:
+        downloaded.unlink(missing_ok=True)
+
+
+def _publish_remote(
+    *,
+    store: ObjectStore,
+    pending: PendingPublication,
+    paths: PublicationPaths,
+) -> RemotePublicationStatus:
+    try:
+        uploaded: RemoteObject = store.upload_create(pending.remote_key, paths.pending_archive)
+    except ObjectStoreError as exc:
+        if exc.kind is not ObjectStoreErrorKind.ALREADY_EXISTS:
+            raise
+        if not _matching_remote_exists(store=store, pending=pending, paths=paths):
+            raise PublicationError(
+                "immutable remote key already exists with different content"
+            ) from exc
+        return RemotePublicationStatus.MATCHED
+    if uploaded.key != pending.remote_key or uploaded.size != pending.archive_size:
+        raise PublicationError("create-only upload returned a mismatched object identity")
+    verified: RemoteObject = store.metadata(pending.remote_key)
+    if verified.key != pending.remote_key or verified.size != pending.archive_size:
+        raise PublicationError("uploaded remote object failed metadata verification")
+    return RemotePublicationStatus.CREATED
+
+
+def _cache_result(
+    *,
+    paths: PublicationPaths,
+    pending: PendingPublication,
+    staging_root: Path | None,
+) -> tuple[RunArchiveMaterializationResult, CachePublicationStatus]:
+    _ = _ensure_concurrent_directory(paths.cache_dir.parent)
+    if paths.cache_dir.exists() or paths.cache_dir.is_symlink():
+        existing: RunArchiveMaterializationResult = verify_materialized_run_directory(
+            run_dir=paths.cache_dir,
+            expected_skill=pending.skill,
+            expected_run_id=pending.run_id,
+        )
+        if existing.manifest_sha256 != pending.manifest_sha256:
+            raise PublicationError("existing cache directory contains different run content")
+        return existing, CachePublicationStatus.PRESENT
+    if staging_root is not None:
+        promoted: RunArchiveMaterializationResult = promote_staging_run_directory(
+            staging_root=staging_root,
+            run_dir=paths.cache_dir,
+            expected_skill=pending.skill,
+            expected_run_id=pending.run_id,
+            expected_manifest_sha256=pending.manifest_sha256,
+        )
+        return promoted, CachePublicationStatus.PROMOTED
+    materialized: RunArchiveMaterializationResult = materialize_run_archive(
+        archive_path=paths.pending_archive,
+        run_dir=paths.cache_dir,
+        expected_skill=pending.skill,
+        expected_run_id=pending.run_id,
+    )
+    return materialized, CachePublicationStatus.MATERIALIZED
+
+
+def _failure_token(exc: Exception) -> str:
+    if isinstance(exc, ObjectStoreError):
+        return f"object-{exc.operation}-{exc.kind.value}"
+    if isinstance(exc, PublicationError):
+        return "publication-invariant"
+    if isinstance(exc, (EOFError, OSError, tarfile.TarError, TypeError, ValueError)):
+        return "local-integrity"
+    return "internal"
+
+
+def _complete_pending(paths: PublicationPaths) -> None:
+    completed: Path = paths.pending_dir.with_name(
+        f".{paths.pending_dir.name}.complete-{os.getpid()}-{os.urandom(4).hex()}"
+    )
+    _ = paths.pending_dir.rename(completed)
+    _fsync_directory(completed.parent)
+    with suppress(OSError):
+        shutil.rmtree(completed)
+
+
+def publish_run(
+    *,
+    request: PublicationRequest,
+    store: ObjectStore | None = None,
+    environ: Mapping[str, str] | None = None,
+) -> PublicationResult:
+    """Publish one immutable archive and atomically populate its local cache."""
+    root: Path = larch_io.validate_trusted_directory(request.repo_root)
+    repo_name: str = _validated_component(root.name, label="repository name", slug=False)
+    skill_name: str = _validated_component(request.skill, label="skill", slug=True)
+    run_name: str = _validated_component(request.run_id, label="run-id", slug=True)
+    normalized_request = replace(
+        request,
+        repo_root=root,
+        skill=skill_name,
+        run_id=run_name,
+    )
+    paths: PublicationPaths = publication_paths(
+        request=normalized_request,
+        environ=environ,
+    )
+    active_store: ObjectStore = (
+        object_store_for(normalized_request.storage_root, environ=environ)
+        if store is None
+        else store
+    )
+    with publication_lock(paths.lock_file):
+        pending: PendingPublication = _pending_for_request(
+            paths=paths,
+            request=normalized_request,
+            repo_name=repo_name,
+        )
+        pending = replace(pending, attempts=pending.attempts + 1, last_error="")
+        _write_pending_metadata(paths, pending)
+        try:
+            remote_status: RemotePublicationStatus = _publish_remote(
+                store=active_store,
+                pending=pending,
+                paths=paths,
+            )
+            cache_result, cache_status = _cache_result(
+                paths=paths,
+                pending=pending,
+                staging_root=normalized_request.staging_root,
+            )
+            if cache_result.manifest_sha256 != pending.manifest_sha256:
+                raise PublicationError("published cache failed manifest identity verification")
+        except (
+            EOFError,
+            ObjectStoreError,
+            OSError,
+            PublicationError,
+            tarfile.TarError,
+            TypeError,
+            ValueError,
+        ) as exc:
+            _write_pending_metadata(paths, replace(pending, last_error=_failure_token(exc)))
+            raise
+        _complete_pending(paths)
+    return PublicationResult(
+        remote_key=pending.remote_key,
+        archive_sha256=pending.archive_sha256,
+        cache_dir=paths.cache_dir,
+        remote_status=remote_status,
+        cache_status=cache_status,
+    )
+
+
+def main(argv: Sequence[str]) -> int:
+    """Publish or retry one run and emit its machine-readable postconditions."""
+    parser = argparse.ArgumentParser(prog="cli.py run-log publish")
+    _ = parser.add_argument("--repo-root", required=True)
+    _ = parser.add_argument("--skill", required=True)
+    _ = parser.add_argument("--run-id", required=True)
+    _ = parser.add_argument("--staging-root")
+    try:
+        args = parser.parse_args(argv)
+    except SystemExit as exc:
+        return int(exc.code) if isinstance(exc.code, int) else config.EXIT_USAGE
+    try:
+        requested_root: Path = Path(args.repo_root)
+        repo_root: Path | None = consumer_repo_root(requested_root)
+        if repo_root is None:
+            raise StorageConfigurationError(
+                f"could not discover a Git repository root from {requested_root}"
+            )
+        storage_root: StorageRoot = discover_storage_root(start=repo_root)
+        result: PublicationResult = publish_run(
+            request=PublicationRequest(
+                repo_root=repo_root,
+                storage_root=storage_root,
+                skill=args.skill,
+                run_id=args.run_id,
+                staging_root=Path(args.staging_root) if args.staging_root else None,
+            ),
+        )
+    except StorageConfigurationError as exc:
+        print(f"publication failed: {exc}", file=sys.stderr)
+        return config.EXIT_STORAGE_CONFIG
+    except (
+        EOFError,
+        ObjectStoreError,
+        OSError,
+        PublicationError,
+        tarfile.TarError,
+        TypeError,
+        ValueError,
+    ) as exc:
+        print(f"publication failed: {exc}", file=sys.stderr)
+        return config.EXIT_INTERNAL_ERROR
+    print(f"REMOTE_KEY={result.remote_key}")
+    print(f"ARCHIVE_SHA256={result.archive_sha256}")
+    print(f"CACHE_DIR={result.cache_dir}")
+    print(f"REMOTE_STATUS={result.remote_status.value}")
+    print(f"CACHE_STATUS={result.cache_status.value}")
+    print("PUBLISH_OK=true")
+    return config.EXIT_OK

--- a/plugin/python/larch/report/run_log_publish.py
+++ b/plugin/python/larch/report/run_log_publish.py
@@ -20,27 +20,17 @@ from pathlib import Path
 from typing import Final, Protocol, cast
 
 from larch import io as larch_io
-from larch.core import config
-from larch.core.repo_roots import consumer_repo_root
+from larch.core import config, repo_roots
+from larch.report import run_log_archive, storage_config
 from larch.report.object_store import (
     ObjectStoreError,
     ObjectStoreErrorKind,
     RemoteObject,
     object_store_for,
 )
-from larch.report.run_log_archive import (
-    RunArchiveMaterializationResult,
-    create_run_archive,
-    materialize_run_archive,
-    promote_staging_run_directory,
-    verify_materialized_run_directory,
-)
+from larch.report.run_log_archive import RunArchiveMaterializationResult
 from larch.report.run_log_batch import validate_run_id_slug
-from larch.report.storage_config import (
-    StorageConfigurationError,
-    StorageRoot,
-    discover_storage_root,
-)
+from larch.report.storage_config import StorageConfigurationError, StorageRoot
 
 _PENDING_SCHEMA_VERSION: Final = 1
 _PENDING_ARCHIVE_NAME: Final = "archive.tar.gz"
@@ -453,7 +443,7 @@ def _create_pending(
     try:
         if request.staging_root is None:
             raise PublicationError("a staging root is required to create a pending archive")
-        created = create_run_archive(
+        created = run_log_archive.create_run_archive(
             staging_root=request.staging_root,
             output_dir=temporary,
             skill=request.skill,
@@ -571,7 +561,7 @@ def _cache_result(
 ) -> tuple[RunArchiveMaterializationResult, CachePublicationStatus]:
     _ = _ensure_concurrent_directory(paths.cache_dir.parent)
     if paths.cache_dir.exists() or paths.cache_dir.is_symlink():
-        existing: RunArchiveMaterializationResult = verify_materialized_run_directory(
+        existing: RunArchiveMaterializationResult = run_log_archive.verify_materialized_run_directory(
             run_dir=paths.cache_dir,
             expected_skill=pending.skill,
             expected_run_id=pending.run_id,
@@ -580,7 +570,7 @@ def _cache_result(
             raise PublicationError("existing cache directory contains different run content")
         return existing, CachePublicationStatus.PRESENT
     if staging_root is not None:
-        promoted: RunArchiveMaterializationResult = promote_staging_run_directory(
+        promoted: RunArchiveMaterializationResult = run_log_archive.promote_staging_run_directory(
             staging_root=staging_root,
             run_dir=paths.cache_dir,
             expected_skill=pending.skill,
@@ -588,7 +578,7 @@ def _cache_result(
             expected_manifest_sha256=pending.manifest_sha256,
         )
         return promoted, CachePublicationStatus.PROMOTED
-    materialized: RunArchiveMaterializationResult = materialize_run_archive(
+    materialized: RunArchiveMaterializationResult = run_log_archive.materialize_run_archive(
         archive_path=paths.pending_archive,
         run_dir=paths.cache_dir,
         expected_skill=pending.skill,
@@ -698,12 +688,14 @@ def main(argv: Sequence[str]) -> int:
         return int(exc.code) if isinstance(exc.code, int) else config.EXIT_USAGE
     try:
         requested_root: Path = Path(args.repo_root)
-        repo_root: Path | None = consumer_repo_root(requested_root)
+        repo_root: Path | None = repo_roots.consumer_repo_root(requested_root)
         if repo_root is None:
             raise StorageConfigurationError(
                 f"could not discover a Git repository root from {requested_root}"
             )
-        storage_root: StorageRoot = discover_storage_root(start=repo_root)
+        storage_root: StorageRoot = storage_config.discover_storage_root(
+            start=repo_root
+        )
         result: PublicationResult = publish_run(
             request=PublicationRequest(
                 repo_root=repo_root,

--- a/python/README.md
+++ b/python/README.md
@@ -34,6 +34,9 @@ Mostly-flat `python/` tree for larch's stdlib-only runtime modules (Python ≥ 3
   documented in `config.MERGE_RESULT_DRIVER_ALREADY_MERGED` for `flush_logs_pre` skip parity.
   Tool-failure batch capture remains deferred to Phase 7 wiring; bash launchers still own
   `append-tool-failure.sh` calls on the live path.
+- `larch/report/run_log_archive.py`, `object_store.py`, `storage_config.py`, and
+  `run_log_publish.py` own deterministic archives, provider-neutral transfer,
+  append-only publication, durable retry, and write-through cache promotion.
 - `tests/`: unit tests mirror package layout under `python/tests/`.
 - `test_support.py`: intentionally remains at `python/` root as a shared pytest helper exempted by `python3 python/cli.py lint flat-tests`. It provides the shared list-queue `RecordingRunner` used by tests such as `test_run_logs.py` and `test_ci_monitor.py`.
 

--- a/python/larch/cli.py
+++ b/python/larch/cli.py
@@ -651,6 +651,7 @@ _REGISTRY: dict[tuple[str, str], tuple[str, str, bool]] = {
     ("run-log", "storage-preflight"): ("larch.report.storage_config", "storage_preflight_main", True),
     ("run-log", "archive"): ("larch.report.run_log_archive", "main", False),
     ("run-log", "materialize"): ("larch.report.run_log_archive", "materialize_main", False),
+    ("run-log", "publish"): ("larch.report.run_log_publish", "main", True),
     ("run-log", "validate-run-id"): ("larch.report.run_logs", "larch_log_validate_run_id_main", True),
     ("run-log", "capture-transcript"): ("larch.report.run_log_flush", "capture_transcript_main", False),
     ("run-log", "render-session-transcript"): ("larch.rendering.render_session_transcript", "main", False),

--- a/python/larch/report/run_log_archive.py
+++ b/python/larch/report/run_log_archive.py
@@ -657,6 +657,23 @@ def _write_materialized_bytes(path: Path, content: bytes, *, root: Path, mode: i
         os.fsync(handle.fileno())
 
 
+def _fsync_directory(path: Path) -> None:
+    directory: Path = larch_io.validate_trusted_directory(path)
+    flags: int = os.O_RDONLY
+    if hasattr(os, "O_DIRECTORY"):
+        flags |= os.O_DIRECTORY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor: int = os.open(directory, flags)
+    try:
+        opened: os.stat_result = os.fstat(descriptor)
+        if not stat.S_ISDIR(opened.st_mode):
+            raise OSError(f"archive directory changed while opening: {directory}")
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
 def _extract_regular_member(
     archive: tarfile.TarFile,
     tar_member: tarfile.TarInfo,
@@ -813,7 +830,122 @@ def _extract_validated_archive(
             temporary_root=temporary_root,
         )
     for member in sorted(directories, key=lambda item: item.path.count("/"), reverse=True):
-        temporary_root.joinpath(*PurePosixPath(member.path).parts).chmod(0o755)
+        directory: Path = temporary_root.joinpath(*PurePosixPath(member.path).parts)
+        directory.chmod(0o755)
+        _fsync_directory(directory)
+    _fsync_directory(temporary_root)
+
+
+def _copy_staging_members(
+    *,
+    staging_root: Path,
+    temporary_root: Path,
+    manifest: RunArchiveManifest,
+) -> None:
+    directories: list[ArchiveMember] = [
+        member for member in manifest.members if member.kind == "directory"
+    ]
+    for member in sorted(directories, key=lambda item: (item.path.count("/"), item.path)):
+        destination: Path = temporary_root.joinpath(*PurePosixPath(member.path).parts)
+        destination.mkdir(mode=0o700)
+        _ = larch_io.validate_trusted_directory(destination, root=temporary_root)
+    _write_materialized_bytes(
+        temporary_root / ARCHIVE_MANIFEST_NAME,
+        manifest.to_bytes(),
+        root=temporary_root,
+        mode=0o644,
+    )
+    for member in manifest.members:
+        if member.kind == "directory":
+            continue
+        expected: os.stat_result = member.source.stat(follow_symlinks=False)
+        destination = temporary_root.joinpath(*PurePosixPath(member.path).parts)
+        digest = hashlib.sha256()
+        written = 0
+        with (
+            _open_regular_member(member.source, root=staging_root, expected=expected) as source,
+            _new_materialized_file(destination, root=temporary_root, mode=member.mode) as output,
+        ):
+            while chunk := source.read(_CHUNK_SIZE):
+                written += len(chunk)
+                _ = output.write(chunk)
+                digest.update(chunk)
+            output.flush()
+            os.fsync(output.fileno())
+        _assert_unchanged(member.source, expected=expected)
+        if written != member.size or digest.hexdigest() != member.sha256:
+            raise OSError(f"archive source changed while promoting cache: {member.source}")
+    for member in sorted(directories, key=lambda item: item.path.count("/"), reverse=True):
+        directory: Path = temporary_root.joinpath(*PurePosixPath(member.path).parts)
+        directory.chmod(0o755)
+        _fsync_directory(directory)
+    _fsync_directory(temporary_root)
+
+
+def promote_staging_run_directory(
+    *,
+    staging_root: Path,
+    run_dir: Path,
+    expected_skill: str,
+    expected_run_id: str,
+    expected_manifest_sha256: str,
+) -> RunArchiveMaterializationResult:
+    """Copy a sanitized staging tree directly into the unpacked run cache."""
+    if not validate_run_id_slug(expected_skill):
+        raise ValueError(f"invalid expected skill: {expected_skill}")
+    if not validate_run_id_slug(expected_run_id):
+        raise ValueError(f"invalid expected run-id: {expected_run_id}")
+    root: Path = larch_io.validate_trusted_directory(staging_root)
+    requested_run_dir: Path = run_dir if run_dir.is_absolute() else Path.cwd() / run_dir
+    if requested_run_dir.name != expected_run_id:
+        raise ValueError("promoted run directory name must match the expected run-id")
+    try:
+        _ = requested_run_dir.relative_to(root)
+    except ValueError:
+        pass
+    else:
+        raise ValueError("promoted run directory must not be inside the staging tree")
+    parent: Path = larch_io.ensure_trusted_directory(requested_run_dir.parent)
+    destination: Path = parent / requested_run_dir.name
+    if destination.exists() or destination.is_symlink():
+        raise FileExistsError(f"refusing to merge staging tree into existing run directory: {destination}")
+    members: tuple[ArchiveMember, ...] = _collect_members(root)
+    manifest = RunArchiveManifest(skill=expected_skill, run_id=expected_run_id, members=members)
+    manifest_sha256: str = hashlib.sha256(manifest.to_bytes()).hexdigest()
+    if manifest_sha256 != expected_manifest_sha256:
+        raise ValueError("staging tree no longer matches the pending archive manifest")
+    temporary_root: Path | None = None
+    try:
+        temporary_root = Path(
+            tempfile.mkdtemp(dir=parent, prefix=f".{destination.name}.promote-")
+        )
+        temporary_root.chmod(0o700)
+        _copy_staging_members(
+            staging_root=root,
+            temporary_root=temporary_root,
+            manifest=manifest,
+        )
+        _ = verify_materialized_run_directory(
+            run_dir=temporary_root,
+            expected_skill=expected_skill,
+            expected_run_id=expected_run_id,
+        )
+        _ = temporary_root.rename(destination)
+        _fsync_directory(parent)
+        temporary_root = None
+        try:
+            return verify_materialized_run_directory(
+                run_dir=destination,
+                expected_skill=expected_skill,
+                expected_run_id=expected_run_id,
+            )
+        except (OSError, TypeError, ValueError):
+            shutil.rmtree(destination)
+            _fsync_directory(parent)
+            raise
+    finally:
+        if temporary_root is not None:
+            shutil.rmtree(temporary_root)
 
 
 def materialize_run_archive(
@@ -867,6 +999,7 @@ def materialize_run_archive(
             limits=active_limits,
         )
         _ = temporary_root.rename(destination)
+        _fsync_directory(parent)
         temporary_root = None
         try:
             return verify_materialized_run_directory(
@@ -877,6 +1010,7 @@ def materialize_run_archive(
             )
         except (OSError, TypeError, ValueError):
             shutil.rmtree(destination)
+            _fsync_directory(parent)
             raise
     finally:
         if temporary_root is not None:

--- a/python/larch/report/run_log_publish.py
+++ b/python/larch/report/run_log_publish.py
@@ -1,0 +1,736 @@
+"""Append-only run archive publication with durable retry and cache promotion."""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import hashlib
+import json
+import os
+import shutil
+import stat
+import sys
+import tarfile
+import tempfile
+from collections.abc import Generator, Mapping, Sequence
+from contextlib import contextmanager, suppress
+from dataclasses import asdict, dataclass, replace
+from enum import StrEnum
+from pathlib import Path
+from typing import Final, Protocol, cast
+
+from larch import io as larch_io
+from larch.core import config
+from larch.core.repo_roots import consumer_repo_root
+from larch.report.object_store import (
+    ObjectStoreError,
+    ObjectStoreErrorKind,
+    RemoteObject,
+    object_store_for,
+)
+from larch.report.run_log_archive import (
+    RunArchiveMaterializationResult,
+    create_run_archive,
+    materialize_run_archive,
+    promote_staging_run_directory,
+    verify_materialized_run_directory,
+)
+from larch.report.run_log_batch import validate_run_id_slug
+from larch.report.storage_config import (
+    StorageConfigurationError,
+    StorageRoot,
+    discover_storage_root,
+)
+
+_PENDING_SCHEMA_VERSION: Final = 1
+_PENDING_ARCHIVE_NAME: Final = "archive.tar.gz"
+_PENDING_METADATA_NAME: Final = "retry.json"
+_ENV_XDG_CACHE_HOME: Final = "XDG_CACHE_HOME"
+_ENV_XDG_STATE_HOME: Final = "XDG_STATE_HOME"
+_CHUNK_SIZE: Final = 1024 * 1024
+_ASCII_CONTROL_BOUND: Final = 32
+_ASCII_DELETE: Final = 127
+_SHA256_HEX_LENGTH: Final = 64
+_PENDING_KEYS: Final = frozenset(
+    {
+        "archive_sha256",
+        "archive_size",
+        "attempts",
+        "last_error",
+        "manifest_sha256",
+        "remote_key",
+        "repo_name",
+        "run_id",
+        "schema_version",
+        "skill",
+        "storage_uri",
+    }
+)
+
+
+class PublicationError(RuntimeError):
+    """A publication or durable retry invariant failed."""
+
+
+class RemotePublicationStatus(StrEnum):
+    """How the immutable remote object reached its postcondition."""
+
+    CREATED = "created"
+    MATCHED = "matched"
+
+
+class CachePublicationStatus(StrEnum):
+    """How the verified unpacked cache reached its postcondition."""
+
+    PROMOTED = "promoted"
+    MATERIALIZED = "materialized"
+    PRESENT = "present"
+
+
+class ObjectStore(Protocol):
+    """Provider-neutral operations required by publication."""
+
+    def upload_create(self, key: str, source: Path) -> RemoteObject: ...
+
+    def download(self, key: str, destination: Path) -> None: ...
+
+    def metadata(self, key: str) -> RemoteObject: ...
+
+
+@dataclass(frozen=True)
+class PublicationPaths:
+    """All local paths owned by one repository/skill/run publication."""
+
+    pending_dir: Path
+    pending_archive: Path
+    pending_metadata: Path
+    cache_dir: Path
+    lock_file: Path
+
+
+@dataclass(frozen=True)
+class PublicationRequest:
+    """Immutable caller inputs for one run publication attempt."""
+
+    repo_root: Path
+    storage_root: StorageRoot
+    skill: str
+    run_id: str
+    staging_root: Path | None
+    cache_home: Path | None = None
+    state_home: Path | None = None
+
+
+@dataclass(frozen=True)
+class PendingPublication:
+    """Content-pinned durable retry record for one immutable object."""
+
+    schema_version: int
+    storage_uri: str
+    repo_name: str
+    skill: str
+    run_id: str
+    remote_key: str
+    archive_sha256: str
+    archive_size: int
+    manifest_sha256: str
+    attempts: int
+    last_error: str
+
+
+@dataclass(frozen=True)
+class PublicationResult:
+    """Verified remote and local postconditions for a published run."""
+
+    remote_key: str
+    archive_sha256: str
+    cache_dir: Path
+    remote_status: RemotePublicationStatus
+    cache_status: CachePublicationStatus
+
+
+def _validated_component(value: str, *, label: str, slug: bool) -> str:
+    invalid_literal: bool = (
+        not value
+        or value in {".", ".."}
+        or "/" in value
+        or "\\" in value
+        or any(
+            ord(character) < _ASCII_CONTROL_BOUND or ord(character) == _ASCII_DELETE
+            for character in value
+        )
+    )
+    if invalid_literal or (slug and not validate_run_id_slug(value)):
+        raise ValueError(f"invalid {label}: {value!r}")
+    return value
+
+
+def _xdg_home(
+    *,
+    environ: Mapping[str, str],
+    variable: str,
+    fallback: Path,
+) -> Path:
+    configured: str = environ.get(variable, "")
+    selected: Path = Path(configured) if configured else fallback
+    if not selected.is_absolute():
+        raise ValueError(f"{variable} must be an absolute path")
+    return selected
+
+
+def publication_paths(
+    *,
+    request: PublicationRequest,
+    environ: Mapping[str, str] | None = None,
+) -> PublicationPaths:
+    """Resolve the literal repository cache path and durable retry path."""
+    root: Path = larch_io.validate_trusted_directory(request.repo_root)
+    repo_name: str = _validated_component(root.name, label="repository name", slug=False)
+    skill_name: str = _validated_component(request.skill, label="skill", slug=True)
+    run_name: str = _validated_component(request.run_id, label="run-id", slug=True)
+    environment: Mapping[str, str] = os.environ if environ is None else environ
+    resolved_cache_home: Path = request.cache_home or _xdg_home(
+        environ=environment,
+        variable=_ENV_XDG_CACHE_HOME,
+        fallback=Path.home() / ".cache",
+    )
+    resolved_state_home: Path = request.state_home or _xdg_home(
+        environ=environment,
+        variable=_ENV_XDG_STATE_HOME,
+        fallback=Path.home() / ".local" / "state",
+    )
+    if not resolved_cache_home.is_absolute() or not resolved_state_home.is_absolute():
+        raise ValueError("publication cache and state homes must be absolute paths")
+    cache_dir: Path = (
+        resolved_cache_home / "larch" / "run-logs" / repo_name / skill_name / run_name
+    )
+    pending_dir: Path = (
+        resolved_state_home
+        / "larch"
+        / "run-log-pending"
+        / repo_name
+        / skill_name
+        / run_name
+    )
+    lock_file: Path = (
+        resolved_state_home
+        / "larch"
+        / "run-log-locks"
+        / repo_name
+        / skill_name
+        / f"{run_name}.lock"
+    )
+    return PublicationPaths(
+        pending_dir=pending_dir,
+        pending_archive=pending_dir / _PENDING_ARCHIVE_NAME,
+        pending_metadata=pending_dir / _PENDING_METADATA_NAME,
+        cache_dir=cache_dir,
+        lock_file=lock_file,
+    )
+
+
+def _ensure_concurrent_directory(path: Path) -> Path:
+    """Create a trusted directory while tolerating a same-path creator race."""
+    directory: Path = path if path.is_absolute() else Path.cwd() / path
+    try:
+        return larch_io.validate_trusted_directory(directory)
+    except OSError:
+        pass
+    if directory == directory.parent:
+        raise OSError(f"cannot create trusted publication directory: {directory}")
+    _ = _ensure_concurrent_directory(directory.parent)
+    with suppress(FileExistsError):
+        directory.mkdir(mode=0o700)
+    return larch_io.validate_trusted_directory(directory)
+
+
+@contextmanager
+def publication_lock(path: Path) -> Generator[None, None, None]:
+    """Hold the blocking advisory lock shared by all operations for one run."""
+    parent: Path = _ensure_concurrent_directory(path.parent)
+    lock_path: Path = parent / path.name
+    if lock_path.is_symlink():
+        raise OSError(f"refusing symlinked publication lock: {lock_path}")
+    flags: int = os.O_RDWR | os.O_CREAT
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor: int = os.open(lock_path, flags, 0o600)
+    try:
+        opened: os.stat_result = os.fstat(descriptor)
+        if not stat.S_ISREG(opened.st_mode):
+            raise OSError(f"publication lock is not a regular file: {lock_path}")
+        os.fchmod(descriptor, 0o600)
+        fcntl.flock(descriptor, fcntl.LOCK_EX)
+        yield
+    finally:
+        with suppress(OSError):
+            fcntl.flock(descriptor, fcntl.LOCK_UN)
+        os.close(descriptor)
+
+
+def _sha256_regular_file(path: Path, *, root: Path) -> tuple[str, int]:
+    trusted_root: Path = larch_io.validate_trusted_directory(root)
+    if path.parent != trusted_root:
+        raise OSError(f"publication archive is outside its trusted directory: {path}")
+    entry: os.stat_result = path.stat(follow_symlinks=False)
+    if not stat.S_ISREG(entry.st_mode):
+        raise OSError(f"publication archive is not a regular file: {path}")
+    flags: int = os.O_RDONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor: int = os.open(path, flags)
+    digest = hashlib.sha256()
+    with os.fdopen(descriptor, "rb") as handle:
+        opened: os.stat_result = os.fstat(handle.fileno())
+        if (opened.st_dev, opened.st_ino, opened.st_size) != (
+            entry.st_dev,
+            entry.st_ino,
+            entry.st_size,
+        ):
+            raise OSError(f"publication archive changed while opening: {path}")
+        while chunk := handle.read(_CHUNK_SIZE):
+            digest.update(chunk)
+    current: os.stat_result = path.stat(follow_symlinks=False)
+    if (current.st_dev, current.st_ino, current.st_size, current.st_mtime_ns) != (
+        entry.st_dev,
+        entry.st_ino,
+        entry.st_size,
+        entry.st_mtime_ns,
+    ):
+        raise OSError(f"publication archive changed while reading: {path}")
+    return digest.hexdigest(), entry.st_size
+
+
+def _fsync_directory(path: Path) -> None:
+    directory: Path = larch_io.validate_trusted_directory(path)
+    flags: int = os.O_RDONLY
+    if hasattr(os, "O_DIRECTORY"):
+        flags |= os.O_DIRECTORY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor: int = os.open(directory, flags)
+    try:
+        opened: os.stat_result = os.fstat(descriptor)
+        if not stat.S_ISDIR(opened.st_mode):
+            raise OSError(f"publication directory changed while opening: {directory}")
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _metadata_text(pending: PendingPublication) -> str:
+    return json.dumps(asdict(pending), ensure_ascii=False, sort_keys=True, separators=(",", ":")) + "\n"
+
+
+def _write_pending_metadata(paths: PublicationPaths, pending: PendingPublication) -> None:
+    larch_io.trusted_atomic_write(
+        paths.pending_metadata,
+        _metadata_text(pending),
+        root=paths.pending_dir,
+    )
+    _fsync_directory(paths.pending_dir)
+
+
+def _parse_pending_metadata(text: str) -> PendingPublication:
+    try:
+        raw: object = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise PublicationError("pending publication metadata is invalid JSON") from exc
+    if not isinstance(raw, dict):
+        raise PublicationError("pending publication metadata has invalid fields")
+    data = cast("dict[str, object]", raw)
+    if frozenset(data) != _PENDING_KEYS:
+        raise PublicationError("pending publication metadata has invalid fields")
+    string_keys: tuple[str, ...] = (
+        "storage_uri",
+        "repo_name",
+        "skill",
+        "run_id",
+        "remote_key",
+        "archive_sha256",
+        "manifest_sha256",
+        "last_error",
+    )
+    if any(not isinstance(data[key], str) for key in string_keys):
+        raise PublicationError("pending publication metadata has invalid string fields")
+    integer_keys: tuple[str, ...] = ("schema_version", "archive_size", "attempts")
+    if any(not isinstance(data[key], int) or isinstance(data[key], bool) for key in integer_keys):
+        raise PublicationError("pending publication metadata has invalid integer fields")
+    return PendingPublication(
+        schema_version=cast("int", data["schema_version"]),
+        storage_uri=cast("str", data["storage_uri"]),
+        repo_name=cast("str", data["repo_name"]),
+        skill=cast("str", data["skill"]),
+        run_id=cast("str", data["run_id"]),
+        remote_key=cast("str", data["remote_key"]),
+        archive_sha256=cast("str", data["archive_sha256"]),
+        archive_size=cast("int", data["archive_size"]),
+        manifest_sha256=cast("str", data["manifest_sha256"]),
+        attempts=cast("int", data["attempts"]),
+        last_error=cast("str", data["last_error"]),
+    )
+
+
+def _validate_pending(
+    *,
+    paths: PublicationPaths,
+    pending: PendingPublication,
+    request: PublicationRequest,
+    repo_name: str,
+) -> PendingPublication:
+    expected_key: str = f"run-logs/{request.skill}/{request.run_id}.tar.gz"
+    identity: tuple[object, ...] = (
+        pending.schema_version,
+        pending.storage_uri,
+        pending.repo_name,
+        pending.skill,
+        pending.run_id,
+        pending.remote_key,
+    )
+    expected_identity: tuple[object, ...] = (
+        _PENDING_SCHEMA_VERSION,
+        request.storage_root.uri,
+        repo_name,
+        request.skill,
+        request.run_id,
+        expected_key,
+    )
+    if identity != expected_identity:
+        raise PublicationError("pending publication identity does not match the live request")
+    if (
+        not _valid_sha256(pending.archive_sha256)
+        or not _valid_sha256(pending.manifest_sha256)
+        or pending.archive_size <= 0
+        or pending.attempts < 0
+    ):
+        raise PublicationError("pending publication metadata has invalid content identity")
+    archive_sha256, archive_size = _sha256_regular_file(
+        paths.pending_archive,
+        root=paths.pending_dir,
+    )
+    if (archive_sha256, archive_size) != (pending.archive_sha256, pending.archive_size):
+        raise PublicationError("pending archive does not match its durable content identity")
+    return pending
+
+
+def _valid_sha256(value: str) -> bool:
+    return len(value) == _SHA256_HEX_LENGTH and all(
+        character in "0123456789abcdef" for character in value
+    )
+
+
+def _load_pending(
+    *,
+    paths: PublicationPaths,
+    request: PublicationRequest,
+    repo_name: str,
+) -> PendingPublication:
+    root: Path = larch_io.validate_trusted_directory(paths.pending_dir)
+    text: str = larch_io.read_trusted_text(
+        paths.pending_metadata,
+        root=root,
+        reject_cr=True,
+    )
+    return _validate_pending(
+        paths=paths,
+        pending=_parse_pending_metadata(text),
+        request=request,
+        repo_name=repo_name,
+    )
+
+
+def _create_pending(
+    *,
+    paths: PublicationPaths,
+    request: PublicationRequest,
+    repo_name: str,
+) -> PendingPublication:
+    parent: Path = _ensure_concurrent_directory(paths.pending_dir.parent)
+    temporary: Path | None = Path(
+        tempfile.mkdtemp(dir=parent, prefix=f".{request.run_id}.pending-")
+    )
+    temporary.chmod(0o700)
+    try:
+        if request.staging_root is None:
+            raise PublicationError("a staging root is required to create a pending archive")
+        created = create_run_archive(
+            staging_root=request.staging_root,
+            output_dir=temporary,
+            skill=request.skill,
+            run_id=request.run_id,
+        )
+        archive_path: Path = temporary / _PENDING_ARCHIVE_NAME
+        _ = created.archive_path.rename(archive_path)
+        pending = PendingPublication(
+            schema_version=_PENDING_SCHEMA_VERSION,
+            storage_uri=request.storage_root.uri,
+            repo_name=repo_name,
+            skill=request.skill,
+            run_id=request.run_id,
+            remote_key=f"run-logs/{request.skill}/{request.run_id}.tar.gz",
+            archive_sha256=created.archive_sha256,
+            archive_size=archive_path.stat(follow_symlinks=False).st_size,
+            manifest_sha256=created.manifest_sha256,
+            attempts=0,
+            last_error="",
+        )
+        temporary_paths = PublicationPaths(
+            pending_dir=temporary,
+            pending_archive=archive_path,
+            pending_metadata=temporary / _PENDING_METADATA_NAME,
+            cache_dir=paths.cache_dir,
+            lock_file=paths.lock_file,
+        )
+        _write_pending_metadata(temporary_paths, pending)
+        _ = temporary.rename(paths.pending_dir)
+        _fsync_directory(parent)
+        temporary = None
+        return _load_pending(
+            paths=paths,
+            request=request,
+            repo_name=repo_name,
+        )
+    finally:
+        if temporary is not None:
+            shutil.rmtree(temporary)
+
+
+def _pending_for_request(
+    *,
+    paths: PublicationPaths,
+    request: PublicationRequest,
+    repo_name: str,
+) -> PendingPublication:
+    if paths.pending_dir.exists() or paths.pending_dir.is_symlink():
+        return _load_pending(
+            paths=paths,
+            request=request,
+            repo_name=repo_name,
+        )
+    if request.staging_root is None:
+        raise PublicationError("no durable pending archive exists and --staging-root was not provided")
+    return _create_pending(
+        paths=paths,
+        request=request,
+        repo_name=repo_name,
+    )
+
+
+def _matching_remote_exists(
+    *,
+    store: ObjectStore,
+    pending: PendingPublication,
+    paths: PublicationPaths,
+) -> bool:
+    remote: RemoteObject = store.metadata(pending.remote_key)
+    if remote.size != pending.archive_size:
+        return False
+    with tempfile.NamedTemporaryFile(
+        dir=paths.pending_dir,
+        prefix=".remote-verify-",
+        delete=False,
+    ) as handle:
+        downloaded: Path = Path(handle.name)
+    try:
+        store.download(pending.remote_key, downloaded)
+        remote_sha256, remote_size = _sha256_regular_file(downloaded, root=paths.pending_dir)
+        return (remote_sha256, remote_size) == (pending.archive_sha256, pending.archive_size)
+    finally:
+        downloaded.unlink(missing_ok=True)
+
+
+def _publish_remote(
+    *,
+    store: ObjectStore,
+    pending: PendingPublication,
+    paths: PublicationPaths,
+) -> RemotePublicationStatus:
+    try:
+        uploaded: RemoteObject = store.upload_create(pending.remote_key, paths.pending_archive)
+    except ObjectStoreError as exc:
+        if exc.kind is not ObjectStoreErrorKind.ALREADY_EXISTS:
+            raise
+        if not _matching_remote_exists(store=store, pending=pending, paths=paths):
+            raise PublicationError(
+                "immutable remote key already exists with different content"
+            ) from exc
+        return RemotePublicationStatus.MATCHED
+    if uploaded.key != pending.remote_key or uploaded.size != pending.archive_size:
+        raise PublicationError("create-only upload returned a mismatched object identity")
+    verified: RemoteObject = store.metadata(pending.remote_key)
+    if verified.key != pending.remote_key or verified.size != pending.archive_size:
+        raise PublicationError("uploaded remote object failed metadata verification")
+    return RemotePublicationStatus.CREATED
+
+
+def _cache_result(
+    *,
+    paths: PublicationPaths,
+    pending: PendingPublication,
+    staging_root: Path | None,
+) -> tuple[RunArchiveMaterializationResult, CachePublicationStatus]:
+    _ = _ensure_concurrent_directory(paths.cache_dir.parent)
+    if paths.cache_dir.exists() or paths.cache_dir.is_symlink():
+        existing: RunArchiveMaterializationResult = verify_materialized_run_directory(
+            run_dir=paths.cache_dir,
+            expected_skill=pending.skill,
+            expected_run_id=pending.run_id,
+        )
+        if existing.manifest_sha256 != pending.manifest_sha256:
+            raise PublicationError("existing cache directory contains different run content")
+        return existing, CachePublicationStatus.PRESENT
+    if staging_root is not None:
+        promoted: RunArchiveMaterializationResult = promote_staging_run_directory(
+            staging_root=staging_root,
+            run_dir=paths.cache_dir,
+            expected_skill=pending.skill,
+            expected_run_id=pending.run_id,
+            expected_manifest_sha256=pending.manifest_sha256,
+        )
+        return promoted, CachePublicationStatus.PROMOTED
+    materialized: RunArchiveMaterializationResult = materialize_run_archive(
+        archive_path=paths.pending_archive,
+        run_dir=paths.cache_dir,
+        expected_skill=pending.skill,
+        expected_run_id=pending.run_id,
+    )
+    return materialized, CachePublicationStatus.MATERIALIZED
+
+
+def _failure_token(exc: Exception) -> str:
+    if isinstance(exc, ObjectStoreError):
+        return f"object-{exc.operation}-{exc.kind.value}"
+    if isinstance(exc, PublicationError):
+        return "publication-invariant"
+    if isinstance(exc, (EOFError, OSError, tarfile.TarError, TypeError, ValueError)):
+        return "local-integrity"
+    return "internal"
+
+
+def _complete_pending(paths: PublicationPaths) -> None:
+    completed: Path = paths.pending_dir.with_name(
+        f".{paths.pending_dir.name}.complete-{os.getpid()}-{os.urandom(4).hex()}"
+    )
+    _ = paths.pending_dir.rename(completed)
+    _fsync_directory(completed.parent)
+    with suppress(OSError):
+        shutil.rmtree(completed)
+
+
+def publish_run(
+    *,
+    request: PublicationRequest,
+    store: ObjectStore | None = None,
+    environ: Mapping[str, str] | None = None,
+) -> PublicationResult:
+    """Publish one immutable archive and atomically populate its local cache."""
+    root: Path = larch_io.validate_trusted_directory(request.repo_root)
+    repo_name: str = _validated_component(root.name, label="repository name", slug=False)
+    skill_name: str = _validated_component(request.skill, label="skill", slug=True)
+    run_name: str = _validated_component(request.run_id, label="run-id", slug=True)
+    normalized_request = replace(
+        request,
+        repo_root=root,
+        skill=skill_name,
+        run_id=run_name,
+    )
+    paths: PublicationPaths = publication_paths(
+        request=normalized_request,
+        environ=environ,
+    )
+    active_store: ObjectStore = (
+        object_store_for(normalized_request.storage_root, environ=environ)
+        if store is None
+        else store
+    )
+    with publication_lock(paths.lock_file):
+        pending: PendingPublication = _pending_for_request(
+            paths=paths,
+            request=normalized_request,
+            repo_name=repo_name,
+        )
+        pending = replace(pending, attempts=pending.attempts + 1, last_error="")
+        _write_pending_metadata(paths, pending)
+        try:
+            remote_status: RemotePublicationStatus = _publish_remote(
+                store=active_store,
+                pending=pending,
+                paths=paths,
+            )
+            cache_result, cache_status = _cache_result(
+                paths=paths,
+                pending=pending,
+                staging_root=normalized_request.staging_root,
+            )
+            if cache_result.manifest_sha256 != pending.manifest_sha256:
+                raise PublicationError("published cache failed manifest identity verification")
+        except (
+            EOFError,
+            ObjectStoreError,
+            OSError,
+            PublicationError,
+            tarfile.TarError,
+            TypeError,
+            ValueError,
+        ) as exc:
+            _write_pending_metadata(paths, replace(pending, last_error=_failure_token(exc)))
+            raise
+        _complete_pending(paths)
+    return PublicationResult(
+        remote_key=pending.remote_key,
+        archive_sha256=pending.archive_sha256,
+        cache_dir=paths.cache_dir,
+        remote_status=remote_status,
+        cache_status=cache_status,
+    )
+
+
+def main(argv: Sequence[str]) -> int:
+    """Publish or retry one run and emit its machine-readable postconditions."""
+    parser = argparse.ArgumentParser(prog="cli.py run-log publish")
+    _ = parser.add_argument("--repo-root", required=True)
+    _ = parser.add_argument("--skill", required=True)
+    _ = parser.add_argument("--run-id", required=True)
+    _ = parser.add_argument("--staging-root")
+    try:
+        args = parser.parse_args(argv)
+    except SystemExit as exc:
+        return int(exc.code) if isinstance(exc.code, int) else config.EXIT_USAGE
+    try:
+        requested_root: Path = Path(args.repo_root)
+        repo_root: Path | None = consumer_repo_root(requested_root)
+        if repo_root is None:
+            raise StorageConfigurationError(
+                f"could not discover a Git repository root from {requested_root}"
+            )
+        storage_root: StorageRoot = discover_storage_root(start=repo_root)
+        result: PublicationResult = publish_run(
+            request=PublicationRequest(
+                repo_root=repo_root,
+                storage_root=storage_root,
+                skill=args.skill,
+                run_id=args.run_id,
+                staging_root=Path(args.staging_root) if args.staging_root else None,
+            ),
+        )
+    except StorageConfigurationError as exc:
+        print(f"publication failed: {exc}", file=sys.stderr)
+        return config.EXIT_STORAGE_CONFIG
+    except (
+        EOFError,
+        ObjectStoreError,
+        OSError,
+        PublicationError,
+        tarfile.TarError,
+        TypeError,
+        ValueError,
+    ) as exc:
+        print(f"publication failed: {exc}", file=sys.stderr)
+        return config.EXIT_INTERNAL_ERROR
+    print(f"REMOTE_KEY={result.remote_key}")
+    print(f"ARCHIVE_SHA256={result.archive_sha256}")
+    print(f"CACHE_DIR={result.cache_dir}")
+    print(f"REMOTE_STATUS={result.remote_status.value}")
+    print(f"CACHE_STATUS={result.cache_status.value}")
+    print("PUBLISH_OK=true")
+    return config.EXIT_OK

--- a/python/larch/report/run_log_publish.py
+++ b/python/larch/report/run_log_publish.py
@@ -20,27 +20,17 @@ from pathlib import Path
 from typing import Final, Protocol, cast
 
 from larch import io as larch_io
-from larch.core import config
-from larch.core.repo_roots import consumer_repo_root
+from larch.core import config, repo_roots
+from larch.report import run_log_archive, storage_config
 from larch.report.object_store import (
     ObjectStoreError,
     ObjectStoreErrorKind,
     RemoteObject,
     object_store_for,
 )
-from larch.report.run_log_archive import (
-    RunArchiveMaterializationResult,
-    create_run_archive,
-    materialize_run_archive,
-    promote_staging_run_directory,
-    verify_materialized_run_directory,
-)
+from larch.report.run_log_archive import RunArchiveMaterializationResult
 from larch.report.run_log_batch import validate_run_id_slug
-from larch.report.storage_config import (
-    StorageConfigurationError,
-    StorageRoot,
-    discover_storage_root,
-)
+from larch.report.storage_config import StorageConfigurationError, StorageRoot
 
 _PENDING_SCHEMA_VERSION: Final = 1
 _PENDING_ARCHIVE_NAME: Final = "archive.tar.gz"
@@ -453,7 +443,7 @@ def _create_pending(
     try:
         if request.staging_root is None:
             raise PublicationError("a staging root is required to create a pending archive")
-        created = create_run_archive(
+        created = run_log_archive.create_run_archive(
             staging_root=request.staging_root,
             output_dir=temporary,
             skill=request.skill,
@@ -571,7 +561,7 @@ def _cache_result(
 ) -> tuple[RunArchiveMaterializationResult, CachePublicationStatus]:
     _ = _ensure_concurrent_directory(paths.cache_dir.parent)
     if paths.cache_dir.exists() or paths.cache_dir.is_symlink():
-        existing: RunArchiveMaterializationResult = verify_materialized_run_directory(
+        existing: RunArchiveMaterializationResult = run_log_archive.verify_materialized_run_directory(
             run_dir=paths.cache_dir,
             expected_skill=pending.skill,
             expected_run_id=pending.run_id,
@@ -580,7 +570,7 @@ def _cache_result(
             raise PublicationError("existing cache directory contains different run content")
         return existing, CachePublicationStatus.PRESENT
     if staging_root is not None:
-        promoted: RunArchiveMaterializationResult = promote_staging_run_directory(
+        promoted: RunArchiveMaterializationResult = run_log_archive.promote_staging_run_directory(
             staging_root=staging_root,
             run_dir=paths.cache_dir,
             expected_skill=pending.skill,
@@ -588,7 +578,7 @@ def _cache_result(
             expected_manifest_sha256=pending.manifest_sha256,
         )
         return promoted, CachePublicationStatus.PROMOTED
-    materialized: RunArchiveMaterializationResult = materialize_run_archive(
+    materialized: RunArchiveMaterializationResult = run_log_archive.materialize_run_archive(
         archive_path=paths.pending_archive,
         run_dir=paths.cache_dir,
         expected_skill=pending.skill,
@@ -698,12 +688,14 @@ def main(argv: Sequence[str]) -> int:
         return int(exc.code) if isinstance(exc.code, int) else config.EXIT_USAGE
     try:
         requested_root: Path = Path(args.repo_root)
-        repo_root: Path | None = consumer_repo_root(requested_root)
+        repo_root: Path | None = repo_roots.consumer_repo_root(requested_root)
         if repo_root is None:
             raise StorageConfigurationError(
                 f"could not discover a Git repository root from {requested_root}"
             )
-        storage_root: StorageRoot = discover_storage_root(start=repo_root)
+        storage_root: StorageRoot = storage_config.discover_storage_root(
+            start=repo_root
+        )
         result: PublicationResult = publish_run(
             request=PublicationRequest(
                 repo_root=repo_root,

--- a/python/tests/report/test_run_log_archive.py
+++ b/python/tests/report/test_run_log_archive.py
@@ -297,6 +297,51 @@ def test_materialize_run_archive_reproduces_and_verifies_tree(tmp_path: Path) ->
     assert not list(run_dir.parent.glob(".run-materialize.materialize-*"))
 
 
+def test_promote_staging_run_directory_copies_without_extracting_archive(tmp_path: Path) -> None:
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    _write_tree(staging)
+    created = _create_materialization_fixture(staging, tmp_path)
+    run_dir = tmp_path / "cache" / "run-materialize"
+
+    result = run_log_archive.promote_staging_run_directory(
+        staging_root=staging,
+        run_dir=run_dir,
+        expected_skill="implement",
+        expected_run_id="run-materialize",
+        expected_manifest_sha256=created.manifest_sha256,
+    )
+
+    assert result.run_dir == run_dir
+    assert result.manifest_sha256 == created.manifest_sha256
+    assert run_log_archive.verify_materialized_run_directory(
+        run_dir=run_dir,
+        expected_skill="implement",
+        expected_run_id="run-materialize",
+    ) == result
+    assert not list(run_dir.parent.glob(".run-materialize.promote-*"))
+
+
+def test_promote_staging_run_directory_rejects_staging_drift(tmp_path: Path) -> None:
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    _write_tree(staging)
+    created = _create_materialization_fixture(staging, tmp_path)
+    _ = (staging / "new.txt").write_text("late mutation", encoding="utf-8")
+    run_dir = tmp_path / "cache" / "run-materialize"
+
+    with pytest.raises(ValueError, match="no longer matches"):
+        _ = run_log_archive.promote_staging_run_directory(
+            staging_root=staging,
+            run_dir=run_dir,
+            expected_skill="implement",
+            expected_run_id="run-materialize",
+            expected_manifest_sha256=created.manifest_sha256,
+        )
+
+    assert not run_dir.exists()
+
+
 @pytest.mark.parametrize("unsafe_name", ["/absolute.txt", "../escape.txt", "nested/../../escape.txt", "a\\b"])
 def test_materialize_rejects_escaping_or_ambiguous_paths(tmp_path: Path, unsafe_name: str) -> None:
     archive_path = tmp_path / "unsafe.tar.gz"

--- a/python/tests/report/test_run_log_publish.py
+++ b/python/tests/report/test_run_log_publish.py
@@ -1,0 +1,428 @@
+"""Tests for immutable publication, durable retry, and write-through caching."""
+
+from __future__ import annotations
+
+import json
+import threading
+from collections.abc import Mapping
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from larch.report import run_log_publish
+from larch.report.object_store import ObjectStoreError, ObjectStoreErrorKind, RemoteObject
+from larch.report.storage_config import StorageRoot
+
+
+class MemoryObjectStore:
+    """Thread-safe create-only object store used by the publication contract tests."""
+
+    def __init__(self, *, fail_uploads: int = 0) -> None:
+        self.objects: dict[str, bytes] = {}
+        self.fail_uploads = fail_uploads
+        self.upload_calls = 0
+        self.download_calls = 0
+        self.metadata_calls = 0
+        self._lock = threading.Lock()
+
+    def upload_create(self, key: str, source: Path) -> RemoteObject:
+        content: bytes = source.read_bytes()
+        with self._lock:
+            self.upload_calls += 1
+            if self.fail_uploads > 0:
+                self.fail_uploads -= 1
+                raise ObjectStoreError(ObjectStoreErrorKind.TRANSPORT, "fake", "upload")
+            if key in self.objects:
+                raise ObjectStoreError(ObjectStoreErrorKind.ALREADY_EXISTS, "fake", "upload")
+            self.objects[key] = content
+        return RemoteObject(key, len(content), "etag", None)
+
+    def download(self, key: str, destination: Path) -> None:
+        with self._lock:
+            self.download_calls += 1
+            content: bytes = self.objects[key]
+        _ = destination.write_bytes(content)
+
+    def metadata(self, key: str) -> RemoteObject:
+        with self._lock:
+            self.metadata_calls += 1
+            content: bytes = self.objects[key]
+        return RemoteObject(key, len(content), "etag", None)
+
+
+def _fixture(tmp_path: Path) -> tuple[Path, Path, Path, Path, StorageRoot]:
+    repo: Path = tmp_path / "literal repo"
+    staging: Path = tmp_path / "staging"
+    cache_home: Path = tmp_path / "cache"
+    state_home: Path = tmp_path / "state"
+    repo.mkdir()
+    staging.mkdir()
+    nested: Path = staging / "nested"
+    nested.mkdir()
+    _ = (staging / "manifest.json").write_text('{"issue_number":7818}\n', encoding="utf-8")
+    _ = (nested / "result.txt").write_text("published\n", encoding="utf-8")
+    return repo, staging, cache_home, state_home, StorageRoot("s3", "bucket", "larch")
+
+
+def _publish(
+    *,
+    repo: Path,
+    staging: Path | None,
+    cache_home: Path,
+    state_home: Path,
+    storage_root: StorageRoot,
+    store: MemoryObjectStore,
+) -> run_log_publish.PublicationResult:
+    return run_log_publish.publish_run(
+        request=run_log_publish.PublicationRequest(
+            repo_root=repo,
+            storage_root=storage_root,
+            skill="implement",
+            run_id="run-7818",
+            staging_root=staging,
+            cache_home=cache_home,
+            state_home=state_home,
+        ),
+        store=store,
+    )
+
+
+def _paths(
+    *,
+    repo: Path,
+    cache_home: Path,
+    state_home: Path,
+) -> run_log_publish.PublicationPaths:
+    return run_log_publish.publication_paths(
+        request=run_log_publish.PublicationRequest(
+            repo_root=repo,
+            storage_root=StorageRoot("s3", "bucket", "larch"),
+            skill="implement",
+            run_id="run-7818",
+            staging_root=None,
+            cache_home=cache_home,
+            state_home=state_home,
+        ),
+    )
+
+
+def _pending_metadata(paths: run_log_publish.PublicationPaths) -> Mapping[str, object]:
+    return cast(
+        "Mapping[str, object]",
+        json.loads(paths.pending_metadata.read_text(encoding="utf-8")),
+    )
+
+
+def test_publish_uses_exact_key_and_promotes_staging_without_download(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, staging, cache_home, state_home, storage_root = _fixture(tmp_path)
+    store = MemoryObjectStore()
+
+    def unexpected_materialization(**_kwargs: object) -> object:
+        raise AssertionError("the normal publication path must not decompress its archive")
+
+    monkeypatch.setattr(run_log_publish, "materialize_run_archive", unexpected_materialization)
+    result = _publish(
+        repo=repo,
+        staging=staging,
+        cache_home=cache_home,
+        state_home=state_home,
+        storage_root=storage_root,
+        store=store,
+    )
+
+    assert result.remote_key == "run-logs/implement/run-7818.tar.gz"
+    assert result.remote_status is run_log_publish.RemotePublicationStatus.CREATED
+    assert result.cache_status is run_log_publish.CachePublicationStatus.PROMOTED
+    assert result.cache_dir == cache_home / "larch/run-logs/literal repo/implement/run-7818"
+    assert (result.cache_dir / "nested/result.txt").read_text(encoding="utf-8") == "published\n"
+    assert store.download_calls == 0
+    assert not _paths(repo=repo, cache_home=cache_home, state_home=state_home).pending_dir.exists()
+
+
+def test_failed_upload_retains_content_pinned_pending_archive_and_retry_metadata(
+    tmp_path: Path,
+) -> None:
+    repo, staging, cache_home, state_home, storage_root = _fixture(tmp_path)
+    store = MemoryObjectStore(fail_uploads=1)
+    paths = _paths(repo=repo, cache_home=cache_home, state_home=state_home)
+
+    with pytest.raises(ObjectStoreError) as failure:
+        _ = _publish(
+            repo=repo,
+            staging=staging,
+            cache_home=cache_home,
+            state_home=state_home,
+            storage_root=storage_root,
+            store=store,
+        )
+
+    assert failure.value.kind is ObjectStoreErrorKind.TRANSPORT
+    assert paths.pending_archive.is_file()
+    metadata = _pending_metadata(paths)
+    assert metadata["attempts"] == 1
+    assert metadata["last_error"] == "object-upload-transport"
+    assert metadata["remote_key"] == "run-logs/implement/run-7818.tar.gz"
+    assert not paths.cache_dir.exists()
+
+    result = _publish(
+        repo=repo,
+        staging=None,
+        cache_home=cache_home,
+        state_home=state_home,
+        storage_root=storage_root,
+        store=store,
+    )
+
+    assert result.remote_status is run_log_publish.RemotePublicationStatus.CREATED
+    assert result.cache_status is run_log_publish.CachePublicationStatus.MATERIALIZED
+    assert paths.cache_dir.is_dir()
+    assert not paths.pending_dir.exists()
+
+
+def test_matching_remote_collision_is_idempotent_but_different_content_fails(
+    tmp_path: Path,
+) -> None:
+    repo, staging, cache_home, state_home, storage_root = _fixture(tmp_path)
+    first_store = MemoryObjectStore(fail_uploads=1)
+    paths = _paths(repo=repo, cache_home=cache_home, state_home=state_home)
+    with pytest.raises(ObjectStoreError):
+        _ = _publish(
+            repo=repo,
+            staging=staging,
+            cache_home=cache_home,
+            state_home=state_home,
+            storage_root=storage_root,
+            store=first_store,
+        )
+    archive_bytes: bytes = paths.pending_archive.read_bytes()
+    first_store.objects["run-logs/implement/run-7818.tar.gz"] = archive_bytes
+
+    matched = _publish(
+        repo=repo,
+        staging=staging,
+        cache_home=cache_home,
+        state_home=state_home,
+        storage_root=storage_root,
+        store=first_store,
+    )
+
+    assert matched.remote_status is run_log_publish.RemotePublicationStatus.MATCHED
+    assert first_store.download_calls == 1
+    assert not paths.pending_dir.exists()
+
+    second_state: Path = tmp_path / "second-state"
+    second_cache: Path = tmp_path / "second-cache"
+    different_store = MemoryObjectStore(fail_uploads=1)
+    with pytest.raises(ObjectStoreError):
+        _ = _publish(
+            repo=repo,
+            staging=staging,
+            cache_home=second_cache,
+            state_home=second_state,
+            storage_root=storage_root,
+            store=different_store,
+        )
+    second_paths = _paths(repo=repo, cache_home=second_cache, state_home=second_state)
+    different_store.objects["run-logs/implement/run-7818.tar.gz"] = (
+        b"x" * second_paths.pending_archive.stat().st_size
+    )
+    with pytest.raises(run_log_publish.PublicationError, match="different content"):
+        _ = _publish(
+            repo=repo,
+            staging=None,
+            cache_home=second_cache,
+            state_home=second_state,
+            storage_root=storage_root,
+            store=different_store,
+        )
+    assert second_paths.pending_archive.is_file()
+    assert _pending_metadata(second_paths)["last_error"] == "publication-invariant"
+
+
+def test_cache_failure_after_upload_retries_from_archive_without_overwrite(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, staging, cache_home, state_home, storage_root = _fixture(tmp_path)
+    store = MemoryObjectStore()
+    paths = _paths(repo=repo, cache_home=cache_home, state_home=state_home)
+    original_promote = run_log_publish.promote_staging_run_directory
+
+    def interrupted_promotion(**_kwargs: object) -> object:
+        raise OSError("simulated cache promotion crash")
+
+    monkeypatch.setattr(run_log_publish, "promote_staging_run_directory", interrupted_promotion)
+    with pytest.raises(OSError, match="simulated cache promotion crash"):
+        _ = _publish(
+            repo=repo,
+            staging=staging,
+            cache_home=cache_home,
+            state_home=state_home,
+            storage_root=storage_root,
+            store=store,
+        )
+    assert paths.pending_archive.is_file()
+    assert len(store.objects) == 1
+
+    monkeypatch.setattr(run_log_publish, "promote_staging_run_directory", original_promote)
+    result = _publish(
+        repo=repo,
+        staging=None,
+        cache_home=cache_home,
+        state_home=state_home,
+        storage_root=storage_root,
+        store=store,
+    )
+
+    assert result.remote_status is run_log_publish.RemotePublicationStatus.MATCHED
+    assert result.cache_status is run_log_publish.CachePublicationStatus.MATERIALIZED
+    assert not paths.pending_dir.exists()
+
+
+def test_crash_before_pending_retirement_reuses_remote_and_cache(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, staging, cache_home, state_home, storage_root = _fixture(tmp_path)
+    store = MemoryObjectStore()
+    paths = _paths(repo=repo, cache_home=cache_home, state_home=state_home)
+    original_complete = run_log_publish._complete_pending  # pyright: ignore[reportPrivateUsage] - crash-window seam
+
+    def interrupted_retirement(_paths: run_log_publish.PublicationPaths) -> None:
+        raise OSError("simulated retirement crash")
+
+    monkeypatch.setattr(run_log_publish, "_complete_pending", interrupted_retirement)
+    with pytest.raises(OSError, match="simulated retirement crash"):
+        _ = _publish(
+            repo=repo,
+            staging=staging,
+            cache_home=cache_home,
+            state_home=state_home,
+            storage_root=storage_root,
+            store=store,
+        )
+    assert paths.pending_archive.is_file()
+    assert paths.cache_dir.is_dir()
+
+    monkeypatch.setattr(run_log_publish, "_complete_pending", original_complete)
+    result = _publish(
+        repo=repo,
+        staging=None,
+        cache_home=cache_home,
+        state_home=state_home,
+        storage_root=storage_root,
+        store=store,
+    )
+
+    assert result.remote_status is run_log_publish.RemotePublicationStatus.MATCHED
+    assert result.cache_status is run_log_publish.CachePublicationStatus.PRESENT
+    assert not paths.pending_dir.exists()
+
+
+def test_concurrent_publications_converge_on_one_remote_and_one_valid_cache(
+    tmp_path: Path,
+) -> None:
+    repo, staging, cache_home, state_home, storage_root = _fixture(tmp_path)
+    store = MemoryObjectStore()
+    results: list[run_log_publish.PublicationResult] = []
+    failures: list[BaseException] = []
+
+    def worker() -> None:
+        try:
+            results.append(
+                _publish(
+                    repo=repo,
+                    staging=staging,
+                    cache_home=cache_home,
+                    state_home=state_home,
+                    storage_root=storage_root,
+                    store=store,
+                )
+            )
+        except BaseException as exc:  # test thread must surface every failure
+            failures.append(exc)
+
+    threads: tuple[threading.Thread, ...] = tuple(threading.Thread(target=worker) for _ in range(2))
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert not failures
+    assert len(results) == 2
+    assert len(store.objects) == 1
+    assert {result.remote_status for result in results} == {
+        run_log_publish.RemotePublicationStatus.CREATED,
+        run_log_publish.RemotePublicationStatus.MATCHED,
+    }
+    assert {result.cache_status for result in results} == {
+        run_log_publish.CachePublicationStatus.PROMOTED,
+        run_log_publish.CachePublicationStatus.PRESENT,
+    }
+    paths = _paths(repo=repo, cache_home=cache_home, state_home=state_home)
+    assert paths.cache_dir.is_dir()
+    assert not paths.pending_dir.exists()
+
+
+def test_pending_identity_mismatch_fails_closed_and_preserves_archive(tmp_path: Path) -> None:
+    repo, staging, cache_home, state_home, storage_root = _fixture(tmp_path)
+    store = MemoryObjectStore(fail_uploads=1)
+    paths = _paths(repo=repo, cache_home=cache_home, state_home=state_home)
+    with pytest.raises(ObjectStoreError):
+        _ = _publish(
+            repo=repo,
+            staging=staging,
+            cache_home=cache_home,
+            state_home=state_home,
+            storage_root=storage_root,
+            store=store,
+        )
+
+    changed_root = StorageRoot("s3", "other-bucket", "larch")
+    with pytest.raises(run_log_publish.PublicationError, match="identity"):
+        _ = _publish(
+            repo=repo,
+            staging=None,
+            cache_home=cache_home,
+            state_home=state_home,
+            storage_root=changed_root,
+            store=store,
+        )
+
+    assert paths.pending_archive.is_file()
+
+
+def test_publish_cli_returns_nonzero_without_clean_success_on_terminal_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo, _staging, _cache_home, _state_home, storage_root = _fixture(tmp_path)
+
+    def fake_repo_root(_start: Path) -> Path:
+        return repo
+
+    def fake_storage_root(*, start: Path) -> StorageRoot:
+        assert start == repo
+        return storage_root
+
+    def fail_publish(**_kwargs: object) -> run_log_publish.PublicationResult:
+        raise ObjectStoreError(ObjectStoreErrorKind.TRANSPORT, "fake", "upload")
+
+    monkeypatch.setattr(run_log_publish, "consumer_repo_root", fake_repo_root)
+    monkeypatch.setattr(run_log_publish, "discover_storage_root", fake_storage_root)
+    monkeypatch.setattr(run_log_publish, "publish_run", fail_publish)
+
+    rc: int = run_log_publish.main(
+        ["--repo-root", str(repo), "--skill", "implement", "--run-id", "run-7818"]
+    )
+
+    captured = capsys.readouterr()
+    assert rc != 0
+    assert captured.out == ""
+    assert "publication failed" in captured.err
+    assert "PUBLISH_OK=true" not in captured.err

--- a/python/tests/report/test_run_log_publish.py
+++ b/python/tests/report/test_run_log_publish.py
@@ -10,7 +10,8 @@ from typing import cast
 
 import pytest
 
-from larch.report import run_log_publish
+from larch.core import repo_roots
+from larch.report import run_log_archive, run_log_publish, storage_config
 from larch.report.object_store import ObjectStoreError, ObjectStoreErrorKind, RemoteObject
 from larch.report.storage_config import StorageRoot
 
@@ -124,7 +125,7 @@ def test_publish_uses_exact_key_and_promotes_staging_without_download(
     def unexpected_materialization(**_kwargs: object) -> object:
         raise AssertionError("the normal publication path must not decompress its archive")
 
-    monkeypatch.setattr(run_log_publish, "materialize_run_archive", unexpected_materialization)
+    monkeypatch.setattr(run_log_archive, "materialize_run_archive", unexpected_materialization)
     result = _publish(
         repo=repo,
         staging=staging,
@@ -250,12 +251,12 @@ def test_cache_failure_after_upload_retries_from_archive_without_overwrite(
     repo, staging, cache_home, state_home, storage_root = _fixture(tmp_path)
     store = MemoryObjectStore()
     paths = _paths(repo=repo, cache_home=cache_home, state_home=state_home)
-    original_promote = run_log_publish.promote_staging_run_directory
+    original_promote = run_log_archive.promote_staging_run_directory
 
     def interrupted_promotion(**_kwargs: object) -> object:
         raise OSError("simulated cache promotion crash")
 
-    monkeypatch.setattr(run_log_publish, "promote_staging_run_directory", interrupted_promotion)
+    monkeypatch.setattr(run_log_archive, "promote_staging_run_directory", interrupted_promotion)
     with pytest.raises(OSError, match="simulated cache promotion crash"):
         _ = _publish(
             repo=repo,
@@ -268,7 +269,7 @@ def test_cache_failure_after_upload_retries_from_archive_without_overwrite(
     assert paths.pending_archive.is_file()
     assert len(store.objects) == 1
 
-    monkeypatch.setattr(run_log_publish, "promote_staging_run_directory", original_promote)
+    monkeypatch.setattr(run_log_archive, "promote_staging_run_directory", original_promote)
     result = _publish(
         repo=repo,
         staging=None,
@@ -413,8 +414,8 @@ def test_publish_cli_returns_nonzero_without_clean_success_on_terminal_failure(
     def fail_publish(**_kwargs: object) -> run_log_publish.PublicationResult:
         raise ObjectStoreError(ObjectStoreErrorKind.TRANSPORT, "fake", "upload")
 
-    monkeypatch.setattr(run_log_publish, "consumer_repo_root", fake_repo_root)
-    monkeypatch.setattr(run_log_publish, "discover_storage_root", fake_storage_root)
+    monkeypatch.setattr(repo_roots, "consumer_repo_root", fake_repo_root)
+    monkeypatch.setattr(storage_config, "discover_storage_root", fake_storage_root)
     monkeypatch.setattr(run_log_publish, "publish_run", fail_publish)
 
     rc: int = run_log_publish.main(


### PR DESCRIPTION
## Summary

- publish deterministic run archives with provider create-only semantics and byte-verified idempotent collisions
- retain identity-pinned archives and retry metadata in durable XDG state after failures
- atomically promote the sanitized staging tree into the literal per-repository cache without download or decompression
- protect publication, cache promotion, and state retirement with a per-run lock and durable filesystem mutations

## Test plan

- `python3 -m pytest -q python/tests/report/test_run_log_archive.py python/tests/report/test_run_log_publish.py python/tests/test_cli.py`
- 20 repeated concurrent-publication regression runs
- focused Ruff, Pyright, and Pylint checks
- changed-file pre-commit suite, including larch repository policy and secret scans

Closes #7818
