### PR TITLE
Fixes #7872: Close runtime projection link gaps

### DIFF
--- a/crates/larch-cli/src/release_plugin_runtime.rs
+++ b/crates/larch-cli/src/release_plugin_runtime.rs
@@ -15,6 +15,7 @@ const DIRECT_FILES: &[&str] = &[
     "SECURITY.md",
     "docs/analysis-state.md",
     "docs/configuration-and-permissions.md",
+    "docs/dev-hook-audit.md",
     "docs/difficulty-floor-globs.tsv",
     "docs/external-reviewers.md",
     "docs/git-operation-inventory.md",
@@ -23,6 +24,7 @@ const DIRECT_FILES: &[&str] = &[
     "docs/installation-and-setup.md",
     "docs/issue-anchored-plan.md",
     "docs/linting.md",
+    "docs/progress-reporting.md",
     "docs/python-migration.md",
     "docs/review-agents.md",
     "docs/run-log-archive.md",
@@ -30,6 +32,9 @@ const DIRECT_FILES: &[&str] = &[
     "docs/run-log-cli.md",
     "docs/run-logs-required-files.tsv",
     "docs/run-logs.md",
+    "docs/rust-async-runtime.md",
+    "docs/rust-parity-harness.md",
+    "docs/rust-testing.md",
     "docs/security/README.md",
     "docs/skills.md",
     "python/cli.py",
@@ -424,6 +429,11 @@ mod tests {
         assert!(paths.contains("docs/git-operation-inventory.md"));
         assert!(paths.contains("docs/github-service-inventory.md"));
         assert!(paths.contains("docs/google-service-inventory.md"));
+        assert!(paths.contains("docs/dev-hook-audit.md"));
+        assert!(paths.contains("docs/progress-reporting.md"));
+        assert!(paths.contains("docs/rust-async-runtime.md"));
+        assert!(paths.contains("docs/rust-parity-harness.md"));
+        assert!(paths.contains("docs/rust-testing.md"));
         assert!(paths.contains("docs/security/README.md"));
         assert!(paths.contains("docs/security/workflow.md"));
         assert!(paths.contains("hooks/hooks.json"));
@@ -533,6 +543,32 @@ mod tests {
             runtime_paths(&root),
             Err(
                 "plugin runtime projection inputs are missing: SECURITY.md, docs/security/README.md"
+                    .to_owned()
+            )
+        );
+    }
+
+    #[test]
+    fn rejects_missing_required_security_supporting_documents() {
+        let fixture = fixture();
+        run_git(
+            fixture.path(),
+            [
+                "rm",
+                "--cached",
+                "docs/dev-hook-audit.md",
+                "docs/progress-reporting.md",
+                "docs/rust-async-runtime.md",
+                "docs/rust-parity-harness.md",
+                "docs/rust-testing.md",
+            ],
+        );
+        let root = repository_root(fixture.path());
+
+        assert_eq!(
+            runtime_paths(&root),
+            Err(
+                "plugin runtime projection inputs are missing: docs/dev-hook-audit.md, docs/progress-reporting.md, docs/rust-async-runtime.md, docs/rust-parity-harness.md, docs/rust-testing.md"
                     .to_owned()
             )
         );

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -33,9 +33,10 @@ generation also scans shipped skill Markdown for `docs/security/*.md`
 references and fails if a target is absent. The same validation runs when CI
 generates the projection and checks it for byte-for-byte drift.
 
-The projection also includes `ARCHITECTURE.md` and the Git, GitHub, and Google
-service inventories linked by the focused supply-chain reference. Those links
-therefore resolve in both a source checkout and an installed plugin.
+The projection also includes `ARCHITECTURE.md`, its linked Rust references, the
+Git, GitHub, and Google service inventories, and the operator documents linked
+by the focused security references. Those links therefore resolve in both a
+source checkout and an installed plugin.
 
 `crates/larch-cli/src/release_plugin_runtime.rs` is the single implementation
 owner.

--- a/docs/security/artifacts-redaction-and-publication.md
+++ b/docs/security/artifacts-redaction-and-publication.md
@@ -2,8 +2,8 @@
 
 This document is the canonical security reference for larch artifacts,
 redaction, diagnostics, secret scanning, retention, and publication. Root
-[`SECURITY.md`](../../SECURITY.md) keeps the public summary and stable
-compatibility headings. [Larch Run Logs](../run-logs.md) owns the detailed
+[`SECURITY.md`](../../SECURITY.md) keeps the public summary. [Larch Run
+Logs](../run-logs.md) owns the detailed
 committed-file selection and batch contracts.
 
 The rules here classify data by where it may go. Redaction and scanning are

--- a/docs/security/supply-chain-credentials-and-services.md
+++ b/docs/security/supply-chain-credentials-and-services.md
@@ -3,8 +3,7 @@
 This document is the canonical security reference for larch release provenance,
 dependency controls, bootstrap and upgrade verification, credential handling,
 transport policy, and typed external service boundaries. The root
-[`SECURITY.md`](../../SECURITY.md) keeps the public summary and stable
-compatibility headings.
+[`SECURITY.md`](../../SECURITY.md) keeps the public summary.
 
 Use the existing operational and architecture documents with this reference:
 

--- a/plugin/docs/dev-hook-audit.md
+++ b/plugin/docs/dev-hook-audit.md
@@ -1,0 +1,177 @@
+# Dev-only PostToolUse audit log
+
+Contributor-only debugging aid that records a JSONL audit trail of every
+`Edit` and `Write` tool invocation Claude Code makes in this project.
+
+`scripts/audit-edit-write.sh` is shipped as part of the larch plugin
+(it lives in the plugin install tree), but it is **not registered or
+enabled by default**. It only runs when a contributor opts in locally
+by adding a `PostToolUse` entry to `.claude/settings.local.json`
+(which is gitignored — see `.gitignore`).
+
+## Enable
+
+Paste one of the two snippets below into `.claude/settings.local.json`
+(create the file if it does not exist — the rest of the file can stay
+untouched). Pick the snippet that matches how you have larch available:
+
+### In-repo dev (editing the larch repo itself)
+
+If you are a larch contributor working inside a clone of this repo and
+your shell cwd is the repo root, `$PWD/scripts/audit-edit-write.sh`
+resolves correctly:
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$PWD/scripts/audit-edit-write.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### Installed plugin (larch installed into another project)
+
+If larch is installed as a plugin in a consumer repo, `$PWD` is the
+consumer project root and will not resolve the larch helper. Use
+`${CLAUDE_PLUGIN_ROOT}/scripts/audit-edit-write.sh` instead — this is
+the same resolution pattern used by `hooks/hooks.json` for the shipped
+PreToolUse hooks:
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/audit-edit-write.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Restart Claude Code (or reload the session). Subsequent `Edit` / `Write`
+tool calls will append a JSONL line to `.claude/hook-audit.log` in the
+project where Claude Code is running (honoring `CLAUDE_PROJECT_DIR`).
+
+## Log format
+
+One JSON object per line:
+
+| Field     | Type   | Meaning                                                  |
+|-----------|--------|----------------------------------------------------------|
+| `ts`      | string | UTC timestamp, ISO-8601 (e.g. `2026-04-19T18:44:12Z`)    |
+| `event`   | string | Always `"PostToolUse"`                                   |
+| `payload` | object | Full hook stdin as emitted by Claude Code                |
+
+The `payload` object is whatever Claude Code sent to the hook on stdin
+— typically an object containing `tool_name`, `tool_input`, and
+related metadata. No fields are stripped or redacted.
+
+Example:
+
+```json
+{"ts":"2026-04-19T18:44:12Z","event":"PostToolUse","payload":{"tool_name":"Edit","tool_input":{"file_path":"/Users/you/repo/file.go","old_string":"...","new_string":"..."}}}
+```
+
+## Disable
+
+Remove the `PostToolUse` entry from `.claude/settings.local.json`
+(or delete the file entirely if it contained nothing else).
+
+## Rotate / clear the log
+
+The script only appends. To clear without deleting the file:
+
+```bash
+truncate -s 0 .claude/hook-audit.log
+```
+
+Or remove it outright:
+
+```bash
+rm .claude/hook-audit.log
+```
+
+There is no automatic rotation — the log grows until you clear it.
+
+## Privacy
+
+**The log is sensitive.** The `payload` object captures `tool_input`,
+which includes:
+
+- **Full file paths** Claude Code edited or wrote (may expose private
+  project layout, user directories, temp file locations).
+- **Full file contents** for `Write` (the `content` field), and the
+  **before/after strings** for `Edit` (the `old_string` / `new_string`
+  fields). These may contain secrets, personally identifiable
+  information, or proprietary code.
+
+The log is gitignored by default (`.gitignore` lists
+`.claude/hook-audit.log`), but the raw file on disk is the developer's
+responsibility:
+
+- **Never commit it.**
+- **Never paste its contents into an issue, pull request, screenshot,
+  or screen share.**
+- **Clear it after debugging**: `truncate -s 0 .claude/hook-audit.log`.
+- If you enable this hook on a project that handles secrets (e.g.
+  editing `.env`, private keys, credentials), consider the log itself
+  a secret-bearing artifact with the same retention discipline.
+
+See the canonical
+[private-session-state and diagnostic policy](security/artifacts-redaction-and-publication.md#private-session-state-and-retention)
+for the project's security posture on this audit log.
+
+## Concurrency note
+
+Under parallel tool use, two `PostToolUse` hook invocations may run
+concurrently. Shell `>>` append is best-effort: if two writes
+interleave their bytes, **a line can be corrupted** (not merely
+omitted), producing a physically malformed JSON record.
+
+Consumers parsing the log should tolerate parse errors on individual
+lines rather than aborting on the first error. A streaming `jq …
+file.log` does NOT skip malformed records — it aborts the whole run at
+the first parse error. Read one line at a time instead, e.g.:
+
+```bash
+# Process each line independently; skip any that fail to parse.
+while IFS= read -r line; do
+    printf '%s\n' "$line" | jq -ec 'select(.event == "PostToolUse")' 2>/dev/null || true
+done < .claude/hook-audit.log
+```
+
+Or use `jq -R 'fromjson? | select(.event == "PostToolUse")' .claude/hook-audit.log`
+which parses each input line as a raw string first and silently drops
+lines where `fromjson` fails to parse — the `?` operator suppresses
+the parse error and emits no output for that line, so `select` never
+sees a malformed record.
+
+Line locking (`flock`) is intentionally not implemented — for a
+contributor-local debugging aid, the added complexity outweighs the
+occasional corrupted line.
+
+## Testing
+
+`scripts/test-audit-edit-write.sh` is the regression harness. It uses
+`mktemp -d` plus `CLAUDE_PROJECT_DIR` override so the test never
+touches the repo's real `.claude/hook-audit.log`. Wired into
+`make lint` via the `test-audit-edit-write` target.

--- a/plugin/docs/progress-reporting.md
+++ b/plugin/docs/progress-reporting.md
@@ -1,0 +1,46 @@
+# Progress reporting
+
+Larch installs a clone-local Claude Code statusline so long `/design`, `/implement`, and review phases can show progress without adding text to the conversation.
+
+## What appears
+
+The statusline reads the latest breadcrumb for the current clone and active run ID, then renders it in yellow:
+
+```text
+larch 14:03: [implement 5] Step 5 — code review started
+```
+
+Breadcrumbs are one-line human events, not bare counters. For example, review code should write `reviewers 7/12 done`, not `reviewers 7/12`. Breadcrumbs identify GitHub entities by number, such as `PR #6626`, and do not include URLs.
+
+Statusline breadcrumbs are local operator diagnostics, not committed run-log
+breadcrumbs or public reports. Keep private paths, hosts, credentials, personal
+data, and repository content out of event text. See the canonical
+[operator-diagnostic classification](security/artifacts-redaction-and-publication.md#operator-visible-diagnostics).
+
+## Run-scoped storage
+
+Breadcrumbs are scoped by clone and active run ID. The active pointer is `~/.cache/larch/progress/<clone-hash>/current`, and the active breadcrumb log is `~/.cache/larch/progress/<clone-hash>/<run-id>/breadcrumbs.log`.
+
+Default writers require a valid `current` pointer. When the clone progress directory, pointer, run ID, run directory, or log path is missing, invalid, unreadable, corrupt, or symlinked, default writes no-op fail silent. The explicit `progress note --run-id` override writes the named run log without changing `current`.
+
+The reader follows `current` through a no-create fd-relative clone-directory traversal and tails only the active run log. Legacy flat `<clone-hash>.log` files are ignored. A fresh run starts empty because `activate_run` points `current` at a new run directory. Activation and deactivation share a clone-local lock. Deactivation requires the expected run ID and clears `current` only when that ID still owns the pointer, so delayed cleanup from an older run cannot remove a newer run.
+
+Fresh Claude session starts capture the active run ID and use the same compare-and-clear operation before statusline installation. This prevents stale prior-run breadcrumbs from appearing before a new run starts. The first visible larch statusline entry after a fresh session should come from the new run's first breadcrumb. Resume and compact events preserve `current` to avoid hiding active foreground work. Only a live, in-budget bgjob whose canonical clone and recorded run ID both match the active pointer protects that pointer from SessionStart reset. The reset deletes only `current`; run directories and `breadcrumbs.log` files remain available for cleanup and audit.
+
+Larch assumes one active larch run per clone. It does not add concurrency semantics for simultaneous `/design` and `/implement` runs in the same checkout.
+
+## Installation and opt out
+
+Session setup and the `SessionStart` hook idempotently merge a larch-owned `statusLine` command into `.claude/settings.local.json` for the current clone. The project-local setting uses `refreshInterval: 2` and a stable launcher at `~/.cache/larch/statusline.sh`.
+
+Set `LARCH_STATUSLINE_DISABLE=1` before session start to skip installation. If `.claude/settings.local.json` contains invalid JSON, a symlinked target, or a non-larch local `statusLine`, larch leaves it untouched.
+
+If you already have a user-scope statusline, larch chains it first and appends larch output. A local non-larch statusline wins and is not overwritten.
+
+## Staleness
+
+Progress files live under `~/.cache/larch/progress/`. The reader is fail silent: missing, empty, unreadable, or corrupt active-run state produces empty stdout and exit 0. When the active run log is old and no live, in-budget bgjob registry row matches both the clone and active run ID, the statusline appends `(stale Nm)`; well after the stale threshold it renders nothing. Prior run logs do not affect staleness unless `current` points at that run.
+
+## Detailed reports
+
+The detailed end-of-run review Gantt remains available through the final-report `render-phase-detail` surface. The old typed `p` / `progress` prompt hook and `progress report` command are retired; the statusline replaces them for live progress.

--- a/plugin/docs/rust-async-runtime.md
+++ b/plugin/docs/rust-async-runtime.md
@@ -1,0 +1,99 @@
+# Rust Async Runtime
+
+Larch uses one Tokio runtime per `larch` process. `larch-cli` owns that runtime
+as part of the composition root. Synchronous command parsing may call
+`LarchRuntime::block_on` once, at the top level. Libraries and command handlers
+must stay asynchronous and must not create or nest runtimes.
+
+## Decision
+
+Use Tokio 1.53.0 with only the I/O utility, macros, process, runtime, signal,
+synchronization, test-time, and time features. Use `tokio-util` 0.7.18 for
+hierarchical cancellation tokens. Both crates are maintained, pure Rust, MIT
+licensed, and support an older Rust version than larch requires.
+
+Tokio owns the facilities larch needs as one integrated stack: a multi-thread
+executor, deterministic timers, signals, synchronization, and task sets. Later
+process and I/O leaves may add their Tokio features only when they add a real
+consumer.
+
+Rejected alternatives:
+
+- `async-std` 1.13.2 is deprecated in favor of `smol`.
+- `smol` 2.0.2 is small, but larch would need separate crates and ownership
+  conventions for signals, process handling, cancellation, and task tracking.
+- A custom standard-library executor would duplicate scheduling, waking,
+  timers, and platform signal behavior without improving larch's contracts.
+
+## Cancellation and deadlines
+
+Every command creates one root `Cancellation`. Each concurrent operation gets
+a child token. Cancellation flows from parent to child, never from child to
+parent or sibling. Cancellation is cooperative. Async loops and external I/O
+must observe their token at bounded intervals.
+
+`run_until` gives cancellation priority over a simultaneously ready timeout.
+Timeouts remain caller-owned policy. A shared primitive never chooses a domain
+timeout. `larch-core` defines injectable `BusinessClock`, `MonotonicClock`, and
+`AsyncClock` ports. A propagated `Deadline` can create a shorter child deadline
+but can never outlive its parent. Production adapters use `SystemClock` for
+business timestamps and `TokioClock` for deadlines and sleeps.
+
+`RetryExecutor` owns the async retry loop. Domain code classifies typed errors
+as a closed `RetryDecision`; usage, authorization, and known permanent failures
+stop without another attempt. `RetryPolicy::default` owns the bounded attempt
+and full-jitter exponential-backoff defaults. Callers inject the jitter source,
+clock, cancellation token, optional deadline, and observation sink. Retry
+observations contain only closed classes, attempt counts, and bounded delays.
+They never contain the operation error or response payload.
+
+## Task ownership and concurrency
+
+Use `TaskSet` for concurrent work. Its non-zero capacity is the explicit
+concurrency bound. The caller owns the set and must join results or call
+`shutdown`. Dropping a set cancels and aborts its tasks, so a library task
+cannot detach from its owner.
+
+Shutdown follows one sequence:
+
+1. Cancel the task-set token.
+2. Allow cooperative cleanup until the caller's grace period expires.
+3. Abort remaining tasks.
+4. Join every task and return completion, abort, and panic counts.
+
+Use a separate `TaskSet` for each ownership domain. Do not place unrelated
+background jobs and request work in one set merely to share a limit.
+
+## Signals and child processes
+
+The composition root listens for SIGINT and, on Unix, SIGTERM. The first signal
+cancels the command root. Normal task-set shutdown then enforces the command's
+grace period.
+
+The process adapter must implement `ChildProcess` for an owned child process
+group. It must capture group identity at spawn time. On cancellation it asks
+the group to stop, waits for the caller's grace period, kills the group if
+needed, and reaps the child. Persisted process identities require the
+[local mutation safety](security/workflow-trust-and-mutations.md#local-mutation-safety)
+re-verification rules before any signal. The generic
+`shutdown_child` helper owns only the graceful, deadline, force, and reap
+sequence. It does not choose platform signals or accept arbitrary process IDs.
+
+`TokioProcessRunner` is the sole product owner of process construction. The
+core `ExternalProcessRunner` port accepts a typed executable and argument
+array, never a command string. The request owns an absolute working directory,
+typed environment overrides, stdin bytes, per-stream capture limit, timeout,
+and shutdown grace period. The adapter clears the ambient environment and
+copies only common allowlisted keys. Vendor credentials require an explicit
+typed override and never enter the common inheritance list. On Unix, each
+child starts in its own process group; cancellation and timeout send SIGTERM
+to the group, escalate to SIGKILL, and reap the direct child. Other platforms
+use Tokio's safest available direct-child kill and reap path.
+
+## Deterministic tests
+
+Production uses the multi-thread runtime. Tests use
+`LarchRuntime::paused_current_thread`. Tokio advances paused time only when no
+other work can make progress, so timeout and cleanup tests complete without
+wall-clock sleep. Inject futures and `ChildProcess` fakes at boundaries. Do not
+mock Tokio's scheduler or use global runtime state.

--- a/plugin/docs/rust-parity-harness.md
+++ b/plugin/docs/rust-parity-harness.md
@@ -1,0 +1,64 @@
+# Rust Parity Harness
+
+The black-box parity harness lives in
+`crates/larch-cli/tests/support/parity.rs`. It runs a Python command and its
+Rust replacement in separate temporary roots. Both roots start with the same
+seed files. The harness compares:
+
+- exit code, stdout, and stderr;
+- every regular file, including binary files and non-UTF-8 output streams;
+- declared UTF-8 side-effect records, such as fake service call logs.
+
+A mismatch reports only the differing channels and truncates large values.
+It reports mismatched file paths as whole units and names how many paths it
+omitted when the bounded diagnostic fills. Each child has a 30-second default
+timeout. A case may select a shorter or longer explicit timeout.
+The harness rejects symlinks, special files, absolute fixture paths, and path
+traversal.
+
+## Service isolation
+
+Children start with a cleared environment. The harness supplies isolated
+home, temporary, cloud-config, and executable directories. It removes inherited
+credentials and points standard GitHub and proxy variables at a closed
+loopback endpoint. A case cannot override credential, service-host, or proxy
+variables. Commands that need GitHub or cloud behavior must use a fixture
+executable or local fixture service and record each permitted call.
+
+This boundary prevents accidental live access through normal clients. It is
+not a security sandbox for hostile test code that opens a hard-coded socket.
+Parity cases must not use direct network APIs.
+
+## Normalization
+
+Normalization is opt-in per case. The harness supports only these rules:
+
+- `SandboxRoot` replaces that command's temporary root with `<SANDBOX>`.
+- `Rfc3339Utc` replaces complete UTC timestamps such as
+  `2026-07-18T20:00:00.123Z` with `<TIMESTAMP>`.
+
+Rules apply to stdout, stderr, text files, and side-effect records. Binary
+files remain byte-exact. Add a new rule only for documented nondeterminism and
+cover its exact match boundary with a test. Do not normalize semantic values.
+
+## Add a parity case
+
+Add a `ParityCase` to a `larch-cli` integration test. Supply absolute Python
+and Rust executable paths, arguments, environment values, seed files, declared
+side-effect record paths, and the smallest needed normalization rule set. Use
+`{sandbox}` in an argument or environment value when the command needs its
+isolated root. Call `assert_case` with a checked-in golden path.
+
+`fixtures/rust-parity/` demonstrates clean, usage-error, malformed-input,
+environmental-failure, and service-isolation cases. The clean case also covers
+text and binary files, side-effect records, temporary paths, and timestamps.
+
+Review a contract change before updating its golden. After Python and Rust
+match, refresh goldens with:
+
+```bash
+LARCH_UPDATE_PARITY_GOLDENS=1 cargo test --locked --package larch-cli --test parity
+```
+
+Inspect and commit the resulting `*.golden.json` diff. CI never sets the
+update variable, so an unreviewed contract change fails.

--- a/plugin/docs/rust-testing.md
+++ b/plugin/docs/rust-testing.md
@@ -1,0 +1,141 @@
+# Rust Testing
+
+Rust tests must be deterministic, offline by default, and safe under Cargo's
+parallel test runner. Use `larch-test-support` from integration tests and from
+crate-local tests where the dependency graph permits it.
+
+## Shared fixtures
+
+- `TestWorkspace` owns a temporary root. It rejects absolute paths and dot
+  segments, rejects symlink traversal, creates parents, and removes the root
+  on drop.
+- `TestEnvironment` builds a complete child environment without changing the
+  test process. Call `env_clear` before applying its iterator to a command.
+- `TestClock` implements the core wall, monotonic, and async clock ports.
+  Sleeps advance injected time without waiting.
+- `FakeProcessRunner` records typed requests and returns queued outcomes.
+  `ProcessOutputBuilder` creates byte-exact success and failure results.
+- `HttpResponseBuilder` creates in-memory responses and rejects invalid status
+  codes, header names, and header line injection.
+- `GitRepository::builder` creates an owned repository through installed Git.
+  `GitFixture` names the shared unborn, detached, refs, changes, conflict,
+  non-UTF-8 path, special-file, attributes and filters, sparse-checkout,
+  submodule, linked-worktree, hooks and signing, remotes, and corruption states.
+  Select `GitObjectFormat::Sha1` or `GitObjectFormat::Sha256`. Match
+  `GitFixtureError::Skip` and print its `FixtureCapability` and reason when the
+  host lacks a feature. Never turn a capability skip into an unreported early
+  return.
+
+Never call `set_current_dir`, `set_var`, or `remove_var` in a test. Do not use a
+shared fixed path, port, clock, response queue, or mutable static. Give each
+test its own fixture and let Cargo run it in parallel.
+
+## Git oracle and semantic snapshots
+
+Git fixtures may invoke installed Git as a test oracle. `GitRepository` finds
+the executable once, then clears the child environment and supplies an owned
+home, temp directory, config, identity, dates, locale, and path. Commands set
+only the child working directory. Fixture code must not change the test
+process environment or working directory. Product crates must still use the
+closed Git interfaces described in `ARCHITECTURE.md`; the fixture API does not
+authorize a production arbitrary-argument Git runner.
+
+Repository read differential tests exercise the public `RepositoryRead` port
+through `GixRepository`. Compare typed IDs, ref targets, config provenance,
+URLs, worktree records, and error classes with parsed Git oracle results. Path
+comparisons may normalize filesystem aliases such as macOS `/var` and
+`/private/var`, but the adapter result must retain its original path bytes.
+For status and change sets, compare staged, unstaged, untracked, ignored, and
+unmerged paths plus change kinds, modes, IDs, conflict stages, and flags. Cover
+pathspec and case configuration, filters and CRLF, sparse indexes, submodules,
+non-UTF-8 paths, symlinks, executable bits, and configured rewrite behavior.
+An unsupported semantic must return its typed error instead of dropping data.
+
+Use `SemanticSnapshot::capture` after each implementation runs against its own
+equivalent repository. Supply the operation's public result through
+`ExecutionSnapshot`. Compare the typed snapshots first. Use
+`SemanticSnapshot::render` only for a checked-in review artifact. The
+`larch-git-snapshot-v1` format captures:
+
+- exit class and bounded public stdout and stderr;
+- object IDs and types, refs, reflogs, index stages and modes, index flags,
+  and byte-preserving untracked and ignored paths;
+- worktree bytes, modes, symlinks, linked-worktree records, operation-state
+  files, relevant config, and hook or helper transcripts;
+- an independent `git fsck --full --no-dangling` result.
+
+Each byte field stores at most 1 MiB plus its full length, truncation state,
+and deterministic checksum. Each filesystem section stores at most 4,096
+entries and records section truncation. Rendered paths and bytes use lowercase
+hex. Capture replaces the owned temporary root with `<ROOT>` and redacts
+credential-bearing config and URL user information. Do not add normalization
+for object IDs, modes, paths, repository state, or other semantic values.
+
+Snapshot reviews must explain every changed semantic field. Update a checked-in
+render only after both implementations produce the intended state. Test
+success, injected failure, interruption, and corruption separately. A failed
+Git probe remains snapshot data so corrupt repositories stay comparable.
+
+Normal Git tests remain offline. Use local repositories for remotes and
+submodules. Use fixture scripts for hooks, filters, credential helpers,
+askpass, signing programs, and other child tools. Store their bounded
+transcripts under `GitRepository::transcript_root`; never use live credentials
+or a remote URL that can resolve to a service. Run the named fixture matrix on
+macOS and Linux. Capability skips must name the missing feature and host error
+in test output.
+
+The final ownership gate runs in the same cross-platform Rust lane. Focused
+coverage is `cargo test --locked --package larch-lint --test git_ownership`.
+It injects direct process creation, arbitrary Git arguments, `gix` bypasses,
+duplicate owners, a new CLI exception, non-atomic command state, and inventory
+drift. The adapter and CLI suites supply the SHA-1/SHA-256, case, path, filter,
+hook, credential, worktree, interruption, recovery, and `git fsck` fixtures.
+
+## Test boundaries
+
+- Unit tests live in a crate-local `#[cfg(test)]` module. They cover private
+  logic through injected ports. Use an owned workspace if filesystem state is
+  part of the behavior; never use the ambient working directory.
+- Integration tests live directly under a crate's `tests/` directory. They
+  cover the public crate boundary and may use owned filesystem fixtures.
+- Golden tests compare complete user-facing or wire-format bytes under
+  `fixtures/`. Update goldens only for an intentional, reviewed contract
+  change. Keep the update switch opt-in and disabled in CI.
+- Property tests cover parsers, codecs, path rules, and other broad input
+  spaces. Fix the generator seed in failure output and keep shrinking enabled.
+  A property test complements named boundary examples; it does not replace
+  them.
+- Live-smoke tests exercise a real remote service or vendor executable. Mark
+  them ignored by default, require an explicit opt-in, and never run them in
+  normal pull-request CI.
+
+Normal unit, integration, golden, property, and coverage runs cannot access an
+external network. Use injected HTTP responses. A transport adapter test may
+bind an ephemeral loopback port when it must exercise socket framing; it cannot
+resolve DNS or contact a non-loopback address.
+
+Do not depend on an installed executable unless the test covers an approved
+executable compatibility boundary. The process adapter may invoke Git, and the
+parity harness may invoke its documented Python and Rust fixture programs.
+Everything else uses `FakeProcessRunner`. Real Claude, Codex, Cursor, service
+credentials, and remote endpoints belong only in explicit live-smoke runs.
+
+## Coverage and CI
+
+Install the pinned tool with `make rust-coverage-install`. Run
+`make rust-coverage` to print the workspace summary, enforce the measured line
+baseline, and write `target/llvm-cov/lcov.info`.
+
+The baseline is 87.377% lines. This was the measured unrounded floor when the
+policy was introduced. It is a no-regression floor, not a chosen repository
+target. Raise it when coverage
+improves. Lower it only with a documented reason and issue. Coverage excludes
+the shared test-support crate, `tests/` and `fixtures/` trees, and build scripts.
+Keep that exclusion expression in the Makefile so local and CI reports match.
+
+The Rust suite remains one workspace test lane while it is fast. When it needs
+partitioning, shard by Cargo package rather than test-name or source-file
+globs. Assign every package to exactly one test shard, keep `--all-features`
+and `--locked` on each shard, and retain one unsharded workspace coverage run.
+Use recorded CI duration to balance package groups. Keep `rust-gate` as the
+stable aggregate check when the internal shard count changes.

--- a/plugin/docs/security/README.md
+++ b/plugin/docs/security/README.md
@@ -33,9 +33,10 @@ generation also scans shipped skill Markdown for `docs/security/*.md`
 references and fails if a target is absent. The same validation runs when CI
 generates the projection and checks it for byte-for-byte drift.
 
-The projection also includes `ARCHITECTURE.md` and the Git, GitHub, and Google
-service inventories linked by the focused supply-chain reference. Those links
-therefore resolve in both a source checkout and an installed plugin.
+The projection also includes `ARCHITECTURE.md`, its linked Rust references, the
+Git, GitHub, and Google service inventories, and the operator documents linked
+by the focused security references. Those links therefore resolve in both a
+source checkout and an installed plugin.
 
 `crates/larch-cli/src/release_plugin_runtime.rs` is the single implementation
 owner.

--- a/plugin/docs/security/artifacts-redaction-and-publication.md
+++ b/plugin/docs/security/artifacts-redaction-and-publication.md
@@ -2,8 +2,8 @@
 
 This document is the canonical security reference for larch artifacts,
 redaction, diagnostics, secret scanning, retention, and publication. Root
-[`SECURITY.md`](../../SECURITY.md) keeps the public summary and stable
-compatibility headings. [Larch Run Logs](../run-logs.md) owns the detailed
+[`SECURITY.md`](../../SECURITY.md) keeps the public summary. [Larch Run
+Logs](../run-logs.md) owns the detailed
 committed-file selection and batch contracts.
 
 The rules here classify data by where it may go. Redaction and scanning are

--- a/plugin/docs/security/supply-chain-credentials-and-services.md
+++ b/plugin/docs/security/supply-chain-credentials-and-services.md
@@ -3,8 +3,7 @@
 This document is the canonical security reference for larch release provenance,
 dependency controls, bootstrap and upgrade verification, credential handling,
 transport policy, and typed external service boundaries. The root
-[`SECURITY.md`](../../SECURITY.md) keeps the public summary and stable
-compatibility headings.
+[`SECURITY.md`](../../SECURITY.md) keeps the public summary.
 
 Use the existing operational and architecture documents with this reference:
 


### PR DESCRIPTION
## Summary

- ship the five operator and Rust references required by the installed security documentation
- make those files required inputs of the canonical Rust runtime projection
- add fail-closed projection coverage for the complete supporting-document set
- remove obsolete compatibility-heading wording and refresh the canonical packaging contract
- regenerate the checked runtime projection

## Architecture

- Reuses `crates/larch-cli/src/release_plugin_runtime.rs` as the sole projection owner.
- Adds mechanical coverage for the defect class.
- Does not change runtime security behavior or command ownership.
- No architectural invariant or guideline deviation.

## Validation

- `cargo test --locked --package larch-cli release_plugin_runtime` (10 passed)
- `cargo clippy --locked --package larch-cli --all-targets -- -D warnings`
- `cargo run --quiet --locked --package larch-cli -- release plugin-runtime --check`
- changed-file Markdown lint
- `python3 python/cli.py checks run-relevant --site local --tmpdir <validated-session-tmpdir>`
- projection source-copy parity and affected-link checks
- `git diff --check`

## Self-review

An unbiased post-validation review found no additional defects. It rechecked scope, source-to-projection parity, affected runtime links, test sensitivity, and the applicable architectural rules.

Fixes #7872
