### PR TITLE
Canonicalize the Step 7 plugin-data parent before composing

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -322,11 +322,23 @@ esac
 
 if [ -n "$RESOLVED_ROOT" ]; then
   echo "Applying the just-released larch marketplace source through the working-tree upgrade script..."
-  PLUGIN_DATA_PARENT="${TMPDIR:-/tmp}"  # macOS TMPDIR ends with /; the %/ trim keeps the composed path //-free for larch.sh path validation
+  # pwd -P canonicalization: larch.sh path validation rejects symlinked ancestors
+  # (macOS /var, /tmp) and embedded //. A relative, missing, or inaccessible
+  # TMPDIR leaves the parent empty and is reported below instead of composing a
+  # misplaced or misleading staging path.
+  PLUGIN_DATA_PARENT=""
+  case "${TMPDIR:-/tmp}" in
+    /*) PLUGIN_DATA_PARENT="$(cd "${TMPDIR:-/tmp}" 2>/dev/null && pwd -P)" || true ;;
+  esac
   upgrade_rc=0
-  upgrade_out=$(
-    LARCH_EXPECTED_STABLE_VERSION="$NEW_VERSION" CLAUDE_PLUGIN_ROOT="$PWD" CLAUDE_PLUGIN_DATA="${PLUGIN_DATA_PARENT%/}/larch-plugin-data" LARCH_BINARY="$WORKTREE_LARCH" "$PWD/scripts/larch.sh" upgrade-larch run --plugin-root "$RESOLVED_ROOT" 2>&1
-  ) || upgrade_rc=$?
+  if [ -n "$PLUGIN_DATA_PARENT" ]; then
+    upgrade_out=$(
+      LARCH_EXPECTED_STABLE_VERSION="$NEW_VERSION" CLAUDE_PLUGIN_ROOT="$PWD" CLAUDE_PLUGIN_DATA="${PLUGIN_DATA_PARENT%/}/larch-plugin-data" LARCH_BINARY="$WORKTREE_LARCH" "$PWD/scripts/larch.sh" upgrade-larch run --plugin-root "$RESOLVED_ROOT" 2>&1
+    ) || upgrade_rc=$?
+  else
+    upgrade_rc=1
+    upgrade_out="TMPDIR (${TMPDIR:-/tmp}) is not an accessible absolute directory; cannot compose CLAUDE_PLUGIN_DATA for the upgrade driver."
+  fi
   printf '%s\n' "$upgrade_out"
   if [[ "$upgrade_out" == *"LARCH_MARKETPLACE_RECONCILED=true"* ]] || \
      { [ "$upgrade_rc" -eq 0 ] && [[ "$upgrade_out" == *"Migrating it to the runtime-only source and reinstalling"* ]]; }; then

--- a/crates/larch-adapters/src/upgrade_larch.rs
+++ b/crates/larch-adapters/src/upgrade_larch.rs
@@ -230,9 +230,9 @@ impl Context {
         if self.plugin_data.is_none() {
             return Err(Failure::new(
                 1,
-                "CLAUDE_PLUGIN_DATA is required. Set it to an absolute path for bounded \
-                 bootstrap staging, such as /tmp/larch-plugin-data; see the documented \
-                 local-dev pattern in docs/installation-and-setup.md.",
+                "CLAUDE_PLUGIN_DATA is required. Set it to an absolute, symlink-free path \
+                 for bounded bootstrap staging; see the documented local-dev pattern in \
+                 docs/installation-and-setup.md. On macOS, /tmp and /var are symlinks.",
             ));
         }
         let script = safe_root_file(root, "scripts/larch.sh")?;

--- a/docs/installation-and-setup.md
+++ b/docs/installation-and-setup.md
@@ -197,15 +197,18 @@ select the executable explicitly:
 
 ```bash
 cargo build --locked --release --package larch-cli
-PLUGIN_DATA_PARENT="${TMPDIR:-/tmp}"
+PLUGIN_DATA_PARENT="$(cd "${TMPDIR:-/tmp}" && pwd -P)"
 CLAUDE_PLUGIN_ROOT="$PWD" \
 CLAUDE_PLUGIN_DATA="${PLUGIN_DATA_PARENT%/}/larch-plugin-data" \
 LARCH_BINARY="$PWD/target/release/larch" \
 "$PWD/scripts/larch.sh" example echo "local build"
 ```
 
-The `%/` trim keeps the composed path free of `//` on macOS, where `TMPDIR`
-ends with a slash; bootstrap path validation rejects embedded `//`.
+`pwd -P` canonicalizes the staging parent because bootstrap path validation
+rejects a path whose existing ancestor is a symlink, and on macOS both
+`TMPDIR` (under `/var`) and the `/tmp` fallback are symlinks into `/private`.
+Canonicalizing also drops the trailing slash macOS puts on `TMPDIR`; the `%/`
+trim keeps the composed path `//`-free if the parent is ever `/`.
 
 `LARCH_BINARY` must be an absolute, regular executable. Its version and target
 self-check must match the active plugin and host.

--- a/plugin/docs/installation-and-setup.md
+++ b/plugin/docs/installation-and-setup.md
@@ -197,15 +197,18 @@ select the executable explicitly:
 
 ```bash
 cargo build --locked --release --package larch-cli
-PLUGIN_DATA_PARENT="${TMPDIR:-/tmp}"
+PLUGIN_DATA_PARENT="$(cd "${TMPDIR:-/tmp}" && pwd -P)"
 CLAUDE_PLUGIN_ROOT="$PWD" \
 CLAUDE_PLUGIN_DATA="${PLUGIN_DATA_PARENT%/}/larch-plugin-data" \
 LARCH_BINARY="$PWD/target/release/larch" \
 "$PWD/scripts/larch.sh" example echo "local build"
 ```
 
-The `%/` trim keeps the composed path free of `//` on macOS, where `TMPDIR`
-ends with a slash; bootstrap path validation rejects embedded `//`.
+`pwd -P` canonicalizes the staging parent because bootstrap path validation
+rejects a path whose existing ancestor is a symlink, and on macOS both
+`TMPDIR` (under `/var`) and the `/tmp` fallback are symlinks into `/private`.
+Canonicalizing also drops the trailing slash macOS puts on `TMPDIR`; the `%/`
+trim keeps the composed path `//`-free if the parent is ever `/`.
 
 `LARCH_BINARY` must be an absolute, regular executable. Its version and target
 self-check must match the active plugin and host.

--- a/python/tests/release/test_release.py
+++ b/python/tests/release/test_release.py
@@ -157,9 +157,19 @@ def test_release_skill_rebuilds_worktree_driver_across_version_change() -> None:
 
 def test_release_skill_step7_upgrade_run_sets_the_driver_env_contract() -> None:
     skill = (ROOT / ".claude/skills/release/SKILL.md").read_text(encoding="utf-8")
-    # The %/ trim is load-bearing: macOS TMPDIR ends with a slash, and an
-    # embedded // fails larch.sh path validation during the release preflight.
-    assert 'PLUGIN_DATA_PARENT="${TMPDIR:-/tmp}"' in skill
+    # The canonicalized parent is load-bearing: macOS TMPDIR lives under the
+    # /var symlink and the /tmp fallback is itself a symlink, so an
+    # uncanonicalized parent fails the larch.sh symlink-ancestor walk during
+    # the release preflight (#7926). A relative, missing, or inaccessible
+    # TMPDIR leaves the parent empty, and the fence reports it instead of
+    # composing a misplaced staging path. test_rust_bootstrap.py runs the
+    # real guard against these compositions.
+    assert 'PLUGIN_DATA_PARENT=""' in skill
+    assert (
+        '/*) PLUGIN_DATA_PARENT="$(cd "${TMPDIR:-/tmp}" 2>/dev/null && pwd -P)"'
+        " || true ;;" in skill
+    )
+    assert 'if [ -n "$PLUGIN_DATA_PARENT" ]; then' in skill
     assert (
         'LARCH_EXPECTED_STABLE_VERSION="$NEW_VERSION" '
         'CLAUDE_PLUGIN_ROOT="$PWD" '

--- a/python/tests/release/test_rust_bootstrap.py
+++ b/python/tests/release/test_rust_bootstrap.py
@@ -396,7 +396,8 @@ def test_step7_fence_leaves_parent_empty_for_broken_or_relative_tmpdir(
     tmp_path: Path,
 ) -> None:
     """A missing or relative TMPDIR must not compose a misleading staging path;
-    the fence leaves the parent empty and reports it instead (#7926 review)."""
+    the fence leaves the parent empty and reports it instead (#7926 review).
+    """
     probe = 'printf "%s" "$PLUGIN_DATA_PARENT"'
     assert _fence_bash(f"{tmp_path}/does-not-exist/", probe) == ""
     assert _fence_bash("relative-tmp", probe) == ""
@@ -405,7 +406,8 @@ def test_step7_fence_leaves_parent_empty_for_broken_or_relative_tmpdir(
 def test_symlink_ancestor_plugin_data_fails_preflight_closed(tmp_path: Path) -> None:
     """Negative control replaying the v55.0.0 Step 7 failure: a TMPDIR-composed
     path whose ancestor is a symlink dies in the walk, proving the sibling
-    positive test exercises the guard and not only the case-arm (#7926)."""
+    positive test exercises the guard and not only the case-arm (#7926).
+    """
     fixture = _fixture(tmp_path)
     tmpdir_value, _ = _macos_shaped_tmpdir(tmp_path)
     environment = _environment(fixture)

--- a/python/tests/release/test_rust_bootstrap.py
+++ b/python/tests/release/test_rust_bootstrap.py
@@ -7,6 +7,7 @@ import hashlib
 import io
 import json
 import os
+import re
 import shutil
 import subprocess
 import tarfile
@@ -21,6 +22,9 @@ VERSION = "1.2.3"
 TAG = f"v{VERSION}"
 SOURCE_COMMIT = "a" * 40
 SCRIPT = Path(__file__).parents[3] / "scripts" / "larch.sh"
+RELEASE_SKILL = (
+    Path(__file__).parents[3] / ".claude" / "skills" / "release" / "SKILL.md"
+)
 
 
 @dataclass(frozen=True)
@@ -319,6 +323,102 @@ def test_release_preflight_verifies_without_touching_plugin_cache_root(tmp_path:
     assert marker.read_text(encoding="utf-8") == "unchanged"
     assert not (fixture.root / "bin").exists()
     assert not list(fixture.data.glob(".larch-bootstrap.*"))
+
+
+def _macos_shaped_tmpdir(tmp_path: Path) -> tuple[str, Path]:
+    """A TMPDIR shaped like macOS: trailing slash, ancestor reached via a symlink.
+
+    Mirrors /var -> private/var, where the real per-user temp directory lives.
+    Returns the TMPDIR value and the symlink-free real directory.
+    """
+    real = tmp_path / "private" / "T"
+    real.mkdir(parents=True)
+    (tmp_path / "var").symlink_to(tmp_path / "private")
+    return f"{tmp_path}/var/T/", real
+
+
+def _fence_parent_block() -> str:
+    """Extract the Step 7 fence's guarded PLUGIN_DATA_PARENT composition block."""
+    lines = RELEASE_SKILL.read_text(encoding="utf-8").splitlines()
+    starts = [
+        index
+        for index, line in enumerate(lines)
+        if line.strip() == 'PLUGIN_DATA_PARENT=""'
+    ]
+    assert len(starts) == 1, "Step 7 fence no longer initializes PLUGIN_DATA_PARENT once"
+    end = next(
+        index
+        for index in range(starts[0], len(lines))
+        if lines[index].strip() == "esac"
+    )
+    return "\n".join(lines[starts[0] : end + 1])
+
+
+def _fence_bash(tmpdir_value: str, tail: str) -> str:
+    """Run the fence's guarded parent composition plus a probe line in bash."""
+    result = subprocess.run(
+        ["/bin/bash", "-c", f"{_fence_parent_block()}\n{tail}"],
+        check=True,
+        capture_output=True,
+        text=True,
+        env={"PATH": os.environ["PATH"], "TMPDIR": tmpdir_value},
+        timeout=20,
+    )
+    return result.stdout
+
+
+def _fence_composed_plugin_data(tmpdir_value: str) -> str:
+    """Evaluate the release Step 7 fence's CLAUDE_PLUGIN_DATA composition in bash."""
+    skill = RELEASE_SKILL.read_text(encoding="utf-8")
+    composition = re.search(r'CLAUDE_PLUGIN_DATA="(\$\{PLUGIN_DATA_PARENT[^"]*)"', skill)
+    assert composition is not None, "Step 7 fence no longer composes CLAUDE_PLUGIN_DATA"
+    return _fence_bash(tmpdir_value, f'printf "%s" "{composition.group(1)}"')
+
+
+def test_step7_fence_plugin_data_passes_preflight_with_symlinked_tmpdir(
+    tmp_path: Path,
+) -> None:
+    """The fence composition survives the full symlink-ancestor walk (#7926)."""
+    fixture = _fixture(tmp_path)
+    tmpdir_value, real_parent = _macos_shaped_tmpdir(tmp_path)
+    composed = _fence_composed_plugin_data(tmpdir_value)
+    assert composed == f"{real_parent.resolve()}/larch-plugin-data"
+    environment = _environment(fixture)
+    environment["CLAUDE_PLUGIN_DATA"] = composed
+
+    result = _run(fixture, "--preflight-release", VERSION, environment=environment)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == f"LARCH_PREFLIGHT_VERSION={VERSION}\n"
+
+
+def test_step7_fence_leaves_parent_empty_for_broken_or_relative_tmpdir(
+    tmp_path: Path,
+) -> None:
+    """A missing or relative TMPDIR must not compose a misleading staging path;
+    the fence leaves the parent empty and reports it instead (#7926 review)."""
+    probe = 'printf "%s" "$PLUGIN_DATA_PARENT"'
+    assert _fence_bash(f"{tmp_path}/does-not-exist/", probe) == ""
+    assert _fence_bash("relative-tmp", probe) == ""
+
+
+def test_symlink_ancestor_plugin_data_fails_preflight_closed(tmp_path: Path) -> None:
+    """Negative control replaying the v55.0.0 Step 7 failure: a TMPDIR-composed
+    path whose ancestor is a symlink dies in the walk, proving the sibling
+    positive test exercises the guard and not only the case-arm (#7926)."""
+    fixture = _fixture(tmp_path)
+    tmpdir_value, _ = _macos_shaped_tmpdir(tmp_path)
+    environment = _environment(fixture)
+    # Pre-#7926 fence shape: TMPDIR taken verbatim, only the trailing slash trimmed.
+    assert tmpdir_value.endswith("/")
+    environment["CLAUDE_PLUGIN_DATA"] = f"{tmpdir_value.rstrip('/')}/larch-plugin-data"
+
+    result = _run(fixture, "--preflight-release", VERSION, environment=environment)
+
+    assert result.returncode == 1
+    assert "is a symlink" in result.stderr
+    assert f"{tmp_path}/var" in result.stderr
+    assert not (fixture.root / "bin").exists()
 
 
 def test_latest_stable_version_uses_the_bounded_bootstrap_surface(tmp_path: Path) -> None:


### PR DESCRIPTION
Fixes #7926

## What broke

`/release` Step 7 composed `CLAUDE_PLUGIN_DATA` from `TMPDIR` verbatim. On macOS `TMPDIR` lives under `/var/folders/…`, and `/var` is a symlink to `/private/var`, so the `scripts/larch.sh` `validate_absolute_path` symlink-ancestor walk rejected the path during the release preflight. The release published, but the local install silently stayed on the prior version — the same operator-visible outcome as #7922, one guard deeper. Observed live on the v55.0.0 cut. #7924's verification exercised only the unsafe-component case-arm, not the symlink walk.

## Fix (operator-approved: issue fix 1, canonicalize)

- `.claude/skills/release/SKILL.md` Step 7: compose the parent with `cd "${TMPDIR:-/tmp}" && pwd -P`. This keeps #7924's nothing-durable TMPDIR decision, removes symlinked ancestors, and also fixes the bare-`/tmp` fallback, which is itself a symlink on macOS. Bash-3.2-safe. A guard added after self-review keeps the warn-and-continue contract precise: a relative, missing, or inaccessible TMPDIR leaves the parent empty, and the fence reports that and skips the driver instead of composing a misplaced (`$PWD`-relative) or misleading (`/larch-plugin-data`) staging path.
- `docs/installation-and-setup.md` + `plugin/docs/` mirror: same canonicalization in the documented local-dev pattern, and the explanation now states why the parent must be symlink-free instead of only the incantation (per operator decision on issue open question 2). The interactive pattern deliberately omits the fence's broken-TMPDIR guard (G-Fix-1 deviation): a failed `cd` prints its own error directly to the operator's terminal, so the failure is already loud there.
- `crates/larch-adapters/src/upgrade_larch.rs`: the missing-variable guard message suggested `/tmp/larch-plugin-data`, a remedy that trips the same walk on macOS; it now asks for an absolute, symlink-free path and names the macOS symlinks. G-Fix-1 sibling; message-only, guard behavior unchanged.
- `scripts/larch.sh` is untouched: the unconditional symlink walk is part of the bounded-staging security posture (issue fix 3 explicitly not taken).

## Verification (operator-approved: offline harness, not a documented manual step)

- `python/tests/release/test_release.py`: the fence prompt-contract pin moves with the fix.
- `python/tests/release/test_rust_bootstrap.py`: two new end-to-end tests run the real `scripts/larch.sh --preflight-release` against a macOS-shaped fixture (`var -> private` symlink, trailing-slash `TMPDIR`), on any CI OS:
  - the fence's actual composition (extracted from SKILL.md and evaluated in bash) passes the full guard walk and preflight;
  - the pre-fix composition still dies in the walk (negative control replaying the v55.0.0 failure, proving the positive test exercises the guard and the third guard layer cannot regress silently again);
  - a broken or relative TMPDIR leaves the fence's parent empty (guard coverage added after self-review).

G-Fix-1 sibling sweep: `grep -rn "PLUGIN_DATA_PARENT\|larch-plugin-data"` — all composition sites are in this diff (fence, docs ×2, Rust message, test pins).

## Self-review

Two fresh-context reviewers (unified-quality and edge-case lenses) reviewed the diff. Converged finding, fixed: the unguarded `cd` composition masked a broken TMPDIR behind a disconnected downstream `mkdir` failure and let a relative TMPDIR silently stage under `$PWD` where the pre-fix shape failed loudly; the fence now guards both and a regression test covers it. Also fixed: a brittle `[:-1]` slice in the negative-control test (now assert + `rstrip`). Reviewer observations left out of scope, matching the issue's own scoping: no automated execution of the docs snippet, the pre-existing dual doc copies (a CI-byte-compared projection), and the Rust-side `validate_absolute()` not walking symlink ancestors (pre-existing; the shell subprocess re-validates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0174BEQFSYAed2gZYHDBiv13
