### PR TITLE
Document deleting cached larch versions on uninstall

### DIFF
--- a/docs/installation-and-setup.md
+++ b/docs/installation-and-setup.md
@@ -293,27 +293,15 @@ for verification and cache-ownership guarantees.
 
 ## Uninstalling
 
-Remove the plugin:
+Remove the plugin and its cached versions:
 
 ```bash
 claude plugin uninstall larch@larch-local
+rm -rf ~/.claude/plugins/cache/larch-local/larch
 ```
 
-`claude plugin uninstall` leaves the `larch-local` marketplace registration
-cached at its last-fetched version. A later `claude plugin install
-larch@larch-local` then reinstalls that cached version, not the latest release.
-For a full uninstall so a later install pulls the latest, also remove the
-marketplace:
-
-```bash
-claude plugin uninstall larch@larch-local
-claude plugin marketplace remove larch-local
-```
-
-To reinstall afterward, re-add the marketplace from its source, then install.
-The re-added marketplace fetches the latest published release:
-
-```bash
-claude plugin marketplace add https://raw.githubusercontent.com/character-ai/larch/main/.claude-plugin/marketplace.json
-claude plugin install larch@larch-local
-```
+The `rm` deletes only larch's cached version directories under the `larch-local`
+marketplace and touches nothing else in the cache. `claude plugin uninstall`
+alone leaves those versions, so a later install reuses a cached version instead
+of the latest. To reinstall the latest afterward, refresh the marketplace
+(`claude plugin marketplace update larch-local`), then install again.

--- a/plugin/docs/installation-and-setup.md
+++ b/plugin/docs/installation-and-setup.md
@@ -293,27 +293,15 @@ for verification and cache-ownership guarantees.
 
 ## Uninstalling
 
-Remove the plugin:
+Remove the plugin and its cached versions:
 
 ```bash
 claude plugin uninstall larch@larch-local
+rm -rf ~/.claude/plugins/cache/larch-local/larch
 ```
 
-`claude plugin uninstall` leaves the `larch-local` marketplace registration
-cached at its last-fetched version. A later `claude plugin install
-larch@larch-local` then reinstalls that cached version, not the latest release.
-For a full uninstall so a later install pulls the latest, also remove the
-marketplace:
-
-```bash
-claude plugin uninstall larch@larch-local
-claude plugin marketplace remove larch-local
-```
-
-To reinstall afterward, re-add the marketplace from its source, then install.
-The re-added marketplace fetches the latest published release:
-
-```bash
-claude plugin marketplace add https://raw.githubusercontent.com/character-ai/larch/main/.claude-plugin/marketplace.json
-claude plugin install larch@larch-local
-```
+The `rm` deletes only larch's cached version directories under the `larch-local`
+marketplace and touches nothing else in the cache. `claude plugin uninstall`
+alone leaves those versions, so a later install reuses a cached version instead
+of the latest. To reinstall the latest afterward, refresh the marketplace
+(`claude plugin marketplace update larch-local`), then install again.


### PR DESCRIPTION
## Problem

`claude plugin uninstall larch@larch-local` removes the active install but leaves larch's cached version directories under `~/.claude/plugins/cache/larch-local/larch/` (one per version). A later `claude plugin install larch@larch-local` reuses a cached version instead of fetching the latest, so an uninstall/reinstall roundtrip "reverts" to a previously installed version.

## Fix

Shorten the Uninstalling section in `docs/installation-and-setup.md` to remove the plugin and delete only larch's cached version directories:

```bash
claude plugin uninstall larch@larch-local
rm -rf ~/.claude/plugins/cache/larch-local/larch
```

The path targets only larch's cached versions under the `larch-local` marketplace; other marketplaces' caches are untouched. Points at `claude plugin marketplace update larch-local` for reinstalling the latest.

Regenerates the plugin runtime projection for the doc.
