### PR TITLE
Fixes #7880: Restore release bootstrap and clean-main checks

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -7,7 +7,11 @@ allowed-tools: AskUserQuestion, Bash, Skill
 disable-model-invocation: true
 ---
 
-**MANDATORY: Follow the complete shared lifecycle contract in `$PWD/skills/shared/run-lifecycle.md` with declared skill `release`.**
+**MANDATORY: Follow the complete shared lifecycle contract in `${CLAUDE_PLUGIN_ROOT}/skills/shared/run-lifecycle.md` with declared skill `release`.**
+
+This is a dev-only checkout skill. If `CLAUDE_PLUGIN_ROOT` is unset, substitute
+the repository root (`$PWD`) for that placeholder in the lifecycle command;
+the lifecycle start remains the first command.
 
 # Release
 

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools: AskUserQuestion, Bash, Skill
 disable-model-invocation: true
 ---
 
-**MANDATORY: Follow the complete shared lifecycle contract in `${CLAUDE_PLUGIN_ROOT}/skills/shared/run-lifecycle.md` with declared skill `release`.**
+**MANDATORY: Follow the complete shared lifecycle contract in `$PWD/skills/shared/run-lifecycle.md` with declared skill `release`.**
 
 # Release
 
@@ -21,25 +21,21 @@ Parse from `$ARGUMENTS` before any Bash helper runs. All boolean flags default t
 
 | Flag | Purpose |
 |------|---------|
-| `--dry-run` | Compute and preview only; exit before any write (no branch, PR, merge, tag, Release, promote, or `/upgrade-larch`) |
+| `--dry-run` | Compute and preview only; the ignored working-tree Rust build may refresh, but no branch, PR, merge, tag, Release, promote, or `/upgrade-larch` write occurs |
 | `--skip-approve`, `-s` | Skip Step 4 approval only when `PR_COUNT>0`, acting as Confirm |
 | `--bump major\|minor\|patch` | Override the aggregate bump type from `release prepare` |
 | `--repo OWNER/REPO` | Hub repo for `gh` (default: `scripts/larch.sh gh resolve-repo`, falling back to `character-ai/larch`) |
 
 ## Step 1 — Parse flags and guard
 
-Resolve `REPO` when `--repo` is omitted:
-
-```bash
-REPO=$("${CLAUDE_PLUGIN_ROOT:-$PWD}/scripts/larch.sh" gh resolve-repo 2>/dev/null || echo "character-ai/larch")
-```
-
 Guard (abort before prepare):
 
 - Current branch MUST be `main` (including when `--dry-run`).
 - Working tree MUST be clean (`git status --porcelain` empty), except `--dry-run` may run with a dirty tree only when the operator accepts inconsistent preview output.
 
-On failure, print a clear operator-visible error and stop.
+On failure, print a clear operator-visible error and stop. Run this raw Git guard before building the working-tree Rust driver, so a refused invocation does not refresh ignored build artifacts.
+
+After the guard passes, build the exact current checkout before its first Rust-backed release command. Always invoke that driver through `scripts/larch.sh`; the explicit environment supplies bootstrap identity without depending on an installed plugin root or a stale same-version binary. Resolve `REPO` through the verified driver when `--repo` was omitted.
 
 **Sync with `origin/main`** (after branch + tree guards pass, non-dry-run only). On `--dry-run`, do not fetch, fast-forward, or otherwise mutate local `main` or the worktree. On non-dry-run, fetch `origin/main` and fast-forward local `main` only when it is strictly behind `origin/main`; refuse (do not rebase) when local `main` has unpublished commits or has diverged, then continue to Step 2 and let `release prepare` report `ERROR=stale-local-main` if the cached refs still show a stale checkout.
 
@@ -85,6 +81,13 @@ else
   sync_out="DRY_RUN_SYNC_SKIPPED=true"
   sync_rc=0
 fi
+if [ "$sync_rc" -eq 0 ] || [ "$sync_rc" -eq 3 ]; then
+  WORKTREE_LARCH="$PWD/target/release/larch"
+  cargo build --quiet --locked --release --package larch-cli
+  if [ -z "${REPO:-}" ]; then
+    REPO=$(CLAUDE_PLUGIN_ROOT="$PWD" LARCH_BINARY="$WORKTREE_LARCH" "$PWD/scripts/larch.sh" gh resolve-repo 2>/dev/null || echo "character-ai/larch")
+  fi
+fi
 ```
 
 Branch on `sync_rc`:
@@ -98,7 +101,8 @@ On **`--dry-run`**: do not invoke `python/cli.py push rebase`; continue to Step 
 
 ```bash
 PREPARE_DIR="$(mktemp -d)"
-prepare_out=$("$PWD/scripts/larch.sh" release prepare \
+WORKTREE_LARCH="$PWD/target/release/larch"
+prepare_out=$(CLAUDE_PLUGIN_ROOT="$PWD" LARCH_BINARY="$WORKTREE_LARCH" "$PWD/scripts/larch.sh" release prepare \
   --repo "$REPO" \
   ${BUMP_OVERRIDE:+--bump "$BUMP_OVERRIDE"} \
   --out-dir "$PREPARE_DIR")
@@ -116,7 +120,7 @@ RECOVERY_NOTES_FILE="$RECOVERY_NOTES_DIR/v${NEW_VERSION}-notes.redacted.md"
 
 Re-derive these paths from `PR_LIST_FILE` in each later Bash fence that consumes notes (Step 3, Step 5, Step 6, and Step 6 recovery) rather than relying on `PREPARE_DIR` or prior shell-local variables surviving across Bash invocations.
 
-On exit **1**, parse `ERROR=` from stdout (e.g. `no-unique-latest-release`, `stale-local-main`, `baseline-tag-unresolvable`, `pr-metadata-incomplete`) and stop.
+On exit **1**, parse `ERROR=` from stdout (e.g. `no-unique-latest-release`, `stale-local-main`, `main-status-failed`, `baseline-tag-unresolvable`, `pr-metadata-incomplete`) and stop.
 
 **Narrate the prepared window** before Step 3: state that `PR_COUNT` PRs merged since `BASELINE_TAG`, then that you are reading the PR list for release notes. When `IGNORED_LARCHLOG_PR_COUNT` is greater than `0`, add that `IGNORED_LARCHLOG_PR_COUNT` larch run-log PRs (`chore(larch-logs): …`) were excluded from the count and notes. `release prepare` already drops those PRs from both `PR_COUNT` and `PR_LIST_FILE`, so the count reflects substantive PRs only.
 
@@ -163,8 +167,10 @@ The `AskUserQuestion` includes `NEW_VERSION`, `BUMP_TYPE`, `PR_COUNT`, and a pre
 # lint-consecutive-bash: ok PR creation must finish before candidate staging
 NOTES_DIR="$(dirname "$PR_LIST_FILE")"
 REDACTED_NOTES_FILE="$NOTES_DIR/notes.redacted.md"
+WORKTREE_LARCH="$PWD/target/release/larch"
 git checkout -b "release/v${NEW_VERSION}"
-"$PWD/scripts/larch.sh" release set-version "${NEW_VERSION}"
+CLAUDE_PLUGIN_ROOT="$PWD" LARCH_BINARY="$WORKTREE_LARCH" "$PWD/scripts/larch.sh" release set-version "${NEW_VERSION}"
+cargo build --quiet --locked --release --package larch-cli
 git add .claude-plugin/plugin.json plugin/.claude-plugin/plugin.json Cargo.toml Cargo.lock
 git commit -m "Release v${NEW_VERSION}"
 python3 "$PWD/python/cli.py" pr create --title "Release v${NEW_VERSION}" --body-file "$REDACTED_NOTES_FILE" --repo "$REPO"
@@ -174,10 +180,11 @@ Record `PR_NUMBER` from `python/cli.py pr create` stdout. Then:
 
 ```bash
 python3 "$PWD/python/cli.py" ci wait --pr "$PR_NUMBER" --repo "$REPO"
-"$PWD/scripts/larch.sh" release ensure-policy --repo "$REPO"
+WORKTREE_LARCH="$PWD/target/release/larch"
+CLAUDE_PLUGIN_ROOT="$PWD" LARCH_BINARY="$WORKTREE_LARCH" "$PWD/scripts/larch.sh" release ensure-policy --repo "$REPO"
 NOTES_DIR="$(dirname "$PR_LIST_FILE")"
 REDACTED_NOTES_FILE="$NOTES_DIR/notes.redacted.md"
-stage_out=$("$PWD/scripts/larch.sh" release stage \
+stage_out=$(CLAUDE_PLUGIN_ROOT="$PWD" LARCH_BINARY="$WORKTREE_LARCH" "$PWD/scripts/larch.sh" release stage \
   --version "$NEW_VERSION" \
   --notes-file "$REDACTED_NOTES_FILE" \
   --repo "$REPO" \
@@ -191,7 +198,7 @@ $stage_out
 EOF
 test -n "$SOURCE_COMMIT"
 TAG="v${NEW_VERSION}"
-asset_run_out=$("$PWD/scripts/larch.sh" release asset-run \
+asset_run_out=$(CLAUDE_PLUGIN_ROOT="$PWD" LARCH_BINARY="$WORKTREE_LARCH" "$PWD/scripts/larch.sh" release asset-run \
   --repo "$REPO" \
   --tag "$TAG" \
   --source-commit "$SOURCE_COMMIT")
@@ -229,7 +236,8 @@ After the workflow succeeds, validate the uploaded draft against the exact candi
 
 ```bash
 SOURCE_COMMIT=$(git rev-parse "v${NEW_VERSION}^{commit}")
-"$PWD/scripts/larch.sh" release validate-draft \
+WORKTREE_LARCH="$PWD/target/release/larch"
+CLAUDE_PLUGIN_ROOT="$PWD" LARCH_BINARY="$WORKTREE_LARCH" "$PWD/scripts/larch.sh" release validate-draft \
   --version "$NEW_VERSION" \
   --repo "$REPO" \
   --pr "$PR_NUMBER" \
@@ -248,7 +256,8 @@ On candidate CI, asset workflow, draft validation, or merge failure, stop before
 
 ```bash
 SOURCE_COMMIT=$(git rev-parse "v${NEW_VERSION}^{commit}")
-"$PWD/scripts/larch.sh" release finish \
+WORKTREE_LARCH="$PWD/target/release/larch"
+CLAUDE_PLUGIN_ROOT="$PWD" LARCH_BINARY="$WORKTREE_LARCH" "$PWD/scripts/larch.sh" release finish \
   --version "$NEW_VERSION" \
   --repo "$REPO" \
   --pr "$PR_NUMBER" \
@@ -260,7 +269,9 @@ SOURCE_COMMIT=$(git rev-parse "v${NEW_VERSION}^{commit}")
 If Step 6 fails after Step 5 merged the release PR, do **not** re-run full `/release`. Re-run Step 6 only with the same version, PR, and source commit:
 
 ```bash
-"$PWD/scripts/larch.sh" release finish \
+WORKTREE_LARCH="$PWD/target/release/larch"
+cargo build --quiet --locked --release --package larch-cli
+CLAUDE_PLUGIN_ROOT="$PWD" LARCH_BINARY="$WORKTREE_LARCH" "$PWD/scripts/larch.sh" release finish \
   --version "$NEW_VERSION" \
   --repo "$REPO" \
   --pr "$PR_NUMBER" \

--- a/crates/larch-cli/src/release_prepare.rs
+++ b/crates/larch-cli/src/release_prepare.rs
@@ -476,8 +476,8 @@ fn verify_clean_main(repository: &GixRepository) -> Result<(), PrepareError> {
         ));
     }
     let status = repository
-        .status(&StatusOptions::default())
-        .map_err(|error| PrepareError::new("dirty-main", error.to_string()))?;
+        .local_status(&StatusOptions::default())
+        .map_err(|error| PrepareError::new("main-status-failed", error.to_string()))?;
     if status.is_dirty() {
         return Err(PrepareError::new("dirty-main", "main worktree is dirty"));
     }

--- a/crates/larch-cli/src/release_prepare/tests.rs
+++ b/crates/larch-cli/src/release_prepare/tests.rs
@@ -12,7 +12,10 @@ mod release_prepare_tests {
     use larch_adapters::{TemporaryRoot, github::GitHubOperationError};
     use larch_core::{GitHubRepositoryRef, ProcessCancellation, RepositoryRead};
     use larch_test_support::{GitFixture, GitRepository};
-    use std::collections::{BTreeMap, BTreeSet};
+    use std::{
+        collections::{BTreeMap, BTreeSet},
+        fs,
+    };
 
     #[derive(Default)]
     struct FakeReleaseService {
@@ -131,6 +134,9 @@ mod release_prepare_tests {
                 b"---\nname: base\nargument-hint: [--old]\n---\n",
             )
             .expect("base skill");
+        repository
+            .write(".gitattributes", b"* text=auto eol=lf\n")
+            .expect("conversion attributes");
         repository.write("README.md", b"base\n").expect("readme");
         checked_git(&repository, ["add", "-A"]);
         checked_git(&repository, ["commit", "--quiet", "-m", "base"]);
@@ -290,6 +296,22 @@ mod release_prepare_tests {
                 &Cancellation::new(),
             ))
             .expect("prepare release with explicit bump");
+    }
+
+    #[test]
+    fn clean_main_distinguishes_status_probe_failure_from_dirty_state() {
+        let fixture = release_repository();
+        let index = fixture.root().join(".git/index");
+        fs::remove_file(&index).expect("remove fixture index");
+        fs::create_dir(&index).expect("replace index with directory");
+        let repository = GixRepository::open(fixture.root()).expect("open repository");
+
+        assert_eq!(
+            verify_clean_main(&repository)
+                .expect_err("status probe must fail")
+                .token,
+            "main-status-failed"
+        );
     }
 
     #[test]

--- a/crates/larch-cli/tests/release_prepare.rs
+++ b/crates/larch-cli/tests/release_prepare.rs
@@ -140,6 +140,35 @@ fn release_prepare_rejects_dirty_and_stale_main_before_network_access() {
         .stdout(predicates::str::contains("ERROR=stale-local-main\n"));
 }
 
+#[test]
+fn release_prepare_accepts_clean_main_with_conversion_attributes() {
+    let repository = repository();
+    git(
+        repository.path(),
+        ["remote", "add", "origin", "https://github.com/o/r.git"],
+    );
+    git(
+        repository.path(),
+        ["update-ref", "refs/remotes/origin/main", "HEAD"],
+    );
+    let out_dir = tempfile::tempdir().expect("output directory");
+
+    larch()
+        .current_dir(repository.path())
+        .env_remove("LARCH_GH_TOKEN")
+        .args([
+            "release",
+            "prepare",
+            "--repo",
+            "o/r",
+            "--out-dir",
+            out_dir.path().to_str().expect("UTF-8 output directory"),
+        ])
+        .assert()
+        .failure()
+        .stdout(predicates::str::contains("ERROR=gh-release-list-failed\n"));
+}
+
 fn assert_bump(repository: &Path, base: &str, expected: &str) {
     larch()
         .current_dir(repository)
@@ -170,6 +199,11 @@ fn repository() -> TempDir {
         "---\nname: base\nargument-hint: [--old]\n---\n",
     )
     .expect("base skill");
+    fs::write(
+        repository.path().join(".gitattributes"),
+        "* text=auto eol=lf\n",
+    )
+    .expect("conversion attributes");
     fs::write(repository.path().join("README.md"), "base\n").expect("readme");
     commit_all(repository.path(), "base");
     repository

--- a/docs/security/supply-chain-credentials-and-services.md
+++ b/docs/security/supply-chain-credentials-and-services.md
@@ -300,6 +300,13 @@ then promotes it. Ambiguous promotion reads back Latest before a retry. The
 final Latest state is verified. The release commands expose no raw Git, `gh`,
 URL, GraphQL, or Python fallback.
 
+The dev-only release skill builds the current checkout before its first
+Rust-backed release command and rebuilds immediately after the candidate
+version write. Every working-tree release command still enters through
+`scripts/larch.sh` with the checkout root and release binary supplied
+explicitly. This prevents an installed or same-version stale binary from
+owning either side of the candidate-version boundary.
+
 Issue-dependency list, add, and remove use the shared live-mutation gate:
 operator mode, or a regular non-symlink session file directly under a canonical
 root that carries `LARCH_LIVE_MUTATION_OK=true` and the matching run ID. Writes
@@ -338,15 +345,19 @@ library diagnostics.
 
 Status and typed tree changes follow the same reopen rule. Status uses the full
 configured `gix` iterator and never writes its optional index-stat refreshes.
-Repository and worktree config that defines an external clean, process,
-textconv, or diff command returns `UnsupportedSemantics` before iteration.
-Callers must route those byte-sensitive cases through the closed exact-diff Git
-CLI operation. User and system filter definitions remain operator-owned config.
-Status rejects repository attributes that select them before `gix` can launch a
-filter. Effective conversion attributes are queried through the configured
-attribute stack. Discovery does not follow symlinks and fails closed when the
-worktree traversal exceeds its entry cap. Typed results contain paths, modes,
-IDs, and flags, but no file content or upstream diagnostic text.
+The strict `RepositoryRead::status` operation returns `UnsupportedSemantics`
+before iteration for repository and worktree clean or process filter config. It
+also rejects repository attributes that select conversion or configured filter
+behavior. Typed tree changes reject configured textconv and external diff
+drivers. Callers that need exact diff interpretation must route those
+byte-sensitive cases through the closed exact-diff Git CLI operation.
+Compatibility callers that consume only status and untracked names use
+`GixRepository::local_status`; it retains configured filters and does not
+promise exact diff semantics. User and system filter definitions remain
+operator-owned config. Effective conversion attributes are queried through the
+configured attribute stack. Discovery does not follow symlinks and fails closed
+when the worktree traversal exceeds its entry cap. Typed results contain paths,
+modes, IDs, and flags, but no file content or upstream diagnostic text.
 
 ### Git mutation compatibility
 

--- a/plugin/docs/security/supply-chain-credentials-and-services.md
+++ b/plugin/docs/security/supply-chain-credentials-and-services.md
@@ -300,6 +300,13 @@ then promotes it. Ambiguous promotion reads back Latest before a retry. The
 final Latest state is verified. The release commands expose no raw Git, `gh`,
 URL, GraphQL, or Python fallback.
 
+The dev-only release skill builds the current checkout before its first
+Rust-backed release command and rebuilds immediately after the candidate
+version write. Every working-tree release command still enters through
+`scripts/larch.sh` with the checkout root and release binary supplied
+explicitly. This prevents an installed or same-version stale binary from
+owning either side of the candidate-version boundary.
+
 Issue-dependency list, add, and remove use the shared live-mutation gate:
 operator mode, or a regular non-symlink session file directly under a canonical
 root that carries `LARCH_LIVE_MUTATION_OK=true` and the matching run ID. Writes
@@ -338,15 +345,19 @@ library diagnostics.
 
 Status and typed tree changes follow the same reopen rule. Status uses the full
 configured `gix` iterator and never writes its optional index-stat refreshes.
-Repository and worktree config that defines an external clean, process,
-textconv, or diff command returns `UnsupportedSemantics` before iteration.
-Callers must route those byte-sensitive cases through the closed exact-diff Git
-CLI operation. User and system filter definitions remain operator-owned config.
-Status rejects repository attributes that select them before `gix` can launch a
-filter. Effective conversion attributes are queried through the configured
-attribute stack. Discovery does not follow symlinks and fails closed when the
-worktree traversal exceeds its entry cap. Typed results contain paths, modes,
-IDs, and flags, but no file content or upstream diagnostic text.
+The strict `RepositoryRead::status` operation returns `UnsupportedSemantics`
+before iteration for repository and worktree clean or process filter config. It
+also rejects repository attributes that select conversion or configured filter
+behavior. Typed tree changes reject configured textconv and external diff
+drivers. Callers that need exact diff interpretation must route those
+byte-sensitive cases through the closed exact-diff Git CLI operation.
+Compatibility callers that consume only status and untracked names use
+`GixRepository::local_status`; it retains configured filters and does not
+promise exact diff semantics. User and system filter definitions remain
+operator-owned config. Effective conversion attributes are queried through the
+configured attribute stack. Discovery does not follow symlinks and fails closed
+when the worktree traversal exceeds its entry cap. Typed results contain paths,
+modes, IDs, and flags, but no file content or upstream diagnostic text.
 
 ### Git mutation compatibility
 

--- a/python/tests/release/test_release.py
+++ b/python/tests/release/test_release.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Sequence
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from larch.core import verify_main
@@ -10,6 +11,9 @@ from larch.core.proc import CommandResult
 
 if TYPE_CHECKING:
     import pytest
+
+
+ROOT = Path(__file__).resolve().parents[3]
 
 
 def cr(argv: tuple[str, ...], stdout: str = "") -> CommandResult:
@@ -114,3 +118,37 @@ def test_verify_main_rejects_numbered_expected_stripped_prefix(
     assert verify_main.main(["--expected-title", "Title (#7)"]) == 0
     out = dict(line.split("=", 1) for line in capsys.readouterr().out.splitlines())
     assert out["VERIFIED"] == "false"
+
+
+def test_release_skill_rebuilds_worktree_driver_across_version_change() -> None:
+    skill = (ROOT / ".claude/skills/release/SKILL.md").read_text(encoding="utf-8")
+    build = "cargo build --quiet --locked --release --package larch-cli"
+    prepare = skill.index('"$PWD/scripts/larch.sh" release prepare')
+    set_version = skill.index('"$PWD/scripts/larch.sh" release set-version')
+    ensure_policy = skill.index('"$PWD/scripts/larch.sh" release ensure-policy')
+
+    first_build = skill.index(build)
+    candidate_build = skill.index(build, first_build + len(build))
+    sync_complete = skill.index('sync_out="DRY_RUN_SYNC_SKIPPED=true"')
+    assert first_build < prepare < set_version < candidate_build < ensure_policy
+    assert sync_complete < first_build
+
+    recovery = skill.index("If Step 6 fails after Step 5 merged the release PR")
+    recovery_build = skill.index(build, recovery)
+    recovery_finish = skill.index('"$PWD/scripts/larch.sh" release finish', recovery)
+    assert recovery < recovery_build < recovery_finish
+
+    worktree_prefix = (
+        'CLAUDE_PLUGIN_ROOT="$PWD" LARCH_BINARY="$WORKTREE_LARCH" '
+        '"$PWD/scripts/larch.sh" release '
+    )
+    for verb in (
+        "prepare",
+        "set-version",
+        "ensure-policy",
+        "stage",
+        "asset-run",
+        "validate-draft",
+        "finish",
+    ):
+        assert f"{worktree_prefix}{verb}" in skill


### PR DESCRIPTION
## Summary

- Bootstrap the dev-only release skill from the synchronized working checkout before release preparation.
- Rebuild after the candidate version write and for standalone publication recovery.
- Use the status-only `local_status` policy for clean-main verification while preserving strict exact-diff behavior elsewhere.
- Distinguish a failed status probe from an actually dirty worktree.
- Document the release bootstrap and Git compatibility security boundaries.

## Root cause

The Rust release cutover called strict status for a clean/dirty predicate. The repository's committed text conversion attributes therefore returned `UnsupportedSemantics`, which release preparation mislabeled as `dirty-main`.

The dev-only skill also called unreleased Rust commands before building the current checkout. Because current main and the last active release share a version until the release candidate is written, version and target checks alone could accept stale binary identity. The candidate version write created a second binary-version boundary that the skill did not rebuild across.

## Validation

- `cargo test --locked --package larch-cli --bin larch release_prepare_tests`
- `cargo test --locked --package larch-cli --test release_prepare`
- `cargo test --locked --package larch-lint --test release_python_free`
- `cargo test --locked --package larch-lint --test production_cargo_run`
- `python3 -m pytest tests/release/test_release.py -q` from `python/`
- `python3 python/cli.py checks run-relevant --site issue-7880 ...`: full coverage passed

## Self-review

The initial implementation built before the optional fast-forward and omitted a fresh-session Step 6 recovery build. Self-review found both defects. The final version builds after synchronization, rebuilds after `release set-version`, and rebuilds in standalone Step 6 recovery. Structural tests pin those orderings and every release wrapper's explicit bootstrap environment.

Fixes #7880
