### PR TITLE
Fixes #7888: Acquire GitHub token from gh

### DIFF
--- a/.github/workflows/rust-release-assets.yaml
+++ b/.github/workflows/rust-release-assets.yaml
@@ -276,7 +276,12 @@ jobs:
           SOURCE_COMMIT: ${{ needs.metadata.outputs.source_commit }}
         run: |
           set -euo pipefail
-          LARCH_GH_TOKEN="$GH_TOKEN" ./target/release/larch release validate-assets \
+          export GH_CONFIG_DIR="$RUNNER_TEMP/larch-gh"
+          mkdir -p "$GH_CONFIG_DIR"
+          chmod 700 "$GH_CONFIG_DIR"
+          printf '%s' "$GH_TOKEN" | env -u GH_TOKEN -u GITHUB_TOKEN GH_CONFIG_DIR="$GH_CONFIG_DIR" gh auth login --hostname github.com --with-token
+          unset GH_TOKEN GITHUB_TOKEN
+          ./target/release/larch release validate-assets \
             --version "$VERSION" \
             --tag "$GITHUB_REF_NAME" \
             --source-commit "$SOURCE_COMMIT" \

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -131,17 +131,19 @@ work:
   non-atomic final rows for the #7675 commands. A later-domain row remains
   Python-owned until its named migration issue performs the atomic cutover.
 - Product child processes use the `ExternalProcessRunner` core port. Its closed
-  enum permits typed Claude, Codex, Cursor, Git, and #7670 larch bootstrap or
-  self-check operations. Larch program paths derive from validated plugin roots.
-  The adapter accepts argument arrays only, rebuilds child environments from an
-  allowlist, bounds output, and owns cancellation, timeout, termination, and reap.
+  enum permits typed Claude, Codex, Cursor, Git, the fixed GitHub credential
+  lookup, and #7670 larch bootstrap or self-check operations. Larch program
+  paths derive from validated plugin roots. The adapter accepts argument arrays
+  only, rebuilds child environments from an allowlist, bounds output, and owns
+  cancellation, timeout, termination, and reap.
   Repository-only lint bootstrap calls stay outside the product dependency
   graph and require reason-bearing lint suppressions.
-- GitHub code uses a larch-owned core service port. Its adapter uses a pinned
-  Octocrab client with native TLS disabled and `rustls` enabled. It accepts only
-  a non-empty `LARCH_GH_TOKEN`, never reads `GH_TOKEN`, `GITHUB_TOKEN`, or
-  GitHub CLI state, and does not expose an arbitrary REST URL or GraphQL
-  document to domain callers.
+- GitHub code uses a larch-owned core service port. A single core resolver
+  acquires the active GitHub CLI credential through the typed `gh auth token`
+  process operation. The clean child environment excludes `LARCH_GH_TOKEN`,
+  `GH_TOKEN`, and `GITHUB_TOKEN`. The adapter uses that result to build a pinned
+  Octocrab client with native TLS disabled and `rustls` enabled, and does not
+  expose an arbitrary REST URL or GraphQL document to domain callers.
 - Attestation domain inputs fix the repository to `character-ai/larch`, the
   release workflow to `.github/workflows/rust-release-assets.yaml`, GitHub's
   OIDC issuer and signer identities, and the trust roots. Callers provide only
@@ -202,5 +204,5 @@ targets without Python and must not introduce an undeclared native runtime
 library. The thin residual `scripts/larch.sh` bootstrap verifies and atomically
 installs the release-matched binary as specified by issue #7670. Its hidden
 `larch bootstrap self-check` command reports the compiled version and target
-for staged validation. Bootstrap use of `gh` does not authorize runtime service
-adapters to shell out to it.
+for staged validation. Runtime use of `gh` is confined to the fixed credential
+lookup. Service API operations remain owned by the typed Rust adapters.

--- a/crates/larch-adapters/src/github/mod.rs
+++ b/crates/larch-adapters/src/github/mod.rs
@@ -28,9 +28,15 @@ pub use release::{
 use bytes::Bytes;
 use http::header::{CONTENT_LENGTH, HeaderName};
 use http_body_util::{BodyExt, Limited};
-use larch_core::{GitHubTransportPolicy, ProcessCancellation, RuntimeRedactor, SafeText, env};
+use larch_core::{
+    ExternalProcessRunner, GitHubToken, GitHubTransportPolicy, ProcessCancellation,
+    RuntimeRedactor, SafeText, acquire_github_token,
+};
+pub use larch_core::{
+    GitHubTokenError as GitHubCredentialError, GitHubTokenErrorKind as GitHubCredentialErrorKind,
+};
 use octocrab::Octocrab;
-use std::{error::Error, ffi::OsString, fmt, future::Future};
+use std::{error::Error, fmt, future::Future, path::Path};
 use tokio::sync::Mutex;
 use url::Url;
 
@@ -39,45 +45,6 @@ const API_VERSION_HEADER: &str = "x-github-api-version";
 const API_VERSION: &str = "2022-11-28";
 const ACCEPT_VALUE: &str = "application/vnd.github+json";
 const USER_AGENT_VALUE: &str = "larch";
-
-/// Reason GitHub credential setup failed before any request was attempted.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum GitHubCredentialErrorKind {
-    Missing,
-    Empty,
-    NonUnicode,
-}
-
-/// Secret-free GitHub credential setup error.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct GitHubCredentialError {
-    kind: GitHubCredentialErrorKind,
-}
-
-impl GitHubCredentialError {
-    #[must_use]
-    pub const fn kind(self) -> GitHubCredentialErrorKind {
-        self.kind
-    }
-}
-
-impl fmt::Display for GitHubCredentialError {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str(match self.kind {
-            GitHubCredentialErrorKind::Missing => {
-                "LARCH_GH_TOKEN is required; export a non-empty GitHub token before starting larch"
-            }
-            GitHubCredentialErrorKind::Empty => {
-                "LARCH_GH_TOKEN must not be empty or whitespace-only"
-            }
-            GitHubCredentialErrorKind::NonUnicode => {
-                "LARCH_GH_TOKEN must be valid Unicode environment text"
-            }
-        })
-    }
-}
-
-impl Error for GitHubCredentialError {}
 
 /// Failure to construct the hardened GitHub service.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -143,39 +110,16 @@ impl fmt::Display for GitHubCompletionError {
 
 impl Error for GitHubCompletionError {}
 
-trait EnvironmentSource {
-    fn read(&self, name: &'static str) -> Option<OsString>;
-}
-
-struct ProcessEnvironment;
-
-impl EnvironmentSource for ProcessEnvironment {
-    fn read(&self, name: &'static str) -> Option<OsString> {
-        std::env::var_os(name)
-    }
-}
-
 // Deliberately non-Debug: a credential must not enter derived diagnostics.
 struct GitHubCredential(String);
 
-impl GitHubCredential {
-    fn load(source: &dyn EnvironmentSource) -> Result<Self, GitHubCredentialError> {
-        let raw = source
-            .read(env::LARCH_GH_TOKEN)
-            .ok_or(GitHubCredentialError {
-                kind: GitHubCredentialErrorKind::Missing,
-            })?;
-        let value = raw.into_string().map_err(|_| GitHubCredentialError {
-            kind: GitHubCredentialErrorKind::NonUnicode,
-        })?;
-        if value.trim().is_empty() {
-            return Err(GitHubCredentialError {
-                kind: GitHubCredentialErrorKind::Empty,
-            });
-        }
-        Ok(Self(value))
+impl From<GitHubToken> for GitHubCredential {
+    fn from(token: GitHubToken) -> Self {
+        Self(token.expose().to_owned())
     }
+}
 
+impl GitHubCredential {
     fn expose(&self) -> &str {
         &self.0
     }
@@ -212,17 +156,22 @@ impl OctocrabGitHubService {
         }
     }
 
-    /// Load the sole supported credential and construct one hardened client.
+    /// Acquire the sole supported credential from `gh` and construct one hardened client.
     ///
     /// # Errors
-    /// Fails before network access when `LARCH_GH_TOKEN` is missing, blank, or
-    /// invalid, or when fixed client configuration cannot be constructed.
-    pub fn from_environment() -> Result<Self, GitHubClientError> {
-        Self::from_source(&ProcessEnvironment)
+    /// Fails before network access when `gh` is absent or unauthenticated, its
+    /// output is invalid, or fixed client configuration cannot be constructed.
+    pub async fn from_gh<R: ExternalProcessRunner + ?Sized>(
+        runner: &R,
+        working_directory: &Path,
+        cancellation: &dyn ProcessCancellation,
+    ) -> Result<Self, GitHubClientError> {
+        let credential = acquire_github_token(runner, working_directory, cancellation).await?;
+        let credential = GitHubCredential::from(credential);
+        Self::from_credential(&credential)
     }
 
-    fn from_source(source: &dyn EnvironmentSource) -> Result<Self, GitHubClientError> {
-        let credential = GitHubCredential::load(source)?;
+    fn from_credential(credential: &GitHubCredential) -> Result<Self, GitHubClientError> {
         let policy = GitHubTransportPolicy::github_com();
         let mut redactor = RuntimeRedactor::default();
         let registered = redactor.register_exact_secret(credential.expose().to_owned());
@@ -237,7 +186,7 @@ impl OctocrabGitHubService {
                 "Octocrab GitHub API version does not match larch policy",
             )));
         }
-        let client = build_client(&credential, policy, API_BASE).map_err(|error| {
+        let client = build_client(credential, policy, API_BASE).map_err(|error| {
             GitHubClientError::Configuration(redactor.safe_text(error.to_string()))
         })?;
         Ok(Self {
@@ -255,15 +204,7 @@ impl OctocrabGitHubService {
 
     #[cfg(test)]
     pub(crate) fn from_test_token(token: &str) -> Self {
-        struct TestEnvironment(OsString);
-
-        impl EnvironmentSource for TestEnvironment {
-            fn read(&self, name: &'static str) -> Option<OsString> {
-                (name == env::LARCH_GH_TOKEN).then(|| self.0.clone())
-            }
-        }
-
-        Self::from_source(&TestEnvironment(OsString::from(token)))
+        Self::from_credential(&GitHubCredential(token.to_owned()))
             .expect("test token and active runtime must construct the client")
     }
 
@@ -440,101 +381,21 @@ mod tests {
     use super::*;
     use crate::runtime::{Cancellation, LarchRuntime};
     use larch_core::{GitHubResponseLimits, GitHubService};
-    use std::{collections::BTreeMap, sync::Mutex};
-
-    struct FakeEnvironment {
-        values: BTreeMap<&'static str, OsString>,
-        reads: Mutex<Vec<&'static str>>,
-    }
-
-    impl FakeEnvironment {
-        fn new(values: impl IntoIterator<Item = (&'static str, &'static str)>) -> Self {
-            Self {
-                values: values
-                    .into_iter()
-                    .map(|(key, value)| (key, OsString::from(value)))
-                    .collect(),
-                reads: Mutex::new(Vec::new()),
-            }
-        }
-    }
-
-    impl EnvironmentSource for FakeEnvironment {
-        fn read(&self, name: &'static str) -> Option<OsString> {
-            self.reads.lock().expect("read log lock").push(name);
-            self.values.get(name).cloned()
-        }
-    }
 
     fn configured_service(runtime: &LarchRuntime) -> OctocrabGitHubService {
         runtime.block_on(async {
-            OctocrabGitHubService::from_source(&FakeEnvironment::new([(
-                env::LARCH_GH_TOKEN,
-                "opaque test credential",
-            )]))
+            OctocrabGitHubService::from_credential(&GitHubCredential(
+                "opaque test credential".to_owned(),
+            ))
             .expect("fixed client should build")
         })
     }
 
     #[test]
-    fn credential_loader_reads_only_larch_token_without_fallbacks() {
-        let source = FakeEnvironment::new([
-            (env::GH_TOKEN, "legacy-token"),
-            (env::GITHUB_TOKEN, "actions-token"),
-        ]);
-
-        let error = GitHubCredential::load(&source)
-            .err()
-            .expect("fallbacks must be ignored");
-
-        assert_eq!(error.kind(), GitHubCredentialErrorKind::Missing);
-        assert_eq!(
-            source.reads.into_inner().expect("read log"),
-            [env::LARCH_GH_TOKEN]
-        );
-    }
-
-    #[test]
-    fn credential_loader_rejects_empty_and_whitespace_values() {
-        for value in ["", " \t\n"] {
-            let error =
-                GitHubCredential::load(&FakeEnvironment::new([(env::LARCH_GH_TOKEN, value)]))
-                    .err()
-                    .expect("blank token must fail");
-            assert_eq!(error.kind(), GitHubCredentialErrorKind::Empty);
-            assert_eq!(
-                error.to_string(),
-                "LARCH_GH_TOKEN must not be empty or whitespace-only"
-            );
-        }
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn credential_loader_rejects_non_unicode_without_echoing_bytes() {
-        use std::os::unix::ffi::OsStringExt;
-
-        let source = FakeEnvironment {
-            values: BTreeMap::from([(env::LARCH_GH_TOKEN, OsString::from_vec(vec![0xff]))]),
-            reads: Mutex::new(Vec::new()),
-        };
-        let error = GitHubCredential::load(&source)
-            .err()
-            .expect("non-Unicode token must fail");
-
-        assert_eq!(error.kind(), GitHubCredentialErrorKind::NonUnicode);
-        assert_eq!(
-            error.to_string(),
-            "LARCH_GH_TOKEN must be valid Unicode environment text"
-        );
-    }
-
-    #[test]
     fn client_construction_outside_runtime_fails_without_secret_diagnostics() {
-        let error = OctocrabGitHubService::from_source(&FakeEnvironment::new([(
-            env::LARCH_GH_TOKEN,
-            "unusual exact secret",
-        )]))
+        let error = OctocrabGitHubService::from_credential(&GitHubCredential(
+            "unusual exact secret".to_owned(),
+        ))
         .err()
         .expect("runtime-less construction must fail");
 

--- a/crates/larch-adapters/src/github/release.rs
+++ b/crates/larch-adapters/src/github/release.rs
@@ -136,7 +136,7 @@ impl fmt::Display for ReleaseServiceError {
             Self::MutationLost => formatter
                 .write_str("GitHub mutation could not be reconciled after an ambiguous outcome"),
             Self::RepositoryPolicyPermission => formatter.write_str(
-                "LARCH_GH_TOKEN requires repository Administration read permission for release policy checks and write permission to enable missing settings",
+                "the active gh credential requires repository Administration read permission for release policy checks and write permission to enable missing settings",
             ),
             Self::RepositoryPolicyStatus(status) => {
                 write!(formatter, "GitHub repository policy request returned status {status}")

--- a/crates/larch-adapters/src/github_actions.rs
+++ b/crates/larch-adapters/src/github_actions.rs
@@ -1344,7 +1344,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "requires LARCH_LIVE_GITHUB_ACTIONS=1, LARCH_LIVE_GITHUB_ACTIONS_RUN_ID, and LARCH_GH_TOKEN"]
+    #[ignore = "requires LARCH_LIVE_GITHUB_ACTIONS=1, LARCH_LIVE_GITHUB_ACTIONS_RUN_ID, and authenticated gh"]
     fn live_completed_public_run_logs_succeeds_without_exposing_token() {
         if std::env::var("LARCH_LIVE_GITHUB_ACTIONS").as_deref() != Ok("1") {
             return;
@@ -1355,9 +1355,13 @@ mod tests {
             .expect("run ID must be an unsigned integer");
         let runtime = crate::runtime::LarchRuntime::new().expect("runtime");
         let output = runtime.block_on(async {
-            let service = OctocrabGitHubService::from_environment()
-                .expect("live GitHub service must construct");
             let cancellation = crate::runtime::Cancellation::new();
+            let runner = crate::process::TokioProcessRunner::default();
+            let working_directory = std::env::current_dir().expect("cwd");
+            let service =
+                OctocrabGitHubService::from_gh(&runner, &working_directory, &cancellation)
+                    .await
+                    .expect("live GitHub service must construct");
             let repository =
                 GitHubRepositoryRef::new("character-ai", "larch").expect("fixed public repository");
             larch_core::run_logs(&service, &repository, run_id, &cancellation).await

--- a/crates/larch-adapters/src/process.rs
+++ b/crates/larch-adapters/src/process.rs
@@ -2,13 +2,11 @@
 
 use crate::logging::JsonlJournal;
 use crate::runtime::{Cancellation, ChildProcess, ChildWait, shutdown_child};
-#[cfg(test)]
-use larch_core::env as larch_env;
 use larch_core::{
     BusinessClock, ChildEnvironment, ExternalProcessRunner, ExternalProgram, HostUtilityProgram,
     JournalRecord, ProcessCancellation, ProcessError, ProcessErrorKind, ProcessEvent,
     ProcessEventKind, ProcessFuture, ProcessObserver, ProcessOutput, ProcessRequest, ProcessStatus,
-    RunId,
+    RunId, env as larch_env,
 };
 use std::{
     env,
@@ -352,6 +350,16 @@ fn copy_allowed_environment(command: &mut Command, request: &ProcessRequest) {
             command.env(key.name(), value);
         }
     }
+    if matches!(request.program(), ExternalProgram::GitHub(_)) {
+        for (key, name) in [
+            (ChildEnvironment::GhConfigDir, larch_env::GH_CONFIG_DIR),
+            (ChildEnvironment::XdgConfigHome, larch_env::XDG_CONFIG_HOME),
+        ] {
+            if let Some(value) = env::var_os(name) {
+                command.env(key.name(), value);
+            }
+        }
+    }
     for (key, value) in request.environment() {
         command.env(key.name(), value);
     }
@@ -605,8 +613,8 @@ mod tests {
     use super::*;
     use crate::runtime::LarchRuntime;
     use larch_core::{
-        ExternalProgram, GitCliOperation, HostUtilityProgram, ProcessRequest, ProcessRequestError,
-        VendorProgram,
+        ExternalProgram, GitCliOperation, GitHubCliOperation, HostUtilityProgram, ProcessRequest,
+        ProcessRequestError, VendorProgram,
     };
     use larch_test_support::{FakeProcessRunner, NeverCancelled, ProcessOutputBuilder, TestClock};
     use std::{
@@ -686,27 +694,33 @@ mod tests {
     }
 
     #[test]
-    fn executable_allowlist_excludes_service_clis_and_arbitrary_paths() {
+    fn executable_allowlist_contains_only_approved_typed_processes() {
         let allowed = [
             ExternalProgram::Vendor(VendorProgram::Claude),
             ExternalProgram::Vendor(VendorProgram::Codex),
             ExternalProgram::Vendor(VendorProgram::Cursor),
             ExternalProgram::Git(GitCliOperation::Version),
+            ExternalProgram::GitHub(GitHubCliOperation::AuthToken),
             ExternalProgram::HostUtility(HostUtilityProgram::Lsof),
         ];
-        assert_eq!(allowed.len(), 5);
+        assert_eq!(allowed.len(), 6);
         assert!(allowed.iter().all(|program| !program.reason().is_empty()));
+        assert!(
+            allowed
+                .iter()
+                .any(|program| matches!(program.executable().to_str(), Some("gh")))
+        );
         assert!(
             !allowed
                 .iter()
-                .any(|program| matches!(program.executable().to_str(), Some("gh" | "gcloud")))
+                .any(|program| matches!(program.executable().to_str(), Some("gcloud")))
         );
         let inherited: Vec<&str> = ChildEnvironment::production()
             .map(ChildEnvironment::name)
             .collect();
-        assert!(!inherited.contains(&larch_env::LARCH_GH_TOKEN));
-        assert!(!inherited.contains(&larch_env::GH_TOKEN));
-        assert!(!inherited.contains(&larch_env::GITHUB_TOKEN));
+        assert!(!inherited.contains(&"LARCH_GH_TOKEN"));
+        assert!(!inherited.contains(&"GH_TOKEN"));
+        assert!(!inherited.contains(&"GITHUB_TOKEN"));
         assert!(!inherited.contains(&"GOOGLE_APPLICATION_CREDENTIALS"));
         assert!(!inherited.contains(&"OPENAI_API_KEY"));
     }

--- a/crates/larch-adapters/src/upgrade_larch.rs
+++ b/crates/larch-adapters/src/upgrade_larch.rs
@@ -122,8 +122,6 @@ impl Context {
         }
         if bootstrap_environment {
             for (key, name) in [
-                (ChildEnvironment::GhToken, env::GH_TOKEN),
-                (ChildEnvironment::GitHubToken, env::GITHUB_TOKEN),
                 (ChildEnvironment::GhConfigDir, env::GH_CONFIG_DIR),
                 (ChildEnvironment::XdgConfigHome, env::XDG_CONFIG_HOME),
             ] {

--- a/crates/larch-cli/src/github_repository_resolution.rs
+++ b/crates/larch-cli/src/github_repository_resolution.rs
@@ -11,7 +11,8 @@ use std::{
 };
 
 use larch_adapters::{
-    GixRepository, github::OctocrabGitHubService, runtime::Cancellation, runtime::LarchRuntime,
+    GixRepository, TokioProcessRunner, github::OctocrabGitHubService, runtime::Cancellation,
+    runtime::LarchRuntime,
 };
 use larch_core::{GitHubRepositoryRef, GitHubService, Remote, RepositoryRead};
 
@@ -251,17 +252,23 @@ where
 }
 
 fn query_github_repository(reference: &GitHubRepositoryRef) -> Result<String, PrimaryFailure> {
+    let working_directory = env::current_dir().map_err(|error| PrimaryFailure {
+        kind: PrimaryFailureKind::Setup,
+        detail: format!("cannot resolve current directory: {error}"),
+    })?;
     let runtime = LarchRuntime::new().map_err(|error| PrimaryFailure {
         kind: PrimaryFailureKind::Setup,
         detail: format!("cannot initialize larch runtime: {error}"),
     })?;
     runtime.block_on(async {
-        let service =
-            OctocrabGitHubService::from_environment().map_err(|error| PrimaryFailure {
+        let runner = TokioProcessRunner::default();
+        let cancellation = Cancellation::new();
+        let service = OctocrabGitHubService::from_gh(&runner, &working_directory, &cancellation)
+            .await
+            .map_err(|error| PrimaryFailure {
                 kind: PrimaryFailureKind::Setup,
                 detail: error.to_string(),
             })?;
-        let cancellation = Cancellation::new();
         match service.repository(reference, &cancellation).await {
             Ok(repository) => Ok(repository.name_with_owner),
             Err(error) => Err(PrimaryFailure {
@@ -273,12 +280,25 @@ fn query_github_repository(reference: &GitHubRepositoryRef) -> Result<String, Pr
 }
 
 fn probe_service_setup() -> Result<(), PrimaryFailure> {
-    OctocrabGitHubService::from_environment()
-        .map(|_| ())
-        .map_err(|error| PrimaryFailure {
-            kind: PrimaryFailureKind::Setup,
-            detail: error.to_string(),
-        })
+    let working_directory = env::current_dir().map_err(|error| PrimaryFailure {
+        kind: PrimaryFailureKind::Setup,
+        detail: format!("cannot resolve current directory: {error}"),
+    })?;
+    let runtime = LarchRuntime::new().map_err(|error| PrimaryFailure {
+        kind: PrimaryFailureKind::Setup,
+        detail: format!("cannot initialize larch runtime: {error}"),
+    })?;
+    runtime.block_on(async {
+        let runner = TokioProcessRunner::default();
+        let cancellation = Cancellation::new();
+        OctocrabGitHubService::from_gh(&runner, &working_directory, &cancellation)
+            .await
+            .map(|_| ())
+            .map_err(|error| PrimaryFailure {
+                kind: PrimaryFailureKind::Setup,
+                detail: error.to_string(),
+            })
+    })
 }
 
 fn origin_repo_candidate(repository: Option<&GixRepository>) -> (String, bool) {

--- a/crates/larch-cli/src/main.rs
+++ b/crates/larch-cli/src/main.rs
@@ -654,7 +654,25 @@ fn run_resolve_repo(arguments: &TrailingArguments) -> ExitCode {
 fn run_logs(arguments: &RunLogsArguments) -> ExitCode {
     let output = match larch_adapters::runtime::LarchRuntime::new() {
         Ok(runtime) => runtime.block_on(async {
-            let service = match larch_adapters::github::OctocrabGitHubService::from_environment() {
+            let cancellation = larch_adapters::runtime::Cancellation::new();
+            let runner = larch_adapters::TokioProcessRunner::default();
+            let working_directory = match std::env::current_dir() {
+                Ok(path) => path,
+                Err(error) => {
+                    return larch_core::run_logs_setup_failure(
+                        &arguments.repository,
+                        arguments.run_id,
+                        format!("cannot resolve current directory: {error}"),
+                    );
+                }
+            };
+            let service = match larch_adapters::github::OctocrabGitHubService::from_gh(
+                &runner,
+                &working_directory,
+                &cancellation,
+            )
+            .await
+            {
                 Ok(service) => service,
                 Err(error) => {
                     return larch_core::run_logs_setup_failure(
@@ -664,7 +682,6 @@ fn run_logs(arguments: &RunLogsArguments) -> ExitCode {
                     );
                 }
             };
-            let cancellation = larch_adapters::runtime::Cancellation::new();
             larch_core::run_logs(
                 &service,
                 &arguments.repository,

--- a/crates/larch-cli/src/release_assets.rs
+++ b/crates/larch-cli/src/release_assets.rs
@@ -12,7 +12,7 @@ use std::{
 
 use flate2::{Compression, GzBuilder, read::GzDecoder};
 use larch_adapters::{
-    PathIntent, TemporaryRoot, atomic_write_bytes, atomic_write_utf8,
+    PathIntent, TemporaryRoot, TokioProcessRunner, atomic_write_bytes, atomic_write_utf8,
     github::{AttestationOperations, OctocrabAttestationTransport, OctocrabGitHubService},
     runtime::{Cancellation, LarchRuntime},
 };
@@ -434,9 +434,13 @@ fn verify_artifact_attestations(
     let runtime = LarchRuntime::new()
         .map_err(|error| AssetError::new(format!("attestation runtime failed: {error}")))?;
     runtime.block_on(async {
-        let service = OctocrabGitHubService::from_environment()
-            .map_err(|error| AssetError::new(error.to_string()))?;
+        let working_directory = std::env::current_dir()
+            .map_err(|error| AssetError::new(format!("credential lookup failed: {error}")))?;
         let cancellation = Cancellation::new();
+        let runner = TokioProcessRunner::default();
+        let service = OctocrabGitHubService::from_gh(&runner, &working_directory, &cancellation)
+            .await
+            .map_err(|error| AssetError::new(error.to_string()))?;
         let transport = OctocrabAttestationTransport::new(&service, &cancellation);
         let operations = AttestationOperations::new(&transport);
         let tag =

--- a/crates/larch-cli/src/release_common.rs
+++ b/crates/larch-cli/src/release_common.rs
@@ -25,18 +25,20 @@ impl ProductionReleaseServices {
     pub fn new() -> Result<Self, String> {
         let cwd = env::current_dir().map_err(|error| error.to_string())?;
         let repository = GixRepository::discover(&cwd).map_err(|error| error.to_string())?;
-        let git_policy = GitCliPolicy::new(cwd).map_err(|error| error.to_string())?;
+        let git_policy = GitCliPolicy::new(cwd.clone()).map_err(|error| error.to_string())?;
         let runtime = LarchRuntime::new().map_err(|error| error.to_string())?;
+        let cancellation = Cancellation::new();
+        let runner = TokioProcessRunner::default();
         let github = runtime
-            .block_on(async { OctocrabGitHubService::from_environment() })
+            .block_on(OctocrabGitHubService::from_gh(&runner, &cwd, &cancellation))
             .map_err(|error| error.to_string())?;
         Ok(Self {
             runtime,
-            cancellation: Cancellation::new(),
+            cancellation,
             github,
             repository,
             git_policy,
-            runner: TokioProcessRunner::default(),
+            runner,
         })
     }
 

--- a/crates/larch-cli/src/release_prepare.rs
+++ b/crates/larch-cli/src/release_prepare.rs
@@ -12,7 +12,8 @@ use std::{
 };
 
 use larch_adapters::{
-    GixRepository, PathIntent, RepositoryRoot, TemporaryRoot, atomic_write_utf8,
+    GixRepository, PathIntent, RepositoryRoot, TemporaryRoot, TokioProcessRunner,
+    atomic_write_utf8,
     github::{OctocrabGitHubService, ReleasePlanningService, ReleasePullRequest},
     runtime::{Cancellation, LarchRuntime},
 };
@@ -178,9 +179,11 @@ fn prepare_inner(arguments: &PrepareArguments) -> Result<(), PrepareError> {
     let runtime = LarchRuntime::new()
         .map_err(|error| PrepareError::new("gh-release-list-failed", error.to_string()))?;
     runtime.block_on(async {
-        let service = OctocrabGitHubService::from_environment()
-            .map_err(|error| PrepareError::new("gh-release-list-failed", error.to_string()))?;
         let cancellation = Cancellation::new();
+        let runner = TokioProcessRunner::default();
+        let service = OctocrabGitHubService::from_gh(&runner, &root, &cancellation)
+            .await
+            .map_err(|error| PrepareError::new("gh-release-list-failed", error.to_string()))?;
         prepare_with_service(
             arguments,
             &out_dir,

--- a/crates/larch-cli/tests/cli.rs
+++ b/crates/larch-cli/tests/cli.rs
@@ -1,6 +1,7 @@
 use std::{
     ffi::{OsStr, OsString},
     fs,
+    os::unix::fs::PermissionsExt as _,
     path::{Path, PathBuf},
     process::{Command as ProcessCommand, Output},
 };
@@ -80,6 +81,20 @@ Options:
 
 fn larch() -> Command {
     Command::cargo_bin("larch").expect("larch binary should build")
+}
+
+fn authenticated_gh(token: &str) -> tempfile::TempDir {
+    let directory = tempfile::tempdir().expect("fake gh directory");
+    let executable = directory.path().join("gh");
+    fs::write(
+        &executable,
+        format!(
+            "#!/bin/sh\n[ -z \"${{LARCH_GH_TOKEN:-}}\" ] || exit 3\n[ -z \"${{GH_TOKEN:-}}\" ] || exit 3\n[ -z \"${{GITHUB_TOKEN:-}}\" ] || exit 3\n[ \"$1\" = auth ] && [ \"$2\" = token ] || exit 2\n[ \"$3\" = --hostname ] && [ \"$4\" = github.com ] || exit 2\nprintf '%s\\n' '{token}'\n"
+        ),
+    )
+    .expect("fake gh");
+    fs::set_permissions(&executable, fs::Permissions::from_mode(0o755)).expect("fake gh mode");
+    directory
 }
 
 #[derive(Debug)]
@@ -414,10 +429,13 @@ fn workflow_path_preserves_its_legacy_stdout_contract() {
 }
 
 #[test]
-fn run_logs_reports_missing_rust_credential_without_fallback() {
-    for generic_credential in ["GH_TOKEN", "GITHUB_TOKEN"] {
+fn run_logs_ignores_token_environment_without_an_authenticated_gh_session() {
+    let home = tempfile::tempdir().expect("isolated home");
+    for generic_credential in ["LARCH_GH_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"] {
         larch()
-            .env_remove("LARCH_GH_TOKEN")
+            .env("HOME", home.path())
+            .env_remove("GH_CONFIG_DIR")
+            .env_remove("XDG_CONFIG_HOME")
             .env(generic_credential, "generic-token-must-not-authenticate")
             .args(["gh", "run-logs", "--run-id", "7", "--repo", "owner/repo"])
             .assert()
@@ -425,7 +443,7 @@ fn run_logs_reports_missing_rust_credential_without_fallback() {
             .stdout(predicate::str::contains(
                 "--- CI log (run 7, repo owner/repo): failed-job log shown.",
             ))
-            .stdout(predicate::str::contains("LARCH_GH_TOKEN is required"))
+            .stdout(predicate::str::contains("GitHub CLI"))
             .stderr("");
     }
 }
@@ -1238,11 +1256,16 @@ fn release_stage_commands_enter_the_rust_service_boundary() {
     for arguments in commands {
         larch()
             .current_dir(repository.path())
-            .env_remove("LARCH_GH_TOKEN")
+            .env("HOME", repository.path())
+            .env_remove("GH_CONFIG_DIR")
+            .env_remove("XDG_CONFIG_HOME")
+            .env("LARCH_GH_TOKEN", "must-not-authenticate")
+            .env("GH_TOKEN", "must-not-authenticate")
+            .env("GITHUB_TOKEN", "must-not-authenticate")
             .args(arguments)
             .assert()
             .failure()
-            .stderr(predicate::str::contains("LARCH_GH_TOKEN is required"));
+            .stderr(predicate::str::contains("GitHub CLI"));
     }
 }
 
@@ -1280,11 +1303,16 @@ fn release_publication_commands_enter_the_rust_service_boundary() {
     for arguments in commands {
         larch()
             .current_dir(repository.path())
-            .env_remove("LARCH_GH_TOKEN")
+            .env("HOME", repository.path())
+            .env_remove("GH_CONFIG_DIR")
+            .env_remove("XDG_CONFIG_HOME")
+            .env("LARCH_GH_TOKEN", "must-not-authenticate")
+            .env("GH_TOKEN", "must-not-authenticate")
+            .env("GITHUB_TOKEN", "must-not-authenticate")
             .args(arguments)
             .assert()
             .failure()
-            .stderr(predicate::str::contains("LARCH_GH_TOKEN is required"));
+            .stderr(predicate::str::contains("GitHub CLI"));
     }
 }
 
@@ -1300,7 +1328,7 @@ fn release_publication_constructs_production_services_before_validating_inputs()
             "https://github.com/character-ai/other.git",
         ],
     );
-    let token = "github_pat_000000000000000000000000000000000000";
+    let gh = authenticated_gh("github_pat_000000000000000000000000000000000000");
     command_at(
         repository.path(),
         &[
@@ -1316,7 +1344,10 @@ fn release_publication_constructs_production_services_before_validating_inputs()
             "1111111111111111111111111111111111111111",
         ],
     )
-    .env("LARCH_GH_TOKEN", token)
+    .env("PATH", gh.path())
+    .env("LARCH_GH_TOKEN", "must-not-authenticate")
+    .env("GH_TOKEN", "must-not-authenticate")
+    .env("GITHUB_TOKEN", "must-not-authenticate")
     .assert()
     .failure()
     .stderr(predicate::str::contains(

--- a/crates/larch-cli/tests/github_repository_resolution.rs
+++ b/crates/larch-cli/tests/github_repository_resolution.rs
@@ -119,7 +119,7 @@ fn remote_repo_absent_named_remote_fails() {
 }
 
 #[test]
-fn resolve_repo_uses_origin_when_service_credentials_are_absent() {
+fn resolve_repo_uses_origin_when_token_environment_is_ignored() {
     let temp = TempDir::new().expect("tempdir");
     let repo = init_repo(temp.path());
     git(
@@ -128,7 +128,12 @@ fn resolve_repo_uses_origin_when_service_credentials_are_absent() {
     );
 
     larch()
-        .env_remove("LARCH_GH_TOKEN")
+        .env("HOME", temp.path())
+        .env_remove("GH_CONFIG_DIR")
+        .env_remove("XDG_CONFIG_HOME")
+        .env("LARCH_GH_TOKEN", "must-not-authenticate")
+        .env("GH_TOKEN", "must-not-authenticate")
+        .env("GITHUB_TOKEN", "must-not-authenticate")
         .args(["gh", "resolve-repo"])
         .current_dir(&repo)
         .assert()
@@ -163,7 +168,12 @@ fn resolve_repo_works_in_linked_worktree() {
     );
 
     larch()
-        .env_remove("LARCH_GH_TOKEN")
+        .env("HOME", temp.path())
+        .env_remove("GH_CONFIG_DIR")
+        .env_remove("XDG_CONFIG_HOME")
+        .env("LARCH_GH_TOKEN", "must-not-authenticate")
+        .env("GH_TOKEN", "must-not-authenticate")
+        .env("GITHUB_TOKEN", "must-not-authenticate")
         .args(["gh", "resolve-repo"])
         .current_dir(&worktree)
         .assert()
@@ -177,7 +187,12 @@ fn resolve_repo_fails_without_repository() {
     let temp = TempDir::new().expect("tempdir");
 
     larch()
-        .env_remove("LARCH_GH_TOKEN")
+        .env("HOME", temp.path())
+        .env_remove("GH_CONFIG_DIR")
+        .env_remove("XDG_CONFIG_HOME")
+        .env("LARCH_GH_TOKEN", "must-not-authenticate")
+        .env("GH_TOKEN", "must-not-authenticate")
+        .env("GITHUB_TOKEN", "must-not-authenticate")
         .args(["gh", "resolve-repo"])
         .current_dir(temp.path())
         .assert()
@@ -192,7 +207,12 @@ fn resolve_repo_fails_when_origin_absent() {
     let repo = init_repo(temp.path());
 
     larch()
-        .env_remove("LARCH_GH_TOKEN")
+        .env("HOME", temp.path())
+        .env_remove("GH_CONFIG_DIR")
+        .env_remove("XDG_CONFIG_HOME")
+        .env("LARCH_GH_TOKEN", "must-not-authenticate")
+        .env("GH_TOKEN", "must-not-authenticate")
+        .env("GITHUB_TOKEN", "must-not-authenticate")
         .args(["gh", "resolve-repo"])
         .current_dir(&repo)
         .assert()
@@ -221,7 +241,12 @@ fn resolve_repo_rejects_malformed_origin() {
     );
 
     larch()
-        .env_remove("LARCH_GH_TOKEN")
+        .env("HOME", temp.path())
+        .env_remove("GH_CONFIG_DIR")
+        .env_remove("XDG_CONFIG_HOME")
+        .env("LARCH_GH_TOKEN", "must-not-authenticate")
+        .env("GH_TOKEN", "must-not-authenticate")
+        .env("GITHUB_TOKEN", "must-not-authenticate")
         .args(["gh", "resolve-repo"])
         .current_dir(&repo)
         .assert()

--- a/crates/larch-cli/tests/release_prepare.rs
+++ b/crates/larch-cli/tests/release_prepare.rs
@@ -155,7 +155,12 @@ fn release_prepare_accepts_clean_main_with_conversion_attributes() {
 
     larch()
         .current_dir(repository.path())
-        .env_remove("LARCH_GH_TOKEN")
+        .env("HOME", repository.path())
+        .env_remove("GH_CONFIG_DIR")
+        .env_remove("XDG_CONFIG_HOME")
+        .env("LARCH_GH_TOKEN", "must-not-authenticate")
+        .env("GH_TOKEN", "must-not-authenticate")
+        .env("GITHUB_TOKEN", "must-not-authenticate")
         .args([
             "release",
             "prepare",

--- a/crates/larch-cli/tests/upgrade_larch.rs
+++ b/crates/larch-cli/tests/upgrade_larch.rs
@@ -149,7 +149,9 @@ fn ordinary_upgrade_preflights_then_preserves_the_active_old_root() {
     fs::write(&marker, "old").expect("marker");
     harness
         .command()
-        .env("GH_TOKEN", "opaque-test-token")
+        .env("GH_TOKEN", "must-not-be-forwarded")
+        .env("GITHUB_TOKEN", "must-not-be-forwarded")
+        .env("GH_CONFIG_DIR", harness.home.join(".config/gh"))
         .arg("upgrade-larch")
         .arg("run")
         .assert()
@@ -167,7 +169,8 @@ fn ordinary_upgrade_preflights_then_preserves_the_active_old_root() {
         .find("claude plugin marketplace update larch-local")
         .expect("refresh");
     assert!(preflight < refresh);
-    assert!(log.contains("bootstrap-gh-token-present"));
+    assert!(!log.contains("bootstrap-gh-token-present"));
+    assert!(log.contains("bootstrap-gh-config-present"));
 }
 
 #[test]
@@ -338,6 +341,8 @@ fn bootstrap_script(root: &Path, version: &str, state: &Path, log: &Path) -> Str
         r#"#!/bin/sh
 printf 'bootstrap %s\n' "$*" >> '{log}'
 [ -z "${{GH_TOKEN:-}}" ] || printf 'bootstrap-gh-token-present\n' >> '{log}'
+[ -z "${{GITHUB_TOKEN:-}}" ] || printf 'bootstrap-gh-token-present\n' >> '{log}'
+[ -z "${{GH_CONFIG_DIR:-}}" ] || printf 'bootstrap-gh-config-present\n' >> '{log}'
 case "${{1:-}}" in
   --latest-stable-version) printf 'LARCH_STABLE_VERSION=2.0.0\n' ;;
   --preflight-release)

--- a/crates/larch-core/src/config.rs
+++ b/crates/larch-core/src/config.rs
@@ -25,12 +25,8 @@ pub mod env {
     pub const CURSOR_API_KEY: &str = "CURSOR_API_KEY";
     /// Temporary directory for an active design run.
     pub const DESIGN_TMPDIR: &str = "DESIGN_TMPDIR";
-    /// Legacy GitHub CLI credential, never read by the Rust GitHub service.
-    pub const GH_TOKEN: &str = "GH_TOKEN";
-    /// Explicit GitHub CLI configuration directory used by the bootstrap exception.
+    /// Explicit GitHub CLI configuration directory used by typed `gh` operations.
     pub const GH_CONFIG_DIR: &str = "GH_CONFIG_DIR";
-    /// GitHub Actions credential, never read by the Rust GitHub service.
-    pub const GITHUB_TOKEN: &str = "GITHUB_TOKEN";
     /// Optional Google Application Default Credentials file.
     pub const GOOGLE_APPLICATION_CREDENTIALS: &str = "GOOGLE_APPLICATION_CREDENTIALS";
     /// Current user's home directory.
@@ -53,8 +49,6 @@ pub mod env {
     pub const LARCH_CURSOR_MODEL: &str = "LARCH_CURSOR_MODEL";
     /// Release version pinned by the release workflow during a local upgrade.
     pub const LARCH_EXPECTED_STABLE_VERSION: &str = "LARCH_EXPECTED_STABLE_VERSION";
-    /// Sole credential read by the Rust GitHub service.
-    pub const LARCH_GH_TOKEN: &str = "LARCH_GH_TOKEN";
     /// Disable run-log commits for the current workflow.
     pub const LARCH_NO_LOGS_COMMIT: &str = "LARCH_NO_LOGS_COMMIT";
     /// Canonical run identifier.
@@ -79,7 +73,7 @@ pub mod env {
     pub const XDG_CONFIG_HOME: &str = "XDG_CONFIG_HOME";
 
     /// Shared names maintained by this module.
-    pub const ALL: [&str; 34] = [
+    pub const ALL: [&str; 31] = [
         ANTHROPIC_API_KEY,
         CLAUDE_PLUGIN_OPTION_CODEX_EFFORT,
         CLAUDE_PLUGIN_OPTION_CODEX_MODEL,
@@ -89,8 +83,6 @@ pub mod env {
         CURSOR_API_KEY,
         DESIGN_TMPDIR,
         GH_CONFIG_DIR,
-        GH_TOKEN,
-        GITHUB_TOKEN,
         GOOGLE_APPLICATION_CREDENTIALS,
         HOME,
         IMPLEMENT_TMPDIR,
@@ -102,7 +94,6 @@ pub mod env {
         LARCH_CODEX_VOTE_MODEL,
         LARCH_CURSOR_MODEL,
         LARCH_EXPECTED_STABLE_VERSION,
-        LARCH_GH_TOKEN,
         LARCH_NO_LOGS_COMMIT,
         LARCH_RUN_ID,
         LOGNAME,
@@ -124,9 +115,6 @@ mod tests {
 
     #[test]
     fn environment_names_preserve_live_public_strings() {
-        assert_eq!(env::GH_TOKEN, "GH_TOKEN");
-        assert_eq!(env::GITHUB_TOKEN, "GITHUB_TOKEN");
-        assert_eq!(env::LARCH_GH_TOKEN, "LARCH_GH_TOKEN");
         assert_eq!(
             env::GOOGLE_APPLICATION_CREDENTIALS,
             "GOOGLE_APPLICATION_CREDENTIALS"

--- a/crates/larch-core/src/github_auth.rs
+++ b/crates/larch-core/src/github_auth.rs
@@ -1,0 +1,269 @@
+//! GitHub credential acquisition through the authenticated GitHub CLI session.
+
+use crate::{
+    ExternalProcessRunner, ExternalProgram, GitHubCliOperation, ProcessCancellation,
+    ProcessErrorKind, ProcessRequest,
+};
+use std::{error::Error, fmt, num::NonZeroUsize, path::Path, time::Duration};
+
+const TOKEN_TIMEOUT: Duration = Duration::from_secs(10);
+const TOKEN_SHUTDOWN_GRACE: Duration = Duration::from_secs(1);
+const TOKEN_OUTPUT_LIMIT: NonZeroUsize = NonZeroUsize::new(64 * 1024).unwrap();
+
+/// Validated credential returned by `gh auth token`.
+///
+/// This type deliberately does not implement `Debug` so derived diagnostics
+/// cannot expose the credential.
+pub struct GitHubToken(String);
+
+impl GitHubToken {
+    /// Expose the credential only at the authenticated transport boundary.
+    #[must_use]
+    pub fn expose(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Reason GitHub credential acquisition failed before network access.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GitHubTokenErrorKind {
+    CliUnavailable,
+    NotAuthenticated,
+    Interrupted,
+    InvalidOutput,
+    InvalidWorkingDirectory,
+}
+
+/// Secret-free GitHub credential acquisition error.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct GitHubTokenError {
+    kind: GitHubTokenErrorKind,
+}
+
+impl GitHubTokenError {
+    #[must_use]
+    pub const fn kind(self) -> GitHubTokenErrorKind {
+        self.kind
+    }
+
+    const fn new(kind: GitHubTokenErrorKind) -> Self {
+        Self { kind }
+    }
+}
+
+impl fmt::Display for GitHubTokenError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self.kind {
+            GitHubTokenErrorKind::CliUnavailable => {
+                "GitHub CLI (gh) is required; install gh and run `gh auth login`"
+            }
+            GitHubTokenErrorKind::NotAuthenticated => {
+                "GitHub CLI is not authenticated; run `gh auth login`"
+            }
+            GitHubTokenErrorKind::Interrupted => {
+                "could not read the GitHub CLI credential; retry `gh auth token`"
+            }
+            GitHubTokenErrorKind::InvalidOutput => {
+                "GitHub CLI returned an invalid credential; run `gh auth login`"
+            }
+            GitHubTokenErrorKind::InvalidWorkingDirectory => {
+                "GitHub CLI credential lookup requires an absolute working directory"
+            }
+        })
+    }
+}
+
+impl Error for GitHubTokenError {}
+
+/// Acquire the sole GitHub credential through the closed `gh auth token` process operation.
+///
+/// # Errors
+/// Returns a secret-free error when `gh` is absent, unauthenticated, interrupted,
+/// or returns malformed or truncated output.
+pub async fn acquire_github_token<R: ExternalProcessRunner + ?Sized>(
+    runner: &R,
+    working_directory: &Path,
+    cancellation: &dyn ProcessCancellation,
+) -> Result<GitHubToken, GitHubTokenError> {
+    let request = ProcessRequest::new(
+        ExternalProgram::GitHub(GitHubCliOperation::AuthToken),
+        std::iter::empty::<&str>(),
+        working_directory.to_path_buf(),
+        TOKEN_TIMEOUT,
+        TOKEN_SHUTDOWN_GRACE,
+        TOKEN_OUTPUT_LIMIT,
+    )
+    .map_err(|_| GitHubTokenError::new(GitHubTokenErrorKind::InvalidWorkingDirectory))?;
+    let output = runner.run(request, cancellation).await.map_err(|error| {
+        let kind = match error.kind() {
+            ProcessErrorKind::Cancelled | ProcessErrorKind::TimedOut => {
+                GitHubTokenErrorKind::Interrupted
+            }
+            ProcessErrorKind::Spawn
+            | ProcessErrorKind::Input
+            | ProcessErrorKind::Wait
+            | ProcessErrorKind::Capture
+            | ProcessErrorKind::Termination => GitHubTokenErrorKind::CliUnavailable,
+        };
+        GitHubTokenError::new(kind)
+    })?;
+    if !output.status().success() {
+        return Err(GitHubTokenError::new(
+            GitHubTokenErrorKind::NotAuthenticated,
+        ));
+    }
+    if output.stdout_truncated() || output.stderr_truncated() {
+        return Err(GitHubTokenError::new(GitHubTokenErrorKind::InvalidOutput));
+    }
+    let raw = String::from_utf8(output.stdout().to_vec())
+        .map_err(|_| GitHubTokenError::new(GitHubTokenErrorKind::InvalidOutput))?;
+    let token = raw.trim();
+    if token.is_empty() || token.bytes().any(|byte| !byte.is_ascii_graphic()) {
+        return Err(GitHubTokenError::new(GitHubTokenErrorKind::InvalidOutput));
+    }
+    Ok(GitHubToken(token.to_owned()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{ProcessError, ProcessFuture, ProcessOutput, ProcessStatus};
+    use std::{
+        future::{self, Future},
+        sync::{Arc, Mutex},
+        task::{Context, Poll, Wake, Waker},
+    };
+
+    struct NoopWake;
+
+    impl Wake for NoopWake {
+        fn wake(self: Arc<Self>) {}
+    }
+
+    fn block_on<F: Future>(future: F) -> F::Output {
+        let waker = Waker::from(Arc::new(NoopWake));
+        let mut context = Context::from_waker(&waker);
+        let mut future = Box::pin(future);
+        loop {
+            match future.as_mut().poll(&mut context) {
+                Poll::Ready(output) => return output,
+                Poll::Pending => std::thread::yield_now(),
+            }
+        }
+    }
+
+    struct NeverCancelled;
+
+    impl ProcessCancellation for NeverCancelled {
+        fn is_cancelled(&self) -> bool {
+            false
+        }
+
+        fn cancelled(&self) -> std::pin::Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+            Box::pin(future::pending())
+        }
+    }
+
+    struct FakeRunner {
+        result: Mutex<Option<Result<ProcessOutput, ProcessError>>>,
+        requests: Mutex<Vec<ProcessRequest>>,
+    }
+
+    impl FakeRunner {
+        fn new(result: Result<ProcessOutput, ProcessError>) -> Self {
+            Self {
+                result: Mutex::new(Some(result)),
+                requests: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    impl ExternalProcessRunner for FakeRunner {
+        fn run<'a>(
+            &'a self,
+            request: ProcessRequest,
+            _cancellation: &'a dyn ProcessCancellation,
+        ) -> ProcessFuture<'a> {
+            self.requests.lock().expect("request lock").push(request);
+            let result = self
+                .result
+                .lock()
+                .expect("result lock")
+                .take()
+                .expect("one fake result");
+            Box::pin(async move { result })
+        }
+    }
+
+    fn output(success: bool, stdout: &[u8]) -> ProcessOutput {
+        ProcessOutput::new(
+            ProcessStatus::new(success, Some(i32::from(!success))),
+            stdout.to_vec(),
+            Vec::new(),
+            false,
+            false,
+        )
+    }
+
+    #[test]
+    fn token_lookup_uses_only_the_closed_gh_operation() {
+        let runner = FakeRunner::new(Ok(output(true, b"opaque-token\n")));
+        let cwd = std::env::current_dir().expect("cwd");
+        let token = block_on(acquire_github_token(&runner, &cwd, &NeverCancelled)).expect("token");
+
+        assert_eq!(token.expose(), "opaque-token");
+        let requests = runner.requests.into_inner().expect("requests");
+        assert_eq!(requests.len(), 1);
+        assert_eq!(
+            requests[0].program(),
+            &ExternalProgram::GitHub(GitHubCliOperation::AuthToken)
+        );
+        assert!(requests[0].arguments().is_empty());
+        assert!(requests[0].environment().is_empty());
+        let mut arguments = requests[0].arguments().to_vec();
+        requests[0].program().append_fixed_arguments(&mut arguments);
+        assert_eq!(
+            arguments,
+            ["auth", "token", "--hostname", "github.com"].map(std::ffi::OsString::from)
+        );
+    }
+
+    #[test]
+    fn token_lookup_rejects_unauthenticated_and_invalid_output() {
+        let cwd = std::env::current_dir().expect("cwd");
+        let unavailable = FakeRunner::new(Err(ProcessError::new(
+            ProcessErrorKind::Spawn,
+            "raw process detail",
+            None,
+        )));
+        let error = block_on(acquire_github_token(&unavailable, &cwd, &NeverCancelled))
+            .err()
+            .expect("missing gh must fail");
+        assert_eq!(error.kind(), GitHubTokenErrorKind::CliUnavailable);
+        assert!(error.to_string().contains("install gh"));
+        assert!(!error.to_string().contains("raw process detail"));
+
+        let unauthenticated = FakeRunner::new(Ok(output(false, b"")));
+        let error = block_on(acquire_github_token(
+            &unauthenticated,
+            &cwd,
+            &NeverCancelled,
+        ))
+        .err()
+        .expect("unauthenticated gh must fail");
+        assert_eq!(error.kind(), GitHubTokenErrorKind::NotAuthenticated);
+        assert!(error.to_string().contains("gh auth login"));
+
+        let empty = FakeRunner::new(Ok(output(true, b" \n")));
+        let error = block_on(acquire_github_token(&empty, &cwd, &NeverCancelled))
+            .err()
+            .expect("empty token must fail");
+        assert_eq!(error.kind(), GitHubTokenErrorKind::InvalidOutput);
+
+        let multiline = FakeRunner::new(Ok(output(true, b"first\nsecond\n")));
+        let error = block_on(acquire_github_token(&multiline, &cwd, &NeverCancelled))
+            .err()
+            .expect("multiline token must fail");
+        assert_eq!(error.kind(), GitHubTokenErrorKind::InvalidOutput);
+    }
+}

--- a/crates/larch-core/src/lib.rs
+++ b/crates/larch-core/src/lib.rs
@@ -8,6 +8,7 @@ mod error;
 mod git;
 mod github;
 mod github_actions;
+mod github_auth;
 mod logging_util;
 mod object_store;
 mod outcome;
@@ -55,15 +56,16 @@ pub use github::{
     resolve_tag_object_id, select_release_for_tag,
 };
 pub use github_actions::{RunLogsOutput, run_logs, run_logs_setup_failure, workflow_path};
+pub use github_auth::{GitHubToken, GitHubTokenError, GitHubTokenErrorKind, acquire_github_token};
 pub use logging_util::emit_kv;
 pub use object_store::{
     ObjectPage, ObjectStore, ObjectStoreError, ObjectStoreFuture, RemoteObject,
 };
 pub use outcome::{ExitCode, WorkflowOutcome};
 pub use process::{
-    ChildEnvironment, ExternalProcessRunner, ExternalProgram, GitCliOperation, HostUtilityProgram,
-    LarchProgram, ProcessCancellation, ProcessError, ProcessErrorKind, ProcessEvent,
-    ProcessEventKind, ProcessFuture, ProcessObserver, ProcessOutput, ProcessRequest,
+    ChildEnvironment, ExternalProcessRunner, ExternalProgram, GitCliOperation, GitHubCliOperation,
+    HostUtilityProgram, LarchProgram, ProcessCancellation, ProcessError, ProcessErrorKind,
+    ProcessEvent, ProcessEventKind, ProcessFuture, ProcessObserver, ProcessOutput, ProcessRequest,
     ProcessRequestError, ProcessRequestErrorKind, ProcessStatus, VendorProgram,
 };
 pub use redaction::{RedactionResult, RuntimeRedactor, SafeText, redact, redact_sensitive_paths};

--- a/crates/larch-core/src/process.rs
+++ b/crates/larch-core/src/process.rs
@@ -30,6 +30,37 @@ pub enum HostUtilityProgram {
     Lsof,
 }
 
+/// Approved GitHub CLI operations used to acquire the active `gh` credential.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GitHubCliOperation {
+    /// Read the token held by the authenticated GitHub CLI session.
+    AuthToken,
+}
+
+impl GitHubCliOperation {
+    /// Return the fixed arguments for this operation.
+    #[must_use]
+    pub const fn arguments(self) -> [&'static str; 4] {
+        match self {
+            Self::AuthToken => ["auth", "token", "--hostname", "github.com"],
+        }
+    }
+
+    /// Return the stable operation label.
+    #[must_use]
+    pub const fn operation(self) -> &'static str {
+        match self {
+            Self::AuthToken => "github.auth-token",
+        }
+    }
+
+    /// Return the allowlist rationale.
+    #[must_use]
+    pub const fn reason(self) -> &'static str {
+        "GitHub credential acquisition through the operator-authenticated gh session"
+    }
+}
+
 impl HostUtilityProgram {
     /// Return the fixed executable name.
     #[must_use]
@@ -151,6 +182,7 @@ impl GitCliOperation {
 pub enum ExternalProgram {
     Vendor(VendorProgram),
     Git(GitCliOperation),
+    GitHub(GitHubCliOperation),
     HostUtility(HostUtilityProgram),
     /// A fixed larch program derived from a validated plugin root.
     Larch(LarchProgram),
@@ -234,6 +266,7 @@ impl ExternalProgram {
         match self {
             Self::Vendor(program) => OsStr::new(program.executable()),
             Self::Git(_) => OsStr::new("git"),
+            Self::GitHub(_) => OsStr::new("gh"),
             Self::HostUtility(program) => OsStr::new(program.executable()),
             Self::Larch(program) => program.executable(),
         }
@@ -247,6 +280,7 @@ impl ExternalProgram {
             Self::Vendor(VendorProgram::Codex) => "vendor.codex",
             Self::Vendor(VendorProgram::Cursor) => "vendor.cursor",
             Self::Git(operation) => operation.subcommand(),
+            Self::GitHub(operation) => operation.operation(),
             Self::HostUtility(program) => program.operation(),
             Self::Larch(program) => program.operation(),
         }
@@ -258,6 +292,7 @@ impl ExternalProgram {
         match self {
             Self::Vendor(program) => program.reason(),
             Self::Git(operation) => operation.reason(),
+            Self::GitHub(operation) => operation.reason(),
             Self::HostUtility(program) => program.reason(),
             Self::Larch(program) => program.reason(),
         }
@@ -265,8 +300,14 @@ impl ExternalProgram {
 
     /// Append the fixed operation prefix before caller-owned arguments.
     pub fn append_fixed_arguments(&self, arguments: &mut Vec<OsString>) {
-        if let Self::Git(operation) = self {
-            arguments.insert(0, OsString::from(operation.subcommand()));
+        match self {
+            Self::Git(operation) => {
+                arguments.insert(0, OsString::from(operation.subcommand()));
+            }
+            Self::GitHub(operation) => {
+                arguments.splice(0..0, operation.arguments().into_iter().map(OsString::from));
+            }
+            Self::Vendor(_) | Self::HostUtility(_) | Self::Larch(_) => {}
         }
     }
 }
@@ -299,8 +340,6 @@ pub enum ChildEnvironment {
     CursorApiKey,
     ClaudePluginRoot,
     ClaudePluginData,
-    GhToken,
-    GitHubToken,
     GhConfigDir,
     XdgConfigHome,
 }
@@ -334,8 +373,6 @@ impl ChildEnvironment {
             Self::CursorApiKey => env::CURSOR_API_KEY,
             Self::ClaudePluginRoot => env::CLAUDE_PLUGIN_ROOT,
             Self::ClaudePluginData => env::CLAUDE_PLUGIN_DATA,
-            Self::GhToken => env::GH_TOKEN,
-            Self::GitHubToken => env::GITHUB_TOKEN,
             Self::GhConfigDir => env::GH_CONFIG_DIR,
             Self::XdgConfigHome => env::XDG_CONFIG_HOME,
         }

--- a/crates/larch-lint/src/rules/service_ownership.rs
+++ b/crates/larch-lint/src/rules/service_ownership.rs
@@ -4,9 +4,9 @@
 //! the `gcloud` service CLI stay confined to `crates/larch-adapters`. Production
 //! skills and scripts must not invoke `gcloud` or leak a service credential into
 //! a child environment. The service inventories must name each concrete-client
-//! owner so ownership never drifts away from its documentation. The clean-install
-//! `gh` bootstrap in `scripts/larch.sh` is a separate installer surface and is
-//! not a runtime service caller; see `docs/github-service-inventory.md`.
+//! owner so ownership never drifts away from its documentation. Runtime `gh` use
+//! is confined to the core-owned typed credential lookup; see
+//! `docs/github-service-inventory.md`.
 
 use std::{
     collections::{BTreeMap, BTreeSet},

--- a/docs/configuration-and-permissions.md
+++ b/docs/configuration-and-permissions.md
@@ -244,33 +244,28 @@ them.
 See the [Google ADC security contract](security/supply-chain-credentials-and-services.md#google-application-default-credentials)
 for the canonical trust boundary.
 
-### `LARCH_GH_TOKEN`
+### GitHub CLI authentication
 
-`LARCH_GH_TOKEN` is the sole credential input for Rust GitHub service calls.
-Set it in the environment before starting larch. Missing, empty, and
-whitespace-only values fail before any network request with setup guidance.
+Rust GitHub service calls acquire their credential by invoking `gh auth token`
+through the closed process runner. Install `gh` and run `gh auth login` before
+starting larch. A missing CLI or inactive login fails before any network
+request with install or authentication guidance.
 
-Larch does not consult `GH_TOKEN`, `GITHUB_TOKEN`, `gh` configuration,
-keychain state, argv, stdin, repository configuration, issue text, or session
-files as fallbacks. The value stays in a non-`Debug` secret wrapper, is
-registered exactly with the runtime redactor, and is excluded from child
-process environments. The same child boundary excludes generic GitHub tokens,
-Google credential paths, and discovered access-token variables. The initial
-transport supports only GitHub.com over HTTPS; GitHub Enterprise needs a
-separate reviewed host policy.
+Larch does not read `LARCH_GH_TOKEN`, `GH_TOKEN`, or `GITHUB_TOKEN`. The
+credential returned by `gh` stays in a non-`Debug` secret wrapper, is registered
+exactly with the runtime redactor, and is excluded from child process
+environments. The initial transport supports only GitHub.com over HTTPS;
+GitHub Enterprise needs a separate reviewed host policy.
 
-`/release` additionally requires repository Administration read permission on
-`LARCH_GH_TOKEN` to verify merge-commit and immutable-release policy. It needs
+`/release` requires repository Administration read permission on the active
+`gh` credential to verify merge-commit and immutable-release policy. It needs
 Administration write only when either setting is disabled and must be enabled.
-Permissions held by `GH_TOKEN` or the active `gh` login do not satisfy this
-Rust service boundary.
 
-Larch never executes the `gh` or `gcloud` service CLI at runtime. The Rust
-process allowlist permits only the vendor agents, Git, and the larch bootstrap
-self-exec, and the `service-ownership` repository rule rejects `gcloud` and
-service-credential child environments in production surfaces. The clean-install
-`gh` in `scripts/larch.sh` runs before any runtime and is a separate installer
-surface.
+The Rust process allowlist permits `gh` only for the fixed `auth token`
+operation. GitHub API operations still use the typed Rust adapter. Larch never
+uses `gh api` as a service fallback and never executes the `gcloud` service CLI.
+The `service-ownership` repository rule rejects `gcloud` and service-credential
+child environments in production surfaces.
 
 See the [GitHub credential and transport security contract](security/supply-chain-credentials-and-services.md#github-credential-and-transport-boundary)
 for the canonical trust boundary.

--- a/docs/github-service-inventory.md
+++ b/docs/github-service-inventory.md
@@ -21,12 +21,13 @@ concrete clients, `gcloud`, and service-credential propagation.
 
 ## Concrete client owner
 
-`crates/larch-adapters/src/github/mod.rs` is the single concrete GitHub client
-owner. `OctocrabGitHubService::from_environment` builds the one private Octocrab
-client, reads exactly `LARCH_GH_TOKEN`, and pins the `api.github.com` and
-`github.com` host allowlist. It verifies that pinned Octocrab supplies one API
-version header. Other adapters layer typed operations over that client and hide
-REST URLs, GraphQL documents, and the client. Only
+`crates/larch-core/src/github_auth.rs` owns the single typed `gh auth token`
+credential lookup. `crates/larch-adapters/src/github/mod.rs` is the single
+concrete GitHub client owner. `OctocrabGitHubService::from_gh` builds the one
+private Octocrab client from the core-owned result and pins the
+`api.github.com` and `github.com` host allowlist. It verifies that pinned
+Octocrab supplies one API version header. Other adapters layer typed operations
+over that client and hide REST URLs, GraphQL documents, and the client. Only
 `crates/larch-adapters` imports Octocrab or names GitHub hosts and GraphQL.
 
 ## Adapter operation ownership
@@ -78,14 +79,13 @@ shell-out.
 
 ## CLI independence and the bootstrap exception
 
-No production runtime path shells out to `gh` from Rust. Rust reaches GitHub only
-through the authenticated Octocrab adapter. Residual `gh` CLI callers in Python,
-scripts, skills, and CI belong to commands still owned by Python and migrate with
-their own leaves; the `gh-argv-literal` rule keeps raw `gh` construction inside
-the Rust GitHub wrapper. The clean-install `gh` usage in `scripts/larch.sh`
-downloads and verifies the release binary before any runtime; it is a separate
-installer surface and does not authorize a runtime service adapter to shell out
-to `gh`.
+The only production Rust invocation of `gh` is the core-owned, fixed
+`gh auth token --hostname github.com` credential lookup. Rust performs GitHub
+API operations only through the authenticated Octocrab adapter. Residual `gh`
+CLI callers in Python, scripts, skills, and CI belong to commands still owned by
+Python and migrate with their own leaves. The `gh-argv-literal` rule keeps raw
+`gh` construction inside approved wrappers. The clean-install `gh` usage in
+`scripts/larch.sh` downloads and verifies the release binary before runtime.
 
 ## Redaction and diagnostics
 

--- a/docs/installation-and-setup.md
+++ b/docs/installation-and-setup.md
@@ -6,53 +6,32 @@
 
 ### Authentication
 
-Set up GitHub and Google credentials before starting larch. Installing `gh` is
-separate from supplying the `LARCH_GH_TOKEN` that larch uses for authenticated
-GitHub requests.
+Set up GitHub and Google credentials before starting larch.
 
 #### GitHub
 
-Larch requires a non-empty `LARCH_GH_TOKEN` in its environment. It does not
-fall back to `GH_TOKEN`, `GITHUB_TOKEN`, GitHub CLI configuration, or keychain
-state.
+Install the [GitHub CLI](https://cli.github.com/) and authenticate it:
 
-Choose one source for the token:
+```bash
+gh auth login
+```
 
-- **Reuse an existing GitHub CLI login.** Run this user setup command in your
-  shell:
-
-  ```bash
-  export LARCH_GH_TOKEN="$(gh auth token)"
-  ```
-
-  To provide the value for one Claude session only, run:
-
-  ```bash
-  LARCH_GH_TOKEN="$(gh auth token)" claude
-  ```
-
-  Larch does not run `gh auth token` during normal service calls.
-
-- **Create a personal access token (PAT).** Create it in GitHub
-  [Settings > Developer settings > Personal access tokens](https://github.com/settings/tokens).
-  Prefer a [fine-grained PAT](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token)
-  when its [repository permissions and API coverage](https://docs.github.com/en/rest/authentication/permissions-required-for-fine-grained-personal-access-tokens)
-  are sufficient. Current larch operations can require a classic PAT when a
-  required GitHub API operation is not available to a fine-grained PAT. Export
-  the selected token as `LARCH_GH_TOKEN`. Keep the value in a password manager
-  or secret manager; never commit it to a repository or a `.env` file.
+Larch invokes `gh auth token` through its typed process boundary and uses the
+active `gh` session for GitHub API requests. It does not read
+`LARCH_GH_TOKEN`, `GH_TOKEN`, or `GITHUB_TOKEN` itself. The active session must
+hold every permission required by the operation. `/release` policy checks need
+repository Administration read permission and need Administration write only
+when they must enable a disabled setting.
 
 Verify the setup without printing the token:
 
 ```bash
-test -n "$LARCH_GH_TOKEN"
-GH_TOKEN="$LARCH_GH_TOKEN" gh api user >/dev/null
+gh auth status
+gh auth token >/dev/null
 ```
 
-The commands succeed silently when `LARCH_GH_TOKEN` is non-empty and
-authenticates to GitHub. The explicit `GH_TOKEN=` assignment is only for this
-manual GitHub CLI verification command. Larch does not make that conversion or
-invoke `gh auth token` during service calls.
+The second command succeeds silently when the active `gh` session can provide
+a token. Neither command prints the credential.
 
 See the [GitHub credential and transport security contract](security/supply-chain-credentials-and-services.md#github-credential-and-transport-boundary)
 for the runtime guarantees and residual limits.

--- a/docs/security/supply-chain-credentials-and-services.md
+++ b/docs/security/supply-chain-credentials-and-services.md
@@ -102,10 +102,11 @@ JSON derived from the canonical owner and plan parsers. It is validation
 evidence, not executable input.
 
 The `service-ownership` rule rejects runtime `gcloud` execution. It also keeps
-clean-install `gh` use in `scripts/larch.sh` separate from runtime service
-access. Bootstrap use of `gh` does not authorize a runtime adapter to shell out.
-Its GitHub operation matrix fails on ownership or migration-state drift,
-including chief-issue placeholders, inventory gaps, and generic-token fallback.
+clean-install `gh` use in `scripts/larch.sh` separate from the fixed runtime
+credential lookup. Neither path authorizes `gh` API calls from a runtime
+adapter. Its GitHub operation matrix fails on ownership or migration-state
+drift, including chief-issue placeholders, inventory gaps, and generic-token
+fallback.
 
 ### Upgrade and rollback boundaries
 
@@ -201,14 +202,15 @@ cutover boundary lives in
 
 ### GitHub credential and transport boundary
 
-The Rust GitHub service reads exactly one non-empty `LARCH_GH_TOKEN` from the
-environment. It never falls back to `GH_TOKEN`, `GITHUB_TOKEN`, GitHub CLI
-configuration, keychain state, argv, stdin, repository content, issue text, or
-session files. Missing, whitespace-only, and non-Unicode values fail before
-network access. The credential is held by a non-`Debug` wrapper, registered by
-exact value with an invocation-owned redactor, and omitted from the typed child
-environment allowlist. Authorization diagnostics pass through that redactor.
-The Octocrab build excludes its tracing feature.
+The Rust GitHub service acquires exactly one credential by invoking
+`gh auth token` through the core-owned typed process operation. The process
+runner uses a clean environment, permits the GitHub CLI configuration selectors,
+and excludes `LARCH_GH_TOKEN`, `GH_TOKEN`, and `GITHUB_TOKEN`. Missing `gh`, an
+inactive login, and empty, truncated, or non-Unicode output fail before network
+access with fixed guidance. The credential is held by a non-`Debug` wrapper,
+registered by exact value with an invocation-owned redactor, and omitted from
+child environments. Authorization diagnostics pass through that redactor. The
+Octocrab build excludes its tracing feature.
 
 The adapter constructs one private Octocrab client inside the larch Tokio
 runtime. Octocrab is pinned with default features disabled and only its rustls
@@ -310,8 +312,9 @@ URL, GraphQL, or Python fallback.
 Repository-policy setup reads the merge-commit and immutable-release settings
 before it writes. It mutates only a setting that is disabled, so an already
 compliant repository requires Administration read but not Administration write
-on `LARCH_GH_TOKEN`. Repairing a disabled setting requires Administration
-write. Missing permission returns a fixed, secret-free policy diagnostic. A
+on the active `gh` credential. Repairing a disabled setting requires
+Administration write. Missing permission returns a fixed, secret-free policy
+diagnostic. A
 required mutation remains fail-closed, and every successful setup performs a
 final read-back of both owning policy surfaces.
 

--- a/plugin/ARCHITECTURE.md
+++ b/plugin/ARCHITECTURE.md
@@ -131,17 +131,19 @@ work:
   non-atomic final rows for the #7675 commands. A later-domain row remains
   Python-owned until its named migration issue performs the atomic cutover.
 - Product child processes use the `ExternalProcessRunner` core port. Its closed
-  enum permits typed Claude, Codex, Cursor, Git, and #7670 larch bootstrap or
-  self-check operations. Larch program paths derive from validated plugin roots.
-  The adapter accepts argument arrays only, rebuilds child environments from an
-  allowlist, bounds output, and owns cancellation, timeout, termination, and reap.
+  enum permits typed Claude, Codex, Cursor, Git, the fixed GitHub credential
+  lookup, and #7670 larch bootstrap or self-check operations. Larch program
+  paths derive from validated plugin roots. The adapter accepts argument arrays
+  only, rebuilds child environments from an allowlist, bounds output, and owns
+  cancellation, timeout, termination, and reap.
   Repository-only lint bootstrap calls stay outside the product dependency
   graph and require reason-bearing lint suppressions.
-- GitHub code uses a larch-owned core service port. Its adapter uses a pinned
-  Octocrab client with native TLS disabled and `rustls` enabled. It accepts only
-  a non-empty `LARCH_GH_TOKEN`, never reads `GH_TOKEN`, `GITHUB_TOKEN`, or
-  GitHub CLI state, and does not expose an arbitrary REST URL or GraphQL
-  document to domain callers.
+- GitHub code uses a larch-owned core service port. A single core resolver
+  acquires the active GitHub CLI credential through the typed `gh auth token`
+  process operation. The clean child environment excludes `LARCH_GH_TOKEN`,
+  `GH_TOKEN`, and `GITHUB_TOKEN`. The adapter uses that result to build a pinned
+  Octocrab client with native TLS disabled and `rustls` enabled, and does not
+  expose an arbitrary REST URL or GraphQL document to domain callers.
 - Attestation domain inputs fix the repository to `character-ai/larch`, the
   release workflow to `.github/workflows/rust-release-assets.yaml`, GitHub's
   OIDC issuer and signer identities, and the trust roots. Callers provide only
@@ -202,5 +204,5 @@ targets without Python and must not introduce an undeclared native runtime
 library. The thin residual `scripts/larch.sh` bootstrap verifies and atomically
 installs the release-matched binary as specified by issue #7670. Its hidden
 `larch bootstrap self-check` command reports the compiled version and target
-for staged validation. Bootstrap use of `gh` does not authorize runtime service
-adapters to shell out to it.
+for staged validation. Runtime use of `gh` is confined to the fixed credential
+lookup. Service API operations remain owned by the typed Rust adapters.

--- a/plugin/docs/configuration-and-permissions.md
+++ b/plugin/docs/configuration-and-permissions.md
@@ -244,33 +244,28 @@ them.
 See the [Google ADC security contract](security/supply-chain-credentials-and-services.md#google-application-default-credentials)
 for the canonical trust boundary.
 
-### `LARCH_GH_TOKEN`
+### GitHub CLI authentication
 
-`LARCH_GH_TOKEN` is the sole credential input for Rust GitHub service calls.
-Set it in the environment before starting larch. Missing, empty, and
-whitespace-only values fail before any network request with setup guidance.
+Rust GitHub service calls acquire their credential by invoking `gh auth token`
+through the closed process runner. Install `gh` and run `gh auth login` before
+starting larch. A missing CLI or inactive login fails before any network
+request with install or authentication guidance.
 
-Larch does not consult `GH_TOKEN`, `GITHUB_TOKEN`, `gh` configuration,
-keychain state, argv, stdin, repository configuration, issue text, or session
-files as fallbacks. The value stays in a non-`Debug` secret wrapper, is
-registered exactly with the runtime redactor, and is excluded from child
-process environments. The same child boundary excludes generic GitHub tokens,
-Google credential paths, and discovered access-token variables. The initial
-transport supports only GitHub.com over HTTPS; GitHub Enterprise needs a
-separate reviewed host policy.
+Larch does not read `LARCH_GH_TOKEN`, `GH_TOKEN`, or `GITHUB_TOKEN`. The
+credential returned by `gh` stays in a non-`Debug` secret wrapper, is registered
+exactly with the runtime redactor, and is excluded from child process
+environments. The initial transport supports only GitHub.com over HTTPS;
+GitHub Enterprise needs a separate reviewed host policy.
 
-`/release` additionally requires repository Administration read permission on
-`LARCH_GH_TOKEN` to verify merge-commit and immutable-release policy. It needs
+`/release` requires repository Administration read permission on the active
+`gh` credential to verify merge-commit and immutable-release policy. It needs
 Administration write only when either setting is disabled and must be enabled.
-Permissions held by `GH_TOKEN` or the active `gh` login do not satisfy this
-Rust service boundary.
 
-Larch never executes the `gh` or `gcloud` service CLI at runtime. The Rust
-process allowlist permits only the vendor agents, Git, and the larch bootstrap
-self-exec, and the `service-ownership` repository rule rejects `gcloud` and
-service-credential child environments in production surfaces. The clean-install
-`gh` in `scripts/larch.sh` runs before any runtime and is a separate installer
-surface.
+The Rust process allowlist permits `gh` only for the fixed `auth token`
+operation. GitHub API operations still use the typed Rust adapter. Larch never
+uses `gh api` as a service fallback and never executes the `gcloud` service CLI.
+The `service-ownership` repository rule rejects `gcloud` and service-credential
+child environments in production surfaces.
 
 See the [GitHub credential and transport security contract](security/supply-chain-credentials-and-services.md#github-credential-and-transport-boundary)
 for the canonical trust boundary.

--- a/plugin/docs/github-service-inventory.md
+++ b/plugin/docs/github-service-inventory.md
@@ -21,12 +21,13 @@ concrete clients, `gcloud`, and service-credential propagation.
 
 ## Concrete client owner
 
-`crates/larch-adapters/src/github/mod.rs` is the single concrete GitHub client
-owner. `OctocrabGitHubService::from_environment` builds the one private Octocrab
-client, reads exactly `LARCH_GH_TOKEN`, and pins the `api.github.com` and
-`github.com` host allowlist. It verifies that pinned Octocrab supplies one API
-version header. Other adapters layer typed operations over that client and hide
-REST URLs, GraphQL documents, and the client. Only
+`crates/larch-core/src/github_auth.rs` owns the single typed `gh auth token`
+credential lookup. `crates/larch-adapters/src/github/mod.rs` is the single
+concrete GitHub client owner. `OctocrabGitHubService::from_gh` builds the one
+private Octocrab client from the core-owned result and pins the
+`api.github.com` and `github.com` host allowlist. It verifies that pinned
+Octocrab supplies one API version header. Other adapters layer typed operations
+over that client and hide REST URLs, GraphQL documents, and the client. Only
 `crates/larch-adapters` imports Octocrab or names GitHub hosts and GraphQL.
 
 ## Adapter operation ownership
@@ -78,14 +79,13 @@ shell-out.
 
 ## CLI independence and the bootstrap exception
 
-No production runtime path shells out to `gh` from Rust. Rust reaches GitHub only
-through the authenticated Octocrab adapter. Residual `gh` CLI callers in Python,
-scripts, skills, and CI belong to commands still owned by Python and migrate with
-their own leaves; the `gh-argv-literal` rule keeps raw `gh` construction inside
-the Rust GitHub wrapper. The clean-install `gh` usage in `scripts/larch.sh`
-downloads and verifies the release binary before any runtime; it is a separate
-installer surface and does not authorize a runtime service adapter to shell out
-to `gh`.
+The only production Rust invocation of `gh` is the core-owned, fixed
+`gh auth token --hostname github.com` credential lookup. Rust performs GitHub
+API operations only through the authenticated Octocrab adapter. Residual `gh`
+CLI callers in Python, scripts, skills, and CI belong to commands still owned by
+Python and migrate with their own leaves. The `gh-argv-literal` rule keeps raw
+`gh` construction inside approved wrappers. The clean-install `gh` usage in
+`scripts/larch.sh` downloads and verifies the release binary before runtime.
 
 ## Redaction and diagnostics
 

--- a/plugin/docs/installation-and-setup.md
+++ b/plugin/docs/installation-and-setup.md
@@ -6,53 +6,32 @@
 
 ### Authentication
 
-Set up GitHub and Google credentials before starting larch. Installing `gh` is
-separate from supplying the `LARCH_GH_TOKEN` that larch uses for authenticated
-GitHub requests.
+Set up GitHub and Google credentials before starting larch.
 
 #### GitHub
 
-Larch requires a non-empty `LARCH_GH_TOKEN` in its environment. It does not
-fall back to `GH_TOKEN`, `GITHUB_TOKEN`, GitHub CLI configuration, or keychain
-state.
+Install the [GitHub CLI](https://cli.github.com/) and authenticate it:
 
-Choose one source for the token:
+```bash
+gh auth login
+```
 
-- **Reuse an existing GitHub CLI login.** Run this user setup command in your
-  shell:
-
-  ```bash
-  export LARCH_GH_TOKEN="$(gh auth token)"
-  ```
-
-  To provide the value for one Claude session only, run:
-
-  ```bash
-  LARCH_GH_TOKEN="$(gh auth token)" claude
-  ```
-
-  Larch does not run `gh auth token` during normal service calls.
-
-- **Create a personal access token (PAT).** Create it in GitHub
-  [Settings > Developer settings > Personal access tokens](https://github.com/settings/tokens).
-  Prefer a [fine-grained PAT](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token)
-  when its [repository permissions and API coverage](https://docs.github.com/en/rest/authentication/permissions-required-for-fine-grained-personal-access-tokens)
-  are sufficient. Current larch operations can require a classic PAT when a
-  required GitHub API operation is not available to a fine-grained PAT. Export
-  the selected token as `LARCH_GH_TOKEN`. Keep the value in a password manager
-  or secret manager; never commit it to a repository or a `.env` file.
+Larch invokes `gh auth token` through its typed process boundary and uses the
+active `gh` session for GitHub API requests. It does not read
+`LARCH_GH_TOKEN`, `GH_TOKEN`, or `GITHUB_TOKEN` itself. The active session must
+hold every permission required by the operation. `/release` policy checks need
+repository Administration read permission and need Administration write only
+when they must enable a disabled setting.
 
 Verify the setup without printing the token:
 
 ```bash
-test -n "$LARCH_GH_TOKEN"
-GH_TOKEN="$LARCH_GH_TOKEN" gh api user >/dev/null
+gh auth status
+gh auth token >/dev/null
 ```
 
-The commands succeed silently when `LARCH_GH_TOKEN` is non-empty and
-authenticates to GitHub. The explicit `GH_TOKEN=` assignment is only for this
-manual GitHub CLI verification command. Larch does not make that conversion or
-invoke `gh auth token` during service calls.
+The second command succeeds silently when the active `gh` session can provide
+a token. Neither command prints the credential.
 
 See the [GitHub credential and transport security contract](security/supply-chain-credentials-and-services.md#github-credential-and-transport-boundary)
 for the runtime guarantees and residual limits.

--- a/plugin/docs/security/supply-chain-credentials-and-services.md
+++ b/plugin/docs/security/supply-chain-credentials-and-services.md
@@ -102,10 +102,11 @@ JSON derived from the canonical owner and plan parsers. It is validation
 evidence, not executable input.
 
 The `service-ownership` rule rejects runtime `gcloud` execution. It also keeps
-clean-install `gh` use in `scripts/larch.sh` separate from runtime service
-access. Bootstrap use of `gh` does not authorize a runtime adapter to shell out.
-Its GitHub operation matrix fails on ownership or migration-state drift,
-including chief-issue placeholders, inventory gaps, and generic-token fallback.
+clean-install `gh` use in `scripts/larch.sh` separate from the fixed runtime
+credential lookup. Neither path authorizes `gh` API calls from a runtime
+adapter. Its GitHub operation matrix fails on ownership or migration-state
+drift, including chief-issue placeholders, inventory gaps, and generic-token
+fallback.
 
 ### Upgrade and rollback boundaries
 
@@ -201,14 +202,15 @@ cutover boundary lives in
 
 ### GitHub credential and transport boundary
 
-The Rust GitHub service reads exactly one non-empty `LARCH_GH_TOKEN` from the
-environment. It never falls back to `GH_TOKEN`, `GITHUB_TOKEN`, GitHub CLI
-configuration, keychain state, argv, stdin, repository content, issue text, or
-session files. Missing, whitespace-only, and non-Unicode values fail before
-network access. The credential is held by a non-`Debug` wrapper, registered by
-exact value with an invocation-owned redactor, and omitted from the typed child
-environment allowlist. Authorization diagnostics pass through that redactor.
-The Octocrab build excludes its tracing feature.
+The Rust GitHub service acquires exactly one credential by invoking
+`gh auth token` through the core-owned typed process operation. The process
+runner uses a clean environment, permits the GitHub CLI configuration selectors,
+and excludes `LARCH_GH_TOKEN`, `GH_TOKEN`, and `GITHUB_TOKEN`. Missing `gh`, an
+inactive login, and empty, truncated, or non-Unicode output fail before network
+access with fixed guidance. The credential is held by a non-`Debug` wrapper,
+registered by exact value with an invocation-owned redactor, and omitted from
+child environments. Authorization diagnostics pass through that redactor. The
+Octocrab build excludes its tracing feature.
 
 The adapter constructs one private Octocrab client inside the larch Tokio
 runtime. Octocrab is pinned with default features disabled and only its rustls
@@ -310,8 +312,9 @@ URL, GraphQL, or Python fallback.
 Repository-policy setup reads the merge-commit and immutable-release settings
 before it writes. It mutates only a setting that is disabled, so an already
 compliant repository requires Administration read but not Administration write
-on `LARCH_GH_TOKEN`. Repairing a disabled setting requires Administration
-write. Missing permission returns a fixed, secret-free policy diagnostic. A
+on the active `gh` credential. Repairing a disabled setting requires
+Administration write. Missing permission returns a fixed, secret-free policy
+diagnostic. A
 required mutation remains fail-closed, and every successful setup performs a
 final read-back of both owning policy surfaces.
 

--- a/python/tests/release/test_assets.py
+++ b/python/tests/release/test_assets.py
@@ -20,7 +20,9 @@ def test_release_workflow_uses_staged_rust_executable_for_asset_commands() -> No
     assert "./target/release/larch release collect-assets" in workflow
     assert "./target/release/larch release validate-assets" in workflow
     assert "--verify-attestations" in workflow
-    assert "LARCH_GH_TOKEN=" in workflow
+    assert "gh auth login --hostname github.com --with-token" in workflow
+    assert "unset GH_TOKEN GITHUB_TOKEN" in workflow
+    assert "LARCH_GH_TOKEN=" not in workflow
     assert "actions/setup-python@" not in workflow
 
 


### PR DESCRIPTION
Fixes #7888

Summary:
- acquire the GitHub token through the typed gh auth token process boundary
- stop recognizing or forwarding LARCH_GH_TOKEN, GH_TOKEN, and GITHUB_TOKEN as runtime configuration
- preserve gh configuration-directory selectors and update release workflow provisioning
- update architecture, security, setup, and generated plugin documentation

Validation:
- make rust-test
- make rust-clippy
- make rust-lint
- make markdownlint
- cargo run -q -p larch-cli -- release plugin-runtime --check
- python3 -m pytest -q python/tests/release/test_assets.py

Self-review:
- corrected explicit child-environment override precedence
- pinned and tested the github.com hostname
- isolated ambient gh configuration in unauthenticated tests
- strengthened black-box proof that token variables do not reach the gh child
- corrected stale architecture and service-inventory claims