### PR TITLE
Fixes #7936: Reconcile the design conditional prompt-source budget

### DIFF
--- a/agent-lint.toml
+++ b/agent-lint.toml
@@ -1303,6 +1303,7 @@ conditional-sources = [
   "skills/design/references/flags.md",
   "skills/design/references/brainstorm.md",
   "skills/design/references/sentinel-host-table.md",
+  "skills/design/references/plan-review.md",
   "skills/shared/final-summary-emit.md",
   "skills/design/references/finalize-step5-failures.md",
   "skills/design/references/approval-gates-gate-a.md",
@@ -1325,9 +1326,19 @@ root-max-content-tokens = 26330
 closure-max-lines = 1680
 closure-max-tokens = 50434
 closure-max-content-tokens = 50307
-conditional-max-lines = 661
-conditional-max-tokens = 18524
-conditional-max-content-tokens = 18465
+# Issue #7936: the prior 661/18524/18465 conditional caps carried an
+# agent-lint v3.0.1 measurement artifact, not smaller reviewed content:
+# brainstorm.md and dialectic-clarifier.md (both branch-gated loads) were
+# misattributed to the always closure, while approval-gates-explicit.md
+# (a second-level Gate B load) and approval-gates-gate-b.md (a mainline
+# unconditional load) were over-counted transitively. The declared sources
+# never grew: their plain sum still equals the 777-line review retired with
+# python/skill-closure-baseline.json (#7593). Caps equal that sum plus
+# plan-review.md, the one SKILL.md-direct conditional load ("Load
+# plan-review.md only for maintainer editing work") missing from the list.
+conditional-max-lines = 790
+conditional-max-tokens = 19694
+conditional-max-content-tokens = 19622
 
 [[lint.prompt-source-budgets]]
 name = "implement"

--- a/docs/linting.md
+++ b/docs/linting.md
@@ -148,7 +148,7 @@ Agent-lint's `--closure-report` emits the same named groups as stable JSON rows.
 Scope is narrow by design:
 
 - Count only `design`, `implement`, and `review` skill closures plus the fixed `panel-tier` source set.
-- Ratchet eager closure for all four targets. Ratchet conditional closure for `review` only.
+- Ratchet eager closure for all four targets. Ratchet conditional closure for the declared `conditional-sources` of `design`, `implement`, and `review`.
 - Count each skill `SKILL.md` plus direct always-loaded prompt-source references.
 - Do not recurse from a referenced file into its references.
 - Track conditional bullets, branch-only routing-table rows, other route-predicate contexts, and the `/implement` `Checks Failure Entry Macro` and `Durable Bail to Step 18 Macro` sections as conditional closure.

--- a/plugin/docs/linting.md
+++ b/plugin/docs/linting.md
@@ -148,7 +148,7 @@ Agent-lint's `--closure-report` emits the same named groups as stable JSON rows.
 Scope is narrow by design:
 
 - Count only `design`, `implement`, and `review` skill closures plus the fixed `panel-tier` source set.
-- Ratchet eager closure for all four targets. Ratchet conditional closure for `review` only.
+- Ratchet eager closure for all four targets. Ratchet conditional closure for the declared `conditional-sources` of `design`, `implement`, and `review`.
 - Count each skill `SKILL.md` plus direct always-loaded prompt-source references.
 - Do not recurse from a referenced file into its references.
 - Track conditional bullets, branch-only routing-table rows, other route-predicate contexts, and the `/implement` `Checks Failure Entry Macro` and `Durable Bail to Step 18 Macro` sections as conditional closure.


### PR DESCRIPTION
Fixes #7936.

## Root cause

The 661/18,524/18,465 conditional caps never described the declared source set. They were seeded at the #7593 migration from agent-lint v3.0.1's heuristic measurement, which differed from the declared list in two ways:

- `brainstorm.md` (189 ln) and `dialectic-clarifier.md` (84 ln), both branch-gated loads, were misattributed to the always closure and excluded from the conditional sum.
- `approval-gates-explicit.md` (44 ln, a second-level Gate B load) and `approval-gates-gate-b.md` (113 ln, a mainline unconditional load) were pulled in transitively.

777 − 273 + 157 = 661. The token deltas match exactly on both token metrics as well.

## Growth attribution

None. The 12 declared files sum to 777/19,371/19,300, byte-identical to the last reviewed baseline in the retired `python/skill-closure-baseline.json` (deleted by #7593). Latest agent-lint simply measures the declared set faithfully.

## Changes

- Restore the reviewed baseline and add `skills/design/references/plan-review.md` (13 ln), the one SKILL.md-direct conditional load missing from the list ("Load `plan-review.md` only for maintainer editing work", SKILL.md). New caps: 790/19,694/19,622, with the reason recorded next to the budget.
- Correct the stale scope line in `docs/linting.md`: conditional closure is ratcheted for `design`, `implement`, and `review`, not `review` only.

## Audit

Every listed source verified as a genuinely conditional SKILL.md-direct load; none moved classification:

| Source | Conditional route |
|---|---|
| flags.md | flag-table "only for background" pointers |
| brainstorm.md | `STEP1D5_ACTION=run` only |
| sentinel-host-table.md | "only when editing sentinels" |
| plan-review.md | "only for maintainer editing work" (newly listed) |
| final-summary-emit.md | terminal readiness profile, point-of-need |
| finalize-step5-failures.md | `SUMMARY_OUTCOME=failed-*` only |
| approval-gates-gate-a.md | Gate A re-entry only |
| settle-rc-dispatch.md | point-of-need at settle steps |
| step2b-drafter-failsafe.md | `failsafe-missing-rows` only |
| step2b5-rc-handling.md | retained-caller branches only |
| decompose-panel.md | Split-path only |
| dialectic-clarifier.md | fingerprint-valid candidates only |
| validator-failure.md | `VALIDATE_STATUS=defects-found` only |

Correctly absent: mainline unconditional loads (discussion-rounds, design-outline, approval-gates, gate-b, gate-c, plan-review-runtime, finalize-step5) and second-level loads (approval-gates-explicit, oos-step5b-dispatch, brainstorm-prompts) per the documented no-recursion contract.

## Verification

- Pinned v3.0.1: design conditional measures 674/18,847/18,787, under the new caps; full `pre-commit run agent-lint` passes.
- Latest agent-lint main (local build): design conditional measures exactly 790/19,694/19,622, equal to the caps, so the ratchet stays tight when the pin bumps.
- `make test-design-structure`: 323 passed.

## Named descope (G-Fix-1 sibling)

The `implement` conditional caps (788/22,725/22,661) carry the same v3.0.1 transitive slack: latest semantics measure 591/18,787/18,740, so the ratchet has ~197 lines of headroom until the agent-lint pin bumps past v3.0.1. Design/implement closure caps have the same slack shape (latest discovery counts the root only). Tightening now would fail the pinned v3.0.1, so this must wait for the pin bump; tracking issue to follow.

Also observed while reconciling, both pre-existing and out of scope: latest agent-lint main panics on this repo's design SKILL.md (`split_clauses` char-boundary bug in `markdown_refs.rs`, upstream agent-lint repo), and `docs/linting.md` documents a `make skill-closure-size` target that does not exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E21Q99VUFUDbKYGdeYmkWn
