### PR TITLE
Pass absolute asset paths and trust the container checkout

### DIFF
--- a/.github/workflows/rust-release-assets.yaml
+++ b/.github/workflows/rust-release-assets.yaml
@@ -184,6 +184,7 @@ jobs:
             "$CONTAINER_IMAGE" \
             bash -euo pipefail -c '
               export PATH="/root/.cargo/bin:$PATH"
+              git config --global --add safe.directory /workspace
               cargo test --locked --package larch-test-support --package larch-adapters --package larch-cli --target "$TARGET"
               cargo build --locked --release --package larch-cli --target "$TARGET"
               binary="target/$TARGET/release/larch"
@@ -212,9 +213,9 @@ jobs:
             --tag "$GITHUB_REF_NAME" \
             --source-commit "$SOURCE_COMMIT" \
             --target "$TARGET" \
-            --binary "target/$TARGET/release/larch" \
-            --license LICENSE \
-            --output-dir dist
+            --binary "$GITHUB_WORKSPACE/target/$TARGET/release/larch" \
+            --license "$GITHUB_WORKSPACE/LICENSE" \
+            --output-dir "$GITHUB_WORKSPACE/dist"
       - name: Attest archive provenance
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
@@ -285,9 +286,9 @@ jobs:
             --version "$VERSION" \
             --tag "$GITHUB_REF_NAME" \
             --source-commit "$SOURCE_COMMIT" \
-            --input-dir incoming \
-            --output-dir dist \
-            --license LICENSE
+            --input-dir "$GITHUB_WORKSPACE/incoming" \
+            --output-dir "$GITHUB_WORKSPACE/dist" \
+            --license "$GITHUB_WORKSPACE/LICENSE"
       - name: Attest manifest and checksums
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
@@ -311,8 +312,8 @@ jobs:
             --version "$VERSION" \
             --tag "$GITHUB_REF_NAME" \
             --source-commit "$SOURCE_COMMIT" \
-            --asset-dir dist \
-            --license LICENSE \
+            --asset-dir "$GITHUB_WORKSPACE/dist" \
+            --license "$GITHUB_WORKSPACE/LICENSE" \
             --verify-attestations
       - name: Upload the validated set to the draft Release
         shell: bash

--- a/docs/git-operation-inventory.md
+++ b/docs/git-operation-inventory.md
@@ -25,7 +25,7 @@ surface	owner	issue	operations
 .claude/skills/rebalance-tests/scripts/rebalance.py	later-domain	#7685	checkout
 .claude/skills/release/SKILL.md	later-domain	#7674	add,checkout,commit,fetch,merge,merge-base,rev-parse
 .github/workflows/ci.yaml	later-domain	#7685	diff,merge-base,rev-parse
-.github/workflows/rust-release-assets.yaml	later-domain	#7685	rev-parse
+.github/workflows/rust-release-assets.yaml	later-domain	#7685	config,rev-parse
 Makefile	later-domain	#7685	merge-base
 agents/_implementer-base.md	later-domain	#7678	commit
 agents/claude-self-reviewer.md	later-domain	#7678	merge-base

--- a/plugin/docs/git-operation-inventory.md
+++ b/plugin/docs/git-operation-inventory.md
@@ -25,7 +25,7 @@ surface	owner	issue	operations
 .claude/skills/rebalance-tests/scripts/rebalance.py	later-domain	#7685	checkout
 .claude/skills/release/SKILL.md	later-domain	#7674	add,checkout,commit,fetch,merge,merge-base,rev-parse
 .github/workflows/ci.yaml	later-domain	#7685	diff,merge-base,rev-parse
-.github/workflows/rust-release-assets.yaml	later-domain	#7685	rev-parse
+.github/workflows/rust-release-assets.yaml	later-domain	#7685	config,rev-parse
 Makefile	later-domain	#7685	merge-base
 agents/_implementer-base.md	later-domain	#7678	commit
 agents/claude-self-reviewer.md	later-domain	#7678	merge-base


### PR DESCRIPTION
## Problem

With the `metadata` timeout fixed, the `rust-release-assets` build matrix ran and exposed two failures:

- **macOS** targets failed at `Package deterministic archive`: `ERROR=validate path for dist: path must be absolute`. `package-asset`, `collect-assets`, and `validate-assets` received relative path arguments, but the shared Rust path-safety check (`crates/larch-adapters/src/filesystem.rs`) requires absolute paths.
- **Linux** targets failed at `Build and smoke-test at the GNU baseline`: `cargo test` runs as root inside the manylinux container over the host-owned `/workspace` checkout, so `release_publish::tests::production_request_inputs_are_fixed_and_locally_verifiable` panicked with `RepositoryError { kind: UntrustedRepository }` (git/gix dubious ownership).

## Fix

- Pass `$GITHUB_WORKSPACE/...` absolute paths to `package-asset` (`--binary`, `--license`, `--output-dir`), `collect-assets` (`--input-dir`, `--output-dir`, `--license`), and `validate-assets` (`--asset-dir`, `--license`). Archive members and the manifest use basenames, so the deterministic archive and attestation subjects are unchanged, and `$GITHUB_WORKSPACE/dist` resolves to the same `./dist` the `actions/attest` and `upload-artifact` steps read.
- Mark `/workspace` safe before the container `cargo test` so gix regains full trust of the checkout. Only the Linux container needs this; macOS builds on the host as the checkout owner.

## Validation

- YAML parses.
- `actionlint` passes.
- `python/tests/release/test_assets.py` passes (4 of 4).

The container trust behavior can only be fully verified by the tag-triggered asset workflow.
