### PR TITLE
Release v56.0.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "55.0.2",
+  "version": "56.0.0",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2482,7 +2482,7 @@ dependencies = [
 
 [[package]]
 name = "larch-adapters"
-version = "55.0.2"
+version = "56.0.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -2514,7 +2514,7 @@ dependencies = [
 
 [[package]]
 name = "larch-cli"
-version = "55.0.2"
+version = "56.0.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -2535,7 +2535,7 @@ dependencies = [
 
 [[package]]
 name = "larch-core"
-version = "55.0.2"
+version = "56.0.0"
 dependencies = [
  "regex",
  "zip",
@@ -2543,7 +2543,7 @@ dependencies = [
 
 [[package]]
 name = "larch-lint"
-version = "55.0.2"
+version = "56.0.0"
 dependencies = [
  "assert_cmd",
  "automod",
@@ -2569,7 +2569,7 @@ dependencies = [
 
 [[package]]
 name = "larch-test-support"
-version = "55.0.2"
+version = "56.0.0"
 dependencies = [
  "larch-core",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2024"
 license = "MIT"
 repository = "https://github.com/character-ai/larch"
 rust-version = "1.94.1"
-version = "55.0.2"
+version = "56.0.0"
 
 [workspace.dependencies]
 assert_cmd = { version = "2.2.2", default-features = false }
@@ -33,9 +33,9 @@ http = { version = "1.4.2", default-features = false, features = ["std"] }
 http-body = { version = "1.0.1", default-features = false }
 http-body-util = { version = "0.1.4", default-features = false }
 inventory = { version = "0.3.24", default-features = false }
-larch-adapters = { version = "=55.0.2", path = "crates/larch-adapters" }
-larch-core = { version = "=55.0.2", path = "crates/larch-core" }
-larch-test-support = { version = "=55.0.2", path = "crates/larch-test-support" }
+larch-adapters = { version = "=56.0.0", path = "crates/larch-adapters" }
+larch-core = { version = "=56.0.0", path = "crates/larch-core" }
+larch-test-support = { version = "=56.0.0", path = "crates/larch-test-support" }
 nix = { version = "0.31.3", default-features = false, features = ["process", "signal"] }
 octocrab = { version = "=0.54.0", default-features = false, features = ["default-client", "jwt-aws-lc-rs", "rustls", "rustls-aws-lc-rs", "timeout"] }
 predicates = { version = "3.1.4", default-features = false }

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "larch",
-  "version": "55.0.2",
+  "version": "56.0.0",
   "description": "Multi-agent workflow automation for Claude Code: issue-anchored `/design` (one direct-drafting flow; plan-review panel), `/bug` (consumer issue-filing helper), `/deps` issue dependency audits, and `/implement` (positional `<issue-N>`, fixed 7200s Step 2 timeout, optional `--merge`, `--forked`, `--draft`, `--no-admin-fallback`, `--no-logs-commit`, `--coder`, `--run-id`). `/implement` Preflight reads the `larch:plan` block from the issue body; `/implement` Step 5 code review always uses the unified strict panel internally (public `--panel` argv removed).",
   "author": {
     "name": "Sergey Zhupanov",


### PR DESCRIPTION
# larch v56.0.0

Aggregate bump: **MAJOR**. 17 PRs merged since `v55.0.2`.

Headline: larch configuration moves to a root-level `config.toml`, and tool
configuration adopts `tools-config.toml` namespaces.

## Added

- `lintlang` runs as a CI linter on the existing third-party lint job (#7960).

## Changed

- larch config migrates from `.larch/config.toml` to root-level `config.toml`.
  Consumers and documentation are updated (#7964).
- Tool configuration adopts `tools-config.toml` namespaces. Run-log caches are
  origin-bound (#7968).
- Skill metadata is Codex-compatible. The stale release Skill grant is removed
  (#7937).
- Exported reviewer and implementer agent metadata conforms to A006 and A030
  (#7938).
- The `/design` conditional prompt-source budget is reconciled with its
  777-line source set (#7940).
- Ambiguous `$PWD` paths in skill prose are replaced. Inline awk parsing is
  extracted (#7941).
- The ScheduleWakeup terminal rule reads as an imperative (#7947).
- Pinned `agent-lint` moves to the latest release, then to 4.0.3 (#7958,
  #7962).

## Fixed

- Skill commands no longer execute the non-executable `python/cli.py` directly
  (#7949, #7953).
- Hypothetical `scripts/foo.sh` examples are no longer treated as missing files
  (#7948).
- Stale Python migration pointers (#7939).
- Stale skill-local test artifacts are removed or repaired (#7950).
- Orphaned `step-7a.md` left by the Step 7a migration (#7954).
- Stale `test-plan-review-loop.sh` reference in the Python README (#7956).
