### PR TITLE
Supply CLAUDE_PLUGIN_DATA to the release Step 7 upgrade fence

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -322,9 +322,10 @@ esac
 
 if [ -n "$RESOLVED_ROOT" ]; then
   echo "Applying the just-released larch marketplace source through the working-tree upgrade script..."
+  PLUGIN_DATA_PARENT="${TMPDIR:-/tmp}"  # macOS TMPDIR ends with /; the %/ trim keeps the composed path //-free for larch.sh path validation
   upgrade_rc=0
   upgrade_out=$(
-    LARCH_EXPECTED_STABLE_VERSION="$NEW_VERSION" CLAUDE_PLUGIN_ROOT="$PWD" LARCH_BINARY="$WORKTREE_LARCH" "$PWD/scripts/larch.sh" upgrade-larch run --plugin-root "$RESOLVED_ROOT" 2>&1
+    LARCH_EXPECTED_STABLE_VERSION="$NEW_VERSION" CLAUDE_PLUGIN_ROOT="$PWD" CLAUDE_PLUGIN_DATA="${PLUGIN_DATA_PARENT%/}/larch-plugin-data" LARCH_BINARY="$WORKTREE_LARCH" "$PWD/scripts/larch.sh" upgrade-larch run --plugin-root "$RESOLVED_ROOT" 2>&1
   ) || upgrade_rc=$?
   printf '%s\n' "$upgrade_out"
   if [[ "$upgrade_out" == *"LARCH_MARKETPLACE_RECONCILED=true"* ]] || \

--- a/crates/larch-adapters/src/upgrade_larch.rs
+++ b/crates/larch-adapters/src/upgrade_larch.rs
@@ -228,7 +228,12 @@ impl Context {
         timeout: Duration,
     ) -> Result<ProcessOutput, Failure> {
         if self.plugin_data.is_none() {
-            return Err(Failure::new(1, "CLAUDE_PLUGIN_DATA is required"));
+            return Err(Failure::new(
+                1,
+                "CLAUDE_PLUGIN_DATA is required. Set it to an absolute path for bounded \
+                 bootstrap staging, such as /tmp/larch-plugin-data; see the documented \
+                 local-dev pattern in docs/installation-and-setup.md.",
+            ));
         }
         let script = safe_root_file(root, "scripts/larch.sh")?;
         let root = script

--- a/crates/larch-cli/tests/upgrade_larch.rs
+++ b/crates/larch-cli/tests/upgrade_larch.rs
@@ -291,6 +291,32 @@ fn interrupted_preflight_is_retryable_and_does_not_mutate_plugin_state() {
 }
 
 #[test]
+fn missing_plugin_data_fails_closed_before_any_mutation_with_the_remedy() {
+    let harness = Harness::new();
+    harness
+        .command()
+        .env_remove("CLAUDE_PLUGIN_DATA")
+        .arg("upgrade-larch")
+        .arg("run")
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("CLAUDE_PLUGIN_DATA is required")
+                .and(predicate::str::contains("docs/installation-and-setup.md")),
+        );
+    let log = fs::read_to_string(&harness.log).expect("log");
+    assert!(!log.contains("bootstrap --preflight-release"));
+    assert_eq!(
+        fs::read_to_string(harness.state.join("installed")).expect("installed state"),
+        "1.0.0"
+    );
+    assert_eq!(
+        fs::read_to_string(harness.state.join("marketplace")).expect("marketplace state"),
+        "remote"
+    );
+}
+
+#[test]
 fn failed_refresh_and_failed_install_leave_the_prior_root_usable() {
     let harness = Harness::new();
     harness.flag("fail_refresh");

--- a/docs/installation-and-setup.md
+++ b/docs/installation-and-setup.md
@@ -191,11 +191,15 @@ select the executable explicitly:
 
 ```bash
 cargo build --locked --release --package larch-cli
+PLUGIN_DATA_PARENT="${TMPDIR:-/tmp}"
 CLAUDE_PLUGIN_ROOT="$PWD" \
-CLAUDE_PLUGIN_DATA="${TMPDIR:-/tmp}/larch-plugin-data" \
+CLAUDE_PLUGIN_DATA="${PLUGIN_DATA_PARENT%/}/larch-plugin-data" \
 LARCH_BINARY="$PWD/target/release/larch" \
 "$PWD/scripts/larch.sh" example echo "local build"
 ```
+
+The `%/` trim keeps the composed path free of `//` on macOS, where `TMPDIR`
+ends with a slash; bootstrap path validation rejects embedded `//`.
 
 `LARCH_BINARY` must be an absolute, regular executable. Its version and target
 self-check must match the active plugin and host.

--- a/plugin/docs/installation-and-setup.md
+++ b/plugin/docs/installation-and-setup.md
@@ -191,11 +191,15 @@ select the executable explicitly:
 
 ```bash
 cargo build --locked --release --package larch-cli
+PLUGIN_DATA_PARENT="${TMPDIR:-/tmp}"
 CLAUDE_PLUGIN_ROOT="$PWD" \
-CLAUDE_PLUGIN_DATA="${TMPDIR:-/tmp}/larch-plugin-data" \
+CLAUDE_PLUGIN_DATA="${PLUGIN_DATA_PARENT%/}/larch-plugin-data" \
 LARCH_BINARY="$PWD/target/release/larch" \
 "$PWD/scripts/larch.sh" example echo "local build"
 ```
+
+The `%/` trim keeps the composed path free of `//` on macOS, where `TMPDIR`
+ends with a slash; bootstrap path validation rejects embedded `//`.
 
 `LARCH_BINARY` must be an absolute, regular executable. Its version and target
 self-check must match the active plugin and host.

--- a/python/tests/release/test_release.py
+++ b/python/tests/release/test_release.py
@@ -153,3 +153,17 @@ def test_release_skill_rebuilds_worktree_driver_across_version_change() -> None:
         "finish",
     ):
         assert f"{worktree_prefix}{verb}" in skill
+
+
+def test_release_skill_step7_upgrade_run_sets_the_driver_env_contract() -> None:
+    skill = (ROOT / ".claude/skills/release/SKILL.md").read_text(encoding="utf-8")
+    # The %/ trim is load-bearing: macOS TMPDIR ends with a slash, and an
+    # embedded // fails larch.sh path validation during the release preflight.
+    assert 'PLUGIN_DATA_PARENT="${TMPDIR:-/tmp}"' in skill
+    assert (
+        'LARCH_EXPECTED_STABLE_VERSION="$NEW_VERSION" '
+        'CLAUDE_PLUGIN_ROOT="$PWD" '
+        'CLAUDE_PLUGIN_DATA="${PLUGIN_DATA_PARENT%/}/larch-plugin-data" '
+        'LARCH_BINARY="$WORKTREE_LARCH" '
+        '"$PWD/scripts/larch.sh" upgrade-larch run' in skill
+    )


### PR DESCRIPTION
## Summary

`/release` Step 7 (local-install refresh) failed on every run: the fence invoked the working-tree upgrade driver with `CLAUDE_PLUGIN_ROOT` and `LARCH_BINARY` only, and the driver's fail-closed bootstrap guard aborted the release preflight with `CLAUDE_PLUGIN_DATA is required`. The release published fine while the local install silently stayed on the prior version (observed live on the v54.0.1 cut, 2026-07-21).

Fixes #7922

## Changes

- `.claude/skills/release/SKILL.md`: the Step 7 `upgrade-larch run` fence now supplies `CLAUDE_PLUGIN_DATA`, composed as `"${PLUGIN_DATA_PARENT%/}/larch-plugin-data"` from `PLUGIN_DATA_PARENT="${TMPDIR:-/tmp}"`. The `%/` trim is load-bearing: macOS `TMPDIR` ends with a slash, and the untrimmed documented pattern embeds `//`, which `larch.sh` `validate_absolute_path` rejects during the release preflight. No `mkdir` is needed; `acquire_lock()` in `scripts/larch.sh` creates the directory before staging.
- `docs/installation-and-setup.md` + `plugin/docs/installation-and-setup.md`: fix the same untrimmed composition in the documented local-dev pattern it came from, so future copiers do not inherit the defect (class fix per G-Fix-1).
- `crates/larch-adapters/src/upgrade_larch.rs`: the `bootstrap()` guard message now names the remedy and points at the documented pattern. The guard itself stays unconditional per the bounded-staging security contract; preflight staging and the bootstrap lock remain confined to `${CLAUDE_PLUGIN_DATA}`.
- `crates/larch-cli/tests/upgrade_larch.rs`: new regression test runs `upgrade-larch run` with `CLAUDE_PLUGIN_DATA` unset and asserts the actionable error, that no bootstrap child was spawned, and zero plugin-state mutation.
- `python/tests/release/test_release.py`: new prompt-contract pin asserts the Step 7 fence carries the full driver env contract, including the trim, so the fence cannot drift from driver requirements again.

## Decisions (operator-confirmed)

- TMPDIR pattern over the harness data directory (`~/.claude/plugins/data/larch-larch-local`): the harness name is an internal convention larch does not own, and preflight only stages and verifies (`publish_binary=false`), so nothing durable belongs there.
- The fail-closed guard stays unconditional; a driver-side fallback would mask harness misconfiguration on the installed-plugin path.
- Call-site audit: `upgrade-larch run` is invoked from exactly two places. The installed-plugin path (`skills/upgrade-larch/SKILL.md`) receives the variable from the harness and is correct as-is; `release-step7-root` and the `release *` verbs never call `bootstrap()` (proven by Steps 1-6 and 8 succeeding on the live run).

## Self-review

An independent adversarial review of the initial diff found one Major issue: the first version copied the documented pattern verbatim (`"${TMPDIR:-/tmp}/larch-plugin-data"`), which on macOS composes an embedded `//` that `validate_absolute_path` rejects, replacing the reported failure with a different preflight failure. Fixed with the `%/` trim, verified live against this machine's trailing-slash `TMPDIR` (untrimmed composition REJECTED by the exact `larch.sh` case-arm, trimmed composition ACCEPTED), and the defective source pattern in the docs was corrected in the same change.

## Testing

- `cargo test --package larch-cli --test upgrade_larch`: 12 passed (11 existing + new regression test).
- `python3 -m pytest python/tests/release/test_release.py`: 9 passed (8 existing + new pin).
- `cargo clippy --all-targets -- -D warnings` on both changed crates: clean; `cargo fmt`: clean.
- `agent-lint` and `markdownlint` on both changed Markdown files: passed.
- Live simulation of the fence composition against this machine's real `TMPDIR` (ends with `/`): trimmed value passes the `larch.sh` validation case-arm, untrimmed value fails it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ta9fQjkHqgnAmSdLziWT68
