### PR TITLE
Fixes #7934: Define Codex-compatible skill metadata

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -3,7 +3,7 @@
 name: release
 description: "Use when cutting a larch release: create and tag a version candidate, validate its draft assets, merge it, publish immutable, and promote Latest."
 argument-hint: "[--dry-run] [--skip-approve|-s] [--bump major|minor|patch] [--repo OWNER/REPO]"
-allowed-tools: AskUserQuestion, Bash, Skill
+allowed-tools: AskUserQuestion, Bash
 disable-model-invocation: true
 ---
 

--- a/agent-lint.toml
+++ b/agent-lint.toml
@@ -1294,6 +1294,44 @@ files = [
 suppress = ["bash-unscoped"]
 reason = "These lifecycle skills require dynamic Bash operations whose valid argv cannot be represented by a stable command-prefix allowlist; prompt policy and script contracts provide command scope."
 
+# Codex discovers this plugin's public `skills/` root but ignores the
+# Claude-specific behavior fields below. Keep the fields: `allowed-tools`
+# limits Claude's tool surface, `argument-hint` supplies Claude's invocation
+# UX, and the three `hooks` entries enforce active Claude safety boundaries.
+# Each listed skill states its operational restrictions in its body. Codex
+# users therefore receive the instructions but no implied permission or hook
+# enforcement. See docs/skills.md#claude-and-codex-skill-metadata.
+[[lint.overrides]]
+files = [
+  "skills/alias/SKILL.md",
+  "skills/block-issue/SKILL.md",
+  "skills/bug/SKILL.md",
+  "skills/cleanup/SKILL.md",
+  "skills/combine-issues/SKILL.md",
+  "skills/deps/SKILL.md",
+  "skills/design/SKILL.md",
+  "skills/difficulty-calibration/SKILL.md",
+  "skills/f/SKILL.md",
+  "skills/fluff-analysis/SKILL.md",
+  "skills/fm/SKILL.md",
+  "skills/im/SKILL.md",
+  "skills/implement/SKILL.md",
+  "skills/issue/SKILL.md",
+  "skills/learn-from-bugs/SKILL.md",
+  "skills/rejected-analysis/SKILL.md",
+  "skills/report-tokens/SKILL.md",
+  "skills/research/SKILL.md",
+  "skills/review-and-fix/SKILL.md",
+  "skills/review/SKILL.md",
+  "skills/set-up-forked-open-source-repo/SKILL.md",
+  "skills/status/SKILL.md",
+  "skills/triage/SKILL.md",
+  "skills/upgrade-larch/SKILL.md",
+  "skills/voter-calibration/SKILL.md",
+]
+suppress = ["CX060"]
+reason = "Reviewed Claude-only behavior metadata; portable instructions and enforcement limits are documented in docs/skills.md."
+
 # Agent-lint owns the former local closure ratchets. Limits equal the last
 # reviewed measurements so growth remains an intentional, tracked TOML change.
 [[lint.prompt-source-budgets]]

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -12,6 +12,25 @@ Every listed public, alias, internal, and dev-only skill uses the shared run
 lifecycle under its declared name. A nested Skill-tool call creates a distinct
 child run whose manifest records the parent skill and run ID.
 
+## Claude and Codex skill metadata
+
+Public skills are discoverable by both Claude and Codex. Skill-body instructions
+are the portable contract. A field that only one runtime honors must never be
+the sole source of a safety or workflow rule.
+
+`allowed-tools`, `argument-hint`, and skill `hooks` are Claude-only metadata.
+They remain in public skills because they restrict Claude's tool surface,
+provide Claude's invocation hint, and enforce active Claude hook boundaries.
+Codex ignores these fields. In Codex, follow the skill body, but do not infer a
+tool permission, an invocation UI hint, or hook enforcement from frontmatter.
+
+When adding an ignored field to a public skill, either express its behavior in
+portable instructions and add an equivalent Codex enforcement mechanism, or
+declare it intentionally Claude-only with a reviewed, reasoned per-file
+`CX060` suppression in [`agent-lint.toml`](../agent-lint.toml). Keep the
+suppression scope to the affected `SKILL.md` files. Do not remove live Claude
+permissions or hooks only to silence the compatibility warning.
+
 ## Public skills
 
 - [`/alias`](#alias)

--- a/plugin/docs/skills.md
+++ b/plugin/docs/skills.md
@@ -12,6 +12,25 @@ Every listed public, alias, internal, and dev-only skill uses the shared run
 lifecycle under its declared name. A nested Skill-tool call creates a distinct
 child run whose manifest records the parent skill and run ID.
 
+## Claude and Codex skill metadata
+
+Public skills are discoverable by both Claude and Codex. Skill-body instructions
+are the portable contract. A field that only one runtime honors must never be
+the sole source of a safety or workflow rule.
+
+`allowed-tools`, `argument-hint`, and skill `hooks` are Claude-only metadata.
+They remain in public skills because they restrict Claude's tool surface,
+provide Claude's invocation hint, and enforce active Claude hook boundaries.
+Codex ignores these fields. In Codex, follow the skill body, but do not infer a
+tool permission, an invocation UI hint, or hook enforcement from frontmatter.
+
+When adding an ignored field to a public skill, either express its behavior in
+portable instructions and add an equivalent Codex enforcement mechanism, or
+declare it intentionally Claude-only with a reviewed, reasoned per-file
+`CX060` suppression in [`agent-lint.toml`](../agent-lint.toml). Keep the
+suppression scope to the affected `SKILL.md` files. Do not remove live Claude
+permissions or hooks only to silence the compatibility warning.
+
 ## Public skills
 
 - [`/alias`](#alias)


### PR DESCRIPTION
## Summary

- document Claude-only public-skill metadata and Codex behavior
- enumerate reviewed CX060 suppressions for all affected exported skills
- remove the unused release Skill grant

Fixes #7934

## Validation

- `pre-commit run agent-lint --files agent-lint.toml docs/skills.md .claude/skills/release/SKILL.md`
- focused agent-lint 4.0.0 CX060 suppression fixture