### PR TITLE
Fixes #7893: Repair release staging recovery

### DIFF
--- a/crates/larch-adapters/src/github/release.rs
+++ b/crates/larch-adapters/src/github/release.rs
@@ -19,7 +19,8 @@ use larch_core::{
     ASSET_MEDIA_TYPE, AssetStreamGuard, GitHubFailureInput, GitHubRateLimitInputs,
     GitHubRequestKind, GitHubRetryAction, ProcessCancellation, ReconciledMutation,
     ReleaseDataError, ReleaseState, RemoteAsset, SafeText, TagObjectId, classify_github_retry,
-    reconcile_mutation, require_asset_content_type, resolve_tag_object_id, select_release_for_tag,
+    reconcile_mutation, require_asset_content_type, resolve_tag_object_id,
+    select_release_for_staging, select_release_for_tag,
 };
 use octocrab::models::repos::{Asset, Release};
 use octocrab::repos::releases::MakeLatest;
@@ -348,6 +349,23 @@ impl<'a, T: ReleaseTransport> ReleaseOperations<'a, T> {
         Ok(select_release_for_tag(tag, releases)?)
     }
 
+    /// Select an exact-tag release or its mutable placeholder draft.
+    ///
+    /// # Errors
+    /// Fails when the transport fails or the staging identity is duplicated.
+    pub async fn release_for_staging(
+        &self,
+        repo: &RepoSlug,
+        input: &DraftReleaseInput,
+    ) -> Result<Option<ReleaseState>, ReleaseServiceError> {
+        let releases = self.transport.list_releases(repo).await?;
+        Ok(select_release_for_staging(
+            &input.tag,
+            &input.target_commitish,
+            releases,
+        )?)
+    }
+
     /// Select the most recently published non-draft release.
     ///
     /// # Errors
@@ -374,7 +392,8 @@ impl<'a, T: ReleaseTransport> ReleaseOperations<'a, T> {
         self.transport.latest_release(repo).await
     }
 
-    /// Create a draft release, reconciling an ambiguous create before retry.
+    /// Create a draft release and reconcile an ambiguous create without a
+    /// duplicate write.
     ///
     /// # Errors
     /// Fails when the transport fails, or when an ambiguous create cannot be
@@ -389,21 +408,19 @@ impl<'a, T: ReleaseTransport> ReleaseOperations<'a, T> {
             Err(error) if is_ambiguous_write(&error) => self.reconcile_create(repo, input).await?,
             Err(other) => return Err(other),
         };
-        if state.tag() != input.tag
-            || !state.is_mutable_draft()
-            || self
-                .transport
-                .release_body(repo, state.database_id())
-                .await?
-                != input.body
-        {
+        if state.tag() != input.tag && state.is_mutable_draft() {
+            return self.update_draft_release(repo, &state, input).await;
+        }
+        if state.tag() != input.tag || !state.is_mutable_draft() {
             return Err(ReleaseServiceError::MutationLost);
         }
+        self.verify_release_body(repo, state.database_id(), &input.body)
+            .await?;
         Ok(state)
     }
 
-    /// Update a mutable draft and verify the exact body on both clear and
-    /// ambiguous mutation outcomes.
+    /// Update a mutable draft and verify its body on both clear and ambiguous
+    /// mutation outcomes.
     ///
     /// # Errors
     /// Fails when the update or its owning-surface read-back fails.
@@ -421,18 +438,22 @@ impl<'a, T: ReleaseTransport> ReleaseOperations<'a, T> {
             .update_draft_release(repo, release.database_id(), input)
             .await;
         match result {
-            Ok(_) => {}
+            Ok(observed) => {
+                if observed.database_id() != release.database_id()
+                    || observed.tag() != input.tag
+                    || !observed.is_mutable_draft()
+                {
+                    return Err(ReleaseServiceError::MutationLost);
+                }
+                self.verify_release_body(repo, release.database_id(), &input.body)
+                    .await?;
+                return Ok(observed);
+            }
             Err(error) if is_ambiguous_write(&error) => {}
             Err(other) => return Err(other),
         }
-        if self
-            .transport
-            .release_body(repo, release.database_id())
-            .await?
-            != input.body
-        {
-            return Err(ReleaseServiceError::MutationLost);
-        }
+        self.verify_release_body(repo, release.database_id(), &input.body)
+            .await?;
         let observed = self
             .release_for_tag(repo, &input.tag)
             .await?
@@ -443,15 +464,29 @@ impl<'a, T: ReleaseTransport> ReleaseOperations<'a, T> {
         Ok(observed)
     }
 
+    async fn verify_release_body(
+        &self,
+        repo: &RepoSlug,
+        release_id: u64,
+        expected: &str,
+    ) -> Result<(), ReleaseServiceError> {
+        let observed = self.transport.release_body(repo, release_id).await?;
+        if release_bodies_match(expected, &observed) {
+            Ok(())
+        } else {
+            Err(ReleaseServiceError::MutationLost)
+        }
+    }
+
     async fn reconcile_create(
         &self,
         repo: &RepoSlug,
         input: &DraftReleaseInput,
     ) -> Result<ReleaseState, ReleaseServiceError> {
-        let existing = self.release_for_tag(repo, &input.tag).await?;
+        let existing = self.release_for_staging(repo, input).await?;
         match reconcile_mutation(GitHubRetryAction::ReconcileMutation, existing.is_some()) {
             ReconciledMutation::AlreadyApplied => existing.ok_or(ReleaseServiceError::MutationLost),
-            _ => self.transport.create_draft_release(repo, input).await,
+            _ => Err(ReleaseServiceError::AmbiguousMutation),
         }
     }
 
@@ -959,7 +994,9 @@ fn map_release(release: &Release) -> Result<ReleaseState, ReleaseServiceError> {
             .as_ref()
             .or(release.created_at.as_ref())
             .map(ToString::to_string);
-        state.with_publication(release.prerelease, published_at)
+        state
+            .with_staging_identity(release.name.clone(), release.target_commitish.clone())
+            .with_publication(release.prerelease, published_at)
     })
     .map_err(ReleaseServiceError::Data)
 }
@@ -1125,11 +1162,13 @@ impl ReleaseTransport for OctocrabReleaseTransport<'_> {
         release_id: u64,
         input: &DraftReleaseInput,
     ) -> ReleaseFuture<'b, ReleaseState> {
-        let url = format!(
-            "https://{API_HOST}/repos/{}/releases/{release_id}",
-            repo.path()
-        );
-        let body = serde_json::json!({"name": input.tag, "body": input.body});
+        let url = format!("/repos/{}/releases/{release_id}", repo.path());
+        let body = serde_json::json!({
+            "name": input.tag,
+            "body": input.body,
+            "tag_name": input.tag,
+            "target_commitish": input.target_commitish,
+        });
         Box::pin(self.guard(async move {
             self.service
                 .client
@@ -1141,10 +1180,7 @@ impl ReleaseTransport for OctocrabReleaseTransport<'_> {
     }
 
     fn release_body<'b>(&'b self, repo: &RepoSlug, release_id: u64) -> ReleaseFuture<'b, String> {
-        let url = format!(
-            "https://{API_HOST}/repos/{}/releases/{release_id}",
-            repo.path()
-        );
+        let url = format!("/repos/{}/releases/{release_id}", repo.path());
         Box::pin(self.guard(async move {
             self.get_json(url)
                 .await?
@@ -1253,6 +1289,11 @@ impl ReleaseTransport for OctocrabReleaseTransport<'_> {
             self.fetch_outcome(response, max_bytes).await
         }))
     }
+}
+
+fn release_bodies_match(expected: &str, observed: &str) -> bool {
+    expected == observed
+        || (!expected.ends_with('\n') && observed.strip_suffix('\n') == Some(expected))
 }
 
 #[cfg(test)]
@@ -1525,7 +1566,31 @@ mod release_tests {
     }
 
     #[test]
-    fn ambiguous_create_retries_the_idempotent_create_when_not_applied() {
+    fn ambiguous_create_adopts_and_repairs_a_placeholder_draft() {
+        let placeholder = release(7, "untagged-abc", true, false, Vec::new())
+            .with_staging_identity(Some("v1".to_owned()), "commit".to_owned());
+        let transport = FakeTransport {
+            releases: vec![placeholder],
+            create: Mutex::new([Err(ReleaseServiceError::AmbiguousMutation)].into()),
+            update: Mutex::new([Ok(release(7, "v1", true, false, Vec::new()))].into()),
+            release_body: "notes\n".to_owned(),
+            ..FakeTransport::default()
+        };
+        let input = DraftReleaseInput {
+            tag: "v1".to_owned(),
+            target_commitish: "commit".to_owned(),
+            body: "notes".to_owned(),
+        };
+
+        let staged = run(ReleaseOperations::new(&transport).stage_draft_release(&repo(), &input))
+            .expect("repaired placeholder");
+
+        assert_eq!(staged.tag(), "v1");
+        assert_eq!(*transport.list_calls.lock().expect("counter"), 1);
+    }
+
+    #[test]
+    fn ambiguous_create_does_not_repeat_while_a_placeholder_may_be_lagging() {
         let transport = FakeTransport {
             create: Mutex::new(
                 [
@@ -1543,9 +1608,11 @@ mod release_tests {
             body: "notes".to_owned(),
         };
 
-        let staged = run(ReleaseOperations::new(&transport).stage_draft_release(&repo(), &input))
-            .expect("retried release");
-        assert_eq!(staged.database_id(), 7);
+        assert_eq!(
+            run(ReleaseOperations::new(&transport).stage_draft_release(&repo(), &input)),
+            Err(ReleaseServiceError::AmbiguousMutation)
+        );
+        assert_eq!(transport.create.lock().expect("queue").len(), 1);
     }
 
     #[test]
@@ -1585,6 +1652,36 @@ mod release_tests {
                 .database_id(),
             7
         );
+    }
+
+    #[test]
+    fn clear_draft_update_uses_its_response_without_an_eventual_list_read() {
+        let staged = release(7, "v1", true, false, Vec::new());
+        let transport = FakeTransport {
+            release_body: "notes\n".to_owned(),
+            update: Mutex::new([Ok(staged.clone())].into()),
+            ..FakeTransport::default()
+        };
+        let input = DraftReleaseInput {
+            tag: "v1".to_owned(),
+            target_commitish: "commit".to_owned(),
+            body: "notes".to_owned(),
+        };
+
+        assert_eq!(
+            run(ReleaseOperations::new(&transport).update_draft_release(&repo(), &staged, &input,)),
+            Ok(staged)
+        );
+        assert_eq!(*transport.list_calls.lock().expect("counter"), 0);
+    }
+
+    #[test]
+    fn release_body_matching_accepts_only_one_added_terminal_newline() {
+        assert!(release_bodies_match("notes", "notes"));
+        assert!(release_bodies_match("notes", "notes\n"));
+        assert!(!release_bodies_match("notes", "notes\n\n"));
+        assert!(!release_bodies_match("notes\n", "notes\n\n"));
+        assert!(!release_bodies_match("notes", "changed\n"));
     }
 
     #[test]
@@ -1995,7 +2092,7 @@ mod transport_tests {
         status: u16,
         headers: Vec<(&'static str, String)>,
         body: Vec<u8>,
-        expected_request: Option<&'static str>,
+        expected_requests: Vec<&'static str>,
     }
 
     fn json_reply(status: u16, value: &serde_json::Value) -> Reply {
@@ -2003,7 +2100,7 @@ mod transport_tests {
             status,
             headers: vec![("Content-Type", "application/json".to_owned())],
             body: value.to_string().into_bytes(),
-            expected_request: None,
+            expected_requests: Vec::new(),
         }
     }
 
@@ -2013,7 +2110,18 @@ mod transport_tests {
         expected_request: &'static str,
     ) -> Reply {
         Reply {
-            expected_request: Some(expected_request),
+            expected_requests: vec![expected_request],
+            ..json_reply(status, value)
+        }
+    }
+
+    fn json_reply_expecting_all(
+        status: u16,
+        value: &serde_json::Value,
+        expected_requests: Vec<&'static str>,
+    ) -> Reply {
+        Reply {
+            expected_requests,
             ..json_reply(status, value)
         }
     }
@@ -2023,7 +2131,7 @@ mod transport_tests {
             status,
             headers: Vec::new(),
             body: Vec::new(),
-            expected_request: Some(expected_request),
+            expected_requests: vec![expected_request],
         }
     }
 
@@ -2032,7 +2140,7 @@ mod transport_tests {
             status: 302,
             headers: vec![("Location", location.to_owned())],
             body: Vec::new(),
-            expected_request: None,
+            expected_requests: Vec::new(),
         }
     }
 
@@ -2041,7 +2149,7 @@ mod transport_tests {
             status: 200,
             headers: vec![("Content-Type", ASSET_MEDIA_TYPE.to_owned())],
             body: bytes,
-            expected_request: None,
+            expected_requests: Vec::new(),
         }
     }
 
@@ -2056,8 +2164,8 @@ mod transport_tests {
                 let mut request = [0_u8; 16_384];
                 let read = socket.read(&mut request).expect("read request");
                 assert!(read > 0, "request must not be empty");
-                if let Some(expected) = reply.expected_request {
-                    let request = String::from_utf8_lossy(&request[..read]);
+                let request = String::from_utf8_lossy(&request[..read]);
+                for expected in reply.expected_requests {
                     assert!(
                         request.contains(expected),
                         "request did not contain {expected:?}: {request}"
@@ -2211,6 +2319,17 @@ mod transport_tests {
         let (service, _base, server) = stub(vec![
             json_reply(200, &json!([release_json(1, "v1", true)])),
             json_reply(201, &release_json(2, "v1", true)),
+            json_reply_expecting_all(
+                200,
+                &release_json(2, "v1", true),
+                vec![
+                    "PATCH /repos/o/r/releases/2",
+                    "\"name\":\"v1\"",
+                    "\"body\":\"notes\"",
+                    "\"tag_name\":\"v1\"",
+                    "\"target_commitish\":\"main\"",
+                ],
+            ),
             json_reply_expecting(
                 200,
                 &release_json(2, "v1", false),
@@ -2250,8 +2369,14 @@ mod transport_tests {
         assert!(created.is_draft());
         assert_eq!(created.database_id(), 2);
 
+        let updated = transport
+            .update_draft_release(&repo, created.database_id(), &input)
+            .await
+            .expect("update draft");
+        assert_eq!(updated.tag(), "v1");
+
         let published = transport
-            .publish_release(&repo, created.database_id())
+            .publish_release(&repo, updated.database_id())
             .await
             .expect("publish");
         assert!(!published.is_draft());

--- a/crates/larch-cli/src/release_stage.rs
+++ b/crates/larch-cli/src/release_stage.rs
@@ -98,6 +98,11 @@ trait Services {
     fn local_tag(&self, tag: &str) -> Result<Option<String>, String>;
     fn create_local_tag(&self, tag: &str, oid: &str) -> Result<(), String>;
     fn push_tag(&self, tag: &str) -> Result<(), String>;
+    fn staged_release(
+        &self,
+        repo: &RepoSlug,
+        input: &DraftReleaseInput,
+    ) -> Result<Option<ReleaseState>, String>;
     fn release(&self, repo: &RepoSlug, tag: &str) -> Result<Option<ReleaseState>, String>;
     fn create_draft(
         &self,
@@ -245,6 +250,17 @@ impl Services for ProductionServices {
             .map_err(|error| error.to_string())
     }
 
+    fn staged_release(
+        &self,
+        repo: &RepoSlug,
+        input: &DraftReleaseInput,
+    ) -> Result<Option<ReleaseState>, String> {
+        let transport = OctocrabReleaseTransport::new(&self.github, &self.cancellation);
+        self.runtime
+            .block_on(ReleaseOperations::new(&transport).release_for_staging(repo, input))
+            .map_err(|error| error.to_string())
+    }
+
     fn release(&self, repo: &RepoSlug, tag: &str) -> Result<Option<ReleaseState>, String> {
         let transport = OctocrabReleaseTransport::new(&self.github, &self.cancellation);
         self.runtime
@@ -358,19 +374,14 @@ fn stage_with(
         target_commitish: source_commit.clone(),
         body: SafeText::from_untrusted(notes).as_str().to_owned(),
     };
-    match services.release(&slug, &tag)? {
-        None => {
-            let _ = services.create_draft(&slug, &input)?;
-        }
+    let release = match services.staged_release(&slug, &input)? {
+        None => services.create_draft(&slug, &input)?,
         Some(release) if release.is_mutable_draft() => {
-            let _ = services.update_draft(&slug, &release, &input)?;
+            services.update_draft(&slug, &release, &input)?
         }
         Some(_) => return Err("staged release is not a mutable draft".to_owned()),
-    }
-    let release = services
-        .release(&slug, &tag)?
-        .ok_or_else(|| "staged release is missing".to_owned())?;
-    if !release.is_mutable_draft() {
+    };
+    if release.tag() != tag || !release.is_mutable_draft() {
         return Err("staged release is not a mutable draft".to_owned());
     }
     Ok(source_commit)
@@ -661,6 +672,16 @@ mod tests {
             *self.remote_tag.borrow_mut() = Some(SOURCE.to_owned());
             Ok(())
         }
+        fn staged_release(
+            &self,
+            _repo: &RepoSlug,
+            _input: &DraftReleaseInput,
+        ) -> Result<Option<ReleaseState>, String> {
+            if self.releases.borrow().is_empty() {
+                return Ok(None);
+            }
+            Ok(self.releases.borrow_mut().remove(0))
+        }
         fn release(&self, _repo: &RepoSlug, _tag: &str) -> Result<Option<ReleaseState>, String> {
             if self.releases.borrow().is_empty() {
                 return Ok(None);
@@ -801,7 +822,7 @@ mod tests {
         let notes = notes();
         let create = FakeServices {
             remote_tag: RefCell::new(None),
-            releases: RefCell::new(vec![None, Some(draft(Vec::new()))]),
+            releases: RefCell::new(vec![None]),
             ..FakeServices::default()
         };
         assert_eq!(
@@ -811,7 +832,7 @@ mod tests {
         assert_eq!(*create.created.borrow(), 1);
 
         let resume = FakeServices {
-            releases: RefCell::new(vec![Some(draft(Vec::new())), Some(draft(Vec::new()))]),
+            releases: RefCell::new(vec![Some(draft(Vec::new()))]),
             ..FakeServices::default()
         };
         assert!(stage_with(&resume, "1.2.3", notes.path(), "character-ai/larch", "7").is_ok());

--- a/crates/larch-core/src/github.rs
+++ b/crates/larch-core/src/github.rs
@@ -971,6 +971,8 @@ fn is_valid_asset_name(name: &str) -> bool {
 pub struct ReleaseState {
     database_id: u64,
     tag: String,
+    name: Option<String>,
+    target_commitish: Option<String>,
     draft: bool,
     immutable: bool,
     prerelease: bool,
@@ -998,6 +1000,8 @@ impl ReleaseState {
         Ok(Self {
             database_id,
             tag: tag.to_owned(),
+            name: None,
+            target_commitish: None,
             draft,
             immutable,
             prerelease: false,
@@ -1014,6 +1018,14 @@ impl ReleaseState {
         self
     }
 
+    /// Attach the GitHub staging identity used to recover a mutable draft.
+    #[must_use]
+    pub fn with_staging_identity(mut self, name: Option<String>, target_commitish: String) -> Self {
+        self.name = name.filter(|value| !value.is_empty());
+        self.target_commitish = (!target_commitish.is_empty()).then_some(target_commitish);
+        self
+    }
+
     /// Return the release database id.
     #[must_use]
     pub const fn database_id(&self) -> u64 {
@@ -1024,6 +1036,18 @@ impl ReleaseState {
     #[must_use]
     pub fn tag(&self) -> &str {
         &self.tag
+    }
+
+    /// Borrow the optional release title returned by GitHub.
+    #[must_use]
+    pub fn name(&self) -> Option<&str> {
+        self.name.as_deref()
+    }
+
+    /// Borrow the optional target commitish returned by GitHub.
+    #[must_use]
+    pub fn target_commitish(&self) -> Option<&str> {
+        self.target_commitish.as_deref()
     }
 
     /// Return whether the release is still a draft.
@@ -1079,6 +1103,41 @@ pub fn select_release_for_tag(
     let mut selected: Option<ReleaseState> = None;
     for release in releases {
         if release.tag() != tag {
+            continue;
+        }
+        if selected.is_some() {
+            return Err(ReleaseDataError::new(
+                ReleaseDataErrorKind::DuplicateReleaseTag,
+            ));
+        }
+        selected = Some(release);
+    }
+    Ok(selected)
+}
+
+/// Select one exact-tag release or its mutable GitHub placeholder draft.
+///
+/// GitHub may temporarily assign an `untagged-*` tag to a draft created just
+/// after its Git ref is pushed. The release name and exact target commit bind
+/// that placeholder to the requested staging transaction without accepting an
+/// unrelated draft.
+///
+/// # Errors
+/// Returns [`ReleaseDataErrorKind::DuplicateReleaseTag`] when more than one
+/// release claims the exact or placeholder staging identity.
+pub fn select_release_for_staging(
+    tag: &str,
+    target_commitish: &str,
+    releases: impl IntoIterator<Item = ReleaseState>,
+) -> Result<Option<ReleaseState>, ReleaseDataError> {
+    let mut selected: Option<ReleaseState> = None;
+    for release in releases {
+        let exact = release.tag() == tag;
+        let placeholder = release.is_mutable_draft()
+            && release.tag().starts_with("untagged-")
+            && release.name() == Some(tag)
+            && release.target_commitish() == Some(target_commitish);
+        if !exact && !placeholder {
             continue;
         }
         if selected.is_some() {
@@ -1441,6 +1500,40 @@ mod release_tests {
                 [release("dup", true, false), release("dup", true, false)]
             )
             .expect_err("duplicate tag should fail")
+            .kind(),
+            ReleaseDataErrorKind::DuplicateReleaseTag
+        );
+    }
+
+    #[test]
+    fn staging_selection_adopts_only_the_exact_mutable_placeholder() {
+        let placeholder = release("untagged-abc", true, false)
+            .with_staging_identity(Some("v2".to_owned()), "commit-2".to_owned());
+        let unrelated = release("untagged-def", true, false)
+            .with_staging_identity(Some("v2".to_owned()), "other".to_owned());
+        let selected =
+            select_release_for_staging("v2", "commit-2", [unrelated, placeholder.clone()])
+                .expect("selection")
+                .expect("placeholder");
+        assert_eq!(selected.database_id(), placeholder.database_id());
+
+        assert!(
+            select_release_for_staging(
+                "v2",
+                "commit-2",
+                [release("untagged-abc", false, false)
+                    .with_staging_identity(Some("v2".to_owned()), "commit-2".to_owned(),)],
+            )
+            .expect("selection")
+            .is_none()
+        );
+        assert_eq!(
+            select_release_for_staging(
+                "v2",
+                "commit-2",
+                [release("v2", true, false), placeholder],
+            )
+            .expect_err("duplicate staging identity should fail")
             .kind(),
             ReleaseDataErrorKind::DuplicateReleaseTag
         );

--- a/crates/larch-core/src/lib.rs
+++ b/crates/larch-core/src/lib.rs
@@ -53,7 +53,7 @@ pub use github::{
     ReconciledMutation, ReleaseDataError, ReleaseDataErrorKind, ReleaseState, RemoteAsset,
     TagObjectId, WorkflowDispatchRequest, WorkflowJob, WorkflowLogArchive, WorkflowRun,
     WorkflowRunFilters, classify_github_retry, reconcile_mutation, require_asset_content_type,
-    resolve_tag_object_id, select_release_for_tag,
+    resolve_tag_object_id, select_release_for_staging, select_release_for_tag,
 };
 pub use github_actions::{RunLogsOutput, run_logs, run_logs_setup_failure, workflow_path};
 pub use github_auth::{GitHubToken, GitHubTokenError, GitHubTokenErrorKind, acquire_github_token};

--- a/crates/larch-test-support/src/git.rs
+++ b/crates/larch-test-support/src/git.rs
@@ -242,7 +242,19 @@ impl GitRepository {
             )
         })?;
         let helper_bin = workspace.create_dir("bin")?;
-        let child_path = std::env::join_paths([git_parent, helper_bin.as_path()])
+        let mut child_path_entries = vec![git_parent.to_path_buf(), helper_bin];
+        for helper in ["basename", "sed", "uname"] {
+            let Ok(path) = find_executable(helper) else {
+                continue;
+            };
+            let Some(parent) = path.parent() else {
+                continue;
+            };
+            if !child_path_entries.iter().any(|entry| entry == parent) {
+                child_path_entries.push(parent.to_path_buf());
+            }
+        }
+        let child_path = std::env::join_paths(&child_path_entries)
             .map_err(|error| io::Error::new(io::ErrorKind::InvalidInput, error))?;
         let environment = TestEnvironment::isolated(&workspace)?
             .set("PATH", child_path)
@@ -1104,17 +1116,21 @@ fn command_output(status: ExitStatus, stdout: Vec<u8>, stderr: Vec<u8>) -> GitCo
 }
 
 fn find_git() -> io::Result<PathBuf> {
+    find_executable(git_binary_name())
+}
+
+fn find_executable(name: &str) -> io::Result<PathBuf> {
     let path = std::env::var_os("PATH")
         .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "PATH is not set"))?;
     for directory in std::env::split_paths(&path) {
-        let candidate = directory.join(git_binary_name());
+        let candidate = directory.join(name);
         if candidate.is_file() {
             return fs::canonicalize(candidate);
         }
     }
     Err(io::Error::new(
         io::ErrorKind::NotFound,
-        "installed Git was not found on PATH",
+        format!("installed {name} was not found on PATH"),
     ))
 }
 
@@ -1384,6 +1400,27 @@ mod tests {
             std::env::vars_os().collect::<std::collections::BTreeMap<_, _>>(),
             original_environment
         );
+    }
+
+    #[test]
+    fn installed_git_path_includes_discovered_shell_helper_directories() {
+        let repository = GitRepository::builder(GitFixture::Unborn)
+            .build()
+            .expect("repository");
+        let fixture_path = repository.environment.get("PATH").expect("fixture PATH");
+        let entries: Vec<_> = std::env::split_paths(fixture_path).collect();
+
+        for helper in ["basename", "sed", "uname"] {
+            let Ok(executable) = find_executable(helper) else {
+                continue;
+            };
+            assert!(
+                executable
+                    .parent()
+                    .is_some_and(|parent| entries.iter().any(|entry| entry == parent)),
+                "fixture PATH omitted {helper} parent"
+            );
+        }
     }
 
     #[test]

--- a/docs/rust-testing.md
+++ b/docs/rust-testing.md
@@ -34,11 +34,15 @@ test its own fixture and let Cargo run it in parallel.
 
 Git fixtures may invoke installed Git as a test oracle. `GitRepository` finds
 the executable once, then clears the child environment and supplies an owned
-home, temp directory, config, identity, dates, locale, and path. Commands set
-only the child working directory. Fixture code must not change the test
-process environment or working directory. Product crates must still use the
-closed Git interfaces described in `ARCHITECTURE.md`; the fixture API does not
-authorize a production arbitrary-argument Git runner.
+home, temp directory, config, identity, dates, locale, and path. The path
+contains the installed Git directory, the fixture helper directory, and only
+the discovered system directories required by Git's shell helpers:
+`basename`, `sed`, and `uname`. This keeps Homebrew and `/usr/local` Git
+portable without inheriting the full ambient path. Commands set only the child
+working directory. Fixture code must not change the test process environment
+or working directory. Product crates must still use the closed Git interfaces
+described in `ARCHITECTURE.md`; the fixture API does not authorize a production
+arbitrary-argument Git runner.
 
 Repository read differential tests exercise the public `RepositoryRead` port
 through `GixRepository`. Compare typed IDs, ref targets, config provenance,

--- a/docs/security/supply-chain-credentials-and-services.md
+++ b/docs/security/supply-chain-credentials-and-services.md
@@ -276,11 +276,18 @@ They do not use Python, `gh`, raw Git, arbitrary HTTP, or a fallback.
 Publication and installation stay with their owning callers.
 
 Ambiguous create, upload, edit, publish, and Latest-promotion outcomes read back
-the owning resource. A landed effect succeeds without another write. Only
-proven absence permits an idempotent retry. Publication preserves the prior
-Latest release. Promotion occurs only after immutable asset and attestation
-verification, and verifies the final Latest postcondition. Policy and draft
-edits always read back their state.
+the owning resource. A landed effect succeeds without another write. An
+ambiguous draft create is not repeated when a temporary placeholder may still
+be absent from the list response; a later staging run adopts it by identity.
+Other mutations retry only after the owning read proves absence. Publication
+preserves the prior Latest release. Promotion occurs only after immutable asset
+and attestation verification, and verifies the final Latest postcondition.
+Policy and draft edits always read back their state. Draft updates carry the
+tag, target commit, title, and body together so a temporary GitHub
+`untagged-*` association can be repaired by release id without creating a
+second draft. Clear mutation responses are validated directly; ambiguous
+responses still require an owning tag read. Body reconciliation accepts only
+an exact match or GitHub's addition of one terminal newline.
 
 Asset download uses an operation-specific host policy that differs from the
 same-origin API continuation policy. A download may leave the API origin for a

--- a/plugin/docs/rust-testing.md
+++ b/plugin/docs/rust-testing.md
@@ -34,11 +34,15 @@ test its own fixture and let Cargo run it in parallel.
 
 Git fixtures may invoke installed Git as a test oracle. `GitRepository` finds
 the executable once, then clears the child environment and supplies an owned
-home, temp directory, config, identity, dates, locale, and path. Commands set
-only the child working directory. Fixture code must not change the test
-process environment or working directory. Product crates must still use the
-closed Git interfaces described in `ARCHITECTURE.md`; the fixture API does not
-authorize a production arbitrary-argument Git runner.
+home, temp directory, config, identity, dates, locale, and path. The path
+contains the installed Git directory, the fixture helper directory, and only
+the discovered system directories required by Git's shell helpers:
+`basename`, `sed`, and `uname`. This keeps Homebrew and `/usr/local` Git
+portable without inheriting the full ambient path. Commands set only the child
+working directory. Fixture code must not change the test process environment
+or working directory. Product crates must still use the closed Git interfaces
+described in `ARCHITECTURE.md`; the fixture API does not authorize a production
+arbitrary-argument Git runner.
 
 Repository read differential tests exercise the public `RepositoryRead` port
 through `GixRepository`. Compare typed IDs, ref targets, config provenance,

--- a/plugin/docs/security/supply-chain-credentials-and-services.md
+++ b/plugin/docs/security/supply-chain-credentials-and-services.md
@@ -276,11 +276,18 @@ They do not use Python, `gh`, raw Git, arbitrary HTTP, or a fallback.
 Publication and installation stay with their owning callers.
 
 Ambiguous create, upload, edit, publish, and Latest-promotion outcomes read back
-the owning resource. A landed effect succeeds without another write. Only
-proven absence permits an idempotent retry. Publication preserves the prior
-Latest release. Promotion occurs only after immutable asset and attestation
-verification, and verifies the final Latest postcondition. Policy and draft
-edits always read back their state.
+the owning resource. A landed effect succeeds without another write. An
+ambiguous draft create is not repeated when a temporary placeholder may still
+be absent from the list response; a later staging run adopts it by identity.
+Other mutations retry only after the owning read proves absence. Publication
+preserves the prior Latest release. Promotion occurs only after immutable asset
+and attestation verification, and verifies the final Latest postcondition.
+Policy and draft edits always read back their state. Draft updates carry the
+tag, target commit, title, and body together so a temporary GitHub
+`untagged-*` association can be repaired by release id without creating a
+second draft. Clear mutation responses are validated directly; ambiguous
+responses still require an owning tag read. Body reconciliation accepts only
+an exact match or GitHub's addition of one terminal newline.
 
 Asset download uses an operation-specific host policy that differs from the
 same-origin API continuation policy. A download may leave the API origin for a


### PR DESCRIPTION
Fixes #7893

## Summary

- adopt GitHub's mutable `untagged-*` draft only when its title and exact target commit match the release candidate
- repair the draft with one full-identity update and verify clear mutation responses without an eventually consistent list read
- tolerate only GitHub's single added terminal newline in release-note reconciliation
- stop repeating an ambiguous draft create while a placeholder may still be propagating
- include the system utility directories required by installed Git shell helpers in the isolated fixture `PATH`
- document the release mutation and Git oracle contracts in the canonical sources and shipped runtime projection

## Root cause

The release adapter selected drafts only by `tag_name`. GitHub created draft `357049444` with an `untagged-*` placeholder while `v54.0.0` propagated, so staging could not rediscover it. Draft updates omitted `tag_name` and `target_commitish`, exact body matching rejected one terminal newline, and the CLI discarded the verified mutation response for an immediate list read.

The asset workflow then failed all four targets in the same differential test. The Git fixture cleared `PATH` to the installed Git directory. Homebrew and `/usr/local` Git keep `sed`, `basename`, and `uname` elsewhere, so `git-submodule` could not initialize its local fixture.

## Safety

- Placeholder adoption requires a mutable draft, the `untagged-*` prefix, the exact release title, and the exact candidate commit.
- Duplicate exact or placeholder identities still fail closed.
- Ambiguous creates perform no second write when list propagation may lag.
- Ambiguous updates still require owning-tag and body read-back.
- The Git fixture adds only directories that contain three named shell utilities. It does not inherit the full ambient `PATH` or any credential variables.

## Validation

- `cargo test --locked --package larch-test-support --package larch-adapters --package larch-cli`
- `cargo clippy --locked --package larch-core --package larch-test-support --package larch-adapters --package larch-cli --all-targets -- -D warnings`
- `cargo run --quiet --locked --package larch-cli -- release plugin-runtime --check`
- `python3 python/cli.py checks run-relevant --site local --tmpdir <validated-session-tmpdir> --repo-root "$PWD"`
- `git diff --check`

The existing `v54.0.0` tag, candidate PR #7892, and mutable draft remain unchanged and available for recovery after this fix lands.
