### PR TITLE
Fixes #7884: Make release policy checks permission-aware

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -172,6 +172,7 @@ The `AskUserQuestion` includes `NEW_VERSION`, `BUMP_TYPE`, `PR_COUNT`, and a pre
 NOTES_DIR="$(dirname "$PR_LIST_FILE")"
 REDACTED_NOTES_FILE="$NOTES_DIR/notes.redacted.md"
 WORKTREE_LARCH="$PWD/target/release/larch"
+CLAUDE_PLUGIN_ROOT="$PWD" LARCH_BINARY="$WORKTREE_LARCH" "$PWD/scripts/larch.sh" release ensure-policy --repo "$REPO"
 git checkout -b "release/v${NEW_VERSION}"
 CLAUDE_PLUGIN_ROOT="$PWD" LARCH_BINARY="$WORKTREE_LARCH" "$PWD/scripts/larch.sh" release set-version "${NEW_VERSION}"
 cargo build --quiet --locked --release --package larch-cli
@@ -185,7 +186,6 @@ Record `PR_NUMBER` from `python/cli.py pr create` stdout. Then:
 ```bash
 python3 "$PWD/python/cli.py" ci wait --pr "$PR_NUMBER" --repo "$REPO"
 WORKTREE_LARCH="$PWD/target/release/larch"
-CLAUDE_PLUGIN_ROOT="$PWD" LARCH_BINARY="$WORKTREE_LARCH" "$PWD/scripts/larch.sh" release ensure-policy --repo "$REPO"
 NOTES_DIR="$(dirname "$PR_LIST_FILE")"
 REDACTED_NOTES_FILE="$NOTES_DIR/notes.redacted.md"
 stage_out=$(CLAUDE_PLUGIN_ROOT="$PWD" LARCH_BINARY="$WORKTREE_LARCH" "$PWD/scripts/larch.sh" release stage \

--- a/crates/larch-adapters/src/github/release.rs
+++ b/crates/larch-adapters/src/github/release.rs
@@ -7,7 +7,10 @@
 //! HTTPS, strips the credential across origins, rejects loops and hop overruns,
 //! and bounds the streamed body by a per-asset byte cap.
 
-use super::{GitHubCompletionError, GitHubHostError, OctocrabGitHubService, validate_approved_url};
+use super::{
+    GitHubCompletionError, GitHubHostError, OctocrabGitHubService, octocrab_status,
+    validate_approved_url,
+};
 use bytes::Bytes;
 use http::header::{HeaderMap, HeaderName};
 use http_body_util::combinators::BoxBody;
@@ -104,6 +107,10 @@ pub enum ReleaseServiceError {
     AmbiguousMutation,
     /// An ambiguous mutation reconciled to a lost effect that must not retry.
     MutationLost,
+    /// The release credential cannot inspect or change repository policy.
+    RepositoryPolicyPermission,
+    /// A repository-policy endpoint returned a definite non-success status.
+    RepositoryPolicyStatus(u16),
     /// The transport failed with an already-redacted diagnostic.
     Transport(SafeText),
 }
@@ -128,6 +135,12 @@ impl fmt::Display for ReleaseServiceError {
                 .write_str("GitHub mutation outcome was ambiguous and awaits reconciliation"),
             Self::MutationLost => formatter
                 .write_str("GitHub mutation could not be reconciled after an ambiguous outcome"),
+            Self::RepositoryPolicyPermission => formatter.write_str(
+                "LARCH_GH_TOKEN requires repository Administration read permission for release policy checks and write permission to enable missing settings",
+            ),
+            Self::RepositoryPolicyStatus(status) => {
+                write!(formatter, "GitHub repository policy request returned status {status}")
+            }
             Self::Transport(detail) => write!(formatter, "GitHub transport failed: {detail}"),
         }
     }
@@ -625,17 +638,22 @@ impl<'a, T: ReleaseTransport> ReleaseOperations<'a, T> {
         &self,
         repo: &RepoSlug,
     ) -> Result<(), ReleaseServiceError> {
-        let merge = self.transport.enable_merge_commits(repo).await;
-        if let Err(error) = &merge
-            && !is_ambiguous_write(error)
-        {
-            return merge;
+        let (merge_commits, immutable_releases) = self.repository_policy(repo).await?;
+        if !merge_commits {
+            let merge = self.transport.enable_merge_commits(repo).await;
+            if let Err(error) = &merge
+                && !is_ambiguous_write(error)
+            {
+                return merge;
+            }
         }
-        let immutable = self.transport.enable_immutable_releases(repo).await;
-        if let Err(error) = &immutable
-            && !is_ambiguous_write(error)
-        {
-            return immutable;
+        if !immutable_releases {
+            let immutable = self.transport.enable_immutable_releases(repo).await;
+            if let Err(error) = &immutable
+                && !is_ambiguous_write(error)
+            {
+                return immutable;
+            }
         }
         if self.verify_repository_policy(repo).await? {
             Ok(())
@@ -780,6 +798,39 @@ impl<'a> OctocrabReleaseTransport<'a> {
         }
     }
 
+    fn policy_read_error(&self, error: &octocrab::Error) -> ReleaseServiceError {
+        if octocrab_status(error) == Some(403) {
+            ReleaseServiceError::RepositoryPolicyPermission
+        } else {
+            self.transport_error(error)
+        }
+    }
+
+    fn policy_mutation_error(&self, error: &octocrab::Error) -> ReleaseServiceError {
+        if octocrab_status(error) == Some(403) {
+            ReleaseServiceError::RepositoryPolicyPermission
+        } else {
+            self.mutation_error(error)
+        }
+    }
+
+    fn policy_status_error(status: u16, mutation: bool) -> ReleaseServiceError {
+        if status == 403 {
+            return ReleaseServiceError::RepositoryPolicyPermission;
+        }
+        if mutation
+            && classify_github_retry(
+                GitHubRequestKind::Mutation,
+                GitHubFailureInput::HttpStatus(status),
+                GitHubRateLimitInputs::NONE,
+            ) == GitHubRetryAction::ReconcileMutation
+        {
+            ReleaseServiceError::AmbiguousMutation
+        } else {
+            ReleaseServiceError::RepositoryPolicyStatus(status)
+        }
+    }
+
     async fn get_json(
         &self,
         url: String,
@@ -791,6 +842,30 @@ impl<'a> OctocrabReleaseTransport<'a> {
             }
             Err(error) => return Err(self.transport_error(&error)),
         };
+        let cap = self.service.policy.limits().body_bytes();
+        let body = collect_bounded(response, cap).await?;
+        serde_json::from_slice(&body)
+            .map(Some)
+            .map_err(|error| self.transport_error_from(&error))
+    }
+
+    async fn get_policy_json(
+        &self,
+        url: String,
+    ) -> Result<Option<serde_json::Value>, ReleaseServiceError> {
+        let response = self
+            .service
+            .client
+            ._get(url)
+            .await
+            .map_err(|error| self.policy_read_error(&error))?;
+        let status = response.status().as_u16();
+        if status == 404 {
+            return Ok(None);
+        }
+        if !response.status().is_success() {
+            return Err(Self::policy_status_error(status, false));
+        }
         let cap = self.service.policy.limits().body_bytes();
         let body = collect_bounded(response, cap).await?;
         serde_json::from_slice(&body)
@@ -964,36 +1039,33 @@ impl ReleaseTransport for OctocrabReleaseTransport<'_> {
     }
 
     fn immutable_releases_enabled<'b>(&'b self, repo: &RepoSlug) -> ReleaseFuture<'b, bool> {
-        let url = format!(
-            "https://{API_HOST}/repos/{}/immutable-releases",
-            repo.path()
-        );
+        let url = format!("/repos/{}/immutable-releases", repo.path());
         Box::pin(self.guard(async move {
-            Ok(self
-                .get_json(url)
-                .await?
-                .as_ref()
-                .and_then(|value| value.get("enabled"))
+            let Some(value) = self.get_policy_json(url).await? else {
+                return Ok(false);
+            };
+            value
+                .get("enabled")
                 .and_then(serde_json::Value::as_bool)
-                .unwrap_or(false))
+                .ok_or(ReleaseServiceError::RepositoryPolicyPermission)
         }))
     }
 
     fn merge_commits_enabled<'b>(&'b self, repo: &RepoSlug) -> ReleaseFuture<'b, bool> {
-        let url = format!("https://{API_HOST}/repos/{}", repo.path());
+        let url = format!("/repos/{}", repo.path());
         Box::pin(self.guard(async move {
-            Ok(self
-                .get_json(url)
-                .await?
-                .as_ref()
-                .and_then(|value| value.get("allow_merge_commit"))
+            let Some(value) = self.get_policy_json(url).await? else {
+                return Ok(false);
+            };
+            value
+                .get("allow_merge_commit")
                 .and_then(serde_json::Value::as_bool)
-                .unwrap_or(false))
+                .ok_or(ReleaseServiceError::RepositoryPolicyPermission)
         }))
     }
 
     fn enable_merge_commits<'b>(&'b self, repo: &RepoSlug) -> ReleaseFuture<'b, ()> {
-        let url = format!("https://{API_HOST}/repos/{}", repo.path());
+        let url = format!("/repos/{}", repo.path());
         Box::pin(self.guard(async move {
             let body = serde_json::json!({"allow_merge_commit": true});
             self.service
@@ -1001,22 +1073,24 @@ impl ReleaseTransport for OctocrabReleaseTransport<'_> {
                 .patch::<serde_json::Value, _, _>(url, Some(&body))
                 .await
                 .map(|_| ())
-                .map_err(|error| self.mutation_error(&error))
+                .map_err(|error| self.policy_mutation_error(&error))
         }))
     }
 
     fn enable_immutable_releases<'b>(&'b self, repo: &RepoSlug) -> ReleaseFuture<'b, ()> {
-        let url = format!(
-            "https://{API_HOST}/repos/{}/immutable-releases",
-            repo.path()
-        );
+        let url = format!("/repos/{}/immutable-releases", repo.path());
         Box::pin(self.guard(async move {
-            self.service
+            let response = self
+                .service
                 .client
                 ._put(url, None::<&()>)
                 .await
-                .map(|_| ())
-                .map_err(|error| self.mutation_error(&error))
+                .map_err(|error| self.policy_mutation_error(&error))?;
+            if response.status().is_success() {
+                Ok(())
+            } else {
+                Err(Self::policy_status_error(response.status().as_u16(), true))
+            }
         }))
     }
 
@@ -1223,6 +1297,10 @@ mod release_tests {
         tag: Option<TagObjectId>,
         immutable: bool,
         merge_commits: bool,
+        immutable_reads: ReleaseQueue<bool>,
+        merge_commit_reads: ReleaseQueue<bool>,
+        immutable_enables: ReleaseQueue<()>,
+        merge_commit_enables: ReleaseQueue<()>,
         release_body: String,
         list: ReleaseQueue<Vec<ReleaseState>>,
         latest: ReleaseQueue<Option<ReleaseState>>,
@@ -1233,6 +1311,8 @@ mod release_tests {
         upload: ReleaseQueue<RemoteAsset>,
         hops: ReleaseQueue<FetchOutcome>,
         list_calls: Mutex<usize>,
+        immutable_enable_calls: Mutex<usize>,
+        merge_commit_enable_calls: Mutex<usize>,
     }
 
     impl ReleaseTransport for FakeTransport {
@@ -1261,21 +1341,27 @@ mod release_tests {
         }
 
         fn immutable_releases_enabled<'a>(&'a self, _repo: &RepoSlug) -> ReleaseFuture<'a, bool> {
+            let scripted = pop(&self.immutable_reads);
             let value = self.immutable;
-            Box::pin(async move { Ok(value) })
+            Box::pin(async move { scripted.unwrap_or(Ok(value)) })
         }
 
         fn merge_commits_enabled<'a>(&'a self, _repo: &RepoSlug) -> ReleaseFuture<'a, bool> {
+            let scripted = pop(&self.merge_commit_reads);
             let value = self.merge_commits;
-            Box::pin(async move { Ok(value) })
+            Box::pin(async move { scripted.unwrap_or(Ok(value)) })
         }
 
         fn enable_merge_commits<'a>(&'a self, _repo: &RepoSlug) -> ReleaseFuture<'a, ()> {
-            Box::pin(async { Ok(()) })
+            *self.merge_commit_enable_calls.lock().expect("call counter") += 1;
+            let outcome = pop(&self.merge_commit_enables);
+            Box::pin(async move { outcome.unwrap_or(Ok(())) })
         }
 
         fn enable_immutable_releases<'a>(&'a self, _repo: &RepoSlug) -> ReleaseFuture<'a, ()> {
-            Box::pin(async { Ok(()) })
+            *self.immutable_enable_calls.lock().expect("call counter") += 1;
+            let outcome = pop(&self.immutable_enables);
+            Box::pin(async move { outcome.unwrap_or(Ok(())) })
         }
 
         fn create_draft_release<'a>(
@@ -1480,6 +1566,14 @@ mod release_tests {
         };
         let operations = ReleaseOperations::new(&transport);
         assert!(run(operations.ensure_repository_policy(&repo())).is_ok());
+        assert_eq!(
+            *transport.merge_commit_enable_calls.lock().expect("counter"),
+            0
+        );
+        assert_eq!(
+            *transport.immutable_enable_calls.lock().expect("counter"),
+            0
+        );
         let input = DraftReleaseInput {
             tag: "v1".to_owned(),
             target_commitish: "commit".to_owned(),
@@ -1490,6 +1584,94 @@ mod release_tests {
                 .expect("reconciled update")
                 .database_id(),
             7
+        );
+    }
+
+    #[test]
+    fn policy_enablement_mutates_only_disabled_settings() {
+        let merge_transport = FakeTransport {
+            immutable: true,
+            merge_commit_reads: Mutex::new([Ok(false), Ok(true)].into()),
+            ..FakeTransport::default()
+        };
+        assert!(
+            run(ReleaseOperations::new(&merge_transport).ensure_repository_policy(&repo())).is_ok()
+        );
+        assert_eq!(
+            *merge_transport
+                .merge_commit_enable_calls
+                .lock()
+                .expect("counter"),
+            1
+        );
+        assert_eq!(
+            *merge_transport
+                .immutable_enable_calls
+                .lock()
+                .expect("counter"),
+            0
+        );
+
+        let immutable_transport = FakeTransport {
+            merge_commits: true,
+            immutable_reads: Mutex::new([Ok(false), Ok(true)].into()),
+            ..FakeTransport::default()
+        };
+        assert!(
+            run(ReleaseOperations::new(&immutable_transport).ensure_repository_policy(&repo()))
+                .is_ok()
+        );
+        assert_eq!(
+            *immutable_transport
+                .merge_commit_enable_calls
+                .lock()
+                .expect("counter"),
+            0
+        );
+        assert_eq!(
+            *immutable_transport
+                .immutable_enable_calls
+                .lock()
+                .expect("counter"),
+            1
+        );
+    }
+
+    #[test]
+    fn policy_enablement_reconciles_ambiguous_missing_setting() {
+        let transport = FakeTransport {
+            immutable: true,
+            merge_commit_reads: Mutex::new([Ok(false), Ok(true)].into()),
+            merge_commit_enables: Mutex::new([Err(ReleaseServiceError::AmbiguousMutation)].into()),
+            ..FakeTransport::default()
+        };
+
+        assert!(run(ReleaseOperations::new(&transport).ensure_repository_policy(&repo())).is_ok());
+        assert_eq!(
+            *transport.merge_commit_enable_calls.lock().expect("counter"),
+            1
+        );
+    }
+
+    #[test]
+    fn policy_enablement_fails_closed_on_definite_missing_setting_error() {
+        let transport = FakeTransport {
+            immutable: true,
+            merge_commit_enables: Mutex::new([Err(ReleaseServiceError::MutationLost)].into()),
+            ..FakeTransport::default()
+        };
+
+        assert_eq!(
+            run(ReleaseOperations::new(&transport).ensure_repository_policy(&repo())),
+            Err(ReleaseServiceError::MutationLost)
+        );
+        assert_eq!(
+            *transport.merge_commit_enable_calls.lock().expect("counter"),
+            1
+        );
+        assert_eq!(
+            *transport.immutable_enable_calls.lock().expect("counter"),
+            0
         );
     }
 
@@ -1779,6 +1961,8 @@ mod release_tests {
             ReleaseServiceError::AssetTooLarge,
             ReleaseServiceError::AmbiguousMutation,
             ReleaseServiceError::MutationLost,
+            ReleaseServiceError::RepositoryPolicyPermission,
+            ReleaseServiceError::RepositoryPolicyStatus(422),
         ] {
             assert!(!error.to_string().is_empty());
         }
@@ -1831,6 +2015,15 @@ mod transport_tests {
         Reply {
             expected_request: Some(expected_request),
             ..json_reply(status, value)
+        }
+    }
+
+    fn empty_reply_expecting(status: u16, expected_request: &'static str) -> Reply {
+        Reply {
+            status,
+            headers: Vec::new(),
+            body: Vec::new(),
+            expected_request: Some(expected_request),
         }
     }
 
@@ -1942,6 +2135,71 @@ mod transport_tests {
 
     fn repo() -> RepoSlug {
         RepoSlug::parse("o", "r").expect("valid slug")
+    }
+
+    #[tokio::test]
+    async fn policy_transport_accepts_no_content_and_maps_missing_permission() {
+        let (service, _base, server) = stub(vec![json_reply(
+            403,
+            &json!({"message": "untrusted upstream detail"}),
+        )]);
+        let cancellation = Cancellation::new();
+        let transport = OctocrabReleaseTransport::new(&service, &cancellation);
+        assert_eq!(
+            transport.merge_commits_enabled(&repo()).await,
+            Err(ReleaseServiceError::RepositoryPolicyPermission)
+        );
+        server.join().expect("permission stub");
+
+        let (service, _base, server) = stub(vec![json_reply(
+            403,
+            &json!({"message": "untrusted upstream detail"}),
+        )]);
+        let cancellation = Cancellation::new();
+        let transport = OctocrabReleaseTransport::new(&service, &cancellation);
+        assert_eq!(
+            transport.enable_merge_commits(&repo()).await,
+            Err(ReleaseServiceError::RepositoryPolicyPermission)
+        );
+        server.join().expect("merge permission stub");
+
+        let (service, _base, server) = stub(vec![json_reply(
+            403,
+            &json!({"message": "untrusted upstream detail"}),
+        )]);
+        let cancellation = Cancellation::new();
+        let transport = OctocrabReleaseTransport::new(&service, &cancellation);
+        assert_eq!(
+            transport.enable_immutable_releases(&repo()).await,
+            Err(ReleaseServiceError::RepositoryPolicyPermission)
+        );
+        server.join().expect("immutable permission stub");
+
+        let (service, _base, server) = stub(vec![json_reply(200, &json!({}))]);
+        let cancellation = Cancellation::new();
+        let transport = OctocrabReleaseTransport::new(&service, &cancellation);
+        assert_eq!(
+            transport.merge_commits_enabled(&repo()).await,
+            Err(ReleaseServiceError::RepositoryPolicyPermission)
+        );
+        server.join().expect("omitted-field stub");
+
+        let (service, _base, server) = stub(vec![
+            json_reply(200, &json!({"allow_merge_commit": true})),
+            json_reply(200, &json!({"enabled": false})),
+            empty_reply_expecting(204, "PUT /repos/o/r/immutable-releases"),
+            json_reply(200, &json!({"allow_merge_commit": true})),
+            json_reply(200, &json!({"enabled": true})),
+        ]);
+        let cancellation = Cancellation::new();
+        let transport = OctocrabReleaseTransport::new(&service, &cancellation);
+        assert!(
+            ReleaseOperations::new(&transport)
+                .ensure_repository_policy(&repo())
+                .await
+                .is_ok()
+        );
+        server.join().expect("policy setup stub");
     }
 
     #[tokio::test]

--- a/docs/configuration-and-permissions.md
+++ b/docs/configuration-and-permissions.md
@@ -259,6 +259,12 @@ Google credential paths, and discovered access-token variables. The initial
 transport supports only GitHub.com over HTTPS; GitHub Enterprise needs a
 separate reviewed host policy.
 
+`/release` additionally requires repository Administration read permission on
+`LARCH_GH_TOKEN` to verify merge-commit and immutable-release policy. It needs
+Administration write only when either setting is disabled and must be enabled.
+Permissions held by `GH_TOKEN` or the active `gh` login do not satisfy this
+Rust service boundary.
+
 Larch never executes the `gh` or `gcloud` service CLI at runtime. The Rust
 process allowlist permits only the vendor agents, Git, and the larch bootstrap
 self-exec, and the `service-ownership` repository rule rejects `gcloud` and

--- a/docs/security/supply-chain-credentials-and-services.md
+++ b/docs/security/supply-chain-credentials-and-services.md
@@ -307,6 +307,14 @@ then promotes it. Ambiguous promotion reads back Latest before a retry. The
 final Latest state is verified. The release commands expose no raw Git, `gh`,
 URL, GraphQL, or Python fallback.
 
+Repository-policy setup reads the merge-commit and immutable-release settings
+before it writes. It mutates only a setting that is disabled, so an already
+compliant repository requires Administration read but not Administration write
+on `LARCH_GH_TOKEN`. Repairing a disabled setting requires Administration
+write. Missing permission returns a fixed, secret-free policy diagnostic. A
+required mutation remains fail-closed, and every successful setup performs a
+final read-back of both owning policy surfaces.
+
 The dev-only release skill builds the current checkout before its first
 Rust-backed release command and rebuilds immediately after the candidate
 version write. Every working-tree release command still enters through

--- a/plugin/docs/configuration-and-permissions.md
+++ b/plugin/docs/configuration-and-permissions.md
@@ -259,6 +259,12 @@ Google credential paths, and discovered access-token variables. The initial
 transport supports only GitHub.com over HTTPS; GitHub Enterprise needs a
 separate reviewed host policy.
 
+`/release` additionally requires repository Administration read permission on
+`LARCH_GH_TOKEN` to verify merge-commit and immutable-release policy. It needs
+Administration write only when either setting is disabled and must be enabled.
+Permissions held by `GH_TOKEN` or the active `gh` login do not satisfy this
+Rust service boundary.
+
 Larch never executes the `gh` or `gcloud` service CLI at runtime. The Rust
 process allowlist permits only the vendor agents, Git, and the larch bootstrap
 self-exec, and the `service-ownership` repository rule rejects `gcloud` and

--- a/plugin/docs/security/supply-chain-credentials-and-services.md
+++ b/plugin/docs/security/supply-chain-credentials-and-services.md
@@ -307,6 +307,14 @@ then promotes it. Ambiguous promotion reads back Latest before a retry. The
 final Latest state is verified. The release commands expose no raw Git, `gh`,
 URL, GraphQL, or Python fallback.
 
+Repository-policy setup reads the merge-commit and immutable-release settings
+before it writes. It mutates only a setting that is disabled, so an already
+compliant repository requires Administration read but not Administration write
+on `LARCH_GH_TOKEN`. Repairing a disabled setting requires Administration
+write. Missing permission returns a fixed, secret-free policy diagnostic. A
+required mutation remains fail-closed, and every successful setup performs a
+final read-back of both owning policy surfaces.
+
 The dev-only release skill builds the current checkout before its first
 Rust-backed release command and rebuilds immediately after the candidate
 version write. Every working-tree release command still enters through

--- a/python/tests/release/test_release.py
+++ b/python/tests/release/test_release.py
@@ -130,7 +130,8 @@ def test_release_skill_rebuilds_worktree_driver_across_version_change() -> None:
     first_build = skill.index(build)
     candidate_build = skill.index(build, first_build + len(build))
     sync_complete = skill.index('sync_out="DRY_RUN_SYNC_SKIPPED=true"')
-    assert first_build < prepare < set_version < candidate_build < ensure_policy
+    checkout = skill.index('git checkout -b "release/v${NEW_VERSION}"')
+    assert first_build < prepare < ensure_policy < checkout < set_version < candidate_build
     assert sync_complete < first_build
 
     recovery = skill.index("If Step 6 fails after Step 5 merged the release PR")


### PR DESCRIPTION
## Summary

- make release policy setup read before write and mutate only disabled settings
- classify missing repository Administration permission with a fixed `LARCH_GH_TOKEN` diagnostic
- handle the immutable-policy endpoint's successful 204 and non-success statuses explicitly
- run approved policy setup before candidate branch, PR, and CI writes
- document the policy credential boundary and refresh the runtime projection

## Root cause

The Rust release migration introduced by #7808 made `LARCH_GH_TOKEN` the sole credential for policy operations without documenting their repository Administration permission. The observed token could publish releases but repository responses omitted `allow_merge_commit`, while immutable-policy reads and repository-policy writes returned 403. GitHub CLI succeeded only because it used a different administrator `GH_TOKEN`.

The initially suspected immutable PUT 204 was not the failure: the run stopped earlier at the policy permission boundary. The old raw PUT path did, however, fail to inspect non-success response statuses, so this change closes that adjacent transport gap.

Fixes #7884

## Validation

- `cargo test --locked --package larch-adapters`
- `cargo test --locked --package larch-cli release_stage`
- `cargo clippy --locked --package larch-adapters --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `cd python && python3 -m pytest tests/release/test_release.py -q`
- `cargo run --quiet --locked --package larch-cli -- release plugin-runtime --check`
- `python3 python/cli.py checks run-relevant --site issue-7884 --tmpdir <TMPDIR> --repo-root "$PWD"`
- live limited-token check returns the fixed Administration-permission diagnostic
- live administrator-token check reports both required policies enabled

## Self-review

An unbiased inline review found and fixed four issues: the provisional 204 misdiagnosis, missing raw-response status classification, an unnecessary helper receiver reported by Clippy, and policy validation occurring after candidate PR/CI creation. The final design preserves the single `LARCH_GH_TOKEN` architecture boundary, bounded response handling, fail-closed mutation behavior, and final policy read-back.
