### PR TITLE
Fixes #7945: Launch skill CLI checks with python3

### DIFF
--- a/plugin/skills/alias/SKILL.md
+++ b/plugin/skills/alias/SKILL.md
@@ -182,7 +182,7 @@ Only include `--merge` in the args if `alias_merge=true`.
 After `/implement` returns, verify the alias SKILL.md actually landed on disk. The sentinel path uses the `$TARGET_DIR` resolved at Step 2 (no separate `git rev-parse` here: the resolved value is the single source of truth, fail-closed at Step 2 if git failed):
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT}/python/cli.py verify skill-called" \
+python3 "${CLAUDE_PLUGIN_ROOT}/python/cli.py" verify skill-called \
   --sentinel-file "$TARGET_DIR/SKILL.md"
 ```
 

--- a/plugin/skills/research/SKILL.md
+++ b/plugin/skills/research/SKILL.md
@@ -94,7 +94,7 @@ Defense in depth: stdout parsing of `ISSUES_*` is the primary post-`/issue` mech
 4. **Mechanical sentinel verification** (defense in depth):
 
    ```bash
-   ${CLAUDE_PLUGIN_ROOT}/python/cli.py verify skill-called --sentinel-file "$RESEARCH_TMPDIR/issue-completed.sentinel"
+   python3 "${CLAUDE_PLUGIN_ROOT}/python/cli.py" verify skill-called --sentinel-file "$RESEARCH_TMPDIR/issue-completed.sentinel"
    ```
 
    Parse `VERIFIED=true|false` and `REASON=<token>` from stdout. On `VERIFIED=true`, continue. On `VERIFIED=false`, print the fail-closed warning citing `REASON` and abort:
@@ -392,7 +392,7 @@ Derive from `RESEARCH_QUESTION`: `[Research Report] <RESEARCH_QUESTION>`, trunca
 4. Sentinel verification (defense in depth):
 
    ```bash
-   ${CLAUDE_PLUGIN_ROOT}/python/cli.py verify skill-called --sentinel-file "$RESEARCH_TMPDIR/research-issue.sentinel"
+   python3 "${CLAUDE_PLUGIN_ROOT}/python/cli.py" verify skill-called --sentinel-file "$RESEARCH_TMPDIR/research-issue.sentinel"
    ```
 
    Parse `VERIFIED` and `REASON`.

--- a/python/tests/skills/_structure_alias_specialized.py
+++ b/python/tests/skills/_structure_alias_specialized.py
@@ -29,6 +29,21 @@ LEGACY_LABELS: frozenset[str] = frozenset(
 )
 
 
+def _verification_failures(text: str) -> list[str]:
+    failures: list[str] = []
+    verification_fence = (
+        f'python3 "${{CLAUDE_PLUGIN_ROOT}}/python/cli.py" verify skill-called {chr(92)}\n'
+        '  --sentinel-file "$TARGET_DIR/SKILL.md"'
+    )
+    if verification_fence not in text:
+        failures.append("(H.2) expected Step 4 verification to launch cli.py with python3")
+    if '"${CLAUDE_PLUGIN_ROOT}/python/cli.py verify skill-called"' in text:
+        failures.append(
+            "(H.3-neg) Step 4 must not quote the cli path and subcommand as one executable"
+        )
+    return failures
+
+
 def run(repo_root: Path) -> list[str]:
     failures: list[str] = []
     skill = repo_root / "skills/alias/SKILL.md"
@@ -72,16 +87,7 @@ def run(repo_root: Path) -> list[str]:
         failures.append("(G) expected announce line to interpolate $TARGET_DIR")
     if '--sentinel-file "$TARGET_DIR/SKILL.md"' not in text:
         failures.append('(H.1) expected --sentinel-file "$TARGET_DIR/SKILL.md" in Step 4')
-    verification_fence = (
-        f'python3 "${{CLAUDE_PLUGIN_ROOT}}/python/cli.py" verify skill-called {chr(92)}\n'
-        '  --sentinel-file "$TARGET_DIR/SKILL.md"'
-    )
-    if verification_fence not in text:
-        failures.append("(H.2) expected Step 4 verification to launch cli.py with python3")
-    if '"${CLAUDE_PLUGIN_ROOT}/python/cli.py verify skill-called"' in text:
-        failures.append(
-            "(H.3-neg) Step 4 must not quote the cli path and subcommand as one executable"
-        )
+    failures.extend(_verification_failures(text))
     if "REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd -P)" in text:
         failures.append(
             "(H.2-neg) old 'REPO_ROOT=$(git rev-parse ... || pwd -P)' still present in Step 4"

--- a/python/tests/skills/_structure_alias_specialized.py
+++ b/python/tests/skills/_structure_alias_specialized.py
@@ -18,6 +18,8 @@ LEGACY_LABELS: frozenset[str] = frozenset(
         "(F-neg) old hardcoded recipe path '.claude/skills/<alias-name>/...' still in Step 3",
         "(G) expected announce line to interpolate $TARGET_DIR",
         '(H.1) expected --sentinel-file "$TARGET_DIR/SKILL.md" in Step 4',
+        "(H.2) expected Step 4 verification to launch cli.py with python3",
+        "(H.3-neg) Step 4 must not quote the cli path and subcommand as one executable",
         "(H.2-neg) old 'REPO_ROOT=$(git rev-parse ... || pwd -P)' still present in Step 4",
         "(I.1) NEVER #5 should mention both flags (--merge, --private)",
         "(I.2) NEVER list should include the TARGET_DIR-threading rule",
@@ -70,6 +72,16 @@ def run(repo_root: Path) -> list[str]:
         failures.append("(G) expected announce line to interpolate $TARGET_DIR")
     if '--sentinel-file "$TARGET_DIR/SKILL.md"' not in text:
         failures.append('(H.1) expected --sentinel-file "$TARGET_DIR/SKILL.md" in Step 4')
+    verification_fence = (
+        f'python3 "${{CLAUDE_PLUGIN_ROOT}}/python/cli.py" verify skill-called {chr(92)}\n'
+        '  --sentinel-file "$TARGET_DIR/SKILL.md"'
+    )
+    if verification_fence not in text:
+        failures.append("(H.2) expected Step 4 verification to launch cli.py with python3")
+    if '"${CLAUDE_PLUGIN_ROOT}/python/cli.py verify skill-called"' in text:
+        failures.append(
+            "(H.3-neg) Step 4 must not quote the cli path and subcommand as one executable"
+        )
     if "REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd -P)" in text:
         failures.append(
             "(H.2-neg) old 'REPO_ROOT=$(git rev-parse ... || pwd -P)' still present in Step 4"

--- a/python/tests/skills/_structure_research_specialized.py
+++ b/python/tests/skills/_structure_research_specialized.py
@@ -226,6 +226,8 @@ def run(repo_root: Path) -> list[str]:
         (skill, 'python/cli.py" research validate-citations', "[python cli] SKILL.md must pin research validate-citations at Step 2.5"),
         (research, 'python/cli.py" research banner', "[python cli] research-phase.md must pin research banner at Step 1.5"),
         (skill, "python/cli.py research render-findings-batch", "[python cli] SKILL.md must pin research render-findings-batch at Step 3"),
+        (skill, 'python3 "${CLAUDE_PLUGIN_ROOT}/python/cli.py" verify skill-called --sentinel-file "$RESEARCH_TMPDIR/issue-completed.sentinel"', "[python cli] filing sentinel verification must launch cli.py with python3"),
+        (skill, 'python3 "${CLAUDE_PLUGIN_ROOT}/python/cli.py" verify skill-called --sentinel-file "$RESEARCH_TMPDIR/research-issue.sentinel"', "[python cli] auto-issue sentinel verification must launch cli.py with python3"),
     ):
         contains(file, literal, label)
     for literal, label in (

--- a/skills/alias/SKILL.md
+++ b/skills/alias/SKILL.md
@@ -182,7 +182,7 @@ Only include `--merge` in the args if `alias_merge=true`.
 After `/implement` returns, verify the alias SKILL.md actually landed on disk. The sentinel path uses the `$TARGET_DIR` resolved at Step 2 (no separate `git rev-parse` here: the resolved value is the single source of truth, fail-closed at Step 2 if git failed):
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT}/python/cli.py verify skill-called" \
+python3 "${CLAUDE_PLUGIN_ROOT}/python/cli.py" verify skill-called \
   --sentinel-file "$TARGET_DIR/SKILL.md"
 ```
 

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -94,7 +94,7 @@ Defense in depth: stdout parsing of `ISSUES_*` is the primary post-`/issue` mech
 4. **Mechanical sentinel verification** (defense in depth):
 
    ```bash
-   ${CLAUDE_PLUGIN_ROOT}/python/cli.py verify skill-called --sentinel-file "$RESEARCH_TMPDIR/issue-completed.sentinel"
+   python3 "${CLAUDE_PLUGIN_ROOT}/python/cli.py" verify skill-called --sentinel-file "$RESEARCH_TMPDIR/issue-completed.sentinel"
    ```
 
    Parse `VERIFIED=true|false` and `REASON=<token>` from stdout. On `VERIFIED=true`, continue. On `VERIFIED=false`, print the fail-closed warning citing `REASON` and abort:
@@ -392,7 +392,7 @@ Derive from `RESEARCH_QUESTION`: `[Research Report] <RESEARCH_QUESTION>`, trunca
 4. Sentinel verification (defense in depth):
 
    ```bash
-   ${CLAUDE_PLUGIN_ROOT}/python/cli.py verify skill-called --sentinel-file "$RESEARCH_TMPDIR/research-issue.sentinel"
+   python3 "${CLAUDE_PLUGIN_ROOT}/python/cli.py" verify skill-called --sentinel-file "$RESEARCH_TMPDIR/research-issue.sentinel"
    ```
 
    Parse `VERIFIED` and `REASON`.


### PR DESCRIPTION
Closes #7945

Use `python3` for the three affected `verify skill-called` fences and pin the interpreter-launched form in the skill-structure suite.