### PR TITLE
Release v54.0.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "53.1.24",
+  "version": "54.0.0",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2482,7 +2482,7 @@ dependencies = [
 
 [[package]]
 name = "larch-adapters"
-version = "53.1.24"
+version = "54.0.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -2514,7 +2514,7 @@ dependencies = [
 
 [[package]]
 name = "larch-cli"
-version = "53.1.24"
+version = "54.0.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -2535,7 +2535,7 @@ dependencies = [
 
 [[package]]
 name = "larch-core"
-version = "53.1.24"
+version = "54.0.0"
 dependencies = [
  "regex",
  "zip",
@@ -2543,7 +2543,7 @@ dependencies = [
 
 [[package]]
 name = "larch-lint"
-version = "53.1.24"
+version = "54.0.0"
 dependencies = [
  "assert_cmd",
  "automod",
@@ -2569,7 +2569,7 @@ dependencies = [
 
 [[package]]
 name = "larch-test-support"
-version = "53.1.24"
+version = "54.0.0"
 dependencies = [
  "larch-core",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2024"
 license = "MIT"
 repository = "https://github.com/character-ai/larch"
 rust-version = "1.94.1"
-version = "53.1.24"
+version = "54.0.0"
 
 [workspace.dependencies]
 assert_cmd = { version = "2.2.2", default-features = false }
@@ -33,9 +33,9 @@ http = { version = "1.4.2", default-features = false, features = ["std"] }
 http-body = { version = "1.0.1", default-features = false }
 http-body-util = { version = "0.1.4", default-features = false }
 inventory = { version = "0.3.24", default-features = false }
-larch-adapters = { version = "=53.1.24", path = "crates/larch-adapters" }
-larch-core = { version = "=53.1.24", path = "crates/larch-core" }
-larch-test-support = { version = "=53.1.24", path = "crates/larch-test-support" }
+larch-adapters = { version = "=54.0.0", path = "crates/larch-adapters" }
+larch-core = { version = "=54.0.0", path = "crates/larch-core" }
+larch-test-support = { version = "=54.0.0", path = "crates/larch-test-support" }
 nix = { version = "0.31.3", default-features = false, features = ["process", "signal"] }
 octocrab = { version = "=0.54.0", default-features = false, features = ["default-client", "jwt-aws-lc-rs", "rustls", "rustls-aws-lc-rs", "timeout"] }
 predicates = { version = "3.1.4", default-features = false }

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "53.1.24",
+  "version": "54.0.0",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## larch v54.0.0

This major release reimplements larch's Git, GitHub, release, and upgrade internals in Rust, cuts run-log storage over to cloud archives, and reorganizes the security documentation. Most changes are internal. Run-log publication and storage configuration change for operators.

### Added

- Universal per-skill run lifecycle: every shipped skill and alias now records start and terminal run-log entries, backed by an enforcement lint.
- Cloud run-log archives: run logs publish to a deterministic, versioned, append-only cloud archive with durable retry, write-through caching, safe bounded extraction, and atomic cache materialization. A new storage-root config and S3 preflight gate publication, and missing cloud runs sync into a local per-repository cache.
- Verified runtime-only plugin installs, with the runtime-only plugin projection built in Rust.
- Provider-neutral object transports for archive storage.
- Aggregate migration governance audit and scheduled governance reporting.

### Changed

- Ported Git operations to a trusted gix-based Rust implementation: status, local changes, branch and ref reads, staging and commit, conflict and rebase controls, main synchronization, phantom probes, and force push. A closed typed Git CLI compatibility adapter backs the cutover, with differential fixtures and semantic snapshots.
- Ported GitHub operations to a hardened Rust transport: repository, issue, pull-request, review, and issue-dependency operations; releases and bounded asset streaming; typed Actions operations; repository resolution; and artifact and immutable-release attestation verification.
- Ported the release and upgrade pipeline to Rust: preparation and bump classification, synchronized version mutation, asset construction and validation, draft staging and validation, immutable publication and promotion, and upgrade-larch orchestration. Release and upgrade now run Python-free.
- Migrated run-log analyzers, both read-only and stateful, onto the synchronized cache, and removed the top-level run-log exceptions.
- Reorganized security documentation into a taxonomy with runtime policy packaging, and extracted supply-chain, credential, service, workflow-trust, mutation, private-finding, artifact, redaction, and publication boundaries into canonical references.
- Hardened trust boundaries: verified Rust runtime entrypoints, rejection of production Cargo and target-binary execution, Git ownership enforcement against argv bypasses, a corrected GitHub credential contract, and closed service-ownership and secret-environment gaps.
- Strengthened workflow governance: executable plans with force admission, plans bound to blocker and base freshness, an issue-mutation owner boundary, shared-owner implementation leases, and clean-install plus issue-registry parity.
- Centralized freshness-checked issue mutations, and completed pull-request merge and issue-dependency mutation parity.
- Removed Git-backed run-log publication and retention workflows, along with archived larch logs, in favor of the cloud archive.
- Sped up Rust CI caching and repository lint.

### Fixed

- /release now bootstraps the migrated Rust driver and no longer misclassifies a clean main as dirty.
- Fixed authenticated GitHub Actions log downloads.
- Removed duplicated Rust hooks from CI lint jobs.
