### PR TITLE
Fixes #7874: Test Git fixtures on release targets

### DIFF
--- a/.github/workflows/rust-release-assets.yaml
+++ b/.github/workflows/rust-release-assets.yaml
@@ -127,7 +127,7 @@ jobs:
           EXPECTED_ARCHITECTURE: ${{ matrix.architecture }}
         run: |
           set -euo pipefail
-          cargo test --locked --package larch-cli --target "$TARGET"
+          cargo test --locked --package larch-test-support --package larch-adapters --package larch-cli --target "$TARGET"
           cargo build --locked --release --package larch-cli --target "$TARGET"
           binary="target/$TARGET/release/larch"
           file "$binary" | grep -F "$EXPECTED_ARCHITECTURE"
@@ -171,7 +171,7 @@ jobs:
             "$CONTAINER_IMAGE" \
             bash -euo pipefail -c '
               export PATH="/root/.cargo/bin:$PATH"
-              cargo test --locked --package larch-cli --target "$TARGET"
+              cargo test --locked --package larch-test-support --package larch-adapters --package larch-cli --target "$TARGET"
               cargo build --locked --release --package larch-cli --target "$TARGET"
               binary="target/$TARGET/release/larch"
               file "$binary" | grep -F "$EXPECTED_ARCHITECTURE"

--- a/python/tests/release/test_assets.py
+++ b/python/tests/release/test_assets.py
@@ -33,11 +33,19 @@ def test_release_workflow_prepares_platform_smoke_test_prerequisites() -> None:
 
     sign = 'codesign --force --sign - --timestamp=none "$binary"'
     verify = 'codesign --verify --verbose=2 "$binary"'
-    cargo_test = 'cargo test --locked --package larch-cli --target "$TARGET"'
+    cargo_test = (
+        "cargo test --locked --package larch-test-support --package larch-adapters "
+        '--package larch-cli --target "$TARGET"'
+    )
+    cli_only_test = 'cargo test --locked --package larch-cli --target "$TARGET"'
+    cargo_build = 'cargo build --locked --release --package larch-cli --target "$TARGET"'
     linux_path = 'export PATH="/root/.cargo/bin:$PATH"'
     assert macos_step.index(sign) < macos_step.index(verify)
     assert linux_path in linux_step
-    assert cargo_test in linux_step
+    assert macos_step.index(cargo_test) < macos_step.index(cargo_build)
+    assert linux_step.index(cargo_test) < linux_step.index(cargo_build)
+    assert cli_only_test not in macos_step
+    assert cli_only_test not in linux_step
 
 
 def test_release_workflow_verifies_draft_assets_by_release_id() -> None:


### PR DESCRIPTION
Closes #7874

## Summary

- run `larch-test-support`, `larch-adapters`, and `larch-cli` tests on every supported release target
- preserve the existing target-specific build, signing, binary, and GNU baseline checks
- strengthen the release workflow contract test for both platform branches and reject CLI-only regression

## Architecture review

- reviewed `ARCHITECTURAL_INVARIANTS.md`; no violation found
- reviewed `ARCHITECTURAL_GUIDELINES.md`; no deviation required
- retained one release-workflow owner and extended its existing structural contract test

## Self-review

Reviewed the complete diff independently for target behavior, release-gate risk, contract strength, and unrelated artifact changes. No findings remained. Both platform branches use the same package set before the release build, and artifact construction and verification are unchanged.

## Tests

- `PYTHONPATH=python python3 -m pytest -q python/tests/release/test_assets.py`
- `pre-commit run --files .github/workflows/rust-release-assets.yaml python/tests/release/test_assets.py`
- `cargo test --locked --package larch-test-support --package larch-adapters --package larch-cli --target aarch64-apple-darwin`
