### PR TITLE
Send a single User-Agent when downloading release assets

### DIFF
--- a/crates/larch-adapters/src/github/mod.rs
+++ b/crates/larch-adapters/src/github/mod.rs
@@ -265,14 +265,16 @@ impl OctocrabGitHubService {
         [("user-agent", USER_AGENT_VALUE), ("accept", ACCEPT_VALUE)]
     }
 
-    /// Headers for the release-asset download client. It omits the
-    /// `application/vnd.github+json` Accept so a per-request
-    /// `application/octet-stream` Accept survives; otherwise Octocrab appends
-    /// the JSON Accept and the GitHub asset endpoint returns metadata instead
-    /// of the binary.
+    /// Headers for the release-asset download client. It adds none of larch's
+    /// API headers. Omitting the `application/vnd.github+json` Accept lets a
+    /// per-request `application/octet-stream` Accept survive; otherwise the
+    /// asset endpoint returns metadata JSON. Omitting the `user-agent` avoids a
+    /// second `User-Agent` header (Octocrab already sets one): the
+    /// release-assets CDN rejects a duplicate `User-Agent` with HTTP 400
+    /// "invalid header name", though `api.github.com` tolerates it.
     #[must_use]
-    pub const fn download_headers() -> [(&'static str, &'static str); 1] {
-        [("user-agent", USER_AGENT_VALUE)]
+    pub const fn download_headers() -> [(&'static str, &'static str); 0] {
+        []
     }
 
     /// Remove the exact runtime credential and standard secret families.
@@ -467,20 +469,14 @@ mod tests {
     }
 
     #[test]
-    fn download_client_headers_omit_the_json_accept() {
-        // The asset-download client must not advertise the vnd.github+json
-        // Accept: Octocrab appends it to the per-request octet-stream Accept,
-        // and the GitHub asset endpoint then returns metadata JSON instead of
-        // the binary.
-        assert_eq!(
-            OctocrabGitHubService::download_headers(),
-            [("user-agent", "larch")]
-        );
-        assert!(
-            !OctocrabGitHubService::download_headers()
-                .iter()
-                .any(|(name, _)| *name == "accept")
-        );
+    fn download_client_adds_no_extra_headers() {
+        // The asset-download client adds none of larch's API headers. It must
+        // not advertise the vnd.github+json Accept (Octocrab appends it to the
+        // per-request octet-stream Accept, so the asset endpoint returns
+        // metadata JSON), and it must not add a second user-agent (Octocrab
+        // already sets one; a duplicate User-Agent makes the release-assets CDN
+        // reject the download with HTTP 400 "invalid header name").
+        assert!(OctocrabGitHubService::download_headers().is_empty());
         // The API client keeps the JSON Accept it needs.
         assert!(
             OctocrabGitHubService::required_headers()


### PR DESCRIPTION
## Problem

`validate-draft` and `release finish` failed downloading release assets with `ERROR=GitHub asset download returned status 400`. The release-assets CDN (IIS-fronted) returned `HTTP Error 400. The request has an invalid header name.`

Captured wire request: the download had **two `User-Agent` headers** — Octocrab sets its own (`user-agent: octocrab`), and larch's download-client header set added a second (`user-agent: larch`) via the append-based `ExtraHeadersLayer`. `api.github.com` tolerates the duplicate (the redirect hop worked), but the release-assets CDN rejects it.

This surfaced only after the octet-stream Accept fix (a previous change) let the download reach the CDN hop for the first time.

## Fix

The release-asset download client adds no larch headers at all: `download_headers()` returns an empty set. This keeps omitting the `vnd.github+json` Accept (so the per-request `octet-stream` Accept survives) and stops adding a second `User-Agent`, leaving Octocrab's single built-in one.

## Validation

- `cargo build`, `clippy`, `fmt`, `larch-lint`, and the plugin projection are clean.
- `larch-adapters` tests pass, including the updated `download_client_adds_no_extra_headers`.
- End-to-end: with this fix, `release validate-draft` returns `DRAFT_ASSETS_VALID=true` (every asset: api.github.com 302 -> CDN 200), and `release finish` published v54.0.0 as an immutable release and promoted it to Latest.
