### PR TITLE
Fixes #7822: Migrate read-only analyzers to synchronized cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,13 +115,13 @@ larch ships **public skills** with the plugin (`skills/`); **private** skills li
       <td><a href="docs/skills.md#difficulty-calibration"><code>/difficulty-calibration</code></a></td>
       <td><code>[--log-root DIR] [--out FILE]</code></td>
     </tr>
-    <tr><td colspan="2">Compare predicted and realized difficulty tiers from committed run logs. Diagnostic only; changes no thresholds, panels, tokens, routing, or reviewer points.</td></tr>
+    <tr><td colspan="2">Compare predicted and realized difficulty tiers from the synchronized run-log cache. Diagnostic only; changes no thresholds, panels, tokens, routing, or reviewer points.</td></tr>
     <tr><td colspan="2"><hr></td></tr>
     <tr>
       <td><a href="docs/skills.md#fluff-analysis"><code>/fluff-analysis</code></a></td>
       <td><code>[--include-in-progress] [--cutoff ISO8601] [--since-version X.Y.Z] [--min-group N] [--log-root DIR] [--out FILE]</code></td>
     </tr>
-    <tr><td colspan="2">Characterize review <strong>fluff</strong> from committed larch run logs — which <code>/design</code> and <code>/implement</code> review suggestions get rejected, deferred to OOS, or accepted-but-low-value — by acceptance baselines, low-acceptance semantic groups, severity cuts, and reviewer-lane splits, then print data-driven recommendations for tightening the reviewer self-filter and judge (voter) instructions.</td></tr>
+    <tr><td colspan="2">Characterize review <strong>fluff</strong> from the synchronized run-log cache. Analyze which <code>/design</code> and <code>/implement</code> suggestions get rejected, deferred to OOS, or accepted but low-value, then print data-driven recommendations.</td></tr>
     <tr><td colspan="2"><hr></td></tr>
     <tr>
       <td><a href="docs/skills.md#gc-run-logs"><code>/gc-run-logs</code></a></td>
@@ -157,13 +157,13 @@ larch ships **public skills** with the plugin (`skills/`); **private** skills li
       <td><a href="docs/skills.md#rejected-analysis"><code>/rejected-analysis</code></a></td>
       <td><code>--n DAYS</code></td>
     </tr>
-    <tr><td colspan="2">Recover verified real rejected code-review findings from committed run logs and file issues by default. Security-sensitive findings are not public-filed, OOS-deferred findings are excluded, and the stable <code>finding_hash</code> uses file plus concern only, excluding run metadata and filesystem state.</td></tr>
+    <tr><td colspan="2">Recover verified real rejected code-review findings from the synchronized run-log cache and file issues by default. Security-sensitive findings are not public-filed, OOS-deferred findings are excluded, and the stable <code>finding_hash</code> uses file plus concern only, excluding run metadata and filesystem state.</td></tr>
     <tr><td colspan="2"><hr></td></tr>
     <tr>
       <td><a href="docs/skills.md#report-tokens"><code>/report-tokens</code></a></td>
       <td><code>--skill &lt;design|implement&gt; [--no-issue] [--no-plot] [--run-id &lt;ID&gt;]</code></td>
     </tr>
-    <tr><td colspan="2">Analyze structured token reports from committed larch run logs, price Claude/Codex/Cursor runs through `python/larch/report/report_tokens_cost.py`, plot skill-aware trends, and print cost-reduction suggestions.</td></tr>
+    <tr><td colspan="2">Analyze structured token reports from the synchronized run-log cache, price Claude/Codex/Cursor runs through `python/larch/report/report_tokens_cost.py`, plot skill-aware trends, and print cost-reduction suggestions.</td></tr>
     <tr><td colspan="2"><hr></td></tr>
     <tr>
       <td><a href="docs/skills.md#research"><code>/research</code></a></td>
@@ -205,7 +205,7 @@ larch ships **public skills** with the plugin (`skills/`); **private** skills li
       <td><a href="docs/skills.md#voter-calibration"><code>/voter-calibration</code></a></td>
       <td><code>[--log-root DIR] [--min-votes N] [--outlier-threshold R] [--high-severity-threshold R] [--out FILE]</code></td>
     </tr>
-    <tr><td colspan="2">Measure voter agreement and chronic outlier voters from committed larch run logs. Diagnostic only; does not affect spawning, thresholds, tokens, or reviewer points.</td></tr>
+    <tr><td colspan="2">Measure voter agreement and chronic outlier voters from the synchronized run-log cache. Diagnostic only; does not affect spawning, thresholds, tokens, or reviewer points.</td></tr>
   </tbody>
 </table>
 

--- a/docs/git-operation-inventory.md
+++ b/docs/git-operation-inventory.md
@@ -105,14 +105,13 @@ python/larch/state/session_env.py	later-domain	#7677	branch,checkout,diff,fetch,
 scripts/block-submodule-edit.sh	later-domain	#7677	rev-parse
 scripts/check-stale-plugin.sh	later-domain	#7674	rev-parse
 scripts/sessionstart-health.sh	later-domain	#7677	branch,rev-parse,sparse-checkout,stash,status
-skills/fluff-analysis/scripts/fluff-analysis.py	later-domain	#7684	rev-parse
 skills/implement/references/checks-repair-loop.md	later-domain	#7681	rev-parse
 skills/implement/references/codex-manifest-schema.md	later-domain	#7681	commit
 skills/implement/references/step2-dispatch.md	later-domain	#7681	commit
 skills/implement/scripts/generate-code-flow-diagram.sh	later-domain	#7681	diff,merge-base,rev-parse
 skills/implement/scripts/oos-disposition-gate.md	later-domain	#7681	merge-base
 skills/implement/scripts/step-architectural-guidelines-write-staged.sh	later-domain	#7681	rev-parse
-skills/voter-calibration/scripts/voter-calibration.py	later-domain	#7684	rev-parse
+skills/voter-calibration/scripts/voter-calibration.py	later-domain	#7684	dynamic
 ```
 <!-- git-ownership-matrix:end -->
 <!-- markdownlint-enable MD010 -->

--- a/docs/run-log-cli.md
+++ b/docs/run-log-cli.md
@@ -82,17 +82,16 @@ Run:
 python3 python/cli.py token measure-cache-efficiency
 ```
 
-The command ranks committed cache-create versus cache-read outliers per run and
-per step. It reads existing committed `token-report.json` and
-`token-report-final.json` files under consumer `larch-logs/<skill>/*/`
-directories. It also uses the existing ledger fallback from
-`report_tokens_scan.py` when available.
+The command ranks cache-create versus cache-read outliers per run and per step.
+It synchronizes the current repository once, then reads `token-report.json` and
+`token-report-final.json` from the unpacked cache. It also uses the existing
+ledger fallback from `report_tokens_scan.py` when available.
 
 Output is measurement only. It does not change token capture, report JSON
 shapes, or CI gates.
 
-The consumer repo root comes from `report_tokens_scan.scan()`
-`ScanResult.repo_root`, not from the plugin checkout. The command writes
+The consumer repo root is resolved once before synchronization, not from the
+plugin checkout. The command writes
 `larch-logs/measure-cache-efficiency/<date>.tsv` under that consumer repo and
 prints:
 

--- a/docs/run-logs.md
+++ b/docs/run-logs.md
@@ -262,7 +262,7 @@ Committed locations are:
 - Implement Step 5: `larch-logs/implement/<RUN_ID>/round-<N>/panel-prompt-sizes.tsv`.
 - Standalone review: `larch-logs/review/<RUN_ID>/panel-prompt-sizes.tsv`, or `larch-logs/review/<RUN_ID>/round-<N>/panel-prompt-sizes.tsv` when the dispatch is round-local.
 
-`python3 python/cli.py token measure-panel-cost` aggregates committed panel TSVs by agent file, plus generated/no-agent buckets for voters and generated prompts. It writes a TSV under `larch-logs/measure-panel-cost/` with dispatch counts, runs observed, loads per run, prompt counts, scaffold and payload counts, agent counts, and total realized counts. Rows rank by scaffold bytes so fixed prompt surface stays visible even when payload-heavy runs dominate realized bytes.
+`python3 python/cli.py token measure-panel-cost` synchronizes once, then aggregates cached panel TSVs by agent file, plus generated/no-agent buckets for voters and generated prompts. It writes repository-owned measurement state under `larch-logs/measure-panel-cost/`. Rows rank by scaffold bytes so fixed prompt surface stays visible even when payload-heavy runs dominate realized bytes.
 
 ### checks digest-size telemetry
 
@@ -275,7 +275,7 @@ Committed locations are:
 
 Writes are best-effort. A telemetry lock or write failure prints a warning and does not change the checks result or the `DIGEST_FILE=` failure envelope. The writer skips telemetry unless exactly one active implement or review run directory exists under the session `larch-logs/` tree.
 
-`python3 python/cli.py token measure-checks-digest-savings` aggregates committed checks-digest TSVs into `larch-logs/measure-checks-digest-savings/<DATE>.tsv`. It reports `status=insufficient-data` until at least 5 valid rows exist. With 5 or more rows, positive aggregate signed token savings yields `recommendation=go-design-validator-extension`; zero or negative aggregate token savings yields `recommendation=no-go-design-validator-extension`. The design-validator digest extension remains gated on a future positive measurement.
+`python3 python/cli.py token measure-checks-digest-savings` synchronizes once, then aggregates cached checks-digest TSVs into repository-owned state at `larch-logs/measure-checks-digest-savings/<DATE>.tsv`. It reports `status=insufficient-data` until at least 5 valid rows exist. With 5 or more rows, positive aggregate signed token savings yields `recommendation=go-design-validator-extension`; zero or negative aggregate token savings yields `recommendation=no-go-design-validator-extension`. The design-validator digest extension remains gated on a future positive measurement.
 
 ### design plan-review `findings-classification.tsv`
 
@@ -589,7 +589,7 @@ A filtered, machine-readable rendering of the Claude Code session, produced by `
 
 The `session-transcript` capture records `SESSION_TRANSCRIPT_STATUS` in the execution-issues `Warnings` section for every capture outcome, including refresh/deferred-commit `captured` outcomes and `render-failed` / `render-empty` when the renderer cannot produce a usable output. The run continues when capture cannot produce a transcript. For `/implement` runs that reach Step 7a, `session-transcript.jsonl` is part of the required-file completeness manifest; pre-Step-7a partial directories remain excluded by the verifier's step reachability rules. The recovery warning records only the discovered transcript basename, not the full operator-local path. See `python/render_session_transcript.md` for the complete schema.
 
-`python3 python/cli.py token measure-references-heatmap` now starts with a `transcript_coverage` section that reports transcript-bearing runs, total runs, missing transcript runs, and the coverage ratio per skill before the per-reference heatmap rows. A skill with transcripts and zero reference reads is reported as measured zero data, not as missing data.
+`python3 python/cli.py token measure-references-heatmap` synchronizes once, then starts with a `transcript_coverage` section that reports transcript-bearing runs, total runs, missing transcript runs, and the coverage ratio per skill before the per-reference heatmap rows. A skill with transcripts and zero reference reads is reported as measured zero data, not as missing data.
 
 ### round-<N>/
 

--- a/plugin/docs/git-operation-inventory.md
+++ b/plugin/docs/git-operation-inventory.md
@@ -105,14 +105,13 @@ python/larch/state/session_env.py	later-domain	#7677	branch,checkout,diff,fetch,
 scripts/block-submodule-edit.sh	later-domain	#7677	rev-parse
 scripts/check-stale-plugin.sh	later-domain	#7674	rev-parse
 scripts/sessionstart-health.sh	later-domain	#7677	branch,rev-parse,sparse-checkout,stash,status
-skills/fluff-analysis/scripts/fluff-analysis.py	later-domain	#7684	rev-parse
 skills/implement/references/checks-repair-loop.md	later-domain	#7681	rev-parse
 skills/implement/references/codex-manifest-schema.md	later-domain	#7681	commit
 skills/implement/references/step2-dispatch.md	later-domain	#7681	commit
 skills/implement/scripts/generate-code-flow-diagram.sh	later-domain	#7681	diff,merge-base,rev-parse
 skills/implement/scripts/oos-disposition-gate.md	later-domain	#7681	merge-base
 skills/implement/scripts/step-architectural-guidelines-write-staged.sh	later-domain	#7681	rev-parse
-skills/voter-calibration/scripts/voter-calibration.py	later-domain	#7684	rev-parse
+skills/voter-calibration/scripts/voter-calibration.py	later-domain	#7684	dynamic
 ```
 <!-- git-ownership-matrix:end -->
 <!-- markdownlint-enable MD010 -->

--- a/plugin/docs/run-log-cli.md
+++ b/plugin/docs/run-log-cli.md
@@ -82,17 +82,16 @@ Run:
 python3 python/cli.py token measure-cache-efficiency
 ```
 
-The command ranks committed cache-create versus cache-read outliers per run and
-per step. It reads existing committed `token-report.json` and
-`token-report-final.json` files under consumer `larch-logs/<skill>/*/`
-directories. It also uses the existing ledger fallback from
-`report_tokens_scan.py` when available.
+The command ranks cache-create versus cache-read outliers per run and per step.
+It synchronizes the current repository once, then reads `token-report.json` and
+`token-report-final.json` from the unpacked cache. It also uses the existing
+ledger fallback from `report_tokens_scan.py` when available.
 
 Output is measurement only. It does not change token capture, report JSON
 shapes, or CI gates.
 
-The consumer repo root comes from `report_tokens_scan.scan()`
-`ScanResult.repo_root`, not from the plugin checkout. The command writes
+The consumer repo root is resolved once before synchronization, not from the
+plugin checkout. The command writes
 `larch-logs/measure-cache-efficiency/<date>.tsv` under that consumer repo and
 prints:
 

--- a/plugin/docs/run-logs.md
+++ b/plugin/docs/run-logs.md
@@ -262,7 +262,7 @@ Committed locations are:
 - Implement Step 5: `larch-logs/implement/<RUN_ID>/round-<N>/panel-prompt-sizes.tsv`.
 - Standalone review: `larch-logs/review/<RUN_ID>/panel-prompt-sizes.tsv`, or `larch-logs/review/<RUN_ID>/round-<N>/panel-prompt-sizes.tsv` when the dispatch is round-local.
 
-`python3 python/cli.py token measure-panel-cost` aggregates committed panel TSVs by agent file, plus generated/no-agent buckets for voters and generated prompts. It writes a TSV under `larch-logs/measure-panel-cost/` with dispatch counts, runs observed, loads per run, prompt counts, scaffold and payload counts, agent counts, and total realized counts. Rows rank by scaffold bytes so fixed prompt surface stays visible even when payload-heavy runs dominate realized bytes.
+`python3 python/cli.py token measure-panel-cost` synchronizes once, then aggregates cached panel TSVs by agent file, plus generated/no-agent buckets for voters and generated prompts. It writes repository-owned measurement state under `larch-logs/measure-panel-cost/`. Rows rank by scaffold bytes so fixed prompt surface stays visible even when payload-heavy runs dominate realized bytes.
 
 ### checks digest-size telemetry
 
@@ -275,7 +275,7 @@ Committed locations are:
 
 Writes are best-effort. A telemetry lock or write failure prints a warning and does not change the checks result or the `DIGEST_FILE=` failure envelope. The writer skips telemetry unless exactly one active implement or review run directory exists under the session `larch-logs/` tree.
 
-`python3 python/cli.py token measure-checks-digest-savings` aggregates committed checks-digest TSVs into `larch-logs/measure-checks-digest-savings/<DATE>.tsv`. It reports `status=insufficient-data` until at least 5 valid rows exist. With 5 or more rows, positive aggregate signed token savings yields `recommendation=go-design-validator-extension`; zero or negative aggregate token savings yields `recommendation=no-go-design-validator-extension`. The design-validator digest extension remains gated on a future positive measurement.
+`python3 python/cli.py token measure-checks-digest-savings` synchronizes once, then aggregates cached checks-digest TSVs into repository-owned state at `larch-logs/measure-checks-digest-savings/<DATE>.tsv`. It reports `status=insufficient-data` until at least 5 valid rows exist. With 5 or more rows, positive aggregate signed token savings yields `recommendation=go-design-validator-extension`; zero or negative aggregate token savings yields `recommendation=no-go-design-validator-extension`. The design-validator digest extension remains gated on a future positive measurement.
 
 ### design plan-review `findings-classification.tsv`
 
@@ -589,7 +589,7 @@ A filtered, machine-readable rendering of the Claude Code session, produced by `
 
 The `session-transcript` capture records `SESSION_TRANSCRIPT_STATUS` in the execution-issues `Warnings` section for every capture outcome, including refresh/deferred-commit `captured` outcomes and `render-failed` / `render-empty` when the renderer cannot produce a usable output. The run continues when capture cannot produce a transcript. For `/implement` runs that reach Step 7a, `session-transcript.jsonl` is part of the required-file completeness manifest; pre-Step-7a partial directories remain excluded by the verifier's step reachability rules. The recovery warning records only the discovered transcript basename, not the full operator-local path. See `python/render_session_transcript.md` for the complete schema.
 
-`python3 python/cli.py token measure-references-heatmap` now starts with a `transcript_coverage` section that reports transcript-bearing runs, total runs, missing transcript runs, and the coverage ratio per skill before the per-reference heatmap rows. A skill with transcripts and zero reference reads is reported as measured zero data, not as missing data.
+`python3 python/cli.py token measure-references-heatmap` synchronizes once, then starts with a `transcript_coverage` section that reports transcript-bearing runs, total runs, missing transcript runs, and the coverage ratio per skill before the per-reference heatmap rows. A skill with transcripts and zero reference reads is reported as measured zero data, not as missing data.
 
 ### round-<N>/
 

--- a/plugin/python/larch/calibration/difficulty_calibration.py
+++ b/plugin/python/larch/calibration/difficulty_calibration.py
@@ -1,4 +1,4 @@
-"""Retrospective difficulty calibration from committed larch run logs."""
+"""Retrospective difficulty calibration from synchronized larch run logs."""
 # pyright: reportUnknownMemberType=false, reportUnknownArgumentType=false, reportArgumentType=false
 
 from __future__ import annotations
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import cast
 
 from larch.calibration import difficulty
+from larch.core import repo_roots
 from larch.report import run_log_corpus
 from larch.report.report_tokens_cost import display_rates
 from larch.report.report_tokens_models import (
@@ -614,7 +615,12 @@ def _collect_skill_runs(log_root: Path, skill: str, state: AnalyzerState, sideca
             state.bump("unratable_missing_rating")
         classification = _classification_outcome(skill, run_dir, state)
         realized, substantiality = _realized_tier(rating, classification, state)
-        rel_link = run_dir.relative_to(log_root.parent).as_posix() if log_root.parent in run_dir.resolve().parents else run_dir.as_posix()
+        try:
+            run_relative = run_dir.resolve().relative_to(log_root.resolve())
+        except (OSError, ValueError):
+            rel_link = run_dir.as_posix()
+        else:
+            rel_link = (Path("larch-logs") / run_relative).as_posix()
         records.append(
             RunRecord(
                 skill=skill,
@@ -634,9 +640,9 @@ def _collect_skill_runs(log_root: Path, skill: str, state: AnalyzerState, sideca
     return records
 
 
-def collect_corpus(log_root: Path) -> Corpus:
+def collect_corpus(log_root: Path, *, state_root: Path | None = None) -> Corpus:
     state = AnalyzerState()
-    sidecar = _read_sidecar(log_root, state)
+    sidecar = _read_sidecar(log_root if state_root is None else state_root, state)
     records: list[RunRecord] = []
     for skill in SKILLS:
         records.extend(_collect_skill_runs(log_root, skill, state, sidecar))
@@ -897,28 +903,37 @@ def render_report(corpus: Corpus) -> str:
     return "\n".join(lines).rstrip() + "\n"
 
 
-def _default_log_root() -> Path:
-    cwd = Path.cwd()
-    for candidate in (cwd, *cwd.parents):
-        if (candidate / ".git").exists():
-            return candidate / "larch-logs"
-    return cwd / "larch-logs"
-
-
 def parse_args(argv: Sequence[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(prog="difficulty-calibration analyze")
-    _ = parser.add_argument("--log-root", default=str(_default_log_root()))
+    _ = parser.add_argument(
+        "--log-root",
+        default="",
+        help="offline fixture corpus override; default synchronizes the current repository cache",
+    )
     _ = parser.add_argument("--out", default="")
     return parser.parse_args(list(argv))
 
 
 def analyze_main(argv: list[str] | None = None) -> int:
     args = parse_args(sys.argv[1:] if argv is None else argv)
-    log_root = Path(str(args.log_root))
+    if args.log_root:
+        log_root = Path(str(args.log_root))
+        state_root = log_root
+    else:
+        repo_root: Path | None = repo_roots.consumer_repo_root()
+        if repo_root is None:
+            print("ERROR: could not discover a Git repository root for run-log synchronization", file=sys.stderr)
+            return 2
+        try:
+            log_root = run_log_corpus.synchronized_repository_log_root(repo_root=repo_root)
+        except run_log_corpus.RunLogCorpusError as exc:
+            print(f"ERROR: {exc}", file=sys.stderr)
+            return 2
+        state_root = repo_root / "larch-logs"
     if not log_root.is_dir():
         print(f"ERROR: --log-root is missing or not a directory: {log_root}", file=sys.stderr)
         return 2
-    corpus = collect_corpus(log_root)
+    corpus = collect_corpus(log_root, state_root=state_root)
     report = render_report(corpus)
     if args.out:
         out = Path(str(args.out))

--- a/plugin/python/larch/issue/rejected_analysis.py
+++ b/plugin/python/larch/issue/rejected_analysis.py
@@ -1,6 +1,6 @@
 # ruff: noqa: C901,PLR0912,PLR0913,PLR0915,PLR2004,PERF401
 # pyright: reportUnusedCallResult=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportArgumentType=false, reportCallIssue=false
-"""Recover verified real rejected code-review findings from committed run logs.
+"""Recover verified real rejected code-review findings from synchronized run logs.
 
 ``finding_hash`` is frozen as ``sha256`` over normalized ``file_path`` and
 ``concern`` only. Run-local ballot ids, line hints, run metadata, voter labels,
@@ -23,7 +23,7 @@ from pathlib import Path
 from typing import Any, Literal
 
 from larch import io as larch_io
-from larch.core import logging_util, proc
+from larch.core import logging_util, proc, repo_roots
 from larch.errors import ShipError
 
 from larch.git import gh
@@ -994,7 +994,7 @@ def _render_prompt(candidate: PreparedCandidate) -> str:
 def prepare(
     *,
     days: int,
-    log_root: Path | str = Path("larch-logs"),
+    log_root: Path | str | None = None,
     work_dir: Path | str | None = None,
     verify_cap: int = DEFAULT_VERIFY_CAP,
     repo_root: Path | str | None = None,
@@ -1005,8 +1005,22 @@ def prepare(
         raise ValueError("days must be positive")
     if verify_cap <= 0:
         raise ValueError("verify_cap must be positive")
-    root = Path(repo_root or Path.cwd()).resolve()
-    logs = (root / log_root).resolve() if not Path(log_root).is_absolute() else Path(log_root)
+    requested_root = Path(repo_root or Path.cwd()).resolve()
+    root = requested_root
+    if log_root is None:
+        discovered_root = repo_roots.consumer_repo_root(requested_root)
+        if discovered_root is None:
+            raise RejectedAnalysisError(
+                "could not discover a Git repository root for run-log synchronization"
+            )
+        root = discovered_root
+        try:
+            logs = run_log_corpus.synchronized_repository_log_root(repo_root=root)
+        except run_log_corpus.RunLogCorpusError as exc:
+            raise RejectedAnalysisError(str(exc)) from exc
+    else:
+        requested_logs = Path(log_root)
+        logs = (root / requested_logs).resolve() if not requested_logs.is_absolute() else requested_logs
     wd = Path(work_dir) if work_dir is not None else Path(tempfile.mkdtemp(prefix="rejected-analysis-", dir=tempfile.gettempdir()))
     wd.mkdir(parents=True, exist_ok=True)
     active_runner = runner or proc.ProcRunner()
@@ -1569,12 +1583,22 @@ def _emit_prepare(result: PrepareResult) -> None:
 def prepare_main(argv: list[str]) -> int:
     parser = argparse.ArgumentParser(prog="rejected-analysis prepare")
     parser.add_argument("--days", "--n", dest="days", type=int, required=True)
-    parser.add_argument("--log-root", default="larch-logs")
+    parser.add_argument(
+        "--log-root",
+        default="",
+        help="offline fixture corpus override; default synchronizes the current repository cache",
+    )
     parser.add_argument("--work-dir", default="")
     parser.add_argument("--verify-cap", type=int, default=DEFAULT_VERIFY_CAP)
     args = parser.parse_args(argv)
     try:
-        result = prepare(days=args.days, log_root=args.log_root, work_dir=args.work_dir or None, verify_cap=args.verify_cap, open_issues=None)
+        result = prepare(
+            days=args.days,
+            log_root=args.log_root or None,
+            work_dir=args.work_dir or None,
+            verify_cap=args.verify_cap,
+            open_issues=None,
+        )
     except (RejectedAnalysisError, ValueError) as exc:
         logging_util.diagnostic(f"rejected-analysis prepare: {exc}")
         return 2

--- a/plugin/python/larch/report/report_tokens_scan.py
+++ b/plugin/python/larch/report/report_tokens_scan.py
@@ -1,4 +1,4 @@
-"""Scan committed larch run logs for report-token records."""
+"""Scan synchronized larch run logs for report-token records."""
 
 from __future__ import annotations
 
@@ -37,6 +37,15 @@ class ScanResult:
     repo_root: Path
     repo_slug: str | None
     records: tuple[RunRecord, ...]
+
+
+@dataclass(frozen=True)
+class ScanRequest:
+    skill: Skill
+    repo_override: str | None
+    limit: int | None
+    resolve_repo: bool
+    corpus_root: Path | None = None
 
 def _warn(message: str) -> None:
     print(f"Warning: {message}", file=sys.stderr)
@@ -132,12 +141,12 @@ def _phase_rows(report: Mapping[str, object]) -> tuple[PhaseRow, ...]:
     return tuple(rows)
 
 def _session_scoped_ledger_path(run_dir: Path) -> Path | None:
-    """Resolve the committed ledger for a run dir using session-id when present."""
+    """Resolve the durable ledger for a run dir using session-id when present."""
     return tokens.run_log_ledger_path(run_dir)
 
 
 def _ledger_fallback_report(run_dir: Path) -> Mapping[str, object] | None:
-    """Recover a token report from the committed session ledger when the canonical
+    """Recover a token report from the durable session ledger when the canonical
     token-report{,-final}.json is absent or unusable (issue #5133). Returns None
     when no usable ledger exists. Symlinked ledgers are skipped for safety.
     """
@@ -185,7 +194,7 @@ def _enrich_model_buckets(report: Mapping[str, object], *, run_dir: Path) -> Map
 
 
 def _resolve_report(run_dir: Path, *, skill: Skill) -> Mapping[str, object] | None:
-    """Load and validate a run's token report, falling back to the committed
+    """Load and validate a run's token report, falling back to the durable
     ledger when the canonical token-report{,-final}.json is absent or unusable
     (issue #5133). Returns None (after a warning) when no priceable report exists.
     """
@@ -258,14 +267,60 @@ def scan(
     limit: int | None = None,
     resolve_repo: bool = True,
 ) -> ScanResult:
+    return _scan_request(
+        runner,
+        request=ScanRequest(
+            skill=skill,
+            repo_override=repo_override,
+            limit=limit,
+            resolve_repo=resolve_repo,
+        ),
+    )
+
+
+def scan_prepared_corpus(
+    runner: Runner,
+    *,
+    skill: Skill,
+    corpus_root: Path,
+) -> ScanResult:
+    """Scan one skill from an already synchronized invocation corpus."""
+    return _scan_request(
+        runner,
+        request=ScanRequest(
+            skill=skill,
+            repo_override=None,
+            limit=None,
+            resolve_repo=False,
+            corpus_root=corpus_root,
+        ),
+    )
+
+
+def _scan_request(runner: Runner, *, request: ScanRequest) -> ScanResult:
     root = _repo_root(runner)
-    slug: str | None = _repo_slug(runner=runner, override=repo_override or os.environ.get("LARCH_REPORT_TOKENS_REPO")) if resolve_repo else None
-    log_base = root / "larch-logs" / skill
-    print(f"Scanning {log_base} for larch run logs (--skill={skill})...", file=sys.stderr)
-    max_dirs: int | None = _limit_value(limit)
+    if request.corpus_root is None:
+        try:
+            log_root: Path = run_log_corpus.synchronized_repository_log_root(repo_root=root)
+        except run_log_corpus.RunLogCorpusError as exc:
+            raise ShipError(f"ERROR: {exc}") from exc
+    else:
+        log_root = request.corpus_root
+    slug: str | None = (
+        _repo_slug(
+            runner=runner,
+            override=request.repo_override
+            or os.environ.get(config.ENV_LARCH_REPORT_TOKENS_REPO),
+        )
+        if request.resolve_repo
+        else None
+    )
+    log_base = log_root / request.skill
+    print(f"Scanning {log_base} for larch run logs (--skill={request.skill})...", file=sys.stderr)
+    max_dirs: int | None = _limit_value(request.limit)
     records: list[RunRecord] = []
     for seen, run_dir in enumerate(_run_dirs(log_base), start=1):
-        record: RunRecord | None = _record(run_dir, skill=skill, repo_slug=slug)
+        record: RunRecord | None = _record(run_dir, skill=request.skill, repo_slug=slug)
         if record is not None:
             records.append(record)
         if max_dirs is not None and seen >= max_dirs:

--- a/plugin/python/larch/report/run_log_corpus.py
+++ b/plugin/python/larch/report/run_log_corpus.py
@@ -1,4 +1,4 @@
-"""Shared safe helpers for committed larch run-log corpus walks."""
+"""Shared safe helpers for larch run-log corpus walks."""
 
 from __future__ import annotations
 
@@ -6,6 +6,7 @@ import json
 import os
 import re
 import stat
+import tarfile
 from collections.abc import Callable, Iterator, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime
@@ -13,7 +14,7 @@ from enum import StrEnum
 from pathlib import Path
 from typing import Any, Literal, cast
 
-from larch.report import run_log_sync
+from larch.report import run_log_sync, storage_config
 from larch.report.report_tokens_models import safe_int
 
 DEFAULT_MANIFEST_CANDIDATES: tuple[str, ...] = ("manifest.json", "run-manifest.json")
@@ -33,6 +34,10 @@ class WalkWarningKind(StrEnum):
     CHILD_UNRESOLVABLE = "child_unresolvable"
     CHILD_ESCAPES = "child_escapes"
     CHILD_NOT_DIR = "child_not_dir"
+
+
+class RunLogCorpusError(RuntimeError):
+    """A repository analyzer could not prepare its synchronized corpus."""
 
 
 @dataclass(frozen=True)
@@ -259,6 +264,41 @@ def synchronized_run_log_root(
         store=store,
         environ=environ,
     ).corpus_root
+
+
+def synchronized_repository_log_root(
+    *,
+    repo_root: Path,
+    store: run_log_sync.SyncObjectStore | None = None,
+    environ: Mapping[str, str] | None = None,
+    cache_home: Path | None = None,
+    state_home: Path | None = None,
+) -> Path:
+    """Load repository config, synchronize once, and return the cache log root."""
+    try:
+        storage_root: storage_config.StorageRoot = storage_config.load_storage_root(
+            repo_root=repo_root,
+            environ=environ,
+        )
+        return synchronized_run_log_root(
+            request=run_log_sync.RunLogSyncRequest(
+                repo_root=repo_root,
+                storage_root=storage_root,
+                cache_home=cache_home,
+                state_home=state_home,
+            ),
+            store=store,
+            environ=environ,
+        )
+    except (
+        EOFError,
+        OSError,
+        RuntimeError,
+        tarfile.TarError,
+        TypeError,
+        ValueError,
+    ) as exc:
+        raise RunLogCorpusError(f"run-log corpus sync failed: {exc}") from exc
 
 
 def review_transcript_dirs(log_base: Path, warn: Callable[[str], None] | None = None) -> list[Path]:

--- a/plugin/python/larch/report/tokens.py
+++ b/plugin/python/larch/report/tokens.py
@@ -1965,14 +1965,11 @@ def _reference_reads_for_run(*, repo: Path, skill: str, run_dir: Path) -> list[O
     return reads
 
 
-def _skill_run_dirs(repo: Path) -> dict[str, list[Path]]:
-    root = repo / "larch-logs"
+def _skill_run_dirs(log_root: Path) -> dict[str, list[Path]]:
     by_skill: dict[str, list[Path]] = {}
-    if not root.is_dir():
+    if not log_root.is_dir():
         return by_skill
-    for skill_dir in sorted(root.iterdir()):
-        if skill_dir.is_symlink() or not skill_dir.is_dir():
-            continue
+    for skill_dir in run_log_corpus.safe_child_run_dirs(log_root):
         runs = list(run_log_corpus.run_dirs(skill_dir))
         if skill_dir.name == "review":
             seen = {path.resolve() for path in runs}
@@ -2115,7 +2112,8 @@ def measure_ngram_duplication() -> Path:
 def measure_references_heatmap() -> Path:
     repo = _repo_root()
     out_path = repo / "larch-logs" / "measure-references-heatmap" / f"{_measure_stamp()}.tsv"
-    run_dirs_by_skill = _skill_run_dirs(repo)
+    log_root = run_log_corpus.synchronized_repository_log_root(repo_root=repo)
+    run_dirs_by_skill = _skill_run_dirs(log_root)
     reads: list[ObservedReferenceRead] = []
     coverage_rows: list[tuple[str, int, int, int, float, str]] = []
     for skill, dirs in run_dirs_by_skill.items():
@@ -2160,7 +2158,8 @@ def measure_references_heatmap() -> Path:
 def measure_realized_cost() -> Path:
     repo = _repo_root()
     out_path = repo / "larch-logs" / "measure-realized-cost" / f"{_measure_stamp()}.tsv"
-    run_dirs_by_skill = _skill_run_dirs(repo)
+    log_root = run_log_corpus.synchronized_repository_log_root(repo_root=repo)
+    run_dirs_by_skill = _skill_run_dirs(log_root)
     skill_paths: dict[str, str] = {}
     skill_texts: list[str] = []
     for skill in sorted(run_dirs_by_skill):
@@ -2506,11 +2505,14 @@ def measure_cache_efficiency() -> Path:
 
     runner = ProcRunner()
     tagged_records: list[tuple[Skill, RunRecord]] = []
-    repo_root: Path | None = None
+    repo_root: Path = _repo_root()
+    log_root: Path = run_log_corpus.synchronized_repository_log_root(repo_root=repo_root)
     for skill in ("design", "implement"):
-        scan_result = report_tokens_scan.scan(runner, skill=skill, resolve_repo=False)
-        if repo_root is None:
-            repo_root = scan_result.repo_root
+        scan_result = report_tokens_scan.scan_prepared_corpus(
+            runner,
+            skill=skill,
+            corpus_root=log_root,
+        )
         tagged_records.extend((skill, record) for record in scan_result.records)
     out_path = repo_root / "larch-logs" / "measure-cache-efficiency" / f"{_measure_stamp()}.tsv"
     out_path.parent.mkdir(parents=True, exist_ok=True)
@@ -2540,9 +2542,15 @@ class _PanelCostAggregate:
     runs: set[tuple[str, str]] = dataclass_field(default_factory=set)
 
 
-def _panel_context_from_tsv(path: Path, repo: Path) -> tuple[str, str] | None:
+def _panel_context_from_tsv(
+    path: Path,
+    repo: Path,
+    *,
+    corpus_root: Path | None = None,
+) -> tuple[str, str] | None:
+    root = repo / "larch-logs" if corpus_root is None else corpus_root
     try:
-        rel = path.relative_to(repo / "larch-logs")
+        rel = path.relative_to(root)
     except ValueError:
         return None
     parts = rel.parts
@@ -2564,8 +2572,12 @@ def _panel_context_from_tsv(path: Path, repo: Path) -> tuple[str, str] | None:
     return skill, run_id
 
 
-def _iter_panel_prompt_size_files(repo: Path) -> list[Path]:
-    root = repo / "larch-logs"
+def _iter_panel_prompt_size_files(
+    repo: Path,
+    *,
+    corpus_root: Path | None = None,
+) -> list[Path]:
+    root = repo / "larch-logs" if corpus_root is None else corpus_root
     if not root.is_dir():
         return []
     paths: list[Path] = []
@@ -2578,7 +2590,9 @@ def _iter_panel_prompt_size_files(repo: Path) -> list[Path]:
                     name=PANEL_PROMPT_SIZE_BASENAME,
                     contain_root=root / skill,
                 )
-                if path.is_file() and not path.is_symlink() and _panel_context_from_tsv(path, repo) is not None
+                if path.is_file()
+                and not path.is_symlink()
+                and _panel_context_from_tsv(path, repo, corpus_root=root) is not None
             )
     return sorted(paths)
 
@@ -2636,8 +2650,12 @@ def _checks_digest_size_row_values(row: Mapping[str, str]) -> dict[str, int] | N
     return values
 
 
-def _iter_checks_digest_size_files(repo: Path) -> list[Path]:
-    root = repo / "larch-logs"
+def _iter_checks_digest_size_files(
+    repo: Path,
+    *,
+    corpus_root: Path | None = None,
+) -> list[Path]:
+    root = repo / "larch-logs" if corpus_root is None else corpus_root
     if not root.is_dir():
         return []
     paths: list[Path] = []
@@ -2704,8 +2722,9 @@ def _render_checks_digest_savings_report(aggregate: ChecksDigestSavingsAggregate
 def measure_checks_digest_savings() -> Path:
     repo = _repo_root()
     out_path = repo / "larch-logs" / "measure-checks-digest-savings" / f"{_measure_stamp()}.tsv"
+    log_root = run_log_corpus.synchronized_repository_log_root(repo_root=repo)
     aggregate = ChecksDigestSavingsAggregate()
-    for tsv in _iter_checks_digest_size_files(repo):
+    for tsv in _iter_checks_digest_size_files(repo, corpus_root=log_root):
         has_header, rows_seen, rows_skipped, rows = _read_checks_digest_size_file(tsv)
         if not has_header:
             continue
@@ -2721,9 +2740,10 @@ def measure_checks_digest_savings() -> Path:
 def measure_panel_cost() -> Path:
     repo = _repo_root()
     out_path = repo / "larch-logs" / "measure-panel-cost" / f"{_measure_stamp()}.tsv"
+    log_root = run_log_corpus.synchronized_repository_log_root(repo_root=repo)
     aggregates: dict[tuple[str, str, str], _PanelCostAggregate] = {}
-    for tsv in _iter_panel_prompt_size_files(repo):
-        context = _panel_context_from_tsv(tsv, repo)
+    for tsv in _iter_panel_prompt_size_files(repo, corpus_root=log_root):
+        context = _panel_context_from_tsv(tsv, repo, corpus_root=log_root)
         if context is None:
             continue
         skill, run_id = context
@@ -3072,14 +3092,22 @@ def compute_pr_line_counts_main(argv: list[str] | None = None) -> int:
 
 def measure_checks_digest_savings_main(argv: list[str] | None = None) -> int:
     _ = argv
-    path = measure_checks_digest_savings()
+    try:
+        path = measure_checks_digest_savings()
+    except run_log_corpus.RunLogCorpusError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return config.EXIT_BAIL
     print(f"WROTE\t{path.relative_to(_repo_root())}")
     return 0
 
 
 def measure_panel_cost_main(argv: list[str] | None = None) -> int:
     _ = argv
-    path = measure_panel_cost()
+    try:
+        path = measure_panel_cost()
+    except run_log_corpus.RunLogCorpusError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return config.EXIT_BAIL
     try:
         rel = path.relative_to(_repo_root()).as_posix()
     except ValueError:
@@ -3104,14 +3132,22 @@ def measure_ngram_duplication_main(argv: list[str] | None = None) -> int:
 
 def measure_references_heatmap_main(argv: list[str] | None = None) -> int:
     _ = argv
-    path = measure_references_heatmap()
+    try:
+        path = measure_references_heatmap()
+    except run_log_corpus.RunLogCorpusError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return config.EXIT_BAIL
     print(f"WROTE\t{path.relative_to(_repo_root())}")
     return 0
 
 
 def measure_realized_cost_main(argv: list[str] | None = None) -> int:
     _ = argv
-    path = measure_realized_cost()
+    try:
+        path = measure_realized_cost()
+    except run_log_corpus.RunLogCorpusError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return config.EXIT_BAIL
     print(f"WROTE\t{path.relative_to(_repo_root())}")
     return 0
 
@@ -3120,7 +3156,7 @@ def measure_cache_efficiency_main(argv: list[str] | None = None) -> int:
     _ = argv
     try:
         path = measure_cache_efficiency()
-    except ShipError as exc:
+    except (ShipError, run_log_corpus.RunLogCorpusError) as exc:
         print(str(exc), file=sys.stderr)
         return config.EXIT_BAIL
     repo_root = _measure_repo_root_from_larch_logs_path(path)

--- a/plugin/skills/difficulty-calibration/SKILL.md
+++ b/plugin/skills/difficulty-calibration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: difficulty-calibration
-description: "Use when comparing predicted and realized larch difficulty tiers from committed run logs. Diagnostic only; changes no thresholds, panels, points, or routing."
+description: "Use when comparing predicted and realized larch difficulty tiers from synchronized run logs. Diagnostic only; changes no thresholds, panels, points, or routing."
 argument-hint: "[--log-root DIR] [--out FILE]"
 allowed-tools: Bash, Read
 ---
@@ -16,9 +16,9 @@ classification and any required evidence before reporting the result.
 
 **MANDATORY: READ ENTIRE FILE before composing user-facing prose: `${CLAUDE_PLUGIN_ROOT}/skills/shared/readability-style.md`.**
 
-Analyze predicted versus realized difficulty tiers from committed `larch-logs/` data.
+Analyze predicted versus realized difficulty tiers from the synchronized run-log cache.
 
-The analyzer is read-only unless `--out FILE` is provided. It reads committed logs only. It does **not** change thresholds, panels, reviewer points, token allocation, or live routing.
+The analyzer is read-only unless `--out FILE` is provided. It syncs once, then reads only the unpacked cache. It does **not** change thresholds, panels, reviewer points, token allocation, or live routing.
 
 ## Usage
 
@@ -36,7 +36,7 @@ Do not re-tally or reformat the analysis in the main agent. The CLI owns extract
 
 Flags:
 
-- `--log-root DIR` - `larch-logs` directory. Default: `<git toplevel>/larch-logs`.
+- `--log-root DIR` - offline fixture corpus override. By default, sync the current repository cache.
 - `--out FILE` - write the report to `FILE` and print only `REPORT_FILE=<path>`.
 
 ## Data Model

--- a/plugin/skills/fluff-analysis/SKILL.md
+++ b/plugin/skills/fluff-analysis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fluff-analysis
-description: "Use when analyzing review fluff in committed larch run logs: rejected, OOS, or accepted-low-value findings, plus tuning recommendations."
+description: "Use when analyzing review fluff in synchronized larch run logs: rejected, OOS, or accepted-low-value findings, plus tuning recommendations."
 allowed-tools: Bash, Read
 ---
 
@@ -8,7 +8,7 @@ allowed-tools: Bash, Read
 
 **MANDATORY: READ ENTIRE FILE before composing user-facing prose: `${CLAUDE_PLUGIN_ROOT}/skills/shared/readability-style.md`.**
 
-Characterize review **fluff** — suggestions that are *not accepted* (rejected or deferred to Out-of-Scope) or *accepted-but-low-value* — from committed larch run logs in the current repository. The analyzer scans `larch-logs/design/*/` and `larch-logs/implement/*/`, normalizes every review finding (outcome, reviewer/voter severity, semantic tags), and prints a markdown report plus recommendations for tightening the reviewer self-filter and judge (voter) instructions.
+Characterize review **fluff** from the synchronized run-log cache in the current repository. This includes suggestions that are *not accepted* (rejected or deferred to Out-of-Scope) or *accepted-but-low-value*. The analyzer normalizes every review finding (outcome, reviewer/voter severity, semantic tags), then prints a markdown report and recommendations for tightening the reviewer self-filter and judge (voter) instructions.
 
 This is the standing tool behind the kind of analysis filed as a `[Analysis Report]` issue: re-run it as the corpus grows to track whether necessity-gate changes (see `skills/shared/review-acceptance-rubric.md`) move acceptance and findings-per-run.
 
@@ -28,13 +28,13 @@ Do not re-derive, re-tally, or re-format the analysis in the main agent — the 
 
 Flags:
 
-- `--include-in-progress` — also read in-progress `/design` session temp dirs under the session cache (a racy snapshot of un-flushed runs). Off by default; committed logs only.
+- `--include-in-progress`: also read in-progress `/design` session temp dirs under the session cache (a racy snapshot of unflushed runs). Off by default.
 - `--cutoff ISO8601` — enable a pre/post comparison section split at this timestamp (e.g. the date a reviewer-instruction change landed). Omitted by default.
 - `--since-version X.Y.Z` — enable a pre/post comparison split by `manifest.json.larch_version`; preferred for release-gated behavior changes.
 - `--min-group N` — minimum findings for a semantic group to appear in the tables. Default: `20`.
 - `--sessions-dir DIR` — session cache dir for `--include-in-progress`. Default: `~/.cache/larch/sessions`.
 - `--inprogress-since ISO8601` — lower bound on in-progress session mtime (skips stale temp dirs).
-- `--log-root DIR` — `larch-logs` directory. Default: `<git toplevel>/larch-logs`.
+- `--log-root DIR`: offline fixture corpus override. By default, sync the current repository cache.
 - `--out FILE` — write the report to `FILE` instead of stdout.
 
 On success, stdout begins with `# Review Fluff Analysis`. If the log root is missing the script exits non-zero with a diagnostic; surface it rather than inventing results.

--- a/plugin/skills/fluff-analysis/scripts/fluff-analysis.md
+++ b/plugin/skills/fluff-analysis/scripts/fluff-analysis.md
@@ -7,7 +7,7 @@ script).
 
 ## Purpose
 
-Read committed larch run logs and print a markdown **review fluff** report:
+Read synchronized larch run logs and print a markdown **review fluff** report:
 acceptance baselines, low-acceptance semantic groups, a testing breakdown,
 severity/quality/uncertain correlations, reviewer-lane splits, an
 accepted-but-low-value proxy, neutral-rate and important-reject-rate false-negative diagnostics, an optional pre/post-cutoff comparison, and
@@ -34,7 +34,7 @@ versions): missing fields degrade to empty, never crash a run.
 ## CLI
 
 ```text
---log-root DIR            larch-logs dir (default: <git toplevel>/larch-logs)
+--log-root DIR            offline fixture corpus override (default: synchronized cache)
 --include-in-progress     also read in-progress design session temp dirs
 --sessions-dir DIR        session cache dir (default: ~/.cache/larch/sessions)
 --inprogress-since ISO    skip in-progress sessions older than this mtime

--- a/plugin/skills/fluff-analysis/scripts/fluff-analysis.py
+++ b/plugin/skills/fluff-analysis/scripts/fluff-analysis.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
-"""fluff-analysis.py — characterize review "fluff" from committed larch run logs.
+"""Characterize review "fluff" from synchronized larch run logs.
 
-Reads committed design + implement run logs (and, optionally, in-progress design
+Reads synchronized design + implement run logs (and, optionally, in-progress design
 session temp dirs), normalizes every review finding into one record stream, and
 prints a markdown report: acceptance baselines, low-acceptance semantic groups,
 testing breakdown, severity/quality/uncertain correlations, reviewer-lane splits,
@@ -22,7 +22,6 @@ import glob
 import json
 import os
 import re
-import subprocess
 import sys
 from pathlib import Path
 
@@ -31,7 +30,7 @@ python_dir = repo_root / "python"
 if str(python_dir) not in sys.path:
     sys.path.insert(0, str(python_dir))
 
-from larch.core import config  # noqa: E402
+from larch.core import config, repo_roots  # noqa: E402
 from larch.core.architectural_guidelines import CLEAN_INVARIANT_PRESENTATION_NOTE, CLEAN_PRESENTATION_NOTE, DESIGN_ASSESSMENT, GUIDELINE_SHIP_OUTCOME_SIDECAR, INVARIANT_DESIGN_ASSESSMENT, INVARIANT_SHIP_OUTCOME_SIDECAR, validate_invariant_ship_outcome_record  # noqa: E402
 from larch.issue.audit_runs import implement_step8_reachable  # noqa: E402
 from larch.issue.rejected_analysis import (  # noqa: E402
@@ -1418,21 +1417,21 @@ def _section_recommendations(i_all, min_group):
 # --------------------------------------------------------------------------
 # CLI
 # --------------------------------------------------------------------------
-def default_log_root():
-    try:
-        proc = subprocess.run(["git", "rev-parse", "--show-toplevel"],
-                              capture_output=True, text=True, timeout=5, check=False)
-        if proc.returncode == 0 and proc.stdout.strip():
-            return os.path.join(proc.stdout.strip(), "larch-logs")
-    except (OSError, subprocess.SubprocessError):
-        pass
-    return os.path.join(os.getcwd(), "larch-logs")
+def selected_log_root(raw_log_root):
+    if raw_log_root:
+        return raw_log_root
+    consumer_root = repo_roots.consumer_repo_root()
+    if consumer_root is None:
+        raise run_log_corpus.RunLogCorpusError(
+            "could not discover a Git repository root for run-log synchronization"
+        )
+    return str(run_log_corpus.synchronized_repository_log_root(repo_root=consumer_root))
 
 
 def main(argv=None):
-    parser = argparse.ArgumentParser(description="Analyze review fluff from committed larch run logs.")
+    parser = argparse.ArgumentParser(description="Analyze review fluff from synchronized larch run logs.")
     parser.add_argument("--log-root", default=None,
-                        help="larch-logs directory (default: <git toplevel>/larch-logs)")
+                        help="offline fixture corpus override; default synchronizes the current repository cache")
     parser.add_argument("--sessions-dir", default=os.path.expanduser("~/.cache/larch/sessions"),
                         help="larch session cache dir (for --include-in-progress)")
     parser.add_argument("--include-in-progress", action="store_true",
@@ -1451,7 +1450,11 @@ def main(argv=None):
                              "pre-period records get empty tags (faster corpus scans)")
     args = parser.parse_args(argv)
 
-    log_root = args.log_root or default_log_root()
+    try:
+        log_root = selected_log_root(args.log_root)
+    except run_log_corpus.RunLogCorpusError as exc:
+        sys.stderr.write(f"ERROR: {exc}\n")
+        return 2
     if not os.path.isdir(log_root):
         sys.stderr.write("ERROR: log root not found: %s\n" % log_root)
         return 2

--- a/plugin/skills/rejected-analysis/SKILL.md
+++ b/plugin/skills/rejected-analysis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rejected-analysis
-description: "Use when recovering verified real rejected code-review findings from committed larch run logs and filing GitHub issues for findings that remain unfixed."
+description: "Use when recovering verified real rejected code-review findings from synchronized larch run logs and filing GitHub issues for findings that remain unfixed."
 argument-hint: "--n DAYS"
 allowed-tools: Bash, Read, Write, Agent, Skill
 ---
@@ -9,7 +9,7 @@ allowed-tools: Bash, Read, Write, Agent, Skill
 
 **MANDATORY: READ ENTIRE FILE before composing user-facing prose: `${CLAUDE_PLUGIN_ROOT}/skills/shared/readability-style.md`.**
 
-Recover **verified real** rejected code-review findings from committed run logs, then file the smallest safe set of issues.
+Recover **verified real** rejected code-review findings from synchronized run logs, then file the smallest safe set of issues.
 
 This is **mutating**. It files by default after verification.
 

--- a/plugin/skills/report-tokens/SKILL.md
+++ b/plugin/skills/report-tokens/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: report-tokens
-description: "Use when analyzing token costs from committed larch run logs for `--skill=design|implement`: price token reports, optionally plot trends, and print cost-reduction suggestions."
+description: "Use when analyzing token costs from synchronized larch run logs for `--skill=design|implement`: price token reports, optionally plot trends, and print cost-reduction suggestions."
 allowed-tools: Bash, Read
 ---
 
@@ -8,7 +8,7 @@ allowed-tools: Bash, Read
 
 **MANDATORY: READ ENTIRE FILE before composing user-facing prose: `${CLAUDE_PLUGIN_ROOT}/skills/shared/readability-style.md`.**
 
-Analyze token costs from committed larch run logs for the selected skill (`--skill=design|implement`) in the current git repository. The CLI delegates to `${CLAUDE_PLUGIN_ROOT}/python/larch/report/report_tokens_cli.py`, which scans `larch-logs/<skill>/*/`, reads the skill-specific token report JSON files, prices each run through `python/larch/report/report_tokens_cost.py`, prints a markdown analysis, writes a durable NDJSON cache snapshot, optionally generates plots, and optionally posts a GitHub `[Implement Analysis Report]` or `[Design Analysis Report]` issue.
+Analyze token costs from synchronized larch run logs for the selected skill (`--skill=design|implement`) in the current Git repository. The CLI syncs once, scans the unpacked cache, reads the skill-specific token report JSON files, prices each run through `python/larch/report/report_tokens_cost.py`, prints a markdown analysis, writes a durable NDJSON cache snapshot, optionally generates plots, and optionally posts a GitHub `[Implement Analysis Report]` or `[Design Analysis Report]` issue.
 
 For `--skill=implement`, reports carry no workflow dimension and graph/per-day trend output aggregates all runs into one `All runs` series/table set. For `--skill=design`, one aggregate report is generated. The filed issue intentionally omits raw per-issue JSON and actual-spend reconciliation unless `LARCH_REPORT_TOKENS_POST_ACTUAL_SPEND=1` is set.
 
@@ -41,4 +41,4 @@ Advertised `Cache JSON:` and plot paths remain on disk after CLI exit and expire
 ## NEVER
 
 1. **NEVER treat dollar output as billing truth.** The CLI uses transparent default rates and prints them with the analysis because vendor pricing and model routing can drift outside larch's control.
-2. **NEVER forward removed replot flags.** Re-run against committed `larch-logs` instead.
+2. **NEVER forward removed replot flags.** Re-run against the synchronized cache instead.

--- a/plugin/skills/voter-calibration/SKILL.md
+++ b/plugin/skills/voter-calibration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: voter-calibration
-description: "Use when analyzing voter agreement, severity calibration, and chronic outliers from committed larch run logs. Diagnostic only; changes no thresholds or points."
+description: "Use when analyzing voter agreement, severity calibration, and chronic outliers from synchronized larch run logs. Diagnostic only; changes no thresholds or points."
 allowed-tools: Bash, Read
 ---
 
@@ -8,7 +8,7 @@ allowed-tools: Bash, Read
 
 **MANDATORY: READ ENTIRE FILE before composing user-facing prose: `${CLAUDE_PLUGIN_ROOT}/skills/shared/readability-style.md`.**
 
-Analyze **voter agreement**, **YES-vote severity spread**, **severity calibration score**, and chronic outlier voters from committed larch run logs.
+Analyze **voter agreement**, **YES-vote severity spread**, **severity calibration score**, and chronic outlier voters from the synchronized run-log cache.
 
 The analyzer measures agreement and severity calibration only. It reports voter-side calibration standing. It does **not** use realized outcomes, issue fate, or reverts. It does **not** affect reviewer/proposer points, spawning, thresholds, token allocation, or live panel verdicts.
 
@@ -28,7 +28,7 @@ Do not re-tally or re-format the analysis in the main agent. The script owns ext
 
 Flags:
 
-- `--log-root DIR` - `larch-logs` directory. Default: `<git toplevel>/larch-logs`.
+- `--log-root DIR` - offline fixture corpus override. By default, sync the current repository cache.
 - `--min-votes N` - minimum eligible votes before outlier flagging. Default: `20`.
 - `--outlier-threshold R` - flag chronic outliers below this agreement rate. Default: `0.50`.
 - `--high-severity-threshold R` - flag voters whose valid YES-vote severities exceed this high-severity rate. Default: `0.90`.

--- a/plugin/skills/voter-calibration/scripts/voter-calibration.md
+++ b/plugin/skills/voter-calibration/scripts/voter-calibration.md
@@ -4,13 +4,13 @@
 
 ## Inputs
 
-The analyzer scans these committed log patterns under `--log-root`:
+The analyzer scans these synchronized log patterns under the resolved corpus root:
 
-- `larch-logs/design/*/plan-review/round-*/findings-classification.tsv`
-- `larch-logs/implement/*/round-*/findings-classification.tsv`
-- `larch-logs/review/*/review-findings-classification-round-*.tsv`
+- `<corpus-root>/design/*/plan-review/round-*/findings-classification.tsv`
+- `<corpus-root>/implement/*/round-*/findings-classification.tsv`
+- `<corpus-root>/review/*/review-findings-classification-round-*.tsv`
 
-Default `--log-root` resolves to `<git toplevel>/larch-logs` when `git rev-parse --show-toplevel` succeeds. It falls back to `cwd/larch-logs` otherwise.
+By default, the analyzer resolves the current Git repository, requires `.larch/config.toml` or `LARCH_LOGS_URI`, synchronizes once, and reads the unpacked cache. `--log-root DIR` bypasses synchronization for offline fixture tests.
 
 ## Optional realized-outcome input
 

--- a/plugin/skills/voter-calibration/scripts/voter-calibration.py
+++ b/plugin/skills/voter-calibration/scripts/voter-calibration.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Analyze voter agreement, severity calibration, and chronic outliers from larch logs."""
+"""Analyze voter agreement, severity calibration, and chronic outliers from synchronized larch logs."""
 from __future__ import annotations
 
 import argparse
@@ -24,7 +24,7 @@ python_path = str(plugin_root / "python")
 if python_path not in sys.path:
     sys.path.insert(0, python_path)
 
-from larch.core import proc  # noqa: E402 - after sys.path manipulation
+from larch.core import proc, repo_roots  # noqa: E402 - after sys.path manipulation
 from larch.git import gh  # noqa: E402 - after sys.path manipulation
 from larch.issue._ground_truth import (  # noqa: E402
     _ground_truth_run_dir,
@@ -73,31 +73,22 @@ class CorpusStats:
     false_negative_rows: list[dict[str, object]] = field(default_factory=list)
 
 
-def _git_toplevel() -> Path | None:
-    proc = subprocess.run(
-        ["git", "rev-parse", "--show-toplevel"],
-        text=True,
-        capture_output=True,
-        check=False,
-    )
-    if proc.returncode != 0:
-        return None
-    value = proc.stdout.strip()
-    return Path(value) if value else None
-
-
-def _default_log_root() -> Path:
-    top = _git_toplevel()
-    if top is not None:
-        return top / "larch-logs"
-    return Path.cwd() / "larch-logs"
-
-
 def _read_text(path: Path) -> str:
     try:
         return path.read_text(encoding="utf-8", errors="replace")
     except OSError:
         return ""
+
+
+def _selected_log_root(raw_log_root: str) -> Path:
+    if raw_log_root:
+        return Path(raw_log_root).expanduser()
+    repo_root = repo_roots.consumer_repo_root()
+    if repo_root is None:
+        raise run_log_corpus.RunLogCorpusError(
+            "could not discover a Git repository root for run-log synchronization"
+        )
+    return run_log_corpus.synchronized_repository_log_root(repo_root=repo_root)
 
 
 def _discover(log_root: Path) -> list[tuple[str, Path]]:
@@ -679,7 +670,11 @@ def main(argv: list[str]) -> int:
     if args.era_since_date and not args.era:
         print("voter-calibration: --era-since-date requires --era", file=sys.stderr)
         return 2
-    log_root = Path(args.log_root).expanduser() if args.log_root else _default_log_root()
+    try:
+        log_root = _selected_log_root(args.log_root)
+    except run_log_corpus.RunLogCorpusError as exc:
+        print(f"voter-calibration: {exc}", file=sys.stderr)
+        return 2
     log_root = log_root.resolve()
     if not log_root.is_dir():
         print(f"voter-calibration: resolved log root is missing: {log_root}", file=sys.stderr)

--- a/python/larch/calibration/difficulty_calibration.py
+++ b/python/larch/calibration/difficulty_calibration.py
@@ -1,4 +1,4 @@
-"""Retrospective difficulty calibration from committed larch run logs."""
+"""Retrospective difficulty calibration from synchronized larch run logs."""
 # pyright: reportUnknownMemberType=false, reportUnknownArgumentType=false, reportArgumentType=false
 
 from __future__ import annotations
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import cast
 
 from larch.calibration import difficulty
+from larch.core import repo_roots
 from larch.report import run_log_corpus
 from larch.report.report_tokens_cost import display_rates
 from larch.report.report_tokens_models import (
@@ -614,7 +615,12 @@ def _collect_skill_runs(log_root: Path, skill: str, state: AnalyzerState, sideca
             state.bump("unratable_missing_rating")
         classification = _classification_outcome(skill, run_dir, state)
         realized, substantiality = _realized_tier(rating, classification, state)
-        rel_link = run_dir.relative_to(log_root.parent).as_posix() if log_root.parent in run_dir.resolve().parents else run_dir.as_posix()
+        try:
+            run_relative = run_dir.resolve().relative_to(log_root.resolve())
+        except (OSError, ValueError):
+            rel_link = run_dir.as_posix()
+        else:
+            rel_link = (Path("larch-logs") / run_relative).as_posix()
         records.append(
             RunRecord(
                 skill=skill,
@@ -634,9 +640,9 @@ def _collect_skill_runs(log_root: Path, skill: str, state: AnalyzerState, sideca
     return records
 
 
-def collect_corpus(log_root: Path) -> Corpus:
+def collect_corpus(log_root: Path, *, state_root: Path | None = None) -> Corpus:
     state = AnalyzerState()
-    sidecar = _read_sidecar(log_root, state)
+    sidecar = _read_sidecar(log_root if state_root is None else state_root, state)
     records: list[RunRecord] = []
     for skill in SKILLS:
         records.extend(_collect_skill_runs(log_root, skill, state, sidecar))
@@ -897,28 +903,37 @@ def render_report(corpus: Corpus) -> str:
     return "\n".join(lines).rstrip() + "\n"
 
 
-def _default_log_root() -> Path:
-    cwd = Path.cwd()
-    for candidate in (cwd, *cwd.parents):
-        if (candidate / ".git").exists():
-            return candidate / "larch-logs"
-    return cwd / "larch-logs"
-
-
 def parse_args(argv: Sequence[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(prog="difficulty-calibration analyze")
-    _ = parser.add_argument("--log-root", default=str(_default_log_root()))
+    _ = parser.add_argument(
+        "--log-root",
+        default="",
+        help="offline fixture corpus override; default synchronizes the current repository cache",
+    )
     _ = parser.add_argument("--out", default="")
     return parser.parse_args(list(argv))
 
 
 def analyze_main(argv: list[str] | None = None) -> int:
     args = parse_args(sys.argv[1:] if argv is None else argv)
-    log_root = Path(str(args.log_root))
+    if args.log_root:
+        log_root = Path(str(args.log_root))
+        state_root = log_root
+    else:
+        repo_root: Path | None = repo_roots.consumer_repo_root()
+        if repo_root is None:
+            print("ERROR: could not discover a Git repository root for run-log synchronization", file=sys.stderr)
+            return 2
+        try:
+            log_root = run_log_corpus.synchronized_repository_log_root(repo_root=repo_root)
+        except run_log_corpus.RunLogCorpusError as exc:
+            print(f"ERROR: {exc}", file=sys.stderr)
+            return 2
+        state_root = repo_root / "larch-logs"
     if not log_root.is_dir():
         print(f"ERROR: --log-root is missing or not a directory: {log_root}", file=sys.stderr)
         return 2
-    corpus = collect_corpus(log_root)
+    corpus = collect_corpus(log_root, state_root=state_root)
     report = render_report(corpus)
     if args.out:
         out = Path(str(args.out))

--- a/python/larch/issue/rejected_analysis.py
+++ b/python/larch/issue/rejected_analysis.py
@@ -1,6 +1,6 @@
 # ruff: noqa: C901,PLR0912,PLR0913,PLR0915,PLR2004,PERF401
 # pyright: reportUnusedCallResult=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportArgumentType=false, reportCallIssue=false
-"""Recover verified real rejected code-review findings from committed run logs.
+"""Recover verified real rejected code-review findings from synchronized run logs.
 
 ``finding_hash`` is frozen as ``sha256`` over normalized ``file_path`` and
 ``concern`` only. Run-local ballot ids, line hints, run metadata, voter labels,
@@ -23,7 +23,7 @@ from pathlib import Path
 from typing import Any, Literal
 
 from larch import io as larch_io
-from larch.core import logging_util, proc
+from larch.core import logging_util, proc, repo_roots
 from larch.errors import ShipError
 
 from larch.git import gh
@@ -994,7 +994,7 @@ def _render_prompt(candidate: PreparedCandidate) -> str:
 def prepare(
     *,
     days: int,
-    log_root: Path | str = Path("larch-logs"),
+    log_root: Path | str | None = None,
     work_dir: Path | str | None = None,
     verify_cap: int = DEFAULT_VERIFY_CAP,
     repo_root: Path | str | None = None,
@@ -1005,8 +1005,22 @@ def prepare(
         raise ValueError("days must be positive")
     if verify_cap <= 0:
         raise ValueError("verify_cap must be positive")
-    root = Path(repo_root or Path.cwd()).resolve()
-    logs = (root / log_root).resolve() if not Path(log_root).is_absolute() else Path(log_root)
+    requested_root = Path(repo_root or Path.cwd()).resolve()
+    root = requested_root
+    if log_root is None:
+        discovered_root = repo_roots.consumer_repo_root(requested_root)
+        if discovered_root is None:
+            raise RejectedAnalysisError(
+                "could not discover a Git repository root for run-log synchronization"
+            )
+        root = discovered_root
+        try:
+            logs = run_log_corpus.synchronized_repository_log_root(repo_root=root)
+        except run_log_corpus.RunLogCorpusError as exc:
+            raise RejectedAnalysisError(str(exc)) from exc
+    else:
+        requested_logs = Path(log_root)
+        logs = (root / requested_logs).resolve() if not requested_logs.is_absolute() else requested_logs
     wd = Path(work_dir) if work_dir is not None else Path(tempfile.mkdtemp(prefix="rejected-analysis-", dir=tempfile.gettempdir()))
     wd.mkdir(parents=True, exist_ok=True)
     active_runner = runner or proc.ProcRunner()
@@ -1569,12 +1583,22 @@ def _emit_prepare(result: PrepareResult) -> None:
 def prepare_main(argv: list[str]) -> int:
     parser = argparse.ArgumentParser(prog="rejected-analysis prepare")
     parser.add_argument("--days", "--n", dest="days", type=int, required=True)
-    parser.add_argument("--log-root", default="larch-logs")
+    parser.add_argument(
+        "--log-root",
+        default="",
+        help="offline fixture corpus override; default synchronizes the current repository cache",
+    )
     parser.add_argument("--work-dir", default="")
     parser.add_argument("--verify-cap", type=int, default=DEFAULT_VERIFY_CAP)
     args = parser.parse_args(argv)
     try:
-        result = prepare(days=args.days, log_root=args.log_root, work_dir=args.work_dir or None, verify_cap=args.verify_cap, open_issues=None)
+        result = prepare(
+            days=args.days,
+            log_root=args.log_root or None,
+            work_dir=args.work_dir or None,
+            verify_cap=args.verify_cap,
+            open_issues=None,
+        )
     except (RejectedAnalysisError, ValueError) as exc:
         logging_util.diagnostic(f"rejected-analysis prepare: {exc}")
         return 2

--- a/python/larch/report/report_tokens_scan.py
+++ b/python/larch/report/report_tokens_scan.py
@@ -1,4 +1,4 @@
-"""Scan committed larch run logs for report-token records."""
+"""Scan synchronized larch run logs for report-token records."""
 
 from __future__ import annotations
 
@@ -37,6 +37,15 @@ class ScanResult:
     repo_root: Path
     repo_slug: str | None
     records: tuple[RunRecord, ...]
+
+
+@dataclass(frozen=True)
+class ScanRequest:
+    skill: Skill
+    repo_override: str | None
+    limit: int | None
+    resolve_repo: bool
+    corpus_root: Path | None = None
 
 def _warn(message: str) -> None:
     print(f"Warning: {message}", file=sys.stderr)
@@ -132,12 +141,12 @@ def _phase_rows(report: Mapping[str, object]) -> tuple[PhaseRow, ...]:
     return tuple(rows)
 
 def _session_scoped_ledger_path(run_dir: Path) -> Path | None:
-    """Resolve the committed ledger for a run dir using session-id when present."""
+    """Resolve the durable ledger for a run dir using session-id when present."""
     return tokens.run_log_ledger_path(run_dir)
 
 
 def _ledger_fallback_report(run_dir: Path) -> Mapping[str, object] | None:
-    """Recover a token report from the committed session ledger when the canonical
+    """Recover a token report from the durable session ledger when the canonical
     token-report{,-final}.json is absent or unusable (issue #5133). Returns None
     when no usable ledger exists. Symlinked ledgers are skipped for safety.
     """
@@ -185,7 +194,7 @@ def _enrich_model_buckets(report: Mapping[str, object], *, run_dir: Path) -> Map
 
 
 def _resolve_report(run_dir: Path, *, skill: Skill) -> Mapping[str, object] | None:
-    """Load and validate a run's token report, falling back to the committed
+    """Load and validate a run's token report, falling back to the durable
     ledger when the canonical token-report{,-final}.json is absent or unusable
     (issue #5133). Returns None (after a warning) when no priceable report exists.
     """
@@ -258,14 +267,60 @@ def scan(
     limit: int | None = None,
     resolve_repo: bool = True,
 ) -> ScanResult:
+    return _scan_request(
+        runner,
+        request=ScanRequest(
+            skill=skill,
+            repo_override=repo_override,
+            limit=limit,
+            resolve_repo=resolve_repo,
+        ),
+    )
+
+
+def scan_prepared_corpus(
+    runner: Runner,
+    *,
+    skill: Skill,
+    corpus_root: Path,
+) -> ScanResult:
+    """Scan one skill from an already synchronized invocation corpus."""
+    return _scan_request(
+        runner,
+        request=ScanRequest(
+            skill=skill,
+            repo_override=None,
+            limit=None,
+            resolve_repo=False,
+            corpus_root=corpus_root,
+        ),
+    )
+
+
+def _scan_request(runner: Runner, *, request: ScanRequest) -> ScanResult:
     root = _repo_root(runner)
-    slug: str | None = _repo_slug(runner=runner, override=repo_override or os.environ.get("LARCH_REPORT_TOKENS_REPO")) if resolve_repo else None
-    log_base = root / "larch-logs" / skill
-    print(f"Scanning {log_base} for larch run logs (--skill={skill})...", file=sys.stderr)
-    max_dirs: int | None = _limit_value(limit)
+    if request.corpus_root is None:
+        try:
+            log_root: Path = run_log_corpus.synchronized_repository_log_root(repo_root=root)
+        except run_log_corpus.RunLogCorpusError as exc:
+            raise ShipError(f"ERROR: {exc}") from exc
+    else:
+        log_root = request.corpus_root
+    slug: str | None = (
+        _repo_slug(
+            runner=runner,
+            override=request.repo_override
+            or os.environ.get(config.ENV_LARCH_REPORT_TOKENS_REPO),
+        )
+        if request.resolve_repo
+        else None
+    )
+    log_base = log_root / request.skill
+    print(f"Scanning {log_base} for larch run logs (--skill={request.skill})...", file=sys.stderr)
+    max_dirs: int | None = _limit_value(request.limit)
     records: list[RunRecord] = []
     for seen, run_dir in enumerate(_run_dirs(log_base), start=1):
-        record: RunRecord | None = _record(run_dir, skill=skill, repo_slug=slug)
+        record: RunRecord | None = _record(run_dir, skill=request.skill, repo_slug=slug)
         if record is not None:
             records.append(record)
         if max_dirs is not None and seen >= max_dirs:

--- a/python/larch/report/run_log_corpus.py
+++ b/python/larch/report/run_log_corpus.py
@@ -1,4 +1,4 @@
-"""Shared safe helpers for committed larch run-log corpus walks."""
+"""Shared safe helpers for larch run-log corpus walks."""
 
 from __future__ import annotations
 
@@ -6,6 +6,7 @@ import json
 import os
 import re
 import stat
+import tarfile
 from collections.abc import Callable, Iterator, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime
@@ -13,7 +14,7 @@ from enum import StrEnum
 from pathlib import Path
 from typing import Any, Literal, cast
 
-from larch.report import run_log_sync
+from larch.report import run_log_sync, storage_config
 from larch.report.report_tokens_models import safe_int
 
 DEFAULT_MANIFEST_CANDIDATES: tuple[str, ...] = ("manifest.json", "run-manifest.json")
@@ -33,6 +34,10 @@ class WalkWarningKind(StrEnum):
     CHILD_UNRESOLVABLE = "child_unresolvable"
     CHILD_ESCAPES = "child_escapes"
     CHILD_NOT_DIR = "child_not_dir"
+
+
+class RunLogCorpusError(RuntimeError):
+    """A repository analyzer could not prepare its synchronized corpus."""
 
 
 @dataclass(frozen=True)
@@ -259,6 +264,41 @@ def synchronized_run_log_root(
         store=store,
         environ=environ,
     ).corpus_root
+
+
+def synchronized_repository_log_root(
+    *,
+    repo_root: Path,
+    store: run_log_sync.SyncObjectStore | None = None,
+    environ: Mapping[str, str] | None = None,
+    cache_home: Path | None = None,
+    state_home: Path | None = None,
+) -> Path:
+    """Load repository config, synchronize once, and return the cache log root."""
+    try:
+        storage_root: storage_config.StorageRoot = storage_config.load_storage_root(
+            repo_root=repo_root,
+            environ=environ,
+        )
+        return synchronized_run_log_root(
+            request=run_log_sync.RunLogSyncRequest(
+                repo_root=repo_root,
+                storage_root=storage_root,
+                cache_home=cache_home,
+                state_home=state_home,
+            ),
+            store=store,
+            environ=environ,
+        )
+    except (
+        EOFError,
+        OSError,
+        RuntimeError,
+        tarfile.TarError,
+        TypeError,
+        ValueError,
+    ) as exc:
+        raise RunLogCorpusError(f"run-log corpus sync failed: {exc}") from exc
 
 
 def review_transcript_dirs(log_base: Path, warn: Callable[[str], None] | None = None) -> list[Path]:

--- a/python/larch/report/tokens.py
+++ b/python/larch/report/tokens.py
@@ -1965,14 +1965,11 @@ def _reference_reads_for_run(*, repo: Path, skill: str, run_dir: Path) -> list[O
     return reads
 
 
-def _skill_run_dirs(repo: Path) -> dict[str, list[Path]]:
-    root = repo / "larch-logs"
+def _skill_run_dirs(log_root: Path) -> dict[str, list[Path]]:
     by_skill: dict[str, list[Path]] = {}
-    if not root.is_dir():
+    if not log_root.is_dir():
         return by_skill
-    for skill_dir in sorted(root.iterdir()):
-        if skill_dir.is_symlink() or not skill_dir.is_dir():
-            continue
+    for skill_dir in run_log_corpus.safe_child_run_dirs(log_root):
         runs = list(run_log_corpus.run_dirs(skill_dir))
         if skill_dir.name == "review":
             seen = {path.resolve() for path in runs}
@@ -2115,7 +2112,8 @@ def measure_ngram_duplication() -> Path:
 def measure_references_heatmap() -> Path:
     repo = _repo_root()
     out_path = repo / "larch-logs" / "measure-references-heatmap" / f"{_measure_stamp()}.tsv"
-    run_dirs_by_skill = _skill_run_dirs(repo)
+    log_root = run_log_corpus.synchronized_repository_log_root(repo_root=repo)
+    run_dirs_by_skill = _skill_run_dirs(log_root)
     reads: list[ObservedReferenceRead] = []
     coverage_rows: list[tuple[str, int, int, int, float, str]] = []
     for skill, dirs in run_dirs_by_skill.items():
@@ -2160,7 +2158,8 @@ def measure_references_heatmap() -> Path:
 def measure_realized_cost() -> Path:
     repo = _repo_root()
     out_path = repo / "larch-logs" / "measure-realized-cost" / f"{_measure_stamp()}.tsv"
-    run_dirs_by_skill = _skill_run_dirs(repo)
+    log_root = run_log_corpus.synchronized_repository_log_root(repo_root=repo)
+    run_dirs_by_skill = _skill_run_dirs(log_root)
     skill_paths: dict[str, str] = {}
     skill_texts: list[str] = []
     for skill in sorted(run_dirs_by_skill):
@@ -2506,11 +2505,14 @@ def measure_cache_efficiency() -> Path:
 
     runner = ProcRunner()
     tagged_records: list[tuple[Skill, RunRecord]] = []
-    repo_root: Path | None = None
+    repo_root: Path = _repo_root()
+    log_root: Path = run_log_corpus.synchronized_repository_log_root(repo_root=repo_root)
     for skill in ("design", "implement"):
-        scan_result = report_tokens_scan.scan(runner, skill=skill, resolve_repo=False)
-        if repo_root is None:
-            repo_root = scan_result.repo_root
+        scan_result = report_tokens_scan.scan_prepared_corpus(
+            runner,
+            skill=skill,
+            corpus_root=log_root,
+        )
         tagged_records.extend((skill, record) for record in scan_result.records)
     out_path = repo_root / "larch-logs" / "measure-cache-efficiency" / f"{_measure_stamp()}.tsv"
     out_path.parent.mkdir(parents=True, exist_ok=True)
@@ -2540,9 +2542,15 @@ class _PanelCostAggregate:
     runs: set[tuple[str, str]] = dataclass_field(default_factory=set)
 
 
-def _panel_context_from_tsv(path: Path, repo: Path) -> tuple[str, str] | None:
+def _panel_context_from_tsv(
+    path: Path,
+    repo: Path,
+    *,
+    corpus_root: Path | None = None,
+) -> tuple[str, str] | None:
+    root = repo / "larch-logs" if corpus_root is None else corpus_root
     try:
-        rel = path.relative_to(repo / "larch-logs")
+        rel = path.relative_to(root)
     except ValueError:
         return None
     parts = rel.parts
@@ -2564,8 +2572,12 @@ def _panel_context_from_tsv(path: Path, repo: Path) -> tuple[str, str] | None:
     return skill, run_id
 
 
-def _iter_panel_prompt_size_files(repo: Path) -> list[Path]:
-    root = repo / "larch-logs"
+def _iter_panel_prompt_size_files(
+    repo: Path,
+    *,
+    corpus_root: Path | None = None,
+) -> list[Path]:
+    root = repo / "larch-logs" if corpus_root is None else corpus_root
     if not root.is_dir():
         return []
     paths: list[Path] = []
@@ -2578,7 +2590,9 @@ def _iter_panel_prompt_size_files(repo: Path) -> list[Path]:
                     name=PANEL_PROMPT_SIZE_BASENAME,
                     contain_root=root / skill,
                 )
-                if path.is_file() and not path.is_symlink() and _panel_context_from_tsv(path, repo) is not None
+                if path.is_file()
+                and not path.is_symlink()
+                and _panel_context_from_tsv(path, repo, corpus_root=root) is not None
             )
     return sorted(paths)
 
@@ -2636,8 +2650,12 @@ def _checks_digest_size_row_values(row: Mapping[str, str]) -> dict[str, int] | N
     return values
 
 
-def _iter_checks_digest_size_files(repo: Path) -> list[Path]:
-    root = repo / "larch-logs"
+def _iter_checks_digest_size_files(
+    repo: Path,
+    *,
+    corpus_root: Path | None = None,
+) -> list[Path]:
+    root = repo / "larch-logs" if corpus_root is None else corpus_root
     if not root.is_dir():
         return []
     paths: list[Path] = []
@@ -2704,8 +2722,9 @@ def _render_checks_digest_savings_report(aggregate: ChecksDigestSavingsAggregate
 def measure_checks_digest_savings() -> Path:
     repo = _repo_root()
     out_path = repo / "larch-logs" / "measure-checks-digest-savings" / f"{_measure_stamp()}.tsv"
+    log_root = run_log_corpus.synchronized_repository_log_root(repo_root=repo)
     aggregate = ChecksDigestSavingsAggregate()
-    for tsv in _iter_checks_digest_size_files(repo):
+    for tsv in _iter_checks_digest_size_files(repo, corpus_root=log_root):
         has_header, rows_seen, rows_skipped, rows = _read_checks_digest_size_file(tsv)
         if not has_header:
             continue
@@ -2721,9 +2740,10 @@ def measure_checks_digest_savings() -> Path:
 def measure_panel_cost() -> Path:
     repo = _repo_root()
     out_path = repo / "larch-logs" / "measure-panel-cost" / f"{_measure_stamp()}.tsv"
+    log_root = run_log_corpus.synchronized_repository_log_root(repo_root=repo)
     aggregates: dict[tuple[str, str, str], _PanelCostAggregate] = {}
-    for tsv in _iter_panel_prompt_size_files(repo):
-        context = _panel_context_from_tsv(tsv, repo)
+    for tsv in _iter_panel_prompt_size_files(repo, corpus_root=log_root):
+        context = _panel_context_from_tsv(tsv, repo, corpus_root=log_root)
         if context is None:
             continue
         skill, run_id = context
@@ -3072,14 +3092,22 @@ def compute_pr_line_counts_main(argv: list[str] | None = None) -> int:
 
 def measure_checks_digest_savings_main(argv: list[str] | None = None) -> int:
     _ = argv
-    path = measure_checks_digest_savings()
+    try:
+        path = measure_checks_digest_savings()
+    except run_log_corpus.RunLogCorpusError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return config.EXIT_BAIL
     print(f"WROTE\t{path.relative_to(_repo_root())}")
     return 0
 
 
 def measure_panel_cost_main(argv: list[str] | None = None) -> int:
     _ = argv
-    path = measure_panel_cost()
+    try:
+        path = measure_panel_cost()
+    except run_log_corpus.RunLogCorpusError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return config.EXIT_BAIL
     try:
         rel = path.relative_to(_repo_root()).as_posix()
     except ValueError:
@@ -3104,14 +3132,22 @@ def measure_ngram_duplication_main(argv: list[str] | None = None) -> int:
 
 def measure_references_heatmap_main(argv: list[str] | None = None) -> int:
     _ = argv
-    path = measure_references_heatmap()
+    try:
+        path = measure_references_heatmap()
+    except run_log_corpus.RunLogCorpusError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return config.EXIT_BAIL
     print(f"WROTE\t{path.relative_to(_repo_root())}")
     return 0
 
 
 def measure_realized_cost_main(argv: list[str] | None = None) -> int:
     _ = argv
-    path = measure_realized_cost()
+    try:
+        path = measure_realized_cost()
+    except run_log_corpus.RunLogCorpusError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return config.EXIT_BAIL
     print(f"WROTE\t{path.relative_to(_repo_root())}")
     return 0
 
@@ -3120,7 +3156,7 @@ def measure_cache_efficiency_main(argv: list[str] | None = None) -> int:
     _ = argv
     try:
         path = measure_cache_efficiency()
-    except ShipError as exc:
+    except (ShipError, run_log_corpus.RunLogCorpusError) as exc:
         print(str(exc), file=sys.stderr)
         return config.EXIT_BAIL
     repo_root = _measure_repo_root_from_larch_logs_path(path)

--- a/python/tests/calibration/test_difficulty_calibration.py
+++ b/python/tests/calibration/test_difficulty_calibration.py
@@ -500,6 +500,44 @@ def test_missing_log_root_exits_2(tmp_path: Path, capsys: pytest.CaptureFixture[
 
     assert rc == 2
     assert "--log-root is missing" in captured.err
+
+
+def test_default_synced_corpus_matches_explicit_fixture(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = _root(tmp_path)
+    run = _run(root, "implement", "SYNCED", applied=difficulty.TRIVIAL)
+    _implement_tsv(run, 1, _code_row("FINDING_1", "accepted"))
+    (root / "rejected-analysis-verdicts.tsv").write_text(
+        SIDECAR_HEADER
+        + "\n1\thash-1\timplement\tSYNCED\t1\tFINDING_1\tv1\tconfirmed\tpython/foo.py:1\tstill broken\t2026-06-20T00:00:00Z\n",
+        encoding="utf-8",
+    )
+    cache_root = tmp_path / "cache" / "larch2"
+    cache_run = _run(cache_root, "implement", "SYNCED", applied=difficulty.TRIVIAL)
+    _implement_tsv(cache_run, 1, _code_row("FINDING_1", "accepted"))
+    explicit_out = tmp_path / "explicit.md"
+    synced_out = tmp_path / "synced.md"
+    sync_calls = 0
+
+    def _sync(*, repo_root: Path) -> Path:
+        nonlocal sync_calls
+        assert repo_root == tmp_path
+        sync_calls += 1
+        return cache_root
+
+    monkeypatch.setattr(dc.repo_roots, "consumer_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(dc.run_log_corpus, "synchronized_repository_log_root", _sync)
+
+    assert dc.analyze_main(["--log-root", str(root), "--out", str(explicit_out)]) == 0
+    _ = capsys.readouterr()
+    assert dc.analyze_main(["--out", str(synced_out)]) == 0
+    _ = capsys.readouterr()
+
+    assert synced_out.read_text(encoding="utf-8") == explicit_out.read_text(encoding="utf-8")
+    assert sync_calls == 1
 # pyright: reportMissingParameterType=false, reportUnknownMemberType=false
 # pyright: reportUnknownParameterType=false, reportUnknownVariableType=false
 # pyright: reportUnusedCallResult=false

--- a/python/tests/issue/test_rejected_analysis.py
+++ b/python/tests/issue/test_rejected_analysis.py
@@ -87,6 +87,46 @@ def test_extractors_and_hash_are_stable_without_filesystem_probe(tmp_path: Path)
     assert ra.compute_finding_hash(changed_metadata) == first
 
 
+def test_prepare_default_synced_corpus_matches_explicit_fixture(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _ = _write_implement_fixture(tmp_path)
+    log_root = tmp_path / "larch-logs"
+    explicit = ra.prepare(
+        days=7,
+        log_root=log_root,
+        work_dir=tmp_path / "explicit-work",
+        repo_root=tmp_path,
+        open_issues=[],
+    )
+    sync_calls = 0
+
+    def _sync(*, repo_root: Path) -> Path:
+        nonlocal sync_calls
+        assert repo_root == tmp_path
+        sync_calls += 1
+        return log_root
+
+    def _repo_root(_start: Path | str | None = None) -> Path:
+        return tmp_path
+
+    monkeypatch.setattr(ra.repo_roots, "consumer_repo_root", _repo_root)
+    monkeypatch.setattr(ra.run_log_corpus, "synchronized_repository_log_root", _sync)
+    synced = ra.prepare(
+        days=7,
+        work_dir=tmp_path / "synced-work",
+        repo_root=tmp_path,
+        open_issues=[],
+    )
+
+    assert synced.stats == explicit.stats
+    assert [candidate.finding for candidate in synced.candidates] == [
+        candidate.finding for candidate in explicit.candidates
+    ]
+    assert sync_calls == 1
+
+
 def test_prepare_keeps_one_yes_and_ledgers_zero_yes_oos_and_duplicates(tmp_path: Path) -> None:
     _write_implement_fixture(tmp_path, run_id="RUN-A", finding_id="FINDING_1", json_id="REJ_CR1_1", concern="Missing required check", path="python/foo.py:12")
     _write_implement_fixture(tmp_path, run_id="RUN-B", finding_id="FINDING_2", json_id="REJ_CR1_2", concern="Zero yes concern", path="python/bar.py:5", vote1="NO", vote2="NO")

--- a/python/tests/report/test_gc_run_logs.py
+++ b/python/tests/report/test_gc_run_logs.py
@@ -12,7 +12,7 @@ import pytest  # noqa: TC002
 
 from larch.report import gc_run_logs
 from larch.core.proc import CommandResult
-from larch.report.report_tokens_scan import scan
+from larch.report.report_tokens_scan import scan_prepared_corpus
 
 
 def _git(repo: Path, *args: str) -> None:
@@ -313,7 +313,11 @@ def test_gc_run_logs_slim_preserves_session_id_for_multi_ledger_recovery(tmp_pat
     assert not (run / "round-1").exists()
     assert (run / "gc-slimmed").is_file()
 
-    result = scan(_ScanRunner(repo), skill="design", repo_override="o/r")
+    result = scan_prepared_corpus(
+        _ScanRunner(repo),
+        skill="design",
+        corpus_root=logs_root,
+    )
     assert len(result.records) == 1
     assert result.records[0].codex.total == 11
 

--- a/python/tests/report/test_read_only_analyzer_sync.py
+++ b/python/tests/report/test_read_only_analyzer_sync.py
@@ -1,0 +1,60 @@
+"""Parity coverage for standalone read-only analyzers using the synced cache."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+def _load_module(name: str, path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize(
+    ("name", "relpath"),
+    [
+        ("fixture_voter_calibration", "skills/voter-calibration/scripts/voter-calibration.py"),
+        ("fixture_fluff_analysis", "skills/fluff-analysis/scripts/fluff-analysis.py"),
+    ],
+)
+def test_default_synced_corpus_matches_explicit_fixture(
+    name: str,
+    relpath: str,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = Path(__file__).resolve().parents[3]
+    module = _load_module(name, repository / relpath)
+    log_root = tmp_path / "larch-logs"
+    for skill in ("design", "implement", "review"):
+        (log_root / skill).mkdir(parents=True)
+    sync_calls = 0
+
+    def _sync(*, repo_root: Path) -> Path:
+        nonlocal sync_calls
+        assert repo_root == tmp_path
+        sync_calls += 1
+        return log_root
+
+    monkeypatch.setattr(module.repo_roots, "consumer_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(module.run_log_corpus, "synchronized_repository_log_root", _sync)
+
+    assert module.main(["--log-root", str(log_root)]) == 0
+    explicit = capsys.readouterr()
+    assert module.main([]) == 0
+    synchronized = capsys.readouterr()
+
+    assert synchronized.out == explicit.out
+    assert synchronized.err == explicit.err
+    assert sync_calls == 1

--- a/python/tests/report/test_report_tokens_scan.py
+++ b/python/tests/report/test_report_tokens_scan.py
@@ -16,7 +16,8 @@ import pytest
 
 from larch.core.proc import CommandResult
 from larch.errors import ShipError
-from larch.report.report_tokens_scan import scan
+from larch.report import run_log_corpus
+from larch.report.report_tokens_scan import scan, scan_prepared_corpus
 
 
 def _calls() -> list[list[str]]:
@@ -46,6 +47,16 @@ class Runner:
                 return CommandResult(tuple(argv), 1, "", "not a git repo", 0.01)
             return CommandResult(tuple(argv), 0, str(self.root), "", 0.01)
         return CommandResult(tuple(argv), 1, "", "gh transient failure", 0.01)
+
+
+@pytest.fixture(autouse=True)
+def _synchronized_fixture_root(  # pyright: ignore[reportUnusedFunction]  # pytest invokes this autouse fixture by registration
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _root(*, repo_root: Path) -> Path:
+        return repo_root / "larch-logs"
+
+    monkeypatch.setattr(run_log_corpus, "synchronized_repository_log_root", _root)
 
 
 def _write_run(base: Path, *, skill: str, good_tokens: bool = True) -> None:
@@ -82,6 +93,35 @@ def test_scan_rejects_git_root_failure(tmp_path: Path) -> None:
     runner = Runner(tmp_path, git_ok=False)
     with pytest.raises(ShipError):
         _ = scan(runner, skill="implement", repo_override="o/r")
+
+
+def test_scan_surfaces_sync_failure_before_analysis(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def _fail(*, repo_root: Path) -> Path:
+        raise run_log_corpus.RunLogCorpusError(f"missing config under {repo_root}")
+
+    monkeypatch.setattr(run_log_corpus, "synchronized_repository_log_root", _fail)
+    with pytest.raises(ShipError, match="missing config"):
+        _ = scan(Runner(tmp_path), skill="implement", repo_override="o/r")
+
+
+def test_scan_prepared_corpus_performs_no_later_sync(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_run(tmp_path, skill="implement")
+
+    def _unexpected_sync(*, repo_root: Path) -> Path:
+        pytest.fail(f"unexpected later sync for {repo_root}")
+
+    monkeypatch.setattr(run_log_corpus, "synchronized_repository_log_root", _unexpected_sync)
+
+    result = scan_prepared_corpus(
+        Runner(tmp_path),
+        skill="implement",
+        corpus_root=tmp_path / "larch-logs",
+    )
+
+    assert len(result.records) == 1
 
 
 def test_scan_rejects_invalid_repo_override(tmp_path: Path) -> None:

--- a/python/tests/report/test_run_log_corpus.py
+++ b/python/tests/report/test_run_log_corpus.py
@@ -5,16 +5,70 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 
 from larch.report import run_log_corpus
+
+if TYPE_CHECKING:
+    from larch.report.object_store import RemoteObject
 
 # pytest.MonkeyPatch is used by enumeration-error coverage below.
 
 
 def _write_manifest(run_dir: Path, payload: object, *, name: str = "manifest.json") -> None:
     _ = (run_dir / name).write_text(json.dumps(payload), encoding="utf-8")
+
+
+class _EmptyStore:
+    def __init__(self) -> None:
+        self.list_calls = 0
+
+    def list_objects(self, prefix: str = "") -> tuple[RemoteObject, ...]:
+        assert prefix == "run-logs/"
+        self.list_calls += 1
+        return ()
+
+    def download(self, key: str, destination: Path) -> None:
+        raise AssertionError(f"unexpected download: {key} to {destination}")
+
+
+def test_synchronized_repository_log_root_lists_once(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    config_dir = repo / ".larch"
+    config_dir.mkdir(parents=True)
+    _ = (config_dir / "config.toml").write_text(
+        '[logs]\nuri = "s3://fixture-bucket/larch"\n',
+        encoding="utf-8",
+    )
+    store = _EmptyStore()
+
+    log_root = run_log_corpus.synchronized_repository_log_root(
+        repo_root=repo,
+        store=store,
+        cache_home=tmp_path / "cache",
+        state_home=tmp_path / "state",
+    )
+
+    assert log_root == tmp_path / "cache" / "larch" / "run-logs" / "repo"
+    assert store.list_calls == 1
+
+
+def test_synchronized_repository_log_root_requires_config(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    store = _EmptyStore()
+
+    with pytest.raises(run_log_corpus.RunLogCorpusError, match="storage configuration is missing"):
+        _ = run_log_corpus.synchronized_repository_log_root(
+            repo_root=repo,
+            store=store,
+            cache_home=tmp_path / "cache",
+            state_home=tmp_path / "state",
+        )
+
+    assert store.list_calls == 0
 
 
 def test_load_run_manifest_rejects_bool_issue_number(tmp_path: Path) -> None:

--- a/python/tests/report/test_tokens.py
+++ b/python/tests/report/test_tokens.py
@@ -15,8 +15,19 @@ import pytest
 
 from larch.core import config
 from larch.report import report_tokens_scan
+from larch.report import run_log_corpus
 from larch.report import tokens
 from larch.report.report_tokens_models import RunRecord, VendorTotals
+
+
+@pytest.fixture(autouse=True)
+def _fixture_corpus_root(  # pyright: ignore[reportUnusedFunction]  # pytest invokes this autouse fixture by registration
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _sync(*, repo_root: Path) -> Path:
+        return repo_root / "larch-logs"
+
+    monkeypatch.setattr(run_log_corpus, "synchronized_repository_log_root", _sync)
 
 
 def test_atomic_text_uses_nofollow(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -1104,6 +1115,7 @@ def _cache_record(
 def test_measure_cache_efficiency_writes_ranked_sections(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     repo = tmp_path / "consumer"
     repo.mkdir()
+    monkeypatch.setattr(tokens, "_repo_root", lambda: repo)  # pyright: ignore[reportPrivateUsage]
     monkeypatch.setenv("LARCH_MEASURE_DATE", "fixture-day")
     design_record = _cache_record(
         number=1,
@@ -1119,12 +1131,28 @@ def test_measure_cache_efficiency_writes_ranked_sections(tmp_path: Path, monkeyp
     )
     zero_record = _cache_record(number=3, title="All zero")
 
-    def fake_scan(_runner: object, *, skill: str, resolve_repo: bool, **_kwargs: object) -> report_tokens_scan.ScanResult:
-        assert resolve_repo is False
+    sync_calls = 0
+    cache_root = tmp_path / "cache" / "larch2"
+
+    def _sync(*, repo_root: Path) -> Path:
+        nonlocal sync_calls
+        assert repo_root == repo
+        sync_calls += 1
+        return cache_root
+
+    def fake_scan(
+        _runner: object,
+        *,
+        skill: str,
+        corpus_root: Path,
+        **_kwargs: object,
+    ) -> report_tokens_scan.ScanResult:
+        assert corpus_root == cache_root
         records = (design_record, zero_record) if skill == "design" else (legacy_record,)
         return report_tokens_scan.ScanResult(repo_root=repo, repo_slug=None, records=records)
 
-    monkeypatch.setattr(report_tokens_scan, "scan", fake_scan)
+    monkeypatch.setattr(run_log_corpus, "synchronized_repository_log_root", _sync)
+    monkeypatch.setattr(report_tokens_scan, "scan_prepared_corpus", fake_scan)
 
     out = tokens.measure_cache_efficiency()
     text = out.read_text(encoding="utf-8")
@@ -1135,6 +1163,7 @@ def test_measure_cache_efficiency_writes_ranked_sections(tmp_path: Path, monkeyp
     assert per_run[0]["ratio"] == "inf"
     assert per_run[0]["title"] == "Legacy zero read"
     assert all(row["title"] != "All zero" for row in per_run)
+    assert sync_calls == 1
 
 
 def test_cache_create_effective_uses_legacy_when_split_zero() -> None:
@@ -1670,6 +1699,39 @@ def test_measure_panel_cost_aggregates_committed_tsvs(tmp_path: Path, monkeypatc
     assert {row["agent_file"] for row in data} >= {"generated/no-agent:voter", "agents/orchestrator-aggregator.md"}
 
 
+def test_measure_panel_cost_reads_synced_cache_and_writes_repository_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "consumer"
+    repo.mkdir()
+    cache_root = tmp_path / "cache" / "consumer"
+    panel = cache_root / "review" / "r1" / "panel-prompt-sizes.tsv"
+    panel.parent.mkdir(parents=True)
+    panel.write_text(
+        "site\tphase\tround_num\tslot\tslot_kind\ttool\toutput\tprompt_bytes\tprompt_tokens\tagent_file\tagent_bytes\tagent_tokens\n"
+        "review\t\t\taggregator\taggregator\tcodex\tagg.txt\t70\t18\tagents/orchestrator-aggregator.md\t30\t8\n",
+        encoding="utf-8",
+    )
+    sync_calls = 0
+
+    def _sync(*, repo_root: Path) -> Path:
+        nonlocal sync_calls
+        assert repo_root == repo
+        sync_calls += 1
+        return cache_root
+
+    monkeypatch.setattr(tokens, "_repo_root", lambda: repo)  # pyright: ignore[reportPrivateUsage]
+    monkeypatch.setattr(tokens, "_measure_stamp", lambda: "2026-07-20")  # pyright: ignore[reportPrivateUsage]
+    monkeypatch.setattr(run_log_corpus, "synchronized_repository_log_root", _sync)
+
+    out = tokens.measure_panel_cost()
+
+    assert out == repo / "larch-logs" / "measure-panel-cost" / "2026-07-20.tsv"
+    assert "agents/orchestrator-aggregator.md" in out.read_text(encoding="utf-8")
+    assert sync_calls == 1
+
+
 def test_measure_panel_cost_ranks_by_scaffold_bytes_before_realized_bytes(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1730,11 +1792,16 @@ def test_iter_panel_and_checks_digest_skip_symlinked_run_dirs(
     linked = root / "implement" / "run-link"
     linked.symlink_to(real)
 
-    monkeypatch.setattr(
-        tokens,
-        "_panel_context_from_tsv",
-        lambda _path, _repo: ("implement", "r1"),  # pyright: ignore[reportUnknownLambdaType, reportUnknownArgumentType]
-    )
+    def _panel_context(
+        _path: Path,
+        _repo: Path,
+        *,
+        corpus_root: Path | None = None,
+    ) -> tuple[str, str]:
+        _ = corpus_root
+        return "implement", "r1"
+
+    monkeypatch.setattr(tokens, "_panel_context_from_tsv", _panel_context)
     panels = tokens._iter_panel_prompt_size_files(tmp_path)  # pyright: ignore[reportPrivateUsage]
     digests = tokens._iter_checks_digest_size_files(tmp_path)  # pyright: ignore[reportPrivateUsage]
     assert panels == [panel]

--- a/skills/difficulty-calibration/SKILL.md
+++ b/skills/difficulty-calibration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: difficulty-calibration
-description: "Use when comparing predicted and realized larch difficulty tiers from committed run logs. Diagnostic only; changes no thresholds, panels, points, or routing."
+description: "Use when comparing predicted and realized larch difficulty tiers from synchronized run logs. Diagnostic only; changes no thresholds, panels, points, or routing."
 argument-hint: "[--log-root DIR] [--out FILE]"
 allowed-tools: Bash, Read
 ---
@@ -16,9 +16,9 @@ classification and any required evidence before reporting the result.
 
 **MANDATORY: READ ENTIRE FILE before composing user-facing prose: `${CLAUDE_PLUGIN_ROOT}/skills/shared/readability-style.md`.**
 
-Analyze predicted versus realized difficulty tiers from committed `larch-logs/` data.
+Analyze predicted versus realized difficulty tiers from the synchronized run-log cache.
 
-The analyzer is read-only unless `--out FILE` is provided. It reads committed logs only. It does **not** change thresholds, panels, reviewer points, token allocation, or live routing.
+The analyzer is read-only unless `--out FILE` is provided. It syncs once, then reads only the unpacked cache. It does **not** change thresholds, panels, reviewer points, token allocation, or live routing.
 
 ## Usage
 
@@ -36,7 +36,7 @@ Do not re-tally or reformat the analysis in the main agent. The CLI owns extract
 
 Flags:
 
-- `--log-root DIR` - `larch-logs` directory. Default: `<git toplevel>/larch-logs`.
+- `--log-root DIR` - offline fixture corpus override. By default, sync the current repository cache.
 - `--out FILE` - write the report to `FILE` and print only `REPORT_FILE=<path>`.
 
 ## Data Model

--- a/skills/fluff-analysis/SKILL.md
+++ b/skills/fluff-analysis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fluff-analysis
-description: "Use when analyzing review fluff in committed larch run logs: rejected, OOS, or accepted-low-value findings, plus tuning recommendations."
+description: "Use when analyzing review fluff in synchronized larch run logs: rejected, OOS, or accepted-low-value findings, plus tuning recommendations."
 allowed-tools: Bash, Read
 ---
 
@@ -8,7 +8,7 @@ allowed-tools: Bash, Read
 
 **MANDATORY: READ ENTIRE FILE before composing user-facing prose: `${CLAUDE_PLUGIN_ROOT}/skills/shared/readability-style.md`.**
 
-Characterize review **fluff** — suggestions that are *not accepted* (rejected or deferred to Out-of-Scope) or *accepted-but-low-value* — from committed larch run logs in the current repository. The analyzer scans `larch-logs/design/*/` and `larch-logs/implement/*/`, normalizes every review finding (outcome, reviewer/voter severity, semantic tags), and prints a markdown report plus recommendations for tightening the reviewer self-filter and judge (voter) instructions.
+Characterize review **fluff** from the synchronized run-log cache in the current repository. This includes suggestions that are *not accepted* (rejected or deferred to Out-of-Scope) or *accepted-but-low-value*. The analyzer normalizes every review finding (outcome, reviewer/voter severity, semantic tags), then prints a markdown report and recommendations for tightening the reviewer self-filter and judge (voter) instructions.
 
 This is the standing tool behind the kind of analysis filed as a `[Analysis Report]` issue: re-run it as the corpus grows to track whether necessity-gate changes (see `skills/shared/review-acceptance-rubric.md`) move acceptance and findings-per-run.
 
@@ -28,13 +28,13 @@ Do not re-derive, re-tally, or re-format the analysis in the main agent — the 
 
 Flags:
 
-- `--include-in-progress` — also read in-progress `/design` session temp dirs under the session cache (a racy snapshot of un-flushed runs). Off by default; committed logs only.
+- `--include-in-progress`: also read in-progress `/design` session temp dirs under the session cache (a racy snapshot of unflushed runs). Off by default.
 - `--cutoff ISO8601` — enable a pre/post comparison section split at this timestamp (e.g. the date a reviewer-instruction change landed). Omitted by default.
 - `--since-version X.Y.Z` — enable a pre/post comparison split by `manifest.json.larch_version`; preferred for release-gated behavior changes.
 - `--min-group N` — minimum findings for a semantic group to appear in the tables. Default: `20`.
 - `--sessions-dir DIR` — session cache dir for `--include-in-progress`. Default: `~/.cache/larch/sessions`.
 - `--inprogress-since ISO8601` — lower bound on in-progress session mtime (skips stale temp dirs).
-- `--log-root DIR` — `larch-logs` directory. Default: `<git toplevel>/larch-logs`.
+- `--log-root DIR`: offline fixture corpus override. By default, sync the current repository cache.
 - `--out FILE` — write the report to `FILE` instead of stdout.
 
 On success, stdout begins with `# Review Fluff Analysis`. If the log root is missing the script exits non-zero with a diagnostic; surface it rather than inventing results.

--- a/skills/fluff-analysis/scripts/fluff-analysis.md
+++ b/skills/fluff-analysis/scripts/fluff-analysis.md
@@ -7,7 +7,7 @@ script).
 
 ## Purpose
 
-Read committed larch run logs and print a markdown **review fluff** report:
+Read synchronized larch run logs and print a markdown **review fluff** report:
 acceptance baselines, low-acceptance semantic groups, a testing breakdown,
 severity/quality/uncertain correlations, reviewer-lane splits, an
 accepted-but-low-value proxy, neutral-rate and important-reject-rate false-negative diagnostics, an optional pre/post-cutoff comparison, and
@@ -34,7 +34,7 @@ versions): missing fields degrade to empty, never crash a run.
 ## CLI
 
 ```text
---log-root DIR            larch-logs dir (default: <git toplevel>/larch-logs)
+--log-root DIR            offline fixture corpus override (default: synchronized cache)
 --include-in-progress     also read in-progress design session temp dirs
 --sessions-dir DIR        session cache dir (default: ~/.cache/larch/sessions)
 --inprogress-since ISO    skip in-progress sessions older than this mtime

--- a/skills/fluff-analysis/scripts/fluff-analysis.py
+++ b/skills/fluff-analysis/scripts/fluff-analysis.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
-"""fluff-analysis.py — characterize review "fluff" from committed larch run logs.
+"""Characterize review "fluff" from synchronized larch run logs.
 
-Reads committed design + implement run logs (and, optionally, in-progress design
+Reads synchronized design + implement run logs (and, optionally, in-progress design
 session temp dirs), normalizes every review finding into one record stream, and
 prints a markdown report: acceptance baselines, low-acceptance semantic groups,
 testing breakdown, severity/quality/uncertain correlations, reviewer-lane splits,
@@ -22,7 +22,6 @@ import glob
 import json
 import os
 import re
-import subprocess
 import sys
 from pathlib import Path
 
@@ -31,7 +30,7 @@ python_dir = repo_root / "python"
 if str(python_dir) not in sys.path:
     sys.path.insert(0, str(python_dir))
 
-from larch.core import config  # noqa: E402
+from larch.core import config, repo_roots  # noqa: E402
 from larch.core.architectural_guidelines import CLEAN_INVARIANT_PRESENTATION_NOTE, CLEAN_PRESENTATION_NOTE, DESIGN_ASSESSMENT, GUIDELINE_SHIP_OUTCOME_SIDECAR, INVARIANT_DESIGN_ASSESSMENT, INVARIANT_SHIP_OUTCOME_SIDECAR, validate_invariant_ship_outcome_record  # noqa: E402
 from larch.issue.audit_runs import implement_step8_reachable  # noqa: E402
 from larch.issue.rejected_analysis import (  # noqa: E402
@@ -1418,21 +1417,21 @@ def _section_recommendations(i_all, min_group):
 # --------------------------------------------------------------------------
 # CLI
 # --------------------------------------------------------------------------
-def default_log_root():
-    try:
-        proc = subprocess.run(["git", "rev-parse", "--show-toplevel"],
-                              capture_output=True, text=True, timeout=5, check=False)
-        if proc.returncode == 0 and proc.stdout.strip():
-            return os.path.join(proc.stdout.strip(), "larch-logs")
-    except (OSError, subprocess.SubprocessError):
-        pass
-    return os.path.join(os.getcwd(), "larch-logs")
+def selected_log_root(raw_log_root):
+    if raw_log_root:
+        return raw_log_root
+    consumer_root = repo_roots.consumer_repo_root()
+    if consumer_root is None:
+        raise run_log_corpus.RunLogCorpusError(
+            "could not discover a Git repository root for run-log synchronization"
+        )
+    return str(run_log_corpus.synchronized_repository_log_root(repo_root=consumer_root))
 
 
 def main(argv=None):
-    parser = argparse.ArgumentParser(description="Analyze review fluff from committed larch run logs.")
+    parser = argparse.ArgumentParser(description="Analyze review fluff from synchronized larch run logs.")
     parser.add_argument("--log-root", default=None,
-                        help="larch-logs directory (default: <git toplevel>/larch-logs)")
+                        help="offline fixture corpus override; default synchronizes the current repository cache")
     parser.add_argument("--sessions-dir", default=os.path.expanduser("~/.cache/larch/sessions"),
                         help="larch session cache dir (for --include-in-progress)")
     parser.add_argument("--include-in-progress", action="store_true",
@@ -1451,7 +1450,11 @@ def main(argv=None):
                              "pre-period records get empty tags (faster corpus scans)")
     args = parser.parse_args(argv)
 
-    log_root = args.log_root or default_log_root()
+    try:
+        log_root = selected_log_root(args.log_root)
+    except run_log_corpus.RunLogCorpusError as exc:
+        sys.stderr.write(f"ERROR: {exc}\n")
+        return 2
     if not os.path.isdir(log_root):
         sys.stderr.write("ERROR: log root not found: %s\n" % log_root)
         return 2

--- a/skills/rejected-analysis/SKILL.md
+++ b/skills/rejected-analysis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rejected-analysis
-description: "Use when recovering verified real rejected code-review findings from committed larch run logs and filing GitHub issues for findings that remain unfixed."
+description: "Use when recovering verified real rejected code-review findings from synchronized larch run logs and filing GitHub issues for findings that remain unfixed."
 argument-hint: "--n DAYS"
 allowed-tools: Bash, Read, Write, Agent, Skill
 ---
@@ -9,7 +9,7 @@ allowed-tools: Bash, Read, Write, Agent, Skill
 
 **MANDATORY: READ ENTIRE FILE before composing user-facing prose: `${CLAUDE_PLUGIN_ROOT}/skills/shared/readability-style.md`.**
 
-Recover **verified real** rejected code-review findings from committed run logs, then file the smallest safe set of issues.
+Recover **verified real** rejected code-review findings from synchronized run logs, then file the smallest safe set of issues.
 
 This is **mutating**. It files by default after verification.
 

--- a/skills/report-tokens/SKILL.md
+++ b/skills/report-tokens/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: report-tokens
-description: "Use when analyzing token costs from committed larch run logs for `--skill=design|implement`: price token reports, optionally plot trends, and print cost-reduction suggestions."
+description: "Use when analyzing token costs from synchronized larch run logs for `--skill=design|implement`: price token reports, optionally plot trends, and print cost-reduction suggestions."
 allowed-tools: Bash, Read
 ---
 
@@ -8,7 +8,7 @@ allowed-tools: Bash, Read
 
 **MANDATORY: READ ENTIRE FILE before composing user-facing prose: `${CLAUDE_PLUGIN_ROOT}/skills/shared/readability-style.md`.**
 
-Analyze token costs from committed larch run logs for the selected skill (`--skill=design|implement`) in the current git repository. The CLI delegates to `${CLAUDE_PLUGIN_ROOT}/python/larch/report/report_tokens_cli.py`, which scans `larch-logs/<skill>/*/`, reads the skill-specific token report JSON files, prices each run through `python/larch/report/report_tokens_cost.py`, prints a markdown analysis, writes a durable NDJSON cache snapshot, optionally generates plots, and optionally posts a GitHub `[Implement Analysis Report]` or `[Design Analysis Report]` issue.
+Analyze token costs from synchronized larch run logs for the selected skill (`--skill=design|implement`) in the current Git repository. The CLI syncs once, scans the unpacked cache, reads the skill-specific token report JSON files, prices each run through `python/larch/report/report_tokens_cost.py`, prints a markdown analysis, writes a durable NDJSON cache snapshot, optionally generates plots, and optionally posts a GitHub `[Implement Analysis Report]` or `[Design Analysis Report]` issue.
 
 For `--skill=implement`, reports carry no workflow dimension and graph/per-day trend output aggregates all runs into one `All runs` series/table set. For `--skill=design`, one aggregate report is generated. The filed issue intentionally omits raw per-issue JSON and actual-spend reconciliation unless `LARCH_REPORT_TOKENS_POST_ACTUAL_SPEND=1` is set.
 
@@ -41,4 +41,4 @@ Advertised `Cache JSON:` and plot paths remain on disk after CLI exit and expire
 ## NEVER
 
 1. **NEVER treat dollar output as billing truth.** The CLI uses transparent default rates and prints them with the analysis because vendor pricing and model routing can drift outside larch's control.
-2. **NEVER forward removed replot flags.** Re-run against committed `larch-logs` instead.
+2. **NEVER forward removed replot flags.** Re-run against the synchronized cache instead.

--- a/skills/voter-calibration/SKILL.md
+++ b/skills/voter-calibration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: voter-calibration
-description: "Use when analyzing voter agreement, severity calibration, and chronic outliers from committed larch run logs. Diagnostic only; changes no thresholds or points."
+description: "Use when analyzing voter agreement, severity calibration, and chronic outliers from synchronized larch run logs. Diagnostic only; changes no thresholds or points."
 allowed-tools: Bash, Read
 ---
 
@@ -8,7 +8,7 @@ allowed-tools: Bash, Read
 
 **MANDATORY: READ ENTIRE FILE before composing user-facing prose: `${CLAUDE_PLUGIN_ROOT}/skills/shared/readability-style.md`.**
 
-Analyze **voter agreement**, **YES-vote severity spread**, **severity calibration score**, and chronic outlier voters from committed larch run logs.
+Analyze **voter agreement**, **YES-vote severity spread**, **severity calibration score**, and chronic outlier voters from the synchronized run-log cache.
 
 The analyzer measures agreement and severity calibration only. It reports voter-side calibration standing. It does **not** use realized outcomes, issue fate, or reverts. It does **not** affect reviewer/proposer points, spawning, thresholds, token allocation, or live panel verdicts.
 
@@ -28,7 +28,7 @@ Do not re-tally or re-format the analysis in the main agent. The script owns ext
 
 Flags:
 
-- `--log-root DIR` - `larch-logs` directory. Default: `<git toplevel>/larch-logs`.
+- `--log-root DIR` - offline fixture corpus override. By default, sync the current repository cache.
 - `--min-votes N` - minimum eligible votes before outlier flagging. Default: `20`.
 - `--outlier-threshold R` - flag chronic outliers below this agreement rate. Default: `0.50`.
 - `--high-severity-threshold R` - flag voters whose valid YES-vote severities exceed this high-severity rate. Default: `0.90`.

--- a/skills/voter-calibration/scripts/test-voter-calibration.sh
+++ b/skills/voter-calibration/scripts/test-voter-calibration.sh
@@ -415,8 +415,10 @@ worktree="$FIX/worktree"
 mkdir -p "$worktree"
 cp -R "$FIX/larch-logs" "$worktree/larch-logs"
 git -C "$worktree" init -q
+default_status=0
 (
   cd "$worktree"
   env -u CLAUDE_PLUGIN_ROOT python3 "$ANALYZER" --min-votes 3 > "$FIX/default-root.md"
-)
-grep -Fq '| code-review | v1 | 4 | 0 | 4 | 0 | 0.000 | true |' "$FIX/default-root.md"
+) 2> "$FIX/default-root.err" || default_status=$?
+[[ "$default_status" -eq 2 ]]
+grep -Fq 'storage configuration is missing' "$FIX/default-root.err"

--- a/skills/voter-calibration/scripts/voter-calibration.md
+++ b/skills/voter-calibration/scripts/voter-calibration.md
@@ -4,13 +4,13 @@
 
 ## Inputs
 
-The analyzer scans these committed log patterns under `--log-root`:
+The analyzer scans these synchronized log patterns under the resolved corpus root:
 
-- `larch-logs/design/*/plan-review/round-*/findings-classification.tsv`
-- `larch-logs/implement/*/round-*/findings-classification.tsv`
-- `larch-logs/review/*/review-findings-classification-round-*.tsv`
+- `<corpus-root>/design/*/plan-review/round-*/findings-classification.tsv`
+- `<corpus-root>/implement/*/round-*/findings-classification.tsv`
+- `<corpus-root>/review/*/review-findings-classification-round-*.tsv`
 
-Default `--log-root` resolves to `<git toplevel>/larch-logs` when `git rev-parse --show-toplevel` succeeds. It falls back to `cwd/larch-logs` otherwise.
+By default, the analyzer resolves the current Git repository, requires `.larch/config.toml` or `LARCH_LOGS_URI`, synchronizes once, and reads the unpacked cache. `--log-root DIR` bypasses synchronization for offline fixture tests.
 
 ## Optional realized-outcome input
 

--- a/skills/voter-calibration/scripts/voter-calibration.py
+++ b/skills/voter-calibration/scripts/voter-calibration.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Analyze voter agreement, severity calibration, and chronic outliers from larch logs."""
+"""Analyze voter agreement, severity calibration, and chronic outliers from synchronized larch logs."""
 from __future__ import annotations
 
 import argparse
@@ -24,7 +24,7 @@ python_path = str(plugin_root / "python")
 if python_path not in sys.path:
     sys.path.insert(0, python_path)
 
-from larch.core import proc  # noqa: E402 - after sys.path manipulation
+from larch.core import proc, repo_roots  # noqa: E402 - after sys.path manipulation
 from larch.git import gh  # noqa: E402 - after sys.path manipulation
 from larch.issue._ground_truth import (  # noqa: E402
     _ground_truth_run_dir,
@@ -73,31 +73,22 @@ class CorpusStats:
     false_negative_rows: list[dict[str, object]] = field(default_factory=list)
 
 
-def _git_toplevel() -> Path | None:
-    proc = subprocess.run(
-        ["git", "rev-parse", "--show-toplevel"],
-        text=True,
-        capture_output=True,
-        check=False,
-    )
-    if proc.returncode != 0:
-        return None
-    value = proc.stdout.strip()
-    return Path(value) if value else None
-
-
-def _default_log_root() -> Path:
-    top = _git_toplevel()
-    if top is not None:
-        return top / "larch-logs"
-    return Path.cwd() / "larch-logs"
-
-
 def _read_text(path: Path) -> str:
     try:
         return path.read_text(encoding="utf-8", errors="replace")
     except OSError:
         return ""
+
+
+def _selected_log_root(raw_log_root: str) -> Path:
+    if raw_log_root:
+        return Path(raw_log_root).expanduser()
+    repo_root = repo_roots.consumer_repo_root()
+    if repo_root is None:
+        raise run_log_corpus.RunLogCorpusError(
+            "could not discover a Git repository root for run-log synchronization"
+        )
+    return run_log_corpus.synchronized_repository_log_root(repo_root=repo_root)
 
 
 def _discover(log_root: Path) -> list[tuple[str, Path]]:
@@ -679,7 +670,11 @@ def main(argv: list[str]) -> int:
     if args.era_since_date and not args.era:
         print("voter-calibration: --era-since-date requires --era", file=sys.stderr)
         return 2
-    log_root = Path(args.log_root).expanduser() if args.log_root else _default_log_root()
+    try:
+        log_root = _selected_log_root(args.log_root)
+    except run_log_corpus.RunLogCorpusError as exc:
+        print(f"voter-calibration: {exc}", file=sys.stderr)
+        return 2
     log_root = log_root.resolve()
     if not log_root.is_dir():
         print(f"voter-calibration: resolved log root is missing: {log_root}", file=sys.stderr)


### PR DESCRIPTION
Closes #7822

Summary:
- synchronize the configured run-log repository once before read-only analyzer scans
- reuse the unpacked cache across later scan waves while keeping mutable measurement and verdict state repository-owned
- preserve report results for identical run sets and add cache parity, fail-fast configuration, and one-sync coverage
- refresh the shipped plugin projection and analyzer documentation

Self-review:
- fixed difficulty calibration sidecar ownership
- migrated omitted measurement readers
- removed a duplicate synchronization path from cache-efficiency analysis
- preserved canonical report links when the physical corpus is outside the repository

Tests:
- 197 focused pytest tests
- fluff, voter, difficulty, and rejected-analysis harnesses
- changed-file pre-commit gate
- targeted pylint: 10.00/10
- run-log walker lint and plugin projection check