### PR TITLE
Fixes #7965: Adopt tools config storage namespaces

### DIFF
--- a/.claude/skills/analyze-bugs/SKILL.md
+++ b/.claude/skills/analyze-bugs/SKILL.md
@@ -29,7 +29,7 @@ backfills older issues absent from a valid cache record.
 Before dispatch, require a clean checkout on `main` synchronized with
 `origin/main`. `analyze-bugs prefetch` keeps immutable evidence bundles under
 `$XDG_CACHE_HOME` and returns a mutable `LEDGER_PATH` under
-`$XDG_STATE_HOME/larch/analysis-state/<repo>/analyze-bugs/`. Use only that
+`$XDG_STATE_HOME/larch/analysis-state/v2/<client-repo>/<storage-origin-id>/analyze-bugs/`. Use only that
 printed ledger path in later stages. The first run imports the legacy cache
 ledger when present. Never commit, push, or open a PR for analyzer state.
 

--- a/.claude/skills/validate-merged/SKILL.md
+++ b/.claude/skills/validate-merged/SKILL.md
@@ -31,7 +31,7 @@ it launches one finder per selected merge and one refuter per candidate. The
 recommended first run is the default 48-hour, 20-merge window.
 
 Read the `STATE_PATH` returned by `validate-merged prepare`. It lives under
-`$XDG_STATE_HOME/larch/analysis-state/<repo>/validate-merged/`. State contains only
+`$XDG_STATE_HOME/larch/analysis-state/v2/<client-repo>/<storage-origin-id>/validate-merged/`. State contains only
 compact merge frontier and unresolved candidate identities, never issue bodies,
 diffs, transcripts, temporary paths, or raw agent output. Do not advance state
 until every enabled stage and the final report pass.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Larch is a Claude Code workflow automation framework that orchestrates multi-age
 - **[Direct design planning and plan reviews](docs/collaborative-sketches.md)** — Step 2b drafts the plan directly, then the [validation panel](docs/topology.md#design.plan_review.cursor_archetypes) reviews it.
 - **[Voting-based review resolution](docs/voting-process.md)** — The YES/NO panel protocol adjudicates plan and code review findings.
 - **[Reviewer competition scoring](docs/point-competition.md)** — Reviewers earn points based on finding quality; a scoreboard tracks accepted, neutral, and rejected findings.
-- **[Tracked runs](docs/run-logs.md)** — Every skill invocation publishes one terminal archive below the configured storage root, such as `s3://zhupanov/larch/run-logs/<skill>/<run-id>.tar.gz`. Nested and alias invocations keep distinct parent-linked archives. `/implement` keeps tracking issues slim with marker-keyed summary comments.
+- **[Tracked runs](docs/run-logs.md)** — Every skill invocation publishes one terminal archive below the derived tool and client-repository root, such as `s3://zhupanov/larch/larch/run-logs/<skill>/<run-id>.tar.gz`. Nested and alias invocations keep distinct parent-linked archives. `/implement` keeps tracking issues slim with marker-keyed summary comments.
 - **[Progress statusline](docs/progress-reporting.md)** — clone-local breadcrumbs show live larch progress without adding report text to model context.
 - **Tiered architectural knowledge** — Optional `ARCHITECTURAL_INVARIANTS.md` and `ARCHITECTURAL_GUIDELINES.md` files are supplied to authoring agents plus the dedicated code-review compliance specialist and `/design` Architecture/Standards reviewer as untrusted, scope-bound evidence.
 

--- a/config.toml
+++ b/config.toml
@@ -1,9 +1,0 @@
-[logs]
-uri = "s3://zhupanov/larch"
-
-[logs.legacy_migration]
-schema = "larch-run-log-migration-inventory-v1"
-source_commit = "251642775413fd758139a4d547763a02902a17ec"
-storage_root = "s3://zhupanov/larch"
-inventory_key = "migration/inventory-v1-251642775413fd758139a4d547763a02902a17ec.json"
-inventory_sha256 = "e5cea85a48bd3177e8193bd1b143ed967635ebbadbd7b36f9619a8515c51f4a7"

--- a/crates/larch-adapters/src/google_storage.rs
+++ b/crates/larch-adapters/src/google_storage.rs
@@ -43,12 +43,17 @@ impl<S: StorageStub + 'static> GoogleCloudStorage<S> {
     }
 }
 impl<S: StorageStub + 'static> ObjectStore for GoogleCloudStorage<S> {
-    fn preflight_bucket<'a>(&'a self, bucket: &'a str) -> ObjectStoreFuture<'a, ()> {
+    fn preflight_prefix<'a>(
+        &'a self,
+        bucket: &'a str,
+        prefix: &'a str,
+    ) -> ObjectStoreFuture<'a, ()> {
         Box::pin(async move {
             transport(
                 self.control
                     .list_objects()
                     .set_parent(bucket_name(bucket))
+                    .set_prefix(prefix)
                     .set_page_size(1)
                     .send()
                     .await,

--- a/crates/larch-adapters/tests/google_storage.rs
+++ b/crates/larch-adapters/tests/google_storage.rs
@@ -44,9 +44,17 @@ impl DataStub for Data {
 impl ControlStub for Control {
     async fn list_objects(
         &self,
-        _request: ListObjectsRequest,
+        request: ListObjectsRequest,
         _options: ControlOptions,
     ) -> google_cloud_storage::Result<Response<ListObjectsResponse>> {
+        assert_eq!(request.parent, "projects/_/buckets/bucket");
+        if request.prefix == "larch/client/" {
+            assert_eq!(request.page_size, 1);
+            assert!(request.page_token.is_empty());
+        } else {
+            assert_eq!(request.prefix, "larch/");
+            assert_eq!(request.page_token, "page");
+        }
         Ok(Response::from(
             ListObjectsResponse::new()
                 .set_objects([object()])
@@ -77,7 +85,10 @@ fn store() -> GoogleCloudStorage<Data> {
 #[tokio::test]
 async fn operations_and_failures_preserve_the_neutral_contract() {
     let store = store();
-    store.preflight_bucket("bucket").await.expect("preflight");
+    store
+        .preflight_prefix("bucket", "larch/client/")
+        .await
+        .expect("preflight");
     let page = store
         .list_page("bucket", "larch/", Some("page"))
         .await

--- a/crates/larch-cli/src/object_store_commands.rs
+++ b/crates/larch-cli/src/object_store_commands.rs
@@ -76,7 +76,7 @@ async fn execute(arguments: &GcsArguments, store: &dyn ObjectStore) -> ExitCode 
         .unwrap_or_else(|| Path::new(""));
     let result = match arguments.operation {
         GcsOperation::Preflight => store
-            .preflight_bucket(&arguments.bucket)
+            .preflight_prefix(&arguments.bucket, arguments.prefix.as_deref().unwrap_or(""))
             .await
             .map(|()| json!({})),
         GcsOperation::List => store

--- a/crates/larch-cli/tests/cli.rs
+++ b/crates/larch-cli/tests/cli.rs
@@ -124,7 +124,7 @@ fn object_store_contract() -> ObjectStoreContract {
 
 fn remote_object() -> RemoteObject {
     RemoteObject {
-        key: "larch/run-logs/design/fixture-run.tar.gz".into(),
+        key: "larch/larch/run-logs/design/fixture-run.tar.gz".into(),
         size: 7,
         etag: Some("fixture-etag".into()),
         version: Some("fixture-version".into()),
@@ -140,7 +140,7 @@ macro_rules! store_method {
 }
 
 impl ObjectStore for ObjectStoreFixture {
-    store_method!(preflight_bucket(_bucket: &'a str) -> (), Ok(()));
+    store_method!(preflight_prefix(_bucket: &'a str, _prefix: &'a str) -> (), Ok(()));
     store_method!(list_page(_bucket: &'a str, _prefix: &'a str, _token: Option<&'a str>) -> ObjectPage, Ok(ObjectPage { objects: vec![remote_object()], next_page_token: None }));
     store_method!(upload_create(_bucket: &'a str, _key: &'a str, _source: &'a Path) -> RemoteObject, Ok(remote_object()));
     store_method!(download(_bucket: &'a str, _key: &'a str, _destination: &'a Path) -> (), Ok(()));

--- a/crates/larch-core/src/object_store.rs
+++ b/crates/larch-core/src/object_store.rs
@@ -32,7 +32,11 @@ pub type ObjectStoreFuture<'a, T> =
 
 /// Narrow object transport port. Workflow policy remains outside adapters.
 pub trait ObjectStore: Send + Sync {
-    fn preflight_bucket<'a>(&'a self, bucket: &'a str) -> ObjectStoreFuture<'a, ()>;
+    fn preflight_prefix<'a>(
+        &'a self,
+        bucket: &'a str,
+        prefix: &'a str,
+    ) -> ObjectStoreFuture<'a, ()>;
     fn list_page<'a>(
         &'a self,
         bucket: &'a str,

--- a/docs/analysis-state.md
+++ b/docs/analysis-state.md
@@ -2,30 +2,40 @@
 
 Run archives are immutable analysis inputs. Stateful analyzers synchronize the
 remote run corpus once, then read ordinary files from
-`${XDG_CACHE_HOME:-$HOME/.cache}/larch/run-logs/<repo>/` for the rest of the
-invocation.
+`${XDG_CACHE_HOME:-$HOME/.cache}/larch/run-logs/v2/<client-repo>/<storage-origin-id>/`
+for the rest of the invocation. They retain the corpus root returned by the
+shared synchronizer and never reconstruct it from the checkout directory.
 
 Mutable cursors, ledgers, retry bundles, generated analyses, and generated
 measurements do not belong under `run-logs/`. They live at:
 
 ```text
-${XDG_STATE_HOME:-$HOME/.local/state}/larch/analysis-state/<repo>/<owner>/
+${XDG_STATE_HOME:-$HOME/.local/state}/larch/analysis-state/v2/
+  <client-repo>/<storage-origin-id>/<owner>/
 ```
 
-Repository and owner names remain literal validated path components. Files use
+The client repository is derived from Git origin. The storage-origin ID is the
+lowercase hexadecimal SHA-256 of the canonical
+`<base>/larch/<client-repo>` URI. Provider, bucket, base-prefix, tool, or
+repository changes therefore select different cache and analyzer-state roots.
+Old basename-keyed state is not silently imported.
+
+Repository and owner names remain validated path components. Files use
 private directories and `0600` modes. Writers use a per-file advisory lock,
 atomic replacement, and an expected SHA-256 identity when a workflow carries
 state across multiple steps. A stale concurrent writer fails without replacing
 the newer file. Corrupt, symlinked, non-regular, or unreadable state fails
 closed.
 
-On first access, migrated owners import their former Git or cache file when the
-new state file is absent. A warm access never rereads or overwrites from the
-legacy path. Run-log cloud sync never lists, downloads, uploads, or interprets
-this mutable state tree.
+Old basename-keyed and repository-local state remains untouched for explicit
+operator cleanup. No v2 owner imports it, including after a provider, bucket,
+prefix, tool, or repository identity change. Run-log cloud sync never lists,
+downloads, uploads, or interprets this mutable state tree.
 
 `/rejected-analysis` owns `rejected-analysis/ledger.tsv` and
 `rejected-analysis/verdicts.tsv`. `/difficulty-calibration` reads the verdict
 sidecar from that owner after one run-log sync. It does not copy mutable state
 into the cache or a run archive. An explicit `--log-root DIR` is an offline
-fixture boundary and may keep a fixture-local legacy sidecar for compatibility.
+fixture boundary: readers use it directly without reading repository storage
+configuration or making network requests. A fixture may keep a local legacy
+sidecar for compatibility.

--- a/docs/configuration-and-permissions.md
+++ b/docs/configuration-and-permissions.md
@@ -190,20 +190,28 @@ The legacy `--codex-available true|false` knob is still accepted by the dispatch
 
 ### Run-log object storage
 
-Each consumer repository must provide a larch storage root in
-`config.toml`:
+Each consumer repository must own a root `tools-config.toml` file and provide
+the larch storage base:
 
 ```toml
-[logs]
-uri = "s3://zhupanov/larch"
+[larch]
+storage_base_uri = "s3://zhupanov"
 ```
 
-`LARCH_LOGS_URI` overrides the file value for the process. It must contain the
-same complete storage-root shape. Do not set it to a bucket root, a
-`run-logs/` prefix, or an individual archive. Larch derives:
+The file is shared by independently configured tools. Each tool owns one table
+named for the tool and ignores unrelated tool tables. There is no global
+version and no configured `client_repo`. Larch requires the file and `[larch]`
+even when `LARCH_STORAGE_BASE_URI` overrides only
+`[larch].storage_base_uri`. A non-empty `LARCH_LOGS_URI` is rejected with
+migration guidance.
+
+The base may be a bucket root or include an optional base prefix. Larch derives
+the client repository from the final repository component of the local Git
+`remote.origin.url`, not from the checkout or worktree directory. It then
+derives:
 
 ```text
-s3://zhupanov/larch/run-logs/<skill>/<run-id>.tar.gz
+<base>/larch/<client-repo>/run-logs/<skill>/<run-id>.tar.gz
 ```
 
 Accepted schemes are `gs://`, `s3://`, and `r2://`. The value must not contain
@@ -215,20 +223,29 @@ discovery. R2 also requires a 32-character lowercase hexadecimal
 `LARCH_R2_ENDPOINT=https://<account-id>.r2.cloudflarestorage.com`. GCS uses the
 Rust transport and Google ADC described below.
 
-The startup check lists the provider bucket root only. Success depends only on
-provider status. Larch ignores stdout, does not inspect objects or permissions,
-does not list the configured prefix, and does not write a probe object. Storage
-credentials remain process or provider inputs. Larch has no credential file or
-repository trust registry.
+The startup check lists at most one result under the exact
+`larch/<client-repo>/` prefix. Success depends only on provider status. Larch
+ignores stdout, does not inspect returned object names, does not list the bucket
+root, and does not write a probe object. Restrict provider credentials to the
+approved tool and repository prefixes. Storage credentials remain process or
+provider inputs. Larch has no credential file or repository trust registry.
 
 The full URI, provider, archive, cache, sync, and error rules live in
 [Run-log storage contracts](run-log-archive.md).
 
-This repository's `config.toml` also contains a
-`[logs.legacy_migration]` table. It pins the verified one-time larch migration
-inventory and applies only to this repository and its exact configured storage
-root. Do not copy it into unrelated consumer repositories. Normal archives do
-not use it.
+This repository's `tools-config.toml` contains only:
+
+```toml
+[larch]
+storage_base_uri = "s3://zhupanov"
+```
+
+The historical manifest-less archive migration is an explicit operator
+operation, not a normal sync fallback. Drain pending v1 publications before
+cutover. Land and release the new runtime while runs are frozen, complete and
+verify the object migration, commit the new config, prewarm a cold v2 cache,
+then resume. Roll back by restoring the prior plugin release and old remote
+prefixes; old basename-keyed local cache and state remain untouched.
 
 ### Google Application Default Credentials
 

--- a/docs/git-operation-inventory.md
+++ b/docs/git-operation-inventory.md
@@ -89,6 +89,7 @@ python/larch/rendering/rendering.py	later-domain	#7683	merge-base
 python/larch/report/final_report.py	later-domain	#7683	rev-parse
 python/larch/report/run_log_commit.py	later-domain	#7683	add,clean,commit,diff,reset,restore,rev-parse,status,symbolic-ref
 python/larch/report/run_log_flush.py	later-domain	#7683	diff
+python/larch/report/storage_config.py	later-domain	#7683	dynamic
 python/larch/report/tokens.py	later-domain	#7683	dynamic
 python/larch/research/research_eval.py	later-domain	#7684	dynamic
 python/larch/review/_raf_util.py	later-domain	#7679	status

--- a/docs/installation-and-setup.md
+++ b/docs/installation-and-setup.md
@@ -108,7 +108,8 @@ export LARCH_R2_ACCOUNT_ID="<32-lowercase-hex-account-id>"
 export LARCH_R2_ENDPOINT="https://${LARCH_R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
 ```
 
-Do not place credentials in `config.toml` or `LARCH_LOGS_URI`. See the
+Do not place credentials in `tools-config.toml` or
+`LARCH_STORAGE_BASE_URI`. See the
 [object-storage credential contract](security/supply-chain-credentials-and-services.md#object-storage-credentials-and-transport).
 
 ### Install
@@ -247,21 +248,28 @@ If you need stricter permissions instead (no `bypassPermissions`), drop that lin
 
 ### Configure run-log storage for every repo where you will run larch
 
-Create `config.toml` at the consumer repository root:
+Create `tools-config.toml` at the consumer repository root:
 
 ```toml
-[logs]
-uri = "<URI>"
+[larch]
+storage_base_uri = "<base-URI>"
 ```
-Example `<URI>` value: `s3://my-bucket-for-larch-logs/my-client-repo-a`.
+Example base values are `s3://my-bucket-for-tool-data`,
+`gs://my-bucket/prod/tools`, and `r2://my-bucket`. A base stops before the
+tool name. Larch derives the client repository from local
+`remote.origin.url`, then writes
+`<base>/larch/<client-repo>/run-logs/<skill>/<run-id>.tar.gz`. Clone and
+worktree directory names do not affect that identity.
 
-The URI is the larch storage root. Larch writes archives below
-`run-logs/<skill>/<run-id>.tar.gz`, so the example does not end in
-`run-logs/`. Set `LARCH_LOGS_URI` before starting larch to replace the file
-value for that process. Accepted schemes are `s3://`, `gs://`, and `r2://`.
+The repository-owned file may contain tables for other tools. Larch owns and
+strictly validates only `[larch]`; it ignores unrelated tool tables. There is
+no global version and no `client_repo` field. The file and `[larch]` remain
+required when `LARCH_STORAGE_BASE_URI` overrides only the base value for one
+process. Accepted schemes are `s3://`, `gs://`, and `r2://`.
 
-At skill startup, larch lists only the bucket root and ignores the listing
-output. It does not probe the configured prefix or attempt a write. See
+At skill startup, larch lists at most one object under the exact
+`larch/<client-repo>/` prefix and ignores the listing output. It does not list
+the bucket root or attempt a write. See
 [Configuration and Permissions](configuration-and-permissions.md#run-log-object-storage)
 and the [language-neutral storage contract](run-log-archive.md).
 

--- a/docs/run-log-archive.md
+++ b/docs/run-log-archive.md
@@ -9,46 +9,77 @@ migration must preserve this contract or version it explicitly.
 
 ## Configuration resolution
 
-Resolve the storage root from the current repository in this order:
+Discover the Git top level from the invocation's startup directory and read
+exactly `tools-config.toml` there. The repository-owned file is shared by
+independently configured tools: each tool owns one table named for the tool and
+ignores unrelated top-level tool tables. There are no shared fields, no global
+version, and no `client_repo` field.
 
-1. Use a non-empty `LARCH_LOGS_URI`.
-2. Otherwise read `[logs].uri` from repository-root `config.toml`.
-3. Fail when neither source supplies a value. Do not infer a bucket, provider, or prefix.
+Larch requires a strict table:
 
-The environment value replaces the file value. The two values are not merged.
-The resolved URI is the larch storage root. It is not the `run-logs/` prefix,
-an archive path, or a bucket-root URI.
+```toml
+[larch]
+storage_base_uri = "s3://zhupanov"
+```
 
-The checked-in configuration is `[logs]` with `uri = "s3://zhupanov/larch"`.
-This repository also owns a versioned `[logs.legacy_migration]` descriptor for
-the one-time historical larch migration. It pins the inventory key, inventory
-SHA-256, source commit, storage root, and schema. Consumer repositories without
-that descriptor do not enable legacy archive handling.
+The file and `[larch]` are required even when
+`LARCH_STORAGE_BASE_URI` replaces only `storage_base_uri` for the process.
+Reject non-empty `LARCH_LOGS_URI`; never probe `config.toml`,
+`.larch/config.toml`, or `tool-config.toml`. Reject a symlinked, unreadable, or
+malformed file and missing, duplicate, unknown, empty, padded, or type-invalid
+larch fields before workflow side effects or object-store requests.
 
-Accept only `gs://`, `s3://`, and `r2://`. Require a plain non-empty bucket
-authority and at least one non-empty prefix segment. Reject credentials, ports,
-queries, fragments, whitespace, control characters, empty segments, `.`, and
-`..`. Preserve accepted bucket and prefix text. Do not hash or silently rewrite
-it.
+`StorageBase` is a validated provider, bucket, and optional base prefix. Accept
+only `gs://`, `s3://`, and `r2://`, including bucket roots. Reject credentials,
+ports, queries, fragments, trailing slashes, whitespace, control characters,
+empty segments, `.`, and `..`. Preserve accepted bucket and prefix text.
+
+`ToolRepositoryStorage` adds the fixed tool `larch` and a derived client
+repository. Larch reads the repository's local `remote.origin.url`, accepts
+standard HTTPS, SSH URL, and SCP-like Git syntax, strips exactly one terminal
+`.git`, converts ASCII uppercase to lowercase, and otherwise requires a strict
+slug. It never uses a checkout or worktree directory name, a provider API,
+bucket text, config field, or environment override for repository identity.
+Missing, ambiguous, credential-bearing, port-bearing, or invalid origins fail
+without echoing embedded credentials.
 
 ## Remote and local layout
 
-For storage root `<URI>`, the only run-archive layout is
-`<URI>/run-logs/<skill-name>/<run-id>.tar.gz`. For the checked-in root, a design
-archive is `s3://zhupanov/larch/run-logs/design/<run-id>.tar.gz`.
+The remote schema is
+`<storage-base>/<tool-name>/<client-repo>/<data-type>/<data>`. The larch tool
+repository is `<base>/larch/<client-repo>`. The implemented data type is
+`run-logs`, so archives use
+`<base>/larch/<client-repo>/run-logs/<skill>/<run-id>.tar.gz`.
+
+The checked-in base produces
+`s3://zhupanov/larch/larch/run-logs/design/<run-id>.tar.gz`. Other examples
+include
+`gs://character-tool-logs/larch/sre/run-logs/investigate/<run-id>.tar.gz`,
+`s3://company-data/prod/tools/larch/service-a/run-logs/review/<run-id>.tar.gz`,
+and `r2://tool-data/larch/service-a/run-logs/review/<run-id>.tar.gz`.
 
 Only skill directories exist directly below `run-logs/`. Mutable analyzer
-state, ledgers, reports, and measurements never appear there.
+state, ledgers, reports, measurements, indexes, and migration artifacts never
+appear there. Future data types must define their own object, collision,
+mutability, and retention contracts.
 
-The unpacked cache layout is
-`${XDG_CACHE_HOME:-$HOME/.cache}/larch/run-logs/<repo-name>/<skill-name>/<run-id>/`.
+Define `storage_origin_id` as lowercase hexadecimal SHA-256 of the canonical
+tool repository URI's UTF-8 bytes. Local paths are:
 
-Keep repository, skill, and run names as validated literal directory names. Do
-not hash them. The cache is a private local copy, not a second publication
-target.
+```text
+${XDG_CACHE_HOME:-$HOME/.cache}/larch/run-logs/v2/
+  <client-repo>/<storage-origin-id>/<skill>/<run-id>/
 
-Content-pinned retry state lives outside the cache at
-`${XDG_STATE_HOME:-$HOME/.local/state}/larch/run-log-pending/`.
+${XDG_STATE_HOME:-$HOME/.local/state}/larch/run-log-pending/v2/
+  <client-repo>/<storage-origin-id>/<skill>/<run-id>/
+
+${XDG_STATE_HOME:-$HOME/.local/state}/larch/run-log-locks/v2/
+  <client-repo>/<storage-origin-id>/<skill>/<run-id>.lock
+```
+
+The cache is private local state, not a publication target. Changing provider,
+bucket, base prefix, tool, or client repository selects a cold namespace. Old
+basename-keyed cache and state are neither renamed nor silently imported.
 
 ## Provider operations
 
@@ -56,21 +87,22 @@ Every provider implements the same operations:
 
 | Operation | Contract |
 |---|---|
-| `preflight_bucket` | List the bucket root and decide success from exit or provider status only. Ignore stdout. Do not list the configured prefix, inspect contents or permissions, call a head-bucket substitute, or write a probe object. |
+| `preflight_prefix` | List the exact `<tool>/<client-repo>/` prefix with a maximum of one result. Decide success from provider status only; ignore object names and provider diagnostics. Do not list the bucket root or write a probe object. |
 | `list` | List the requested prefix through every page. Return relative keys, byte sizes, and optional opaque ETag and version values. Reject malformed pages, repeated page tokens, and keys outside the configured root. |
 | `upload_create` | Create one object only if absent. Never replace an existing object. Return normalized metadata. |
 | `metadata` | Return normalized metadata for one exact key. |
 | `download` | Write to a private sibling temporary file and atomically promote it. Never merge with a destination. |
 
-For `s3://zhupanov/larch`, startup preflight is equivalent to
-`aws s3 ls s3://zhupanov`.
+For the checked-in base and repository, startup preflight lists only
+`larch/larch/` in bucket `zhupanov`.
 
 S3 and R2 use the AWS CLI transport and standard AWS credential discovery. R2
 also requires `LARCH_R2_ACCOUNT_ID` and `LARCH_R2_ENDPOINT`. The endpoint must
 be `https://<account-id>.r2.cloudflarestorage.com`, and the account ID must
 match the host. GCS uses the narrow Rust transport through
 `${CLAUDE_PLUGIN_ROOT}/scripts/larch.sh` and standard Google Application Default
-Credentials.
+Credentials. Credentials should grant list, read, and write only to approved
+tool and client-repository prefixes.
 
 ## Machine-readable errors
 
@@ -127,7 +159,7 @@ tree. It never merges with or replaces a destination. Cache entries contain ordi
 `python3 python/cli.py run-log publish --repo-root <root> --skill <skill>
 --run-id <run-id> --staging-root <tree>` persists the archive before attempting
 the create-only upload to `run-logs/<skill>/<run-id>.tar.gz`. Failed attempts
-remain under `${XDG_STATE_HOME:-$HOME/.local/state}/larch/run-log-pending/`
+remain under the storage-origin-specific `run-log-pending/v2` path
 with content-pinned retry metadata. Repeating the command may omit
 `--staging-root` when that pending state exists. When pending state already
 exists, the publisher retries and populates the cache from that archive. It
@@ -136,8 +168,7 @@ does not use a later mutable staging tree as the retry source.
 An existing remote key succeeds only when its downloaded bytes match the
 pending archive; different content fails closed. A new upload is verified by
 remote metadata. The normal success path copies the sanitized staging tree
-directly into
-`${XDG_CACHE_HOME:-$HOME/.cache}/larch/run-logs/<repo>/<skill>/<run-id>/`,
+directly into the storage-origin-specific `run-logs/v2` cache,
 without downloading or decompressing the archive. Retry without staging safely
 materializes the durable archive instead. A per-run lock covers upload,
 collision verification, cache promotion, and atomic retirement of pending
@@ -152,25 +183,18 @@ per-run publication lock, replaced atomically after validation, and restored if
 repair fails. Interrupted download, materialization, promotion, and quarantine
 entries are removed before the next attempt.
 
-The checked-in legacy migration descriptor is a narrow compatibility boundary.
-Sync first applies the normal `archive-manifest.json` contract. Only a readable
-archive with no root archive manifest can trigger legacy lookup. Sync then
-downloads the pinned migration inventory at most once for that repository sync,
-verifies its SHA-256, and validates its bounded schema, source commit, storage
-root, object identities, source-file rows, and totals. The archive must have an
-exact inventory record, and its byte size and SHA-256 must match that record.
+Normal synchronization accepts only manifest-bearing archives. It does not read
+a legacy migration descriptor, inventory, or basename-keyed cache. The retained
+legacy descriptor parser is an explicit operator API for the coordinated
+historical migration only; it does not discover repository configuration or
+participate in normal sync.
 
-Legacy extraction accepts only inventory-covered regular PAX members with safe
-canonical paths, supported modes, matching sizes, and matching SHA-256 digests.
-It rejects links, devices, special files, collisions, traversal, extra or
-missing members, corrupt streams, and expansion-limit violations. After private
-extraction succeeds, sync writes a local schema-version-1
-`archive-manifest.json`, verifies the complete directory, and promotes it
-atomically. It never writes, replaces, renames, or deletes a remote object.
-Later syncs validate the local directory and perform listing only.
+Cut over while runs are frozen: land and release this runtime, drain v1 pending
+publications, complete and verify the object migration, commit the new config,
+prewarm a clean v2 cache, then resume. Roll back by restoring the prior plugin
+release and old remote prefixes. The old local cache and state remain untouched.
 
-The command returns the unpacked repository corpus at
-`${XDG_CACHE_HOME:-$HOME/.cache}/larch/run-logs/<repo>/`. The shared
+The command returns the unpacked storage-origin-specific repository corpus. The shared
 `run_log_corpus.synchronized_run_log_root` API performs the same one-time sync
 and returns that root. An analyzer must retain the returned path and use normal
 local file reads for all later files and waves in the same invocation.
@@ -186,7 +210,4 @@ I-Cutover-1. In one change, prove Rust parity against the shared fixtures,
 switch every production caller to `${CLAUDE_PLUGIN_ROOT}/scripts/larch.sh`,
 remove the Python registration and implementation, and prove clean-install
 execution. Do not add a compatibility shim, bridge, implementation selector,
-fallback, or dual-write period. Rust must consume the same repository-owned
-legacy migration descriptor and enforce the same inventory, archive, extraction,
-and synthesized-manifest validation contract. The hard cutover must not retain
-an undocumented Python-only exception.
+fallback, or dual-write period.

--- a/docs/run-log-batches.md
+++ b/docs/run-log-batches.md
@@ -21,6 +21,12 @@ still passes through the run-log trim, temporary-path redaction, secret scrub,
 and publication checks described in the canonical
 [run-log security contract](security/artifacts-redaction-and-publication.md#run-logs-and-breadcrumbs).
 
+Batch names are relative to the lifecycle-owned staging tree. They never select
+or reconstruct remote storage. The shared lifecycle routes the terminal archive
+to `<base>/larch/<client-repo>/run-logs/<skill>/<run-id>.tar.gz`; analyzers
+read batches only below the storage-origin-bound corpus root returned by the
+shared synchronizer.
+
 `architectural-invariant-outcome` is a replace-mode `.json` batch with the
 `json-object` sanitizer. It writes
 `larch-logs/implement/<RUN_ID>/architectural-invariant-outcome.json` when an

--- a/docs/run-log-cli.md
+++ b/docs/run-log-cli.md
@@ -60,12 +60,30 @@ lists the configured `run-logs/` prefix once and emits `CORPUS_ROOT`,
 `LISTED_ARCHIVES`, `PRESENT_RUNS`, `DOWNLOADED_RUNS`, `REPAIRED_RUNS`, and
 `SYNC_OK=true`. See [Run-log storage contracts](run-log-archive.md).
 
+Storage preflight and lifecycle start resolve repository-root
+`tools-config.toml`, derive the client repository from local Git origin, list
+at most one result under the exact `larch/<client-repo>/` prefix, and emit:
+
+```text
+STORAGE_BASE_URI=<canonical base>
+CLIENT_REPO=<derived repository name>
+TOOL_REPO_URI=<canonical base>/larch/<client-repo>
+RUN_LOGS_URI=<tool repository URI>/run-logs/
+PREFLIGHT_OK=true
+```
+
+Lifecycle start emits the first four values with its lifecycle envelope.
+Persisted context pins the same tool URI, client repository, and
+storage-origin ID; publication fails if config, environment, or Git identity
+changes mid-run.
+
 The universal lifecycle starts each invocation with a declared skill and either
-a caller-supplied `--run-id` or a generated UUID after the configured bucket
+a caller-supplied `--run-id` or a generated UUID after the configured prefix
 preflight succeeds. `--log-root <absolute-path>` selects specialized staging;
 `--adopt-existing` adopts a matching manifest already created there. The start
 envelope returns `CONTEXT_FILE`, whose durable JSON record binds repository,
-storage URI, skill, run ID, log root, and run directory. Child runs also record the
+tool repository URI, client repository, storage-origin ID, skill, run ID, log
+root, and run directory. Child runs also record the
 parent skill and run ID, but retain their own archive. Every terminal verb
 writes `final-report.md`, records a missing transcript as an execution issue
 when capture is unavailable, and attempts the same create-only publication.

--- a/docs/run-logs.md
+++ b/docs/run-logs.md
@@ -8,6 +8,21 @@ The configured storage root, deterministic archive, provider, cache, sync,
 error, and Rust-handoff contracts are defined in
 [Run-log storage contracts](run-log-archive.md).
 
+Every writer and default reader resolves one pinned tool repository per
+invocation from repository-root `tools-config.toml` and local Git origin:
+
+```text
+<storage-base>/larch/<client-repo>/run-logs/<skill>/<run-id>.tar.gz
+```
+
+The base may be an S3, GCS, or R2 bucket root or include an optional prefix.
+The client repository is derived from `remote.origin.url`; checkout and
+worktree names do not affect it. Synchronization returns a v2 cache root bound
+to the SHA-256 identity of the canonical tool repository URI. Analysis skills
+retain that returned root for all reads. Their explicit `--log-root` options
+remain offline-fixture bypasses that do not load storage configuration or use
+the network.
+
 ## Universal skill lifecycle
 
 `skills/shared/run-lifecycle.md` defines the shared start and terminal contract,

--- a/docs/security/artifacts-redaction-and-publication.md
+++ b/docs/security/artifacts-redaction-and-publication.md
@@ -273,7 +273,9 @@ not broaden who should receive it.
 
 This boundary applies to every public, alias, internal child, and dev-only skill
 archive. A durable lifecycle context binds the selected staging root to one
-repository, storage URI, skill, and run ID before publication. Parent-child metadata identifies run relationships but does not change
+repository, canonical tool repository URI, derived client repository,
+storage-origin ID, skill, and run ID before publication. A config, environment,
+or Git-origin change before publication fails closed. Parent-child metadata identifies run relationships but does not change
 the classification, redaction, or publication rules for either archive.
 
 `python/cli.py run-log sync` treats the remote inventory and downloaded archives
@@ -285,22 +287,18 @@ invalid entry, restores it on failure, and removes stale private transfer and
 repair state under the same lock. See
 [Run-log archive format](../run-log-archive.md).
 
-The larch repository pins its one-time legacy migration inventory in repository
-configuration. A manifest-less archive reaches the compatibility extractor only
-when its exact object key, compressed byte size, archive SHA-256, member rows,
-expanded size, source commit, and storage root match that hash-verified bounded
-inventory. The extractor rejects unsafe paths, collisions, links, devices,
-special files, unsupported modes, missing or extra members, content mismatches,
-and expansion-limit violations. It promotes a private extraction only after it
-synthesizes and verifies the normal local `archive-manifest.json`. Repositories
-without the descriptor, and unrecognized manifest-less archives, fail closed.
-No compatibility operation mutates remote storage.
+Normal synchronization rejects manifest-less archives and never loads a legacy
+migration descriptor or inventory. The retained legacy parser is available
+only to an explicit operator migration API. It does not discover normal
+repository configuration or change the sync trust boundary.
 
 Mutable analyzer state is not an archive and never appears under `run-logs/`.
-It stays under the private XDG state home with owner-scoped paths, `0600`
-files, atomic replacement, per-file locks, and stale-writer detection. Treat
-its ledgers, retry bundles, and generated reports as untrusted private operator
-state. See [Analyzer state](../analysis-state.md).
+It stays under the private, client-repository and storage-origin-bound XDG state
+home with owner-scoped paths, `0600` files, atomic replacement, per-file locks,
+and stale-writer detection. Provider, bucket, prefix, tool, or repository
+changes cannot reuse another origin's cache, locks, pending publication, or
+analyzer state. Treat its ledgers, retry bundles, and generated reports as
+untrusted private operator state. See [Analyzer state](../analysis-state.md).
 
 `/design` and standalone `/review` require storage preflight before session
 work. Their terminal paths preserve the existing design allowlists, review

--- a/docs/security/supply-chain-credentials-and-services.md
+++ b/docs/security/supply-chain-credentials-and-services.md
@@ -187,6 +187,14 @@ and the hardened ADC boundary above. S3 and R2 use standard AWS credential
 resolution. R2 also requires a matching account ID and an HTTPS endpoint on the
 account's Cloudflare host.
 
+Repository-root `tools-config.toml` selects only a credential-free storage
+base. Larch derives the fixed `larch/<client-repo>/` scope from local Git
+origin. The provider credential remains the authority and should grant list,
+read, and create-only write only for approved tool and repository prefixes.
+Startup lists that exact prefix with a maximum of one result; it never lists the
+bucket root or writes a probe. The process ignores returned object names and
+reduces provider failures to credential-free classes.
+
 The provider-neutral transport accepts only validated bucket roots and object
 keys. Uploads are create-only. Downloads use a private temporary file and atomic
 promotion. Provider diagnostics are reduced to fixed, credential-free failure

--- a/docs/workflow-lifecycle.md
+++ b/docs/workflow-lifecycle.md
@@ -108,15 +108,19 @@ Certain steps in the workflow depend on configuration prerequisites and are skip
 
 ## Run-log lifecycle
 
-Every shipped skill resolves `config.toml` or `LARCH_LOGS_URI`, validates
-the storage root, and performs the provider bucket-root preflight before run
-work. Each invocation owns one skill name, run ID, staging tree, durable context,
-and terminal publication. Specialized design, implement, and review owners adopt
-their rich staging trees into that same lifecycle. Nested and alias calls publish
-separate parent-linked archives; nested review is a child of its implement run.
+Every shipped skill requires root `tools-config.toml` and `[larch]`, derives
+the client repository from local `remote.origin.url`, resolves one
+`ToolRepositoryStorage`, and performs a prefix-scoped provider preflight before
+run work. Each invocation pins the base URI, client repository, canonical tool
+repository URI, and storage-origin ID in its durable context. A config,
+environment, or Git-origin change before publication fails closed.
+Specialized design, implement, and review owners adopt their rich staging trees
+into that same lifecycle. Nested and alias calls publish separate parent-linked
+archives; nested review is a child of its implement run.
 
 Terminal paths sanitize the final staging tree and publish exactly one
-create-only object at `<URI>/run-logs/<skill>/<run-id>.tar.gz`. Success also
+create-only object at
+`<base>/larch/<client-repo>/run-logs/<skill>/<run-id>.tar.gz`. Success also
 requires a validated unpacked cache directory. Failure returns nonzero and
 keeps a content-pinned pending archive for retry. No run-log path creates a Git
 branch, commit, push, pull request, or merge.

--- a/plugin/docs/analysis-state.md
+++ b/plugin/docs/analysis-state.md
@@ -2,30 +2,40 @@
 
 Run archives are immutable analysis inputs. Stateful analyzers synchronize the
 remote run corpus once, then read ordinary files from
-`${XDG_CACHE_HOME:-$HOME/.cache}/larch/run-logs/<repo>/` for the rest of the
-invocation.
+`${XDG_CACHE_HOME:-$HOME/.cache}/larch/run-logs/v2/<client-repo>/<storage-origin-id>/`
+for the rest of the invocation. They retain the corpus root returned by the
+shared synchronizer and never reconstruct it from the checkout directory.
 
 Mutable cursors, ledgers, retry bundles, generated analyses, and generated
 measurements do not belong under `run-logs/`. They live at:
 
 ```text
-${XDG_STATE_HOME:-$HOME/.local/state}/larch/analysis-state/<repo>/<owner>/
+${XDG_STATE_HOME:-$HOME/.local/state}/larch/analysis-state/v2/
+  <client-repo>/<storage-origin-id>/<owner>/
 ```
 
-Repository and owner names remain literal validated path components. Files use
+The client repository is derived from Git origin. The storage-origin ID is the
+lowercase hexadecimal SHA-256 of the canonical
+`<base>/larch/<client-repo>` URI. Provider, bucket, base-prefix, tool, or
+repository changes therefore select different cache and analyzer-state roots.
+Old basename-keyed state is not silently imported.
+
+Repository and owner names remain validated path components. Files use
 private directories and `0600` modes. Writers use a per-file advisory lock,
 atomic replacement, and an expected SHA-256 identity when a workflow carries
 state across multiple steps. A stale concurrent writer fails without replacing
 the newer file. Corrupt, symlinked, non-regular, or unreadable state fails
 closed.
 
-On first access, migrated owners import their former Git or cache file when the
-new state file is absent. A warm access never rereads or overwrites from the
-legacy path. Run-log cloud sync never lists, downloads, uploads, or interprets
-this mutable state tree.
+Old basename-keyed and repository-local state remains untouched for explicit
+operator cleanup. No v2 owner imports it, including after a provider, bucket,
+prefix, tool, or repository identity change. Run-log cloud sync never lists,
+downloads, uploads, or interprets this mutable state tree.
 
 `/rejected-analysis` owns `rejected-analysis/ledger.tsv` and
 `rejected-analysis/verdicts.tsv`. `/difficulty-calibration` reads the verdict
 sidecar from that owner after one run-log sync. It does not copy mutable state
 into the cache or a run archive. An explicit `--log-root DIR` is an offline
-fixture boundary and may keep a fixture-local legacy sidecar for compatibility.
+fixture boundary: readers use it directly without reading repository storage
+configuration or making network requests. A fixture may keep a local legacy
+sidecar for compatibility.

--- a/plugin/docs/configuration-and-permissions.md
+++ b/plugin/docs/configuration-and-permissions.md
@@ -190,20 +190,28 @@ The legacy `--codex-available true|false` knob is still accepted by the dispatch
 
 ### Run-log object storage
 
-Each consumer repository must provide a larch storage root in
-`config.toml`:
+Each consumer repository must own a root `tools-config.toml` file and provide
+the larch storage base:
 
 ```toml
-[logs]
-uri = "s3://zhupanov/larch"
+[larch]
+storage_base_uri = "s3://zhupanov"
 ```
 
-`LARCH_LOGS_URI` overrides the file value for the process. It must contain the
-same complete storage-root shape. Do not set it to a bucket root, a
-`run-logs/` prefix, or an individual archive. Larch derives:
+The file is shared by independently configured tools. Each tool owns one table
+named for the tool and ignores unrelated tool tables. There is no global
+version and no configured `client_repo`. Larch requires the file and `[larch]`
+even when `LARCH_STORAGE_BASE_URI` overrides only
+`[larch].storage_base_uri`. A non-empty `LARCH_LOGS_URI` is rejected with
+migration guidance.
+
+The base may be a bucket root or include an optional base prefix. Larch derives
+the client repository from the final repository component of the local Git
+`remote.origin.url`, not from the checkout or worktree directory. It then
+derives:
 
 ```text
-s3://zhupanov/larch/run-logs/<skill>/<run-id>.tar.gz
+<base>/larch/<client-repo>/run-logs/<skill>/<run-id>.tar.gz
 ```
 
 Accepted schemes are `gs://`, `s3://`, and `r2://`. The value must not contain
@@ -215,20 +223,29 @@ discovery. R2 also requires a 32-character lowercase hexadecimal
 `LARCH_R2_ENDPOINT=https://<account-id>.r2.cloudflarestorage.com`. GCS uses the
 Rust transport and Google ADC described below.
 
-The startup check lists the provider bucket root only. Success depends only on
-provider status. Larch ignores stdout, does not inspect objects or permissions,
-does not list the configured prefix, and does not write a probe object. Storage
-credentials remain process or provider inputs. Larch has no credential file or
-repository trust registry.
+The startup check lists at most one result under the exact
+`larch/<client-repo>/` prefix. Success depends only on provider status. Larch
+ignores stdout, does not inspect returned object names, does not list the bucket
+root, and does not write a probe object. Restrict provider credentials to the
+approved tool and repository prefixes. Storage credentials remain process or
+provider inputs. Larch has no credential file or repository trust registry.
 
 The full URI, provider, archive, cache, sync, and error rules live in
 [Run-log storage contracts](run-log-archive.md).
 
-This repository's `config.toml` also contains a
-`[logs.legacy_migration]` table. It pins the verified one-time larch migration
-inventory and applies only to this repository and its exact configured storage
-root. Do not copy it into unrelated consumer repositories. Normal archives do
-not use it.
+This repository's `tools-config.toml` contains only:
+
+```toml
+[larch]
+storage_base_uri = "s3://zhupanov"
+```
+
+The historical manifest-less archive migration is an explicit operator
+operation, not a normal sync fallback. Drain pending v1 publications before
+cutover. Land and release the new runtime while runs are frozen, complete and
+verify the object migration, commit the new config, prewarm a cold v2 cache,
+then resume. Roll back by restoring the prior plugin release and old remote
+prefixes; old basename-keyed local cache and state remain untouched.
 
 ### Google Application Default Credentials
 

--- a/plugin/docs/git-operation-inventory.md
+++ b/plugin/docs/git-operation-inventory.md
@@ -89,6 +89,7 @@ python/larch/rendering/rendering.py	later-domain	#7683	merge-base
 python/larch/report/final_report.py	later-domain	#7683	rev-parse
 python/larch/report/run_log_commit.py	later-domain	#7683	add,clean,commit,diff,reset,restore,rev-parse,status,symbolic-ref
 python/larch/report/run_log_flush.py	later-domain	#7683	diff
+python/larch/report/storage_config.py	later-domain	#7683	dynamic
 python/larch/report/tokens.py	later-domain	#7683	dynamic
 python/larch/research/research_eval.py	later-domain	#7684	dynamic
 python/larch/review/_raf_util.py	later-domain	#7679	status

--- a/plugin/docs/installation-and-setup.md
+++ b/plugin/docs/installation-and-setup.md
@@ -108,7 +108,8 @@ export LARCH_R2_ACCOUNT_ID="<32-lowercase-hex-account-id>"
 export LARCH_R2_ENDPOINT="https://${LARCH_R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
 ```
 
-Do not place credentials in `config.toml` or `LARCH_LOGS_URI`. See the
+Do not place credentials in `tools-config.toml` or
+`LARCH_STORAGE_BASE_URI`. See the
 [object-storage credential contract](security/supply-chain-credentials-and-services.md#object-storage-credentials-and-transport).
 
 ### Install
@@ -247,21 +248,28 @@ If you need stricter permissions instead (no `bypassPermissions`), drop that lin
 
 ### Configure run-log storage for every repo where you will run larch
 
-Create `config.toml` at the consumer repository root:
+Create `tools-config.toml` at the consumer repository root:
 
 ```toml
-[logs]
-uri = "<URI>"
+[larch]
+storage_base_uri = "<base-URI>"
 ```
-Example `<URI>` value: `s3://my-bucket-for-larch-logs/my-client-repo-a`.
+Example base values are `s3://my-bucket-for-tool-data`,
+`gs://my-bucket/prod/tools`, and `r2://my-bucket`. A base stops before the
+tool name. Larch derives the client repository from local
+`remote.origin.url`, then writes
+`<base>/larch/<client-repo>/run-logs/<skill>/<run-id>.tar.gz`. Clone and
+worktree directory names do not affect that identity.
 
-The URI is the larch storage root. Larch writes archives below
-`run-logs/<skill>/<run-id>.tar.gz`, so the example does not end in
-`run-logs/`. Set `LARCH_LOGS_URI` before starting larch to replace the file
-value for that process. Accepted schemes are `s3://`, `gs://`, and `r2://`.
+The repository-owned file may contain tables for other tools. Larch owns and
+strictly validates only `[larch]`; it ignores unrelated tool tables. There is
+no global version and no `client_repo` field. The file and `[larch]` remain
+required when `LARCH_STORAGE_BASE_URI` overrides only the base value for one
+process. Accepted schemes are `s3://`, `gs://`, and `r2://`.
 
-At skill startup, larch lists only the bucket root and ignores the listing
-output. It does not probe the configured prefix or attempt a write. See
+At skill startup, larch lists at most one object under the exact
+`larch/<client-repo>/` prefix and ignores the listing output. It does not list
+the bucket root or attempt a write. See
 [Configuration and Permissions](configuration-and-permissions.md#run-log-object-storage)
 and the [language-neutral storage contract](run-log-archive.md).
 

--- a/plugin/docs/run-log-archive.md
+++ b/plugin/docs/run-log-archive.md
@@ -9,46 +9,77 @@ migration must preserve this contract or version it explicitly.
 
 ## Configuration resolution
 
-Resolve the storage root from the current repository in this order:
+Discover the Git top level from the invocation's startup directory and read
+exactly `tools-config.toml` there. The repository-owned file is shared by
+independently configured tools: each tool owns one table named for the tool and
+ignores unrelated top-level tool tables. There are no shared fields, no global
+version, and no `client_repo` field.
 
-1. Use a non-empty `LARCH_LOGS_URI`.
-2. Otherwise read `[logs].uri` from repository-root `config.toml`.
-3. Fail when neither source supplies a value. Do not infer a bucket, provider, or prefix.
+Larch requires a strict table:
 
-The environment value replaces the file value. The two values are not merged.
-The resolved URI is the larch storage root. It is not the `run-logs/` prefix,
-an archive path, or a bucket-root URI.
+```toml
+[larch]
+storage_base_uri = "s3://zhupanov"
+```
 
-The checked-in configuration is `[logs]` with `uri = "s3://zhupanov/larch"`.
-This repository also owns a versioned `[logs.legacy_migration]` descriptor for
-the one-time historical larch migration. It pins the inventory key, inventory
-SHA-256, source commit, storage root, and schema. Consumer repositories without
-that descriptor do not enable legacy archive handling.
+The file and `[larch]` are required even when
+`LARCH_STORAGE_BASE_URI` replaces only `storage_base_uri` for the process.
+Reject non-empty `LARCH_LOGS_URI`; never probe `config.toml`,
+`.larch/config.toml`, or `tool-config.toml`. Reject a symlinked, unreadable, or
+malformed file and missing, duplicate, unknown, empty, padded, or type-invalid
+larch fields before workflow side effects or object-store requests.
 
-Accept only `gs://`, `s3://`, and `r2://`. Require a plain non-empty bucket
-authority and at least one non-empty prefix segment. Reject credentials, ports,
-queries, fragments, whitespace, control characters, empty segments, `.`, and
-`..`. Preserve accepted bucket and prefix text. Do not hash or silently rewrite
-it.
+`StorageBase` is a validated provider, bucket, and optional base prefix. Accept
+only `gs://`, `s3://`, and `r2://`, including bucket roots. Reject credentials,
+ports, queries, fragments, trailing slashes, whitespace, control characters,
+empty segments, `.`, and `..`. Preserve accepted bucket and prefix text.
+
+`ToolRepositoryStorage` adds the fixed tool `larch` and a derived client
+repository. Larch reads the repository's local `remote.origin.url`, accepts
+standard HTTPS, SSH URL, and SCP-like Git syntax, strips exactly one terminal
+`.git`, converts ASCII uppercase to lowercase, and otherwise requires a strict
+slug. It never uses a checkout or worktree directory name, a provider API,
+bucket text, config field, or environment override for repository identity.
+Missing, ambiguous, credential-bearing, port-bearing, or invalid origins fail
+without echoing embedded credentials.
 
 ## Remote and local layout
 
-For storage root `<URI>`, the only run-archive layout is
-`<URI>/run-logs/<skill-name>/<run-id>.tar.gz`. For the checked-in root, a design
-archive is `s3://zhupanov/larch/run-logs/design/<run-id>.tar.gz`.
+The remote schema is
+`<storage-base>/<tool-name>/<client-repo>/<data-type>/<data>`. The larch tool
+repository is `<base>/larch/<client-repo>`. The implemented data type is
+`run-logs`, so archives use
+`<base>/larch/<client-repo>/run-logs/<skill>/<run-id>.tar.gz`.
+
+The checked-in base produces
+`s3://zhupanov/larch/larch/run-logs/design/<run-id>.tar.gz`. Other examples
+include
+`gs://character-tool-logs/larch/sre/run-logs/investigate/<run-id>.tar.gz`,
+`s3://company-data/prod/tools/larch/service-a/run-logs/review/<run-id>.tar.gz`,
+and `r2://tool-data/larch/service-a/run-logs/review/<run-id>.tar.gz`.
 
 Only skill directories exist directly below `run-logs/`. Mutable analyzer
-state, ledgers, reports, and measurements never appear there.
+state, ledgers, reports, measurements, indexes, and migration artifacts never
+appear there. Future data types must define their own object, collision,
+mutability, and retention contracts.
 
-The unpacked cache layout is
-`${XDG_CACHE_HOME:-$HOME/.cache}/larch/run-logs/<repo-name>/<skill-name>/<run-id>/`.
+Define `storage_origin_id` as lowercase hexadecimal SHA-256 of the canonical
+tool repository URI's UTF-8 bytes. Local paths are:
 
-Keep repository, skill, and run names as validated literal directory names. Do
-not hash them. The cache is a private local copy, not a second publication
-target.
+```text
+${XDG_CACHE_HOME:-$HOME/.cache}/larch/run-logs/v2/
+  <client-repo>/<storage-origin-id>/<skill>/<run-id>/
 
-Content-pinned retry state lives outside the cache at
-`${XDG_STATE_HOME:-$HOME/.local/state}/larch/run-log-pending/`.
+${XDG_STATE_HOME:-$HOME/.local/state}/larch/run-log-pending/v2/
+  <client-repo>/<storage-origin-id>/<skill>/<run-id>/
+
+${XDG_STATE_HOME:-$HOME/.local/state}/larch/run-log-locks/v2/
+  <client-repo>/<storage-origin-id>/<skill>/<run-id>.lock
+```
+
+The cache is private local state, not a publication target. Changing provider,
+bucket, base prefix, tool, or client repository selects a cold namespace. Old
+basename-keyed cache and state are neither renamed nor silently imported.
 
 ## Provider operations
 
@@ -56,21 +87,22 @@ Every provider implements the same operations:
 
 | Operation | Contract |
 |---|---|
-| `preflight_bucket` | List the bucket root and decide success from exit or provider status only. Ignore stdout. Do not list the configured prefix, inspect contents or permissions, call a head-bucket substitute, or write a probe object. |
+| `preflight_prefix` | List the exact `<tool>/<client-repo>/` prefix with a maximum of one result. Decide success from provider status only; ignore object names and provider diagnostics. Do not list the bucket root or write a probe object. |
 | `list` | List the requested prefix through every page. Return relative keys, byte sizes, and optional opaque ETag and version values. Reject malformed pages, repeated page tokens, and keys outside the configured root. |
 | `upload_create` | Create one object only if absent. Never replace an existing object. Return normalized metadata. |
 | `metadata` | Return normalized metadata for one exact key. |
 | `download` | Write to a private sibling temporary file and atomically promote it. Never merge with a destination. |
 
-For `s3://zhupanov/larch`, startup preflight is equivalent to
-`aws s3 ls s3://zhupanov`.
+For the checked-in base and repository, startup preflight lists only
+`larch/larch/` in bucket `zhupanov`.
 
 S3 and R2 use the AWS CLI transport and standard AWS credential discovery. R2
 also requires `LARCH_R2_ACCOUNT_ID` and `LARCH_R2_ENDPOINT`. The endpoint must
 be `https://<account-id>.r2.cloudflarestorage.com`, and the account ID must
 match the host. GCS uses the narrow Rust transport through
 `${CLAUDE_PLUGIN_ROOT}/scripts/larch.sh` and standard Google Application Default
-Credentials.
+Credentials. Credentials should grant list, read, and write only to approved
+tool and client-repository prefixes.
 
 ## Machine-readable errors
 
@@ -127,7 +159,7 @@ tree. It never merges with or replaces a destination. Cache entries contain ordi
 `python3 python/cli.py run-log publish --repo-root <root> --skill <skill>
 --run-id <run-id> --staging-root <tree>` persists the archive before attempting
 the create-only upload to `run-logs/<skill>/<run-id>.tar.gz`. Failed attempts
-remain under `${XDG_STATE_HOME:-$HOME/.local/state}/larch/run-log-pending/`
+remain under the storage-origin-specific `run-log-pending/v2` path
 with content-pinned retry metadata. Repeating the command may omit
 `--staging-root` when that pending state exists. When pending state already
 exists, the publisher retries and populates the cache from that archive. It
@@ -136,8 +168,7 @@ does not use a later mutable staging tree as the retry source.
 An existing remote key succeeds only when its downloaded bytes match the
 pending archive; different content fails closed. A new upload is verified by
 remote metadata. The normal success path copies the sanitized staging tree
-directly into
-`${XDG_CACHE_HOME:-$HOME/.cache}/larch/run-logs/<repo>/<skill>/<run-id>/`,
+directly into the storage-origin-specific `run-logs/v2` cache,
 without downloading or decompressing the archive. Retry without staging safely
 materializes the durable archive instead. A per-run lock covers upload,
 collision verification, cache promotion, and atomic retirement of pending
@@ -152,25 +183,18 @@ per-run publication lock, replaced atomically after validation, and restored if
 repair fails. Interrupted download, materialization, promotion, and quarantine
 entries are removed before the next attempt.
 
-The checked-in legacy migration descriptor is a narrow compatibility boundary.
-Sync first applies the normal `archive-manifest.json` contract. Only a readable
-archive with no root archive manifest can trigger legacy lookup. Sync then
-downloads the pinned migration inventory at most once for that repository sync,
-verifies its SHA-256, and validates its bounded schema, source commit, storage
-root, object identities, source-file rows, and totals. The archive must have an
-exact inventory record, and its byte size and SHA-256 must match that record.
+Normal synchronization accepts only manifest-bearing archives. It does not read
+a legacy migration descriptor, inventory, or basename-keyed cache. The retained
+legacy descriptor parser is an explicit operator API for the coordinated
+historical migration only; it does not discover repository configuration or
+participate in normal sync.
 
-Legacy extraction accepts only inventory-covered regular PAX members with safe
-canonical paths, supported modes, matching sizes, and matching SHA-256 digests.
-It rejects links, devices, special files, collisions, traversal, extra or
-missing members, corrupt streams, and expansion-limit violations. After private
-extraction succeeds, sync writes a local schema-version-1
-`archive-manifest.json`, verifies the complete directory, and promotes it
-atomically. It never writes, replaces, renames, or deletes a remote object.
-Later syncs validate the local directory and perform listing only.
+Cut over while runs are frozen: land and release this runtime, drain v1 pending
+publications, complete and verify the object migration, commit the new config,
+prewarm a clean v2 cache, then resume. Roll back by restoring the prior plugin
+release and old remote prefixes. The old local cache and state remain untouched.
 
-The command returns the unpacked repository corpus at
-`${XDG_CACHE_HOME:-$HOME/.cache}/larch/run-logs/<repo>/`. The shared
+The command returns the unpacked storage-origin-specific repository corpus. The shared
 `run_log_corpus.synchronized_run_log_root` API performs the same one-time sync
 and returns that root. An analyzer must retain the returned path and use normal
 local file reads for all later files and waves in the same invocation.
@@ -186,7 +210,4 @@ I-Cutover-1. In one change, prove Rust parity against the shared fixtures,
 switch every production caller to `${CLAUDE_PLUGIN_ROOT}/scripts/larch.sh`,
 remove the Python registration and implementation, and prove clean-install
 execution. Do not add a compatibility shim, bridge, implementation selector,
-fallback, or dual-write period. Rust must consume the same repository-owned
-legacy migration descriptor and enforce the same inventory, archive, extraction,
-and synthesized-manifest validation contract. The hard cutover must not retain
-an undocumented Python-only exception.
+fallback, or dual-write period.

--- a/plugin/docs/run-log-batches.md
+++ b/plugin/docs/run-log-batches.md
@@ -21,6 +21,12 @@ still passes through the run-log trim, temporary-path redaction, secret scrub,
 and publication checks described in the canonical
 [run-log security contract](security/artifacts-redaction-and-publication.md#run-logs-and-breadcrumbs).
 
+Batch names are relative to the lifecycle-owned staging tree. They never select
+or reconstruct remote storage. The shared lifecycle routes the terminal archive
+to `<base>/larch/<client-repo>/run-logs/<skill>/<run-id>.tar.gz`; analyzers
+read batches only below the storage-origin-bound corpus root returned by the
+shared synchronizer.
+
 `architectural-invariant-outcome` is a replace-mode `.json` batch with the
 `json-object` sanitizer. It writes
 `larch-logs/implement/<RUN_ID>/architectural-invariant-outcome.json` when an

--- a/plugin/docs/run-log-cli.md
+++ b/plugin/docs/run-log-cli.md
@@ -60,12 +60,30 @@ lists the configured `run-logs/` prefix once and emits `CORPUS_ROOT`,
 `LISTED_ARCHIVES`, `PRESENT_RUNS`, `DOWNLOADED_RUNS`, `REPAIRED_RUNS`, and
 `SYNC_OK=true`. See [Run-log storage contracts](run-log-archive.md).
 
+Storage preflight and lifecycle start resolve repository-root
+`tools-config.toml`, derive the client repository from local Git origin, list
+at most one result under the exact `larch/<client-repo>/` prefix, and emit:
+
+```text
+STORAGE_BASE_URI=<canonical base>
+CLIENT_REPO=<derived repository name>
+TOOL_REPO_URI=<canonical base>/larch/<client-repo>
+RUN_LOGS_URI=<tool repository URI>/run-logs/
+PREFLIGHT_OK=true
+```
+
+Lifecycle start emits the first four values with its lifecycle envelope.
+Persisted context pins the same tool URI, client repository, and
+storage-origin ID; publication fails if config, environment, or Git identity
+changes mid-run.
+
 The universal lifecycle starts each invocation with a declared skill and either
-a caller-supplied `--run-id` or a generated UUID after the configured bucket
+a caller-supplied `--run-id` or a generated UUID after the configured prefix
 preflight succeeds. `--log-root <absolute-path>` selects specialized staging;
 `--adopt-existing` adopts a matching manifest already created there. The start
 envelope returns `CONTEXT_FILE`, whose durable JSON record binds repository,
-storage URI, skill, run ID, log root, and run directory. Child runs also record the
+tool repository URI, client repository, storage-origin ID, skill, run ID, log
+root, and run directory. Child runs also record the
 parent skill and run ID, but retain their own archive. Every terminal verb
 writes `final-report.md`, records a missing transcript as an execution issue
 when capture is unavailable, and attempts the same create-only publication.

--- a/plugin/docs/run-logs.md
+++ b/plugin/docs/run-logs.md
@@ -8,6 +8,21 @@ The configured storage root, deterministic archive, provider, cache, sync,
 error, and Rust-handoff contracts are defined in
 [Run-log storage contracts](run-log-archive.md).
 
+Every writer and default reader resolves one pinned tool repository per
+invocation from repository-root `tools-config.toml` and local Git origin:
+
+```text
+<storage-base>/larch/<client-repo>/run-logs/<skill>/<run-id>.tar.gz
+```
+
+The base may be an S3, GCS, or R2 bucket root or include an optional prefix.
+The client repository is derived from `remote.origin.url`; checkout and
+worktree names do not affect it. Synchronization returns a v2 cache root bound
+to the SHA-256 identity of the canonical tool repository URI. Analysis skills
+retain that returned root for all reads. Their explicit `--log-root` options
+remain offline-fixture bypasses that do not load storage configuration or use
+the network.
+
 ## Universal skill lifecycle
 
 `skills/shared/run-lifecycle.md` defines the shared start and terminal contract,

--- a/plugin/docs/security/artifacts-redaction-and-publication.md
+++ b/plugin/docs/security/artifacts-redaction-and-publication.md
@@ -273,7 +273,9 @@ not broaden who should receive it.
 
 This boundary applies to every public, alias, internal child, and dev-only skill
 archive. A durable lifecycle context binds the selected staging root to one
-repository, storage URI, skill, and run ID before publication. Parent-child metadata identifies run relationships but does not change
+repository, canonical tool repository URI, derived client repository,
+storage-origin ID, skill, and run ID before publication. A config, environment,
+or Git-origin change before publication fails closed. Parent-child metadata identifies run relationships but does not change
 the classification, redaction, or publication rules for either archive.
 
 `python/cli.py run-log sync` treats the remote inventory and downloaded archives
@@ -285,22 +287,18 @@ invalid entry, restores it on failure, and removes stale private transfer and
 repair state under the same lock. See
 [Run-log archive format](../run-log-archive.md).
 
-The larch repository pins its one-time legacy migration inventory in repository
-configuration. A manifest-less archive reaches the compatibility extractor only
-when its exact object key, compressed byte size, archive SHA-256, member rows,
-expanded size, source commit, and storage root match that hash-verified bounded
-inventory. The extractor rejects unsafe paths, collisions, links, devices,
-special files, unsupported modes, missing or extra members, content mismatches,
-and expansion-limit violations. It promotes a private extraction only after it
-synthesizes and verifies the normal local `archive-manifest.json`. Repositories
-without the descriptor, and unrecognized manifest-less archives, fail closed.
-No compatibility operation mutates remote storage.
+Normal synchronization rejects manifest-less archives and never loads a legacy
+migration descriptor or inventory. The retained legacy parser is available
+only to an explicit operator migration API. It does not discover normal
+repository configuration or change the sync trust boundary.
 
 Mutable analyzer state is not an archive and never appears under `run-logs/`.
-It stays under the private XDG state home with owner-scoped paths, `0600`
-files, atomic replacement, per-file locks, and stale-writer detection. Treat
-its ledgers, retry bundles, and generated reports as untrusted private operator
-state. See [Analyzer state](../analysis-state.md).
+It stays under the private, client-repository and storage-origin-bound XDG state
+home with owner-scoped paths, `0600` files, atomic replacement, per-file locks,
+and stale-writer detection. Provider, bucket, prefix, tool, or repository
+changes cannot reuse another origin's cache, locks, pending publication, or
+analyzer state. Treat its ledgers, retry bundles, and generated reports as
+untrusted private operator state. See [Analyzer state](../analysis-state.md).
 
 `/design` and standalone `/review` require storage preflight before session
 work. Their terminal paths preserve the existing design allowlists, review

--- a/plugin/docs/security/supply-chain-credentials-and-services.md
+++ b/plugin/docs/security/supply-chain-credentials-and-services.md
@@ -187,6 +187,14 @@ and the hardened ADC boundary above. S3 and R2 use standard AWS credential
 resolution. R2 also requires a matching account ID and an HTTPS endpoint on the
 account's Cloudflare host.
 
+Repository-root `tools-config.toml` selects only a credential-free storage
+base. Larch derives the fixed `larch/<client-repo>/` scope from local Git
+origin. The provider credential remains the authority and should grant list,
+read, and create-only write only for approved tool and repository prefixes.
+Startup lists that exact prefix with a maximum of one result; it never lists the
+bucket root or writes a probe. The process ignores returned object names and
+reduces provider failures to credential-free classes.
+
 The provider-neutral transport accepts only validated bucket roots and object
 keys. Uploads are create-only. Downloads use a private temporary file and atomic
 promotion. Provider diagnostics are reduced to fixed, credential-free failure

--- a/plugin/python/larch/calibration/difficulty_calibration.py
+++ b/plugin/python/larch/calibration/difficulty_calibration.py
@@ -16,7 +16,7 @@ from typing import cast
 
 from larch.calibration import difficulty
 from larch.core import repo_roots
-from larch.report import analysis_state, run_log_corpus
+from larch.report import analysis_state, run_log_corpus, storage_config
 from larch.report.report_tokens_cost import display_rates
 from larch.report.report_tokens_models import (
     VendorName,
@@ -928,11 +928,16 @@ def analyze_main(argv: list[str] | None = None) -> int:
             print("ERROR: could not discover a Git repository root for run-log synchronization", file=sys.stderr)
             return 2
         try:
-            log_root = run_log_corpus.synchronized_repository_log_root(repo_root=repo_root)
-        except run_log_corpus.RunLogCorpusError as exc:
+            storage = storage_config.load_tool_repository_storage(repo_root=repo_root)
+            log_root = run_log_corpus.synchronized_repository_log_root(
+                repo_root=repo_root, storage=storage
+            )
+        except (run_log_corpus.RunLogCorpusError, storage_config.StorageConfigurationError) as exc:
             print(f"ERROR: {exc}", file=sys.stderr)
             return 2
-        state_root = analysis_state.repository_state_root(repo_root=repo_root)
+        state_root = analysis_state.repository_state_root(
+            repo_root=repo_root, storage=storage
+        )
     if not log_root.is_dir():
         print(f"ERROR: --log-root is missing or not a directory: {log_root}", file=sys.stderr)
         return 2

--- a/plugin/python/larch/core/config.py
+++ b/plugin/python/larch/core/config.py
@@ -40,11 +40,16 @@ EXIT_INTERNAL_ERROR: Final = 1
 EXIT_STORAGE_CONFIG: Final = EXIT_USAGE
 EXIT_STORAGE_PREFLIGHT: Final = EXIT_INTERNAL_ERROR
 ENV_LARCH_LOGS_URI: Final = "LARCH_LOGS_URI"
-STORAGE_CONFIG_RELPATH: Final = "config.toml"
+ENV_LARCH_STORAGE_BASE_URI: Final = "LARCH_STORAGE_BASE_URI"
+STORAGE_CONFIG_RELPATH: Final = "tools-config.toml"
+LARCH_TOOL_NAME: Final = "larch"
+STORAGE_BASE_URI_FIELD: Final = "storage_base_uri"
+RUN_LOGS_DATA_TYPE: Final = "run-logs"
 STORAGE_URI_SCHEMES: Final[tuple[str, ...]] = ("gs", "r2", "s3")
 AWS_CLI: Final = "aws"
 AWS_CLI_NOT_FOUND_EXIT_CODE: Final = 127
 STORAGE_PREFLIGHT_TIMEOUT_SEC: Final = 30
+STORAGE_GIT_IDENTITY_TIMEOUT_SEC: Final = 10
 RUN_LOG_ARCHIVE_MAX_MEMBERS: Final = 10_000
 RUN_LOG_ARCHIVE_MAX_MEMBER_BYTES: Final = 256 * 1024 * 1024
 RUN_LOG_ARCHIVE_MAX_EXPANDED_BYTES: Final = 1024 * 1024 * 1024
@@ -305,14 +310,12 @@ STALL_RECOVERY_BAIL_REASON_TOKENS: Final[tuple[str, ...]] = tuple(dict.fromkeys(
 )))
 
 # Repository-scoped mutable analyzer state. Paths are relative to
-# $XDG_STATE_HOME/larch/analysis-state/<repo>/, never larch-logs/.
+# $XDG_STATE_HOME/larch/analysis-state/v2/<client>/<storage-origin-id>/,
+# never larch-logs/.
 LEARN_FROM_BUGS_NUDGE_THRESHOLD: Final = 25
 LEARN_FROM_BUGS_STATE_RELPATH: Final = "learn-from-bugs/state.json"
 ANALYZE_BUGS_STATE_RELPATH: Final = "analyze-bugs/state.json"
 VALIDATE_MERGED_STATE_RELPATH: Final = "validate-merged/state.json"
-LEGACY_LEARN_FROM_BUGS_STATE_RELPATH: Final = "larch-logs/shared/learn-from-bugs-state.json"
-LEGACY_ANALYZE_BUGS_STATE_RELPATH: Final = "larch-logs/shared/analyze-bugs-state.json"
-LEGACY_VALIDATE_MERGED_STATE_RELPATH: Final = "larch-logs/shared/validate-merged-state.json"
 
 # Transient retry defaults shared with python/retry.py.
 TRANSIENT_RETRY_MAX_ATTEMPTS: Final = 3

--- a/plugin/python/larch/design/design_pause.py
+++ b/plugin/python/larch/design/design_pause.py
@@ -321,7 +321,7 @@ def pause_load_main(argv: Sequence[str]) -> int:
         return _load_fail_clear(issue=issue, repo=repo, error="legacy-git-snapshot")
     try:
         repo_root = Path(repo_top)
-        storage_root = storage_config.discover_storage_root(start=repo_root)
+        storage_root = storage_config.discover_tool_repository_storage(start=repo_root)
         publication_paths = run_log_publish.publication_paths(
             request=run_log_publish.PublicationRequest(
                 repo_root=repo_root,

--- a/plugin/python/larch/issue/analyze_bugs.py
+++ b/plugin/python/larch/issue/analyze_bugs.py
@@ -1342,7 +1342,6 @@ def prefetch(
     checkout = repo_roots.consumer_repo_root() or Path.cwd().resolve()
     state_root = Path(state_root_arg).expanduser().resolve() if state_root_arg else analysis_state.repository_state_root(repo_root=checkout)
     ledger_path = state_root / "analyze-bugs" / _sanitize_repo_slug(repo) / "ledger.jsonl"
-    _ = analysis_state.import_legacy_file(path=ledger_path, legacy_path=repo_root / "ledger.jsonl")
     rows = [
         build_bundle_record(runner=runner, issue=issue, repo=repo, evidence_ref=evidence_ref, run_dir=run_dir, diff_cap=diff_cap, body_cap=body_cap)
         for issue in issues

--- a/plugin/python/larch/issue/learn_from_bugs.py
+++ b/plugin/python/larch/issue/learn_from_bugs.py
@@ -261,10 +261,10 @@ def state_path(root: Path) -> Path:
     if not root_path.is_absolute():
         root_path = Path.cwd() / root_path
     root_path = root_path.resolve()
-    target = analysis_state.repository_state_root(repo_root=root_path) / config.LEARN_FROM_BUGS_STATE_RELPATH
-    if not target.exists() and not target.is_symlink():
-        _ = analysis_state.import_legacy_file(path=target, legacy_path=root_path / config.LEGACY_LEARN_FROM_BUGS_STATE_RELPATH)
-    return target
+    return (
+        analysis_state.repository_state_root(repo_root=root_path)
+        / config.LEARN_FROM_BUGS_STATE_RELPATH
+    )
 
 
 def _int_field(payload: Mapping[str, object], key: str, default: int) -> int:

--- a/plugin/python/larch/issue/rejected_analysis.py
+++ b/plugin/python/larch/issue/rejected_analysis.py
@@ -28,15 +28,13 @@ from larch.errors import ShipError
 
 from larch.git import gh
 from larch.issue import issue_wire
-from larch.report import analysis_state, run_log_corpus
+from larch.report import analysis_state, run_log_corpus, storage_config
 from larch.review import voting
 from larch.review.review_types import parse_canonical_heading
 
 DEFAULT_VERIFY_CAP = 100
 LEDGER_PATH = Path("rejected-analysis/ledger.tsv")
 VERDICT_SIDECAR = Path("rejected-analysis/verdicts.tsv")
-LEGACY_LEDGER_PATH = Path("larch-logs/rejected-analysis-ledger.tsv")
-LEGACY_VERDICT_SIDECAR = Path("larch-logs/rejected-analysis-verdicts.tsv")
 INGEST_STATUS_FILE = "ingest-status.jsonl"
 FINDING_HASH_FIELDS = ("file_path", "concern")
 LEDGER_SCHEMA_VERSION = "1"
@@ -1001,6 +999,7 @@ def prepare(
     verify_cap: int = DEFAULT_VERIFY_CAP,
     repo_root: Path | str | None = None,
     state_root: Path | str | None = None,
+    storage: storage_config.ToolRepositoryStorage | None = None,
     runner: proc.Runner | None = None,
     open_issues: Sequence[OpenIssue] | None = (),
 ) -> PrepareResult:
@@ -1018,7 +1017,14 @@ def prepare(
             )
         root = discovered_root
         try:
-            logs = run_log_corpus.synchronized_repository_log_root(repo_root=root)
+            logs = (
+                run_log_corpus.synchronized_repository_log_root(repo_root=root)
+                if storage is None
+                else run_log_corpus.synchronized_repository_log_root(
+                    repo_root=root,
+                    storage=storage,
+                )
+            )
         except run_log_corpus.RunLogCorpusError as exc:
             raise RejectedAnalysisError(str(exc)) from exc
     else:
@@ -1030,8 +1036,6 @@ def prepare(
     active_runner = runner or proc.ProcRunner()
     issues = _query_open_issues(active_runner, repo_root=root) if open_issues is None else list(open_issues)
     ledger_path = mutable_root / LEDGER_PATH
-    if state_root is not None:
-        _ = analysis_state.import_legacy_file(path=ledger_path, legacy_path=root / LEGACY_LEDGER_PATH)
     committed_hashes = _read_ledger_hashes(ledger_path)
     all_findings: list[RejectedFinding] = []
     ledger_entries: list[LedgerEntry] = []
@@ -1091,6 +1095,7 @@ def prepare(
     _write_json(wd / "candidates.json", [_candidate_to_json(candidate) for candidate in candidates])
     _write_jsonl(wd / "drops.jsonl", [entry.to_row() for entry in ledger_entries])
     (wd / "repo-root.txt").write_text(str(root) + "\n", encoding="utf-8")
+    (wd / "state-root.txt").write_text(str(mutable_root) + "\n", encoding="utf-8")
     return PrepareResult(
         work_dir=wd,
         verify_count=len(candidates),
@@ -1480,9 +1485,6 @@ def record(
     root = Path(repo_root or Path.cwd()).resolve()
     mutable_root = Path(state_root).resolve() if state_root is not None else root
     ledger_path = mutable_root / LEDGER_PATH
-    if state_root is not None:
-        _ = analysis_state.import_legacy_file(path=ledger_path, legacy_path=root / LEGACY_LEDGER_PATH)
-        _ = analysis_state.import_legacy_file(path=mutable_root / VERDICT_SIDECAR, legacy_path=root / LEGACY_VERDICT_SIDECAR)
     pending_rows = _merge_ledger_rows(_read_ledger_entries(wd / "ledger-pending.tsv"))
     status_map = _load_ingest_status_map(wd)
     candidate_list = _load_candidates(wd)
@@ -1613,13 +1615,27 @@ def prepare_main(argv: list[str]) -> int:
         repo_root = repo_roots.consumer_repo_root(Path.cwd().resolve())
         if repo_root is None:
             raise RejectedAnalysisError("could not discover a Git repository root")
+        storage = (
+            None
+            if args.log_root
+            else storage_config.load_tool_repository_storage(repo_root=repo_root)
+        )
+        state_root = (
+            repo_root
+            if storage is None
+            else analysis_state.repository_state_root(
+                repo_root=repo_root,
+                storage=storage,
+            )
+        )
         result = prepare(
             days=args.days,
             log_root=args.log_root or None,
             work_dir=args.work_dir or None,
             verify_cap=args.verify_cap,
             repo_root=repo_root,
-            state_root=analysis_state.repository_state_root(repo_root=repo_root),
+            state_root=state_root,
+            storage=storage,
             open_issues=None,
         )
     except (RejectedAnalysisError, ValueError) as exc:
@@ -1678,6 +1694,14 @@ def _repo_root_from_work_dir(work_dir: Path) -> Path | None:
     return Path(text).resolve() if text else None
 
 
+def _state_root_from_work_dir(work_dir: Path) -> Path | None:
+    path = work_dir / "state-root.txt"
+    if not path.is_file():
+        return None
+    text = path.read_text(encoding="utf-8").strip()
+    return Path(text).resolve() if text else None
+
+
 def record_main(argv: list[str]) -> int:
     parser = argparse.ArgumentParser(prog="rejected-analysis record")
     parser.add_argument("--work-dir", required=True)
@@ -1689,6 +1713,7 @@ def record_main(argv: list[str]) -> int:
     args = parser.parse_args(argv)
     work_dir = Path(args.work_dir)
     repo_root = Path(args.repo_root).resolve() if args.repo_root else _repo_root_from_work_dir(work_dir)
+    state_root = _state_root_from_work_dir(work_dir)
     try:
         result = record(
             work_dir=args.work_dir,
@@ -1697,7 +1722,7 @@ def record_main(argv: list[str]) -> int:
             issues_failed=args.issues_failed,
             launch_failures=args.launch_failures,
             repo_root=repo_root,
-            state_root=analysis_state.repository_state_root(repo_root=repo_root) if repo_root else None,
+            state_root=state_root,
         )
     except RejectedAnalysisError as exc:
         logging_util.diagnostic(f"rejected-analysis record: {exc}")

--- a/plugin/python/larch/issue/validate_merged.py
+++ b/plugin/python/larch/issue/validate_merged.py
@@ -70,12 +70,7 @@ def _timestamp(value: object, *, label: str) -> str:
 
 def state_path(root: Path) -> Path:
     repo_root = root.expanduser().resolve()
-    target = analysis_state.repository_state_root(repo_root=repo_root) / STATE_RELPATH
-    try:
-        _ = analysis_state.import_legacy_file(path=target, legacy_path=repo_root / config.LEGACY_VALIDATE_MERGED_STATE_RELPATH)
-    except analysis_state.AnalysisStateError as exc:
-        raise ValidateMergedError(str(exc)) from exc
-    return target
+    return analysis_state.repository_state_root(repo_root=repo_root) / STATE_RELPATH
 
 
 def _candidate_from_raw(raw: object) -> dict[str, str]:

--- a/plugin/python/larch/report/analysis_state.py
+++ b/plugin/python/larch/report/analysis_state.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Final
 from larch import io as larch_io
-from larch.report import run_log_publish
+from larch.report import run_log_publish, storage_config
 
 _ENV_XDG_STATE_HOME: Final = "XDG_STATE_HOME"
 MISSING_DIGEST: Final = "missing"
@@ -34,13 +34,18 @@ class StateSnapshot:
 def repository_state_root(
     *,
     repo_root: Path,
+    storage: storage_config.ToolRepositoryStorage | None = None,
     state_home: Path | None = None,
     environ: Mapping[str, str] | None = None,
 ) -> Path:
     """Return the literal repository root for mutable analyzer state."""
     trusted_repo = larch_io.validate_trusted_directory(repo_root)
-    repo_name = run_log_publish.validated_component(
-        trusted_repo.name, label="repository name", slug=False
+    active_storage: storage_config.ToolRepositoryStorage = (
+        storage
+        if storage is not None
+        else storage_config.load_tool_repository_storage(
+            repo_root=trusted_repo, environ=environ
+        )
     )
     environment = os.environ if environ is None else environ
     resolved_home = state_home or run_log_publish.xdg_home(
@@ -50,12 +55,20 @@ def repository_state_root(
     )
     if not resolved_home.is_absolute():
         raise ValueError("analysis state home must be an absolute path")
-    return resolved_home.expanduser().resolve() / "larch" / "analysis-state" / repo_name
+    return (
+        resolved_home.expanduser().resolve()
+        / "larch"
+        / "analysis-state"
+        / "v2"
+        / active_storage.client_repo
+        / active_storage.storage_origin_id
+    )
 
 
-def state_path(
+def state_path(  # noqa: PLR0913 - state identity, owner, home, and environment remain explicit.
     *,
     repo_root: Path,
+    storage: storage_config.ToolRepositoryStorage | None = None,
     owner: str,
     name: str,
     state_home: Path | None = None,
@@ -69,16 +82,20 @@ def state_path(
     )
     return (
         repository_state_root(
-            repo_root=repo_root, state_home=state_home, environ=environ
+            repo_root=repo_root,
+            storage=storage,
+            state_home=state_home,
+            environ=environ,
         )
         / owner_name
         / file_name
     )
 
 
-def output_path(
+def output_path(  # noqa: PLR0913 - output creation shares the explicit state-path boundary.
     *,
     repo_root: Path,
+    storage: storage_config.ToolRepositoryStorage | None = None,
     owner: str,
     name: str,
     state_home: Path | None = None,
@@ -86,6 +103,7 @@ def output_path(
 ) -> Path:
     path = state_path(
         repo_root=repo_root,
+        storage=storage,
         owner=owner,
         name=name,
         state_home=state_home,
@@ -171,16 +189,3 @@ def append_bytes(path: Path, data: bytes) -> None:
     with state_lock(path):
         current = _snapshot_unlocked(path).data or b""
         _atomic_write_unlocked(path, current + data)
-
-
-def import_legacy_file(*, path: Path, legacy_path: Path) -> StateSnapshot:
-    """Import a regular legacy file once, then ignore later legacy changes."""
-    with state_lock(path):
-        current = _snapshot_unlocked(path)
-        if current.data is not None:
-            return current
-        legacy = _snapshot_unlocked(legacy_path)
-        if legacy.data is None:
-            return current
-        _atomic_write_unlocked(path, legacy.data)
-        return StateSnapshot(legacy.data, legacy.digest)

--- a/plugin/python/larch/report/object_store.py
+++ b/plugin/python/larch/report/object_store.py
@@ -59,8 +59,20 @@ class CommandObjectStore:
         if not isinstance(value, dict):
             raise ObjectStoreError(ObjectStoreErrorKind.INVALID_RESPONSE, self.root.scheme, operation)
         return cast("dict[str, object]", value)
-    def preflight_bucket(self) -> None:
-        command = self._gcs("preflight") if self.root.scheme == "gs" else self._aws("s3", "ls", f"s3://{self.root.bucket}")
+    def preflight_prefix(self) -> None:
+        remote_prefix = self._list_prefix("")
+        command = (
+            self._gcs("preflight", "--prefix", remote_prefix)
+            if self.root.scheme == "gs"
+            else self._aws(
+                "s3api", "list-objects-v2",
+                "--bucket", self.root.bucket,
+                "--prefix", remote_prefix,
+                "--max-keys", "1",
+                "--no-paginate",
+                "--output", "json",
+            )
+        )
         _ = self._run(command, "preflight")
     def list_objects(self, prefix: str = "") -> tuple[RemoteObject, ...]:
         remote_prefix, token = self._list_prefix(prefix), None

--- a/plugin/python/larch/report/run_lifecycle.py
+++ b/plugin/python/larch/report/run_lifecycle.py
@@ -27,11 +27,15 @@ from larch.report import (
     run_logs,
     storage_config,
 )
-from larch.report.run_log_publish import ObjectStore, PublicationRequest, PublicationResult
-from larch.report.storage_config import StorageRoot
+from larch.report.run_log_publish import (
+    ObjectStore,
+    PublicationRequest,
+    PublicationResult,
+)
+from larch.report.storage_config import ToolRepositoryStorage
 
-LIFECYCLE_SCHEMA_VERSION: Final = 1
-LIFECYCLE_CONTEXT_SCHEMA_VERSION: Final = 1
+LIFECYCLE_SCHEMA_VERSION: Final = 2
+LIFECYCLE_CONTEXT_SCHEMA_VERSION: Final = 2
 LIFECYCLE_CONTEXT_BASENAME: Final = "context.json"
 UNIVERSAL_FINAL_REPORT: Final = "final-report.md"
 UNIVERSAL_EXECUTION_ISSUES: Final = "execution-issues.ndjson"
@@ -55,7 +59,18 @@ def _require_lifecycle(condition: bool, message: str) -> None:  # noqa: FBT001 -
         raise RunLifecycleError(message)
 
 
-TERMINAL_EXCEPTIONS: Final = (EOFError, object_store.ObjectStoreError, OSError, run_log_publish.PublicationError, RunLifecycleError, ShipError, storage_config.StorageConfigurationError, tarfile.TarError, TypeError, ValueError)
+TERMINAL_EXCEPTIONS: Final = (
+    EOFError,
+    object_store.ObjectStoreError,
+    OSError,
+    run_log_publish.PublicationError,
+    RunLifecycleError,
+    ShipError,
+    storage_config.StorageConfigurationError,
+    tarfile.TarError,
+    TypeError,
+    ValueError,
+)
 
 
 @dataclass(frozen=True)
@@ -63,7 +78,7 @@ class LifecycleStart:
     """Validated state created for one skill invocation."""
 
     repo_root: Path
-    storage_root: StorageRoot
+    storage_root: ToolRepositoryStorage
     skill: str
     run_id: str
     log_root: Path
@@ -87,7 +102,9 @@ def _utc_now() -> str:
 def _validated_repo_root(repo_root: Path) -> Path:
     resolved = repo_roots.consumer_repo_root(repo_root)
     if resolved is None:
-        raise RunLifecycleError(f"could not discover a Git repository root from {repo_root}")
+        raise RunLifecycleError(
+            f"could not discover a Git repository root from {repo_root}"
+        )
     return larch_io.validate_trusted_directory(resolved)
 
 
@@ -100,71 +117,198 @@ def _state_home(environ: Mapping[str, str]) -> Path:
 
 
 def lifecycle_log_root(
-    *, repo_root: Path, environ: Mapping[str, str] | None = None
+    *,
+    repo_root: Path,
+    storage: ToolRepositoryStorage,
+    environ: Mapping[str, str] | None = None,
 ) -> Path:
     """Return the durable mutable staging root for universal skill runs."""
     environment = os.environ if environ is None else environ
-    root = _validated_repo_root(repo_root)
-    repo_name = run_log_publish.validated_component(
-        root.name, label="repository name", slug=False
+    _ = _validated_repo_root(repo_root)
+    return (
+        _state_home(environment)
+        / "larch"
+        / "run-lifecycle"
+        / "v2"
+        / storage.client_repo
+        / storage.storage_origin_id
+        / "staging"
     )
-    return _state_home(environment) / "larch" / "run-lifecycle" / repo_name / "staging"
 
 
-def _context_file(*, repo_root: Path, skill: str, run_id: str, environ: Mapping[str, str]) -> Path:
-    return _state_home(environ) / "larch" / "run-lifecycle" / run_log_publish.validated_component(repo_root.name, label="repository name", slug=False) / "contexts" / skill / run_id / LIFECYCLE_CONTEXT_BASENAME
+def _context_file(
+    *,
+    storage: ToolRepositoryStorage,
+    skill: str,
+    run_id: str,
+    environ: Mapping[str, str],
+) -> Path:
+    return (
+        _state_home(environ)
+        / "larch"
+        / "run-lifecycle"
+        / "v2"
+        / storage.client_repo
+        / storage.storage_origin_id
+        / "contexts"
+        / skill
+        / run_id
+        / LIFECYCLE_CONTEXT_BASENAME
+    )
 
 
 def _write_context(*, started: LifecycleStart) -> None:
-    larch_io.atomic_write(started.context_file, json.dumps({"schema_version": LIFECYCLE_CONTEXT_SCHEMA_VERSION, "repo_root": str(started.repo_root), "storage_uri": started.storage_root.uri, "skill": started.skill, "run_id": started.run_id, "log_root": str(started.log_root), "run_dir": str(started.run_dir)}, separators=(",", ":"), sort_keys=True) + "\n", mode=0o600, nofollow=True)
+    larch_io.atomic_write(
+        started.context_file,
+        json.dumps(
+            {
+                "schema_version": LIFECYCLE_CONTEXT_SCHEMA_VERSION,
+                "repo_root": str(started.repo_root),
+                "storage_base_uri": started.storage_root.base.uri,
+                "client_repo": started.storage_root.client_repo,
+                "tool_repo_uri": started.storage_root.uri,
+                "storage_origin_id": started.storage_root.storage_origin_id,
+                "skill": started.skill,
+                "run_id": started.run_id,
+                "log_root": str(started.log_root),
+                "run_dir": str(started.run_dir),
+            },
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        + "\n",
+        mode=0o600,
+        nofollow=True,
+    )
 
 
-def load_run_context(*, repo_root: Path, skill: str, run_id: str, environ: Mapping[str, str] | None = None) -> LifecycleStart:
+def load_run_context(
+    *,
+    repo_root: Path,
+    skill: str,
+    run_id: str,
+    environ: Mapping[str, str] | None = None,
+    storage_root: ToolRepositoryStorage | None = None,
+) -> LifecycleStart:
     """Rehydrate one lifecycle context without inherited shell state."""
     environment = os.environ if environ is None else environ
     root = _validated_repo_root(repo_root)
     skill_name = run_log_publish.validated_component(skill, label="skill", slug=True)
     run_name = run_log_publish.validated_component(run_id, label="run-id", slug=True)
-    context_file = _context_file(repo_root=root, skill=skill_name, run_id=run_name, environ=environment)
-    _require_lifecycle(not context_file.is_symlink() and context_file.is_file(), f"lifecycle context is missing or unsafe: {context_file}")
+    active_storage = storage_root or storage_config.load_tool_repository_storage(
+        repo_root=root, environ=environment
+    )
+    context_file = _context_file(
+        storage=active_storage,
+        skill=skill_name,
+        run_id=run_name,
+        environ=environment,
+    )
+    _require_lifecycle(
+        not context_file.is_symlink() and context_file.is_file(),
+        f"lifecycle context is missing or unsafe: {context_file}",
+    )
     raw: object = json.loads(context_file.read_text(encoding="utf-8"))
     _require_lifecycle(isinstance(raw, dict), "lifecycle context must be a JSON object")
     data = cast("dict[str, object]", raw)
-    expected: dict[str, object] = {"schema_version": LIFECYCLE_CONTEXT_SCHEMA_VERSION, "repo_root": str(root), "skill": skill_name, "run_id": run_name}
-    _require_lifecycle(all(data.get(key) == value for key, value in expected.items()), "lifecycle context identity mismatch")
-    storage_uri, log_root_raw, run_dir_raw = data.get("storage_uri"), data.get("log_root"), data.get("run_dir")
-    _require_lifecycle(all(isinstance(value, str) and value for value in (storage_uri, log_root_raw, run_dir_raw)), "lifecycle context paths or storage URI are missing")
-    storage_root = storage_config._parse_storage_uri(str(storage_uri))  # pyright: ignore[reportPrivateUsage]  # persisted context reuses canonical parser  # noqa: SLF001 - sibling parser owns validation
+    expected: dict[str, object] = {
+        "schema_version": LIFECYCLE_CONTEXT_SCHEMA_VERSION,
+        "repo_root": str(root),
+        "skill": skill_name,
+        "run_id": run_name,
+    }
+    _require_lifecycle(
+        all(data.get(key) == value for key, value in expected.items()),
+        "lifecycle context identity mismatch",
+    )
+    tool_repo_uri = data.get("tool_repo_uri")
+    client_repo = data.get("client_repo")
+    storage_origin_id = data.get("storage_origin_id")
+    storage_base_uri = data.get("storage_base_uri")
+    log_root_raw, run_dir_raw = data.get("log_root"), data.get("run_dir")
+    _require_lifecycle(
+        all(
+            isinstance(value, str) and value
+            for value in (
+                tool_repo_uri,
+                client_repo,
+                storage_origin_id,
+                storage_base_uri,
+                log_root_raw,
+                run_dir_raw,
+            )
+        ),
+        "lifecycle context paths or storage identity are missing",
+    )
+    storage = storage_config.parse_tool_repository_uri(
+        str(tool_repo_uri), expected_client_repo=str(client_repo)
+    )
+    _require_lifecycle(
+        storage == active_storage
+        and storage.base.uri == storage_base_uri
+        and storage.storage_origin_id == storage_origin_id,
+        "configured storage or Git origin changed after lifecycle start",
+    )
     log_root = Path(str(log_root_raw))
     run_dir = Path(str(run_dir_raw))
-    _require_lifecycle(log_root.is_absolute() and run_dir == log_root / skill_name / run_name, "lifecycle context staging path mismatch")
-    return LifecycleStart(root, storage_root, skill_name, run_name, log_root, run_dir, context_file)
+    _require_lifecycle(
+        log_root.is_absolute() and run_dir == log_root / skill_name / run_name,
+        "lifecycle context staging path mismatch",
+    )
+    return LifecycleStart(
+        root, storage, skill_name, run_name, log_root, run_dir, context_file
+    )
 
 
-def _parent_identity_from_context(*, repo_root: Path, context_file: Path, environ: Mapping[str, str]) -> tuple[str, str]:
-    _require_lifecycle(context_file.is_absolute() and not context_file.is_symlink() and context_file.is_file(), "parent lifecycle context is missing or unsafe")
+def _parent_identity_from_context(
+    *,
+    repo_root: Path,
+    context_file: Path,
+    environ: Mapping[str, str],
+    storage: ToolRepositoryStorage,
+) -> tuple[str, str]:
+    _require_lifecycle(
+        context_file.is_absolute()
+        and not context_file.is_symlink()
+        and context_file.is_file(),
+        "parent lifecycle context is missing or unsafe",
+    )
     raw: object = json.loads(context_file.read_text(encoding="utf-8"))
-    _require_lifecycle(isinstance(raw, dict), "parent lifecycle context identity is missing")
+    _require_lifecycle(
+        isinstance(raw, dict), "parent lifecycle context identity is missing"
+    )
     data = cast("dict[str, object]", raw)
-    _require_lifecycle(isinstance(data.get("skill"), str) and isinstance(data.get("run_id"), str), "parent lifecycle context identity is missing")
-    parent = load_run_context(repo_root=repo_root, skill=cast("str", data["skill"]), run_id=cast("str", data["run_id"]), environ=environ)
-    _require_lifecycle(parent.context_file == context_file, "parent lifecycle context path mismatch")
+    _require_lifecycle(
+        isinstance(data.get("skill"), str) and isinstance(data.get("run_id"), str),
+        "parent lifecycle context identity is missing",
+    )
+    parent = load_run_context(
+        repo_root=repo_root,
+        skill=cast("str", data["skill"]),
+        run_id=cast("str", data["run_id"]),
+        environ=environ,
+        storage_root=storage,
+    )
+    _require_lifecycle(
+        parent.context_file == context_file, "parent lifecycle context path mismatch"
+    )
     return parent.skill, parent.run_id
 
 
-def _preflight_storage(storage_root: StorageRoot) -> None:
-    if storage_root.scheme == "s3":
-        storage_config.preflight_s3_bucket(storage_root=storage_root)
-        return
-    object_store.object_store_for(storage_root).preflight_bucket()
+def _preflight_storage(storage: ToolRepositoryStorage) -> None:
+    storage_config.preflight_tool_repository(storage=storage)
 
 
 def _validate_parent(*, parent_skill: str, parent_run_id: str) -> None:
     if bool(parent_skill) != bool(parent_run_id):
         raise ValueError("--parent-skill and --parent-run-id must be provided together")
     if parent_skill:
-        _ = run_log_publish.validated_component(parent_skill, label="parent skill", slug=True)
-        _ = run_log_publish.validated_component(parent_run_id, label="parent run-id", slug=True)
+        _ = run_log_publish.validated_component(
+            parent_skill, label="parent skill", slug=True
+        )
+        _ = run_log_publish.validated_component(
+            parent_run_id, label="parent run-id", slug=True
+        )
 
 
 def start_run(  # noqa: PLR0913 - lifecycle boundary validates identity, adoption, storage, and parent state together.
@@ -173,31 +317,45 @@ def start_run(  # noqa: PLR0913 - lifecycle boundary validates identity, adoptio
     skill: str,
     parent_skill: str = "",
     parent_run_id: str = "",
-    run_id: str | None = None, log_root: Path | None = None, issue: str = "",
-    adopt_existing: bool = False, parent_context: Path | None = None,
+    run_id: str | None = None,
+    log_root: Path | None = None,
+    issue: str = "",
+    adopt_existing: bool = False,
+    parent_context: Path | None = None,
     environ: Mapping[str, str] | None = None,
-    storage_root: StorageRoot | None = None,
-    preflight: Callable[[StorageRoot], None] = _preflight_storage,
+    storage_root: ToolRepositoryStorage | None = None,
+    preflight: Callable[[ToolRepositoryStorage], None] = _preflight_storage,
 ) -> LifecycleStart:
     """Preflight storage and create a unique, isolated skill-run staging tree."""
     environment = os.environ if environ is None else environ
     root = _validated_repo_root(repo_root)
     skill_name = run_log_publish.validated_component(skill, label="skill", slug=True)
-    if parent_context is not None:
-        if parent_skill or parent_run_id:
-            raise ValueError("parent context cannot be combined with explicit parent identity")
-        parent_skill, parent_run_id = _parent_identity_from_context(repo_root=root, context_file=parent_context, environ=environment)
-    _validate_parent(parent_skill=parent_skill, parent_run_id=parent_run_id)
-    active_storage = storage_root or storage_config.load_storage_root(
+    active_storage = storage_root or storage_config.load_tool_repository_storage(
         repo_root=root, environ=environment
     )
+    if parent_context is not None:
+        if parent_skill or parent_run_id:
+            raise ValueError(
+                "parent context cannot be combined with explicit parent identity"
+            )
+        parent_skill, parent_run_id = _parent_identity_from_context(
+            repo_root=root,
+            context_file=parent_context,
+            environ=environment,
+            storage=active_storage,
+        )
+    _validate_parent(parent_skill=parent_skill, parent_run_id=parent_run_id)
     preflight(active_storage)
     selected_run_id = run_id or str(uuid.uuid4())
     run_name = run_log_publish.validated_component(
         selected_run_id, label="run-id", slug=True
     )
-    selected_log_root = log_root or lifecycle_log_root(repo_root=root, environ=environment)
-    _require_lifecycle(selected_log_root.is_absolute(), "lifecycle log root must be absolute")
+    selected_log_root = log_root or lifecycle_log_root(
+        repo_root=root, storage=active_storage, environ=environment
+    )
+    _require_lifecycle(
+        selected_log_root.is_absolute(), "lifecycle log root must be absolute"
+    )
     init = run_logs.log_init(
         log_root=selected_log_root,
         skill=skill_name,
@@ -213,35 +371,88 @@ def start_run(  # noqa: PLR0913 - lifecycle boundary validates identity, adoptio
         raise RunLifecycleError(f"run ID already exists: {run_name}")
     run_dir = init.path.parent
     manifest = run_log_manifest._read_manifest_v2(init.path)  # noqa: SLF001 - sibling lifecycle owns this manifest transition.
-    _require_lifecycle(manifest.get("lifecycle_schema_version") in {None, LIFECYCLE_SCHEMA_VERSION}, "unsupported lifecycle schema version")
+    _require_lifecycle(
+        manifest.get("lifecycle_schema_version") in {None, LIFECYCLE_SCHEMA_VERSION},
+        "unsupported lifecycle schema version",
+    )
     expected_parent_skill = parent_skill or None
     expected_parent_run_id = parent_run_id or None
-    _require_lifecycle(manifest.get("parent_skill") == expected_parent_skill, "existing lifecycle parent skill mismatch")
-    _require_lifecycle(manifest.get("parent_run_id") == expected_parent_run_id, "existing lifecycle parent run ID mismatch")
-    _require_lifecycle(manifest.get("skill") == skill_name and manifest.get("run_id") == run_name, "new lifecycle manifest identity mismatch")
+    _require_lifecycle(
+        manifest.get("parent_skill") == expected_parent_skill,
+        "existing lifecycle parent skill mismatch",
+    )
+    _require_lifecycle(
+        manifest.get("parent_run_id") == expected_parent_run_id,
+        "existing lifecycle parent run ID mismatch",
+    )
+    _require_lifecycle(
+        manifest.get("skill") == skill_name and manifest.get("run_id") == run_name,
+        "new lifecycle manifest identity mismatch",
+    )
     if manifest.get("lifecycle_schema_version") == LIFECYCLE_SCHEMA_VERSION:
-        _require_lifecycle(manifest.get("storage_uri") == active_storage.uri, "configured storage root changed after lifecycle start")
+        _require_lifecycle(
+            manifest.get("tool_repo_uri") == active_storage.uri
+            and manifest.get("client_repo") == active_storage.client_repo
+            and manifest.get("storage_origin_id") == active_storage.storage_origin_id,
+            "configured storage or Git origin changed after lifecycle start",
+        )
     else:
         _ = run_log_manifest._update_manifest_v2(  # noqa: SLF001 - sibling lifecycle owns this manifest transition.
             path=init.path,
-            updates={"status": config.MANIFEST_STATUS_IN_PROGRESS, "lifecycle_schema_version": LIFECYCLE_SCHEMA_VERSION, "storage_uri": active_storage.uri, "terminal_outcome": None, "finished_at": None},
+            updates={
+                "status": config.MANIFEST_STATUS_IN_PROGRESS,
+                "lifecycle_schema_version": LIFECYCLE_SCHEMA_VERSION,
+                "storage_base_uri": active_storage.base.uri,
+                "client_repo": active_storage.client_repo,
+                "tool_repo_uri": active_storage.uri,
+                "storage_origin_id": active_storage.storage_origin_id,
+                "terminal_outcome": None,
+                "finished_at": None,
+            },
         )
-    context_file = _context_file(repo_root=root, skill=skill_name, run_id=run_name, environ=environment)
-    started = LifecycleStart(root, active_storage, skill_name, run_name, selected_log_root, run_dir, context_file)
+    context_file = _context_file(
+        storage=active_storage,
+        skill=skill_name,
+        run_id=run_name,
+        environ=environment,
+    )
+    started = LifecycleStart(
+        root,
+        active_storage,
+        skill_name,
+        run_name,
+        selected_log_root,
+        run_dir,
+        context_file,
+    )
     if not (run_dir / UNIVERSAL_EXECUTION_ISSUES).is_file():
-        run_log_batch.atomic_write_text(path=run_dir / UNIVERSAL_EXECUTION_ISSUES, content="")
+        run_log_batch.atomic_write_text(
+            path=run_dir / UNIVERSAL_EXECUTION_ISSUES, content=""
+        )
     if context_file.is_file():
-        existing = load_run_context(repo_root=root, skill=skill_name, run_id=run_name, environ=environment)
-        _require_lifecycle(existing == started, "existing lifecycle context does not match adoption")
+        existing = load_run_context(
+            repo_root=root,
+            skill=skill_name,
+            run_id=run_name,
+            environ=environment,
+            storage_root=active_storage,
+        )
+        _require_lifecycle(
+            existing == started, "existing lifecycle context does not match adoption"
+        )
     else:
         _write_context(started=started)
     return started
 
 
-def _terminal_manifest(*, run_dir: Path, skill: str, run_id: str) -> tuple[Path, dict[str, object]]:
+def _terminal_manifest(
+    *, run_dir: Path, skill: str, run_id: str
+) -> tuple[Path, dict[str, object]]:
     manifest_path = run_dir / "manifest.json"
     if manifest_path.is_symlink() or not manifest_path.is_file():
-        raise RunLifecycleError(f"lifecycle manifest is missing or unsafe: {manifest_path}")
+        raise RunLifecycleError(
+            f"lifecycle manifest is missing or unsafe: {manifest_path}"
+        )
     manifest = run_log_manifest._read_manifest_v2(manifest_path)  # noqa: SLF001 - sibling lifecycle validates its own manifest.
     if manifest.get("skill") != skill or manifest.get("run_id") != run_id:
         raise RunLifecycleError("lifecycle manifest identity mismatch")
@@ -260,7 +471,8 @@ def _render_final_report(*, skill: str, run_id: str, outcome: str) -> str:
 
 
 def _missing_transcript_issue(*, skill: str, run_id: str) -> str:
-    return json.dumps(
+    return (
+        json.dumps(
         {
             "phase": "terminal",
             "step": "run-lifecycle",
@@ -272,11 +484,19 @@ def _missing_transcript_issue(*, skill: str, run_id: str) -> str:
         },
         separators=(",", ":"),
         sort_keys=True,
-    ) + "\n"
+        )
+        + "\n"
+    )
 
 
 def _write_terminal_artifacts(  # noqa: PLR0913 - terminal identity inputs stay explicit.
-    *, run_dir: Path, manifest_path: Path, manifest: dict[str, object], skill: str, run_id: str, outcome: str
+    *,
+    run_dir: Path,
+    manifest_path: Path,
+    manifest: dict[str, object],
+    skill: str,
+    run_id: str,
+    outcome: str,
 ) -> None:
     existing = manifest.get("terminal_outcome")
     if existing is not None and existing != outcome:
@@ -286,7 +506,9 @@ def _write_terminal_artifacts(  # noqa: PLR0913 - terminal identity inputs stay 
     report_path = run_dir / UNIVERSAL_FINAL_REPORT
     report = _render_final_report(skill=skill, run_id=run_id, outcome=outcome)
     if report_path.exists() and report_path.read_text(encoding="utf-8") != report:
-        raise RunLifecycleError("existing universal final report does not match terminal outcome")
+        raise RunLifecycleError(
+            "existing universal final report does not match terminal outcome"
+        )
     run_log_batch.atomic_write_text(
         path=report_path,
         content=report,
@@ -295,7 +517,9 @@ def _write_terminal_artifacts(  # noqa: PLR0913 - terminal identity inputs stay 
     issues_path = run_dir / UNIVERSAL_EXECUTION_ISSUES
     if not transcript.is_file():
         issue = _missing_transcript_issue(skill=skill, run_id=run_id)
-        existing_issues = issues_path.read_text(encoding="utf-8") if issues_path.is_file() else ""
+        existing_issues = (
+            issues_path.read_text(encoding="utf-8") if issues_path.is_file() else ""
+        )
         if issue not in existing_issues:
             run_log_batch.atomic_write_text(
                 path=issues_path,
@@ -318,7 +542,7 @@ def finish_run(  # noqa: PLR0913 - publication dependencies stay explicit and in
     run_id: str,
     outcome: str,
     environ: Mapping[str, str] | None = None,
-    storage_root: StorageRoot | None = None,
+    storage_root: ToolRepositoryStorage | None = None,
     store: ObjectStore | None = None,
     pre_scrub_violations: int = 0,
 ) -> LifecycleTerminal:
@@ -329,14 +553,34 @@ def finish_run(  # noqa: PLR0913 - publication dependencies stay explicit and in
     root = _validated_repo_root(repo_root)
     skill_name = run_log_publish.validated_component(skill, label="skill", slug=True)
     run_name = run_log_publish.validated_component(run_id, label="run-id", slug=True)
-    started = load_run_context(repo_root=root, skill=skill_name, run_id=run_name, environ=environment)
+    active_storage = storage_root or storage_config.load_tool_repository_storage(
+        repo_root=root, environ=environment
+    )
+    started = load_run_context(
+        repo_root=root,
+        skill=skill_name,
+        run_id=run_name,
+        environ=environment,
+        storage_root=active_storage,
+    )
     log_root = started.log_root
     run_dir = started.run_dir
     if run_dir.is_symlink() or not run_dir.is_dir():
-        raise RunLifecycleError(f"lifecycle run directory is missing or unsafe: {run_dir}")
+        raise RunLifecycleError(
+            f"lifecycle run directory is missing or unsafe: {run_dir}"
+        )
     manifest_path, manifest = _terminal_manifest(
         run_dir=run_dir, skill=skill_name, run_id=run_name
     )
+    if (
+        started.storage_root != active_storage
+        or manifest.get("tool_repo_uri") != active_storage.uri
+        or manifest.get("client_repo") != active_storage.client_repo
+        or manifest.get("storage_origin_id") != active_storage.storage_origin_id
+    ):
+        raise RunLifecycleError(
+            "configured storage or Git origin changed after lifecycle start"
+        )
     _write_terminal_artifacts(
         run_dir=run_dir,
         manifest_path=manifest_path,
@@ -345,12 +589,6 @@ def finish_run(  # noqa: PLR0913 - publication dependencies stay explicit and in
         run_id=run_name,
         outcome=outcome,
     )
-    active_storage = storage_root or storage_config.load_storage_root(
-        repo_root=root, environ=environment
-    )
-    recorded_storage = manifest.get("storage_uri")
-    if recorded_storage != active_storage.uri:
-        raise RunLifecycleError("configured storage root changed after lifecycle start")
     publication, violations = run_log_publish.publish_log_run(
         request=PublicationRequest(
             repo_root=root,
@@ -392,13 +630,21 @@ def start_main(argv: Sequence[str]) -> int:
     _ = parser.add_argument("--lifecycle-parent-context")
     try:
         args = parser.parse_args(argv)
-        result = start_run(repo_root=_resolve_cli_repo_root(args.repo_root), skill=args.skill, parent_skill=args.parent_skill, parent_run_id=args.parent_run_id,
-            run_id=args.run_id, log_root=Path(args.log_root) if args.log_root else None, issue=args.issue, adopt_existing=args.adopt_existing,
+        result = start_run(
+            repo_root=_resolve_cli_repo_root(args.repo_root),
+            skill=args.skill,
+            parent_skill=args.parent_skill,
+            parent_run_id=args.parent_run_id,
+            run_id=args.run_id,
+            log_root=Path(args.log_root) if args.log_root else None,
+            issue=args.issue,
+            adopt_existing=args.adopt_existing,
             parent_context=(
                 Path(args.lifecycle_parent_context)
                 if args.lifecycle_parent_context
                 else None
-            ))
+            ),
+        )
     except SystemExit as exc:
         return int(exc.code) if isinstance(exc.code, int) else config.EXIT_USAGE
     except storage_config.StorageConfigurationError as exc:
@@ -418,7 +664,11 @@ def start_main(argv: Sequence[str]) -> int:
     print(f"LOG_ROOT={result.log_root}")
     print(f"RUN_DIR={result.run_dir}")
     print(f"CONTEXT_FILE={result.context_file}")
-    print(f"STORAGE_URI={result.storage_root.uri}")
+    print(f"STORAGE_BASE_URI={result.storage_root.base.uri}")
+    print(f"CLIENT_REPO={result.storage_root.client_repo}")
+    print(f"TOOL_REPO_URI={result.storage_root.uri}")
+    print(f"RUN_LOGS_URI={result.storage_root.run_logs_uri}")
+    print("PREFLIGHT_OK=true")
     print("LIFECYCLE_STARTED=true")
     return config.EXIT_OK
 

--- a/plugin/python/larch/report/run_log_corpus.py
+++ b/plugin/python/larch/report/run_log_corpus.py
@@ -266,9 +266,10 @@ def synchronized_run_log_root(
     ).corpus_root
 
 
-def synchronized_repository_log_root(
+def synchronized_repository_log_root(  # noqa: PLR0913 - sync dependencies and pinned storage are injectable.
     *,
     repo_root: Path,
+    storage: storage_config.ToolRepositoryStorage | None = None,
     store: run_log_sync.SyncObjectStore | None = None,
     environ: Mapping[str, str] | None = None,
     cache_home: Path | None = None,
@@ -276,14 +277,18 @@ def synchronized_repository_log_root(
 ) -> Path:
     """Load repository config, synchronize once, and return the cache log root."""
     try:
-        storage_root: storage_config.StorageRoot = storage_config.load_storage_root(
-            repo_root=repo_root,
-            environ=environ,
+        active_storage: storage_config.ToolRepositoryStorage = (
+            storage
+            if storage is not None
+            else storage_config.load_tool_repository_storage(
+                repo_root=repo_root,
+                environ=environ,
+            )
         )
         return synchronized_run_log_root(
             request=run_log_sync.RunLogSyncRequest(
                 repo_root=repo_root,
-                storage_root=storage_root,
+                storage_root=active_storage,
                 cache_home=cache_home,
                 state_home=state_home,
             ),

--- a/plugin/python/larch/report/run_log_manifest.py
+++ b/plugin/python/larch/report/run_log_manifest.py
@@ -592,7 +592,7 @@ def required_artifacts_for_run(
     repo_root: Path | None = None,
 ) -> list[RequiredArtifact]:
     artifacts: list[RequiredArtifact] = []
-    if manifest.extra and manifest.extra.get("lifecycle_schema_version") == 1:
+    if manifest.extra and manifest.extra.get("lifecycle_schema_version") in {1, 2}:
         artifacts.extend([
             RequiredArtifact(
                 slug="final-report",
@@ -722,7 +722,7 @@ def verify_run_log_completeness(
     if manifest is None:
         return False, ["manifest.json"]
     universal = bool(
-        manifest.extra and manifest.extra.get("lifecycle_schema_version") == 1
+        manifest.extra and manifest.extra.get("lifecycle_schema_version") in {1, 2}
     )
     execution_issues_path = _committed_execution_issues_path(
         run_dir, skill, universal=universal

--- a/plugin/python/larch/report/run_log_migration.py
+++ b/plugin/python/larch/report/run_log_migration.py
@@ -15,7 +15,10 @@ from typing import Protocol, cast
 from larch.core import config
 from larch.report import run_log_archive
 from larch.report.run_log_batch import validate_run_id_slug
-from larch.report.storage_config import LegacyMigrationDescriptor, StorageRoot
+from larch.report.storage_config import (
+    LegacyMigrationDescriptor,
+    StorageBase,
+)
 
 _INVENTORY_KEYS: frozenset[str] = frozenset(
     {"archives", "schema", "source_commit", "source_files", "storage_root", "totals"}
@@ -142,7 +145,7 @@ def _canonical_path(value: object, *, label: str) -> str:
 
 
 def _validated_archive_row(  # noqa: C901 - strict row validation stays transactional
-    raw: object, *, storage_root: StorageRoot
+    raw: object, *, storage_root: StorageBase
 ) -> _ArchiveRow:
     if not isinstance(raw, dict):
         raise TypeError("migration inventory archive row must be an object")
@@ -192,8 +195,10 @@ def _validated_archive_row(  # noqa: C901 - strict row validation stays transact
         )
         if not valid_identity:
             raise ValueError("migration inventory run archive identity is invalid")
-    elif skill is not None or run_id is not None or not relative_key.startswith(
-        "migration/"
+    elif (
+        skill is not None
+        or run_id is not None
+        or not relative_key.startswith("migration/")
     ):
         raise ValueError("migration inventory residual archive identity is invalid")
     return _ArchiveRow(
@@ -264,7 +269,7 @@ def parse_inventory(  # noqa: C901,PLR0912,PLR0915 - strict schema cross-checks 
     encoded: bytes,
     *,
     descriptor: LegacyMigrationDescriptor,
-    storage_root: StorageRoot,
+    storage_root: StorageBase,
 ) -> LegacyMigrationInventory:
     """Parse and cross-check a hash-verified migration inventory."""
     if len(encoded) > config.RUN_LOG_MIGRATION_INVENTORY_MAX_BYTES:
@@ -406,7 +411,9 @@ def _read_inventory_bytes(path: Path) -> bytes:
         if opened.st_size > config.RUN_LOG_MIGRATION_INVENTORY_MAX_BYTES:
             raise ValueError("migration inventory exceeds byte limit")
         with os.fdopen(descriptor, "rb", closefd=False) as handle:
-            encoded: bytes = handle.read(config.RUN_LOG_MIGRATION_INVENTORY_MAX_BYTES + 1)
+            encoded: bytes = handle.read(
+                config.RUN_LOG_MIGRATION_INVENTORY_MAX_BYTES + 1
+            )
         if len(encoded) != opened.st_size:
             raise ValueError("migration inventory changed while reading")
         return encoded
@@ -418,7 +425,7 @@ def download_and_parse_inventory(
     *,
     store: MigrationObjectStore,
     descriptor: LegacyMigrationDescriptor,
-    storage_root: StorageRoot,
+    storage_root: StorageBase,
     temporary_dir: Path,
 ) -> LegacyMigrationInventory:
     """Download one pinned inventory, verify its hash, and parse it strictly."""

--- a/plugin/python/larch/report/run_log_publish.py
+++ b/plugin/python/larch/report/run_log_publish.py
@@ -30,10 +30,13 @@ from larch.report.object_store import (
 )
 from larch.report.run_log_archive import RunArchiveMaterializationResult
 from larch.report.run_log_batch import validate_run_id_slug
-from larch.report.storage_config import StorageConfigurationError, StorageRoot
+from larch.report.storage_config import (
+    StorageConfigurationError,
+    ToolRepositoryStorage,
+)
 from larch.errors import ShipError
 
-_PENDING_SCHEMA_VERSION: Final = 1
+_PENDING_SCHEMA_VERSION: Final = 2
 _PENDING_ARCHIVE_NAME: Final = "archive.tar.gz"
 _PENDING_METADATA_NAME: Final = "retry.json"
 _ENV_XDG_CACHE_HOME: Final = "XDG_CACHE_HOME"
@@ -50,11 +53,12 @@ _PENDING_KEYS: Final = frozenset(
         "last_error",
         "manifest_sha256",
         "remote_key",
-        "repo_name",
+        "client_repo",
         "run_id",
         "schema_version",
         "skill",
-        "storage_uri",
+        "storage_origin_id",
+        "tool_repo_uri",
     }
 )
 
@@ -104,7 +108,7 @@ class PublicationRequest:
     """Immutable caller inputs for one run publication attempt."""
 
     repo_root: Path
-    storage_root: StorageRoot
+    storage_root: ToolRepositoryStorage
     skill: str
     run_id: str
     staging_root: Path | None
@@ -117,8 +121,9 @@ class PendingPublication:
     """Content-pinned durable retry record for one immutable object."""
 
     schema_version: int
-    storage_uri: str
-    repo_name: str
+    tool_repo_uri: str
+    client_repo: str
+    storage_origin_id: str
     skill: str
     run_id: str
     remote_key: str
@@ -171,13 +176,11 @@ def xdg_home(
 
 def repository_cache_root(
     *,
-    repo_root: Path,
+    storage: ToolRepositoryStorage,
     cache_home: Path | None = None,
     environ: Mapping[str, str] | None = None,
 ) -> Path:
-    """Return the literal per-repository root for unpacked run archives."""
-    root: Path = larch_io.validate_trusted_directory(repo_root)
-    repo_name: str = validated_component(root.name, label="repository name", slug=False)
+    """Return the storage-origin-bound v2 root for unpacked run archives."""
     environment: Mapping[str, str] = os.environ if environ is None else environ
     resolved_cache_home: Path = cache_home or xdg_home(
         environ=environment,
@@ -186,7 +189,14 @@ def repository_cache_root(
     )
     if not resolved_cache_home.is_absolute():
         raise ValueError("publication cache home must be an absolute path")
-    return resolved_cache_home / "larch" / "run-logs" / repo_name
+    return (
+        resolved_cache_home
+        / "larch"
+        / "run-logs"
+        / "v2"
+        / storage.client_repo
+        / storage.storage_origin_id
+    )
 
 
 def publication_paths(
@@ -195,13 +205,12 @@ def publication_paths(
     environ: Mapping[str, str] | None = None,
 ) -> PublicationPaths:
     """Resolve the literal repository cache path and durable retry path."""
-    root: Path = larch_io.validate_trusted_directory(request.repo_root)
-    repo_name: str = validated_component(root.name, label="repository name", slug=False)
+    _ = larch_io.validate_trusted_directory(request.repo_root)
     skill_name: str = validated_component(request.skill, label="skill", slug=True)
     run_name: str = validated_component(request.run_id, label="run-id", slug=True)
     environment: Mapping[str, str] = os.environ if environ is None else environ
     cache_root: Path = repository_cache_root(
-        repo_root=root,
+        storage=request.storage_root,
         cache_home=request.cache_home,
         environ=environment,
     )
@@ -217,7 +226,9 @@ def publication_paths(
         resolved_state_home
         / "larch"
         / "run-log-pending"
-        / repo_name
+        / "v2"
+        / request.storage_root.client_repo
+        / request.storage_root.storage_origin_id
         / skill_name
         / run_name
     )
@@ -225,7 +236,9 @@ def publication_paths(
         resolved_state_home
         / "larch"
         / "run-log-locks"
-        / repo_name
+        / "v2"
+        / request.storage_root.client_repo
+        / request.storage_root.storage_origin_id
         / skill_name
         / f"{run_name}.lock"
     )
@@ -328,10 +341,17 @@ def _fsync_directory(path: Path) -> None:
 
 
 def _metadata_text(pending: PendingPublication) -> str:
-    return json.dumps(asdict(pending), ensure_ascii=False, sort_keys=True, separators=(",", ":")) + "\n"
+    return (
+        json.dumps(
+            asdict(pending), ensure_ascii=False, sort_keys=True, separators=(",", ":")
+        )
+        + "\n"
+    )
 
 
-def _write_pending_metadata(paths: PublicationPaths, pending: PendingPublication) -> None:
+def _write_pending_metadata(
+    paths: PublicationPaths, pending: PendingPublication
+) -> None:
     larch_io.trusted_atomic_write(
         paths.pending_metadata,
         _metadata_text(pending),
@@ -351,8 +371,9 @@ def _parse_pending_metadata(text: str) -> PendingPublication:
     if frozenset(data) != _PENDING_KEYS:
         raise PublicationError("pending publication metadata has invalid fields")
     string_keys: tuple[str, ...] = (
-        "storage_uri",
-        "repo_name",
+        "tool_repo_uri",
+        "client_repo",
+        "storage_origin_id",
         "skill",
         "run_id",
         "remote_key",
@@ -363,12 +384,18 @@ def _parse_pending_metadata(text: str) -> PendingPublication:
     if any(not isinstance(data[key], str) for key in string_keys):
         raise PublicationError("pending publication metadata has invalid string fields")
     integer_keys: tuple[str, ...] = ("schema_version", "archive_size", "attempts")
-    if any(not isinstance(data[key], int) or isinstance(data[key], bool) for key in integer_keys):
-        raise PublicationError("pending publication metadata has invalid integer fields")
+    if any(
+        not isinstance(data[key], int) or isinstance(data[key], bool)
+        for key in integer_keys
+    ):
+        raise PublicationError(
+            "pending publication metadata has invalid integer fields"
+        )
     return PendingPublication(
         schema_version=cast("int", data["schema_version"]),
-        storage_uri=cast("str", data["storage_uri"]),
-        repo_name=cast("str", data["repo_name"]),
+        tool_repo_uri=cast("str", data["tool_repo_uri"]),
+        client_repo=cast("str", data["client_repo"]),
+        storage_origin_id=cast("str", data["storage_origin_id"]),
         skill=cast("str", data["skill"]),
         run_id=cast("str", data["run_id"]),
         remote_key=cast("str", data["remote_key"]),
@@ -385,13 +412,13 @@ def _validate_pending(
     paths: PublicationPaths,
     pending: PendingPublication,
     request: PublicationRequest,
-    repo_name: str,
 ) -> PendingPublication:
     expected_key: str = f"run-logs/{request.skill}/{request.run_id}.tar.gz"
     identity: tuple[object, ...] = (
         pending.schema_version,
-        pending.storage_uri,
-        pending.repo_name,
+        pending.tool_repo_uri,
+        pending.client_repo,
+        pending.storage_origin_id,
         pending.skill,
         pending.run_id,
         pending.remote_key,
@@ -399,26 +426,33 @@ def _validate_pending(
     expected_identity: tuple[object, ...] = (
         _PENDING_SCHEMA_VERSION,
         request.storage_root.uri,
-        repo_name,
+        request.storage_root.client_repo,
+        request.storage_root.storage_origin_id,
         request.skill,
         request.run_id,
         expected_key,
     )
     if identity != expected_identity:
-        raise PublicationError("pending publication identity does not match the live request")
+        raise PublicationError(
+            "pending publication identity does not match the live request"
+        )
     if (
         not _valid_sha256(pending.archive_sha256)
         or not _valid_sha256(pending.manifest_sha256)
         or pending.archive_size <= 0
         or pending.attempts < 0
     ):
-        raise PublicationError("pending publication metadata has invalid content identity")
+        raise PublicationError(
+            "pending publication metadata has invalid content identity"
+        )
     archive_sha256, archive_size = _sha256_regular_file(
         paths.pending_archive,
         root=paths.pending_dir,
     )
     if (archive_sha256, archive_size) != (pending.archive_sha256, pending.archive_size):
-        raise PublicationError("pending archive does not match its durable content identity")
+        raise PublicationError(
+            "pending archive does not match its durable content identity"
+        )
     return pending
 
 
@@ -432,7 +466,6 @@ def _load_pending(
     *,
     paths: PublicationPaths,
     request: PublicationRequest,
-    repo_name: str,
 ) -> PendingPublication:
     root: Path = larch_io.validate_trusted_directory(paths.pending_dir)
     text: str = larch_io.read_trusted_text(
@@ -444,7 +477,6 @@ def _load_pending(
         paths=paths,
         pending=_parse_pending_metadata(text),
         request=request,
-        repo_name=repo_name,
     )
 
 
@@ -452,7 +484,6 @@ def _create_pending(
     *,
     paths: PublicationPaths,
     request: PublicationRequest,
-    repo_name: str,
 ) -> PendingPublication:
     parent: Path = ensure_concurrent_directory(paths.pending_dir.parent)
     temporary: Path | None = Path(
@@ -461,7 +492,9 @@ def _create_pending(
     temporary.chmod(0o700)
     try:
         if request.staging_root is None:
-            raise PublicationError("a staging root is required to create a pending archive")
+            raise PublicationError(
+                "a staging root is required to create a pending archive"
+            )
         created = run_log_archive.create_run_archive(
             staging_root=request.staging_root,
             output_dir=temporary,
@@ -472,8 +505,9 @@ def _create_pending(
         _ = created.archive_path.rename(archive_path)
         pending = PendingPublication(
             schema_version=_PENDING_SCHEMA_VERSION,
-            storage_uri=request.storage_root.uri,
-            repo_name=repo_name,
+            tool_repo_uri=request.storage_root.uri,
+            client_repo=request.storage_root.client_repo,
+            storage_origin_id=request.storage_root.storage_origin_id,
             skill=request.skill,
             run_id=request.run_id,
             remote_key=f"run-logs/{request.skill}/{request.run_id}.tar.gz",
@@ -497,7 +531,6 @@ def _create_pending(
         return _load_pending(
             paths=paths,
             request=request,
-            repo_name=repo_name,
         )
     finally:
         if temporary is not None:
@@ -508,20 +541,19 @@ def _pending_for_request(
     *,
     paths: PublicationPaths,
     request: PublicationRequest,
-    repo_name: str,
 ) -> PendingPublication:
     if paths.pending_dir.exists() or paths.pending_dir.is_symlink():
         return _load_pending(
             paths=paths,
             request=request,
-            repo_name=repo_name,
         )
     if request.staging_root is None:
-        raise PublicationError("no durable pending archive exists and --staging-root was not provided")
+        raise PublicationError(
+            "no durable pending archive exists and --staging-root was not provided"
+        )
     return _create_pending(
         paths=paths,
         request=request,
-        repo_name=repo_name,
     )
 
 
@@ -542,8 +574,13 @@ def _matching_remote_exists(
         downloaded: Path = Path(handle.name)
     try:
         store.download(pending.remote_key, downloaded)
-        remote_sha256, remote_size = _sha256_regular_file(downloaded, root=paths.pending_dir)
-        return (remote_sha256, remote_size) == (pending.archive_sha256, pending.archive_size)
+        remote_sha256, remote_size = _sha256_regular_file(
+            downloaded, root=paths.pending_dir
+        )
+        return (remote_sha256, remote_size) == (
+            pending.archive_sha256,
+            pending.archive_size,
+        )
     finally:
         downloaded.unlink(missing_ok=True)
 
@@ -555,7 +592,9 @@ def _publish_remote(
     paths: PublicationPaths,
 ) -> RemotePublicationStatus:
     try:
-        uploaded: RemoteObject = store.upload_create(pending.remote_key, paths.pending_archive)
+        uploaded: RemoteObject = store.upload_create(
+            pending.remote_key, paths.pending_archive
+        )
     except ObjectStoreError as exc:
         if exc.kind is not ObjectStoreErrorKind.ALREADY_EXISTS:
             raise
@@ -565,7 +604,9 @@ def _publish_remote(
             ) from exc
         return RemotePublicationStatus.MATCHED
     if uploaded.key != pending.remote_key or uploaded.size != pending.archive_size:
-        raise PublicationError("create-only upload returned a mismatched object identity")
+        raise PublicationError(
+            "create-only upload returned a mismatched object identity"
+        )
     verified: RemoteObject = store.metadata(pending.remote_key)
     if verified.key != pending.remote_key or verified.size != pending.archive_size:
         raise PublicationError("uploaded remote object failed metadata verification")
@@ -580,32 +621,40 @@ def _cache_result(
 ) -> tuple[RunArchiveMaterializationResult, CachePublicationStatus]:
     _ = ensure_concurrent_directory(paths.cache_dir.parent)
     if paths.cache_dir.exists() or paths.cache_dir.is_symlink():
-        existing: RunArchiveMaterializationResult = run_log_archive.verify_materialized_run_directory(
+        existing: RunArchiveMaterializationResult = (
+            run_log_archive.verify_materialized_run_directory(
             run_dir=paths.cache_dir,
             expected_skill=pending.skill,
             expected_run_id=pending.run_id,
         )
+        )
         if existing.manifest_sha256 != pending.manifest_sha256:
-            raise PublicationError("existing cache directory contains different run content")
+            raise PublicationError(
+                "existing cache directory contains different run content"
+            )
         return existing, CachePublicationStatus.PRESENT
     if staging_root is not None:
         try:
-            promoted: RunArchiveMaterializationResult = run_log_archive.promote_staging_run_directory(
+            promoted: RunArchiveMaterializationResult = (
+                run_log_archive.promote_staging_run_directory(
                 staging_root=staging_root,
                 run_dir=paths.cache_dir,
                 expected_skill=pending.skill,
                 expected_run_id=pending.run_id,
                 expected_manifest_sha256=pending.manifest_sha256,
             )
+            )
         except run_log_archive.StagingManifestMismatchError:
             pass
         else:
             return promoted, CachePublicationStatus.PROMOTED
-    materialized: RunArchiveMaterializationResult = run_log_archive.materialize_run_archive(
+    materialized: RunArchiveMaterializationResult = (
+        run_log_archive.materialize_run_archive(
         archive_path=paths.pending_archive,
         run_dir=paths.cache_dir,
         expected_skill=pending.skill,
         expected_run_id=pending.run_id,
+    )
     )
     return materialized, CachePublicationStatus.MATERIALIZED
 
@@ -638,7 +687,6 @@ def publish_run(
 ) -> PublicationResult:
     """Publish one immutable archive and atomically populate its local cache."""
     root: Path = larch_io.validate_trusted_directory(request.repo_root)
-    repo_name: str = validated_component(root.name, label="repository name", slug=False)
     skill_name: str = validated_component(request.skill, label="skill", slug=True)
     run_name: str = validated_component(request.run_id, label="run-id", slug=True)
     normalized_request = replace(
@@ -657,11 +705,12 @@ def publish_run(
         else store
     )
     with publication_lock(paths.lock_file):
-        retrying_pending: bool = paths.pending_dir.exists() or paths.pending_dir.is_symlink()
+        retrying_pending: bool = (
+            paths.pending_dir.exists() or paths.pending_dir.is_symlink()
+        )
         pending: PendingPublication = _pending_for_request(
             paths=paths,
             request=normalized_request,
-            repo_name=repo_name,
         )
         pending = replace(pending, attempts=pending.attempts + 1, last_error="")
         _write_pending_metadata(paths, pending)
@@ -674,10 +723,14 @@ def publish_run(
             cache_result, cache_status = _cache_result(
                 paths=paths,
                 pending=pending,
-                staging_root=None if retrying_pending else normalized_request.staging_root,
+                staging_root=None
+                if retrying_pending
+                else normalized_request.staging_root,
             )
             if cache_result.manifest_sha256 != pending.manifest_sha256:
-                raise PublicationError("published cache failed manifest identity verification")
+                raise PublicationError(
+                    "published cache failed manifest identity verification"
+                )
         except (
             EOFError,
             ObjectStoreError,
@@ -687,7 +740,9 @@ def publish_run(
             TypeError,
             ValueError,
         ) as exc:
-            _write_pending_metadata(paths, replace(pending, last_error=_failure_token(exc)))
+            _write_pending_metadata(
+                paths, replace(pending, last_error=_failure_token(exc))
+            )
             raise
         _complete_pending(paths)
     return PublicationResult(
@@ -751,12 +806,12 @@ def main(argv: Sequence[str]) -> int:
             raise StorageConfigurationError(
                 f"could not discover a Git repository root from {requested_root}"
             )
-        storage_root: StorageRoot = storage_config.discover_storage_root(
-            start=repo_root
+        storage: ToolRepositoryStorage = (
+            storage_config.discover_tool_repository_storage(start=repo_root)
         )
         request = PublicationRequest(
             repo_root=repo_root,
-            storage_root=storage_root,
+            storage_root=storage,
             skill=args.skill,
             run_id=args.run_id,
             staging_root=Path(args.staging_root) if args.staging_root else None,

--- a/plugin/python/larch/report/run_log_sync.py
+++ b/plugin/python/larch/report/run_log_sync.py
@@ -16,9 +16,12 @@ from pathlib import Path
 from typing import Protocol
 
 from larch.core import config, repo_roots
-from larch.report import run_log_archive, run_log_migration, run_log_publish, storage_config
+from larch.report import run_log_archive, run_log_publish, storage_config
 from larch.report.object_store import ObjectStoreError, RemoteObject, object_store_for
-from larch.report.storage_config import StorageConfigurationError, StorageRoot
+from larch.report.storage_config import (
+    StorageConfigurationError,
+    ToolRepositoryStorage,
+)
 
 _REMOTE_PREFIX = "run-logs/"
 _ARCHIVE_SUFFIX = ".tar.gz"
@@ -50,7 +53,7 @@ class RunLogSyncRequest:
     """Immutable inputs for one repository-scoped synchronization."""
 
     repo_root: Path
-    storage_root: StorageRoot
+    storage_root: ToolRepositoryStorage
     cache_home: Path | None = None
     state_home: Path | None = None
 
@@ -96,43 +99,6 @@ class RepositorySyncResult:
     @property
     def repaired_count(self) -> int:
         return sum(run.status is CacheSyncStatus.REPAIRED for run in self.runs)
-
-
-class _LegacyMigrationLoader:
-    """Lazily download a repository-scoped migration inventory at most once."""
-
-    def __init__(self, *, request: RunLogSyncRequest, store: SyncObjectStore, temporary_dir: Path) -> None:
-        self._request = request
-        self._store = store
-        self._temporary_dir = temporary_dir
-        self._attempted = False
-        self._inventory: run_log_migration.LegacyMigrationInventory | None = None
-
-    def archive_for(self, remote_key: str) -> run_log_archive.LegacyRunArchive:
-        if not self._attempted:
-            self._attempted = True
-            try:
-                descriptor = storage_config.load_legacy_migration_descriptor(
-                    repo_root=self._request.repo_root, storage_root=self._request.storage_root,
-                )
-            except StorageConfigurationError as exc:
-                raise RunLogSyncError("legacy migration descriptor is invalid") from exc
-            if descriptor is None:
-                raise RunLogSyncError(
-                    "manifest-less run archive is not recognized by a repository migration descriptor"
-                )
-            self._inventory = run_log_migration.download_and_parse_inventory(
-                store=self._store, descriptor=descriptor, storage_root=self._request.storage_root,
-                temporary_dir=self._temporary_dir,
-            )
-        if self._inventory is None:
-            raise RunLogSyncError("legacy migration inventory is unavailable")
-        record: run_log_archive.LegacyRunArchive | None = self._inventory.archive_for(remote_key)
-        if record is None:
-            raise RunLogSyncError(
-                "manifest-less run archive is not recognized by the pinned migration inventory"
-            )
-        return record
 
 
 def _remote_run_archive(remote: RemoteObject) -> RemoteRunArchive:
@@ -227,7 +193,6 @@ def _download_and_materialize(
     store: SyncObjectStore,
     archive: RemoteRunArchive,
     cache_dir: Path,
-    migration: _LegacyMigrationLoader,
 ) -> None:
     with tempfile.NamedTemporaryFile(
         dir=cache_dir.parent,
@@ -243,17 +208,12 @@ def _download_and_materialize(
             raise RunLogSyncError(
                 f"downloaded archive does not match listed size: {archive.remote_key!r}"
             )
-        try:
-            _ = run_log_archive.materialize_run_archive(
-                archive_path=archive_path, run_dir=cache_dir,
-                expected_skill=archive.skill, expected_run_id=archive.run_id,
-            )
-        except run_log_archive.MissingArchiveManifestError:
-            legacy: run_log_archive.LegacyRunArchive = migration.archive_for(archive.remote_key)
-            _ = run_log_archive.materialize_legacy_run_archive(
-                archive_path=archive_path, run_dir=cache_dir,
-                expected_skill=archive.skill, expected_run_id=archive.run_id, legacy=legacy,
-            )
+        _ = run_log_archive.materialize_run_archive(
+            archive_path=archive_path,
+            run_dir=cache_dir,
+            expected_skill=archive.skill,
+            expected_run_id=archive.run_id,
+        )
     finally:
         archive_path.unlink(missing_ok=True)
 
@@ -264,7 +224,6 @@ def _sync_archive(
     archive: RemoteRunArchive,
     store: SyncObjectStore,
     environ: Mapping[str, str] | None,
-    migration: _LegacyMigrationLoader,
 ) -> SyncedRun:
     paths: run_log_publish.PublicationPaths = run_log_publish.publication_paths(
         request=run_log_publish.PublicationRequest(
@@ -302,7 +261,6 @@ def _sync_archive(
                 store=store,
                 archive=archive,
                 cache_dir=paths.cache_dir,
-                migration=migration,
             )
         except (
             EOFError,
@@ -347,21 +305,17 @@ def sync_repository_run_logs(
         active_store.list_objects(_REMOTE_PREFIX)
     )
     corpus_root: Path = run_log_publish.repository_cache_root(
-        repo_root=request.repo_root,
+        storage=request.storage_root,
         cache_home=request.cache_home,
         environ=environ,
     )
     _ = run_log_publish.ensure_concurrent_directory(corpus_root)
-    migration = _LegacyMigrationLoader(
-        request=request, store=active_store, temporary_dir=corpus_root,
-    )
     runs: tuple[SyncedRun, ...] = tuple(
         _sync_archive(
             request=request,
             archive=archive,
             store=active_store,
             environ=environ,
-            migration=migration,
         )
         for archive in inventory
     )
@@ -383,13 +337,13 @@ def main(argv: Sequence[str]) -> int:
             raise StorageConfigurationError(
                 f"could not discover a Git repository root from {requested_root}"
             )
-        storage_root: StorageRoot = storage_config.discover_storage_root(
-            start=repo_root
+        storage: ToolRepositoryStorage = (
+            storage_config.discover_tool_repository_storage(start=repo_root)
         )
         result: RepositorySyncResult = sync_repository_run_logs(
             request=RunLogSyncRequest(
                 repo_root=repo_root,
-                storage_root=storage_root,
+                storage_root=storage,
             )
         )
     except StorageConfigurationError as exc:

--- a/plugin/python/larch/report/storage_config.py
+++ b/plugin/python/larch/report/storage_config.py
@@ -1,13 +1,15 @@
-"""Storage-root configuration and provider-neutral bucket preflight."""
+"""Repository-owned storage configuration and derived tool namespace."""
 
 from __future__ import annotations
 
 import argparse
 import contextlib
+import hashlib
 import os
+import re
 import sys
 import tomllib
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Final, cast
@@ -17,47 +19,93 @@ from larch.core import config, proc
 from larch.core.repo_roots import consumer_repo_root
 from larch.report.object_store import ObjectStoreError, object_store_for
 
-_MIN_URI_PATH_SEGMENT_COUNT: Final = 2
 _ASCII_CONTROL_CHARACTER_MAX: Final = 32
+_ASCII_DELETE: Final = 127
 _SHA256_HEX_LENGTH: Final = 64
 _GIT_COMMIT_HEX_LENGTH: Final = 40
+_TOOL_REPOSITORY_SUFFIX_PARTS: Final = 2
+_CLIENT_REPO_RE: Final = re.compile(r"^[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?$")
+_SCP_REMOTE_RE: Final = re.compile(
+    r"^(?:(?P<user>[A-Za-z0-9._-]+)@)?(?P<host>[^/:@\s]+):(?P<path>[^:\s]+)$"
+)
 
 
 class StorageConfigurationError(ValueError):
-    """The repository's storage-root configuration is missing or invalid."""
+    """The repository's storage configuration or identity is invalid."""
 
 
 class StoragePreflightError(RuntimeError):
-    """The configured storage bucket cannot be used for a startup preflight."""
+    """The configured tool and repository prefix cannot be listed."""
 
 
 @dataclass(frozen=True)
-class StorageRoot:
-    """Validated larch storage root, without credentials or object names."""
+class StorageBase:
+    """Validated provider, bucket, and optional base prefix."""
 
     scheme: str
     bucket: str
-    prefix: str
+    prefix: str = ""
 
     @property
     def uri(self) -> str:
-        """Return the canonical configured storage-root URI."""
-        return f"{self.scheme}://{self.bucket}/{self.prefix}"
-
-    @property
-    def run_logs_uri(self) -> str:
-        """Return the deterministic remote root for run archives."""
-        return f"{self.uri}/run-logs/"
+        """Return the canonical configured base URI."""
+        suffix: str = f"/{self.prefix}" if self.prefix else ""
+        return f"{self.scheme}://{self.bucket}{suffix}"
 
     @property
     def bucket_uri(self) -> str:
-        """Return the provider bucket root used by existence preflights."""
+        """Return the provider bucket root."""
         return f"{self.scheme}://{self.bucket}"
 
 
 @dataclass(frozen=True)
+class ToolRepositoryStorage:
+    """The fixed larch namespace for one Git-origin-derived repository."""
+
+    base: StorageBase
+    client_repo: str
+
+    @property
+    def scheme(self) -> str:
+        return self.base.scheme
+
+    @property
+    def bucket(self) -> str:
+        return self.base.bucket
+
+    @property
+    def prefix(self) -> str:
+        parts: tuple[str, ...] = tuple(
+            part
+            for part in (self.base.prefix, config.LARCH_TOOL_NAME, self.client_repo)
+            if part
+        )
+        return "/".join(parts)
+
+    @property
+    def uri(self) -> str:
+        """Return the canonical tool and client-repository root."""
+        return f"{self.scheme}://{self.bucket}/{self.prefix}"
+
+    @property
+    def storage_origin_id(self) -> str:
+        """Bind local mutable state to the complete canonical remote origin."""
+        return hashlib.sha256(self.uri.encode("utf-8")).hexdigest()
+
+    def data_uri(self, data_type: str) -> str:
+        """Return one validated child data namespace."""
+        child: str = _validated_path_component(data_type, label="data type")
+        return f"{self.uri}/{child}/"
+
+    @property
+    def run_logs_uri(self) -> str:
+        """Return the deterministic remote root for run archives."""
+        return self.data_uri(config.RUN_LOGS_DATA_TYPE)
+
+
+@dataclass(frozen=True)
 class LegacyMigrationDescriptor:
-    """Repository-owned trust anchor for one historical migration inventory."""
+    """Operator-supplied trust anchor for one historical migration inventory."""
 
     schema: str
     source_commit: str
@@ -68,213 +116,443 @@ class LegacyMigrationDescriptor:
 
 def run_log_reference(*, repo_root: Path | None, skill: str, run_id: str) -> str:
     """Render a provider-neutral run identity for public summaries."""
-    provider = "unknown"
+    provider: str = "unknown"
     if repo_root is not None:
         with contextlib.suppress(StorageConfigurationError):
-            provider = load_storage_root(repo_root=repo_root).scheme
+            provider = load_tool_repository_storage(repo_root=repo_root).scheme
     return f"provider `{provider}`, skill `{skill}`, run ID `{run_id}`"
 
 
 def _validated_bucket(parsed: SplitResult) -> str:
-    """Return a plain bucket authority with no credentials or port."""
-    if parsed.username is not None or parsed.password is not None or "@" in parsed.netloc:
-        raise StorageConfigurationError("[logs].uri must not contain credentials")
+    """Return the exact plain bucket authority with no credentials or port."""
+    if (
+        parsed.username is not None
+        or parsed.password is not None
+        or "@" in parsed.netloc
+    ):
+        raise StorageConfigurationError(
+            "[larch].storage_base_uri must not contain credentials"
+        )
     try:
-        port = parsed.port
+        port: int | None = parsed.port
     except ValueError as exc:
-        raise StorageConfigurationError("[logs].uri must contain a valid bucket name without a port") from exc
-    if not parsed.netloc or port is not None or parsed.hostname != parsed.netloc:
-        raise StorageConfigurationError("[logs].uri must contain a plain bucket name without a port")
-    if any(character.isspace() for character in parsed.netloc):
-        raise StorageConfigurationError("[logs].uri bucket must not contain whitespace")
-    return parsed.netloc
+        raise StorageConfigurationError(
+            "[larch].storage_base_uri must contain a plain bucket name without a port"
+        ) from exc
+    bucket: str = parsed.netloc
+    if (
+        not bucket
+        or port is not None
+        or ":" in bucket
+        or "\\" in bucket
+        or any(
+            character.isspace()
+            or ord(character) < _ASCII_CONTROL_CHARACTER_MAX
+            or ord(character) == _ASCII_DELETE
+            for character in bucket
+        )
+    ):
+        raise StorageConfigurationError(
+            "[larch].storage_base_uri must contain a plain bucket name without a port"
+        )
+    return bucket
 
 
 def _validated_prefix(path: str) -> str:
-    """Return a normalized non-empty storage-root prefix."""
-    segments = path.split("/")
-    if not path.startswith("/") or len(segments) < _MIN_URI_PATH_SEGMENT_COUNT or not segments[1:]:
-        raise StorageConfigurationError("[logs].uri must include a non-empty storage-root prefix")
-    prefix_segments = segments[1:]
+    """Return an exact optional base prefix."""
+    if not path:
+        return ""
+    if not path.startswith("/") or path.endswith("/"):
+        raise StorageConfigurationError(
+            "[larch].storage_base_uri must not have a trailing slash"
+        )
+    prefix_segments: list[str] = path[1:].split("/")
     if any(not segment or segment in {".", ".."} for segment in prefix_segments):
-        raise StorageConfigurationError("[logs].uri prefix must not contain empty, '.' or '..' segments")
+        raise StorageConfigurationError(
+            "[larch].storage_base_uri prefix must not contain empty, '.' or '..' segments"
+        )
     if any(
-        any(character.isspace() or ord(character) < _ASCII_CONTROL_CHARACTER_MAX for character in segment)
+        "\\" in segment
+        or any(
+            character.isspace()
+            or ord(character) < _ASCII_CONTROL_CHARACTER_MAX
+            or ord(character) == _ASCII_DELETE
+            for character in segment
+        )
         for segment in prefix_segments
     ):
-        raise StorageConfigurationError("[logs].uri prefix must not contain whitespace or control characters")
+        raise StorageConfigurationError(
+            "[larch].storage_base_uri prefix must not contain whitespace or control characters"
+        )
     return "/".join(prefix_segments)
 
 
-def _parse_storage_uri(raw_uri: str) -> StorageRoot:
+def parse_storage_base_uri(raw_uri: str) -> StorageBase:
+    """Validate a base URI without adding the tool or repository namespace."""
     if not raw_uri or raw_uri != raw_uri.strip():
-        raise StorageConfigurationError("[logs].uri must be a non-empty URI without surrounding whitespace")
-    parsed = urlsplit(raw_uri)
-    if parsed.scheme not in config.STORAGE_URI_SCHEMES:
-        accepted = ", ".join(f"{scheme}://" for scheme in config.STORAGE_URI_SCHEMES)
-        raise StorageConfigurationError(f"[logs].uri must use one of: {accepted}")
+        raise StorageConfigurationError(
+            "[larch].storage_base_uri must be a non-empty URI without surrounding whitespace"
+        )
+    parsed: SplitResult = urlsplit(raw_uri)
+    if (
+        parsed.scheme not in config.STORAGE_URI_SCHEMES
+        or not raw_uri.startswith(f"{parsed.scheme}://")
+    ):
+        accepted: str = ", ".join(
+            f"{scheme}://" for scheme in config.STORAGE_URI_SCHEMES
+        )
+        raise StorageConfigurationError(
+            f"[larch].storage_base_uri must use one of: {accepted}"
+        )
     if parsed.query or parsed.fragment:
-        raise StorageConfigurationError("[logs].uri must not contain a query or fragment")
-    return StorageRoot(
+        raise StorageConfigurationError(
+            "[larch].storage_base_uri must not contain a query or fragment"
+        )
+    return StorageBase(
         scheme=parsed.scheme,
         bucket=_validated_bucket(parsed),
         prefix=_validated_prefix(parsed.path),
     )
 
 
+def parse_tool_repository_uri(
+    raw_uri: str, *, expected_client_repo: str | None = None
+) -> ToolRepositoryStorage:
+    """Rehydrate a canonical persisted tool-repository URI."""
+    parsed: SplitResult = urlsplit(raw_uri)
+    if parsed.scheme not in config.STORAGE_URI_SCHEMES:
+        raise StorageConfigurationError(
+            "persisted tool repository URI has an invalid scheme"
+        )
+    bucket: str = _validated_bucket(parsed)
+    prefix: str = _validated_prefix(parsed.path)
+    parts: list[str] = prefix.split("/")
+    if (
+        len(parts) < _TOOL_REPOSITORY_SUFFIX_PARTS
+        or parts[-2] != config.LARCH_TOOL_NAME
+    ):
+        raise StorageConfigurationError(
+            "persisted tool repository URI has an invalid namespace"
+        )
+    client_repo: str = validate_client_repo(parts[-1])
+    if expected_client_repo is not None and client_repo != expected_client_repo:
+        raise StorageConfigurationError("persisted tool repository identity changed")
+    base_prefix: str = "/".join(parts[:-2])
+    storage: ToolRepositoryStorage = ToolRepositoryStorage(
+        StorageBase(parsed.scheme, bucket, base_prefix), client_repo
+    )
+    if storage.uri != raw_uri:
+        raise StorageConfigurationError(
+            "persisted tool repository URI is not canonical"
+        )
+    return storage
+
+
 def _load_repository_config(repo_root: Path) -> dict[str, object]:
     config_path: Path = repo_root / config.STORAGE_CONFIG_RELPATH
-    if config_path.is_symlink() or not config_path.is_file():
+    repo_label: str = repo_root.name or str(repo_root)
+    if config_path.is_symlink():
         raise StorageConfigurationError(
-            f"storage configuration is missing: create {config.STORAGE_CONFIG_RELPATH} at the repository root "
-            f"or set {config.ENV_LARCH_LOGS_URI}"
+            f"{config.STORAGE_CONFIG_RELPATH}: refusing symlink in Git repository {repo_label}"
+        )
+    if not config_path.is_file():
+        raise StorageConfigurationError(
+            f"{config.STORAGE_CONFIG_RELPATH}: missing required file in Git repository "
+            f"{repo_label}; add [larch] with storage_base_uri"
         )
     try:
         with config_path.open("rb") as handle:
             return cast("dict[str, object]", tomllib.load(handle))
+    except OSError as exc:
+        raise StorageConfigurationError(
+            f"{config.STORAGE_CONFIG_RELPATH}: cannot read configuration in Git repository "
+            f"{repo_label}; add readable [larch] with storage_base_uri"
+        ) from exc
     except tomllib.TOMLDecodeError as exc:
-        raise StorageConfigurationError(f"invalid {config.STORAGE_CONFIG_RELPATH}: {exc}") from exc
+        raise StorageConfigurationError(
+            f"{config.STORAGE_CONFIG_RELPATH}: malformed TOML in Git repository {repo_label}"
+        ) from exc
 
 
-def load_storage_root(*, repo_root: Path, environ: Mapping[str, str] | None = None) -> StorageRoot:
-    """Load and validate storage configuration, honoring the environment override."""
-    environment = os.environ if environ is None else environ
-    override = environment.get(config.ENV_LARCH_LOGS_URI, "")
-    if override:
-        return _parse_storage_uri(override)
+def _configured_storage_base(
+    *, repo_root: Path, environ: Mapping[str, str]
+) -> StorageBase:
     raw_data: dict[str, object] = _load_repository_config(repo_root)
-    raw_logs = raw_data.get("logs")
-    if not isinstance(raw_logs, dict):
-        raise StorageConfigurationError(f"invalid {config.STORAGE_CONFIG_RELPATH}: missing [logs] table")
-    logs = cast("dict[str, object]", raw_logs)
-    uri = logs.get("uri")
-    if not isinstance(uri, str):
-        raise StorageConfigurationError(f"invalid {config.STORAGE_CONFIG_RELPATH}: [logs].uri must be a string")
-    return _parse_storage_uri(uri)
+    raw_larch: object = raw_data.get(config.LARCH_TOOL_NAME)
+    repo_label: str = repo_root.name or str(repo_root)
+    if not isinstance(raw_larch, dict):
+        raise StorageConfigurationError(
+            f"{config.STORAGE_CONFIG_RELPATH}: missing required [larch] table; "
+            f"larch cannot run in Git repository {repo_label}; add [larch] with storage_base_uri"
+        )
+    larch_table: dict[str, object] = cast("dict[str, object]", raw_larch)
+    if frozenset(larch_table) != frozenset({config.STORAGE_BASE_URI_FIELD}):
+        raise StorageConfigurationError(
+            f"{config.STORAGE_CONFIG_RELPATH}: [larch] must contain only "
+            f"{config.STORAGE_BASE_URI_FIELD}"
+        )
+    configured: object = larch_table.get(config.STORAGE_BASE_URI_FIELD)
+    if not isinstance(configured, str):
+        raise StorageConfigurationError(
+            f"{config.STORAGE_CONFIG_RELPATH}: "
+            f"[larch].{config.STORAGE_BASE_URI_FIELD} must be a string"
+        )
+    legacy_override: str = environ.get(config.ENV_LARCH_LOGS_URI, "")
+    if legacy_override:
+        raise StorageConfigurationError(
+            f"{config.ENV_LARCH_LOGS_URI} is no longer supported; remove it and use "
+            f"{config.ENV_LARCH_STORAGE_BASE_URI} for a base-only override"
+        )
+    override: str = environ.get(config.ENV_LARCH_STORAGE_BASE_URI, "")
+    return parse_storage_base_uri(override or configured)
 
 
-def load_legacy_migration_descriptor(  # noqa: C901 - strict descriptor schema is validated as one transaction
-    *, repo_root: Path, storage_root: StorageRoot
-) -> LegacyMigrationDescriptor | None:
-    """Load a repository-scoped legacy inventory descriptor, when configured."""
-    raw_data: dict[str, object] = _load_repository_config(repo_root)
-    raw_logs: object = raw_data.get("logs")
-    if not isinstance(raw_logs, dict):
-        raise StorageConfigurationError(f"invalid {config.STORAGE_CONFIG_RELPATH}: missing [logs] table")
-    logs = cast("dict[str, object]", raw_logs)
-    raw_descriptor: object = logs.get("legacy_migration")
-    if raw_descriptor is None:
-        return None
-    if not isinstance(raw_descriptor, dict):
+def validate_client_repo(value: str) -> str:
+    """Validate the closed lowercase client-repository slug."""
+    if not _CLIENT_REPO_RE.fullmatch(value) or value in {".", ".."}:
         raise StorageConfigurationError(
-            f"invalid {config.STORAGE_CONFIG_RELPATH}: [logs.legacy_migration] must be a table"
+            "Git remote.origin.url did not yield a valid lowercase repository slug; "
+            "set remote.origin.url to a standard HTTPS, SSH, or SCP-like repository URL"
         )
-    descriptor = cast("dict[str, object]", raw_descriptor)
-    required: frozenset[str] = frozenset({
-        "inventory_key", "inventory_sha256", "schema", "source_commit", "storage_root",
-    })
-    if frozenset(descriptor) != required:
-        raise StorageConfigurationError(
-            f"invalid {config.STORAGE_CONFIG_RELPATH}: [logs.legacy_migration] has invalid fields"
+    return value
+
+
+def _repository_leaf(remote: str) -> str:
+    """Extract the final path component without returning remote text in errors."""
+    if (
+        not remote
+        or remote != remote.strip()
+        or any(
+            ord(character) < _ASCII_CONTROL_CHARACTER_MAX
+            or ord(character) == _ASCII_DELETE
+            for character in remote
         )
-    if not all(isinstance(descriptor[key], str) for key in required):
-        raise StorageConfigurationError(
-            f"invalid {config.STORAGE_CONFIG_RELPATH}: [logs.legacy_migration] values must be strings"
-        )
-    values = cast("dict[str, str]", descriptor)
-    digest: str = values["inventory_sha256"]
-    commit: str = values["source_commit"]
-    inventory_key: str = values["inventory_key"]
-    if len(digest) != _SHA256_HEX_LENGTH or any(character not in "0123456789abcdef" for character in digest):
-        raise StorageConfigurationError(
-            f"invalid {config.STORAGE_CONFIG_RELPATH}: legacy inventory SHA-256 is malformed"
-        )
-    if len(commit) != _GIT_COMMIT_HEX_LENGTH or any(character not in "0123456789abcdef" for character in commit):
-        raise StorageConfigurationError(
-            f"invalid {config.STORAGE_CONFIG_RELPATH}: legacy source commit is malformed"
-        )
-    key_parts: list[str] = inventory_key.split("/")
-    if inventory_key.startswith("/") or not inventory_key.endswith(".json") or any(
-        not part or part in {".", ".."} for part in key_parts
     ):
         raise StorageConfigurationError(
-            f"invalid {config.STORAGE_CONFIG_RELPATH}: legacy inventory key is unsafe"
+            "remote.origin.url is missing or malformed; set it to a standard HTTPS, SSH, "
+            "or SCP-like repository URL"
         )
-    if values["storage_root"] != storage_root.uri:
-        raise StorageConfigurationError("legacy migration descriptor does not match the active storage root")
-    if not values["schema"]:
+    path: str
+    if "://" in remote:
+        parsed: SplitResult = urlsplit(remote)
+        if (
+            parsed.scheme not in {"https", "ssh"}
+            or not parsed.netloc
+            or parsed.password is not None
+            or (parsed.scheme == "https" and parsed.username is not None)
+            or parsed.port is not None
+            or parsed.query
+            or parsed.fragment
+            or not parsed.path.startswith("/")
+        ):
+            raise StorageConfigurationError(
+                "remote.origin.url uses unsupported or credential-bearing syntax; "
+                "set a credential-free standard HTTPS or SSH repository URL"
+            )
+        path = parsed.path
+    else:
+        match: re.Match[str] | None = _SCP_REMOTE_RE.fullmatch(remote)
+        if match is None:
+            raise StorageConfigurationError(
+                "remote.origin.url uses unsupported or ambiguous syntax; set a standard "
+                "HTTPS, SSH, or SCP-like repository URL"
+            )
+        path = match.group("path")
+    path_segments: list[str] = path.lstrip("/").split("/")
+    if (
+        path.endswith("/")
+        or "//" in path
+        or any(not segment or segment in {".", ".."} for segment in path_segments)
+    ):
         raise StorageConfigurationError(
-            f"invalid {config.STORAGE_CONFIG_RELPATH}: legacy migration schema is empty"
-        )
-    return LegacyMigrationDescriptor(
-        schema=values["schema"], source_commit=commit, storage_root=values["storage_root"],
-        inventory_key=inventory_key, inventory_sha256=digest,
+            "remote.origin.url has an ambiguous repository path; set a standard repository URL"
     )
+    leaf: str = path_segments[-1].removesuffix(".git")
+    lowered: str = leaf.lower()
+    return validate_client_repo(lowered)
 
 
-def discover_storage_root(
+def derive_client_repo(
+    *,
+    repo_root: Path,
+    runner: proc.Runner | None = None,
+) -> str:
+    """Read the local origin and derive its canonical repository slug."""
+    active_runner: proc.Runner = proc.ProcRunner() if runner is None else runner
+    try:
+        result: proc.CommandResult = active_runner.run(
+            [
+                "git",
+                "-C",
+                str(repo_root),
+                "config",
+                "--local",
+                "--get",
+                "remote.origin.url",
+            ],
+            timeout=config.STORAGE_GIT_IDENTITY_TIMEOUT_SEC,
+            check=False,
+        )
+    except OSError as exc:
+        raise StorageConfigurationError(
+            "could not read local remote.origin.url; configure an origin repository remote"
+        ) from exc
+    if result.returncode != 0 or not result.stdout.strip():
+        raise StorageConfigurationError(
+            "local remote.origin.url is missing; configure an origin repository remote"
+        )
+    return _repository_leaf(result.stdout.strip())
+
+
+def load_tool_repository_storage(
+    *,
+    repo_root: Path,
+    environ: Mapping[str, str] | None = None,
+    runner: proc.Runner | None = None,
+) -> ToolRepositoryStorage:
+    """Require repository config and derive the fixed larch/client namespace."""
+    environment: Mapping[str, str] = os.environ if environ is None else environ
+    base: StorageBase = _configured_storage_base(
+        repo_root=repo_root, environ=environment
+    )
+    client_repo: str = derive_client_repo(repo_root=repo_root, runner=runner)
+    return ToolRepositoryStorage(base=base, client_repo=client_repo)
+
+
+def discover_tool_repository_storage(
     *,
     start: Path | None = None,
     environ: Mapping[str, str] | None = None,
     root_resolver: Callable[[Path | None], Path | None] = consumer_repo_root,
-) -> StorageRoot:
-    """Discover the Git repository root, then load its storage configuration."""
-    repo_root = root_resolver(start)
+    runner: proc.Runner | None = None,
+) -> ToolRepositoryStorage:
+    """Resolve the startup Git root, then pin config and origin identity."""
+    repo_root: Path | None = root_resolver(start)
     if repo_root is None:
-        location = str(start) if start is not None else str(Path.cwd())
-        raise StorageConfigurationError(f"could not discover a Git repository root from {location}")
-    return load_storage_root(repo_root=repo_root, environ=environ)
-
-
-def preflight_s3_bucket(*, storage_root: StorageRoot, runner: proc.Runner | None = None) -> None:
-    """Require a successful AWS bucket-root list, without inspecting its output."""
-    if storage_root.scheme != "s3":
-        raise StoragePreflightError(
-            f"S3 startup preflight requires an s3:// storage root, got {storage_root.scheme}://"
+        location: str = str(start) if start is not None else str(Path.cwd())
+        raise StorageConfigurationError(
+            f"could not discover a Git repository root from startup CWD {location}"
         )
-    active_runner = proc.ProcRunner() if runner is None else runner
-    result = active_runner.run(
-        [config.AWS_CLI, "s3", "ls", storage_root.bucket_uri],
-        timeout=config.STORAGE_PREFLIGHT_TIMEOUT_SEC,
-        check=False,
-    )
-    if result.returncode == 0:
-        return
-    if result.returncode == config.AWS_CLI_NOT_FOUND_EXIT_CODE:
-        raise StoragePreflightError(
-            f"AWS CLI is required for S3 storage preflight; install '{config.AWS_CLI}' and retry"
-        )
-    raise StoragePreflightError(
-        f"S3 bucket-root list failed for {storage_root.bucket_uri} (exit {result.returncode}); "
-        "verify normal AWS credential discovery and bucket access"
+    return load_tool_repository_storage(
+        repo_root=repo_root, environ=environ, runner=runner
     )
 
 
-def storage_preflight_main(argv: list[str]) -> int:
-    """Run the configured provider's bucket-root startup preflight."""
+def _validated_path_component(value: str, *, label: str) -> str:
+    if (
+        not value
+        or value in {".", ".."}
+        or "/" in value
+        or "\\" in value
+        or any(
+            character.isspace()
+            or ord(character) < _ASCII_CONTROL_CHARACTER_MAX
+            or ord(character) == _ASCII_DELETE
+            for character in value
+        )
+    ):
+        raise StorageConfigurationError(f"invalid {label}")
+    return value
+
+
+def parse_legacy_migration_descriptor(
+    raw_descriptor: object, *, storage_root: StorageBase
+) -> LegacyMigrationDescriptor:
+    """Validate an explicit operator migration descriptor without config discovery."""
+    if not isinstance(raw_descriptor, dict):
+        raise StorageConfigurationError("legacy migration descriptor must be a table")
+    descriptor: dict[str, object] = cast("dict[str, object]", raw_descriptor)
+    required: frozenset[str] = frozenset(
+        {
+            "inventory_key",
+            "inventory_sha256",
+            "schema",
+            "source_commit",
+            "storage_root",
+        }
+    )
+    if frozenset(descriptor) != required or not all(
+        isinstance(descriptor[key], str) for key in required
+    ):
+        raise StorageConfigurationError(
+            "legacy migration descriptor has invalid fields"
+        )
+    values: dict[str, str] = cast("dict[str, str]", descriptor)
+    digest: str = values["inventory_sha256"]
+    commit: str = values["source_commit"]
+    inventory_key: str = values["inventory_key"]
+    if len(digest) != _SHA256_HEX_LENGTH or any(
+        character not in "0123456789abcdef" for character in digest
+    ):
+        raise StorageConfigurationError("legacy inventory SHA-256 is malformed")
+    if len(commit) != _GIT_COMMIT_HEX_LENGTH or any(
+        character not in "0123456789abcdef" for character in commit
+    ):
+        raise StorageConfigurationError("legacy source commit is malformed")
+    key_parts: list[str] = inventory_key.split("/")
+    if (
+        inventory_key.startswith("/")
+        or not inventory_key.endswith(".json")
+        or any(not part or part in {".", ".."} for part in key_parts)
+    ):
+        raise StorageConfigurationError("legacy inventory key is unsafe")
+    if values["storage_root"] != storage_root.uri:
+        raise StorageConfigurationError(
+            "legacy migration descriptor does not match the explicit storage root"
+        )
+    if not values["schema"]:
+        raise StorageConfigurationError("legacy migration schema is empty")
+    return LegacyMigrationDescriptor(
+        schema=values["schema"],
+        source_commit=commit,
+        storage_root=values["storage_root"],
+        inventory_key=inventory_key,
+        inventory_sha256=digest,
+    )
+
+
+def preflight_tool_repository(
+    *,
+    storage: ToolRepositoryStorage,
+    environ: Mapping[str, str] | None = None,
+    runner: proc.Runner | None = None,
+) -> None:
+    """List at most one object under the exact tool/repository prefix."""
+    try:
+        object_store_for(storage, environ=environ, runner=runner).preflight_prefix()
+    except ObjectStoreError as exc:
+        if exc.kind.value == "configuration" and storage.scheme in {"s3", "r2"}:
+            raise StoragePreflightError(
+                f"AWS CLI is required for {storage.scheme.upper()} storage preflight; "
+                f"install '{config.AWS_CLI}' and retry"
+            ) from exc
+        raise StoragePreflightError(
+            f"{storage.scheme} prefix preflight failed for the configured larch repository "
+            "namespace; verify provider credentials and prefix-scoped list access"
+        ) from exc
+
+
+def storage_preflight_main(argv: Sequence[str]) -> int:
+    """Run the configured provider's prefix-scoped startup preflight."""
     parser = argparse.ArgumentParser(prog="cli.py run-log storage-preflight")
     _ = parser.add_argument("--repo-root", default="")
     try:
         args = parser.parse_args(argv)
     except SystemExit as exc:
         return int(exc.code) if isinstance(exc.code, int) else config.EXIT_USAGE
-    start = Path(args.repo_root) if args.repo_root else None
+    start: Path | None = Path(args.repo_root) if args.repo_root else None
     try:
-        storage_root = discover_storage_root(start=start)
-        if storage_root.scheme == "s3":
-            preflight_s3_bucket(storage_root=storage_root)
-        else:
-            object_store_for(storage_root).preflight_bucket()
+        storage: ToolRepositoryStorage = discover_tool_repository_storage(start=start)
+        preflight_tool_repository(storage=storage)
     except StorageConfigurationError as exc:
         print(f"storage preflight failed: {exc}", file=sys.stderr)
         return config.EXIT_STORAGE_CONFIG
     except StoragePreflightError as exc:
         print(f"storage preflight failed: {exc}", file=sys.stderr)
         return config.EXIT_STORAGE_PREFLIGHT
-    except ObjectStoreError as exc:
-        print(f"storage preflight failed: {exc}", file=sys.stderr)
-        return config.EXIT_STORAGE_PREFLIGHT
-    print(f"STORAGE_URI={storage_root.uri}")
-    print(f"RUN_LOGS_URI={storage_root.run_logs_uri}")
+    print(f"STORAGE_BASE_URI={storage.base.uri}")
+    print(f"CLIENT_REPO={storage.client_repo}")
+    print(f"TOOL_REPO_URI={storage.uri}")
+    print(f"RUN_LOGS_URI={storage.run_logs_uri}")
     print("PREFLIGHT_OK=true")
     return config.EXIT_OK

--- a/plugin/python/larch/report/storage_config.py
+++ b/plugin/python/larch/report/storage_config.py
@@ -335,15 +335,23 @@ def _repository_leaf(remote: str) -> str:
     path: str
     if "://" in remote:
         parsed: SplitResult = urlsplit(remote)
-        if (
+        try:
+            has_port: bool = parsed.port is not None
+        except ValueError:
+            has_port = True
+        unsupported_shape: bool = (
             parsed.scheme not in {"https", "ssh"}
             or not parsed.netloc
-            or parsed.password is not None
-            or (parsed.scheme == "https" and parsed.username is not None)
-            or parsed.port is not None
-            or parsed.query
-            or parsed.fragment
             or not parsed.path.startswith("/")
+        )
+        credential_bearing: bool = parsed.password is not None or (
+            parsed.scheme == "https" and parsed.username is not None
+        )
+        decorated: bool = has_port or bool(parsed.query) or bool(parsed.fragment)
+        if (
+            unsupported_shape
+            or credential_bearing
+            or decorated
         ):
             raise StorageConfigurationError(
                 "remote.origin.url uses unsupported or credential-bearing syntax; "

--- a/plugin/python/larch/report/tokens.py
+++ b/plugin/python/larch/report/tokens.py
@@ -26,7 +26,7 @@ from larch.core.repo_roots import RepoRootProbeOptions, repo_root_probe
 from larch.git import gh
 from larch.errors import ShipError
 from larch.report import analysis_state, markdown_block
-from larch.report import run_log_corpus
+from larch.report import run_log_corpus, storage_config
 from larch.report.report_tokens_models import RunRecord, Skill, VendorTotals, safe_int
 from larch.rendering.render_session_transcript import strip_plugin_cache_read_suffix
 
@@ -2032,8 +2032,11 @@ def _ngram_source_files(repo: Path) -> list[str]:
 def _measure_stamp() -> str:
     return os.environ.get("LARCH_MEASURE_DATE", datetime.now().strftime("%Y-%m-%d"))
 
-def _measurement_output(*, repo: Path, owner: str, suffix: str) -> Path:
-    return analysis_state.output_path(repo_root=repo, owner=owner, name=f"{_measure_stamp()}.{suffix}")
+def _measurement_storage(repo: Path) -> storage_config.ToolRepositoryStorage:
+    return storage_config.load_tool_repository_storage(repo_root=repo)
+
+def _measurement_output(*, repo: Path, storage: storage_config.ToolRepositoryStorage, owner: str, suffix: str) -> Path:
+    return analysis_state.output_path(repo_root=repo, storage=storage, owner=owner, name=f"{_measure_stamp()}.{suffix}")
 
 
 # Subprocess-isolated tiktoken encoder: the string literal below is not an AST Import
@@ -2061,7 +2064,8 @@ def _tiktoken_count_texts(texts: list[str]) -> list[int]:
 
 def measure_md_cost() -> Path:
     repo = _repo_root()
-    out_path = _measurement_output(repo=repo, owner="measure-md-cost", suffix="tsv")
+    storage = _measurement_storage(repo)
+    out_path = _measurement_output(repo=repo, storage=storage, owner="measure-md-cost", suffix="tsv")
     files = proc.run(["git", "-C", str(repo), "ls-files", "-z", "*.md"], stderr=subprocess.DEVNULL, check=True).stdout.split("\x00")
     out_path.parent.mkdir(parents=True, exist_ok=True)
     tier1_imports = _claude_root_imports(repo)
@@ -2092,7 +2096,8 @@ def measure_md_cost() -> Path:
 
 def measure_ngram_duplication() -> Path:
     repo = _repo_root()
-    out_path = _measurement_output(repo=repo, owner="measure-ngram-duplication", suffix="txt")
+    storage = _measurement_storage(repo)
+    out_path = _measurement_output(repo=repo, storage=storage, owner="measure-ngram-duplication", suffix="txt")
     size = int(os.environ.get("LARCH_MEASURE_NGRAM_SIZE", "6"))
     min_files = int(os.environ.get("LARCH_MEASURE_NGRAM_MIN_FILES", "3"))
     limit = int(os.environ.get("LARCH_MEASURE_NGRAM_LIMIT", "50"))
@@ -2114,8 +2119,9 @@ def measure_ngram_duplication() -> Path:
 
 def measure_references_heatmap() -> Path:
     repo = _repo_root()
-    out_path = _measurement_output(repo=repo, owner="measure-references-heatmap", suffix="tsv")
-    log_root = run_log_corpus.synchronized_repository_log_root(repo_root=repo)
+    storage = _measurement_storage(repo)
+    out_path = _measurement_output(repo=repo, storage=storage, owner="measure-references-heatmap", suffix="tsv")
+    log_root = run_log_corpus.synchronized_repository_log_root(repo_root=repo, storage=storage)
     run_dirs_by_skill = _skill_run_dirs(log_root)
     reads: list[ObservedReferenceRead] = []
     coverage_rows: list[tuple[str, int, int, int, float, str]] = []
@@ -2160,8 +2166,9 @@ def measure_references_heatmap() -> Path:
 
 def measure_realized_cost() -> Path:
     repo = _repo_root()
-    out_path = _measurement_output(repo=repo, owner="measure-realized-cost", suffix="tsv")
-    log_root = run_log_corpus.synchronized_repository_log_root(repo_root=repo)
+    storage = _measurement_storage(repo)
+    out_path = _measurement_output(repo=repo, storage=storage, owner="measure-realized-cost", suffix="tsv")
+    log_root = run_log_corpus.synchronized_repository_log_root(repo_root=repo, storage=storage)
     run_dirs_by_skill = _skill_run_dirs(log_root)
     skill_paths: dict[str, str] = {}
     skill_texts: list[str] = []
@@ -2509,7 +2516,8 @@ def measure_cache_efficiency() -> Path:
     runner = ProcRunner()
     tagged_records: list[tuple[Skill, RunRecord]] = []
     repo_root: Path = _repo_root()
-    log_root: Path = run_log_corpus.synchronized_repository_log_root(repo_root=repo_root)
+    storage = _measurement_storage(repo_root)
+    log_root: Path = run_log_corpus.synchronized_repository_log_root(repo_root=repo_root, storage=storage)
     for skill in ("design", "implement"):
         scan_result = report_tokens_scan.scan_prepared_corpus(
             runner,
@@ -2517,7 +2525,7 @@ def measure_cache_efficiency() -> Path:
             corpus_root=log_root,
         )
         tagged_records.extend((skill, record) for record in scan_result.records)
-    out_path = _measurement_output(repo=repo_root, owner="measure-cache-efficiency", suffix="tsv")
+    out_path = _measurement_output(repo=repo_root, storage=storage, owner="measure-cache-efficiency", suffix="tsv")
     out_path.parent.mkdir(parents=True, exist_ok=True)
     per_run, per_step = _measure_cache_efficiency_records(tagged_records=tagged_records)
     _atomic_text(path=out_path, text=_render_cache_efficiency_tsv(per_run=per_run, per_step=per_step))
@@ -2724,8 +2732,9 @@ def _render_checks_digest_savings_report(aggregate: ChecksDigestSavingsAggregate
 
 def measure_checks_digest_savings() -> Path:
     repo = _repo_root()
-    out_path = _measurement_output(repo=repo, owner="measure-checks-digest-savings", suffix="tsv")
-    log_root = run_log_corpus.synchronized_repository_log_root(repo_root=repo)
+    storage = _measurement_storage(repo)
+    out_path = _measurement_output(repo=repo, storage=storage, owner="measure-checks-digest-savings", suffix="tsv")
+    log_root = run_log_corpus.synchronized_repository_log_root(repo_root=repo, storage=storage)
     aggregate = ChecksDigestSavingsAggregate()
     for tsv in _iter_checks_digest_size_files(repo, corpus_root=log_root):
         has_header, rows_seen, rows_skipped, rows = _read_checks_digest_size_file(tsv)
@@ -2742,8 +2751,9 @@ def measure_checks_digest_savings() -> Path:
 
 def measure_panel_cost() -> Path:
     repo = _repo_root()
-    out_path = _measurement_output(repo=repo, owner="measure-panel-cost", suffix="tsv")
-    log_root = run_log_corpus.synchronized_repository_log_root(repo_root=repo)
+    storage = _measurement_storage(repo)
+    out_path = _measurement_output(repo=repo, storage=storage, owner="measure-panel-cost", suffix="tsv")
+    log_root = run_log_corpus.synchronized_repository_log_root(repo_root=repo, storage=storage)
     aggregates: dict[tuple[str, str, str], _PanelCostAggregate] = {}
     for tsv in _iter_panel_prompt_size_files(repo, corpus_root=log_root):
         context = _panel_context_from_tsv(tsv, repo, corpus_root=log_root)

--- a/plugin/skills/learn-from-bugs/SKILL.md
+++ b/plugin/skills/learn-from-bugs/SKILL.md
@@ -187,7 +187,7 @@ Use this one fragment for all three marker-producing paths: default mode after S
 
 This is a shared definition, not an immediate Step 4 action: first branch on `FILE_MODE` below. Default mode runs it before Step 5; filing mode runs it only after the no-residual or successful-create path has finished. Do not publish before that mode-specific work completes.
 
-Run the whole fragment as one Bash call. `learn-from-bugs state-publish` writes the reconciled marker under `$XDG_STATE_HOME/larch/analysis-state/<repo>/learn-from-bugs/` with private permissions and no Git mutation:
+Run the whole fragment as one Bash call. `learn-from-bugs state-publish` writes the reconciled marker under `$XDG_STATE_HOME/larch/analysis-state/v2/<client-repo>/<storage-origin-id>/learn-from-bugs/` with private permissions and no Git mutation:
 
 ```bash
 set -euo pipefail

--- a/plugin/skills/shared/run-lifecycle.md
+++ b/plugin/skills/shared/run-lifecycle.md
@@ -21,17 +21,18 @@ duplicate, missing, or later flags fail. When set, pass
 The lifecycle CLI validates it and derives the immutable parent; no other parent
 IDs or environment variables are allowed.
 
-Parse `RUN_ID`, `SKILL`, `LOG_ROOT`, `RUN_DIR`, `CONTEXT_FILE`, `STORAGE_URI`, and
-`LIFECYCLE_STARTED` from stdout without `eval` or `source`. Stop if the command
-fails or `LIFECYCLE_STARTED` is not `true`.
+Parse `RUN_ID`, `SKILL`, `LOG_ROOT`, `RUN_DIR`, `CONTEXT_FILE`,
+`STORAGE_BASE_URI`, `CLIENT_REPO`, `TOOL_REPO_URI`, `RUN_LOGS_URI`,
+`PREFLIGHT_OK`, and `LIFECYCLE_STARTED` from stdout without `eval` or `source`.
+Stop if the command fails or either success value is not `true`.
 
 Callers that already own a run ID pass `--run-id "<id>"`. Specialized owners
 also pass their absolute `--log-root` and `--adopt-existing` when rich artifact
 setup created the manifest first. A specialized owner whose Step 0 `session
 setup` parse binds `REPO_ROOT` passes `--repo-root "$REPO_ROOT"` to the start
 and terminal commands instead of the generic fallback shown here. The context file persists the validated
-identity, staging root, and storage URI so later subprocesses rehydrate them
-without shell state.
+identity, staging root, canonical tool repository URI, and storage-origin ID so
+later subprocesses rehydrate them without shell state.
 
 After start succeeds, run exactly one matching terminal command before the
 skill returns. A terminal command must succeed with `LIFECYCLE_FLUSHED=true`.

--- a/plugin/skills/voter-calibration/scripts/voter-calibration.md
+++ b/plugin/skills/voter-calibration/scripts/voter-calibration.md
@@ -10,7 +10,10 @@ The analyzer scans these synchronized log patterns under the resolved corpus roo
 - `<corpus-root>/implement/*/round-*/findings-classification.tsv`
 - `<corpus-root>/review/*/review-findings-classification-round-*.tsv`
 
-By default, the analyzer resolves the current Git repository, requires `config.toml` or `LARCH_LOGS_URI`, synchronizes once, and reads the unpacked cache. `--log-root DIR` bypasses synchronization for offline fixture tests.
+By default, the analyzer resolves the current Git repository, requires
+`tools-config.toml` and `[larch]`, derives repository identity from Git origin,
+synchronizes once, and reads the returned unpacked cache. `--log-root DIR`
+bypasses configuration and synchronization for offline fixture tests.
 
 ## Optional realized-outcome input
 

--- a/python/larch/calibration/difficulty_calibration.py
+++ b/python/larch/calibration/difficulty_calibration.py
@@ -16,7 +16,7 @@ from typing import cast
 
 from larch.calibration import difficulty
 from larch.core import repo_roots
-from larch.report import analysis_state, run_log_corpus
+from larch.report import analysis_state, run_log_corpus, storage_config
 from larch.report.report_tokens_cost import display_rates
 from larch.report.report_tokens_models import (
     VendorName,
@@ -928,11 +928,16 @@ def analyze_main(argv: list[str] | None = None) -> int:
             print("ERROR: could not discover a Git repository root for run-log synchronization", file=sys.stderr)
             return 2
         try:
-            log_root = run_log_corpus.synchronized_repository_log_root(repo_root=repo_root)
-        except run_log_corpus.RunLogCorpusError as exc:
+            storage = storage_config.load_tool_repository_storage(repo_root=repo_root)
+            log_root = run_log_corpus.synchronized_repository_log_root(
+                repo_root=repo_root, storage=storage
+            )
+        except (run_log_corpus.RunLogCorpusError, storage_config.StorageConfigurationError) as exc:
             print(f"ERROR: {exc}", file=sys.stderr)
             return 2
-        state_root = analysis_state.repository_state_root(repo_root=repo_root)
+        state_root = analysis_state.repository_state_root(
+            repo_root=repo_root, storage=storage
+        )
     if not log_root.is_dir():
         print(f"ERROR: --log-root is missing or not a directory: {log_root}", file=sys.stderr)
         return 2

--- a/python/larch/core/config.py
+++ b/python/larch/core/config.py
@@ -40,11 +40,16 @@ EXIT_INTERNAL_ERROR: Final = 1
 EXIT_STORAGE_CONFIG: Final = EXIT_USAGE
 EXIT_STORAGE_PREFLIGHT: Final = EXIT_INTERNAL_ERROR
 ENV_LARCH_LOGS_URI: Final = "LARCH_LOGS_URI"
-STORAGE_CONFIG_RELPATH: Final = "config.toml"
+ENV_LARCH_STORAGE_BASE_URI: Final = "LARCH_STORAGE_BASE_URI"
+STORAGE_CONFIG_RELPATH: Final = "tools-config.toml"
+LARCH_TOOL_NAME: Final = "larch"
+STORAGE_BASE_URI_FIELD: Final = "storage_base_uri"
+RUN_LOGS_DATA_TYPE: Final = "run-logs"
 STORAGE_URI_SCHEMES: Final[tuple[str, ...]] = ("gs", "r2", "s3")
 AWS_CLI: Final = "aws"
 AWS_CLI_NOT_FOUND_EXIT_CODE: Final = 127
 STORAGE_PREFLIGHT_TIMEOUT_SEC: Final = 30
+STORAGE_GIT_IDENTITY_TIMEOUT_SEC: Final = 10
 RUN_LOG_ARCHIVE_MAX_MEMBERS: Final = 10_000
 RUN_LOG_ARCHIVE_MAX_MEMBER_BYTES: Final = 256 * 1024 * 1024
 RUN_LOG_ARCHIVE_MAX_EXPANDED_BYTES: Final = 1024 * 1024 * 1024
@@ -305,14 +310,12 @@ STALL_RECOVERY_BAIL_REASON_TOKENS: Final[tuple[str, ...]] = tuple(dict.fromkeys(
 )))
 
 # Repository-scoped mutable analyzer state. Paths are relative to
-# $XDG_STATE_HOME/larch/analysis-state/<repo>/, never larch-logs/.
+# $XDG_STATE_HOME/larch/analysis-state/v2/<client>/<storage-origin-id>/,
+# never larch-logs/.
 LEARN_FROM_BUGS_NUDGE_THRESHOLD: Final = 25
 LEARN_FROM_BUGS_STATE_RELPATH: Final = "learn-from-bugs/state.json"
 ANALYZE_BUGS_STATE_RELPATH: Final = "analyze-bugs/state.json"
 VALIDATE_MERGED_STATE_RELPATH: Final = "validate-merged/state.json"
-LEGACY_LEARN_FROM_BUGS_STATE_RELPATH: Final = "larch-logs/shared/learn-from-bugs-state.json"
-LEGACY_ANALYZE_BUGS_STATE_RELPATH: Final = "larch-logs/shared/analyze-bugs-state.json"
-LEGACY_VALIDATE_MERGED_STATE_RELPATH: Final = "larch-logs/shared/validate-merged-state.json"
 
 # Transient retry defaults shared with python/retry.py.
 TRANSIENT_RETRY_MAX_ATTEMPTS: Final = 3

--- a/python/larch/design/design_pause.py
+++ b/python/larch/design/design_pause.py
@@ -321,7 +321,7 @@ def pause_load_main(argv: Sequence[str]) -> int:
         return _load_fail_clear(issue=issue, repo=repo, error="legacy-git-snapshot")
     try:
         repo_root = Path(repo_top)
-        storage_root = storage_config.discover_storage_root(start=repo_root)
+        storage_root = storage_config.discover_tool_repository_storage(start=repo_root)
         publication_paths = run_log_publish.publication_paths(
             request=run_log_publish.PublicationRequest(
                 repo_root=repo_root,

--- a/python/larch/issue/analyze_bugs.py
+++ b/python/larch/issue/analyze_bugs.py
@@ -1342,7 +1342,6 @@ def prefetch(
     checkout = repo_roots.consumer_repo_root() or Path.cwd().resolve()
     state_root = Path(state_root_arg).expanduser().resolve() if state_root_arg else analysis_state.repository_state_root(repo_root=checkout)
     ledger_path = state_root / "analyze-bugs" / _sanitize_repo_slug(repo) / "ledger.jsonl"
-    _ = analysis_state.import_legacy_file(path=ledger_path, legacy_path=repo_root / "ledger.jsonl")
     rows = [
         build_bundle_record(runner=runner, issue=issue, repo=repo, evidence_ref=evidence_ref, run_dir=run_dir, diff_cap=diff_cap, body_cap=body_cap)
         for issue in issues

--- a/python/larch/issue/learn_from_bugs.py
+++ b/python/larch/issue/learn_from_bugs.py
@@ -261,10 +261,10 @@ def state_path(root: Path) -> Path:
     if not root_path.is_absolute():
         root_path = Path.cwd() / root_path
     root_path = root_path.resolve()
-    target = analysis_state.repository_state_root(repo_root=root_path) / config.LEARN_FROM_BUGS_STATE_RELPATH
-    if not target.exists() and not target.is_symlink():
-        _ = analysis_state.import_legacy_file(path=target, legacy_path=root_path / config.LEGACY_LEARN_FROM_BUGS_STATE_RELPATH)
-    return target
+    return (
+        analysis_state.repository_state_root(repo_root=root_path)
+        / config.LEARN_FROM_BUGS_STATE_RELPATH
+    )
 
 
 def _int_field(payload: Mapping[str, object], key: str, default: int) -> int:

--- a/python/larch/issue/rejected_analysis.py
+++ b/python/larch/issue/rejected_analysis.py
@@ -28,15 +28,13 @@ from larch.errors import ShipError
 
 from larch.git import gh
 from larch.issue import issue_wire
-from larch.report import analysis_state, run_log_corpus
+from larch.report import analysis_state, run_log_corpus, storage_config
 from larch.review import voting
 from larch.review.review_types import parse_canonical_heading
 
 DEFAULT_VERIFY_CAP = 100
 LEDGER_PATH = Path("rejected-analysis/ledger.tsv")
 VERDICT_SIDECAR = Path("rejected-analysis/verdicts.tsv")
-LEGACY_LEDGER_PATH = Path("larch-logs/rejected-analysis-ledger.tsv")
-LEGACY_VERDICT_SIDECAR = Path("larch-logs/rejected-analysis-verdicts.tsv")
 INGEST_STATUS_FILE = "ingest-status.jsonl"
 FINDING_HASH_FIELDS = ("file_path", "concern")
 LEDGER_SCHEMA_VERSION = "1"
@@ -1001,6 +999,7 @@ def prepare(
     verify_cap: int = DEFAULT_VERIFY_CAP,
     repo_root: Path | str | None = None,
     state_root: Path | str | None = None,
+    storage: storage_config.ToolRepositoryStorage | None = None,
     runner: proc.Runner | None = None,
     open_issues: Sequence[OpenIssue] | None = (),
 ) -> PrepareResult:
@@ -1018,7 +1017,14 @@ def prepare(
             )
         root = discovered_root
         try:
-            logs = run_log_corpus.synchronized_repository_log_root(repo_root=root)
+            logs = (
+                run_log_corpus.synchronized_repository_log_root(repo_root=root)
+                if storage is None
+                else run_log_corpus.synchronized_repository_log_root(
+                    repo_root=root,
+                    storage=storage,
+                )
+            )
         except run_log_corpus.RunLogCorpusError as exc:
             raise RejectedAnalysisError(str(exc)) from exc
     else:
@@ -1030,8 +1036,6 @@ def prepare(
     active_runner = runner or proc.ProcRunner()
     issues = _query_open_issues(active_runner, repo_root=root) if open_issues is None else list(open_issues)
     ledger_path = mutable_root / LEDGER_PATH
-    if state_root is not None:
-        _ = analysis_state.import_legacy_file(path=ledger_path, legacy_path=root / LEGACY_LEDGER_PATH)
     committed_hashes = _read_ledger_hashes(ledger_path)
     all_findings: list[RejectedFinding] = []
     ledger_entries: list[LedgerEntry] = []
@@ -1091,6 +1095,7 @@ def prepare(
     _write_json(wd / "candidates.json", [_candidate_to_json(candidate) for candidate in candidates])
     _write_jsonl(wd / "drops.jsonl", [entry.to_row() for entry in ledger_entries])
     (wd / "repo-root.txt").write_text(str(root) + "\n", encoding="utf-8")
+    (wd / "state-root.txt").write_text(str(mutable_root) + "\n", encoding="utf-8")
     return PrepareResult(
         work_dir=wd,
         verify_count=len(candidates),
@@ -1480,9 +1485,6 @@ def record(
     root = Path(repo_root or Path.cwd()).resolve()
     mutable_root = Path(state_root).resolve() if state_root is not None else root
     ledger_path = mutable_root / LEDGER_PATH
-    if state_root is not None:
-        _ = analysis_state.import_legacy_file(path=ledger_path, legacy_path=root / LEGACY_LEDGER_PATH)
-        _ = analysis_state.import_legacy_file(path=mutable_root / VERDICT_SIDECAR, legacy_path=root / LEGACY_VERDICT_SIDECAR)
     pending_rows = _merge_ledger_rows(_read_ledger_entries(wd / "ledger-pending.tsv"))
     status_map = _load_ingest_status_map(wd)
     candidate_list = _load_candidates(wd)
@@ -1613,13 +1615,27 @@ def prepare_main(argv: list[str]) -> int:
         repo_root = repo_roots.consumer_repo_root(Path.cwd().resolve())
         if repo_root is None:
             raise RejectedAnalysisError("could not discover a Git repository root")
+        storage = (
+            None
+            if args.log_root
+            else storage_config.load_tool_repository_storage(repo_root=repo_root)
+        )
+        state_root = (
+            repo_root
+            if storage is None
+            else analysis_state.repository_state_root(
+                repo_root=repo_root,
+                storage=storage,
+            )
+        )
         result = prepare(
             days=args.days,
             log_root=args.log_root or None,
             work_dir=args.work_dir or None,
             verify_cap=args.verify_cap,
             repo_root=repo_root,
-            state_root=analysis_state.repository_state_root(repo_root=repo_root),
+            state_root=state_root,
+            storage=storage,
             open_issues=None,
         )
     except (RejectedAnalysisError, ValueError) as exc:
@@ -1678,6 +1694,14 @@ def _repo_root_from_work_dir(work_dir: Path) -> Path | None:
     return Path(text).resolve() if text else None
 
 
+def _state_root_from_work_dir(work_dir: Path) -> Path | None:
+    path = work_dir / "state-root.txt"
+    if not path.is_file():
+        return None
+    text = path.read_text(encoding="utf-8").strip()
+    return Path(text).resolve() if text else None
+
+
 def record_main(argv: list[str]) -> int:
     parser = argparse.ArgumentParser(prog="rejected-analysis record")
     parser.add_argument("--work-dir", required=True)
@@ -1689,6 +1713,7 @@ def record_main(argv: list[str]) -> int:
     args = parser.parse_args(argv)
     work_dir = Path(args.work_dir)
     repo_root = Path(args.repo_root).resolve() if args.repo_root else _repo_root_from_work_dir(work_dir)
+    state_root = _state_root_from_work_dir(work_dir)
     try:
         result = record(
             work_dir=args.work_dir,
@@ -1697,7 +1722,7 @@ def record_main(argv: list[str]) -> int:
             issues_failed=args.issues_failed,
             launch_failures=args.launch_failures,
             repo_root=repo_root,
-            state_root=analysis_state.repository_state_root(repo_root=repo_root) if repo_root else None,
+            state_root=state_root,
         )
     except RejectedAnalysisError as exc:
         logging_util.diagnostic(f"rejected-analysis record: {exc}")

--- a/python/larch/issue/validate_merged.py
+++ b/python/larch/issue/validate_merged.py
@@ -70,12 +70,7 @@ def _timestamp(value: object, *, label: str) -> str:
 
 def state_path(root: Path) -> Path:
     repo_root = root.expanduser().resolve()
-    target = analysis_state.repository_state_root(repo_root=repo_root) / STATE_RELPATH
-    try:
-        _ = analysis_state.import_legacy_file(path=target, legacy_path=repo_root / config.LEGACY_VALIDATE_MERGED_STATE_RELPATH)
-    except analysis_state.AnalysisStateError as exc:
-        raise ValidateMergedError(str(exc)) from exc
-    return target
+    return analysis_state.repository_state_root(repo_root=repo_root) / STATE_RELPATH
 
 
 def _candidate_from_raw(raw: object) -> dict[str, str]:

--- a/python/larch/report/analysis_state.py
+++ b/python/larch/report/analysis_state.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Final
 from larch import io as larch_io
-from larch.report import run_log_publish
+from larch.report import run_log_publish, storage_config
 
 _ENV_XDG_STATE_HOME: Final = "XDG_STATE_HOME"
 MISSING_DIGEST: Final = "missing"
@@ -34,13 +34,18 @@ class StateSnapshot:
 def repository_state_root(
     *,
     repo_root: Path,
+    storage: storage_config.ToolRepositoryStorage | None = None,
     state_home: Path | None = None,
     environ: Mapping[str, str] | None = None,
 ) -> Path:
     """Return the literal repository root for mutable analyzer state."""
     trusted_repo = larch_io.validate_trusted_directory(repo_root)
-    repo_name = run_log_publish.validated_component(
-        trusted_repo.name, label="repository name", slug=False
+    active_storage: storage_config.ToolRepositoryStorage = (
+        storage
+        if storage is not None
+        else storage_config.load_tool_repository_storage(
+            repo_root=trusted_repo, environ=environ
+        )
     )
     environment = os.environ if environ is None else environ
     resolved_home = state_home or run_log_publish.xdg_home(
@@ -50,12 +55,20 @@ def repository_state_root(
     )
     if not resolved_home.is_absolute():
         raise ValueError("analysis state home must be an absolute path")
-    return resolved_home.expanduser().resolve() / "larch" / "analysis-state" / repo_name
+    return (
+        resolved_home.expanduser().resolve()
+        / "larch"
+        / "analysis-state"
+        / "v2"
+        / active_storage.client_repo
+        / active_storage.storage_origin_id
+    )
 
 
-def state_path(
+def state_path(  # noqa: PLR0913 - state identity, owner, home, and environment remain explicit.
     *,
     repo_root: Path,
+    storage: storage_config.ToolRepositoryStorage | None = None,
     owner: str,
     name: str,
     state_home: Path | None = None,
@@ -69,16 +82,20 @@ def state_path(
     )
     return (
         repository_state_root(
-            repo_root=repo_root, state_home=state_home, environ=environ
+            repo_root=repo_root,
+            storage=storage,
+            state_home=state_home,
+            environ=environ,
         )
         / owner_name
         / file_name
     )
 
 
-def output_path(
+def output_path(  # noqa: PLR0913 - output creation shares the explicit state-path boundary.
     *,
     repo_root: Path,
+    storage: storage_config.ToolRepositoryStorage | None = None,
     owner: str,
     name: str,
     state_home: Path | None = None,
@@ -86,6 +103,7 @@ def output_path(
 ) -> Path:
     path = state_path(
         repo_root=repo_root,
+        storage=storage,
         owner=owner,
         name=name,
         state_home=state_home,
@@ -171,16 +189,3 @@ def append_bytes(path: Path, data: bytes) -> None:
     with state_lock(path):
         current = _snapshot_unlocked(path).data or b""
         _atomic_write_unlocked(path, current + data)
-
-
-def import_legacy_file(*, path: Path, legacy_path: Path) -> StateSnapshot:
-    """Import a regular legacy file once, then ignore later legacy changes."""
-    with state_lock(path):
-        current = _snapshot_unlocked(path)
-        if current.data is not None:
-            return current
-        legacy = _snapshot_unlocked(legacy_path)
-        if legacy.data is None:
-            return current
-        _atomic_write_unlocked(path, legacy.data)
-        return StateSnapshot(legacy.data, legacy.digest)

--- a/python/larch/report/object_store.py
+++ b/python/larch/report/object_store.py
@@ -59,8 +59,20 @@ class CommandObjectStore:
         if not isinstance(value, dict):
             raise ObjectStoreError(ObjectStoreErrorKind.INVALID_RESPONSE, self.root.scheme, operation)
         return cast("dict[str, object]", value)
-    def preflight_bucket(self) -> None:
-        command = self._gcs("preflight") if self.root.scheme == "gs" else self._aws("s3", "ls", f"s3://{self.root.bucket}")
+    def preflight_prefix(self) -> None:
+        remote_prefix = self._list_prefix("")
+        command = (
+            self._gcs("preflight", "--prefix", remote_prefix)
+            if self.root.scheme == "gs"
+            else self._aws(
+                "s3api", "list-objects-v2",
+                "--bucket", self.root.bucket,
+                "--prefix", remote_prefix,
+                "--max-keys", "1",
+                "--no-paginate",
+                "--output", "json",
+            )
+        )
         _ = self._run(command, "preflight")
     def list_objects(self, prefix: str = "") -> tuple[RemoteObject, ...]:
         remote_prefix, token = self._list_prefix(prefix), None

--- a/python/larch/report/run_lifecycle.py
+++ b/python/larch/report/run_lifecycle.py
@@ -27,11 +27,15 @@ from larch.report import (
     run_logs,
     storage_config,
 )
-from larch.report.run_log_publish import ObjectStore, PublicationRequest, PublicationResult
-from larch.report.storage_config import StorageRoot
+from larch.report.run_log_publish import (
+    ObjectStore,
+    PublicationRequest,
+    PublicationResult,
+)
+from larch.report.storage_config import ToolRepositoryStorage
 
-LIFECYCLE_SCHEMA_VERSION: Final = 1
-LIFECYCLE_CONTEXT_SCHEMA_VERSION: Final = 1
+LIFECYCLE_SCHEMA_VERSION: Final = 2
+LIFECYCLE_CONTEXT_SCHEMA_VERSION: Final = 2
 LIFECYCLE_CONTEXT_BASENAME: Final = "context.json"
 UNIVERSAL_FINAL_REPORT: Final = "final-report.md"
 UNIVERSAL_EXECUTION_ISSUES: Final = "execution-issues.ndjson"
@@ -55,7 +59,18 @@ def _require_lifecycle(condition: bool, message: str) -> None:  # noqa: FBT001 -
         raise RunLifecycleError(message)
 
 
-TERMINAL_EXCEPTIONS: Final = (EOFError, object_store.ObjectStoreError, OSError, run_log_publish.PublicationError, RunLifecycleError, ShipError, storage_config.StorageConfigurationError, tarfile.TarError, TypeError, ValueError)
+TERMINAL_EXCEPTIONS: Final = (
+    EOFError,
+    object_store.ObjectStoreError,
+    OSError,
+    run_log_publish.PublicationError,
+    RunLifecycleError,
+    ShipError,
+    storage_config.StorageConfigurationError,
+    tarfile.TarError,
+    TypeError,
+    ValueError,
+)
 
 
 @dataclass(frozen=True)
@@ -63,7 +78,7 @@ class LifecycleStart:
     """Validated state created for one skill invocation."""
 
     repo_root: Path
-    storage_root: StorageRoot
+    storage_root: ToolRepositoryStorage
     skill: str
     run_id: str
     log_root: Path
@@ -87,7 +102,9 @@ def _utc_now() -> str:
 def _validated_repo_root(repo_root: Path) -> Path:
     resolved = repo_roots.consumer_repo_root(repo_root)
     if resolved is None:
-        raise RunLifecycleError(f"could not discover a Git repository root from {repo_root}")
+        raise RunLifecycleError(
+            f"could not discover a Git repository root from {repo_root}"
+        )
     return larch_io.validate_trusted_directory(resolved)
 
 
@@ -100,71 +117,198 @@ def _state_home(environ: Mapping[str, str]) -> Path:
 
 
 def lifecycle_log_root(
-    *, repo_root: Path, environ: Mapping[str, str] | None = None
+    *,
+    repo_root: Path,
+    storage: ToolRepositoryStorage,
+    environ: Mapping[str, str] | None = None,
 ) -> Path:
     """Return the durable mutable staging root for universal skill runs."""
     environment = os.environ if environ is None else environ
-    root = _validated_repo_root(repo_root)
-    repo_name = run_log_publish.validated_component(
-        root.name, label="repository name", slug=False
+    _ = _validated_repo_root(repo_root)
+    return (
+        _state_home(environment)
+        / "larch"
+        / "run-lifecycle"
+        / "v2"
+        / storage.client_repo
+        / storage.storage_origin_id
+        / "staging"
     )
-    return _state_home(environment) / "larch" / "run-lifecycle" / repo_name / "staging"
 
 
-def _context_file(*, repo_root: Path, skill: str, run_id: str, environ: Mapping[str, str]) -> Path:
-    return _state_home(environ) / "larch" / "run-lifecycle" / run_log_publish.validated_component(repo_root.name, label="repository name", slug=False) / "contexts" / skill / run_id / LIFECYCLE_CONTEXT_BASENAME
+def _context_file(
+    *,
+    storage: ToolRepositoryStorage,
+    skill: str,
+    run_id: str,
+    environ: Mapping[str, str],
+) -> Path:
+    return (
+        _state_home(environ)
+        / "larch"
+        / "run-lifecycle"
+        / "v2"
+        / storage.client_repo
+        / storage.storage_origin_id
+        / "contexts"
+        / skill
+        / run_id
+        / LIFECYCLE_CONTEXT_BASENAME
+    )
 
 
 def _write_context(*, started: LifecycleStart) -> None:
-    larch_io.atomic_write(started.context_file, json.dumps({"schema_version": LIFECYCLE_CONTEXT_SCHEMA_VERSION, "repo_root": str(started.repo_root), "storage_uri": started.storage_root.uri, "skill": started.skill, "run_id": started.run_id, "log_root": str(started.log_root), "run_dir": str(started.run_dir)}, separators=(",", ":"), sort_keys=True) + "\n", mode=0o600, nofollow=True)
+    larch_io.atomic_write(
+        started.context_file,
+        json.dumps(
+            {
+                "schema_version": LIFECYCLE_CONTEXT_SCHEMA_VERSION,
+                "repo_root": str(started.repo_root),
+                "storage_base_uri": started.storage_root.base.uri,
+                "client_repo": started.storage_root.client_repo,
+                "tool_repo_uri": started.storage_root.uri,
+                "storage_origin_id": started.storage_root.storage_origin_id,
+                "skill": started.skill,
+                "run_id": started.run_id,
+                "log_root": str(started.log_root),
+                "run_dir": str(started.run_dir),
+            },
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        + "\n",
+        mode=0o600,
+        nofollow=True,
+    )
 
 
-def load_run_context(*, repo_root: Path, skill: str, run_id: str, environ: Mapping[str, str] | None = None) -> LifecycleStart:
+def load_run_context(
+    *,
+    repo_root: Path,
+    skill: str,
+    run_id: str,
+    environ: Mapping[str, str] | None = None,
+    storage_root: ToolRepositoryStorage | None = None,
+) -> LifecycleStart:
     """Rehydrate one lifecycle context without inherited shell state."""
     environment = os.environ if environ is None else environ
     root = _validated_repo_root(repo_root)
     skill_name = run_log_publish.validated_component(skill, label="skill", slug=True)
     run_name = run_log_publish.validated_component(run_id, label="run-id", slug=True)
-    context_file = _context_file(repo_root=root, skill=skill_name, run_id=run_name, environ=environment)
-    _require_lifecycle(not context_file.is_symlink() and context_file.is_file(), f"lifecycle context is missing or unsafe: {context_file}")
+    active_storage = storage_root or storage_config.load_tool_repository_storage(
+        repo_root=root, environ=environment
+    )
+    context_file = _context_file(
+        storage=active_storage,
+        skill=skill_name,
+        run_id=run_name,
+        environ=environment,
+    )
+    _require_lifecycle(
+        not context_file.is_symlink() and context_file.is_file(),
+        f"lifecycle context is missing or unsafe: {context_file}",
+    )
     raw: object = json.loads(context_file.read_text(encoding="utf-8"))
     _require_lifecycle(isinstance(raw, dict), "lifecycle context must be a JSON object")
     data = cast("dict[str, object]", raw)
-    expected: dict[str, object] = {"schema_version": LIFECYCLE_CONTEXT_SCHEMA_VERSION, "repo_root": str(root), "skill": skill_name, "run_id": run_name}
-    _require_lifecycle(all(data.get(key) == value for key, value in expected.items()), "lifecycle context identity mismatch")
-    storage_uri, log_root_raw, run_dir_raw = data.get("storage_uri"), data.get("log_root"), data.get("run_dir")
-    _require_lifecycle(all(isinstance(value, str) and value for value in (storage_uri, log_root_raw, run_dir_raw)), "lifecycle context paths or storage URI are missing")
-    storage_root = storage_config._parse_storage_uri(str(storage_uri))  # pyright: ignore[reportPrivateUsage]  # persisted context reuses canonical parser  # noqa: SLF001 - sibling parser owns validation
+    expected: dict[str, object] = {
+        "schema_version": LIFECYCLE_CONTEXT_SCHEMA_VERSION,
+        "repo_root": str(root),
+        "skill": skill_name,
+        "run_id": run_name,
+    }
+    _require_lifecycle(
+        all(data.get(key) == value for key, value in expected.items()),
+        "lifecycle context identity mismatch",
+    )
+    tool_repo_uri = data.get("tool_repo_uri")
+    client_repo = data.get("client_repo")
+    storage_origin_id = data.get("storage_origin_id")
+    storage_base_uri = data.get("storage_base_uri")
+    log_root_raw, run_dir_raw = data.get("log_root"), data.get("run_dir")
+    _require_lifecycle(
+        all(
+            isinstance(value, str) and value
+            for value in (
+                tool_repo_uri,
+                client_repo,
+                storage_origin_id,
+                storage_base_uri,
+                log_root_raw,
+                run_dir_raw,
+            )
+        ),
+        "lifecycle context paths or storage identity are missing",
+    )
+    storage = storage_config.parse_tool_repository_uri(
+        str(tool_repo_uri), expected_client_repo=str(client_repo)
+    )
+    _require_lifecycle(
+        storage == active_storage
+        and storage.base.uri == storage_base_uri
+        and storage.storage_origin_id == storage_origin_id,
+        "configured storage or Git origin changed after lifecycle start",
+    )
     log_root = Path(str(log_root_raw))
     run_dir = Path(str(run_dir_raw))
-    _require_lifecycle(log_root.is_absolute() and run_dir == log_root / skill_name / run_name, "lifecycle context staging path mismatch")
-    return LifecycleStart(root, storage_root, skill_name, run_name, log_root, run_dir, context_file)
+    _require_lifecycle(
+        log_root.is_absolute() and run_dir == log_root / skill_name / run_name,
+        "lifecycle context staging path mismatch",
+    )
+    return LifecycleStart(
+        root, storage, skill_name, run_name, log_root, run_dir, context_file
+    )
 
 
-def _parent_identity_from_context(*, repo_root: Path, context_file: Path, environ: Mapping[str, str]) -> tuple[str, str]:
-    _require_lifecycle(context_file.is_absolute() and not context_file.is_symlink() and context_file.is_file(), "parent lifecycle context is missing or unsafe")
+def _parent_identity_from_context(
+    *,
+    repo_root: Path,
+    context_file: Path,
+    environ: Mapping[str, str],
+    storage: ToolRepositoryStorage,
+) -> tuple[str, str]:
+    _require_lifecycle(
+        context_file.is_absolute()
+        and not context_file.is_symlink()
+        and context_file.is_file(),
+        "parent lifecycle context is missing or unsafe",
+    )
     raw: object = json.loads(context_file.read_text(encoding="utf-8"))
-    _require_lifecycle(isinstance(raw, dict), "parent lifecycle context identity is missing")
+    _require_lifecycle(
+        isinstance(raw, dict), "parent lifecycle context identity is missing"
+    )
     data = cast("dict[str, object]", raw)
-    _require_lifecycle(isinstance(data.get("skill"), str) and isinstance(data.get("run_id"), str), "parent lifecycle context identity is missing")
-    parent = load_run_context(repo_root=repo_root, skill=cast("str", data["skill"]), run_id=cast("str", data["run_id"]), environ=environ)
-    _require_lifecycle(parent.context_file == context_file, "parent lifecycle context path mismatch")
+    _require_lifecycle(
+        isinstance(data.get("skill"), str) and isinstance(data.get("run_id"), str),
+        "parent lifecycle context identity is missing",
+    )
+    parent = load_run_context(
+        repo_root=repo_root,
+        skill=cast("str", data["skill"]),
+        run_id=cast("str", data["run_id"]),
+        environ=environ,
+        storage_root=storage,
+    )
+    _require_lifecycle(
+        parent.context_file == context_file, "parent lifecycle context path mismatch"
+    )
     return parent.skill, parent.run_id
 
 
-def _preflight_storage(storage_root: StorageRoot) -> None:
-    if storage_root.scheme == "s3":
-        storage_config.preflight_s3_bucket(storage_root=storage_root)
-        return
-    object_store.object_store_for(storage_root).preflight_bucket()
+def _preflight_storage(storage: ToolRepositoryStorage) -> None:
+    storage_config.preflight_tool_repository(storage=storage)
 
 
 def _validate_parent(*, parent_skill: str, parent_run_id: str) -> None:
     if bool(parent_skill) != bool(parent_run_id):
         raise ValueError("--parent-skill and --parent-run-id must be provided together")
     if parent_skill:
-        _ = run_log_publish.validated_component(parent_skill, label="parent skill", slug=True)
-        _ = run_log_publish.validated_component(parent_run_id, label="parent run-id", slug=True)
+        _ = run_log_publish.validated_component(
+            parent_skill, label="parent skill", slug=True
+        )
+        _ = run_log_publish.validated_component(
+            parent_run_id, label="parent run-id", slug=True
+        )
 
 
 def start_run(  # noqa: PLR0913 - lifecycle boundary validates identity, adoption, storage, and parent state together.
@@ -173,31 +317,45 @@ def start_run(  # noqa: PLR0913 - lifecycle boundary validates identity, adoptio
     skill: str,
     parent_skill: str = "",
     parent_run_id: str = "",
-    run_id: str | None = None, log_root: Path | None = None, issue: str = "",
-    adopt_existing: bool = False, parent_context: Path | None = None,
+    run_id: str | None = None,
+    log_root: Path | None = None,
+    issue: str = "",
+    adopt_existing: bool = False,
+    parent_context: Path | None = None,
     environ: Mapping[str, str] | None = None,
-    storage_root: StorageRoot | None = None,
-    preflight: Callable[[StorageRoot], None] = _preflight_storage,
+    storage_root: ToolRepositoryStorage | None = None,
+    preflight: Callable[[ToolRepositoryStorage], None] = _preflight_storage,
 ) -> LifecycleStart:
     """Preflight storage and create a unique, isolated skill-run staging tree."""
     environment = os.environ if environ is None else environ
     root = _validated_repo_root(repo_root)
     skill_name = run_log_publish.validated_component(skill, label="skill", slug=True)
-    if parent_context is not None:
-        if parent_skill or parent_run_id:
-            raise ValueError("parent context cannot be combined with explicit parent identity")
-        parent_skill, parent_run_id = _parent_identity_from_context(repo_root=root, context_file=parent_context, environ=environment)
-    _validate_parent(parent_skill=parent_skill, parent_run_id=parent_run_id)
-    active_storage = storage_root or storage_config.load_storage_root(
+    active_storage = storage_root or storage_config.load_tool_repository_storage(
         repo_root=root, environ=environment
     )
+    if parent_context is not None:
+        if parent_skill or parent_run_id:
+            raise ValueError(
+                "parent context cannot be combined with explicit parent identity"
+            )
+        parent_skill, parent_run_id = _parent_identity_from_context(
+            repo_root=root,
+            context_file=parent_context,
+            environ=environment,
+            storage=active_storage,
+        )
+    _validate_parent(parent_skill=parent_skill, parent_run_id=parent_run_id)
     preflight(active_storage)
     selected_run_id = run_id or str(uuid.uuid4())
     run_name = run_log_publish.validated_component(
         selected_run_id, label="run-id", slug=True
     )
-    selected_log_root = log_root or lifecycle_log_root(repo_root=root, environ=environment)
-    _require_lifecycle(selected_log_root.is_absolute(), "lifecycle log root must be absolute")
+    selected_log_root = log_root or lifecycle_log_root(
+        repo_root=root, storage=active_storage, environ=environment
+    )
+    _require_lifecycle(
+        selected_log_root.is_absolute(), "lifecycle log root must be absolute"
+    )
     init = run_logs.log_init(
         log_root=selected_log_root,
         skill=skill_name,
@@ -213,35 +371,88 @@ def start_run(  # noqa: PLR0913 - lifecycle boundary validates identity, adoptio
         raise RunLifecycleError(f"run ID already exists: {run_name}")
     run_dir = init.path.parent
     manifest = run_log_manifest._read_manifest_v2(init.path)  # noqa: SLF001 - sibling lifecycle owns this manifest transition.
-    _require_lifecycle(manifest.get("lifecycle_schema_version") in {None, LIFECYCLE_SCHEMA_VERSION}, "unsupported lifecycle schema version")
+    _require_lifecycle(
+        manifest.get("lifecycle_schema_version") in {None, LIFECYCLE_SCHEMA_VERSION},
+        "unsupported lifecycle schema version",
+    )
     expected_parent_skill = parent_skill or None
     expected_parent_run_id = parent_run_id or None
-    _require_lifecycle(manifest.get("parent_skill") == expected_parent_skill, "existing lifecycle parent skill mismatch")
-    _require_lifecycle(manifest.get("parent_run_id") == expected_parent_run_id, "existing lifecycle parent run ID mismatch")
-    _require_lifecycle(manifest.get("skill") == skill_name and manifest.get("run_id") == run_name, "new lifecycle manifest identity mismatch")
+    _require_lifecycle(
+        manifest.get("parent_skill") == expected_parent_skill,
+        "existing lifecycle parent skill mismatch",
+    )
+    _require_lifecycle(
+        manifest.get("parent_run_id") == expected_parent_run_id,
+        "existing lifecycle parent run ID mismatch",
+    )
+    _require_lifecycle(
+        manifest.get("skill") == skill_name and manifest.get("run_id") == run_name,
+        "new lifecycle manifest identity mismatch",
+    )
     if manifest.get("lifecycle_schema_version") == LIFECYCLE_SCHEMA_VERSION:
-        _require_lifecycle(manifest.get("storage_uri") == active_storage.uri, "configured storage root changed after lifecycle start")
+        _require_lifecycle(
+            manifest.get("tool_repo_uri") == active_storage.uri
+            and manifest.get("client_repo") == active_storage.client_repo
+            and manifest.get("storage_origin_id") == active_storage.storage_origin_id,
+            "configured storage or Git origin changed after lifecycle start",
+        )
     else:
         _ = run_log_manifest._update_manifest_v2(  # noqa: SLF001 - sibling lifecycle owns this manifest transition.
             path=init.path,
-            updates={"status": config.MANIFEST_STATUS_IN_PROGRESS, "lifecycle_schema_version": LIFECYCLE_SCHEMA_VERSION, "storage_uri": active_storage.uri, "terminal_outcome": None, "finished_at": None},
+            updates={
+                "status": config.MANIFEST_STATUS_IN_PROGRESS,
+                "lifecycle_schema_version": LIFECYCLE_SCHEMA_VERSION,
+                "storage_base_uri": active_storage.base.uri,
+                "client_repo": active_storage.client_repo,
+                "tool_repo_uri": active_storage.uri,
+                "storage_origin_id": active_storage.storage_origin_id,
+                "terminal_outcome": None,
+                "finished_at": None,
+            },
         )
-    context_file = _context_file(repo_root=root, skill=skill_name, run_id=run_name, environ=environment)
-    started = LifecycleStart(root, active_storage, skill_name, run_name, selected_log_root, run_dir, context_file)
+    context_file = _context_file(
+        storage=active_storage,
+        skill=skill_name,
+        run_id=run_name,
+        environ=environment,
+    )
+    started = LifecycleStart(
+        root,
+        active_storage,
+        skill_name,
+        run_name,
+        selected_log_root,
+        run_dir,
+        context_file,
+    )
     if not (run_dir / UNIVERSAL_EXECUTION_ISSUES).is_file():
-        run_log_batch.atomic_write_text(path=run_dir / UNIVERSAL_EXECUTION_ISSUES, content="")
+        run_log_batch.atomic_write_text(
+            path=run_dir / UNIVERSAL_EXECUTION_ISSUES, content=""
+        )
     if context_file.is_file():
-        existing = load_run_context(repo_root=root, skill=skill_name, run_id=run_name, environ=environment)
-        _require_lifecycle(existing == started, "existing lifecycle context does not match adoption")
+        existing = load_run_context(
+            repo_root=root,
+            skill=skill_name,
+            run_id=run_name,
+            environ=environment,
+            storage_root=active_storage,
+        )
+        _require_lifecycle(
+            existing == started, "existing lifecycle context does not match adoption"
+        )
     else:
         _write_context(started=started)
     return started
 
 
-def _terminal_manifest(*, run_dir: Path, skill: str, run_id: str) -> tuple[Path, dict[str, object]]:
+def _terminal_manifest(
+    *, run_dir: Path, skill: str, run_id: str
+) -> tuple[Path, dict[str, object]]:
     manifest_path = run_dir / "manifest.json"
     if manifest_path.is_symlink() or not manifest_path.is_file():
-        raise RunLifecycleError(f"lifecycle manifest is missing or unsafe: {manifest_path}")
+        raise RunLifecycleError(
+            f"lifecycle manifest is missing or unsafe: {manifest_path}"
+        )
     manifest = run_log_manifest._read_manifest_v2(manifest_path)  # noqa: SLF001 - sibling lifecycle validates its own manifest.
     if manifest.get("skill") != skill or manifest.get("run_id") != run_id:
         raise RunLifecycleError("lifecycle manifest identity mismatch")
@@ -260,7 +471,8 @@ def _render_final_report(*, skill: str, run_id: str, outcome: str) -> str:
 
 
 def _missing_transcript_issue(*, skill: str, run_id: str) -> str:
-    return json.dumps(
+    return (
+        json.dumps(
         {
             "phase": "terminal",
             "step": "run-lifecycle",
@@ -272,11 +484,19 @@ def _missing_transcript_issue(*, skill: str, run_id: str) -> str:
         },
         separators=(",", ":"),
         sort_keys=True,
-    ) + "\n"
+        )
+        + "\n"
+    )
 
 
 def _write_terminal_artifacts(  # noqa: PLR0913 - terminal identity inputs stay explicit.
-    *, run_dir: Path, manifest_path: Path, manifest: dict[str, object], skill: str, run_id: str, outcome: str
+    *,
+    run_dir: Path,
+    manifest_path: Path,
+    manifest: dict[str, object],
+    skill: str,
+    run_id: str,
+    outcome: str,
 ) -> None:
     existing = manifest.get("terminal_outcome")
     if existing is not None and existing != outcome:
@@ -286,7 +506,9 @@ def _write_terminal_artifacts(  # noqa: PLR0913 - terminal identity inputs stay 
     report_path = run_dir / UNIVERSAL_FINAL_REPORT
     report = _render_final_report(skill=skill, run_id=run_id, outcome=outcome)
     if report_path.exists() and report_path.read_text(encoding="utf-8") != report:
-        raise RunLifecycleError("existing universal final report does not match terminal outcome")
+        raise RunLifecycleError(
+            "existing universal final report does not match terminal outcome"
+        )
     run_log_batch.atomic_write_text(
         path=report_path,
         content=report,
@@ -295,7 +517,9 @@ def _write_terminal_artifacts(  # noqa: PLR0913 - terminal identity inputs stay 
     issues_path = run_dir / UNIVERSAL_EXECUTION_ISSUES
     if not transcript.is_file():
         issue = _missing_transcript_issue(skill=skill, run_id=run_id)
-        existing_issues = issues_path.read_text(encoding="utf-8") if issues_path.is_file() else ""
+        existing_issues = (
+            issues_path.read_text(encoding="utf-8") if issues_path.is_file() else ""
+        )
         if issue not in existing_issues:
             run_log_batch.atomic_write_text(
                 path=issues_path,
@@ -318,7 +542,7 @@ def finish_run(  # noqa: PLR0913 - publication dependencies stay explicit and in
     run_id: str,
     outcome: str,
     environ: Mapping[str, str] | None = None,
-    storage_root: StorageRoot | None = None,
+    storage_root: ToolRepositoryStorage | None = None,
     store: ObjectStore | None = None,
     pre_scrub_violations: int = 0,
 ) -> LifecycleTerminal:
@@ -329,14 +553,34 @@ def finish_run(  # noqa: PLR0913 - publication dependencies stay explicit and in
     root = _validated_repo_root(repo_root)
     skill_name = run_log_publish.validated_component(skill, label="skill", slug=True)
     run_name = run_log_publish.validated_component(run_id, label="run-id", slug=True)
-    started = load_run_context(repo_root=root, skill=skill_name, run_id=run_name, environ=environment)
+    active_storage = storage_root or storage_config.load_tool_repository_storage(
+        repo_root=root, environ=environment
+    )
+    started = load_run_context(
+        repo_root=root,
+        skill=skill_name,
+        run_id=run_name,
+        environ=environment,
+        storage_root=active_storage,
+    )
     log_root = started.log_root
     run_dir = started.run_dir
     if run_dir.is_symlink() or not run_dir.is_dir():
-        raise RunLifecycleError(f"lifecycle run directory is missing or unsafe: {run_dir}")
+        raise RunLifecycleError(
+            f"lifecycle run directory is missing or unsafe: {run_dir}"
+        )
     manifest_path, manifest = _terminal_manifest(
         run_dir=run_dir, skill=skill_name, run_id=run_name
     )
+    if (
+        started.storage_root != active_storage
+        or manifest.get("tool_repo_uri") != active_storage.uri
+        or manifest.get("client_repo") != active_storage.client_repo
+        or manifest.get("storage_origin_id") != active_storage.storage_origin_id
+    ):
+        raise RunLifecycleError(
+            "configured storage or Git origin changed after lifecycle start"
+        )
     _write_terminal_artifacts(
         run_dir=run_dir,
         manifest_path=manifest_path,
@@ -345,12 +589,6 @@ def finish_run(  # noqa: PLR0913 - publication dependencies stay explicit and in
         run_id=run_name,
         outcome=outcome,
     )
-    active_storage = storage_root or storage_config.load_storage_root(
-        repo_root=root, environ=environment
-    )
-    recorded_storage = manifest.get("storage_uri")
-    if recorded_storage != active_storage.uri:
-        raise RunLifecycleError("configured storage root changed after lifecycle start")
     publication, violations = run_log_publish.publish_log_run(
         request=PublicationRequest(
             repo_root=root,
@@ -392,13 +630,21 @@ def start_main(argv: Sequence[str]) -> int:
     _ = parser.add_argument("--lifecycle-parent-context")
     try:
         args = parser.parse_args(argv)
-        result = start_run(repo_root=_resolve_cli_repo_root(args.repo_root), skill=args.skill, parent_skill=args.parent_skill, parent_run_id=args.parent_run_id,
-            run_id=args.run_id, log_root=Path(args.log_root) if args.log_root else None, issue=args.issue, adopt_existing=args.adopt_existing,
+        result = start_run(
+            repo_root=_resolve_cli_repo_root(args.repo_root),
+            skill=args.skill,
+            parent_skill=args.parent_skill,
+            parent_run_id=args.parent_run_id,
+            run_id=args.run_id,
+            log_root=Path(args.log_root) if args.log_root else None,
+            issue=args.issue,
+            adopt_existing=args.adopt_existing,
             parent_context=(
                 Path(args.lifecycle_parent_context)
                 if args.lifecycle_parent_context
                 else None
-            ))
+            ),
+        )
     except SystemExit as exc:
         return int(exc.code) if isinstance(exc.code, int) else config.EXIT_USAGE
     except storage_config.StorageConfigurationError as exc:
@@ -418,7 +664,11 @@ def start_main(argv: Sequence[str]) -> int:
     print(f"LOG_ROOT={result.log_root}")
     print(f"RUN_DIR={result.run_dir}")
     print(f"CONTEXT_FILE={result.context_file}")
-    print(f"STORAGE_URI={result.storage_root.uri}")
+    print(f"STORAGE_BASE_URI={result.storage_root.base.uri}")
+    print(f"CLIENT_REPO={result.storage_root.client_repo}")
+    print(f"TOOL_REPO_URI={result.storage_root.uri}")
+    print(f"RUN_LOGS_URI={result.storage_root.run_logs_uri}")
+    print("PREFLIGHT_OK=true")
     print("LIFECYCLE_STARTED=true")
     return config.EXIT_OK
 

--- a/python/larch/report/run_log_corpus.py
+++ b/python/larch/report/run_log_corpus.py
@@ -266,9 +266,10 @@ def synchronized_run_log_root(
     ).corpus_root
 
 
-def synchronized_repository_log_root(
+def synchronized_repository_log_root(  # noqa: PLR0913 - sync dependencies and pinned storage are injectable.
     *,
     repo_root: Path,
+    storage: storage_config.ToolRepositoryStorage | None = None,
     store: run_log_sync.SyncObjectStore | None = None,
     environ: Mapping[str, str] | None = None,
     cache_home: Path | None = None,
@@ -276,14 +277,18 @@ def synchronized_repository_log_root(
 ) -> Path:
     """Load repository config, synchronize once, and return the cache log root."""
     try:
-        storage_root: storage_config.StorageRoot = storage_config.load_storage_root(
-            repo_root=repo_root,
-            environ=environ,
+        active_storage: storage_config.ToolRepositoryStorage = (
+            storage
+            if storage is not None
+            else storage_config.load_tool_repository_storage(
+                repo_root=repo_root,
+                environ=environ,
+            )
         )
         return synchronized_run_log_root(
             request=run_log_sync.RunLogSyncRequest(
                 repo_root=repo_root,
-                storage_root=storage_root,
+                storage_root=active_storage,
                 cache_home=cache_home,
                 state_home=state_home,
             ),

--- a/python/larch/report/run_log_manifest.py
+++ b/python/larch/report/run_log_manifest.py
@@ -592,7 +592,7 @@ def required_artifacts_for_run(
     repo_root: Path | None = None,
 ) -> list[RequiredArtifact]:
     artifacts: list[RequiredArtifact] = []
-    if manifest.extra and manifest.extra.get("lifecycle_schema_version") == 1:
+    if manifest.extra and manifest.extra.get("lifecycle_schema_version") in {1, 2}:
         artifacts.extend([
             RequiredArtifact(
                 slug="final-report",
@@ -722,7 +722,7 @@ def verify_run_log_completeness(
     if manifest is None:
         return False, ["manifest.json"]
     universal = bool(
-        manifest.extra and manifest.extra.get("lifecycle_schema_version") == 1
+        manifest.extra and manifest.extra.get("lifecycle_schema_version") in {1, 2}
     )
     execution_issues_path = _committed_execution_issues_path(
         run_dir, skill, universal=universal

--- a/python/larch/report/run_log_migration.py
+++ b/python/larch/report/run_log_migration.py
@@ -15,7 +15,10 @@ from typing import Protocol, cast
 from larch.core import config
 from larch.report import run_log_archive
 from larch.report.run_log_batch import validate_run_id_slug
-from larch.report.storage_config import LegacyMigrationDescriptor, StorageRoot
+from larch.report.storage_config import (
+    LegacyMigrationDescriptor,
+    StorageBase,
+)
 
 _INVENTORY_KEYS: frozenset[str] = frozenset(
     {"archives", "schema", "source_commit", "source_files", "storage_root", "totals"}
@@ -142,7 +145,7 @@ def _canonical_path(value: object, *, label: str) -> str:
 
 
 def _validated_archive_row(  # noqa: C901 - strict row validation stays transactional
-    raw: object, *, storage_root: StorageRoot
+    raw: object, *, storage_root: StorageBase
 ) -> _ArchiveRow:
     if not isinstance(raw, dict):
         raise TypeError("migration inventory archive row must be an object")
@@ -192,8 +195,10 @@ def _validated_archive_row(  # noqa: C901 - strict row validation stays transact
         )
         if not valid_identity:
             raise ValueError("migration inventory run archive identity is invalid")
-    elif skill is not None or run_id is not None or not relative_key.startswith(
-        "migration/"
+    elif (
+        skill is not None
+        or run_id is not None
+        or not relative_key.startswith("migration/")
     ):
         raise ValueError("migration inventory residual archive identity is invalid")
     return _ArchiveRow(
@@ -264,7 +269,7 @@ def parse_inventory(  # noqa: C901,PLR0912,PLR0915 - strict schema cross-checks 
     encoded: bytes,
     *,
     descriptor: LegacyMigrationDescriptor,
-    storage_root: StorageRoot,
+    storage_root: StorageBase,
 ) -> LegacyMigrationInventory:
     """Parse and cross-check a hash-verified migration inventory."""
     if len(encoded) > config.RUN_LOG_MIGRATION_INVENTORY_MAX_BYTES:
@@ -406,7 +411,9 @@ def _read_inventory_bytes(path: Path) -> bytes:
         if opened.st_size > config.RUN_LOG_MIGRATION_INVENTORY_MAX_BYTES:
             raise ValueError("migration inventory exceeds byte limit")
         with os.fdopen(descriptor, "rb", closefd=False) as handle:
-            encoded: bytes = handle.read(config.RUN_LOG_MIGRATION_INVENTORY_MAX_BYTES + 1)
+            encoded: bytes = handle.read(
+                config.RUN_LOG_MIGRATION_INVENTORY_MAX_BYTES + 1
+            )
         if len(encoded) != opened.st_size:
             raise ValueError("migration inventory changed while reading")
         return encoded
@@ -418,7 +425,7 @@ def download_and_parse_inventory(
     *,
     store: MigrationObjectStore,
     descriptor: LegacyMigrationDescriptor,
-    storage_root: StorageRoot,
+    storage_root: StorageBase,
     temporary_dir: Path,
 ) -> LegacyMigrationInventory:
     """Download one pinned inventory, verify its hash, and parse it strictly."""

--- a/python/larch/report/run_log_publish.py
+++ b/python/larch/report/run_log_publish.py
@@ -30,10 +30,13 @@ from larch.report.object_store import (
 )
 from larch.report.run_log_archive import RunArchiveMaterializationResult
 from larch.report.run_log_batch import validate_run_id_slug
-from larch.report.storage_config import StorageConfigurationError, StorageRoot
+from larch.report.storage_config import (
+    StorageConfigurationError,
+    ToolRepositoryStorage,
+)
 from larch.errors import ShipError
 
-_PENDING_SCHEMA_VERSION: Final = 1
+_PENDING_SCHEMA_VERSION: Final = 2
 _PENDING_ARCHIVE_NAME: Final = "archive.tar.gz"
 _PENDING_METADATA_NAME: Final = "retry.json"
 _ENV_XDG_CACHE_HOME: Final = "XDG_CACHE_HOME"
@@ -50,11 +53,12 @@ _PENDING_KEYS: Final = frozenset(
         "last_error",
         "manifest_sha256",
         "remote_key",
-        "repo_name",
+        "client_repo",
         "run_id",
         "schema_version",
         "skill",
-        "storage_uri",
+        "storage_origin_id",
+        "tool_repo_uri",
     }
 )
 
@@ -104,7 +108,7 @@ class PublicationRequest:
     """Immutable caller inputs for one run publication attempt."""
 
     repo_root: Path
-    storage_root: StorageRoot
+    storage_root: ToolRepositoryStorage
     skill: str
     run_id: str
     staging_root: Path | None
@@ -117,8 +121,9 @@ class PendingPublication:
     """Content-pinned durable retry record for one immutable object."""
 
     schema_version: int
-    storage_uri: str
-    repo_name: str
+    tool_repo_uri: str
+    client_repo: str
+    storage_origin_id: str
     skill: str
     run_id: str
     remote_key: str
@@ -171,13 +176,11 @@ def xdg_home(
 
 def repository_cache_root(
     *,
-    repo_root: Path,
+    storage: ToolRepositoryStorage,
     cache_home: Path | None = None,
     environ: Mapping[str, str] | None = None,
 ) -> Path:
-    """Return the literal per-repository root for unpacked run archives."""
-    root: Path = larch_io.validate_trusted_directory(repo_root)
-    repo_name: str = validated_component(root.name, label="repository name", slug=False)
+    """Return the storage-origin-bound v2 root for unpacked run archives."""
     environment: Mapping[str, str] = os.environ if environ is None else environ
     resolved_cache_home: Path = cache_home or xdg_home(
         environ=environment,
@@ -186,7 +189,14 @@ def repository_cache_root(
     )
     if not resolved_cache_home.is_absolute():
         raise ValueError("publication cache home must be an absolute path")
-    return resolved_cache_home / "larch" / "run-logs" / repo_name
+    return (
+        resolved_cache_home
+        / "larch"
+        / "run-logs"
+        / "v2"
+        / storage.client_repo
+        / storage.storage_origin_id
+    )
 
 
 def publication_paths(
@@ -195,13 +205,12 @@ def publication_paths(
     environ: Mapping[str, str] | None = None,
 ) -> PublicationPaths:
     """Resolve the literal repository cache path and durable retry path."""
-    root: Path = larch_io.validate_trusted_directory(request.repo_root)
-    repo_name: str = validated_component(root.name, label="repository name", slug=False)
+    _ = larch_io.validate_trusted_directory(request.repo_root)
     skill_name: str = validated_component(request.skill, label="skill", slug=True)
     run_name: str = validated_component(request.run_id, label="run-id", slug=True)
     environment: Mapping[str, str] = os.environ if environ is None else environ
     cache_root: Path = repository_cache_root(
-        repo_root=root,
+        storage=request.storage_root,
         cache_home=request.cache_home,
         environ=environment,
     )
@@ -217,7 +226,9 @@ def publication_paths(
         resolved_state_home
         / "larch"
         / "run-log-pending"
-        / repo_name
+        / "v2"
+        / request.storage_root.client_repo
+        / request.storage_root.storage_origin_id
         / skill_name
         / run_name
     )
@@ -225,7 +236,9 @@ def publication_paths(
         resolved_state_home
         / "larch"
         / "run-log-locks"
-        / repo_name
+        / "v2"
+        / request.storage_root.client_repo
+        / request.storage_root.storage_origin_id
         / skill_name
         / f"{run_name}.lock"
     )
@@ -328,10 +341,17 @@ def _fsync_directory(path: Path) -> None:
 
 
 def _metadata_text(pending: PendingPublication) -> str:
-    return json.dumps(asdict(pending), ensure_ascii=False, sort_keys=True, separators=(",", ":")) + "\n"
+    return (
+        json.dumps(
+            asdict(pending), ensure_ascii=False, sort_keys=True, separators=(",", ":")
+        )
+        + "\n"
+    )
 
 
-def _write_pending_metadata(paths: PublicationPaths, pending: PendingPublication) -> None:
+def _write_pending_metadata(
+    paths: PublicationPaths, pending: PendingPublication
+) -> None:
     larch_io.trusted_atomic_write(
         paths.pending_metadata,
         _metadata_text(pending),
@@ -351,8 +371,9 @@ def _parse_pending_metadata(text: str) -> PendingPublication:
     if frozenset(data) != _PENDING_KEYS:
         raise PublicationError("pending publication metadata has invalid fields")
     string_keys: tuple[str, ...] = (
-        "storage_uri",
-        "repo_name",
+        "tool_repo_uri",
+        "client_repo",
+        "storage_origin_id",
         "skill",
         "run_id",
         "remote_key",
@@ -363,12 +384,18 @@ def _parse_pending_metadata(text: str) -> PendingPublication:
     if any(not isinstance(data[key], str) for key in string_keys):
         raise PublicationError("pending publication metadata has invalid string fields")
     integer_keys: tuple[str, ...] = ("schema_version", "archive_size", "attempts")
-    if any(not isinstance(data[key], int) or isinstance(data[key], bool) for key in integer_keys):
-        raise PublicationError("pending publication metadata has invalid integer fields")
+    if any(
+        not isinstance(data[key], int) or isinstance(data[key], bool)
+        for key in integer_keys
+    ):
+        raise PublicationError(
+            "pending publication metadata has invalid integer fields"
+        )
     return PendingPublication(
         schema_version=cast("int", data["schema_version"]),
-        storage_uri=cast("str", data["storage_uri"]),
-        repo_name=cast("str", data["repo_name"]),
+        tool_repo_uri=cast("str", data["tool_repo_uri"]),
+        client_repo=cast("str", data["client_repo"]),
+        storage_origin_id=cast("str", data["storage_origin_id"]),
         skill=cast("str", data["skill"]),
         run_id=cast("str", data["run_id"]),
         remote_key=cast("str", data["remote_key"]),
@@ -385,13 +412,13 @@ def _validate_pending(
     paths: PublicationPaths,
     pending: PendingPublication,
     request: PublicationRequest,
-    repo_name: str,
 ) -> PendingPublication:
     expected_key: str = f"run-logs/{request.skill}/{request.run_id}.tar.gz"
     identity: tuple[object, ...] = (
         pending.schema_version,
-        pending.storage_uri,
-        pending.repo_name,
+        pending.tool_repo_uri,
+        pending.client_repo,
+        pending.storage_origin_id,
         pending.skill,
         pending.run_id,
         pending.remote_key,
@@ -399,26 +426,33 @@ def _validate_pending(
     expected_identity: tuple[object, ...] = (
         _PENDING_SCHEMA_VERSION,
         request.storage_root.uri,
-        repo_name,
+        request.storage_root.client_repo,
+        request.storage_root.storage_origin_id,
         request.skill,
         request.run_id,
         expected_key,
     )
     if identity != expected_identity:
-        raise PublicationError("pending publication identity does not match the live request")
+        raise PublicationError(
+            "pending publication identity does not match the live request"
+        )
     if (
         not _valid_sha256(pending.archive_sha256)
         or not _valid_sha256(pending.manifest_sha256)
         or pending.archive_size <= 0
         or pending.attempts < 0
     ):
-        raise PublicationError("pending publication metadata has invalid content identity")
+        raise PublicationError(
+            "pending publication metadata has invalid content identity"
+        )
     archive_sha256, archive_size = _sha256_regular_file(
         paths.pending_archive,
         root=paths.pending_dir,
     )
     if (archive_sha256, archive_size) != (pending.archive_sha256, pending.archive_size):
-        raise PublicationError("pending archive does not match its durable content identity")
+        raise PublicationError(
+            "pending archive does not match its durable content identity"
+        )
     return pending
 
 
@@ -432,7 +466,6 @@ def _load_pending(
     *,
     paths: PublicationPaths,
     request: PublicationRequest,
-    repo_name: str,
 ) -> PendingPublication:
     root: Path = larch_io.validate_trusted_directory(paths.pending_dir)
     text: str = larch_io.read_trusted_text(
@@ -444,7 +477,6 @@ def _load_pending(
         paths=paths,
         pending=_parse_pending_metadata(text),
         request=request,
-        repo_name=repo_name,
     )
 
 
@@ -452,7 +484,6 @@ def _create_pending(
     *,
     paths: PublicationPaths,
     request: PublicationRequest,
-    repo_name: str,
 ) -> PendingPublication:
     parent: Path = ensure_concurrent_directory(paths.pending_dir.parent)
     temporary: Path | None = Path(
@@ -461,7 +492,9 @@ def _create_pending(
     temporary.chmod(0o700)
     try:
         if request.staging_root is None:
-            raise PublicationError("a staging root is required to create a pending archive")
+            raise PublicationError(
+                "a staging root is required to create a pending archive"
+            )
         created = run_log_archive.create_run_archive(
             staging_root=request.staging_root,
             output_dir=temporary,
@@ -472,8 +505,9 @@ def _create_pending(
         _ = created.archive_path.rename(archive_path)
         pending = PendingPublication(
             schema_version=_PENDING_SCHEMA_VERSION,
-            storage_uri=request.storage_root.uri,
-            repo_name=repo_name,
+            tool_repo_uri=request.storage_root.uri,
+            client_repo=request.storage_root.client_repo,
+            storage_origin_id=request.storage_root.storage_origin_id,
             skill=request.skill,
             run_id=request.run_id,
             remote_key=f"run-logs/{request.skill}/{request.run_id}.tar.gz",
@@ -497,7 +531,6 @@ def _create_pending(
         return _load_pending(
             paths=paths,
             request=request,
-            repo_name=repo_name,
         )
     finally:
         if temporary is not None:
@@ -508,20 +541,19 @@ def _pending_for_request(
     *,
     paths: PublicationPaths,
     request: PublicationRequest,
-    repo_name: str,
 ) -> PendingPublication:
     if paths.pending_dir.exists() or paths.pending_dir.is_symlink():
         return _load_pending(
             paths=paths,
             request=request,
-            repo_name=repo_name,
         )
     if request.staging_root is None:
-        raise PublicationError("no durable pending archive exists and --staging-root was not provided")
+        raise PublicationError(
+            "no durable pending archive exists and --staging-root was not provided"
+        )
     return _create_pending(
         paths=paths,
         request=request,
-        repo_name=repo_name,
     )
 
 
@@ -542,8 +574,13 @@ def _matching_remote_exists(
         downloaded: Path = Path(handle.name)
     try:
         store.download(pending.remote_key, downloaded)
-        remote_sha256, remote_size = _sha256_regular_file(downloaded, root=paths.pending_dir)
-        return (remote_sha256, remote_size) == (pending.archive_sha256, pending.archive_size)
+        remote_sha256, remote_size = _sha256_regular_file(
+            downloaded, root=paths.pending_dir
+        )
+        return (remote_sha256, remote_size) == (
+            pending.archive_sha256,
+            pending.archive_size,
+        )
     finally:
         downloaded.unlink(missing_ok=True)
 
@@ -555,7 +592,9 @@ def _publish_remote(
     paths: PublicationPaths,
 ) -> RemotePublicationStatus:
     try:
-        uploaded: RemoteObject = store.upload_create(pending.remote_key, paths.pending_archive)
+        uploaded: RemoteObject = store.upload_create(
+            pending.remote_key, paths.pending_archive
+        )
     except ObjectStoreError as exc:
         if exc.kind is not ObjectStoreErrorKind.ALREADY_EXISTS:
             raise
@@ -565,7 +604,9 @@ def _publish_remote(
             ) from exc
         return RemotePublicationStatus.MATCHED
     if uploaded.key != pending.remote_key or uploaded.size != pending.archive_size:
-        raise PublicationError("create-only upload returned a mismatched object identity")
+        raise PublicationError(
+            "create-only upload returned a mismatched object identity"
+        )
     verified: RemoteObject = store.metadata(pending.remote_key)
     if verified.key != pending.remote_key or verified.size != pending.archive_size:
         raise PublicationError("uploaded remote object failed metadata verification")
@@ -580,32 +621,40 @@ def _cache_result(
 ) -> tuple[RunArchiveMaterializationResult, CachePublicationStatus]:
     _ = ensure_concurrent_directory(paths.cache_dir.parent)
     if paths.cache_dir.exists() or paths.cache_dir.is_symlink():
-        existing: RunArchiveMaterializationResult = run_log_archive.verify_materialized_run_directory(
+        existing: RunArchiveMaterializationResult = (
+            run_log_archive.verify_materialized_run_directory(
             run_dir=paths.cache_dir,
             expected_skill=pending.skill,
             expected_run_id=pending.run_id,
         )
+        )
         if existing.manifest_sha256 != pending.manifest_sha256:
-            raise PublicationError("existing cache directory contains different run content")
+            raise PublicationError(
+                "existing cache directory contains different run content"
+            )
         return existing, CachePublicationStatus.PRESENT
     if staging_root is not None:
         try:
-            promoted: RunArchiveMaterializationResult = run_log_archive.promote_staging_run_directory(
+            promoted: RunArchiveMaterializationResult = (
+                run_log_archive.promote_staging_run_directory(
                 staging_root=staging_root,
                 run_dir=paths.cache_dir,
                 expected_skill=pending.skill,
                 expected_run_id=pending.run_id,
                 expected_manifest_sha256=pending.manifest_sha256,
             )
+            )
         except run_log_archive.StagingManifestMismatchError:
             pass
         else:
             return promoted, CachePublicationStatus.PROMOTED
-    materialized: RunArchiveMaterializationResult = run_log_archive.materialize_run_archive(
+    materialized: RunArchiveMaterializationResult = (
+        run_log_archive.materialize_run_archive(
         archive_path=paths.pending_archive,
         run_dir=paths.cache_dir,
         expected_skill=pending.skill,
         expected_run_id=pending.run_id,
+    )
     )
     return materialized, CachePublicationStatus.MATERIALIZED
 
@@ -638,7 +687,6 @@ def publish_run(
 ) -> PublicationResult:
     """Publish one immutable archive and atomically populate its local cache."""
     root: Path = larch_io.validate_trusted_directory(request.repo_root)
-    repo_name: str = validated_component(root.name, label="repository name", slug=False)
     skill_name: str = validated_component(request.skill, label="skill", slug=True)
     run_name: str = validated_component(request.run_id, label="run-id", slug=True)
     normalized_request = replace(
@@ -657,11 +705,12 @@ def publish_run(
         else store
     )
     with publication_lock(paths.lock_file):
-        retrying_pending: bool = paths.pending_dir.exists() or paths.pending_dir.is_symlink()
+        retrying_pending: bool = (
+            paths.pending_dir.exists() or paths.pending_dir.is_symlink()
+        )
         pending: PendingPublication = _pending_for_request(
             paths=paths,
             request=normalized_request,
-            repo_name=repo_name,
         )
         pending = replace(pending, attempts=pending.attempts + 1, last_error="")
         _write_pending_metadata(paths, pending)
@@ -674,10 +723,14 @@ def publish_run(
             cache_result, cache_status = _cache_result(
                 paths=paths,
                 pending=pending,
-                staging_root=None if retrying_pending else normalized_request.staging_root,
+                staging_root=None
+                if retrying_pending
+                else normalized_request.staging_root,
             )
             if cache_result.manifest_sha256 != pending.manifest_sha256:
-                raise PublicationError("published cache failed manifest identity verification")
+                raise PublicationError(
+                    "published cache failed manifest identity verification"
+                )
         except (
             EOFError,
             ObjectStoreError,
@@ -687,7 +740,9 @@ def publish_run(
             TypeError,
             ValueError,
         ) as exc:
-            _write_pending_metadata(paths, replace(pending, last_error=_failure_token(exc)))
+            _write_pending_metadata(
+                paths, replace(pending, last_error=_failure_token(exc))
+            )
             raise
         _complete_pending(paths)
     return PublicationResult(
@@ -751,12 +806,12 @@ def main(argv: Sequence[str]) -> int:
             raise StorageConfigurationError(
                 f"could not discover a Git repository root from {requested_root}"
             )
-        storage_root: StorageRoot = storage_config.discover_storage_root(
-            start=repo_root
+        storage: ToolRepositoryStorage = (
+            storage_config.discover_tool_repository_storage(start=repo_root)
         )
         request = PublicationRequest(
             repo_root=repo_root,
-            storage_root=storage_root,
+            storage_root=storage,
             skill=args.skill,
             run_id=args.run_id,
             staging_root=Path(args.staging_root) if args.staging_root else None,

--- a/python/larch/report/run_log_sync.py
+++ b/python/larch/report/run_log_sync.py
@@ -16,9 +16,12 @@ from pathlib import Path
 from typing import Protocol
 
 from larch.core import config, repo_roots
-from larch.report import run_log_archive, run_log_migration, run_log_publish, storage_config
+from larch.report import run_log_archive, run_log_publish, storage_config
 from larch.report.object_store import ObjectStoreError, RemoteObject, object_store_for
-from larch.report.storage_config import StorageConfigurationError, StorageRoot
+from larch.report.storage_config import (
+    StorageConfigurationError,
+    ToolRepositoryStorage,
+)
 
 _REMOTE_PREFIX = "run-logs/"
 _ARCHIVE_SUFFIX = ".tar.gz"
@@ -50,7 +53,7 @@ class RunLogSyncRequest:
     """Immutable inputs for one repository-scoped synchronization."""
 
     repo_root: Path
-    storage_root: StorageRoot
+    storage_root: ToolRepositoryStorage
     cache_home: Path | None = None
     state_home: Path | None = None
 
@@ -96,43 +99,6 @@ class RepositorySyncResult:
     @property
     def repaired_count(self) -> int:
         return sum(run.status is CacheSyncStatus.REPAIRED for run in self.runs)
-
-
-class _LegacyMigrationLoader:
-    """Lazily download a repository-scoped migration inventory at most once."""
-
-    def __init__(self, *, request: RunLogSyncRequest, store: SyncObjectStore, temporary_dir: Path) -> None:
-        self._request = request
-        self._store = store
-        self._temporary_dir = temporary_dir
-        self._attempted = False
-        self._inventory: run_log_migration.LegacyMigrationInventory | None = None
-
-    def archive_for(self, remote_key: str) -> run_log_archive.LegacyRunArchive:
-        if not self._attempted:
-            self._attempted = True
-            try:
-                descriptor = storage_config.load_legacy_migration_descriptor(
-                    repo_root=self._request.repo_root, storage_root=self._request.storage_root,
-                )
-            except StorageConfigurationError as exc:
-                raise RunLogSyncError("legacy migration descriptor is invalid") from exc
-            if descriptor is None:
-                raise RunLogSyncError(
-                    "manifest-less run archive is not recognized by a repository migration descriptor"
-                )
-            self._inventory = run_log_migration.download_and_parse_inventory(
-                store=self._store, descriptor=descriptor, storage_root=self._request.storage_root,
-                temporary_dir=self._temporary_dir,
-            )
-        if self._inventory is None:
-            raise RunLogSyncError("legacy migration inventory is unavailable")
-        record: run_log_archive.LegacyRunArchive | None = self._inventory.archive_for(remote_key)
-        if record is None:
-            raise RunLogSyncError(
-                "manifest-less run archive is not recognized by the pinned migration inventory"
-            )
-        return record
 
 
 def _remote_run_archive(remote: RemoteObject) -> RemoteRunArchive:
@@ -227,7 +193,6 @@ def _download_and_materialize(
     store: SyncObjectStore,
     archive: RemoteRunArchive,
     cache_dir: Path,
-    migration: _LegacyMigrationLoader,
 ) -> None:
     with tempfile.NamedTemporaryFile(
         dir=cache_dir.parent,
@@ -243,17 +208,12 @@ def _download_and_materialize(
             raise RunLogSyncError(
                 f"downloaded archive does not match listed size: {archive.remote_key!r}"
             )
-        try:
-            _ = run_log_archive.materialize_run_archive(
-                archive_path=archive_path, run_dir=cache_dir,
-                expected_skill=archive.skill, expected_run_id=archive.run_id,
-            )
-        except run_log_archive.MissingArchiveManifestError:
-            legacy: run_log_archive.LegacyRunArchive = migration.archive_for(archive.remote_key)
-            _ = run_log_archive.materialize_legacy_run_archive(
-                archive_path=archive_path, run_dir=cache_dir,
-                expected_skill=archive.skill, expected_run_id=archive.run_id, legacy=legacy,
-            )
+        _ = run_log_archive.materialize_run_archive(
+            archive_path=archive_path,
+            run_dir=cache_dir,
+            expected_skill=archive.skill,
+            expected_run_id=archive.run_id,
+        )
     finally:
         archive_path.unlink(missing_ok=True)
 
@@ -264,7 +224,6 @@ def _sync_archive(
     archive: RemoteRunArchive,
     store: SyncObjectStore,
     environ: Mapping[str, str] | None,
-    migration: _LegacyMigrationLoader,
 ) -> SyncedRun:
     paths: run_log_publish.PublicationPaths = run_log_publish.publication_paths(
         request=run_log_publish.PublicationRequest(
@@ -302,7 +261,6 @@ def _sync_archive(
                 store=store,
                 archive=archive,
                 cache_dir=paths.cache_dir,
-                migration=migration,
             )
         except (
             EOFError,
@@ -347,21 +305,17 @@ def sync_repository_run_logs(
         active_store.list_objects(_REMOTE_PREFIX)
     )
     corpus_root: Path = run_log_publish.repository_cache_root(
-        repo_root=request.repo_root,
+        storage=request.storage_root,
         cache_home=request.cache_home,
         environ=environ,
     )
     _ = run_log_publish.ensure_concurrent_directory(corpus_root)
-    migration = _LegacyMigrationLoader(
-        request=request, store=active_store, temporary_dir=corpus_root,
-    )
     runs: tuple[SyncedRun, ...] = tuple(
         _sync_archive(
             request=request,
             archive=archive,
             store=active_store,
             environ=environ,
-            migration=migration,
         )
         for archive in inventory
     )
@@ -383,13 +337,13 @@ def main(argv: Sequence[str]) -> int:
             raise StorageConfigurationError(
                 f"could not discover a Git repository root from {requested_root}"
             )
-        storage_root: StorageRoot = storage_config.discover_storage_root(
-            start=repo_root
+        storage: ToolRepositoryStorage = (
+            storage_config.discover_tool_repository_storage(start=repo_root)
         )
         result: RepositorySyncResult = sync_repository_run_logs(
             request=RunLogSyncRequest(
                 repo_root=repo_root,
-                storage_root=storage_root,
+                storage_root=storage,
             )
         )
     except StorageConfigurationError as exc:

--- a/python/larch/report/storage_config.py
+++ b/python/larch/report/storage_config.py
@@ -1,13 +1,15 @@
-"""Storage-root configuration and provider-neutral bucket preflight."""
+"""Repository-owned storage configuration and derived tool namespace."""
 
 from __future__ import annotations
 
 import argparse
 import contextlib
+import hashlib
 import os
+import re
 import sys
 import tomllib
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Final, cast
@@ -17,47 +19,93 @@ from larch.core import config, proc
 from larch.core.repo_roots import consumer_repo_root
 from larch.report.object_store import ObjectStoreError, object_store_for
 
-_MIN_URI_PATH_SEGMENT_COUNT: Final = 2
 _ASCII_CONTROL_CHARACTER_MAX: Final = 32
+_ASCII_DELETE: Final = 127
 _SHA256_HEX_LENGTH: Final = 64
 _GIT_COMMIT_HEX_LENGTH: Final = 40
+_TOOL_REPOSITORY_SUFFIX_PARTS: Final = 2
+_CLIENT_REPO_RE: Final = re.compile(r"^[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?$")
+_SCP_REMOTE_RE: Final = re.compile(
+    r"^(?:(?P<user>[A-Za-z0-9._-]+)@)?(?P<host>[^/:@\s]+):(?P<path>[^:\s]+)$"
+)
 
 
 class StorageConfigurationError(ValueError):
-    """The repository's storage-root configuration is missing or invalid."""
+    """The repository's storage configuration or identity is invalid."""
 
 
 class StoragePreflightError(RuntimeError):
-    """The configured storage bucket cannot be used for a startup preflight."""
+    """The configured tool and repository prefix cannot be listed."""
 
 
 @dataclass(frozen=True)
-class StorageRoot:
-    """Validated larch storage root, without credentials or object names."""
+class StorageBase:
+    """Validated provider, bucket, and optional base prefix."""
 
     scheme: str
     bucket: str
-    prefix: str
+    prefix: str = ""
 
     @property
     def uri(self) -> str:
-        """Return the canonical configured storage-root URI."""
-        return f"{self.scheme}://{self.bucket}/{self.prefix}"
-
-    @property
-    def run_logs_uri(self) -> str:
-        """Return the deterministic remote root for run archives."""
-        return f"{self.uri}/run-logs/"
+        """Return the canonical configured base URI."""
+        suffix: str = f"/{self.prefix}" if self.prefix else ""
+        return f"{self.scheme}://{self.bucket}{suffix}"
 
     @property
     def bucket_uri(self) -> str:
-        """Return the provider bucket root used by existence preflights."""
+        """Return the provider bucket root."""
         return f"{self.scheme}://{self.bucket}"
 
 
 @dataclass(frozen=True)
+class ToolRepositoryStorage:
+    """The fixed larch namespace for one Git-origin-derived repository."""
+
+    base: StorageBase
+    client_repo: str
+
+    @property
+    def scheme(self) -> str:
+        return self.base.scheme
+
+    @property
+    def bucket(self) -> str:
+        return self.base.bucket
+
+    @property
+    def prefix(self) -> str:
+        parts: tuple[str, ...] = tuple(
+            part
+            for part in (self.base.prefix, config.LARCH_TOOL_NAME, self.client_repo)
+            if part
+        )
+        return "/".join(parts)
+
+    @property
+    def uri(self) -> str:
+        """Return the canonical tool and client-repository root."""
+        return f"{self.scheme}://{self.bucket}/{self.prefix}"
+
+    @property
+    def storage_origin_id(self) -> str:
+        """Bind local mutable state to the complete canonical remote origin."""
+        return hashlib.sha256(self.uri.encode("utf-8")).hexdigest()
+
+    def data_uri(self, data_type: str) -> str:
+        """Return one validated child data namespace."""
+        child: str = _validated_path_component(data_type, label="data type")
+        return f"{self.uri}/{child}/"
+
+    @property
+    def run_logs_uri(self) -> str:
+        """Return the deterministic remote root for run archives."""
+        return self.data_uri(config.RUN_LOGS_DATA_TYPE)
+
+
+@dataclass(frozen=True)
 class LegacyMigrationDescriptor:
-    """Repository-owned trust anchor for one historical migration inventory."""
+    """Operator-supplied trust anchor for one historical migration inventory."""
 
     schema: str
     source_commit: str
@@ -68,213 +116,443 @@ class LegacyMigrationDescriptor:
 
 def run_log_reference(*, repo_root: Path | None, skill: str, run_id: str) -> str:
     """Render a provider-neutral run identity for public summaries."""
-    provider = "unknown"
+    provider: str = "unknown"
     if repo_root is not None:
         with contextlib.suppress(StorageConfigurationError):
-            provider = load_storage_root(repo_root=repo_root).scheme
+            provider = load_tool_repository_storage(repo_root=repo_root).scheme
     return f"provider `{provider}`, skill `{skill}`, run ID `{run_id}`"
 
 
 def _validated_bucket(parsed: SplitResult) -> str:
-    """Return a plain bucket authority with no credentials or port."""
-    if parsed.username is not None or parsed.password is not None or "@" in parsed.netloc:
-        raise StorageConfigurationError("[logs].uri must not contain credentials")
+    """Return the exact plain bucket authority with no credentials or port."""
+    if (
+        parsed.username is not None
+        or parsed.password is not None
+        or "@" in parsed.netloc
+    ):
+        raise StorageConfigurationError(
+            "[larch].storage_base_uri must not contain credentials"
+        )
     try:
-        port = parsed.port
+        port: int | None = parsed.port
     except ValueError as exc:
-        raise StorageConfigurationError("[logs].uri must contain a valid bucket name without a port") from exc
-    if not parsed.netloc or port is not None or parsed.hostname != parsed.netloc:
-        raise StorageConfigurationError("[logs].uri must contain a plain bucket name without a port")
-    if any(character.isspace() for character in parsed.netloc):
-        raise StorageConfigurationError("[logs].uri bucket must not contain whitespace")
-    return parsed.netloc
+        raise StorageConfigurationError(
+            "[larch].storage_base_uri must contain a plain bucket name without a port"
+        ) from exc
+    bucket: str = parsed.netloc
+    if (
+        not bucket
+        or port is not None
+        or ":" in bucket
+        or "\\" in bucket
+        or any(
+            character.isspace()
+            or ord(character) < _ASCII_CONTROL_CHARACTER_MAX
+            or ord(character) == _ASCII_DELETE
+            for character in bucket
+        )
+    ):
+        raise StorageConfigurationError(
+            "[larch].storage_base_uri must contain a plain bucket name without a port"
+        )
+    return bucket
 
 
 def _validated_prefix(path: str) -> str:
-    """Return a normalized non-empty storage-root prefix."""
-    segments = path.split("/")
-    if not path.startswith("/") or len(segments) < _MIN_URI_PATH_SEGMENT_COUNT or not segments[1:]:
-        raise StorageConfigurationError("[logs].uri must include a non-empty storage-root prefix")
-    prefix_segments = segments[1:]
+    """Return an exact optional base prefix."""
+    if not path:
+        return ""
+    if not path.startswith("/") or path.endswith("/"):
+        raise StorageConfigurationError(
+            "[larch].storage_base_uri must not have a trailing slash"
+        )
+    prefix_segments: list[str] = path[1:].split("/")
     if any(not segment or segment in {".", ".."} for segment in prefix_segments):
-        raise StorageConfigurationError("[logs].uri prefix must not contain empty, '.' or '..' segments")
+        raise StorageConfigurationError(
+            "[larch].storage_base_uri prefix must not contain empty, '.' or '..' segments"
+        )
     if any(
-        any(character.isspace() or ord(character) < _ASCII_CONTROL_CHARACTER_MAX for character in segment)
+        "\\" in segment
+        or any(
+            character.isspace()
+            or ord(character) < _ASCII_CONTROL_CHARACTER_MAX
+            or ord(character) == _ASCII_DELETE
+            for character in segment
+        )
         for segment in prefix_segments
     ):
-        raise StorageConfigurationError("[logs].uri prefix must not contain whitespace or control characters")
+        raise StorageConfigurationError(
+            "[larch].storage_base_uri prefix must not contain whitespace or control characters"
+        )
     return "/".join(prefix_segments)
 
 
-def _parse_storage_uri(raw_uri: str) -> StorageRoot:
+def parse_storage_base_uri(raw_uri: str) -> StorageBase:
+    """Validate a base URI without adding the tool or repository namespace."""
     if not raw_uri or raw_uri != raw_uri.strip():
-        raise StorageConfigurationError("[logs].uri must be a non-empty URI without surrounding whitespace")
-    parsed = urlsplit(raw_uri)
-    if parsed.scheme not in config.STORAGE_URI_SCHEMES:
-        accepted = ", ".join(f"{scheme}://" for scheme in config.STORAGE_URI_SCHEMES)
-        raise StorageConfigurationError(f"[logs].uri must use one of: {accepted}")
+        raise StorageConfigurationError(
+            "[larch].storage_base_uri must be a non-empty URI without surrounding whitespace"
+        )
+    parsed: SplitResult = urlsplit(raw_uri)
+    if (
+        parsed.scheme not in config.STORAGE_URI_SCHEMES
+        or not raw_uri.startswith(f"{parsed.scheme}://")
+    ):
+        accepted: str = ", ".join(
+            f"{scheme}://" for scheme in config.STORAGE_URI_SCHEMES
+        )
+        raise StorageConfigurationError(
+            f"[larch].storage_base_uri must use one of: {accepted}"
+        )
     if parsed.query or parsed.fragment:
-        raise StorageConfigurationError("[logs].uri must not contain a query or fragment")
-    return StorageRoot(
+        raise StorageConfigurationError(
+            "[larch].storage_base_uri must not contain a query or fragment"
+        )
+    return StorageBase(
         scheme=parsed.scheme,
         bucket=_validated_bucket(parsed),
         prefix=_validated_prefix(parsed.path),
     )
 
 
+def parse_tool_repository_uri(
+    raw_uri: str, *, expected_client_repo: str | None = None
+) -> ToolRepositoryStorage:
+    """Rehydrate a canonical persisted tool-repository URI."""
+    parsed: SplitResult = urlsplit(raw_uri)
+    if parsed.scheme not in config.STORAGE_URI_SCHEMES:
+        raise StorageConfigurationError(
+            "persisted tool repository URI has an invalid scheme"
+        )
+    bucket: str = _validated_bucket(parsed)
+    prefix: str = _validated_prefix(parsed.path)
+    parts: list[str] = prefix.split("/")
+    if (
+        len(parts) < _TOOL_REPOSITORY_SUFFIX_PARTS
+        or parts[-2] != config.LARCH_TOOL_NAME
+    ):
+        raise StorageConfigurationError(
+            "persisted tool repository URI has an invalid namespace"
+        )
+    client_repo: str = validate_client_repo(parts[-1])
+    if expected_client_repo is not None and client_repo != expected_client_repo:
+        raise StorageConfigurationError("persisted tool repository identity changed")
+    base_prefix: str = "/".join(parts[:-2])
+    storage: ToolRepositoryStorage = ToolRepositoryStorage(
+        StorageBase(parsed.scheme, bucket, base_prefix), client_repo
+    )
+    if storage.uri != raw_uri:
+        raise StorageConfigurationError(
+            "persisted tool repository URI is not canonical"
+        )
+    return storage
+
+
 def _load_repository_config(repo_root: Path) -> dict[str, object]:
     config_path: Path = repo_root / config.STORAGE_CONFIG_RELPATH
-    if config_path.is_symlink() or not config_path.is_file():
+    repo_label: str = repo_root.name or str(repo_root)
+    if config_path.is_symlink():
         raise StorageConfigurationError(
-            f"storage configuration is missing: create {config.STORAGE_CONFIG_RELPATH} at the repository root "
-            f"or set {config.ENV_LARCH_LOGS_URI}"
+            f"{config.STORAGE_CONFIG_RELPATH}: refusing symlink in Git repository {repo_label}"
+        )
+    if not config_path.is_file():
+        raise StorageConfigurationError(
+            f"{config.STORAGE_CONFIG_RELPATH}: missing required file in Git repository "
+            f"{repo_label}; add [larch] with storage_base_uri"
         )
     try:
         with config_path.open("rb") as handle:
             return cast("dict[str, object]", tomllib.load(handle))
+    except OSError as exc:
+        raise StorageConfigurationError(
+            f"{config.STORAGE_CONFIG_RELPATH}: cannot read configuration in Git repository "
+            f"{repo_label}; add readable [larch] with storage_base_uri"
+        ) from exc
     except tomllib.TOMLDecodeError as exc:
-        raise StorageConfigurationError(f"invalid {config.STORAGE_CONFIG_RELPATH}: {exc}") from exc
+        raise StorageConfigurationError(
+            f"{config.STORAGE_CONFIG_RELPATH}: malformed TOML in Git repository {repo_label}"
+        ) from exc
 
 
-def load_storage_root(*, repo_root: Path, environ: Mapping[str, str] | None = None) -> StorageRoot:
-    """Load and validate storage configuration, honoring the environment override."""
-    environment = os.environ if environ is None else environ
-    override = environment.get(config.ENV_LARCH_LOGS_URI, "")
-    if override:
-        return _parse_storage_uri(override)
+def _configured_storage_base(
+    *, repo_root: Path, environ: Mapping[str, str]
+) -> StorageBase:
     raw_data: dict[str, object] = _load_repository_config(repo_root)
-    raw_logs = raw_data.get("logs")
-    if not isinstance(raw_logs, dict):
-        raise StorageConfigurationError(f"invalid {config.STORAGE_CONFIG_RELPATH}: missing [logs] table")
-    logs = cast("dict[str, object]", raw_logs)
-    uri = logs.get("uri")
-    if not isinstance(uri, str):
-        raise StorageConfigurationError(f"invalid {config.STORAGE_CONFIG_RELPATH}: [logs].uri must be a string")
-    return _parse_storage_uri(uri)
+    raw_larch: object = raw_data.get(config.LARCH_TOOL_NAME)
+    repo_label: str = repo_root.name or str(repo_root)
+    if not isinstance(raw_larch, dict):
+        raise StorageConfigurationError(
+            f"{config.STORAGE_CONFIG_RELPATH}: missing required [larch] table; "
+            f"larch cannot run in Git repository {repo_label}; add [larch] with storage_base_uri"
+        )
+    larch_table: dict[str, object] = cast("dict[str, object]", raw_larch)
+    if frozenset(larch_table) != frozenset({config.STORAGE_BASE_URI_FIELD}):
+        raise StorageConfigurationError(
+            f"{config.STORAGE_CONFIG_RELPATH}: [larch] must contain only "
+            f"{config.STORAGE_BASE_URI_FIELD}"
+        )
+    configured: object = larch_table.get(config.STORAGE_BASE_URI_FIELD)
+    if not isinstance(configured, str):
+        raise StorageConfigurationError(
+            f"{config.STORAGE_CONFIG_RELPATH}: "
+            f"[larch].{config.STORAGE_BASE_URI_FIELD} must be a string"
+        )
+    legacy_override: str = environ.get(config.ENV_LARCH_LOGS_URI, "")
+    if legacy_override:
+        raise StorageConfigurationError(
+            f"{config.ENV_LARCH_LOGS_URI} is no longer supported; remove it and use "
+            f"{config.ENV_LARCH_STORAGE_BASE_URI} for a base-only override"
+        )
+    override: str = environ.get(config.ENV_LARCH_STORAGE_BASE_URI, "")
+    return parse_storage_base_uri(override or configured)
 
 
-def load_legacy_migration_descriptor(  # noqa: C901 - strict descriptor schema is validated as one transaction
-    *, repo_root: Path, storage_root: StorageRoot
-) -> LegacyMigrationDescriptor | None:
-    """Load a repository-scoped legacy inventory descriptor, when configured."""
-    raw_data: dict[str, object] = _load_repository_config(repo_root)
-    raw_logs: object = raw_data.get("logs")
-    if not isinstance(raw_logs, dict):
-        raise StorageConfigurationError(f"invalid {config.STORAGE_CONFIG_RELPATH}: missing [logs] table")
-    logs = cast("dict[str, object]", raw_logs)
-    raw_descriptor: object = logs.get("legacy_migration")
-    if raw_descriptor is None:
-        return None
-    if not isinstance(raw_descriptor, dict):
+def validate_client_repo(value: str) -> str:
+    """Validate the closed lowercase client-repository slug."""
+    if not _CLIENT_REPO_RE.fullmatch(value) or value in {".", ".."}:
         raise StorageConfigurationError(
-            f"invalid {config.STORAGE_CONFIG_RELPATH}: [logs.legacy_migration] must be a table"
+            "Git remote.origin.url did not yield a valid lowercase repository slug; "
+            "set remote.origin.url to a standard HTTPS, SSH, or SCP-like repository URL"
         )
-    descriptor = cast("dict[str, object]", raw_descriptor)
-    required: frozenset[str] = frozenset({
-        "inventory_key", "inventory_sha256", "schema", "source_commit", "storage_root",
-    })
-    if frozenset(descriptor) != required:
-        raise StorageConfigurationError(
-            f"invalid {config.STORAGE_CONFIG_RELPATH}: [logs.legacy_migration] has invalid fields"
+    return value
+
+
+def _repository_leaf(remote: str) -> str:
+    """Extract the final path component without returning remote text in errors."""
+    if (
+        not remote
+        or remote != remote.strip()
+        or any(
+            ord(character) < _ASCII_CONTROL_CHARACTER_MAX
+            or ord(character) == _ASCII_DELETE
+            for character in remote
         )
-    if not all(isinstance(descriptor[key], str) for key in required):
-        raise StorageConfigurationError(
-            f"invalid {config.STORAGE_CONFIG_RELPATH}: [logs.legacy_migration] values must be strings"
-        )
-    values = cast("dict[str, str]", descriptor)
-    digest: str = values["inventory_sha256"]
-    commit: str = values["source_commit"]
-    inventory_key: str = values["inventory_key"]
-    if len(digest) != _SHA256_HEX_LENGTH or any(character not in "0123456789abcdef" for character in digest):
-        raise StorageConfigurationError(
-            f"invalid {config.STORAGE_CONFIG_RELPATH}: legacy inventory SHA-256 is malformed"
-        )
-    if len(commit) != _GIT_COMMIT_HEX_LENGTH or any(character not in "0123456789abcdef" for character in commit):
-        raise StorageConfigurationError(
-            f"invalid {config.STORAGE_CONFIG_RELPATH}: legacy source commit is malformed"
-        )
-    key_parts: list[str] = inventory_key.split("/")
-    if inventory_key.startswith("/") or not inventory_key.endswith(".json") or any(
-        not part or part in {".", ".."} for part in key_parts
     ):
         raise StorageConfigurationError(
-            f"invalid {config.STORAGE_CONFIG_RELPATH}: legacy inventory key is unsafe"
+            "remote.origin.url is missing or malformed; set it to a standard HTTPS, SSH, "
+            "or SCP-like repository URL"
         )
-    if values["storage_root"] != storage_root.uri:
-        raise StorageConfigurationError("legacy migration descriptor does not match the active storage root")
-    if not values["schema"]:
+    path: str
+    if "://" in remote:
+        parsed: SplitResult = urlsplit(remote)
+        if (
+            parsed.scheme not in {"https", "ssh"}
+            or not parsed.netloc
+            or parsed.password is not None
+            or (parsed.scheme == "https" and parsed.username is not None)
+            or parsed.port is not None
+            or parsed.query
+            or parsed.fragment
+            or not parsed.path.startswith("/")
+        ):
+            raise StorageConfigurationError(
+                "remote.origin.url uses unsupported or credential-bearing syntax; "
+                "set a credential-free standard HTTPS or SSH repository URL"
+            )
+        path = parsed.path
+    else:
+        match: re.Match[str] | None = _SCP_REMOTE_RE.fullmatch(remote)
+        if match is None:
+            raise StorageConfigurationError(
+                "remote.origin.url uses unsupported or ambiguous syntax; set a standard "
+                "HTTPS, SSH, or SCP-like repository URL"
+            )
+        path = match.group("path")
+    path_segments: list[str] = path.lstrip("/").split("/")
+    if (
+        path.endswith("/")
+        or "//" in path
+        or any(not segment or segment in {".", ".."} for segment in path_segments)
+    ):
         raise StorageConfigurationError(
-            f"invalid {config.STORAGE_CONFIG_RELPATH}: legacy migration schema is empty"
-        )
-    return LegacyMigrationDescriptor(
-        schema=values["schema"], source_commit=commit, storage_root=values["storage_root"],
-        inventory_key=inventory_key, inventory_sha256=digest,
+            "remote.origin.url has an ambiguous repository path; set a standard repository URL"
     )
+    leaf: str = path_segments[-1].removesuffix(".git")
+    lowered: str = leaf.lower()
+    return validate_client_repo(lowered)
 
 
-def discover_storage_root(
+def derive_client_repo(
+    *,
+    repo_root: Path,
+    runner: proc.Runner | None = None,
+) -> str:
+    """Read the local origin and derive its canonical repository slug."""
+    active_runner: proc.Runner = proc.ProcRunner() if runner is None else runner
+    try:
+        result: proc.CommandResult = active_runner.run(
+            [
+                "git",
+                "-C",
+                str(repo_root),
+                "config",
+                "--local",
+                "--get",
+                "remote.origin.url",
+            ],
+            timeout=config.STORAGE_GIT_IDENTITY_TIMEOUT_SEC,
+            check=False,
+        )
+    except OSError as exc:
+        raise StorageConfigurationError(
+            "could not read local remote.origin.url; configure an origin repository remote"
+        ) from exc
+    if result.returncode != 0 or not result.stdout.strip():
+        raise StorageConfigurationError(
+            "local remote.origin.url is missing; configure an origin repository remote"
+        )
+    return _repository_leaf(result.stdout.strip())
+
+
+def load_tool_repository_storage(
+    *,
+    repo_root: Path,
+    environ: Mapping[str, str] | None = None,
+    runner: proc.Runner | None = None,
+) -> ToolRepositoryStorage:
+    """Require repository config and derive the fixed larch/client namespace."""
+    environment: Mapping[str, str] = os.environ if environ is None else environ
+    base: StorageBase = _configured_storage_base(
+        repo_root=repo_root, environ=environment
+    )
+    client_repo: str = derive_client_repo(repo_root=repo_root, runner=runner)
+    return ToolRepositoryStorage(base=base, client_repo=client_repo)
+
+
+def discover_tool_repository_storage(
     *,
     start: Path | None = None,
     environ: Mapping[str, str] | None = None,
     root_resolver: Callable[[Path | None], Path | None] = consumer_repo_root,
-) -> StorageRoot:
-    """Discover the Git repository root, then load its storage configuration."""
-    repo_root = root_resolver(start)
+    runner: proc.Runner | None = None,
+) -> ToolRepositoryStorage:
+    """Resolve the startup Git root, then pin config and origin identity."""
+    repo_root: Path | None = root_resolver(start)
     if repo_root is None:
-        location = str(start) if start is not None else str(Path.cwd())
-        raise StorageConfigurationError(f"could not discover a Git repository root from {location}")
-    return load_storage_root(repo_root=repo_root, environ=environ)
-
-
-def preflight_s3_bucket(*, storage_root: StorageRoot, runner: proc.Runner | None = None) -> None:
-    """Require a successful AWS bucket-root list, without inspecting its output."""
-    if storage_root.scheme != "s3":
-        raise StoragePreflightError(
-            f"S3 startup preflight requires an s3:// storage root, got {storage_root.scheme}://"
+        location: str = str(start) if start is not None else str(Path.cwd())
+        raise StorageConfigurationError(
+            f"could not discover a Git repository root from startup CWD {location}"
         )
-    active_runner = proc.ProcRunner() if runner is None else runner
-    result = active_runner.run(
-        [config.AWS_CLI, "s3", "ls", storage_root.bucket_uri],
-        timeout=config.STORAGE_PREFLIGHT_TIMEOUT_SEC,
-        check=False,
-    )
-    if result.returncode == 0:
-        return
-    if result.returncode == config.AWS_CLI_NOT_FOUND_EXIT_CODE:
-        raise StoragePreflightError(
-            f"AWS CLI is required for S3 storage preflight; install '{config.AWS_CLI}' and retry"
-        )
-    raise StoragePreflightError(
-        f"S3 bucket-root list failed for {storage_root.bucket_uri} (exit {result.returncode}); "
-        "verify normal AWS credential discovery and bucket access"
+    return load_tool_repository_storage(
+        repo_root=repo_root, environ=environ, runner=runner
     )
 
 
-def storage_preflight_main(argv: list[str]) -> int:
-    """Run the configured provider's bucket-root startup preflight."""
+def _validated_path_component(value: str, *, label: str) -> str:
+    if (
+        not value
+        or value in {".", ".."}
+        or "/" in value
+        or "\\" in value
+        or any(
+            character.isspace()
+            or ord(character) < _ASCII_CONTROL_CHARACTER_MAX
+            or ord(character) == _ASCII_DELETE
+            for character in value
+        )
+    ):
+        raise StorageConfigurationError(f"invalid {label}")
+    return value
+
+
+def parse_legacy_migration_descriptor(
+    raw_descriptor: object, *, storage_root: StorageBase
+) -> LegacyMigrationDescriptor:
+    """Validate an explicit operator migration descriptor without config discovery."""
+    if not isinstance(raw_descriptor, dict):
+        raise StorageConfigurationError("legacy migration descriptor must be a table")
+    descriptor: dict[str, object] = cast("dict[str, object]", raw_descriptor)
+    required: frozenset[str] = frozenset(
+        {
+            "inventory_key",
+            "inventory_sha256",
+            "schema",
+            "source_commit",
+            "storage_root",
+        }
+    )
+    if frozenset(descriptor) != required or not all(
+        isinstance(descriptor[key], str) for key in required
+    ):
+        raise StorageConfigurationError(
+            "legacy migration descriptor has invalid fields"
+        )
+    values: dict[str, str] = cast("dict[str, str]", descriptor)
+    digest: str = values["inventory_sha256"]
+    commit: str = values["source_commit"]
+    inventory_key: str = values["inventory_key"]
+    if len(digest) != _SHA256_HEX_LENGTH or any(
+        character not in "0123456789abcdef" for character in digest
+    ):
+        raise StorageConfigurationError("legacy inventory SHA-256 is malformed")
+    if len(commit) != _GIT_COMMIT_HEX_LENGTH or any(
+        character not in "0123456789abcdef" for character in commit
+    ):
+        raise StorageConfigurationError("legacy source commit is malformed")
+    key_parts: list[str] = inventory_key.split("/")
+    if (
+        inventory_key.startswith("/")
+        or not inventory_key.endswith(".json")
+        or any(not part or part in {".", ".."} for part in key_parts)
+    ):
+        raise StorageConfigurationError("legacy inventory key is unsafe")
+    if values["storage_root"] != storage_root.uri:
+        raise StorageConfigurationError(
+            "legacy migration descriptor does not match the explicit storage root"
+        )
+    if not values["schema"]:
+        raise StorageConfigurationError("legacy migration schema is empty")
+    return LegacyMigrationDescriptor(
+        schema=values["schema"],
+        source_commit=commit,
+        storage_root=values["storage_root"],
+        inventory_key=inventory_key,
+        inventory_sha256=digest,
+    )
+
+
+def preflight_tool_repository(
+    *,
+    storage: ToolRepositoryStorage,
+    environ: Mapping[str, str] | None = None,
+    runner: proc.Runner | None = None,
+) -> None:
+    """List at most one object under the exact tool/repository prefix."""
+    try:
+        object_store_for(storage, environ=environ, runner=runner).preflight_prefix()
+    except ObjectStoreError as exc:
+        if exc.kind.value == "configuration" and storage.scheme in {"s3", "r2"}:
+            raise StoragePreflightError(
+                f"AWS CLI is required for {storage.scheme.upper()} storage preflight; "
+                f"install '{config.AWS_CLI}' and retry"
+            ) from exc
+        raise StoragePreflightError(
+            f"{storage.scheme} prefix preflight failed for the configured larch repository "
+            "namespace; verify provider credentials and prefix-scoped list access"
+        ) from exc
+
+
+def storage_preflight_main(argv: Sequence[str]) -> int:
+    """Run the configured provider's prefix-scoped startup preflight."""
     parser = argparse.ArgumentParser(prog="cli.py run-log storage-preflight")
     _ = parser.add_argument("--repo-root", default="")
     try:
         args = parser.parse_args(argv)
     except SystemExit as exc:
         return int(exc.code) if isinstance(exc.code, int) else config.EXIT_USAGE
-    start = Path(args.repo_root) if args.repo_root else None
+    start: Path | None = Path(args.repo_root) if args.repo_root else None
     try:
-        storage_root = discover_storage_root(start=start)
-        if storage_root.scheme == "s3":
-            preflight_s3_bucket(storage_root=storage_root)
-        else:
-            object_store_for(storage_root).preflight_bucket()
+        storage: ToolRepositoryStorage = discover_tool_repository_storage(start=start)
+        preflight_tool_repository(storage=storage)
     except StorageConfigurationError as exc:
         print(f"storage preflight failed: {exc}", file=sys.stderr)
         return config.EXIT_STORAGE_CONFIG
     except StoragePreflightError as exc:
         print(f"storage preflight failed: {exc}", file=sys.stderr)
         return config.EXIT_STORAGE_PREFLIGHT
-    except ObjectStoreError as exc:
-        print(f"storage preflight failed: {exc}", file=sys.stderr)
-        return config.EXIT_STORAGE_PREFLIGHT
-    print(f"STORAGE_URI={storage_root.uri}")
-    print(f"RUN_LOGS_URI={storage_root.run_logs_uri}")
+    print(f"STORAGE_BASE_URI={storage.base.uri}")
+    print(f"CLIENT_REPO={storage.client_repo}")
+    print(f"TOOL_REPO_URI={storage.uri}")
+    print(f"RUN_LOGS_URI={storage.run_logs_uri}")
     print("PREFLIGHT_OK=true")
     return config.EXIT_OK

--- a/python/larch/report/storage_config.py
+++ b/python/larch/report/storage_config.py
@@ -335,15 +335,23 @@ def _repository_leaf(remote: str) -> str:
     path: str
     if "://" in remote:
         parsed: SplitResult = urlsplit(remote)
-        if (
+        try:
+            has_port: bool = parsed.port is not None
+        except ValueError:
+            has_port = True
+        unsupported_shape: bool = (
             parsed.scheme not in {"https", "ssh"}
             or not parsed.netloc
-            or parsed.password is not None
-            or (parsed.scheme == "https" and parsed.username is not None)
-            or parsed.port is not None
-            or parsed.query
-            or parsed.fragment
             or not parsed.path.startswith("/")
+        )
+        credential_bearing: bool = parsed.password is not None or (
+            parsed.scheme == "https" and parsed.username is not None
+        )
+        decorated: bool = has_port or bool(parsed.query) or bool(parsed.fragment)
+        if (
+            unsupported_shape
+            or credential_bearing
+            or decorated
         ):
             raise StorageConfigurationError(
                 "remote.origin.url uses unsupported or credential-bearing syntax; "

--- a/python/larch/report/tokens.py
+++ b/python/larch/report/tokens.py
@@ -26,7 +26,7 @@ from larch.core.repo_roots import RepoRootProbeOptions, repo_root_probe
 from larch.git import gh
 from larch.errors import ShipError
 from larch.report import analysis_state, markdown_block
-from larch.report import run_log_corpus
+from larch.report import run_log_corpus, storage_config
 from larch.report.report_tokens_models import RunRecord, Skill, VendorTotals, safe_int
 from larch.rendering.render_session_transcript import strip_plugin_cache_read_suffix
 
@@ -2032,8 +2032,11 @@ def _ngram_source_files(repo: Path) -> list[str]:
 def _measure_stamp() -> str:
     return os.environ.get("LARCH_MEASURE_DATE", datetime.now().strftime("%Y-%m-%d"))
 
-def _measurement_output(*, repo: Path, owner: str, suffix: str) -> Path:
-    return analysis_state.output_path(repo_root=repo, owner=owner, name=f"{_measure_stamp()}.{suffix}")
+def _measurement_storage(repo: Path) -> storage_config.ToolRepositoryStorage:
+    return storage_config.load_tool_repository_storage(repo_root=repo)
+
+def _measurement_output(*, repo: Path, storage: storage_config.ToolRepositoryStorage, owner: str, suffix: str) -> Path:
+    return analysis_state.output_path(repo_root=repo, storage=storage, owner=owner, name=f"{_measure_stamp()}.{suffix}")
 
 
 # Subprocess-isolated tiktoken encoder: the string literal below is not an AST Import
@@ -2061,7 +2064,8 @@ def _tiktoken_count_texts(texts: list[str]) -> list[int]:
 
 def measure_md_cost() -> Path:
     repo = _repo_root()
-    out_path = _measurement_output(repo=repo, owner="measure-md-cost", suffix="tsv")
+    storage = _measurement_storage(repo)
+    out_path = _measurement_output(repo=repo, storage=storage, owner="measure-md-cost", suffix="tsv")
     files = proc.run(["git", "-C", str(repo), "ls-files", "-z", "*.md"], stderr=subprocess.DEVNULL, check=True).stdout.split("\x00")
     out_path.parent.mkdir(parents=True, exist_ok=True)
     tier1_imports = _claude_root_imports(repo)
@@ -2092,7 +2096,8 @@ def measure_md_cost() -> Path:
 
 def measure_ngram_duplication() -> Path:
     repo = _repo_root()
-    out_path = _measurement_output(repo=repo, owner="measure-ngram-duplication", suffix="txt")
+    storage = _measurement_storage(repo)
+    out_path = _measurement_output(repo=repo, storage=storage, owner="measure-ngram-duplication", suffix="txt")
     size = int(os.environ.get("LARCH_MEASURE_NGRAM_SIZE", "6"))
     min_files = int(os.environ.get("LARCH_MEASURE_NGRAM_MIN_FILES", "3"))
     limit = int(os.environ.get("LARCH_MEASURE_NGRAM_LIMIT", "50"))
@@ -2114,8 +2119,9 @@ def measure_ngram_duplication() -> Path:
 
 def measure_references_heatmap() -> Path:
     repo = _repo_root()
-    out_path = _measurement_output(repo=repo, owner="measure-references-heatmap", suffix="tsv")
-    log_root = run_log_corpus.synchronized_repository_log_root(repo_root=repo)
+    storage = _measurement_storage(repo)
+    out_path = _measurement_output(repo=repo, storage=storage, owner="measure-references-heatmap", suffix="tsv")
+    log_root = run_log_corpus.synchronized_repository_log_root(repo_root=repo, storage=storage)
     run_dirs_by_skill = _skill_run_dirs(log_root)
     reads: list[ObservedReferenceRead] = []
     coverage_rows: list[tuple[str, int, int, int, float, str]] = []
@@ -2160,8 +2166,9 @@ def measure_references_heatmap() -> Path:
 
 def measure_realized_cost() -> Path:
     repo = _repo_root()
-    out_path = _measurement_output(repo=repo, owner="measure-realized-cost", suffix="tsv")
-    log_root = run_log_corpus.synchronized_repository_log_root(repo_root=repo)
+    storage = _measurement_storage(repo)
+    out_path = _measurement_output(repo=repo, storage=storage, owner="measure-realized-cost", suffix="tsv")
+    log_root = run_log_corpus.synchronized_repository_log_root(repo_root=repo, storage=storage)
     run_dirs_by_skill = _skill_run_dirs(log_root)
     skill_paths: dict[str, str] = {}
     skill_texts: list[str] = []
@@ -2509,7 +2516,8 @@ def measure_cache_efficiency() -> Path:
     runner = ProcRunner()
     tagged_records: list[tuple[Skill, RunRecord]] = []
     repo_root: Path = _repo_root()
-    log_root: Path = run_log_corpus.synchronized_repository_log_root(repo_root=repo_root)
+    storage = _measurement_storage(repo_root)
+    log_root: Path = run_log_corpus.synchronized_repository_log_root(repo_root=repo_root, storage=storage)
     for skill in ("design", "implement"):
         scan_result = report_tokens_scan.scan_prepared_corpus(
             runner,
@@ -2517,7 +2525,7 @@ def measure_cache_efficiency() -> Path:
             corpus_root=log_root,
         )
         tagged_records.extend((skill, record) for record in scan_result.records)
-    out_path = _measurement_output(repo=repo_root, owner="measure-cache-efficiency", suffix="tsv")
+    out_path = _measurement_output(repo=repo_root, storage=storage, owner="measure-cache-efficiency", suffix="tsv")
     out_path.parent.mkdir(parents=True, exist_ok=True)
     per_run, per_step = _measure_cache_efficiency_records(tagged_records=tagged_records)
     _atomic_text(path=out_path, text=_render_cache_efficiency_tsv(per_run=per_run, per_step=per_step))
@@ -2724,8 +2732,9 @@ def _render_checks_digest_savings_report(aggregate: ChecksDigestSavingsAggregate
 
 def measure_checks_digest_savings() -> Path:
     repo = _repo_root()
-    out_path = _measurement_output(repo=repo, owner="measure-checks-digest-savings", suffix="tsv")
-    log_root = run_log_corpus.synchronized_repository_log_root(repo_root=repo)
+    storage = _measurement_storage(repo)
+    out_path = _measurement_output(repo=repo, storage=storage, owner="measure-checks-digest-savings", suffix="tsv")
+    log_root = run_log_corpus.synchronized_repository_log_root(repo_root=repo, storage=storage)
     aggregate = ChecksDigestSavingsAggregate()
     for tsv in _iter_checks_digest_size_files(repo, corpus_root=log_root):
         has_header, rows_seen, rows_skipped, rows = _read_checks_digest_size_file(tsv)
@@ -2742,8 +2751,9 @@ def measure_checks_digest_savings() -> Path:
 
 def measure_panel_cost() -> Path:
     repo = _repo_root()
-    out_path = _measurement_output(repo=repo, owner="measure-panel-cost", suffix="tsv")
-    log_root = run_log_corpus.synchronized_repository_log_root(repo_root=repo)
+    storage = _measurement_storage(repo)
+    out_path = _measurement_output(repo=repo, storage=storage, owner="measure-panel-cost", suffix="tsv")
+    log_root = run_log_corpus.synchronized_repository_log_root(repo_root=repo, storage=storage)
     aggregates: dict[tuple[str, str, str], _PanelCostAggregate] = {}
     for tsv in _iter_panel_prompt_size_files(repo, corpus_root=log_root):
         context = _panel_context_from_tsv(tsv, repo, corpus_root=log_root)

--- a/python/tests/calibration/test_difficulty_calibration.py
+++ b/python/tests/calibration/test_difficulty_calibration.py
@@ -522,17 +522,33 @@ def test_default_synced_corpus_matches_explicit_fixture(
     synced_out = tmp_path / "synced.md"
     sync_calls = 0
 
-    def _sync(*, repo_root: Path) -> Path:
+    storage_root = dc.storage_config.ToolRepositoryStorage(
+        dc.storage_config.StorageBase("s3", "fixture-bucket"), "fixture-repo"
+    )
+
+    def _sync(*, repo_root: Path, storage: dc.storage_config.ToolRepositoryStorage) -> Path:
+        _ = storage
         nonlocal sync_calls
         assert repo_root == tmp_path
         sync_calls += 1
         return cache_root
 
-    def _state_root(*, repo_root: Path) -> Path:
+    def _state_root(*, repo_root: Path, storage: dc.storage_config.ToolRepositoryStorage) -> Path:
+        _ = storage
         assert repo_root == tmp_path
         return root
 
     monkeypatch.setattr(dc.repo_roots, "consumer_repo_root", lambda: tmp_path)
+    def _load_storage(
+        **_kwargs: object,
+    ) -> dc.storage_config.ToolRepositoryStorage:
+        return storage_root
+
+    monkeypatch.setattr(
+        dc.storage_config,
+        "load_tool_repository_storage",
+        _load_storage,
+    )
     monkeypatch.setattr(dc.run_log_corpus, "synchronized_repository_log_root", _sync)
     monkeypatch.setattr(dc.analysis_state, "repository_state_root", _state_root)
 

--- a/python/tests/design/test_design_log_publish_flow.py
+++ b/python/tests/design/test_design_log_publish_flow.py
@@ -14,8 +14,9 @@ import pytest
 from larch.design import design_log_publish_flow
 from larch.design import design_summary
 from larch.report import run_lifecycle, run_log_publish as run_log_publisher, run_logs
-from larch.report.storage_config import StorageRoot
-from test_support import operator_repo_with_remote as _operator_repo_with_remote
+from larch.report import storage_config
+from larch.report.storage_config import StorageBase, ToolRepositoryStorage
+from test_support import operator_repo_with_remote as _base_operator_repo_with_remote
 from test_support import write_gh_pr_stub as _write_gh_stub
 
 RUN_ID = "ABCDEF01-2345-6789-ABCD-EF0123456789"
@@ -23,6 +24,21 @@ RUN_ID = "ABCDEF01-2345-6789-ABCD-EF0123456789"
 
 def _git(*argv: str, cwd: Path) -> None:
     _ = subprocess.run(["git", *argv], cwd=cwd, check=True, capture_output=True)
+
+def _operator_repo_with_remote(tmp_path: Path) -> Path:
+    repo = _base_operator_repo_with_remote(tmp_path)
+    local_remote = subprocess.run(
+        ["git", "remote", "get-url", "origin"], cwd=repo, check=True,
+        capture_output=True, text=True,
+    ).stdout.strip()
+    _git("remote", "set-url", "--push", "origin", local_remote, cwd=repo)
+    _git("remote", "set-url", "origin", "git@github.com:fixture/consumer.git", cwd=repo)
+    _ = (repo / "tools-config.toml").write_text(
+        '[larch]\nstorage_base_uri = "s3://bucket"\n', encoding="utf-8"
+    )
+    _git("add", "tools-config.toml", cwd=repo)
+    _git("commit", "-q", "-m", "storage config", cwd=repo)
+    return repo
 
 
 def _operator_repo_with_guidelines(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
@@ -95,6 +111,8 @@ elif args[:2] == ["s3api", "get-object"]:
     destination = Path(args[args.index("--key") + 2])
     shutil.copy2(root / key, destination)
     print("{}")
+elif args[:2] == ["s3api", "list-objects-v2"]:
+    print('{"Contents":[]}')
 elif args[:2] == ["s3", "ls"]:
     raise SystemExit(0)
 else:
@@ -105,7 +123,9 @@ else:
     aws_stub.chmod(0o755)
     env = os.environ.copy()
     env["PATH"] = f"{bin_dir}:{env.get('PATH', '')}"
-    env["LARCH_LOGS_URI"] = "s3://bucket/larch"
+    _ = (repo / "tools-config.toml").write_text(
+        '[larch]\nstorage_base_uri = "s3://bucket"\n', encoding="utf-8"
+    )
     env["XDG_CACHE_HOME"] = str(bin_dir.parent / "cache")
     env["XDG_STATE_HOME"] = str(bin_dir.parent / "state")
     # The real cli is used for run-log init/commit + redact; all git writes are
@@ -161,7 +181,11 @@ else:
 
 
 def _cached_run(repo: Path, bin_dir: Path) -> Path:
-    return bin_dir.parent / "cache" / "larch" / "run-logs" / repo.name / "design" / RUN_ID
+    storage = storage_config.load_tool_repository_storage(repo_root=repo, environ={})
+    return (
+        bin_dir.parent / "cache" / "larch" / "run-logs" / "v2"
+        / storage.client_repo / storage.storage_origin_id / "design" / RUN_ID
+    )
 
 
 def _patch_archive_publish(
@@ -176,7 +200,7 @@ def _patch_archive_publish(
         _ = run_logs.log_init(log_root=staging_root, skill="design", run_id=RUN_ID)
         return run_lifecycle.LifecycleStart(
             repo_root=cache_dir.parent,
-            storage_root=StorageRoot("s3", "bucket", "larch"),
+            storage_root=ToolRepositoryStorage(StorageBase("s3", "bucket"), "consumer"),
             skill="design",
             run_id=RUN_ID,
             log_root=staging_root,
@@ -695,7 +719,10 @@ def test_log_publish_creates_cloud_archive_and_cache_without_git_mutation(tmp_pa
     summary = (cached / "final-summary.md").read_text(encoding="utf-8")
     assert "STALE-SENTINEL" not in summary
     assert "<!-- larch:run-summary v=1 -->" in summary
-    assert (tmp_path / "remote" / "larch" / "run-logs" / "design" / f"{RUN_ID}.tar.gz").is_file()
+    assert (
+        tmp_path / "remote" / "larch" / "consumer" / "run-logs"
+        / "design" / f"{RUN_ID}.tar.gz"
+    ).is_file()
     meta = (design / ".design-log-publish-metadata.env").read_text(encoding="utf-8")
     assert f"DESIGN_LOG_REMOTE_KEY=run-logs/design/{RUN_ID}.tar.gz" in meta
 
@@ -890,7 +917,11 @@ def test_log_publish_upload_failure_keeps_tree_clean_and_durable_pending(
         check=False,
     )
     assert status.stdout.strip() == "", status.stdout
-    pending = tmp_path / "state" / "larch" / "run-log-pending" / repo.name / "design" / RUN_ID
+    storage = storage_config.load_tool_repository_storage(repo_root=repo, environ={})
+    pending = (
+        tmp_path / "state" / "larch" / "run-log-pending" / "v2"
+        / storage.client_repo / storage.storage_origin_id / "design" / RUN_ID
+    )
     assert (pending / "archive.tar.gz").is_file()
     assert (pending / "retry.json").is_file()
 
@@ -1258,7 +1289,7 @@ def test_publish_design_logs_classifies_archive_finalization_failure(
     monkeypatch.setattr(design_log_publish_flow, "_copy_tree_redacted", _copy_ok)
     context = run_lifecycle.LifecycleStart(
         repo_root=tmp_path,
-        storage_root=StorageRoot("s3", "bucket", "larch"),
+        storage_root=ToolRepositoryStorage(StorageBase("s3", "bucket"), "consumer"),
         skill="design",
         run_id="RUN1",
         log_root=tmp_path / "logs",

--- a/python/tests/design/test_design_pause.py
+++ b/python/tests/design/test_design_pause.py
@@ -149,7 +149,7 @@ def _patch_load(
     monkeypatch.setattr(design_pause.gh, "issue_view_body", fake_issue_view_body)  # type: ignore[attr-defined]
     monkeypatch.setattr(design_pause.subprocess, "run", fake.run)  # type: ignore[attr-defined]
     monkeypatch.setattr(
-        design_pause.storage_config, "discover_storage_root", fake_storage_root
+        design_pause.storage_config, "discover_tool_repository_storage", fake_storage_root
     )
     monkeypatch.setattr(
         design_pause.run_log_publish,
@@ -346,14 +346,17 @@ def test_pause_save_uses_real_log_publish_path(
         )
         return result, 0
 
-    storage_root = run_lifecycle.storage_config.StorageRoot("s3", "test-bucket", "test-prefix")
+    storage_root = run_lifecycle.storage_config.ToolRepositoryStorage(
+        run_lifecycle.storage_config.StorageBase("s3", "test-bucket"),
+        "test-repo",
+    )
 
     def fake_storage_root(**_kwargs: object) -> object:
         return storage_root
 
     monkeypatch.setattr(
         run_lifecycle.storage_config,
-        "load_storage_root",
+        "load_tool_repository_storage",
         fake_storage_root,
     )
     _ = run_lifecycle.start_run(repo_root=repo, skill="design", run_id="RUN1", log_root=design / "larch-logs", storage_root=storage_root, preflight=lambda _root: None)

--- a/python/tests/design/test_design_summary.py
+++ b/python/tests/design/test_design_summary.py
@@ -759,7 +759,15 @@ def test_published_run_logs_path_requires_completed_log_publication(tmp_path: Pa
     assert design_summary._published_run_logs_path(design_tmpdir=tmp_path, run_id="run-1") == "N/A"  # pyright: ignore[reportPrivateUsage]
     repo = tmp_path / "repo"
     repo.mkdir()
-    _ = (repo / "config.toml").write_text('[logs]\nuri = "s3://bucket/root"\n', encoding="utf-8")
+    _ = subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    _ = subprocess.run(
+        ["git", "remote", "add", "origin", "git@github.com:fixture/repo.git"],
+        cwd=repo,
+        check=True,
+    )
+    _ = (repo / "tools-config.toml").write_text(
+        '[larch]\nstorage_base_uri = "s3://bucket"\n', encoding="utf-8"
+    )
     _ = (tmp_path / "source-env.sh").write_text(f"REPO_ROOT={repo}\n", encoding="utf-8")
     _ = result.write_text("LOG_PUBLISH_COMPLETED=true\n", encoding="utf-8")
     assert design_summary._published_run_logs_path(design_tmpdir=tmp_path, run_id="run-1") == "provider `s3`, skill `design`, run ID `run-1`"  # pyright: ignore[reportPrivateUsage]

--- a/python/tests/issue/test_audit_runs.py
+++ b/python/tests/issue/test_audit_runs.py
@@ -15,6 +15,7 @@ from larch.core import architectural_guidelines as ag
 from larch.core import config
 from larch.issue import audit_runs, learn_from_bugs
 from larch.core.proc import CommandResult
+from larch.report import storage_config
 
 
 @pytest.fixture(autouse=True)
@@ -22,6 +23,14 @@ def _isolated_analysis_state(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "xdg-state"))
+    storage = storage_config.ToolRepositoryStorage(
+        storage_config.StorageBase("s3", "test-bucket"), "r"
+    )
+    monkeypatch.setattr(
+        storage_config,
+        "load_tool_repository_storage",
+        lambda **_kwargs: storage,
+    )
 
 
 
@@ -98,6 +107,7 @@ def _write_learn_from_bugs_state(
     scan_started_at: str | None = "2026-07-09T01:00:00Z",
 ) -> None:
     marker = learn_from_bugs.state_path(root)
+    marker.parent.mkdir(parents=True, exist_ok=True)
     payload: dict[str, object] = {
         "schema_version": 1,
         "run_date": run_date,
@@ -114,6 +124,19 @@ def _write_learn_from_bugs_state(
 
 def _gh_issue_rows(count: int, *, title: str = "[BUG] fixed", closed_at: str = "2026-07-09T02:00:00Z") -> str:
     return json.dumps([{"number": n + 1, "title": title, "closedAt": closed_at} for n in range(count)])
+
+
+def test_learn_from_bugs_state_does_not_import_legacy_repository_state(
+    tmp_path: Path,
+) -> None:
+    legacy = tmp_path / "larch-logs" / "shared" / "learn-from-bugs-state.json"
+    legacy.parent.mkdir(parents=True)
+    _ = legacy.write_text('{"schema_version":1}\n', encoding="utf-8")
+
+    marker = learn_from_bugs.state_path(tmp_path)
+
+    assert not marker.exists()
+    assert legacy.read_text(encoding="utf-8") == '{"schema_version":1}\n'
 
 
 def test_bugs_backlog_nudge_missing_marker_prints_never_run_without_gh(
@@ -133,6 +156,7 @@ def test_bugs_backlog_nudge_symlink_marker_is_unusable(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     marker = learn_from_bugs.state_path(tmp_path)
+    marker.parent.mkdir(parents=True, exist_ok=True)
     marker.symlink_to(tmp_path / "target.json")
 
     def fail_run(argv: list[str], **_kwargs: object) -> CommandResult:

--- a/python/tests/issue/test_learn_from_bugs.py
+++ b/python/tests/issue/test_learn_from_bugs.py
@@ -14,6 +14,7 @@ from larch.core import architectural_guidelines as ag
 from larch.core.proc import CommandResult
 from larch.issue import learn_from_bugs
 from larch.issue.title_match import BUG_PREFIX
+from larch.report import storage_config
 from test_support import RecordingRunner, RunCall
 
 
@@ -22,6 +23,18 @@ def _isolated_analysis_state(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "xdg-state"))
+    storage = storage_config.ToolRepositoryStorage(
+        storage_config.StorageBase("s3", "test-bucket"), "repository"
+    )
+
+    def load_storage(**_kwargs: object) -> storage_config.ToolRepositoryStorage:
+        return storage
+
+    monkeypatch.setattr(
+        storage_config,
+        "load_tool_repository_storage",
+        load_storage,
+    )
 
 
 def _result(stdout: str = "", rc: int = 0, stderr: str = "") -> CommandResult:

--- a/python/tests/issue/test_rejected_analysis.py
+++ b/python/tests/issue/test_rejected_analysis.py
@@ -127,6 +127,57 @@ def test_prepare_default_synced_corpus_matches_explicit_fixture(
     assert sync_calls == 1
 
 
+def test_prepare_main_log_root_bypasses_repository_storage(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    log_root = tmp_path / "offline-logs"
+    log_root.mkdir()
+    work_dir = tmp_path / "work"
+
+    def repo_root(_start: Path | str | None = None) -> Path:
+        return tmp_path
+
+    def no_open_issues(
+        *_args: object,
+        **_kwargs: object,
+    ) -> list[ra.OpenIssue]:
+        return []
+
+    monkeypatch.setattr(
+        ra.repo_roots,
+        "consumer_repo_root",
+        repo_root,
+    )
+    monkeypatch.setattr(ra, "_query_open_issues", no_open_issues)
+
+    def fail_storage(**_kwargs: object) -> None:
+        raise AssertionError("offline --log-root must not load repository storage")
+
+    monkeypatch.setattr(
+        ra.storage_config,
+        "load_tool_repository_storage",
+        fail_storage,
+    )
+
+    assert (
+        ra.prepare_main(
+            [
+                "--days",
+                "7",
+                "--log-root",
+                str(log_root),
+                "--work-dir",
+                str(work_dir),
+            ]
+        )
+        == 0
+    )
+    assert (work_dir / "state-root.txt").read_text(encoding="utf-8").strip() == str(
+        tmp_path
+    )
+
+
 def test_prepare_keeps_one_yes_and_ledgers_zero_yes_oos_and_duplicates(tmp_path: Path) -> None:
     _write_implement_fixture(tmp_path, run_id="RUN-A", finding_id="FINDING_1", json_id="REJ_CR1_1", concern="Missing required check", path="python/foo.py:12")
     _write_implement_fixture(tmp_path, run_id="RUN-B", finding_id="FINDING_2", json_id="REJ_CR1_2", concern="Zero yes concern", path="python/bar.py:5", vote1="NO", vote2="NO")

--- a/python/tests/report/test_analysis_state.py
+++ b/python/tests/report/test_analysis_state.py
@@ -6,13 +6,16 @@ import stat
 from pathlib import Path
 import pytest
 from larch.report import analysis_state
+from larch.report.storage_config import StorageBase, ToolRepositoryStorage
 
 
 def _path(tmp_path: Path) -> Path:
     repo = tmp_path / "literal repo"
     repo.mkdir(exist_ok=True)
+    storage = ToolRepositoryStorage(StorageBase("s3", "bucket"), "literal-repo")
     return analysis_state.state_path(
         repo_root=repo,
+        storage=storage,
         state_home=tmp_path / "state",
         owner="validate-merged",
         name="state.json",
@@ -27,19 +30,19 @@ def test_first_write_uses_private_repository_scoped_state(tmp_path: Path) -> Non
     assert (
         path
         == tmp_path
-        / "state/larch/analysis-state/literal repo/validate-merged/state.json"
+        / "state"
+        / "larch"
+        / "analysis-state"
+        / "v2"
+        / "literal-repo"
+        / ToolRepositoryStorage(
+            StorageBase("s3", "bucket"), "literal-repo"
+        ).storage_origin_id
+        / "validate-merged"
+        / "state.json"
     )
     assert analysis_state.read_snapshot(path).digest == digest
     assert stat.S_IMODE(path.stat().st_mode) == 0o600
-
-
-def test_warm_read_imports_legacy_once(tmp_path: Path) -> None:
-    path, legacy = _path(tmp_path), tmp_path / "legacy.json"
-    _ = legacy.write_bytes(b"first\n")
-    cold = analysis_state.import_legacy_file(path=path, legacy_path=legacy)
-    _ = legacy.write_bytes(b"later\n")
-    assert analysis_state.import_legacy_file(path=path, legacy_path=legacy) == cold
-    assert path.read_bytes() == b"first\n"
 
 
 def test_corrupt_non_regular_state_fails_closed(tmp_path: Path) -> None:

--- a/python/tests/report/test_object_store.py
+++ b/python/tests/report/test_object_store.py
@@ -7,7 +7,7 @@ from typing import cast
 import pytest
 from larch.core import config, proc
 from larch.report.object_store import ObjectStoreError, ObjectStoreErrorKind, object_store_for
-from larch.report.storage_config import StorageRoot
+from larch.report.storage_config import StorageBase, ToolRepositoryStorage
 _ACCOUNT = "0123456789abcdef0123456789abcdef"
 _ENDPOINT = f"https://{_ACCOUNT}.r2.cloudflarestorage.com"
 _CONTRACT_PATH = Path(__file__).parents[3] / "tests/fixtures/run-log-object-store-contract-v1.json"
@@ -33,28 +33,30 @@ class FakeRunner:
         return self.responses.pop(0)
 def _store(scheme: str, runner: FakeRunner):
     environ = {config.ENV_LARCH_R2_ACCOUNT_ID: _ACCOUNT, config.ENV_LARCH_R2_ENDPOINT: _ENDPOINT}
-    return object_store_for(StorageRoot(scheme, "bucket", "larch"), environ=environ, runner=cast("proc.Runner", runner))
+    storage = ToolRepositoryStorage(StorageBase(scheme, "bucket"), "larch")
+    return object_store_for(storage, environ=environ, runner=cast("proc.Runner", runner))
 @pytest.mark.parametrize("scheme", ["s3", "gs", "r2"])
-def test_preflight_uses_bucket_root_exit_status_only(scheme: str) -> None:
+def test_preflight_lists_only_the_tool_repository_prefix(scheme: str) -> None:
     runner = FakeRunner(_result(payload={"unexpected": "output"}))
-    _store(scheme, runner).preflight_bucket()
-    assert "larch" not in runner.calls[0]
+    _store(scheme, runner).preflight_prefix()
+    assert "larch/larch/" in runner.calls[0]
     assert "bucket" in " ".join(runner.calls[0])
+    assert scheme == "gs" or runner.calls[0][runner.calls[0].index("--max-keys") + 1] == "1"
     with pytest.raises((ObjectStoreError, RuntimeError)):
-        _store(scheme, FakeRunner(_result(1, {"objects": [{"key": "larch/run"}]}))).preflight_bucket()
+        _store(scheme, FakeRunner(_result(1, {"objects": [{"key": "larch/larch/run"}]}))).preflight_prefix()
 @pytest.mark.parametrize("scheme", ["s3", "gs", "r2"])
 def test_list_paginates_from_empty_prefix(scheme: str) -> None:
     if scheme == "gs":
-        pages = ({"objects": [{"key": "larch/a", "size": 1}], "next_page_token": "two"}, {"objects": [{"key": "larch/b", "size": 2}]})
+        pages = ({"objects": [{"key": "larch/larch/a", "size": 1}], "next_page_token": "two"}, {"objects": [{"key": "larch/larch/b", "size": 2}]})
     else:
-        pages = ({"Contents": [{"Key": "larch/a", "Size": 1}], "NextContinuationToken": "two"}, {"Contents": [{"Key": "larch/b", "Size": 2}]})
+        pages = ({"Contents": [{"Key": "larch/larch/a", "Size": 1}], "NextContinuationToken": "two"}, {"Contents": [{"Key": "larch/larch/b", "Size": 2}]})
     runner = FakeRunner(*(_result(payload=page) for page in pages))
     objects = _store(scheme, runner).list_objects()
     assert [(item.key, item.size) for item in objects] == [("a", 1), ("b", 2)]
-    assert "larch/" in runner.calls[0]
+    assert "larch/larch/" in runner.calls[0]
     assert "two" in runner.calls[1]
     assert scheme == "gs" or "--no-paginate" in runner.calls[0]
-    outside = {"objects": [{"key": "larch/../outside", "size": 1}]} if scheme == "gs" else {"Contents": [{"Key": "larch/../outside", "Size": 1}]}
+    outside = {"objects": [{"key": "larch/larch/../outside", "size": 1}]} if scheme == "gs" else {"Contents": [{"Key": "larch/larch/../outside", "Size": 1}]}
     with pytest.raises(ObjectStoreError):
         _ = _store(scheme, FakeRunner(_result(payload=outside))).list_objects()
 
@@ -63,13 +65,13 @@ def test_list_paginates_from_empty_prefix(scheme: str) -> None:
 def test_list_paginates_the_complete_run_log_prefix(scheme: str) -> None:
     if scheme == "gs":
         pages = (
-            {"objects": [{"key": "larch/run-logs/design/run-a.tar.gz", "size": 1}], "next_page_token": "two"},
-            {"objects": [{"key": "larch/run-logs/review/run-b.tar.gz", "size": 2}]},
+            {"objects": [{"key": "larch/larch/run-logs/design/run-a.tar.gz", "size": 1}], "next_page_token": "two"},
+            {"objects": [{"key": "larch/larch/run-logs/review/run-b.tar.gz", "size": 2}]},
         )
     else:
         pages = (
-            {"Contents": [{"Key": "larch/run-logs/design/run-a.tar.gz", "Size": 1}], "NextContinuationToken": "two"},
-            {"Contents": [{"Key": "larch/run-logs/review/run-b.tar.gz", "Size": 2}]},
+            {"Contents": [{"Key": "larch/larch/run-logs/design/run-a.tar.gz", "Size": 1}], "NextContinuationToken": "two"},
+            {"Contents": [{"Key": "larch/larch/run-logs/review/run-b.tar.gz", "Size": 2}]},
         )
     runner = FakeRunner(*(_result(payload=page) for page in pages))
 
@@ -79,13 +81,13 @@ def test_list_paginates_the_complete_run_log_prefix(scheme: str) -> None:
         "run-logs/design/run-a.tar.gz",
         "run-logs/review/run-b.tar.gz",
     ]
-    assert "larch/run-logs/" in runner.calls[0]
+    assert "larch/larch/run-logs/" in runner.calls[0]
     assert "two" in runner.calls[1]
 @pytest.mark.parametrize("scheme", ["s3", "gs", "r2"])
 def test_upload_is_create_only(scheme: str, tmp_path: Path) -> None:
     source = tmp_path / "archive"
     _ = source.write_bytes(b"archive")
-    payload = {"key": "larch/run", "size": 7} if scheme == "gs" else {"ETag": "tag"}
+    payload = {"key": "larch/larch/run", "size": 7} if scheme == "gs" else {"ETag": "tag"}
     runner = FakeRunner(_result(payload=payload))
     assert _store(scheme, runner).upload_create("run", source).key == "run"
     command = runner.calls[0]
@@ -93,11 +95,11 @@ def test_upload_is_create_only(scheme: str, tmp_path: Path) -> None:
     assert scheme != "r2" or command[command.index("--endpoint-url") + 1] == _ENDPOINT
     if scheme == "r2":
         with pytest.raises(ObjectStoreError) as failure:
-            _ = object_store_for(StorageRoot("r2", "bucket", "larch"), environ={}, runner=cast("proc.Runner", FakeRunner()))
+            _ = object_store_for(ToolRepositoryStorage(StorageBase("r2", "bucket"), "larch"), environ={}, runner=cast("proc.Runner", FakeRunner()))
         assert failure.value.kind is ObjectStoreErrorKind.CONFIGURATION
 @pytest.mark.parametrize("scheme", ["s3", "gs", "r2"])
 def test_metadata_and_download_normalize_providers(scheme: str, tmp_path: Path) -> None:
-    payload = {"key": "larch/run", "size": 7, "etag": "tag", "version": "2"} if scheme == "gs" else {"ContentLength": 7, "ETag": "tag", "VersionId": "2"}
+    payload = {"key": "larch/larch/run", "size": 7, "etag": "tag", "version": "2"} if scheme == "gs" else {"ContentLength": 7, "ETag": "tag", "VersionId": "2"}
     item = _store(scheme, FakeRunner(_result(payload=payload))).metadata("run")
     assert (item.key, item.size, item.etag, item.version) == ("run", 7, "tag", "2")
     destination = tmp_path / "archive"
@@ -112,7 +114,7 @@ def test_gcs_transport_matches_shared_machine_contract(tmp_path: Path) -> None:
     assert contract["schema_version"] == 1
     remote = cast("dict[str, object]", contract["remote_object"])
     page = cast("dict[str, object]", contract["list_page"])
-    key = str(remote["key"]).removeprefix("larch/")
+    key = str(remote["key"]).removeprefix("larch/larch/")
 
     listed = _store("gs", FakeRunner(_result(payload=page))).list_objects("run-logs/")
     assert listed[0]._asdict() == {

--- a/python/tests/report/test_run_lifecycle.py
+++ b/python/tests/report/test_run_lifecycle.py
@@ -138,7 +138,7 @@ def test_mid_run_repository_identity_change_fails_before_publication(
             store=store,
         )
 
-    assert store.upload_calls == []
+    assert not store.upload_calls
 
 
 def test_manifest_storage_identity_mismatch_fails_before_terminal_writes(

--- a/python/tests/report/test_run_lifecycle.py
+++ b/python/tests/report/test_run_lifecycle.py
@@ -16,8 +16,12 @@ import pytest
 
 from larch.core import alias_skill
 from larch.report import run_lifecycle, run_log_manifest, run_log_publish, run_logs
-from larch.report.object_store import ObjectStoreError, ObjectStoreErrorKind, RemoteObject
-from larch.report.storage_config import StorageRoot
+from larch.report.object_store import (
+    ObjectStoreError,
+    ObjectStoreErrorKind,
+    RemoteObject,
+)
+from larch.report.storage_config import StorageBase, ToolRepositoryStorage
 
 
 class MemoryObjectStore:
@@ -35,9 +39,7 @@ class MemoryObjectStore:
             self.upload_calls.append(key)
             if self.fail_uploads:
                 self.fail_uploads -= 1
-                raise ObjectStoreError(
-                    ObjectStoreErrorKind.TRANSPORT, "fake", "upload"
-                )
+                raise ObjectStoreError(ObjectStoreErrorKind.TRANSPORT, "fake", "upload")
             if key in self.objects:
                 raise ObjectStoreError(
                     ObjectStoreErrorKind.ALREADY_EXISTS, "fake", "upload"
@@ -54,7 +56,9 @@ class MemoryObjectStore:
 
 
 @pytest.fixture
-def lifecycle_fixture(tmp_path: Path) -> tuple[Path, dict[str, str], StorageRoot]:
+def lifecycle_fixture(
+    tmp_path: Path,
+) -> tuple[Path, dict[str, str], ToolRepositoryStorage]:
     repo = tmp_path / "consumer"
     repo.mkdir()
     _ = subprocess.run(
@@ -67,7 +71,11 @@ def lifecycle_fixture(tmp_path: Path) -> tuple[Path, dict[str, str], StorageRoot
         "XDG_STATE_HOME": str(tmp_path / "state"),
         "XDG_CACHE_HOME": str(tmp_path / "cache"),
     }
-    return repo, environment, StorageRoot("s3", "bucket", "larch")
+    return (
+        repo,
+        environment,
+        ToolRepositoryStorage(StorageBase("s3", "bucket"), "consumer"),
+    )
 
 
 def test_final_report_renderer_names_terminal_identity() -> None:
@@ -79,9 +87,100 @@ def test_final_report_renderer_names_terminal_identity() -> None:
     assert "Outcome: `success`" in report
 
 
+@pytest.mark.parametrize("changed_identity", ["storage-base", "git-origin"])
+def test_mid_run_repository_identity_change_fails_before_publication(
+    lifecycle_fixture: tuple[Path, dict[str, str], ToolRepositoryStorage],
+    changed_identity: str,
+) -> None:
+    repo, environment, _storage = lifecycle_fixture
+    _ = subprocess.run(
+        ["git", "remote", "add", "origin", "git@github.com:fixture/consumer.git"],
+        cwd=repo,
+        check=True,
+    )
+    _ = (repo / "tools-config.toml").write_text(
+        '[larch]\nstorage_base_uri = "s3://bucket"\n',
+        encoding="utf-8",
+    )
+    started = run_lifecycle.start_run(
+        repo_root=repo,
+        skill="status",
+        run_id=f"identity-change-{changed_identity}",
+        environ=environment,
+        preflight=lambda _storage: None,
+    )
+    if changed_identity == "storage-base":
+        _ = (repo / "tools-config.toml").write_text(
+            '[larch]\nstorage_base_uri = "gs://other-bucket"\n',
+            encoding="utf-8",
+        )
+    else:
+        _ = subprocess.run(
+            [
+                "git",
+                "remote",
+                "set-url",
+                "origin",
+                "git@github.com:fixture/other-repository.git",
+            ],
+            cwd=repo,
+            check=True,
+        )
+    store = MemoryObjectStore()
+
+    with pytest.raises(run_lifecycle.RunLifecycleError):
+        _ = run_lifecycle.finish_run(
+            repo_root=repo,
+            skill="status",
+            run_id=started.run_id,
+            outcome="failure",
+            environ=environment,
+            store=store,
+        )
+
+    assert store.upload_calls == []
+
+
+def test_manifest_storage_identity_mismatch_fails_before_terminal_writes(
+    lifecycle_fixture: tuple[Path, dict[str, str], ToolRepositoryStorage],
+) -> None:
+    repo, environment, storage_root = lifecycle_fixture
+    started = run_lifecycle.start_run(
+        repo_root=repo,
+        skill="status",
+        run_id="manifest-identity-change",
+        environ=environment,
+        storage_root=storage_root,
+        preflight=lambda _storage: None,
+    )
+    manifest_path = started.run_dir / "manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["tool_repo_uri"] = "s3://other/larch/consumer"
+    _ = manifest_path.write_text(
+        json.dumps(manifest, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+    with pytest.raises(
+        run_lifecycle.RunLifecycleError,
+        match="configured storage or Git origin changed",
+    ):
+        _ = run_lifecycle.finish_run(
+            repo_root=repo,
+            skill="status",
+            run_id=started.run_id,
+            outcome="failure",
+            environ=environment,
+            storage_root=storage_root,
+            store=MemoryObjectStore(),
+        )
+
+    assert not (started.run_dir / run_lifecycle.UNIVERSAL_FINAL_REPORT).exists()
+
+
 @pytest.mark.parametrize("outcome", ["success", "failure", "cancelled", "early-return"])
 def test_reference_skill_publishes_every_terminal_outcome(
-    lifecycle_fixture: tuple[Path, dict[str, str], StorageRoot], outcome: str
+    lifecycle_fixture: tuple[Path, dict[str, str], ToolRepositoryStorage],
+    outcome: str,
 ) -> None:
     repo, environment, storage_root = lifecycle_fixture
     preflights: list[str] = []
@@ -121,25 +220,59 @@ def test_reference_skill_publishes_every_terminal_outcome(
 
 @pytest.mark.parametrize("skill", ["implement", "design", "review"])
 def test_specialized_staging_has_one_identity_context_and_terminal_upload(
-    lifecycle_fixture: tuple[Path, dict[str, str], StorageRoot], skill: str
+    lifecycle_fixture: tuple[Path, dict[str, str], ToolRepositoryStorage],
+    skill: str,
 ) -> None:
     repo, environment, storage_root = lifecycle_fixture
     run_id = f"{skill}-specialized-run"
     log_root = repo.parent / f"{skill}-session" / "larch-logs"
     _ = run_logs.log_init(log_root=log_root, skill=skill, run_id=run_id)
-    started = run_lifecycle.start_run(repo_root=repo, skill=skill, run_id=run_id, log_root=log_root, adopt_existing=True, environ=environment, storage_root=storage_root, preflight=lambda _root: None)
+    started = run_lifecycle.start_run(
+        repo_root=repo,
+        skill=skill,
+        run_id=run_id,
+        log_root=log_root,
+        adopt_existing=True,
+        environ=environment,
+        storage_root=storage_root,
+        preflight=lambda _root: None,
+    )
     artifact = started.run_dir / "specialized-artifact.txt"
     _ = artifact.write_text(f"{skill} artifact\n", encoding="utf-8")
     context = json.loads(started.context_file.read_text(encoding="utf-8"))
     store = MemoryObjectStore()
-    terminal = run_lifecycle.finish_run(repo_root=repo, skill=skill, run_id=run_id, outcome="success", environ=environment, storage_root=storage_root, store=store)
-    assert (context["skill"], context["run_id"], context["log_root"], store.upload_calls, started.context_file.exists(), (terminal.publication.cache_dir / artifact.name).read_text(encoding="utf-8")) == (skill, run_id, str(log_root), [f"run-logs/{skill}/{run_id}.tar.gz"], False, f"{skill} artifact\n")
+    terminal = run_lifecycle.finish_run(
+        repo_root=repo,
+        skill=skill,
+        run_id=run_id,
+        outcome="success",
+        environ=environment,
+        storage_root=storage_root,
+        store=store,
+    )
+    assert (
+        context["skill"],
+        context["run_id"],
+        context["log_root"],
+        store.upload_calls,
+        started.context_file.exists(),
+        (terminal.publication.cache_dir / artifact.name).read_text(encoding="utf-8"),
+    ) == (
+        skill,
+        run_id,
+        str(log_root),
+        [f"run-logs/{skill}/{run_id}.tar.gz"],
+        False,
+        f"{skill} artifact\n",
+    )
 
 
-@pytest.mark.parametrize(("parent_skill", "child_skill"), [("f", "implement"), ("implement", "review")])
+@pytest.mark.parametrize(
+    ("parent_skill", "child_skill"), [("f", "implement"), ("implement", "review")]
+)
 @pytest.mark.parametrize("child_outcome", ["success", "failure"])
 def test_alias_target_and_nested_review_record_parent_child_ids(
-    lifecycle_fixture: tuple[Path, dict[str, str], StorageRoot],
+    lifecycle_fixture: tuple[Path, dict[str, str], ToolRepositoryStorage],
     parent_skill: str,
     child_skill: str,
     child_outcome: str,
@@ -147,7 +280,7 @@ def test_alias_target_and_nested_review_record_parent_child_ids(
 ) -> None:
     repo, environment, storage_root = lifecycle_fixture
 
-    def preflight(_root: StorageRoot) -> None:
+    def preflight(_root: ToolRepositoryStorage) -> None:
         return
 
     start_run = run_lifecycle.start_run
@@ -166,13 +299,22 @@ def test_alias_target_and_nested_review_record_parent_child_ids(
         skill: str, run_id: str, parent_context: Path | None = None
     ) -> run_lifecycle.LifecycleStart:
         argv = [
-            "--repo-root", str(repo), "--skill", skill, "--run-id", run_id,
+            "--repo-root",
+            str(repo),
+            "--skill",
+            skill,
+            "--run-id",
+            run_id,
         ]
         if parent_context:
             argv.extend(["--lifecycle-parent-context", str(parent_context)])
         assert run_lifecycle.start_main(argv) == 0
         return run_lifecycle.load_run_context(
-            repo_root=repo, skill=skill, run_id=run_id, environ=environment
+            repo_root=repo,
+            skill=skill,
+            run_id=run_id,
+            environ=environment,
+            storage_root=storage_root,
         )
 
     parent = start_from_skill_call(parent_skill, f"{parent_skill}-parent-run")
@@ -180,10 +322,23 @@ def test_alias_target_and_nested_review_record_parent_child_ids(
     if parent_skill == "f":
         generated = StringIO()
         with redirect_stdout(generated):
-            assert alias_skill.generate_main([
-                "--name", "f", "--target", "implement", "--target-dir", "/tmp/skills/f",
-                "--flags", "", "--version", "test",
-            ]) == 0
+            assert (
+                alias_skill.generate_main(
+                    [
+                        "--name",
+                        "f",
+                        "--target",
+                        "implement",
+                        "--target-dir",
+                        "/tmp/skills/f",
+                        "--flags",
+                        "",
+                        "--version",
+                        "test",
+                    ]
+                )
+                == 0
+            )
         call_args = next(
             line.removeprefix("- args: ")
             for line in generated.getvalue().splitlines()
@@ -191,8 +346,12 @@ def test_alias_target_and_nested_review_record_parent_child_ids(
         )
         parsed_args = shlex.split(call_args)
         assert parsed_args[:2] == ["--lifecycle-parent-context", "$CONTEXT_FILE"]
-        child_parent_context = Path(parsed_args[1].replace("$CONTEXT_FILE", str(parent.context_file)))
-    child = start_from_skill_call(child_skill, f"{child_skill}-child-run", child_parent_context)
+        child_parent_context = Path(
+            parsed_args[1].replace("$CONTEXT_FILE", str(parent.context_file))
+        )
+    child = start_from_skill_call(
+        child_skill, f"{child_skill}-child-run", child_parent_context
+    )
     store = MemoryObjectStore()
 
     child_terminal = run_lifecycle.finish_run(
@@ -224,16 +383,22 @@ def test_alias_target_and_nested_review_record_parent_child_ids(
             encoding="utf-8"
         )
     )
-    assert (parent_manifest["skill"], child_manifest["skill"], child_manifest["terminal_outcome"]) == (parent_skill, child_skill, child_outcome)
+    assert (
+        parent_manifest["skill"],
+        child_manifest["skill"],
+        child_manifest["terminal_outcome"],
+    ) == (parent_skill, child_skill, child_outcome)
     assert child_manifest["run_id"] == child.run_id
     assert child_manifest["parent_skill"] == parent.skill
     assert child_manifest["parent_run_id"] == parent.run_id
-    assert child_terminal.publication.remote_key != parent_terminal.publication.remote_key
+    assert (
+        child_terminal.publication.remote_key != parent_terminal.publication.remote_key
+    )
     assert len(store.objects) == 2
 
 
 def test_upload_failure_is_loud_and_retry_uses_durable_pending_archive(
-    lifecycle_fixture: tuple[Path, dict[str, str], StorageRoot]
+    lifecycle_fixture: tuple[Path, dict[str, str], ToolRepositoryStorage],
 ) -> None:
     repo, environment, storage_root = lifecycle_fixture
     started = run_lifecycle.start_run(
@@ -269,9 +434,21 @@ def test_upload_failure_is_loud_and_retry_uses_durable_pending_archive(
     )
     assert paths.pending_archive.is_file()
     assert started.run_dir.is_dir()
-    manifest_before_restart = (started.run_dir / "manifest.json").read_text(encoding="utf-8")
-    _ = run_lifecycle.start_run(repo_root=repo, skill=started.skill, run_id=started.run_id, adopt_existing=True, environ=environment, storage_root=storage_root, preflight=lambda _root: None)
-    assert (started.run_dir / "manifest.json").read_text(encoding="utf-8") == manifest_before_restart
+    manifest_before_restart = (started.run_dir / "manifest.json").read_text(
+        encoding="utf-8"
+    )
+    _ = run_lifecycle.start_run(
+        repo_root=repo,
+        skill=started.skill,
+        run_id=started.run_id,
+        adopt_existing=True,
+        environ=environment,
+        storage_root=storage_root,
+        preflight=lambda _root: None,
+    )
+    assert (started.run_dir / "manifest.json").read_text(
+        encoding="utf-8"
+    ) == manifest_before_restart
 
     retried = run_lifecycle.finish_run(
         repo_root=repo,
@@ -287,7 +464,7 @@ def test_upload_failure_is_loud_and_retry_uses_durable_pending_archive(
 
 
 def test_parent_metadata_must_be_complete(
-    lifecycle_fixture: tuple[Path, dict[str, str], StorageRoot]
+    lifecycle_fixture: tuple[Path, dict[str, str], ToolRepositoryStorage],
 ) -> None:
     repo, environment, storage_root = lifecycle_fixture
     with pytest.raises(ValueError, match="provided together"):
@@ -302,7 +479,7 @@ def test_parent_metadata_must_be_complete(
 
 
 def test_universal_artifacts_extend_existing_skill_requirements(
-    lifecycle_fixture: tuple[Path, dict[str, str], StorageRoot]
+    lifecycle_fixture: tuple[Path, dict[str, str], ToolRepositoryStorage],
 ) -> None:
     repo, environment, storage_root = lifecycle_fixture
     started = run_lifecycle.start_run(
@@ -313,7 +490,9 @@ def test_universal_artifacts_extend_existing_skill_requirements(
         storage_root=storage_root,
         preflight=lambda _root: None,
     )
-    _ = (started.run_dir / "code-review-tally.json").write_text("{}\n", encoding="utf-8")
+    _ = (started.run_dir / "code-review-tally.json").write_text(
+        "{}\n", encoding="utf-8"
+    )
     manifest = run_log_manifest.Manifest.from_json(
         json.loads((started.run_dir / "manifest.json").read_text(encoding="utf-8"))
     )
@@ -332,7 +511,7 @@ def test_universal_artifacts_extend_existing_skill_requirements(
 
 
 def test_design_adopts_universal_ndjson_waiver_without_contract_fork(
-    lifecycle_fixture: tuple[Path, dict[str, str], StorageRoot]
+    lifecycle_fixture: tuple[Path, dict[str, str], ToolRepositoryStorage],
 ) -> None:
     repo, environment, storage_root = lifecycle_fixture
     started = run_lifecycle.start_run(
@@ -358,7 +537,7 @@ def test_design_adopts_universal_ndjson_waiver_without_contract_fork(
 
 
 def test_parent_identity_is_immutable_after_start(
-    lifecycle_fixture: tuple[Path, dict[str, str], StorageRoot]
+    lifecycle_fixture: tuple[Path, dict[str, str], ToolRepositoryStorage],
 ) -> None:
     repo, environment, storage_root = lifecycle_fixture
     started = run_lifecycle.start_run(
@@ -389,7 +568,7 @@ def test_parent_identity_is_immutable_after_start(
     ],
 )
 def test_terminal_cli_converts_publication_exceptions_to_loud_failure(
-    lifecycle_fixture: tuple[Path, dict[str, str], StorageRoot],
+    lifecycle_fixture: tuple[Path, dict[str, str], ToolRepositoryStorage],
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
     error: Exception,

--- a/python/tests/report/test_run_log_corpus.py
+++ b/python/tests/report/test_run_log_corpus.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
 
 from larch.report import run_log_corpus
+from larch.report.storage_config import StorageBase, ToolRepositoryStorage
 
 if TYPE_CHECKING:
     from larch.report.object_store import RemoteObject
@@ -37,8 +39,13 @@ class _EmptyStore:
 def test_synchronized_repository_log_root_lists_once(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     repo.mkdir(parents=True)
-    _ = (repo / "config.toml").write_text(
-        '[logs]\nuri = "s3://fixture-bucket/larch"\n',
+    _ = subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    _ = subprocess.run(
+        ["git", "remote", "add", "origin", "git@github.com:fixture/repo.git"],
+        cwd=repo, check=True,
+    )
+    _ = (repo / "tools-config.toml").write_text(
+        '[larch]\nstorage_base_uri = "s3://fixture-bucket"\n',
         encoding="utf-8",
     )
     store = _EmptyStore()
@@ -50,7 +57,11 @@ def test_synchronized_repository_log_root_lists_once(tmp_path: Path) -> None:
         state_home=tmp_path / "state",
     )
 
-    assert log_root == tmp_path / "cache" / "larch" / "run-logs" / "repo"
+    storage = ToolRepositoryStorage(StorageBase("s3", "fixture-bucket"), "repo")
+    assert log_root == (
+        tmp_path / "cache" / "larch" / "run-logs" / "v2"
+        / "repo" / storage.storage_origin_id
+    )
     assert store.list_calls == 1
 
 
@@ -59,7 +70,7 @@ def test_synchronized_repository_log_root_requires_config(tmp_path: Path) -> Non
     repo.mkdir()
     store = _EmptyStore()
 
-    with pytest.raises(run_log_corpus.RunLogCorpusError, match="storage configuration is missing"):
+    with pytest.raises(run_log_corpus.RunLogCorpusError, match=r"tools-config\.toml"):
         _ = run_log_corpus.synchronized_repository_log_root(
             repo_root=repo,
             store=store,

--- a/python/tests/report/test_run_log_migration.py
+++ b/python/tests/report/test_run_log_migration.py
@@ -9,7 +9,10 @@ from typing import cast
 import pytest
 
 from larch.report import run_log_migration
-from larch.report.storage_config import LegacyMigrationDescriptor, StorageRoot
+from larch.report.storage_config import (
+    LegacyMigrationDescriptor,
+    StorageBase,
+)
 
 
 def _descriptor() -> LegacyMigrationDescriptor:
@@ -66,7 +69,7 @@ def _parse(payload: dict[str, object]) -> run_log_migration.LegacyMigrationInven
     return run_log_migration.parse_inventory(
         json.dumps(payload).encode(),
         descriptor=_descriptor(),
-        storage_root=StorageRoot("s3", "bucket", "larch"),
+        storage_root=StorageBase("s3", "bucket", "larch"),
     )
 
 
@@ -89,7 +92,7 @@ def test_parse_inventory_rejects_duplicate_json_keys() -> None:
         _ = run_log_migration.parse_inventory(
             duplicate,
             descriptor=_descriptor(),
-            storage_root=StorageRoot("s3", "bucket", "larch"),
+            storage_root=StorageBase("s3", "bucket", "larch"),
         )
 
 

--- a/python/tests/report/test_run_log_publish.py
+++ b/python/tests/report/test_run_log_publish.py
@@ -12,8 +12,12 @@ import pytest
 
 from larch.core import repo_roots
 from larch.report import run_log_archive, run_log_publish, run_logs, storage_config
-from larch.report.object_store import ObjectStoreError, ObjectStoreErrorKind, RemoteObject
-from larch.report.storage_config import StorageRoot
+from larch.report.object_store import (
+    ObjectStoreError,
+    ObjectStoreErrorKind,
+    RemoteObject,
+)
+from larch.report.storage_config import StorageBase, ToolRepositoryStorage
 
 
 class MemoryObjectStore:
@@ -35,7 +39,9 @@ class MemoryObjectStore:
                 self.fail_uploads -= 1
                 raise ObjectStoreError(ObjectStoreErrorKind.TRANSPORT, "fake", "upload")
             if key in self.objects:
-                raise ObjectStoreError(ObjectStoreErrorKind.ALREADY_EXISTS, "fake", "upload")
+                raise ObjectStoreError(
+                    ObjectStoreErrorKind.ALREADY_EXISTS, "fake", "upload"
+                )
             self.objects[key] = content
         return RemoteObject(key, len(content), "etag", None)
 
@@ -52,7 +58,9 @@ class MemoryObjectStore:
         return RemoteObject(key, len(content), "etag", None)
 
 
-def _fixture(tmp_path: Path) -> tuple[Path, Path, Path, Path, StorageRoot]:
+def _fixture(
+    tmp_path: Path,
+) -> tuple[Path, Path, Path, Path, ToolRepositoryStorage]:
     repo: Path = tmp_path / "literal repo"
     staging: Path = tmp_path / "staging"
     cache_home: Path = tmp_path / "cache"
@@ -61,9 +69,12 @@ def _fixture(tmp_path: Path) -> tuple[Path, Path, Path, Path, StorageRoot]:
     staging.mkdir()
     nested: Path = staging / "nested"
     nested.mkdir()
-    _ = (staging / "manifest.json").write_text('{"issue_number":7818}\n', encoding="utf-8")
+    _ = (staging / "manifest.json").write_text(
+        '{"issue_number":7818}\n', encoding="utf-8"
+    )
     _ = (nested / "result.txt").write_text("published\n", encoding="utf-8")
-    return repo, staging, cache_home, state_home, StorageRoot("s3", "bucket", "larch")
+    storage = ToolRepositoryStorage(StorageBase("s3", "bucket"), "literal-repo")
+    return repo, staging, cache_home, state_home, storage
 
 
 def _publish(
@@ -72,7 +83,7 @@ def _publish(
     staging: Path | None,
     cache_home: Path,
     state_home: Path,
-    storage_root: StorageRoot,
+    storage_root: ToolRepositoryStorage,
     store: MemoryObjectStore,
 ) -> run_log_publish.PublicationResult:
     return run_log_publish.publish_run(
@@ -98,7 +109,9 @@ def _paths(
     return run_log_publish.publication_paths(
         request=run_log_publish.PublicationRequest(
             repo_root=repo,
-            storage_root=StorageRoot("s3", "bucket", "larch"),
+            storage_root=ToolRepositoryStorage(
+                StorageBase("s3", "bucket"), "literal-repo"
+            ),
             skill="implement",
             run_id="run-7818",
             staging_root=None,
@@ -123,9 +136,13 @@ def test_publish_uses_exact_key_and_promotes_staging_without_download(
     store = MemoryObjectStore()
 
     def unexpected_materialization(**_kwargs: object) -> object:
-        raise AssertionError("the normal publication path must not decompress its archive")
+        raise AssertionError(
+            "the normal publication path must not decompress its archive"
+        )
 
-    monkeypatch.setattr(run_log_archive, "materialize_run_archive", unexpected_materialization)
+    monkeypatch.setattr(
+        run_log_archive, "materialize_run_archive", unexpected_materialization
+    )
     result = _publish(
         repo=repo,
         staging=staging,
@@ -138,10 +155,23 @@ def test_publish_uses_exact_key_and_promotes_staging_without_download(
     assert result.remote_key == "run-logs/implement/run-7818.tar.gz"
     assert result.remote_status is run_log_publish.RemotePublicationStatus.CREATED
     assert result.cache_status is run_log_publish.CachePublicationStatus.PROMOTED
-    assert result.cache_dir == cache_home / "larch/run-logs/literal repo/implement/run-7818"
-    assert (result.cache_dir / "nested/result.txt").read_text(encoding="utf-8") == "published\n"
+    assert result.cache_dir == (
+        cache_home
+        / "larch"
+        / "run-logs"
+        / "v2"
+        / storage_root.client_repo
+        / storage_root.storage_origin_id
+        / "implement"
+        / "run-7818"
+    )
+    assert (result.cache_dir / "nested/result.txt").read_text(
+        encoding="utf-8"
+    ) == "published\n"
     assert store.download_calls == 0
-    assert not _paths(repo=repo, cache_home=cache_home, state_home=state_home).pending_dir.exists()
+    assert not _paths(
+        repo=repo, cache_home=cache_home, state_home=state_home
+    ).pending_dir.exists()
 
 
 def test_publish_log_run_finalizes_review_staging_without_git(
@@ -174,7 +204,16 @@ def test_publish_log_run_finalizes_review_staging_without_git(
     )
 
     assert result.remote_key == f"run-logs/review/{run_id}.tar.gz"
-    assert result.cache_dir == cache_home / "larch/run-logs/literal repo/review" / run_id
+    assert result.cache_dir == (
+        cache_home
+        / "larch"
+        / "run-logs"
+        / "v2"
+        / storage_root.client_repo
+        / storage_root.storage_origin_id
+        / "review"
+        / run_id
+    )
     assert scrub_violations == 1
     cached = (result.cache_dir / "review-round-summary.md").read_text(encoding="utf-8")
     assert raw_token not in cached
@@ -236,7 +275,9 @@ def test_retry_materializes_pending_archive_when_live_staging_changed(
             storage_root=storage_root,
             store=store,
         )
-    _ = (staging / "nested/result.txt").write_text("new terminal state\n", encoding="utf-8")
+    _ = (staging / "nested/result.txt").write_text(
+        "new terminal state\n", encoding="utf-8"
+    )
     result = _publish(
         repo=repo,
         staging=staging,
@@ -247,7 +288,9 @@ def test_retry_materializes_pending_archive_when_live_staging_changed(
     )
 
     assert result.cache_status is run_log_publish.CachePublicationStatus.MATERIALIZED
-    assert (result.cache_dir / "nested/result.txt").read_text(encoding="utf-8") == "published\n"
+    assert (result.cache_dir / "nested/result.txt").read_text(
+        encoding="utf-8"
+    ) == "published\n"
 
 
 def test_matching_remote_collision_is_idempotent_but_different_content_fails(
@@ -322,7 +365,9 @@ def test_cache_failure_after_upload_retries_from_archive_without_overwrite(
     def interrupted_promotion(**_kwargs: object) -> object:
         raise OSError("simulated cache promotion crash")
 
-    monkeypatch.setattr(run_log_archive, "promote_staging_run_directory", interrupted_promotion)
+    monkeypatch.setattr(
+        run_log_archive, "promote_staging_run_directory", interrupted_promotion
+    )
     with pytest.raises(OSError, match="simulated cache promotion crash"):
         _ = _publish(
             repo=repo,
@@ -335,7 +380,9 @@ def test_cache_failure_after_upload_retries_from_archive_without_overwrite(
     assert paths.pending_archive.is_file()
     assert len(store.objects) == 1
 
-    monkeypatch.setattr(run_log_archive, "promote_staging_run_directory", original_promote)
+    monkeypatch.setattr(
+        run_log_archive, "promote_staging_run_directory", original_promote
+    )
     result = _publish(
         repo=repo,
         staging=None,
@@ -413,7 +460,9 @@ def test_concurrent_publications_converge_on_one_remote_and_one_valid_cache(
         except BaseException as exc:  # test thread must surface every failure
             failures.append(exc)
 
-    threads: tuple[threading.Thread, ...] = tuple(threading.Thread(target=worker) for _ in range(2))
+    threads: tuple[threading.Thread, ...] = tuple(
+        threading.Thread(target=worker) for _ in range(2)
+    )
     for thread in threads:
         thread.start()
     for thread in threads:
@@ -435,7 +484,9 @@ def test_concurrent_publications_converge_on_one_remote_and_one_valid_cache(
     assert not paths.pending_dir.exists()
 
 
-def test_pending_identity_mismatch_fails_closed_and_preserves_archive(tmp_path: Path) -> None:
+def test_pending_identity_mismatch_fails_closed_and_preserves_archive(
+    tmp_path: Path,
+) -> None:
     repo, staging, cache_home, state_home, storage_root = _fixture(tmp_path)
     store = MemoryObjectStore(fail_uploads=1)
     paths = _paths(repo=repo, cache_home=cache_home, state_home=state_home)
@@ -449,8 +500,12 @@ def test_pending_identity_mismatch_fails_closed_and_preserves_archive(tmp_path: 
             store=store,
         )
 
-    changed_root = StorageRoot("s3", "other-bucket", "larch")
-    with pytest.raises(run_log_publish.PublicationError, match="identity"):
+    changed_root = ToolRepositoryStorage(
+        StorageBase("s3", "other-bucket"), "literal-repo"
+    )
+    with pytest.raises(
+        run_log_publish.PublicationError, match="no durable pending archive"
+    ):
         _ = _publish(
             repo=repo,
             staging=None,
@@ -463,6 +518,75 @@ def test_pending_identity_mismatch_fails_closed_and_preserves_archive(tmp_path: 
     assert paths.pending_archive.is_file()
 
 
+def test_checkout_names_do_not_select_cache_or_mutable_state(tmp_path: Path) -> None:
+    cache_home = tmp_path / "cache"
+    state_home = tmp_path / "state"
+    first_repo = tmp_path / "same-name-a" / "checkout"
+    second_repo = tmp_path / "same-name-b" / "checkout"
+    first_repo.mkdir(parents=True)
+    second_repo.mkdir(parents=True)
+    shared_origin = ToolRepositoryStorage(StorageBase("s3", "bucket"), "shared-repo")
+    other_origin = ToolRepositoryStorage(StorageBase("s3", "bucket"), "other-repo")
+    changed_base = ToolRepositoryStorage(StorageBase("gs", "bucket"), "shared-repo")
+
+    shared_first = run_log_publish.publication_paths(
+        request=run_log_publish.PublicationRequest(
+            repo_root=first_repo,
+            storage_root=shared_origin,
+            skill="review",
+            run_id="run-1",
+            staging_root=None,
+            cache_home=cache_home,
+            state_home=state_home,
+        ),
+        environ={},
+    )
+    shared_second = run_log_publish.publication_paths(
+        request=run_log_publish.PublicationRequest(
+            repo_root=second_repo,
+            storage_root=shared_origin,
+            skill="review",
+            run_id="run-1",
+            staging_root=None,
+            cache_home=cache_home,
+            state_home=state_home,
+        ),
+        environ={},
+    )
+    unrelated = run_log_publish.publication_paths(
+        request=run_log_publish.PublicationRequest(
+            repo_root=second_repo,
+            storage_root=other_origin,
+            skill="review",
+            run_id="run-1",
+            staging_root=None,
+            cache_home=cache_home,
+            state_home=state_home,
+        ),
+        environ={},
+    )
+    different_base = run_log_publish.publication_paths(
+        request=run_log_publish.PublicationRequest(
+            repo_root=first_repo,
+            storage_root=changed_base,
+            skill="review",
+            run_id="run-1",
+            staging_root=None,
+            cache_home=cache_home,
+            state_home=state_home,
+        ),
+        environ={},
+    )
+
+    assert shared_first == shared_second
+    assert shared_first.cache_dir != unrelated.cache_dir
+    assert shared_first.pending_dir != unrelated.pending_dir
+    assert shared_first.lock_file != unrelated.lock_file
+    assert shared_first.cache_dir != different_base.cache_dir
+    assert shared_first.pending_dir != different_base.pending_dir
+    assert shared_first.lock_file != different_base.lock_file
+
+
 def test_publish_cli_returns_nonzero_without_clean_success_on_terminal_failure(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -473,7 +597,7 @@ def test_publish_cli_returns_nonzero_without_clean_success_on_terminal_failure(
     def fake_repo_root(_start: Path) -> Path:
         return repo
 
-    def fake_storage_root(*, start: Path) -> StorageRoot:
+    def fake_storage_root(*, start: Path) -> ToolRepositoryStorage:
         assert start == repo
         return storage_root
 
@@ -481,7 +605,11 @@ def test_publish_cli_returns_nonzero_without_clean_success_on_terminal_failure(
         raise ObjectStoreError(ObjectStoreErrorKind.TRANSPORT, "fake", "upload")
 
     monkeypatch.setattr(repo_roots, "consumer_repo_root", fake_repo_root)
-    monkeypatch.setattr(storage_config, "discover_storage_root", fake_storage_root)
+    monkeypatch.setattr(
+        storage_config,
+        "discover_tool_repository_storage",
+        fake_storage_root,
+    )
     monkeypatch.setattr(run_log_publish, "publish_run", fail_publish)
 
     rc: int = run_log_publish.main(

--- a/python/tests/report/test_run_log_sync.py
+++ b/python/tests/report/test_run_log_sync.py
@@ -3,11 +3,9 @@
 from __future__ import annotations
 
 import threading
-import tarfile
 import gzip
-import hashlib
 import io
-import json
+import tarfile
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
@@ -16,7 +14,7 @@ import pytest
 from larch.core import config
 from larch.report import run_log_archive, run_log_corpus, run_log_sync
 from larch.report.object_store import RemoteObject
-from larch.report.storage_config import StorageRoot
+from larch.report.storage_config import StorageBase, ToolRepositoryStorage
 
 
 class MemoryObjectStore:
@@ -52,114 +50,17 @@ class MemoryObjectStore:
         _ = destination.write_bytes(content)
 
 
-def _legacy_archive(entries: list[tuple[str, bytes, bytes]]) -> bytes:
+def _manifestless_archive() -> bytes:
     output = io.BytesIO()
     with gzip.GzipFile(filename="", mode="wb", fileobj=output, mtime=0) as compressed:
         with tarfile.open(
             fileobj=compressed, mode="w", format=tarfile.PAX_FORMAT
         ) as archive:
-            for name, content, kind in entries:
-                info = tarfile.TarInfo(name)
-                info.type = kind
-                info.size = len(content)
-                info.mode = 0o644
-                info.mtime = 0
-                info.uid = 0
-                info.gid = 0
-                info.uname = ""
-                info.gname = ""
-                archive.addfile(
-                    info, io.BytesIO(content) if kind == tarfile.REGTYPE else None
-                )
+            info = tarfile.TarInfo("manifest.json")
+            info.size = 3
+            info.mode = 0o644
+            archive.addfile(info, io.BytesIO(b"{}\n"))
     return output.getvalue()
-
-
-def _legacy_fixture(
-    tmp_path: Path,
-    *,
-    run_id: str = "legacy-run",
-    entries: list[tuple[str, bytes, bytes]] | None = None,
-    archive_digest: str | None = None,
-    archive_size: int | None = None,
-    inventory_mutation: dict[str, object] | None = None,
-) -> tuple[dict[str, bytes], str]:
-    active_entries = entries or [
-        (
-            "manifest.json",
-            b'{"issue_number":7886,"started_at":"2026-07-20T00:00:00Z"}\n',
-            tarfile.REGTYPE,
-        ),
-        (
-            "token-report.json",
-            b'{"claude":{"totals":{"total":10}},"BUCKETS_claude":{"input":10}}\n',
-            tarfile.REGTYPE,
-        ),
-    ]
-    archive_bytes = _legacy_archive(active_entries)
-    remote_key = f"run-logs/implement/{run_id}.tar.gz"
-    object_key = f"larch/{remote_key}"
-    source_files = [
-        {
-            "archive_member_path": name,
-            "archive_object_key": object_key,
-            "bytes": len(content),
-            "git_oid": hashlib.sha1(content).hexdigest(),  # noqa: S324 - fixture models Git SHA-1 object IDs
-            "mode": "100644",
-            "path": f"larch-logs/implement/{run_id}/{name}",
-            "sha256": hashlib.sha256(content).hexdigest(),
-        }
-        for name, content, kind in active_entries
-        if kind == tarfile.REGTYPE and not name.startswith("../")
-    ]
-    archive_row: dict[str, object] = {
-        "archive_bytes": len(archive_bytes) if archive_size is None else archive_size,
-        "kind": "run",
-        "member_count": len(source_files),
-        "object_key": object_key,
-        "run_id": run_id,
-        "sha256": archive_digest or hashlib.sha256(archive_bytes).hexdigest(),
-        "skill": "implement",
-        "uncompressed_bytes": sum(int(row["bytes"]) for row in source_files),
-    }
-    inventory: dict[str, object] = {
-        "archives": [archive_row],
-        "schema": "larch-run-log-migration-inventory-v1",
-        "source_commit": "a" * 40,
-        "source_files": source_files,
-        "storage_root": "s3://bucket/larch",
-        "totals": {
-            "archive_bytes": archive_row["archive_bytes"],
-            "archive_objects": 1,
-            "members": len(source_files),
-            "run_directories": 1,
-            "source_paths": len(source_files),
-            "uncompressed_bytes": archive_row["uncompressed_bytes"],
-        },
-    }
-    if inventory_mutation:
-        inventory.update(inventory_mutation)
-    inventory_bytes = (json.dumps(inventory, sort_keys=True) + "\n").encode()
-    inventory_key = "migration/test-inventory.json"
-    config_path = tmp_path / "repo" / "config.toml"
-    config_path.parent.mkdir(parents=True, exist_ok=True)
-    _ = config_path.write_text(
-        "\n".join(
-            [
-                "[logs]",
-                'uri = "s3://bucket/larch"',
-                "",
-                "[logs.legacy_migration]",
-                'schema = "larch-run-log-migration-inventory-v1"',
-                f'source_commit = "{"a" * 40}"',
-                'storage_root = "s3://bucket/larch"',
-                f'inventory_key = "{inventory_key}"',
-                f'inventory_sha256 = "{hashlib.sha256(inventory_bytes).hexdigest()}"',
-                "",
-            ]
-        ),
-        encoding="utf-8",
-    )
-    return {remote_key: archive_bytes, inventory_key: inventory_bytes}, remote_key
 
 
 def _archive_bytes(tmp_path: Path, *, skill: str, run_id: str, content: str) -> bytes:
@@ -189,7 +90,7 @@ def _request(
 ) -> run_log_sync.RunLogSyncRequest:
     return run_log_sync.RunLogSyncRequest(
         repo_root=repo,
-        storage_root=StorageRoot("s3", "bucket", "larch"),
+        storage_root=ToolRepositoryStorage(StorageBase("s3", "bucket"), "consumer"),
         cache_home=cache_home,
         state_home=state_home,
     )
@@ -215,7 +116,14 @@ def test_cold_then_warm_sync_lists_once_per_call_and_downloads_each_run_once(
 
     cold = run_log_sync.sync_repository_run_logs(request=request, store=store)
 
-    assert cold.corpus_root == cache_home / "larch/run-logs/literal repo"
+    assert cold.corpus_root == (
+        cache_home
+        / "larch"
+        / "run-logs"
+        / "v2"
+        / request.storage_root.client_repo
+        / request.storage_root.storage_origin_id
+    )
     assert cold.listed_count == 2
     assert cold.downloaded_count == 2
     assert cold.present_count == 0
@@ -347,7 +255,16 @@ def test_failed_repair_restores_invalid_entry_and_removes_download_temporary(
     key = "run-logs/review/run-broken.tar.gz"
     store = MemoryObjectStore({key: b"not-an-archive"})
     request = _request(repo=repo, cache_home=cache_home, state_home=state_home)
-    run_dir = cache_home / "larch/run-logs/repo/review/run-broken"
+    run_dir = (
+        cache_home
+        / "larch"
+        / "run-logs"
+        / "v2"
+        / request.storage_root.client_repo
+        / request.storage_root.storage_origin_id
+        / "review"
+        / "run-broken"
+    )
     run_dir.mkdir(parents=True)
     _ = (run_dir / "partial.txt").write_text("preserve for retry\n", encoding="utf-8")
 
@@ -453,143 +370,15 @@ def test_concurrent_syncs_share_the_publication_lock_and_download_once(
     assert store.list_calls == ["run-logs/", "run-logs/"]
 
 
-def test_legacy_cold_sync_verifies_extracts_and_warm_sync_lists_only(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    objects, remote_key = _legacy_fixture(tmp_path)
-    store = MemoryObjectStore(objects)
-    request = _request(
-        repo=tmp_path / "repo",
-        cache_home=tmp_path / "cache",
-        state_home=tmp_path / "state",
-    )
-    calls = 0
-    materialize = run_log_archive.materialize_legacy_run_archive
-
-    def counted_materialize(**kwargs: object) -> object:
-        nonlocal calls
-        calls += 1
-        return materialize(**kwargs)  # pyright: ignore[reportArgumentType] - forwards the exact production keyword contract
-
-    monkeypatch.setattr(
-        run_log_archive, "materialize_legacy_run_archive", counted_materialize
-    )
-
-    cold = run_log_sync.sync_repository_run_logs(request=request, store=store)
-    run_dir = cold.corpus_root / "implement/legacy-run"
-
-    assert cold.downloaded_count == 1
-    assert calls == 1
-    assert store.download_calls == [remote_key, "migration/test-inventory.json"]
-    assert (run_dir / "manifest.json").is_file()
-    assert (run_dir / "token-report.json").is_file()
-    assert (run_dir / run_log_archive.ARCHIVE_MANIFEST_NAME).is_file()
-    _ = run_log_archive.verify_materialized_run_directory(
-        run_dir=run_dir,
-        expected_skill="implement",
-        expected_run_id="legacy-run",
-    )
-
-    warm = run_log_sync.sync_repository_run_logs(request=request, store=store)
-
-    assert warm.present_count == 1
-    assert warm.downloaded_count == 0
-    assert calls == 1
-    assert store.list_calls == ["run-logs/", "run-logs/"]
-    assert store.download_calls == [remote_key, "migration/test-inventory.json"]
-
-
-def test_mixed_legacy_and_versioned_archives_materialize_together(
-    tmp_path: Path,
-) -> None:
-    objects, remote_key = _legacy_fixture(tmp_path)
-    normal_key = "run-logs/design/normal-run.tar.gz"
-    objects[normal_key] = _archive_bytes(
-        tmp_path, skill="design", run_id="normal-run", content="normal\n"
-    )
-    store = MemoryObjectStore(objects)
-
-    result = run_log_sync.sync_repository_run_logs(
-        request=_request(
-            repo=tmp_path / "repo",
-            cache_home=tmp_path / "cache",
-            state_home=tmp_path / "state",
-        ),
-        store=store,
-    )
-
-    assert result.downloaded_count == 2
-    assert (result.corpus_root / "implement/legacy-run/token-report.json").is_file()
-    assert (result.corpus_root / "design/normal-run/nested/result.txt").is_file()
-    assert store.download_calls == [
-        normal_key,
-        remote_key,
-        "migration/test-inventory.json",
-    ]
-
-
-@pytest.mark.parametrize(
-    ("fixture_kwargs", "message"),
-    [
-        ({"archive_digest": "0" * 64}, "archive digest"),
-        ({"archive_size": 1}, "archive size"),
-        (
-            {"inventory_mutation": {"source_commit": "b" * 40}},
-            "source commit",
-        ),
-        (
-            {"inventory_mutation": {"storage_root": "s3://other/larch"}},
-            "storage root",
-        ),
-    ],
-)
-def test_legacy_sync_rejects_unpinned_or_inconsistent_inventory(
-    tmp_path: Path,
-    fixture_kwargs: dict[str, object],
-    message: str,
-) -> None:
-    objects, _ = _legacy_fixture(tmp_path, **fixture_kwargs)  # pyright: ignore[reportArgumentType] - parametrized fixture keyword coverage
-    store = MemoryObjectStore(objects)
-
-    with pytest.raises(ValueError, match=message):
-        _ = run_log_sync.sync_repository_run_logs(
-            request=_request(
-                repo=tmp_path / "repo",
-                cache_home=tmp_path / "cache",
-                state_home=tmp_path / "state",
-            ),
-            store=store,
-        )
-
-
-def test_legacy_sync_rejects_wrong_inventory_hash(tmp_path: Path) -> None:
-    objects, _ = _legacy_fixture(tmp_path)
-    objects["migration/test-inventory.json"] += b" "
-    store = MemoryObjectStore(objects)
-
-    with pytest.raises(ValueError, match="inventory digest"):
-        _ = run_log_sync.sync_repository_run_logs(
-            request=_request(
-                repo=tmp_path / "repo",
-                cache_home=tmp_path / "cache",
-                state_home=tmp_path / "state",
-            ),
-            store=store,
-        )
-
-
-def test_manifestless_archive_without_exact_inventory_record_fails_closed(
+def test_manifestless_archive_fails_without_legacy_config_or_inventory_download(
     tmp_path: Path,
 ) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()
     key = "run-logs/implement/unknown-run.tar.gz"
-    store = MemoryObjectStore(
-        {key: _legacy_archive([("manifest.json", b"{}\n", tarfile.REGTYPE)])}
-    )
+    store = MemoryObjectStore({key: _manifestless_archive()})
 
-    with pytest.raises(run_log_sync.RunLogSyncError, match="descriptor"):
+    with pytest.raises(run_log_archive.MissingArchiveManifestError):
         _ = run_log_sync.sync_repository_run_logs(
             request=_request(
                 repo=repo,

--- a/python/tests/report/test_storage_config.py
+++ b/python/tests/report/test_storage_config.py
@@ -290,6 +290,7 @@ def test_git_origin_derivation_supports_standard_syntax(
     [
         "https://user:secret@example.com/org/repo.git",
         "https://example.com:443/org/repo.git",
+        "ssh://example.com:notaport/org/repo.git",
         "file:///tmp/repo.git",
         "git@github.com:org/../repo.git",
         "git@github.com:org/-repo.git",

--- a/python/tests/report/test_storage_config.py
+++ b/python/tests/report/test_storage_config.py
@@ -1,9 +1,12 @@
-"""Tests for repository storage-root configuration and S3 preflight."""
+"""Repository config, Git identity, and derived storage contract tests."""
 
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from pathlib import Path
+import subprocess
+import tomllib
+from typing import cast
 
 import pytest
 
@@ -11,21 +14,38 @@ from larch.core import config, proc
 from larch.report import storage_config
 
 
-def _write_config(repo_root: Path, uri: str) -> None:
-    _ = (repo_root / "config.toml").write_text(f'[logs]\nuri = "{uri}"\n', encoding="utf-8")
+def _write_config(
+    repo_root: Path,
+    uri: str = "s3://zhupanov",
+    *,
+    extra: str = "",
+) -> None:
+    _ = (repo_root / "tools-config.toml").write_text(
+        f'[larch]\nstorage_base_uri = "{uri}"\n{extra}',
+        encoding="utf-8",
+    )
 
 
-def _result(*, returncode: int, stdout: str = "", stderr: str = "") -> proc.CommandResult:
+def _result(
+    *,
+    returncode: int = 0,
+    stdout: str = "",
+    stderr: str = "",
+) -> proc.CommandResult:
     return proc.CommandResult(
-        argv=(), returncode=returncode, stdout=stdout, stderr=stderr, duration=0.0
+        argv=(),
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+        duration=0.0,
     )
 
 
 class FakeRunner:
-    """Capture the preflight command without invoking the AWS CLI."""
+    """Return queued command results and retain credential-free argv."""
 
-    def __init__(self, result: proc.CommandResult) -> None:
-        self.result = result
+    def __init__(self, *results: proc.CommandResult) -> None:
+        self.results: list[proc.CommandResult] = list(results)
         self.calls: list[tuple[str, ...]] = []
 
     def run(
@@ -41,138 +61,399 @@ class FakeRunner:
     ) -> proc.CommandResult:
         _ = timeout, cwd, env, check, stdout, stderr
         self.calls.append(tuple(argv))
-        return self.result
+        return self.results.pop(0)
 
 
-def test_load_storage_root_derives_run_logs_uri(tmp_path: Path) -> None:
-    _write_config(tmp_path, "s3://zhupanov/larch")
-
-    storage_root = storage_config.load_storage_root(repo_root=tmp_path, environ={})
-
-    assert storage_root.uri == "s3://zhupanov/larch"
-    assert storage_root.run_logs_uri == "s3://zhupanov/larch/run-logs/"
-
-
-def test_environment_storage_uri_overrides_repository_config(tmp_path: Path) -> None:
-    _write_config(tmp_path, "s3://file-root/larch")
-
-    storage_root = storage_config.load_storage_root(
-        repo_root=tmp_path,
-        environ={config.ENV_LARCH_LOGS_URI: "s3://environment-root/override"},
+def _load(
+    repo_root: Path,
+    *,
+    uri: str = "s3://zhupanov",
+    origin: str = "git@github.com:character-ai/larch.git",
+    environ: Mapping[str, str] | None = None,
+) -> storage_config.ToolRepositoryStorage:
+    _write_config(repo_root, uri)
+    return storage_config.load_tool_repository_storage(
+        repo_root=repo_root,
+        environ={} if environ is None else environ,
+        runner=FakeRunner(_result(stdout=f"{origin}\n")),
     )
 
-    assert storage_root.uri == "s3://environment-root/override"
+
+@pytest.mark.parametrize(
+    ("base_uri", "expected"),
+    [
+        ("s3://zhupanov", "s3://zhupanov/larch/larch"),
+        (
+            "s3://company-data/prod/tools",
+            "s3://company-data/prod/tools/larch/larch",
+        ),
+        ("gs://character-tool-logs", "gs://character-tool-logs/larch/larch"),
+        ("r2://archive-bucket/base", "r2://archive-bucket/base/larch/larch"),
+    ],
+)
+def test_load_derives_tool_repository_and_run_logs_uri(
+    tmp_path: Path, base_uri: str, expected: str
+) -> None:
+    storage = _load(tmp_path, uri=base_uri)
+
+    assert storage.base.uri == base_uri
+    assert storage.client_repo == "larch"
+    assert storage.uri == expected
+    assert storage.run_logs_uri == f"{expected}/run-logs/"
+    assert len(storage.storage_origin_id) == 64
 
 
-def test_load_storage_root_does_not_use_former_larch_directory(tmp_path: Path) -> None:
-    legacy_directory = tmp_path / ".larch"
-    legacy_directory.mkdir()
-    _ = (legacy_directory / "config.toml").write_text(
-        '[logs]\nuri = "s3://legacy-root/larch"\n', encoding="utf-8"
+def test_base_override_requires_config_and_changes_only_base(tmp_path: Path) -> None:
+    storage = _load(
+        tmp_path,
+        uri="s3://file-root/base",
+        environ={config.ENV_LARCH_STORAGE_BASE_URI: "gs://override"},
     )
+    assert storage.uri == "gs://override/larch/larch"
 
-    with pytest.raises(storage_config.StorageConfigurationError, match=r"config\.toml"):
-        _ = storage_config.load_storage_root(repo_root=tmp_path, environ={})
-
-
-def test_load_legacy_migration_descriptor_is_repository_scoped(tmp_path: Path) -> None:
-    _ = (tmp_path / "config.toml").write_text("""[logs]
-uri = "s3://zhupanov/larch"
-
-[logs.legacy_migration]
-schema = "larch-run-log-migration-inventory-v1"
-source_commit = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-storage_root = "s3://zhupanov/larch"
-inventory_key = "migration/inventory.json"
-inventory_sha256 = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-""", encoding="utf-8")
-
-    descriptor = storage_config.load_legacy_migration_descriptor(
-        repo_root=tmp_path, storage_root=storage_config.StorageRoot("s3", "zhupanov", "larch"),
-    )
-
-    assert descriptor is not None
-    assert descriptor.inventory_key == "migration/inventory.json"
-    assert descriptor.inventory_sha256 == "b" * 64
-
-
-def test_load_legacy_migration_descriptor_rejects_other_storage_root(tmp_path: Path) -> None:
-    _ = (tmp_path / "config.toml").write_text("""[logs]
-uri = "s3://zhupanov/larch"
-
-[logs.legacy_migration]
-schema = "larch-run-log-migration-inventory-v1"
-source_commit = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-storage_root = "s3://zhupanov/larch"
-inventory_key = "migration/inventory.json"
-inventory_sha256 = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-""", encoding="utf-8")
-
-    with pytest.raises(storage_config.StorageConfigurationError, match="active storage root"):
-        _ = storage_config.load_legacy_migration_descriptor(
-            repo_root=tmp_path, storage_root=storage_config.StorageRoot("s3", "other", "larch"),
+    missing = tmp_path / "missing"
+    missing.mkdir()
+    with pytest.raises(
+        storage_config.StorageConfigurationError, match="missing required file"
+    ):
+        _ = storage_config.load_tool_repository_storage(
+            repo_root=missing,
+            environ={config.ENV_LARCH_STORAGE_BASE_URI: "gs://override"},
+            runner=FakeRunner(
+                _result(stdout="git@github.com:character-ai/larch.git\n")
+            ),
         )
 
 
-def test_discover_storage_root_uses_the_git_toplevel(tmp_path: Path) -> None:
-    _write_config(tmp_path, "s3://zhupanov/larch")
+def test_legacy_environment_override_is_rejected_with_guidance(tmp_path: Path) -> None:
+    _write_config(tmp_path)
+    with pytest.raises(
+        storage_config.StorageConfigurationError,
+        match=r"LARCH_LOGS_URI.*LARCH_STORAGE_BASE_URI",
+    ):
+        _ = storage_config.load_tool_repository_storage(
+            repo_root=tmp_path,
+            environ={config.ENV_LARCH_LOGS_URI: "s3://old/root"},
+            runner=FakeRunner(
+                _result(stdout="git@github.com:character-ai/larch.git\n")
+            ),
+        )
 
-    def fake_consumer_repo_root(start: Path | None = None) -> Path:
-        assert start == tmp_path / "nested"
-        return tmp_path
 
-    storage_root = storage_config.discover_storage_root(
-        start=tmp_path / "nested",
+@pytest.mark.parametrize("former", ["config.toml", "tool-config.toml"])
+def test_former_or_singular_config_names_are_not_probed(
+    tmp_path: Path, former: str
+) -> None:
+    _ = (tmp_path / former).write_text(
+        '[larch]\nstorage_base_uri = "s3://ignored"\n', encoding="utf-8"
+    )
+    with pytest.raises(
+        storage_config.StorageConfigurationError, match=r"tools-config\.toml"
+    ):
+        _ = storage_config.load_tool_repository_storage(
+            repo_root=tmp_path,
+            environ={},
+            runner=FakeRunner(
+                _result(stdout="git@github.com:character-ai/larch.git\n")
+            ),
+        )
+
+
+def test_dot_larch_config_is_not_probed(tmp_path: Path) -> None:
+    legacy_directory = tmp_path / ".larch"
+    legacy_directory.mkdir()
+    _ = (legacy_directory / "config.toml").write_text(
+        '[larch]\nstorage_base_uri = "s3://ignored"\n', encoding="utf-8"
+    )
+    with pytest.raises(
+        storage_config.StorageConfigurationError, match=r"tools-config\.toml"
+    ):
+        _ = storage_config.load_tool_repository_storage(
+            repo_root=tmp_path,
+            environ={},
+            runner=FakeRunner(
+                _result(stdout="git@github.com:character-ai/larch.git\n")
+            ),
+        )
+
+
+def test_config_is_strict_for_larch_and_ignores_other_tools(tmp_path: Path) -> None:
+    _ = (tmp_path / "tools-config.toml").write_text(
+        '[sre]\nanything = true\n\n[larch]\nstorage_base_uri = "s3://zhupanov"\n',
+        encoding="utf-8",
+    )
+    storage = storage_config.load_tool_repository_storage(
+        repo_root=tmp_path,
         environ={},
-        root_resolver=fake_consumer_repo_root,
+        runner=FakeRunner(_result(stdout="git@github.com:character-ai/larch.git\n")),
+    )
+    assert storage.client_repo == "larch"
+
+    _write_config(tmp_path, extra='client_repo = "wrong"\n')
+    with pytest.raises(
+        storage_config.StorageConfigurationError, match="must contain only"
+    ):
+        _ = storage_config.load_tool_repository_storage(
+            repo_root=tmp_path,
+            environ={},
+            runner=FakeRunner(
+                _result(stdout="git@github.com:character-ai/larch.git\n")
+            ),
+        )
+
+
+def test_missing_larch_table_error_is_actionable(tmp_path: Path) -> None:
+    _ = (tmp_path / "tools-config.toml").write_text(
+        "[sre]\nvalue = 1\n", encoding="utf-8"
+    )
+    with pytest.raises(storage_config.StorageConfigurationError) as failure:
+        _ = storage_config.load_tool_repository_storage(
+            repo_root=tmp_path,
+            environ={},
+            runner=FakeRunner(
+                _result(stdout="git@github.com:character-ai/larch.git\n")
+            ),
+        )
+    message = str(failure.value)
+    assert all(
+        token in message
+        for token in (
+            "Git repository",
+            "tools-config.toml",
+            "[larch]",
+            "storage_base_uri",
+        )
     )
 
-    assert storage_root.uri == "s3://zhupanov/larch"
 
-
-def test_missing_storage_config_has_setup_guidance(tmp_path: Path) -> None:
-    with pytest.raises(storage_config.StorageConfigurationError, match="LARCH_LOGS_URI"):
-        _ = storage_config.load_storage_root(repo_root=tmp_path, environ={})
+def test_symlinked_config_is_rejected(tmp_path: Path) -> None:
+    target = tmp_path / "actual.toml"
+    _ = target.write_text(
+        '[larch]\nstorage_base_uri = "s3://bucket"\n', encoding="utf-8"
+    )
+    (tmp_path / "tools-config.toml").symlink_to(target)
+    with pytest.raises(
+        storage_config.StorageConfigurationError, match="refusing symlink"
+    ):
+        _ = storage_config.load_tool_repository_storage(
+            repo_root=tmp_path,
+            environ={},
+            runner=FakeRunner(_result(stdout="git@github.com:org/repo.git\n")),
+        )
 
 
 @pytest.mark.parametrize(
     ("uri", "message"),
     [
-        ("s3://bucket", "non-empty storage-root prefix"),
-        ("https://bucket/prefix", "must use one of"),
-        ("s3://key:secret@bucket/prefix", "must not contain credentials"),
-        ("s3://bucket:not-a-port/prefix", "valid bucket name without a port"),
-        ("s3://bucket/a/../prefix", "must not contain empty, '.' or '..' segments"),
+        ("https://bucket", "must use one of"),
+        ("S3://bucket", "must use one of"),
+        ("s3://key:secret@bucket", "must not contain credentials"),
+        ("s3://bucket:443", "without a port"),
+        ("s3://bucket/a/../prefix", r"must not contain empty, '\.' or '\.\.'"),
+        ("s3://bucket/a//prefix", r"must not contain empty, '\.' or '\.\.'"),
+        ("s3://bucket/prefix/", "trailing slash"),
+        ("s3://bucket/prefix?query=1", "query or fragment"),
+        ("s3://bucket/prefix#fragment", "query or fragment"),
+        (r"s3://bucket\\other/prefix", "plain bucket name"),
+        (r"s3://bucket/base\\prefix", "whitespace or control characters"),
+        (" s3://bucket", "surrounding whitespace"),
     ],
 )
-def test_storage_uri_rejects_unsafe_or_incomplete_shapes(uri: str, message: str) -> None:
+def test_storage_base_rejects_unsafe_shapes(uri: str, message: str) -> None:
     with pytest.raises(storage_config.StorageConfigurationError, match=message):
-        _ = storage_config._parse_storage_uri(uri)  # pyright: ignore[reportPrivateUsage] - direct URI boundary coverage
+        _ = storage_config.parse_storage_base_uri(uri)
 
 
-def test_s3_preflight_uses_bucket_root_exit_status_only() -> None:
-    runner = FakeRunner(_result(returncode=0, stdout="larch/\n"))
-    storage_root = storage_config.StorageRoot(scheme="s3", bucket="zhupanov", prefix="larch")
+@pytest.mark.parametrize(
+    ("origin", "client_repo"),
+    [
+        ("https://github.com/character-ai/Agent-Lint.git", "agent-lint"),
+        ("ssh://git@github.com/character-ai/larch.git", "larch"),
+        ("git@github.com:character-ai/larch.git", "larch"),
+        ("github.com:character-ai/service_a", "service_a"),
+    ],
+)
+def test_git_origin_derivation_supports_standard_syntax(
+    tmp_path: Path, origin: str, client_repo: str
+) -> None:
+    _write_config(tmp_path)
+    storage = storage_config.load_tool_repository_storage(
+        repo_root=tmp_path,
+        environ={},
+        runner=FakeRunner(_result(stdout=f"{origin}\n")),
+    )
+    assert storage.client_repo == client_repo
 
-    storage_config.preflight_s3_bucket(storage_root=storage_root, runner=runner)
 
-    assert runner.calls == [(config.AWS_CLI, "s3", "ls", "s3://zhupanov")]
+@pytest.mark.parametrize(
+    "origin",
+    [
+        "https://user:secret@example.com/org/repo.git",
+        "https://example.com:443/org/repo.git",
+        "file:///tmp/repo.git",
+        "git@github.com:org/../repo.git",
+        "git@github.com:org/-repo.git",
+        "git@github.com:org/repo-.git",
+        "ambiguous",
+        "",
+    ],
+)
+def test_git_origin_derivation_rejects_unsafe_or_ambiguous_values(
+    tmp_path: Path, origin: str
+) -> None:
+    _write_config(tmp_path)
+    with pytest.raises(storage_config.StorageConfigurationError) as failure:
+        _ = storage_config.load_tool_repository_storage(
+            repo_root=tmp_path,
+            environ={},
+            runner=FakeRunner(_result(stdout=f"{origin}\n")),
+        )
+    assert "secret" not in str(failure.value)
 
 
-def test_s3_preflight_does_not_accept_output_when_listing_fails() -> None:
-    runner = FakeRunner(_result(returncode=1, stdout="larch/\n", stderr="access denied"))
-    storage_root = storage_config.StorageRoot(scheme="s3", bucket="zhupanov", prefix="larch")
+def test_discovery_uses_git_toplevel_from_nested_startup_cwd(tmp_path: Path) -> None:
+    _write_config(tmp_path)
 
-    with pytest.raises(storage_config.StoragePreflightError, match="exit 1") as exc_info:
-        storage_config.preflight_s3_bucket(storage_root=storage_root, runner=runner)
+    def fake_consumer_repo_root(start: Path | None = None) -> Path:
+        assert start == tmp_path / "nested"
+        return tmp_path
 
-    assert "larch/" not in str(exc_info.value)
-    assert runner.calls == [(config.AWS_CLI, "s3", "ls", "s3://zhupanov")]
+    storage = storage_config.discover_tool_repository_storage(
+        start=tmp_path / "nested",
+        environ={},
+        root_resolver=fake_consumer_repo_root,
+        runner=FakeRunner(_result(stdout="git@github.com:character-ai/larch.git\n")),
+    )
+    assert storage.uri == "s3://zhupanov/larch/larch"
 
 
-def test_s3_preflight_reports_missing_aws_cli() -> None:
-    runner = FakeRunner(_result(returncode=config.AWS_CLI_NOT_FOUND_EXIT_CODE))
-    storage_root = storage_config.StorageRoot(scheme="s3", bucket="zhupanov", prefix="larch")
+def test_discovery_uses_linked_worktree_git_identity(tmp_path: Path) -> None:
+    checkout = tmp_path / "larch2"
+    checkout.mkdir()
+    _ = subprocess.run(["git", "init", "-q"], cwd=checkout, check=True)
+    _ = subprocess.run(
+        ["git", "config", "user.email", "fixture@example.com"],
+        cwd=checkout,
+        check=True,
+    )
+    _ = subprocess.run(
+        ["git", "config", "user.name", "Fixture"],
+        cwd=checkout,
+        check=True,
+    )
+    _ = subprocess.run(
+        [
+            "git",
+            "remote",
+            "add",
+            "origin",
+            "git@github.com:character-ai/Agent-Lint.git",
+        ],
+        cwd=checkout,
+        check=True,
+    )
+    _write_config(checkout)
+    _ = subprocess.run(["git", "add", "tools-config.toml"], cwd=checkout, check=True)
+    _ = subprocess.run(
+        ["git", "commit", "-q", "-m", "fixture"],
+        cwd=checkout,
+        check=True,
+    )
+    worktree = tmp_path / "agent-lint-worktree"
+    _ = subprocess.run(
+        ["git", "worktree", "add", "-q", "-b", "fixture-worktree", str(worktree)],
+        cwd=checkout,
+        check=True,
+    )
+    nested = worktree / "nested"
+    nested.mkdir()
 
-    with pytest.raises(storage_config.StoragePreflightError, match="AWS CLI is required"):
-        storage_config.preflight_s3_bucket(storage_root=storage_root, runner=runner)
+    storage = storage_config.discover_tool_repository_storage(
+        start=nested,
+        environ={},
+    )
+
+    assert storage.client_repo == "agent-lint"
+    assert storage.uri == "s3://zhupanov/larch/agent-lint"
+
+
+def test_preflight_machine_envelope_names_derived_namespaces(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    storage = storage_config.ToolRepositoryStorage(
+        storage_config.StorageBase("s3", "company-data", "prod/tools"),
+        "service-a",
+    )
+    preflighted: list[storage_config.ToolRepositoryStorage] = []
+
+    def discover_storage(**_kwargs: object) -> storage_config.ToolRepositoryStorage:
+        return storage
+
+    def preflight_storage(**kwargs: object) -> None:
+        preflighted.append(
+            cast(
+                "storage_config.ToolRepositoryStorage",
+                kwargs["storage"],
+            )
+        )
+
+    monkeypatch.setattr(
+        storage_config,
+        "discover_tool_repository_storage",
+        discover_storage,
+    )
+    monkeypatch.setattr(
+        storage_config,
+        "preflight_tool_repository",
+        preflight_storage,
+    )
+
+    assert storage_config.storage_preflight_main(["--repo-root", str(tmp_path)]) == 0
+
+    assert preflighted == [storage]
+    assert capsys.readouterr().out.splitlines() == [
+        "STORAGE_BASE_URI=s3://company-data/prod/tools",
+        "CLIENT_REPO=service-a",
+        "TOOL_REPO_URI=s3://company-data/prod/tools/larch/service-a",
+        "RUN_LOGS_URI=s3://company-data/prod/tools/larch/service-a/run-logs/",
+        "PREFLIGHT_OK=true",
+    ]
+
+
+def test_checked_config_and_published_examples_match_executable_contract() -> None:
+    repo_root = Path(__file__).parents[3]
+    config_text = (repo_root / "tools-config.toml").read_text(encoding="utf-8")
+    assert config_text == '[larch]\nstorage_base_uri = "s3://zhupanov"\n'
+    assert tomllib.loads(config_text) == {
+        "larch": {"storage_base_uri": "s3://zhupanov"}
+    }
+
+    storage = storage_config.ToolRepositoryStorage(
+        storage_config.parse_storage_base_uri("s3://company-data/prod/tools"),
+        "service-a",
+    )
+    archive_doc = (repo_root / "docs/run-log-archive.md").read_text(encoding="utf-8")
+    analysis_doc = (repo_root / "docs/analysis-state.md").read_text(encoding="utf-8")
+    assert f"{storage.run_logs_uri}review/<run-id>.tar.gz" in archive_doc
+    assert "tools-config.toml" in archive_doc
+    assert "run-logs/v2/" in archive_doc
+    assert "analysis-state/v2/" in analysis_doc
+
+
+def test_legacy_descriptor_parser_is_explicit_and_config_independent() -> None:
+    storage = storage_config.ToolRepositoryStorage(
+        storage_config.StorageBase("s3", "zhupanov"), "larch"
+    )
+    descriptor = storage_config.parse_legacy_migration_descriptor(
+        {
+            "schema": "larch-run-log-migration-inventory-v1",
+            "source_commit": "a" * 40,
+            "storage_root": storage.base.uri,
+            "inventory_key": "migration/inventory.json",
+            "inventory_sha256": "b" * 64,
+        },
+        storage_root=storage.base,
+    )
+    assert descriptor.inventory_key == "migration/inventory.json"

--- a/python/tests/report/test_tokens.py
+++ b/python/tests/report/test_tokens.py
@@ -16,6 +16,7 @@ import pytest
 from larch.core import config
 from larch.report import report_tokens_scan
 from larch.report import run_log_corpus
+from larch.report import storage_config
 from larch.report import tokens
 from larch.report.report_tokens_models import RunRecord, VendorTotals
 
@@ -24,10 +25,23 @@ from larch.report.report_tokens_models import RunRecord, VendorTotals
 def _fixture_corpus_root(  # pyright: ignore[reportUnusedFunction]  # pytest invokes this autouse fixture by registration
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    def _sync(*, repo_root: Path) -> Path:
+    storage_root = storage_config.ToolRepositoryStorage(
+        storage_config.StorageBase("s3", "fixture-bucket"), "fixture-repo"
+    )
+
+    def _sync(*, repo_root: Path, storage: storage_config.ToolRepositoryStorage | None = None) -> Path:
+        _ = storage
         return repo_root / "larch-logs"
 
+    def _load_storage(**_kwargs: object) -> storage_config.ToolRepositoryStorage:
+        return storage_root
+
     monkeypatch.setattr(run_log_corpus, "synchronized_repository_log_root", _sync)
+    monkeypatch.setattr(
+        storage_config,
+        "load_tool_repository_storage",
+        _load_storage,
+    )
 
 
 def test_atomic_text_uses_nofollow(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -1134,7 +1148,8 @@ def test_measure_cache_efficiency_writes_ranked_sections(tmp_path: Path, monkeyp
     sync_calls = 0
     cache_root = tmp_path / "cache" / "larch2"
 
-    def _sync(*, repo_root: Path) -> Path:
+    def _sync(*, repo_root: Path, storage: storage_config.ToolRepositoryStorage | None = None) -> Path:
+        _ = storage
         nonlocal sync_calls
         assert repo_root == repo
         sync_calls += 1
@@ -1715,7 +1730,8 @@ def test_measure_panel_cost_reads_synced_cache_and_writes_analyzer_state(
     )
     sync_calls = 0
 
-    def _sync(*, repo_root: Path) -> Path:
+    def _sync(*, repo_root: Path, storage: storage_config.ToolRepositoryStorage | None = None) -> Path:
+        _ = storage
         nonlocal sync_calls
         assert repo_root == repo
         sync_calls += 1
@@ -1728,7 +1744,14 @@ def test_measure_panel_cost_reads_synced_cache_and_writes_analyzer_state(
 
     out = tokens.measure_panel_cost()
 
-    assert out == tmp_path / "state/larch/analysis-state/consumer/measure-panel-cost/2026-07-20.tsv"
+    expected_storage = storage_config.ToolRepositoryStorage(
+        storage_config.StorageBase("s3", "fixture-bucket"), "fixture-repo"
+    )
+    assert out == (
+        tmp_path / "state/larch/analysis-state/v2/fixture-repo"
+        / expected_storage.storage_origin_id
+        / "measure-panel-cost/2026-07-20.tsv"
+    )
     assert "agents/orchestrator-aggregator.md" in out.read_text(encoding="utf-8")
     assert sync_calls == 1
 

--- a/skills/learn-from-bugs/SKILL.md
+++ b/skills/learn-from-bugs/SKILL.md
@@ -187,7 +187,7 @@ Use this one fragment for all three marker-producing paths: default mode after S
 
 This is a shared definition, not an immediate Step 4 action: first branch on `FILE_MODE` below. Default mode runs it before Step 5; filing mode runs it only after the no-residual or successful-create path has finished. Do not publish before that mode-specific work completes.
 
-Run the whole fragment as one Bash call. `learn-from-bugs state-publish` writes the reconciled marker under `$XDG_STATE_HOME/larch/analysis-state/<repo>/learn-from-bugs/` with private permissions and no Git mutation:
+Run the whole fragment as one Bash call. `learn-from-bugs state-publish` writes the reconciled marker under `$XDG_STATE_HOME/larch/analysis-state/v2/<client-repo>/<storage-origin-id>/learn-from-bugs/` with private permissions and no Git mutation:
 
 ```bash
 set -euo pipefail

--- a/skills/shared/run-lifecycle.md
+++ b/skills/shared/run-lifecycle.md
@@ -21,17 +21,18 @@ duplicate, missing, or later flags fail. When set, pass
 The lifecycle CLI validates it and derives the immutable parent; no other parent
 IDs or environment variables are allowed.
 
-Parse `RUN_ID`, `SKILL`, `LOG_ROOT`, `RUN_DIR`, `CONTEXT_FILE`, `STORAGE_URI`, and
-`LIFECYCLE_STARTED` from stdout without `eval` or `source`. Stop if the command
-fails or `LIFECYCLE_STARTED` is not `true`.
+Parse `RUN_ID`, `SKILL`, `LOG_ROOT`, `RUN_DIR`, `CONTEXT_FILE`,
+`STORAGE_BASE_URI`, `CLIENT_REPO`, `TOOL_REPO_URI`, `RUN_LOGS_URI`,
+`PREFLIGHT_OK`, and `LIFECYCLE_STARTED` from stdout without `eval` or `source`.
+Stop if the command fails or either success value is not `true`.
 
 Callers that already own a run ID pass `--run-id "<id>"`. Specialized owners
 also pass their absolute `--log-root` and `--adopt-existing` when rich artifact
 setup created the manifest first. A specialized owner whose Step 0 `session
 setup` parse binds `REPO_ROOT` passes `--repo-root "$REPO_ROOT"` to the start
 and terminal commands instead of the generic fallback shown here. The context file persists the validated
-identity, staging root, and storage URI so later subprocesses rehydrate them
-without shell state.
+identity, staging root, canonical tool repository URI, and storage-origin ID so
+later subprocesses rehydrate them without shell state.
 
 After start succeeds, run exactly one matching terminal command before the
 skill returns. A terminal command must succeed with `LIFECYCLE_FLUSHED=true`.

--- a/skills/voter-calibration/scripts/test-voter-calibration.sh
+++ b/skills/voter-calibration/scripts/test-voter-calibration.sh
@@ -421,4 +421,4 @@ default_status=0
   env -u CLAUDE_PLUGIN_ROOT python3 "$ANALYZER" --min-votes 3 > "$FIX/default-root.md"
 ) 2> "$FIX/default-root.err" || default_status=$?
 [[ "$default_status" -eq 2 ]]
-grep -Fq 'storage configuration is missing' "$FIX/default-root.err"
+grep -Fq 'tools-config.toml: missing required file' "$FIX/default-root.err"

--- a/skills/voter-calibration/scripts/voter-calibration.md
+++ b/skills/voter-calibration/scripts/voter-calibration.md
@@ -10,7 +10,10 @@ The analyzer scans these synchronized log patterns under the resolved corpus roo
 - `<corpus-root>/implement/*/round-*/findings-classification.tsv`
 - `<corpus-root>/review/*/review-findings-classification-round-*.tsv`
 
-By default, the analyzer resolves the current Git repository, requires `config.toml` or `LARCH_LOGS_URI`, synchronizes once, and reads the unpacked cache. `--log-root DIR` bypasses synchronization for offline fixture tests.
+By default, the analyzer resolves the current Git repository, requires
+`tools-config.toml` and `[larch]`, derives repository identity from Git origin,
+synchronizes once, and reads the returned unpacked cache. `--log-root DIR`
+bypasses configuration and synchronization for offline fixture tests.
 
 ## Optional realized-outcome input
 

--- a/tests/fixtures/run-log-object-store-contract-v1.json
+++ b/tests/fixtures/run-log-object-store-contract-v1.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "remote_object": {
     "etag": "fixture-etag",
-    "key": "larch/run-logs/design/fixture-run.tar.gz",
+    "key": "larch/larch/run-logs/design/fixture-run.tar.gz",
     "size": 7,
     "version": "fixture-version"
   },
@@ -11,7 +11,7 @@
     "objects": [
       {
         "etag": "fixture-etag",
-        "key": "larch/run-logs/design/fixture-run.tar.gz",
+        "key": "larch/larch/run-logs/design/fixture-run.tar.gz",
         "size": 7,
         "version": "fixture-version"
       }

--- a/tools-config.toml
+++ b/tools-config.toml
@@ -1,0 +1,2 @@
+[larch]
+storage_base_uri = "s3://zhupanov"


### PR DESCRIPTION
## Summary

- replace repository-specific run-log configuration with strict root `tools-config.toml` and Git-origin-derived namespaces
- bind caches, pending publications, lifecycle state, and analyzer state to the canonical storage origin
- add prefix-scoped provider preflight, reader/writer coverage, migration boundaries, and published contract documentation

## Verification

- 1,499 affected Python tests passed (1 skipped)
- scoped pre-commit suite passed, including pyright, gitleaks, larch-lint, Rust fmt, and Clippy
- focused S3/GCS/R2 transport, lifecycle, corpus, fluff-analysis, voter-calibration, and plugin projection checks passed

Fixes #7965