### PR TITLE
Release v55.0.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "55.0.1",
+  "version": "55.0.2",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2482,7 +2482,7 @@ dependencies = [
 
 [[package]]
 name = "larch-adapters"
-version = "55.0.1"
+version = "55.0.2"
 dependencies = [
  "bytes",
  "chrono",
@@ -2514,7 +2514,7 @@ dependencies = [
 
 [[package]]
 name = "larch-cli"
-version = "55.0.1"
+version = "55.0.2"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -2535,7 +2535,7 @@ dependencies = [
 
 [[package]]
 name = "larch-core"
-version = "55.0.1"
+version = "55.0.2"
 dependencies = [
  "regex",
  "zip",
@@ -2543,7 +2543,7 @@ dependencies = [
 
 [[package]]
 name = "larch-lint"
-version = "55.0.1"
+version = "55.0.2"
 dependencies = [
  "assert_cmd",
  "automod",
@@ -2569,7 +2569,7 @@ dependencies = [
 
 [[package]]
 name = "larch-test-support"
-version = "55.0.1"
+version = "55.0.2"
 dependencies = [
  "larch-core",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2024"
 license = "MIT"
 repository = "https://github.com/character-ai/larch"
 rust-version = "1.94.1"
-version = "55.0.1"
+version = "55.0.2"
 
 [workspace.dependencies]
 assert_cmd = { version = "2.2.2", default-features = false }
@@ -33,9 +33,9 @@ http = { version = "1.4.2", default-features = false, features = ["std"] }
 http-body = { version = "1.0.1", default-features = false }
 http-body-util = { version = "0.1.4", default-features = false }
 inventory = { version = "0.3.24", default-features = false }
-larch-adapters = { version = "=55.0.1", path = "crates/larch-adapters" }
-larch-core = { version = "=55.0.1", path = "crates/larch-core" }
-larch-test-support = { version = "=55.0.1", path = "crates/larch-test-support" }
+larch-adapters = { version = "=55.0.2", path = "crates/larch-adapters" }
+larch-core = { version = "=55.0.2", path = "crates/larch-core" }
+larch-test-support = { version = "=55.0.2", path = "crates/larch-test-support" }
 nix = { version = "0.31.3", default-features = false, features = ["process", "signal"] }
 octocrab = { version = "=0.54.0", default-features = false, features = ["default-client", "jwt-aws-lc-rs", "rustls", "rustls-aws-lc-rs", "timeout"] }
 predicates = { version = "3.1.4", default-features = false }

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "55.0.1",
+  "version": "55.0.2",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
# larch v55.0.2

## Fixed

- `/combine-issues` now ships as a public exported plugin skill instead of a private one ([#7930](https://github.com/character-ai/larch/pull/7930))
