### PR TITLE
Fixes #7819: Sync cloud run logs into repository cache

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -94,6 +94,17 @@ operator's XDG state directory. The normal write-through path copies the
 already-sanitized staging tree and does not trust remote bytes; a staging-less
 retry routes the retained archive through the bounded materializer above.
 
+`python/cli.py run-log sync` treats the remote inventory and every downloaded
+archive as untrusted. It accepts only the exact
+`run-logs/<skill>/<run-id>.tar.gz` layout, rejects invalid and colliding local
+names before download, checks the downloaded size against the listing, and
+routes all content through bounded materialization. Synchronization shares the
+publisher's per-run lock. It never replaces a valid cache entry. An invalid
+entry is quarantined and restored if repair fails; successful repair promotes a
+fully verified directory before removing the quarantine. Stale private
+download, extraction, promotion, and quarantine entries are removed under the
+same lock.
+
 ## Google ADC Trust Boundary
 
 Only trusted operator configuration can select Google ADC. Larch does not shell

--- a/crates/larch-lint/data/command-registry.toml
+++ b/crates/larch-lint/data/command-registry.toml
@@ -5918,6 +5918,18 @@ migration_issue = 7683
 
 [[commands]]
 domain = "run-log"
+verb = "sync"
+python_module = "larch.report.run_log_sync"
+python_function = "main"
+machine_stdout = true
+owner = "python"
+implementation_parity = "pending"
+consumer_cutover = "pending"
+python_removal = "pending"
+migration_issue = 7683
+
+[[commands]]
+domain = "run-log"
 verb = "append"
 python_module = "larch.report.run_logs"
 python_function = "larch_log_append_main"

--- a/docs/run-log-archive.md
+++ b/docs/run-log-archive.md
@@ -45,3 +45,17 @@ without downloading or decompressing the archive. Retry without staging safely
 materializes the durable archive instead. A per-run lock covers upload,
 collision verification, cache promotion, and atomic retirement of pending
 state.
+
+`python3 python/cli.py run-log sync --repo-root <root>` lists the complete
+`run-logs/` remote prefix once, including every provider pagination page. It
+downloads and safely materializes only runs without a valid local directory.
+Valid cached runs remain untouched. Invalid entries are quarantined under the
+per-run publication lock, replaced atomically after validation, and restored if
+repair fails. Interrupted download, materialization, promotion, and quarantine
+entries are removed before the next attempt.
+
+The command returns the unpacked repository corpus at
+`${XDG_CACHE_HOME:-$HOME/.cache}/larch/run-logs/<repo>/`. The shared
+`run_log_corpus.synchronized_run_log_root` API performs the same one-time sync
+and returns that root. An analyzer must retain the returned path and use normal
+local file reads for all later files and waves in the same invocation.

--- a/docs/run-log-cli.md
+++ b/docs/run-log-cli.md
@@ -38,6 +38,15 @@ empty `LOG_PATH`, empty `SHA256`, empty `COMMIT_SHA`, `BYTES=0`,
 - `run-log append-entry`
 - `run-log append-failure`
 - `run-log publish-breadcrumbs`
+- `run-log archive`
+- `run-log materialize`
+- `run-log publish`
+- `run-log sync`
+
+The archive lifecycle verbs use their own machine envelopes. `run-log sync`
+lists the configured `run-logs/` prefix once and emits `CORPUS_ROOT`,
+`LISTED_ARCHIVES`, `PRESENT_RUNS`, `DOWNLOADED_RUNS`, `REPAIRED_RUNS`, and
+`SYNC_OK=true`. See [Run-log archive format](run-log-archive.md).
 
 `exists` exits 0 only after argument, log-root, slug, and batch validation
 succeed. It sets `UNCHANGED=true` when the batch file exists.

--- a/plugin/SECURITY.md
+++ b/plugin/SECURITY.md
@@ -94,6 +94,17 @@ operator's XDG state directory. The normal write-through path copies the
 already-sanitized staging tree and does not trust remote bytes; a staging-less
 retry routes the retained archive through the bounded materializer above.
 
+`python/cli.py run-log sync` treats the remote inventory and every downloaded
+archive as untrusted. It accepts only the exact
+`run-logs/<skill>/<run-id>.tar.gz` layout, rejects invalid and colliding local
+names before download, checks the downloaded size against the listing, and
+routes all content through bounded materialization. Synchronization shares the
+publisher's per-run lock. It never replaces a valid cache entry. An invalid
+entry is quarantined and restored if repair fails; successful repair promotes a
+fully verified directory before removing the quarantine. Stale private
+download, extraction, promotion, and quarantine entries are removed under the
+same lock.
+
 ## Google ADC Trust Boundary
 
 Only trusted operator configuration can select Google ADC. Larch does not shell

--- a/plugin/docs/run-log-archive.md
+++ b/plugin/docs/run-log-archive.md
@@ -45,3 +45,17 @@ without downloading or decompressing the archive. Retry without staging safely
 materializes the durable archive instead. A per-run lock covers upload,
 collision verification, cache promotion, and atomic retirement of pending
 state.
+
+`python3 python/cli.py run-log sync --repo-root <root>` lists the complete
+`run-logs/` remote prefix once, including every provider pagination page. It
+downloads and safely materializes only runs without a valid local directory.
+Valid cached runs remain untouched. Invalid entries are quarantined under the
+per-run publication lock, replaced atomically after validation, and restored if
+repair fails. Interrupted download, materialization, promotion, and quarantine
+entries are removed before the next attempt.
+
+The command returns the unpacked repository corpus at
+`${XDG_CACHE_HOME:-$HOME/.cache}/larch/run-logs/<repo>/`. The shared
+`run_log_corpus.synchronized_run_log_root` API performs the same one-time sync
+and returns that root. An analyzer must retain the returned path and use normal
+local file reads for all later files and waves in the same invocation.

--- a/plugin/docs/run-log-cli.md
+++ b/plugin/docs/run-log-cli.md
@@ -38,6 +38,15 @@ empty `LOG_PATH`, empty `SHA256`, empty `COMMIT_SHA`, `BYTES=0`,
 - `run-log append-entry`
 - `run-log append-failure`
 - `run-log publish-breadcrumbs`
+- `run-log archive`
+- `run-log materialize`
+- `run-log publish`
+- `run-log sync`
+
+The archive lifecycle verbs use their own machine envelopes. `run-log sync`
+lists the configured `run-logs/` prefix once and emits `CORPUS_ROOT`,
+`LISTED_ARCHIVES`, `PRESENT_RUNS`, `DOWNLOADED_RUNS`, `REPAIRED_RUNS`, and
+`SYNC_OK=true`. See [Run-log archive format](run-log-archive.md).
 
 `exists` exits 0 only after argument, log-root, slug, and batch validation
 succeed. It sets `UNCHANGED=true` when the batch file exists.

--- a/plugin/python/larch/cli.py
+++ b/plugin/python/larch/cli.py
@@ -652,6 +652,7 @@ _REGISTRY: dict[tuple[str, str], tuple[str, str, bool]] = {
     ("run-log", "archive"): ("larch.report.run_log_archive", "main", False),
     ("run-log", "materialize"): ("larch.report.run_log_archive", "materialize_main", False),
     ("run-log", "publish"): ("larch.report.run_log_publish", "main", True),
+    ("run-log", "sync"): ("larch.report.run_log_sync", "main", True),
     ("run-log", "validate-run-id"): ("larch.report.run_logs", "larch_log_validate_run_id_main", True),
     ("run-log", "capture-transcript"): ("larch.report.run_log_flush", "capture_transcript_main", False),
     ("run-log", "render-session-transcript"): ("larch.rendering.render_session_transcript", "main", False),

--- a/plugin/python/larch/report/object_store.py
+++ b/plugin/python/larch/report/object_store.py
@@ -36,6 +36,12 @@ class CommandObjectStore:
         if invalid:
             raise ObjectStoreError(ObjectStoreErrorKind.CONFIGURATION, self.root.scheme, "key")
         return f"{self.root.prefix}/{relative}" if relative else f"{self.root.prefix}/"
+    def _list_prefix(self, relative: str) -> str:
+        trailing = relative.endswith("/")
+        normalized = relative[:-1] if trailing else relative
+        if trailing and not normalized:
+            raise ObjectStoreError(ObjectStoreErrorKind.CONFIGURATION, self.root.scheme, "key")
+        return self._key(normalized, empty=True) + ("/" if trailing else "")
     def _aws(self, *args: str) -> list[str]:
         return [config.AWS_CLI, *args, *(["--endpoint-url", self.endpoint] if self.endpoint else [])]
     def _gcs(self, operation: str, *args: str) -> list[str]:
@@ -57,7 +63,7 @@ class CommandObjectStore:
         command = self._gcs("preflight") if self.root.scheme == "gs" else self._aws("s3", "ls", f"s3://{self.root.bucket}")
         _ = self._run(command, "preflight")
     def list_objects(self, prefix: str = "") -> tuple[RemoteObject, ...]:
-        remote_prefix, token = self._key(prefix, empty=True), None
+        remote_prefix, token = self._list_prefix(prefix), None
         objects: list[RemoteObject] = []
         seen: set[str] = set()
         while True:

--- a/plugin/python/larch/report/run_log_corpus.py
+++ b/plugin/python/larch/report/run_log_corpus.py
@@ -13,6 +13,7 @@ from enum import StrEnum
 from pathlib import Path
 from typing import Any, Literal, cast
 
+from larch.report import run_log_sync
 from larch.report.report_tokens_models import safe_int
 
 DEFAULT_MANIFEST_CANDIDATES: tuple[str, ...] = ("manifest.json", "run-manifest.json")
@@ -230,6 +231,34 @@ def safe_child_run_dirs(
 def run_dirs(log_base: Path, warn: Callable[[str], None] | None = None) -> list[Path]:
     """Return symlink-safe, manifest-accepted child run directories."""
     return [path for path in safe_child_run_dirs(log_base, warn=warn) if is_valid_run_dir(path, warn=warn)]
+
+
+def synchronize_run_log_corpus(
+    *,
+    request: run_log_sync.RunLogSyncRequest,
+    store: run_log_sync.SyncObjectStore | None = None,
+    environ: Mapping[str, str] | None = None,
+) -> run_log_sync.RepositorySyncResult:
+    """Synchronize once and return the repository's ordinary local-file corpus."""
+    return run_log_sync.sync_repository_run_logs(
+        request=request,
+        store=store,
+        environ=environ,
+    )
+
+
+def synchronized_run_log_root(
+    *,
+    request: run_log_sync.RunLogSyncRequest,
+    store: run_log_sync.SyncObjectStore | None = None,
+    environ: Mapping[str, str] | None = None,
+) -> Path:
+    """Synchronize once and expose the unpacked root for all later read waves."""
+    return synchronize_run_log_corpus(
+        request=request,
+        store=store,
+        environ=environ,
+    ).corpus_root
 
 
 def review_transcript_dirs(log_base: Path, warn: Callable[[str], None] | None = None) -> list[Path]:

--- a/plugin/python/larch/report/run_log_publish.py
+++ b/plugin/python/larch/report/run_log_publish.py
@@ -139,7 +139,7 @@ class PublicationResult:
     cache_status: CachePublicationStatus
 
 
-def _validated_component(value: str, *, label: str, slug: bool) -> str:
+def validated_component(value: str, *, label: str, slug: bool) -> str:
     invalid_literal: bool = (
         not value
         or value in {".", ".."}
@@ -155,7 +155,7 @@ def _validated_component(value: str, *, label: str, slug: bool) -> str:
     return value
 
 
-def _xdg_home(
+def xdg_home(
     *,
     environ: Mapping[str, str],
     variable: str,
@@ -168,6 +168,26 @@ def _xdg_home(
     return selected
 
 
+def repository_cache_root(
+    *,
+    repo_root: Path,
+    cache_home: Path | None = None,
+    environ: Mapping[str, str] | None = None,
+) -> Path:
+    """Return the literal per-repository root for unpacked run archives."""
+    root: Path = larch_io.validate_trusted_directory(repo_root)
+    repo_name: str = validated_component(root.name, label="repository name", slug=False)
+    environment: Mapping[str, str] = os.environ if environ is None else environ
+    resolved_cache_home: Path = cache_home or xdg_home(
+        environ=environment,
+        variable=_ENV_XDG_CACHE_HOME,
+        fallback=Path.home() / ".cache",
+    )
+    if not resolved_cache_home.is_absolute():
+        raise ValueError("publication cache home must be an absolute path")
+    return resolved_cache_home / "larch" / "run-logs" / repo_name
+
+
 def publication_paths(
     *,
     request: PublicationRequest,
@@ -175,25 +195,23 @@ def publication_paths(
 ) -> PublicationPaths:
     """Resolve the literal repository cache path and durable retry path."""
     root: Path = larch_io.validate_trusted_directory(request.repo_root)
-    repo_name: str = _validated_component(root.name, label="repository name", slug=False)
-    skill_name: str = _validated_component(request.skill, label="skill", slug=True)
-    run_name: str = _validated_component(request.run_id, label="run-id", slug=True)
+    repo_name: str = validated_component(root.name, label="repository name", slug=False)
+    skill_name: str = validated_component(request.skill, label="skill", slug=True)
+    run_name: str = validated_component(request.run_id, label="run-id", slug=True)
     environment: Mapping[str, str] = os.environ if environ is None else environ
-    resolved_cache_home: Path = request.cache_home or _xdg_home(
+    cache_root: Path = repository_cache_root(
+        repo_root=root,
+        cache_home=request.cache_home,
         environ=environment,
-        variable=_ENV_XDG_CACHE_HOME,
-        fallback=Path.home() / ".cache",
     )
-    resolved_state_home: Path = request.state_home or _xdg_home(
+    resolved_state_home: Path = request.state_home or xdg_home(
         environ=environment,
         variable=_ENV_XDG_STATE_HOME,
         fallback=Path.home() / ".local" / "state",
     )
-    if not resolved_cache_home.is_absolute() or not resolved_state_home.is_absolute():
-        raise ValueError("publication cache and state homes must be absolute paths")
-    cache_dir: Path = (
-        resolved_cache_home / "larch" / "run-logs" / repo_name / skill_name / run_name
-    )
+    if not resolved_state_home.is_absolute():
+        raise ValueError("publication state home must be an absolute path")
+    cache_dir: Path = cache_root / skill_name / run_name
     pending_dir: Path = (
         resolved_state_home
         / "larch"
@@ -219,7 +237,7 @@ def publication_paths(
     )
 
 
-def _ensure_concurrent_directory(path: Path) -> Path:
+def ensure_concurrent_directory(path: Path) -> Path:
     """Create a trusted directory while tolerating a same-path creator race."""
     directory: Path = path if path.is_absolute() else Path.cwd() / path
     try:
@@ -228,7 +246,7 @@ def _ensure_concurrent_directory(path: Path) -> Path:
         pass
     if directory == directory.parent:
         raise OSError(f"cannot create trusted publication directory: {directory}")
-    _ = _ensure_concurrent_directory(directory.parent)
+    _ = ensure_concurrent_directory(directory.parent)
     with suppress(FileExistsError):
         directory.mkdir(mode=0o700)
     return larch_io.validate_trusted_directory(directory)
@@ -237,7 +255,7 @@ def _ensure_concurrent_directory(path: Path) -> Path:
 @contextmanager
 def publication_lock(path: Path) -> Generator[None, None, None]:
     """Hold the blocking advisory lock shared by all operations for one run."""
-    parent: Path = _ensure_concurrent_directory(path.parent)
+    parent: Path = ensure_concurrent_directory(path.parent)
     lock_path: Path = parent / path.name
     if lock_path.is_symlink():
         raise OSError(f"refusing symlinked publication lock: {lock_path}")
@@ -435,7 +453,7 @@ def _create_pending(
     request: PublicationRequest,
     repo_name: str,
 ) -> PendingPublication:
-    parent: Path = _ensure_concurrent_directory(paths.pending_dir.parent)
+    parent: Path = ensure_concurrent_directory(paths.pending_dir.parent)
     temporary: Path | None = Path(
         tempfile.mkdtemp(dir=parent, prefix=f".{request.run_id}.pending-")
     )
@@ -559,7 +577,7 @@ def _cache_result(
     pending: PendingPublication,
     staging_root: Path | None,
 ) -> tuple[RunArchiveMaterializationResult, CachePublicationStatus]:
-    _ = _ensure_concurrent_directory(paths.cache_dir.parent)
+    _ = ensure_concurrent_directory(paths.cache_dir.parent)
     if paths.cache_dir.exists() or paths.cache_dir.is_symlink():
         existing: RunArchiveMaterializationResult = run_log_archive.verify_materialized_run_directory(
             run_dir=paths.cache_dir,
@@ -615,9 +633,9 @@ def publish_run(
 ) -> PublicationResult:
     """Publish one immutable archive and atomically populate its local cache."""
     root: Path = larch_io.validate_trusted_directory(request.repo_root)
-    repo_name: str = _validated_component(root.name, label="repository name", slug=False)
-    skill_name: str = _validated_component(request.skill, label="skill", slug=True)
-    run_name: str = _validated_component(request.run_id, label="run-id", slug=True)
+    repo_name: str = validated_component(root.name, label="repository name", slug=False)
+    skill_name: str = validated_component(request.skill, label="skill", slug=True)
+    run_name: str = validated_component(request.run_id, label="run-id", slug=True)
     normalized_request = replace(
         request,
         repo_root=root,

--- a/plugin/python/larch/report/run_log_sync.py
+++ b/plugin/python/larch/report/run_log_sync.py
@@ -1,0 +1,367 @@
+"""Repository-scoped synchronization of immutable cloud run archives."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import stat
+import sys
+import tarfile
+import tempfile
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Protocol
+
+from larch.core import config, repo_roots
+from larch.report import run_log_archive, run_log_publish, storage_config
+from larch.report.object_store import ObjectStoreError, RemoteObject, object_store_for
+from larch.report.storage_config import StorageConfigurationError, StorageRoot
+
+_REMOTE_PREFIX = "run-logs/"
+_ARCHIVE_SUFFIX = ".tar.gz"
+_ARCHIVE_KEY_PARTS = 2
+
+
+class RunLogSyncError(RuntimeError):
+    """A remote inventory or local cache synchronization invariant failed."""
+
+
+class SyncObjectStore(Protocol):
+    """Provider-neutral object operations required by synchronization."""
+
+    def list_objects(self, prefix: str = "") -> tuple[RemoteObject, ...]: ...
+
+    def download(self, key: str, destination: Path) -> None: ...
+
+
+class CacheSyncStatus(StrEnum):
+    """How one remote archive reached its validated local postcondition."""
+
+    PRESENT = "present"
+    DOWNLOADED = "downloaded"
+    REPAIRED = "repaired"
+
+
+@dataclass(frozen=True)
+class RunLogSyncRequest:
+    """Immutable inputs for one repository-scoped synchronization."""
+
+    repo_root: Path
+    storage_root: StorageRoot
+    cache_home: Path | None = None
+    state_home: Path | None = None
+
+
+@dataclass(frozen=True)
+class RemoteRunArchive:
+    """Validated identity and listing metadata for one remote run archive."""
+
+    remote_key: str
+    skill: str
+    run_id: str
+    size: int
+
+
+@dataclass(frozen=True)
+class SyncedRun:
+    """Validated local result for one remote run archive."""
+
+    remote_key: str
+    cache_dir: Path
+    status: CacheSyncStatus
+
+
+@dataclass(frozen=True)
+class RepositorySyncResult:
+    """Complete repository cache result returned after one remote listing."""
+
+    corpus_root: Path
+    runs: tuple[SyncedRun, ...]
+
+    @property
+    def listed_count(self) -> int:
+        return len(self.runs)
+
+    @property
+    def present_count(self) -> int:
+        return sum(run.status is CacheSyncStatus.PRESENT for run in self.runs)
+
+    @property
+    def downloaded_count(self) -> int:
+        return sum(run.status is not CacheSyncStatus.PRESENT for run in self.runs)
+
+    @property
+    def repaired_count(self) -> int:
+        return sum(run.status is CacheSyncStatus.REPAIRED for run in self.runs)
+
+
+def _remote_run_archive(remote: RemoteObject) -> RemoteRunArchive:
+    if not remote.key.startswith(_REMOTE_PREFIX):
+        raise RunLogSyncError(
+            f"listed object is outside {_REMOTE_PREFIX}: {remote.key!r}"
+        )
+    relative: str = remote.key.removeprefix(_REMOTE_PREFIX)
+    parts: list[str] = relative.split("/")
+    if len(parts) != _ARCHIVE_KEY_PARTS or not parts[1].endswith(_ARCHIVE_SUFFIX):
+        raise RunLogSyncError(f"invalid run archive key: {remote.key!r}")
+    try:
+        skill: str = run_log_publish.validated_component(
+            parts[0], label="remote skill", slug=True
+        )
+        run_id: str = run_log_publish.validated_component(
+            parts[1].removesuffix(_ARCHIVE_SUFFIX),
+            label="remote run-id",
+            slug=True,
+        )
+    except ValueError as exc:
+        raise RunLogSyncError(f"invalid run archive key: {remote.key!r}") from exc
+    if isinstance(remote.size, bool) or remote.size <= 0:
+        raise RunLogSyncError(f"run archive has invalid size: {remote.key!r}")
+    return RemoteRunArchive(remote.key, skill, run_id, remote.size)
+
+
+def _validated_inventory(
+    objects: tuple[RemoteObject, ...],
+) -> tuple[RemoteRunArchive, ...]:
+    archives: list[RemoteRunArchive] = []
+    remote_keys: set[str] = set()
+    local_names: dict[tuple[str, str], str] = {}
+    for remote in objects:
+        archive: RemoteRunArchive = _remote_run_archive(remote)
+        if archive.remote_key in remote_keys:
+            raise RunLogSyncError(
+                f"duplicate run archive listing: {archive.remote_key!r}"
+            )
+        remote_keys.add(archive.remote_key)
+        local_key: tuple[str, str] = (
+            archive.skill.casefold(),
+            archive.run_id.casefold(),
+        )
+        previous: str | None = local_names.get(local_key)
+        if previous is not None:
+            raise RunLogSyncError(
+                f"run archive names collide in the local cache: {previous!r} and {archive.remote_key!r}"
+            )
+        local_names[local_key] = archive.remote_key
+        archives.append(archive)
+    return tuple(sorted(archives, key=lambda archive: archive.remote_key))
+
+
+def _remove_entry(path: Path) -> None:
+    try:
+        mode: int = path.lstat().st_mode
+    except FileNotFoundError:
+        return
+    if stat.S_ISDIR(mode):
+        shutil.rmtree(path)
+    else:
+        path.unlink()
+
+
+def _remove_interrupted_entries(parent: Path, *, run_id: str) -> None:
+    for suffix in ("download-*", "invalid-*", "materialize-*", "promote-*"):
+        for path in parent.glob(f".{run_id}.{suffix}"):
+            _remove_entry(path)
+
+
+def _existing_cache_is_valid(cache_dir: Path, *, archive: RemoteRunArchive) -> bool:
+    try:
+        entry: os.stat_result = cache_dir.lstat()
+    except FileNotFoundError:
+        return False
+    if stat.S_ISLNK(entry.st_mode) or not stat.S_ISDIR(entry.st_mode):
+        return False
+    try:
+        _ = run_log_archive.verify_materialized_run_directory(
+            run_dir=cache_dir,
+            expected_skill=archive.skill,
+            expected_run_id=archive.run_id,
+        )
+    except (FileNotFoundError, RuntimeError, TypeError, ValueError):
+        return False
+    return True
+
+
+def _download_and_materialize(
+    *,
+    store: SyncObjectStore,
+    archive: RemoteRunArchive,
+    cache_dir: Path,
+) -> None:
+    with tempfile.NamedTemporaryFile(
+        dir=cache_dir.parent,
+        prefix=f".{archive.run_id}.download-",
+        suffix=_ARCHIVE_SUFFIX,
+        delete=False,
+    ) as handle:
+        archive_path: Path = Path(handle.name)
+    try:
+        store.download(archive.remote_key, archive_path)
+        entry: os.stat_result = archive_path.stat(follow_symlinks=False)
+        if not stat.S_ISREG(entry.st_mode) or entry.st_size != archive.size:
+            raise RunLogSyncError(
+                f"downloaded archive does not match listed size: {archive.remote_key!r}"
+            )
+        _ = run_log_archive.materialize_run_archive(
+            archive_path=archive_path,
+            run_dir=cache_dir,
+            expected_skill=archive.skill,
+            expected_run_id=archive.run_id,
+        )
+    finally:
+        archive_path.unlink(missing_ok=True)
+
+
+def _sync_archive(
+    *,
+    request: RunLogSyncRequest,
+    archive: RemoteRunArchive,
+    store: SyncObjectStore,
+    environ: Mapping[str, str] | None,
+) -> SyncedRun:
+    paths: run_log_publish.PublicationPaths = run_log_publish.publication_paths(
+        request=run_log_publish.PublicationRequest(
+            repo_root=request.repo_root,
+            storage_root=request.storage_root,
+            skill=archive.skill,
+            run_id=archive.run_id,
+            staging_root=None,
+            cache_home=request.cache_home,
+            state_home=request.state_home,
+        ),
+        environ=environ,
+    )
+    with run_log_publish.publication_lock(paths.lock_file):
+        parent: Path = run_log_publish.ensure_concurrent_directory(
+            paths.cache_dir.parent
+        )
+        _remove_interrupted_entries(parent, run_id=archive.run_id)
+        if _existing_cache_is_valid(paths.cache_dir, archive=archive):
+            return SyncedRun(
+                archive.remote_key, paths.cache_dir, CacheSyncStatus.PRESENT
+            )
+
+        had_invalid_entry: bool = (
+            paths.cache_dir.exists() or paths.cache_dir.is_symlink()
+        )
+        quarantine: Path | None = None
+        if had_invalid_entry:
+            quarantine = parent / (
+                f".{archive.run_id}.invalid-{os.getpid()}-{os.urandom(4).hex()}"
+            )
+            _ = paths.cache_dir.rename(quarantine)
+        try:
+            _download_and_materialize(
+                store=store,
+                archive=archive,
+                cache_dir=paths.cache_dir,
+            )
+        except (
+            EOFError,
+            ObjectStoreError,
+            OSError,
+            RunLogSyncError,
+            RuntimeError,
+            tarfile.TarError,
+            TypeError,
+            ValueError,
+        ):
+            if paths.cache_dir.exists() or paths.cache_dir.is_symlink():
+                _remove_entry(paths.cache_dir)
+            if quarantine is not None and (
+                quarantine.exists() or quarantine.is_symlink()
+            ):
+                _ = quarantine.rename(paths.cache_dir)
+            raise
+        if quarantine is not None:
+            _remove_entry(quarantine)
+        status: CacheSyncStatus = (
+            CacheSyncStatus.REPAIRED
+            if had_invalid_entry
+            else CacheSyncStatus.DOWNLOADED
+        )
+        return SyncedRun(archive.remote_key, paths.cache_dir, status)
+
+
+def sync_repository_run_logs(
+    *,
+    request: RunLogSyncRequest,
+    store: SyncObjectStore | None = None,
+    environ: Mapping[str, str] | None = None,
+) -> RepositorySyncResult:
+    """List remote archives once and materialize every missing repository run."""
+    active_store: SyncObjectStore = (
+        object_store_for(request.storage_root, environ=environ)
+        if store is None
+        else store
+    )
+    inventory: tuple[RemoteRunArchive, ...] = _validated_inventory(
+        active_store.list_objects(_REMOTE_PREFIX)
+    )
+    corpus_root: Path = run_log_publish.repository_cache_root(
+        repo_root=request.repo_root,
+        cache_home=request.cache_home,
+        environ=environ,
+    )
+    _ = run_log_publish.ensure_concurrent_directory(corpus_root)
+    runs: tuple[SyncedRun, ...] = tuple(
+        _sync_archive(
+            request=request,
+            archive=archive,
+            store=active_store,
+            environ=environ,
+        )
+        for archive in inventory
+    )
+    return RepositorySyncResult(corpus_root=corpus_root, runs=runs)
+
+
+def main(argv: Sequence[str]) -> int:
+    """Synchronize one repository cache and emit its machine envelope."""
+    parser = argparse.ArgumentParser(prog="cli.py run-log sync")
+    _ = parser.add_argument("--repo-root", required=True)
+    try:
+        args = parser.parse_args(argv)
+    except SystemExit as exc:
+        return int(exc.code) if isinstance(exc.code, int) else config.EXIT_USAGE
+    try:
+        requested_root: Path = Path(args.repo_root)
+        repo_root: Path | None = repo_roots.consumer_repo_root(requested_root)
+        if repo_root is None:
+            raise StorageConfigurationError(
+                f"could not discover a Git repository root from {requested_root}"
+            )
+        storage_root: StorageRoot = storage_config.discover_storage_root(
+            start=repo_root
+        )
+        result: RepositorySyncResult = sync_repository_run_logs(
+            request=RunLogSyncRequest(
+                repo_root=repo_root,
+                storage_root=storage_root,
+            )
+        )
+    except StorageConfigurationError as exc:
+        print(f"run-log sync failed: {exc}", file=sys.stderr)
+        return config.EXIT_STORAGE_CONFIG
+    except (
+        EOFError,
+        ObjectStoreError,
+        OSError,
+        RunLogSyncError,
+        RuntimeError,
+        tarfile.TarError,
+        TypeError,
+        ValueError,
+    ) as exc:
+        print(f"run-log sync failed: {exc}", file=sys.stderr)
+        return config.EXIT_INTERNAL_ERROR
+    print(f"CORPUS_ROOT={result.corpus_root}")
+    print(f"LISTED_ARCHIVES={result.listed_count}")
+    print(f"PRESENT_RUNS={result.present_count}")
+    print(f"DOWNLOADED_RUNS={result.downloaded_count}")
+    print(f"REPAIRED_RUNS={result.repaired_count}")
+    print("SYNC_OK=true")
+    return config.EXIT_OK

--- a/python/README.md
+++ b/python/README.md
@@ -34,9 +34,10 @@ Mostly-flat `python/` tree for larch's stdlib-only runtime modules (Python ≥ 3
   documented in `config.MERGE_RESULT_DRIVER_ALREADY_MERGED` for `flush_logs_pre` skip parity.
   Tool-failure batch capture remains deferred to Phase 7 wiring; bash launchers still own
   `append-tool-failure.sh` calls on the live path.
-- `larch/report/run_log_archive.py`, `object_store.py`, `storage_config.py`, and
-  `run_log_publish.py` own deterministic archives, provider-neutral transfer,
-  append-only publication, durable retry, and write-through cache promotion.
+- `larch/report/run_log_archive.py`, `object_store.py`, `storage_config.py`,
+  `run_log_publish.py`, and `run_log_sync.py` own deterministic archives,
+  provider-neutral transfer, append-only publication, durable retry,
+  write-through cache promotion, and repository-scoped cache synchronization.
 - `tests/`: unit tests mirror package layout under `python/tests/`.
 - `test_support.py`: intentionally remains at `python/` root as a shared pytest helper exempted by `python3 python/cli.py lint flat-tests`. It provides the shared list-queue `RecordingRunner` used by tests such as `test_run_logs.py` and `test_ci_monitor.py`.
 

--- a/python/larch/cli.py
+++ b/python/larch/cli.py
@@ -652,6 +652,7 @@ _REGISTRY: dict[tuple[str, str], tuple[str, str, bool]] = {
     ("run-log", "archive"): ("larch.report.run_log_archive", "main", False),
     ("run-log", "materialize"): ("larch.report.run_log_archive", "materialize_main", False),
     ("run-log", "publish"): ("larch.report.run_log_publish", "main", True),
+    ("run-log", "sync"): ("larch.report.run_log_sync", "main", True),
     ("run-log", "validate-run-id"): ("larch.report.run_logs", "larch_log_validate_run_id_main", True),
     ("run-log", "capture-transcript"): ("larch.report.run_log_flush", "capture_transcript_main", False),
     ("run-log", "render-session-transcript"): ("larch.rendering.render_session_transcript", "main", False),

--- a/python/larch/report/object_store.py
+++ b/python/larch/report/object_store.py
@@ -36,6 +36,12 @@ class CommandObjectStore:
         if invalid:
             raise ObjectStoreError(ObjectStoreErrorKind.CONFIGURATION, self.root.scheme, "key")
         return f"{self.root.prefix}/{relative}" if relative else f"{self.root.prefix}/"
+    def _list_prefix(self, relative: str) -> str:
+        trailing = relative.endswith("/")
+        normalized = relative[:-1] if trailing else relative
+        if trailing and not normalized:
+            raise ObjectStoreError(ObjectStoreErrorKind.CONFIGURATION, self.root.scheme, "key")
+        return self._key(normalized, empty=True) + ("/" if trailing else "")
     def _aws(self, *args: str) -> list[str]:
         return [config.AWS_CLI, *args, *(["--endpoint-url", self.endpoint] if self.endpoint else [])]
     def _gcs(self, operation: str, *args: str) -> list[str]:
@@ -57,7 +63,7 @@ class CommandObjectStore:
         command = self._gcs("preflight") if self.root.scheme == "gs" else self._aws("s3", "ls", f"s3://{self.root.bucket}")
         _ = self._run(command, "preflight")
     def list_objects(self, prefix: str = "") -> tuple[RemoteObject, ...]:
-        remote_prefix, token = self._key(prefix, empty=True), None
+        remote_prefix, token = self._list_prefix(prefix), None
         objects: list[RemoteObject] = []
         seen: set[str] = set()
         while True:

--- a/python/larch/report/run_log_corpus.py
+++ b/python/larch/report/run_log_corpus.py
@@ -13,6 +13,7 @@ from enum import StrEnum
 from pathlib import Path
 from typing import Any, Literal, cast
 
+from larch.report import run_log_sync
 from larch.report.report_tokens_models import safe_int
 
 DEFAULT_MANIFEST_CANDIDATES: tuple[str, ...] = ("manifest.json", "run-manifest.json")
@@ -230,6 +231,34 @@ def safe_child_run_dirs(
 def run_dirs(log_base: Path, warn: Callable[[str], None] | None = None) -> list[Path]:
     """Return symlink-safe, manifest-accepted child run directories."""
     return [path for path in safe_child_run_dirs(log_base, warn=warn) if is_valid_run_dir(path, warn=warn)]
+
+
+def synchronize_run_log_corpus(
+    *,
+    request: run_log_sync.RunLogSyncRequest,
+    store: run_log_sync.SyncObjectStore | None = None,
+    environ: Mapping[str, str] | None = None,
+) -> run_log_sync.RepositorySyncResult:
+    """Synchronize once and return the repository's ordinary local-file corpus."""
+    return run_log_sync.sync_repository_run_logs(
+        request=request,
+        store=store,
+        environ=environ,
+    )
+
+
+def synchronized_run_log_root(
+    *,
+    request: run_log_sync.RunLogSyncRequest,
+    store: run_log_sync.SyncObjectStore | None = None,
+    environ: Mapping[str, str] | None = None,
+) -> Path:
+    """Synchronize once and expose the unpacked root for all later read waves."""
+    return synchronize_run_log_corpus(
+        request=request,
+        store=store,
+        environ=environ,
+    ).corpus_root
 
 
 def review_transcript_dirs(log_base: Path, warn: Callable[[str], None] | None = None) -> list[Path]:

--- a/python/larch/report/run_log_publish.py
+++ b/python/larch/report/run_log_publish.py
@@ -139,7 +139,7 @@ class PublicationResult:
     cache_status: CachePublicationStatus
 
 
-def _validated_component(value: str, *, label: str, slug: bool) -> str:
+def validated_component(value: str, *, label: str, slug: bool) -> str:
     invalid_literal: bool = (
         not value
         or value in {".", ".."}
@@ -155,7 +155,7 @@ def _validated_component(value: str, *, label: str, slug: bool) -> str:
     return value
 
 
-def _xdg_home(
+def xdg_home(
     *,
     environ: Mapping[str, str],
     variable: str,
@@ -168,6 +168,26 @@ def _xdg_home(
     return selected
 
 
+def repository_cache_root(
+    *,
+    repo_root: Path,
+    cache_home: Path | None = None,
+    environ: Mapping[str, str] | None = None,
+) -> Path:
+    """Return the literal per-repository root for unpacked run archives."""
+    root: Path = larch_io.validate_trusted_directory(repo_root)
+    repo_name: str = validated_component(root.name, label="repository name", slug=False)
+    environment: Mapping[str, str] = os.environ if environ is None else environ
+    resolved_cache_home: Path = cache_home or xdg_home(
+        environ=environment,
+        variable=_ENV_XDG_CACHE_HOME,
+        fallback=Path.home() / ".cache",
+    )
+    if not resolved_cache_home.is_absolute():
+        raise ValueError("publication cache home must be an absolute path")
+    return resolved_cache_home / "larch" / "run-logs" / repo_name
+
+
 def publication_paths(
     *,
     request: PublicationRequest,
@@ -175,25 +195,23 @@ def publication_paths(
 ) -> PublicationPaths:
     """Resolve the literal repository cache path and durable retry path."""
     root: Path = larch_io.validate_trusted_directory(request.repo_root)
-    repo_name: str = _validated_component(root.name, label="repository name", slug=False)
-    skill_name: str = _validated_component(request.skill, label="skill", slug=True)
-    run_name: str = _validated_component(request.run_id, label="run-id", slug=True)
+    repo_name: str = validated_component(root.name, label="repository name", slug=False)
+    skill_name: str = validated_component(request.skill, label="skill", slug=True)
+    run_name: str = validated_component(request.run_id, label="run-id", slug=True)
     environment: Mapping[str, str] = os.environ if environ is None else environ
-    resolved_cache_home: Path = request.cache_home or _xdg_home(
+    cache_root: Path = repository_cache_root(
+        repo_root=root,
+        cache_home=request.cache_home,
         environ=environment,
-        variable=_ENV_XDG_CACHE_HOME,
-        fallback=Path.home() / ".cache",
     )
-    resolved_state_home: Path = request.state_home or _xdg_home(
+    resolved_state_home: Path = request.state_home or xdg_home(
         environ=environment,
         variable=_ENV_XDG_STATE_HOME,
         fallback=Path.home() / ".local" / "state",
     )
-    if not resolved_cache_home.is_absolute() or not resolved_state_home.is_absolute():
-        raise ValueError("publication cache and state homes must be absolute paths")
-    cache_dir: Path = (
-        resolved_cache_home / "larch" / "run-logs" / repo_name / skill_name / run_name
-    )
+    if not resolved_state_home.is_absolute():
+        raise ValueError("publication state home must be an absolute path")
+    cache_dir: Path = cache_root / skill_name / run_name
     pending_dir: Path = (
         resolved_state_home
         / "larch"
@@ -219,7 +237,7 @@ def publication_paths(
     )
 
 
-def _ensure_concurrent_directory(path: Path) -> Path:
+def ensure_concurrent_directory(path: Path) -> Path:
     """Create a trusted directory while tolerating a same-path creator race."""
     directory: Path = path if path.is_absolute() else Path.cwd() / path
     try:
@@ -228,7 +246,7 @@ def _ensure_concurrent_directory(path: Path) -> Path:
         pass
     if directory == directory.parent:
         raise OSError(f"cannot create trusted publication directory: {directory}")
-    _ = _ensure_concurrent_directory(directory.parent)
+    _ = ensure_concurrent_directory(directory.parent)
     with suppress(FileExistsError):
         directory.mkdir(mode=0o700)
     return larch_io.validate_trusted_directory(directory)
@@ -237,7 +255,7 @@ def _ensure_concurrent_directory(path: Path) -> Path:
 @contextmanager
 def publication_lock(path: Path) -> Generator[None, None, None]:
     """Hold the blocking advisory lock shared by all operations for one run."""
-    parent: Path = _ensure_concurrent_directory(path.parent)
+    parent: Path = ensure_concurrent_directory(path.parent)
     lock_path: Path = parent / path.name
     if lock_path.is_symlink():
         raise OSError(f"refusing symlinked publication lock: {lock_path}")
@@ -435,7 +453,7 @@ def _create_pending(
     request: PublicationRequest,
     repo_name: str,
 ) -> PendingPublication:
-    parent: Path = _ensure_concurrent_directory(paths.pending_dir.parent)
+    parent: Path = ensure_concurrent_directory(paths.pending_dir.parent)
     temporary: Path | None = Path(
         tempfile.mkdtemp(dir=parent, prefix=f".{request.run_id}.pending-")
     )
@@ -559,7 +577,7 @@ def _cache_result(
     pending: PendingPublication,
     staging_root: Path | None,
 ) -> tuple[RunArchiveMaterializationResult, CachePublicationStatus]:
-    _ = _ensure_concurrent_directory(paths.cache_dir.parent)
+    _ = ensure_concurrent_directory(paths.cache_dir.parent)
     if paths.cache_dir.exists() or paths.cache_dir.is_symlink():
         existing: RunArchiveMaterializationResult = run_log_archive.verify_materialized_run_directory(
             run_dir=paths.cache_dir,
@@ -615,9 +633,9 @@ def publish_run(
 ) -> PublicationResult:
     """Publish one immutable archive and atomically populate its local cache."""
     root: Path = larch_io.validate_trusted_directory(request.repo_root)
-    repo_name: str = _validated_component(root.name, label="repository name", slug=False)
-    skill_name: str = _validated_component(request.skill, label="skill", slug=True)
-    run_name: str = _validated_component(request.run_id, label="run-id", slug=True)
+    repo_name: str = validated_component(root.name, label="repository name", slug=False)
+    skill_name: str = validated_component(request.skill, label="skill", slug=True)
+    run_name: str = validated_component(request.run_id, label="run-id", slug=True)
     normalized_request = replace(
         request,
         repo_root=root,

--- a/python/larch/report/run_log_sync.py
+++ b/python/larch/report/run_log_sync.py
@@ -1,0 +1,367 @@
+"""Repository-scoped synchronization of immutable cloud run archives."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import stat
+import sys
+import tarfile
+import tempfile
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Protocol
+
+from larch.core import config, repo_roots
+from larch.report import run_log_archive, run_log_publish, storage_config
+from larch.report.object_store import ObjectStoreError, RemoteObject, object_store_for
+from larch.report.storage_config import StorageConfigurationError, StorageRoot
+
+_REMOTE_PREFIX = "run-logs/"
+_ARCHIVE_SUFFIX = ".tar.gz"
+_ARCHIVE_KEY_PARTS = 2
+
+
+class RunLogSyncError(RuntimeError):
+    """A remote inventory or local cache synchronization invariant failed."""
+
+
+class SyncObjectStore(Protocol):
+    """Provider-neutral object operations required by synchronization."""
+
+    def list_objects(self, prefix: str = "") -> tuple[RemoteObject, ...]: ...
+
+    def download(self, key: str, destination: Path) -> None: ...
+
+
+class CacheSyncStatus(StrEnum):
+    """How one remote archive reached its validated local postcondition."""
+
+    PRESENT = "present"
+    DOWNLOADED = "downloaded"
+    REPAIRED = "repaired"
+
+
+@dataclass(frozen=True)
+class RunLogSyncRequest:
+    """Immutable inputs for one repository-scoped synchronization."""
+
+    repo_root: Path
+    storage_root: StorageRoot
+    cache_home: Path | None = None
+    state_home: Path | None = None
+
+
+@dataclass(frozen=True)
+class RemoteRunArchive:
+    """Validated identity and listing metadata for one remote run archive."""
+
+    remote_key: str
+    skill: str
+    run_id: str
+    size: int
+
+
+@dataclass(frozen=True)
+class SyncedRun:
+    """Validated local result for one remote run archive."""
+
+    remote_key: str
+    cache_dir: Path
+    status: CacheSyncStatus
+
+
+@dataclass(frozen=True)
+class RepositorySyncResult:
+    """Complete repository cache result returned after one remote listing."""
+
+    corpus_root: Path
+    runs: tuple[SyncedRun, ...]
+
+    @property
+    def listed_count(self) -> int:
+        return len(self.runs)
+
+    @property
+    def present_count(self) -> int:
+        return sum(run.status is CacheSyncStatus.PRESENT for run in self.runs)
+
+    @property
+    def downloaded_count(self) -> int:
+        return sum(run.status is not CacheSyncStatus.PRESENT for run in self.runs)
+
+    @property
+    def repaired_count(self) -> int:
+        return sum(run.status is CacheSyncStatus.REPAIRED for run in self.runs)
+
+
+def _remote_run_archive(remote: RemoteObject) -> RemoteRunArchive:
+    if not remote.key.startswith(_REMOTE_PREFIX):
+        raise RunLogSyncError(
+            f"listed object is outside {_REMOTE_PREFIX}: {remote.key!r}"
+        )
+    relative: str = remote.key.removeprefix(_REMOTE_PREFIX)
+    parts: list[str] = relative.split("/")
+    if len(parts) != _ARCHIVE_KEY_PARTS or not parts[1].endswith(_ARCHIVE_SUFFIX):
+        raise RunLogSyncError(f"invalid run archive key: {remote.key!r}")
+    try:
+        skill: str = run_log_publish.validated_component(
+            parts[0], label="remote skill", slug=True
+        )
+        run_id: str = run_log_publish.validated_component(
+            parts[1].removesuffix(_ARCHIVE_SUFFIX),
+            label="remote run-id",
+            slug=True,
+        )
+    except ValueError as exc:
+        raise RunLogSyncError(f"invalid run archive key: {remote.key!r}") from exc
+    if isinstance(remote.size, bool) or remote.size <= 0:
+        raise RunLogSyncError(f"run archive has invalid size: {remote.key!r}")
+    return RemoteRunArchive(remote.key, skill, run_id, remote.size)
+
+
+def _validated_inventory(
+    objects: tuple[RemoteObject, ...],
+) -> tuple[RemoteRunArchive, ...]:
+    archives: list[RemoteRunArchive] = []
+    remote_keys: set[str] = set()
+    local_names: dict[tuple[str, str], str] = {}
+    for remote in objects:
+        archive: RemoteRunArchive = _remote_run_archive(remote)
+        if archive.remote_key in remote_keys:
+            raise RunLogSyncError(
+                f"duplicate run archive listing: {archive.remote_key!r}"
+            )
+        remote_keys.add(archive.remote_key)
+        local_key: tuple[str, str] = (
+            archive.skill.casefold(),
+            archive.run_id.casefold(),
+        )
+        previous: str | None = local_names.get(local_key)
+        if previous is not None:
+            raise RunLogSyncError(
+                f"run archive names collide in the local cache: {previous!r} and {archive.remote_key!r}"
+            )
+        local_names[local_key] = archive.remote_key
+        archives.append(archive)
+    return tuple(sorted(archives, key=lambda archive: archive.remote_key))
+
+
+def _remove_entry(path: Path) -> None:
+    try:
+        mode: int = path.lstat().st_mode
+    except FileNotFoundError:
+        return
+    if stat.S_ISDIR(mode):
+        shutil.rmtree(path)
+    else:
+        path.unlink()
+
+
+def _remove_interrupted_entries(parent: Path, *, run_id: str) -> None:
+    for suffix in ("download-*", "invalid-*", "materialize-*", "promote-*"):
+        for path in parent.glob(f".{run_id}.{suffix}"):
+            _remove_entry(path)
+
+
+def _existing_cache_is_valid(cache_dir: Path, *, archive: RemoteRunArchive) -> bool:
+    try:
+        entry: os.stat_result = cache_dir.lstat()
+    except FileNotFoundError:
+        return False
+    if stat.S_ISLNK(entry.st_mode) or not stat.S_ISDIR(entry.st_mode):
+        return False
+    try:
+        _ = run_log_archive.verify_materialized_run_directory(
+            run_dir=cache_dir,
+            expected_skill=archive.skill,
+            expected_run_id=archive.run_id,
+        )
+    except (FileNotFoundError, RuntimeError, TypeError, ValueError):
+        return False
+    return True
+
+
+def _download_and_materialize(
+    *,
+    store: SyncObjectStore,
+    archive: RemoteRunArchive,
+    cache_dir: Path,
+) -> None:
+    with tempfile.NamedTemporaryFile(
+        dir=cache_dir.parent,
+        prefix=f".{archive.run_id}.download-",
+        suffix=_ARCHIVE_SUFFIX,
+        delete=False,
+    ) as handle:
+        archive_path: Path = Path(handle.name)
+    try:
+        store.download(archive.remote_key, archive_path)
+        entry: os.stat_result = archive_path.stat(follow_symlinks=False)
+        if not stat.S_ISREG(entry.st_mode) or entry.st_size != archive.size:
+            raise RunLogSyncError(
+                f"downloaded archive does not match listed size: {archive.remote_key!r}"
+            )
+        _ = run_log_archive.materialize_run_archive(
+            archive_path=archive_path,
+            run_dir=cache_dir,
+            expected_skill=archive.skill,
+            expected_run_id=archive.run_id,
+        )
+    finally:
+        archive_path.unlink(missing_ok=True)
+
+
+def _sync_archive(
+    *,
+    request: RunLogSyncRequest,
+    archive: RemoteRunArchive,
+    store: SyncObjectStore,
+    environ: Mapping[str, str] | None,
+) -> SyncedRun:
+    paths: run_log_publish.PublicationPaths = run_log_publish.publication_paths(
+        request=run_log_publish.PublicationRequest(
+            repo_root=request.repo_root,
+            storage_root=request.storage_root,
+            skill=archive.skill,
+            run_id=archive.run_id,
+            staging_root=None,
+            cache_home=request.cache_home,
+            state_home=request.state_home,
+        ),
+        environ=environ,
+    )
+    with run_log_publish.publication_lock(paths.lock_file):
+        parent: Path = run_log_publish.ensure_concurrent_directory(
+            paths.cache_dir.parent
+        )
+        _remove_interrupted_entries(parent, run_id=archive.run_id)
+        if _existing_cache_is_valid(paths.cache_dir, archive=archive):
+            return SyncedRun(
+                archive.remote_key, paths.cache_dir, CacheSyncStatus.PRESENT
+            )
+
+        had_invalid_entry: bool = (
+            paths.cache_dir.exists() or paths.cache_dir.is_symlink()
+        )
+        quarantine: Path | None = None
+        if had_invalid_entry:
+            quarantine = parent / (
+                f".{archive.run_id}.invalid-{os.getpid()}-{os.urandom(4).hex()}"
+            )
+            _ = paths.cache_dir.rename(quarantine)
+        try:
+            _download_and_materialize(
+                store=store,
+                archive=archive,
+                cache_dir=paths.cache_dir,
+            )
+        except (
+            EOFError,
+            ObjectStoreError,
+            OSError,
+            RunLogSyncError,
+            RuntimeError,
+            tarfile.TarError,
+            TypeError,
+            ValueError,
+        ):
+            if paths.cache_dir.exists() or paths.cache_dir.is_symlink():
+                _remove_entry(paths.cache_dir)
+            if quarantine is not None and (
+                quarantine.exists() or quarantine.is_symlink()
+            ):
+                _ = quarantine.rename(paths.cache_dir)
+            raise
+        if quarantine is not None:
+            _remove_entry(quarantine)
+        status: CacheSyncStatus = (
+            CacheSyncStatus.REPAIRED
+            if had_invalid_entry
+            else CacheSyncStatus.DOWNLOADED
+        )
+        return SyncedRun(archive.remote_key, paths.cache_dir, status)
+
+
+def sync_repository_run_logs(
+    *,
+    request: RunLogSyncRequest,
+    store: SyncObjectStore | None = None,
+    environ: Mapping[str, str] | None = None,
+) -> RepositorySyncResult:
+    """List remote archives once and materialize every missing repository run."""
+    active_store: SyncObjectStore = (
+        object_store_for(request.storage_root, environ=environ)
+        if store is None
+        else store
+    )
+    inventory: tuple[RemoteRunArchive, ...] = _validated_inventory(
+        active_store.list_objects(_REMOTE_PREFIX)
+    )
+    corpus_root: Path = run_log_publish.repository_cache_root(
+        repo_root=request.repo_root,
+        cache_home=request.cache_home,
+        environ=environ,
+    )
+    _ = run_log_publish.ensure_concurrent_directory(corpus_root)
+    runs: tuple[SyncedRun, ...] = tuple(
+        _sync_archive(
+            request=request,
+            archive=archive,
+            store=active_store,
+            environ=environ,
+        )
+        for archive in inventory
+    )
+    return RepositorySyncResult(corpus_root=corpus_root, runs=runs)
+
+
+def main(argv: Sequence[str]) -> int:
+    """Synchronize one repository cache and emit its machine envelope."""
+    parser = argparse.ArgumentParser(prog="cli.py run-log sync")
+    _ = parser.add_argument("--repo-root", required=True)
+    try:
+        args = parser.parse_args(argv)
+    except SystemExit as exc:
+        return int(exc.code) if isinstance(exc.code, int) else config.EXIT_USAGE
+    try:
+        requested_root: Path = Path(args.repo_root)
+        repo_root: Path | None = repo_roots.consumer_repo_root(requested_root)
+        if repo_root is None:
+            raise StorageConfigurationError(
+                f"could not discover a Git repository root from {requested_root}"
+            )
+        storage_root: StorageRoot = storage_config.discover_storage_root(
+            start=repo_root
+        )
+        result: RepositorySyncResult = sync_repository_run_logs(
+            request=RunLogSyncRequest(
+                repo_root=repo_root,
+                storage_root=storage_root,
+            )
+        )
+    except StorageConfigurationError as exc:
+        print(f"run-log sync failed: {exc}", file=sys.stderr)
+        return config.EXIT_STORAGE_CONFIG
+    except (
+        EOFError,
+        ObjectStoreError,
+        OSError,
+        RunLogSyncError,
+        RuntimeError,
+        tarfile.TarError,
+        TypeError,
+        ValueError,
+    ) as exc:
+        print(f"run-log sync failed: {exc}", file=sys.stderr)
+        return config.EXIT_INTERNAL_ERROR
+    print(f"CORPUS_ROOT={result.corpus_root}")
+    print(f"LISTED_ARCHIVES={result.listed_count}")
+    print(f"PRESENT_RUNS={result.present_count}")
+    print(f"DOWNLOADED_RUNS={result.downloaded_count}")
+    print(f"REPAIRED_RUNS={result.repaired_count}")
+    print("SYNC_OK=true")
+    return config.EXIT_OK

--- a/python/tests/report/test_object_store.py
+++ b/python/tests/report/test_object_store.py
@@ -50,6 +50,30 @@ def test_list_paginates_from_empty_prefix(scheme: str) -> None:
     outside = {"objects": [{"key": "larch/../outside", "size": 1}]} if scheme == "gs" else {"Contents": [{"Key": "larch/../outside", "Size": 1}]}
     with pytest.raises(ObjectStoreError):
         _ = _store(scheme, FakeRunner(_result(payload=outside))).list_objects()
+
+
+@pytest.mark.parametrize("scheme", ["s3", "gs", "r2"])
+def test_list_paginates_the_complete_run_log_prefix(scheme: str) -> None:
+    if scheme == "gs":
+        pages = (
+            {"objects": [{"key": "larch/run-logs/design/run-a.tar.gz", "size": 1}], "next_page_token": "two"},
+            {"objects": [{"key": "larch/run-logs/review/run-b.tar.gz", "size": 2}]},
+        )
+    else:
+        pages = (
+            {"Contents": [{"Key": "larch/run-logs/design/run-a.tar.gz", "Size": 1}], "NextContinuationToken": "two"},
+            {"Contents": [{"Key": "larch/run-logs/review/run-b.tar.gz", "Size": 2}]},
+        )
+    runner = FakeRunner(*(_result(payload=page) for page in pages))
+
+    objects = _store(scheme, runner).list_objects("run-logs/")
+
+    assert [item.key for item in objects] == [
+        "run-logs/design/run-a.tar.gz",
+        "run-logs/review/run-b.tar.gz",
+    ]
+    assert "larch/run-logs/" in runner.calls[0]
+    assert "two" in runner.calls[1]
 @pytest.mark.parametrize("scheme", ["s3", "gs", "r2"])
 def test_upload_is_create_only(scheme: str, tmp_path: Path) -> None:
     source = tmp_path / "archive"

--- a/python/tests/report/test_run_log_sync.py
+++ b/python/tests/report/test_run_log_sync.py
@@ -1,0 +1,338 @@
+"""Tests for repository-scoped cloud run-log synchronization."""
+
+from __future__ import annotations
+
+import threading
+import tarfile
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+from larch.report import run_log_archive, run_log_corpus, run_log_sync
+from larch.report.object_store import RemoteObject
+from larch.report.storage_config import StorageRoot
+
+
+class MemoryObjectStore:
+    """Thread-safe immutable archive store for sync contract tests."""
+
+    def __init__(self, objects: dict[str, bytes]) -> None:
+        self.objects = objects
+        self.list_calls: list[str] = []
+        self.download_calls: list[str] = []
+        self.download_started: threading.Event | None = None
+        self.release_download: threading.Event | None = None
+        self._lock = threading.Lock()
+
+    def list_objects(self, prefix: str = "") -> tuple[RemoteObject, ...]:
+        with self._lock:
+            self.list_calls.append(prefix)
+            return tuple(
+                RemoteObject(key, len(content), None, None)
+                for key, content in sorted(self.objects.items())
+                if key.startswith(prefix)
+            )
+
+    def download(self, key: str, destination: Path) -> None:
+        with self._lock:
+            self.download_calls.append(key)
+            content: bytes = self.objects[key]
+        if self.download_started is not None:
+            self.download_started.set()
+        if self.release_download is not None and not self.release_download.wait(
+            timeout=5
+        ):
+            raise TimeoutError("test download release timed out")
+        _ = destination.write_bytes(content)
+
+
+def _archive_bytes(tmp_path: Path, *, skill: str, run_id: str, content: str) -> bytes:
+    staging = tmp_path / f"staging-{skill}-{run_id}"
+    staging.mkdir()
+    _ = (staging / "manifest.json").write_text(
+        '{"issue_number":7819,"started_at":"2026-07-20T00:00:00+00:00"}\n',
+        encoding="utf-8",
+    )
+    nested = staging / "nested"
+    nested.mkdir()
+    _ = (nested / "result.txt").write_text(content, encoding="utf-8")
+    created = run_log_archive.create_run_archive(
+        staging_root=staging,
+        output_dir=tmp_path / f"archives-{skill}-{run_id}",
+        skill=skill,
+        run_id=run_id,
+    )
+    return created.archive_path.read_bytes()
+
+
+def _request(
+    *,
+    repo: Path,
+    cache_home: Path,
+    state_home: Path,
+) -> run_log_sync.RunLogSyncRequest:
+    return run_log_sync.RunLogSyncRequest(
+        repo_root=repo,
+        storage_root=StorageRoot("s3", "bucket", "larch"),
+        cache_home=cache_home,
+        state_home=state_home,
+    )
+
+
+def test_cold_then_warm_sync_lists_once_per_call_and_downloads_each_run_once(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "literal repo"
+    repo.mkdir()
+    cache_home = tmp_path / "cache"
+    state_home = tmp_path / "state"
+    objects = {
+        "run-logs/design/design-run.tar.gz": _archive_bytes(
+            tmp_path, skill="design", run_id="design-run", content="design\n"
+        ),
+        "run-logs/implement/implement-run.tar.gz": _archive_bytes(
+            tmp_path, skill="implement", run_id="implement-run", content="implement\n"
+        ),
+    }
+    store = MemoryObjectStore(objects)
+    request = _request(repo=repo, cache_home=cache_home, state_home=state_home)
+
+    cold = run_log_sync.sync_repository_run_logs(request=request, store=store)
+
+    assert cold.corpus_root == cache_home / "larch/run-logs/literal repo"
+    assert cold.listed_count == 2
+    assert cold.downloaded_count == 2
+    assert cold.present_count == 0
+    assert cold.repaired_count == 0
+    assert store.list_calls == ["run-logs/"]
+    assert store.download_calls == sorted(objects)
+    assert (cold.corpus_root / "implement/implement-run/nested/result.txt").read_text(
+        encoding="utf-8"
+    ) == "implement\n"
+
+    warm = run_log_sync.sync_repository_run_logs(request=request, store=store)
+
+    assert warm.listed_count == 2
+    assert warm.downloaded_count == 0
+    assert warm.present_count == 2
+    assert warm.repaired_count == 0
+    assert store.list_calls == ["run-logs/", "run-logs/"]
+    assert store.download_calls == sorted(objects)
+
+
+def test_shared_corpus_api_syncs_once_then_supports_multiple_local_read_waves(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    cache_home = tmp_path / "cache"
+    state_home = tmp_path / "state"
+    store = MemoryObjectStore(
+        {
+            "run-logs/implement/run-wave.tar.gz": _archive_bytes(
+                tmp_path,
+                skill="implement",
+                run_id="run-wave",
+                content="wave\n",
+            )
+        }
+    )
+
+    corpus_root = run_log_corpus.synchronized_run_log_root(
+        request=_request(repo=repo, cache_home=cache_home, state_home=state_home),
+        store=store,
+    )
+
+    first_wave = run_log_corpus.run_dirs(corpus_root / "implement")
+    second_wave = run_log_corpus.safe_child_run_dirs(corpus_root / "implement")
+    assert [path.name for path in first_wave] == ["run-wave"]
+    assert [path.name for path in second_wave] == ["run-wave"]
+    assert store.list_calls == ["run-logs/"]
+    assert store.download_calls == ["run-logs/implement/run-wave.tar.gz"]
+
+
+def test_invalid_cache_and_interrupted_materialization_are_repaired(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    cache_home = tmp_path / "cache"
+    state_home = tmp_path / "state"
+    key = "run-logs/review/run-repair.tar.gz"
+    store = MemoryObjectStore(
+        {
+            key: _archive_bytes(
+                tmp_path, skill="review", run_id="run-repair", content="clean\n"
+            )
+        }
+    )
+    request = _request(repo=repo, cache_home=cache_home, state_home=state_home)
+    first = run_log_sync.sync_repository_run_logs(request=request, store=store)
+    run_dir = first.corpus_root / "review/run-repair"
+    _ = (run_dir / "nested/result.txt").write_text("corrupt\n", encoding="utf-8")
+    interrupted = run_dir.parent / ".run-repair.materialize-interrupted"
+    interrupted.mkdir()
+    _ = (interrupted / "partial").write_text("partial", encoding="utf-8")
+
+    repaired = run_log_sync.sync_repository_run_logs(request=request, store=store)
+
+    assert repaired.repaired_count == 1
+    assert repaired.downloaded_count == 1
+    assert (run_dir / "nested/result.txt").read_text(encoding="utf-8") == "clean\n"
+    assert not interrupted.exists()
+    assert store.download_calls == [key, key]
+
+
+def test_unverifiable_cache_fails_without_replacement_or_download(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    cache_home = tmp_path / "cache"
+    state_home = tmp_path / "state"
+    key = "run-logs/review/run-unreadable.tar.gz"
+    store = MemoryObjectStore(
+        {
+            key: _archive_bytes(
+                tmp_path,
+                skill="review",
+                run_id="run-unreadable",
+                content="valid\n",
+            )
+        }
+    )
+    request = _request(repo=repo, cache_home=cache_home, state_home=state_home)
+    first = run_log_sync.sync_repository_run_logs(request=request, store=store)
+    run_dir = first.corpus_root / "review/run-unreadable"
+
+    def unreadable_cache(**_kwargs: object) -> object:
+        raise PermissionError("temporarily unreadable")
+
+    monkeypatch.setattr(
+        run_log_archive,
+        "verify_materialized_run_directory",
+        unreadable_cache,
+    )
+    with pytest.raises(PermissionError, match="temporarily unreadable"):
+        _ = run_log_sync.sync_repository_run_logs(request=request, store=store)
+
+    assert (run_dir / "nested/result.txt").read_text(encoding="utf-8") == "valid\n"
+    assert store.download_calls == [key]
+
+
+def test_failed_repair_restores_invalid_entry_and_removes_download_temporary(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    cache_home = tmp_path / "cache"
+    state_home = tmp_path / "state"
+    key = "run-logs/review/run-broken.tar.gz"
+    store = MemoryObjectStore({key: b"not-an-archive"})
+    request = _request(repo=repo, cache_home=cache_home, state_home=state_home)
+    run_dir = cache_home / "larch/run-logs/repo/review/run-broken"
+    run_dir.mkdir(parents=True)
+    _ = (run_dir / "partial.txt").write_text("preserve for retry\n", encoding="utf-8")
+
+    with pytest.raises((tarfile.ReadError, run_log_sync.RunLogSyncError)):
+        _ = run_log_sync.sync_repository_run_logs(request=request, store=store)
+
+    assert (run_dir / "partial.txt").read_text(
+        encoding="utf-8"
+    ) == "preserve for retry\n"
+    assert not list(run_dir.parent.glob(".run-broken.download-*"))
+    assert not list(run_dir.parent.glob(".run-broken.invalid-*"))
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "run-logs/run.tar.gz",
+        "run-logs/implement/nested/run.tar.gz",
+        "run-logs/implement/run.zip",
+        "run-logs/bad skill/run.tar.gz",
+    ],
+)
+def test_invalid_remote_inventory_fails_before_download(
+    tmp_path: Path, key: str
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    store = MemoryObjectStore({key: b"archive"})
+
+    with pytest.raises(run_log_sync.RunLogSyncError):
+        _ = run_log_sync.sync_repository_run_logs(
+            request=_request(
+                repo=repo,
+                cache_home=tmp_path / "cache",
+                state_home=tmp_path / "state",
+            ),
+            store=store,
+        )
+
+    assert not store.download_calls
+
+
+def test_case_colliding_remote_names_fail_before_download(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    store = MemoryObjectStore(
+        {
+            "run-logs/review/Run-A.tar.gz": b"first",
+            "run-logs/REVIEW/run-a.tar.gz": b"second",
+        }
+    )
+
+    with pytest.raises(run_log_sync.RunLogSyncError, match="collide"):
+        _ = run_log_sync.sync_repository_run_logs(
+            request=_request(
+                repo=repo,
+                cache_home=tmp_path / "cache",
+                state_home=tmp_path / "state",
+            ),
+            store=store,
+        )
+
+    assert not store.download_calls
+
+
+def test_concurrent_syncs_share_the_publication_lock_and_download_once(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    key = "run-logs/implement/run-concurrent.tar.gz"
+    store = MemoryObjectStore(
+        {
+            key: _archive_bytes(
+                tmp_path,
+                skill="implement",
+                run_id="run-concurrent",
+                content="concurrent\n",
+            )
+        }
+    )
+    store.download_started = threading.Event()
+    store.release_download = threading.Event()
+    request = _request(
+        repo=repo,
+        cache_home=tmp_path / "cache",
+        state_home=tmp_path / "state",
+    )
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        first = pool.submit(
+            run_log_sync.sync_repository_run_logs, request=request, store=store
+        )
+        assert store.download_started.wait(timeout=5)
+        second = pool.submit(
+            run_log_sync.sync_repository_run_logs, request=request, store=store
+        )
+        store.release_download.set()
+        results = (first.result(timeout=5), second.result(timeout=5))
+
+    assert sorted(result.downloaded_count for result in results) == [0, 1]
+    assert store.download_calls == [key]
+    assert store.list_calls == ["run-logs/", "run-logs/"]

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -182,6 +182,15 @@ def test_run_log_storage_preflight_entrypoint_is_machine_stdout() -> None:
     assert ("run-log", "storage-preflight") in cli._MACHINE_STDOUT_KEYS  # pyright: ignore[reportPrivateUsage]
 
 
+def test_run_log_sync_entrypoint_is_machine_stdout() -> None:
+    assert cli._REGISTRY[("run-log", "sync")] == (  # pyright: ignore[reportPrivateUsage]
+        "larch.report.run_log_sync",
+        "main",
+        True,
+    )
+    assert ("run-log", "sync") in cli._MACHINE_STDOUT_KEYS  # pyright: ignore[reportPrivateUsage]
+
+
 def test_dispatch_oos_serialize() -> None:
     mock_main = MagicMock(return_value=0)
     with patch.dict("sys.modules", {"larch.issue.oos": MagicMock(oos_serialize_main=mock_main)}):


### PR DESCRIPTION
## Summary

- synchronize the complete paginated cloud run-log inventory into a literal per-repository cache
- preserve valid cached runs and atomically repair invalid or interrupted entries under the publication lock
- expose the synchronized local corpus root for later analyzer read waves
- document and test the security, CLI, pagination, warm-cache, and concurrency contracts

## Test plan

- `python3 -m pytest -q python/tests/report/test_run_log_sync.py python/tests/report/test_object_store.py python/tests/report/test_run_log_publish.py python/tests/report/test_run_log_archive.py python/tests/report/test_run_log_corpus.py python/tests/test_cli.py`
- Ruff on changed Python files
- Pylint on changed runtime modules
- Pyright on changed Python files
- `python3 python/cli.py lint run-log-walkers`
- `cargo run --quiet --locked --package larch-lint -- rule command-registry`
- `cargo run --quiet --locked --package larch-cli -- release plugin-runtime --check`
- Markdown lint on changed Markdown files

Closes #7819