### PR TITLE
Release v54.0.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "53.1.24",
+  "version": "54.0.0",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2482,7 +2482,7 @@ dependencies = [
 
 [[package]]
 name = "larch-adapters"
-version = "53.1.24"
+version = "54.0.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -2514,7 +2514,7 @@ dependencies = [
 
 [[package]]
 name = "larch-cli"
-version = "53.1.24"
+version = "54.0.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -2535,7 +2535,7 @@ dependencies = [
 
 [[package]]
 name = "larch-core"
-version = "53.1.24"
+version = "54.0.0"
 dependencies = [
  "regex",
  "zip",
@@ -2543,7 +2543,7 @@ dependencies = [
 
 [[package]]
 name = "larch-lint"
-version = "53.1.24"
+version = "54.0.0"
 dependencies = [
  "assert_cmd",
  "automod",
@@ -2569,7 +2569,7 @@ dependencies = [
 
 [[package]]
 name = "larch-test-support"
-version = "53.1.24"
+version = "54.0.0"
 dependencies = [
  "larch-core",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2024"
 license = "MIT"
 repository = "https://github.com/character-ai/larch"
 rust-version = "1.94.1"
-version = "53.1.24"
+version = "54.0.0"
 
 [workspace.dependencies]
 assert_cmd = { version = "2.2.2", default-features = false }
@@ -33,9 +33,9 @@ http = { version = "1.4.2", default-features = false, features = ["std"] }
 http-body = { version = "1.0.1", default-features = false }
 http-body-util = { version = "0.1.4", default-features = false }
 inventory = { version = "0.3.24", default-features = false }
-larch-adapters = { version = "=53.1.24", path = "crates/larch-adapters" }
-larch-core = { version = "=53.1.24", path = "crates/larch-core" }
-larch-test-support = { version = "=53.1.24", path = "crates/larch-test-support" }
+larch-adapters = { version = "=54.0.0", path = "crates/larch-adapters" }
+larch-core = { version = "=54.0.0", path = "crates/larch-core" }
+larch-test-support = { version = "=54.0.0", path = "crates/larch-test-support" }
 nix = { version = "0.31.3", default-features = false, features = ["process", "signal"] }
 octocrab = { version = "=0.54.0", default-features = false, features = ["default-client", "jwt-aws-lc-rs", "rustls", "rustls-aws-lc-rs", "timeout"] }
 predicates = { version = "3.1.4", default-features = false }

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "53.1.24",
+  "version": "54.0.0",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
## v54.0.0

Major release since v53.1.24. Core Git, GitHub, release, and upgrade operations move to a verified Rust runtime. Run logs move to a cloud archive lifecycle. The security documentation set is restructured.

### Removed

- The `gc-run-logs` skill. Run-log housekeeping now runs through the cloud archive lifecycle. Git-backed run-log publication and retention workflows are gone (#7879).

### Added

- Cloud run-log archive: storage-root config with S3 preflight, a deterministic versioned run-archive format, append-only publication with durable retry and write-through caching, and safe bounded extraction with atomic cache materialization (#7832, #7833, #7863, #7844).
- A universal per-skill run lifecycle: one run ID, staging tree, and terminal publisher per invocation, plus an enforcement lint and instrumentation across every shipped skill and alias (#7869, #7890, #7878).
- Verified runtime-only plugin install path (#7722).
- Rust boundaries: hardened GitHub transport, typed GitHub Actions operations, trusted gix repository reads, a Google ADC and cloud-client boundary, provider-neutral object transports, and a closed typed Git CLI compatibility adapter (#7741, #7744, #7743, #7740, #7846, #7746).
- Aggregate migration governance audit and scheduled governance reporting (#7813, #7834).

### Changed

- Ported Git operations to Rust: status, branch and ref reads, staging, commit, conflict and rebase controls, phantom probes, main sync, force push, and the push rebase consumer cutover (#7766, #7777, #7795, #7774, #7775, #7790, #7792, #7805, #7770, #7848).
- Ported GitHub operations to Rust: repository and issue operations, pull-request, review, and issue-dependency operations, releases and bounded asset streaming, Actions helper commands, repository resolution, and artifact and immutable-release attestation verification (#7742, #7773, #7771, #7769, #7791, #7793, #7847, #7849).
- Ported the release and upgrade paths to Rust: preparation and bump classification, synchronized version mutation, asset construction and validation, draft staging, immutable publication and promotion, upgrade-larch orchestration, and the runtime-only plugin projection (#7794, #7803, #7802, #7808, #7811, #7772, #7767).
- Enforced verified Rust runtime entrypoints, rejected production Cargo and target-binary execution, verified that release and upgrade are Python-free, and preserved Python-first contracts for the Rust handoff (#7778, #7797, #7835, #7882).
- Cut over implement, design, and review run logs to cloud archive publication. Migrated read-only and stateful analyzers to the synchronized cache. Synced missing cloud runs into the local cache. Materialized verified legacy migration archives. Removed archived logs (#7866, #7867, #7870, #7871, #7864, #7889, #7831).
- Restructured the security docs: a document taxonomy with runtime policy packaging; supply-chain, credential, service, workflow-trust, mutation, and private-finding boundaries; consolidated artifact, redaction, and publication guidance; canonical references; and closed runtime-projection link gaps (#7860, #7861, #7862, #7865, #7868, #7875).
- Tightened plan and issue enforcement: freshness-checked issue mutations, executable-plan and force admission, plan binding to blocker and base freshness, and the issue-mutation owner boundary (#7796, #7798, #7801, #7804).
- Enforced retirement and ownership boundaries: registry-caller and Python retirement checks, shared-owner implementation leases, a shared-service ownership audit with CLI independence, a Git ownership audit hardened against argv bypasses, clean-install and issue-registry parity, dependency security parity, the GitHub credential contract, and closed service-ownership and secret-environment gaps (#7799, #7800, #7807, #7806, #7809, #7851, #7810, #7877, #7845, #7859).
- Sped up Rust CI caching and repository lint. Added differential Git fixtures, broadened GitCli coverage, and ran release platform tests on Git fixture packages (#7729, #7739, #7768, #7876).

### Fixed

- `/release` could not bootstrap the migrated Rust driver and misclassified a clean main (#7881).
- `/release` ensure-policy rewrote already-enabled settings and rejected release-scoped tokens (#7885).
- The GitHub token is now acquired from `gh`; token env-var recognition is dropped (#7891).
- Authenticated GitHub Actions log downloads (#7850).
- Removed duplicated Rust hooks from CI lint jobs (#7763).
