### PR TITLE
Raise release asset metadata timeout and cache Rust host builds

### DIFF
--- a/.github/workflows/rust-release-assets.yaml
+++ b/.github/workflows/rust-release-assets.yaml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   metadata:
     runs-on: ubuntu-22.04
-    timeout-minutes: 5
+    timeout-minutes: 15
     outputs:
       version: ${{ steps.identity.outputs.VERSION }}
       source_commit: ${{ steps.identity.outputs.SOURCE_COMMIT }}
@@ -35,6 +35,19 @@ jobs:
           set -euo pipefail
           rustup show active-toolchain
           cargo --version
+      - name: Cache Rust build
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          # GitHub cache entries are immutable. Include Rust sources so a
+          # successful Rust change publishes its updated workspace binaries.
+          key: cargo-${{ runner.os }}-${{ runner.arch }}-${{ github.job }}-${{ hashFiles('Cargo.lock', 'Cargo.toml', 'rust-toolchain.toml', 'crates/**/Cargo.toml', 'Makefile') }}-${{ hashFiles('crates/**/*.rs') }}
+          restore-keys: |
+            cargo-${{ runner.os }}-${{ runner.arch }}-${{ github.job }}-${{ hashFiles('Cargo.lock', 'Cargo.toml', 'rust-toolchain.toml', 'crates/**/Cargo.toml', 'Makefile') }}-
+            cargo-${{ runner.os }}-${{ runner.arch }}-${{ github.job }}-
       - name: Build the host release binary
         shell: bash
         run: |
@@ -237,6 +250,19 @@ jobs:
           set -euo pipefail
           rustup show active-toolchain
           cargo --version
+      - name: Cache Rust build
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          # GitHub cache entries are immutable. Include Rust sources so a
+          # successful Rust change publishes its updated workspace binaries.
+          key: cargo-${{ runner.os }}-${{ runner.arch }}-${{ github.job }}-${{ hashFiles('Cargo.lock', 'Cargo.toml', 'rust-toolchain.toml', 'crates/**/Cargo.toml', 'Makefile') }}-${{ hashFiles('crates/**/*.rs') }}
+          restore-keys: |
+            cargo-${{ runner.os }}-${{ runner.arch }}-${{ github.job }}-${{ hashFiles('Cargo.lock', 'Cargo.toml', 'rust-toolchain.toml', 'crates/**/Cargo.toml', 'Makefile') }}-
+            cargo-${{ runner.os }}-${{ runner.arch }}-${{ github.job }}-
       - name: Build the host release binary
         shell: bash
         run: |


### PR DESCRIPTION
## Problem

The `rust-release-assets` `metadata` job builds the host `larch-cli` release binary under `timeout-minutes: 5` with no Rust cache. A cold release build takes about 5 minutes, so the `v54.0.0` asset run was cancelled at the timeout. GitHub reported "The job has exceeded the maximum execution time of 5m0s." The `build` and `collect` jobs were skipped, so no assets were produced.

## Fix

- Raise `metadata.timeout-minutes` to 15, matching the `collect` job that runs the same cold host build.
- Add the `ci.yaml` Rust cache step to the `metadata` and `collect` jobs. Paths `~/.cargo/registry`, `~/.cargo/git`, and `target`, keyed on `Cargo.lock`, the toolchain, and `crates/**`, scoped per job. `actions/cache` is SHA-pinned to v5.1.0 to match this workflow's hardened pin style.

## Scope

The `build` matrix (4 targets) is left uncached. Its Linux targets compile inside manylinux containers where host caching is awkward, and it has a 35-minute budget, so it is not at timeout risk.

## Validation

- YAML parses.
- `actionlint` passes.
- `python/tests/release/test_assets.py` passes (4 of 4).
