### PR TITLE
Build the release target without re-running the suite in-container

### DIFF
--- a/.github/workflows/rust-release-assets.yaml
+++ b/.github/workflows/rust-release-assets.yaml
@@ -185,7 +185,6 @@ jobs:
             bash -euo pipefail -c '
               export PATH="/root/.cargo/bin:$PATH"
               git config --global --add safe.directory /workspace
-              cargo test --locked --package larch-test-support --package larch-adapters --package larch-cli --target "$TARGET"
               cargo build --locked --release --package larch-cli --target "$TARGET"
               binary="target/$TARGET/release/larch"
               file "$binary" | grep -F "$EXPECTED_ARCHITECTURE"

--- a/python/tests/release/test_assets.py
+++ b/python/tests/release/test_assets.py
@@ -45,7 +45,12 @@ def test_release_workflow_prepares_platform_smoke_test_prerequisites() -> None:
     assert macos_step.index(sign) < macos_step.index(verify)
     assert linux_path in linux_step
     assert macos_step.index(cargo_test) < macos_step.index(cargo_build)
-    assert linux_step.index(cargo_test) < linux_step.index(cargo_build)
+    # The Linux container builds the target but does not re-run the suite:
+    # host-environment-sensitive tests (git trust, signal reaping) fail as
+    # root with no PID-1 reaper, and the full suite already runs on this
+    # commit in ci.yaml. The container still smoke-tests the built binary.
+    assert cargo_test not in linux_step
+    assert cargo_build in linux_step
     assert cli_only_test not in macos_step
     assert cli_only_test not in linux_step
 


### PR DESCRIPTION
## Problem

The `rust-release-assets` build matrix runs a "smoke-test" step that re-executes the full `cargo test` suite. For Linux targets this runs as root inside the manylinux container over the host-owned `/workspace` checkout, with no PID-1 reaper. Host-environment-sensitive tests fail there:

- `production_request_inputs_are_fixed_and_locally_verifiable`: `UntrustedRepository` (git dubious ownership) — fixed earlier with `safe.directory`.
- `interrupted_commit_cleans_up_children_and_temporary_message`: hangs because a `SIGSTOP`'d hook child is never reaped, so `larch` never exits.

Each fix reveals the next environment-sensitive test. The full suite already runs on the tagged commit in `ci.yaml` (`rust-build-test` -> `make rust-test`), so re-running it in the container is both fragile and redundant.

## Fix

- Drop the in-container `cargo test` from the Linux build-matrix step. The container still builds the target and smoke-tests the built binary (architecture, `--version`, `ldd`, glibc floor).
- Keep the `safe.directory` line as a defensive measure, which also keeps the git-operation inventory entry valid.
- Update `test_assets.py`, which previously enforced the full in-container suite, to assert the container builds without re-running the suite.
- macOS targets continue to run the full suite on the host (they pass and are not containerized).

## Validation

- YAML parses; `actionlint` passes.
- `python/tests/release/test_assets.py` passes (4 of 4).
- `larch-lint` passes (git-operation inventory unchanged).
- Plugin runtime projection unchanged (`plugin-runtime --check` clean).
