### PR TITLE
Release v54.0.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "53.1.24",
+  "version": "54.0.0",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2482,7 +2482,7 @@ dependencies = [
 
 [[package]]
 name = "larch-adapters"
-version = "53.1.24"
+version = "54.0.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -2514,7 +2514,7 @@ dependencies = [
 
 [[package]]
 name = "larch-cli"
-version = "53.1.24"
+version = "54.0.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -2535,7 +2535,7 @@ dependencies = [
 
 [[package]]
 name = "larch-core"
-version = "53.1.24"
+version = "54.0.0"
 dependencies = [
  "regex",
  "zip",
@@ -2543,7 +2543,7 @@ dependencies = [
 
 [[package]]
 name = "larch-lint"
-version = "53.1.24"
+version = "54.0.0"
 dependencies = [
  "assert_cmd",
  "automod",
@@ -2569,7 +2569,7 @@ dependencies = [
 
 [[package]]
 name = "larch-test-support"
-version = "53.1.24"
+version = "54.0.0"
 dependencies = [
  "larch-core",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2024"
 license = "MIT"
 repository = "https://github.com/character-ai/larch"
 rust-version = "1.94.1"
-version = "53.1.24"
+version = "54.0.0"
 
 [workspace.dependencies]
 assert_cmd = { version = "2.2.2", default-features = false }
@@ -33,9 +33,9 @@ http = { version = "1.4.2", default-features = false, features = ["std"] }
 http-body = { version = "1.0.1", default-features = false }
 http-body-util = { version = "0.1.4", default-features = false }
 inventory = { version = "0.3.24", default-features = false }
-larch-adapters = { version = "=53.1.24", path = "crates/larch-adapters" }
-larch-core = { version = "=53.1.24", path = "crates/larch-core" }
-larch-test-support = { version = "=53.1.24", path = "crates/larch-test-support" }
+larch-adapters = { version = "=54.0.0", path = "crates/larch-adapters" }
+larch-core = { version = "=54.0.0", path = "crates/larch-core" }
+larch-test-support = { version = "=54.0.0", path = "crates/larch-test-support" }
 nix = { version = "0.31.3", default-features = false, features = ["process", "signal"] }
 octocrab = { version = "=0.54.0", default-features = false, features = ["default-client", "jwt-aws-lc-rs", "rustls", "rustls-aws-lc-rs", "timeout"] }
 predicates = { version = "3.1.4", default-features = false }

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "53.1.24",
+  "version": "54.0.0",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
Major release. This release completes the larch runtime migration from Python and Bash to a single Rust `larch` binary, moves run-log storage to a versioned cloud archive, restructures the security documentation, and tightens plan and mutation governance.

### Added

- Runtime-only plugin release install path with verified releases.
- Deterministic versioned run archive format with append-only publication, durable retry, and write-through caching.
- Storage-root configuration with S3 preflight and provider-neutral object transports.
- Cloud run sync into a per-repository local cache, including materialized legacy migration archives.
- Universal per-skill run lifecycle with an enforcement lint; every shipped skill and alias is instrumented.
- Aggregate migration governance audit with scheduled reporting.
- Safe bounded archive extraction with atomic cache materialization.

### Changed

Rust runtime migration:

- Ported Git operations to Rust and gix: status and local changes, staging and commit, branch and ref reads, conflict and rebase controls, phantom probes, main synchronization, and branch and force push.
- Ported GitHub operations to Rust: repository and issue operations; pull-request, review, and issue-dependency operations; releases and bounded asset streaming; typed Actions operations; and repository resolution.
- Built a hardened Rust GitHub transport, trusted gix metadata reads, a Google ADC and cloud-client boundary, and a closed typed Git CLI compatibility adapter.
- Ported the release pipeline to Rust: preparation and bump classification, synchronized version mutation, asset construction and validation, draft staging and validation, and immutable publication and promotion.
- Ported upgrade-larch orchestration and runtime-only plugin projection to Rust.
- Enforced verified Rust runtime entrypoints and rejected production Cargo and target-binary execution.
- Verified the release and upgrade paths are Python-free; completed registry-caller and Python-retirement checks.

Run logs and cloud archive:

- Cut implement, design, and review run logs over to cloud archive publication.
- Migrated read-only and stateful run-log analyzers to the synchronized cache and removed top-level run-log exceptions.
- Removed Git-backed run-log publication and retention workflows and archived larch logs.

Security documentation:

- Established a security documentation taxonomy with runtime policy packaging.
- Extracted supply-chain, credential, and service boundaries and the workflow trust, mutation, and private-finding contracts.
- Consolidated artifact, redaction, and publication guidance; canonicalized references and retired historical SECURITY.md detail.

Plan and mutation governance:

- Enforced executable plans and force admission and bound plans to blocker and base freshness.
- Enforced the issue-mutation owner boundary and shared-owner implementation leases.
- Audited shared service and Git ownership and enforced CLI independence and the final exception boundary.
- Hardened Git ownership enforcement against argv bypasses.
- Required clean-install and issue-registry parity.

Tests and CI:

- Sped up Rust CI caching and repository lint.
- Built differential Git repository fixtures and semantic snapshots, broadened GitCli differential coverage, and updated release platform tests to run Git fixture packages.

### Fixed

- /release could not bootstrap the migrated Rust driver and misclassified clean main.
- /release ensure-policy rewrote enabled settings and rejected release-scoped tokens.
- /release notes window included the previous release's own PR.
- Repaired the Rust release asset workflow: raised the metadata build timeout, added Rust caching, passed absolute asset paths, trusted the container checkout, and dropped the redundant in-container test suite.
- Alias lifecycle parent context was documented but not wired or linted.
- GitHub token is now acquired from gh; token env-var recognition dropped.
- Repaired Rust release staging and target Git fixtures.
- Fixed authenticated GitHub Actions log downloads.
- Corrected the GitHub credential contract and centralized freshness-checked issue mutations.
- Restored dependency security parity and exact migration ownership.
- analyze-issues live mode ignored the synchronized run-log cache.
- Retired gc-run-logs Git mutation workflow no longer ships as an executable module.
- Removed duplicated Rust hooks from CI lint jobs.
