### PR TITLE
Fixes #7970: narrow anti-read-poll matcher

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -34,7 +34,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Read|Bash",
+        "matcher": "Read",
         "hooks": [
           {
             "type": "command",

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -34,7 +34,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Read|Bash",
+        "matcher": "Read",
         "hooks": [
           {
             "type": "command",

--- a/scripts/test-hook-anti-read-poll.sh
+++ b/scripts/test-hook-anti-read-poll.sh
@@ -93,10 +93,10 @@ assert_no_hook_state() {
     fi
 }
 
-if jq -e --arg cmd 'hook-anti-read-poll.sh' '.hooks.PostToolUse[]? | select(.matcher == "Read|Bash") | .hooks[]? | select(.command | test($cmd))' "$HOOKS_JSON" >/dev/null 2>&1; then
-    pass 'hooks.json registers hook-anti-read-poll.sh under matcher Read|Bash'
+if jq -e --arg cmd 'hook-anti-read-poll.sh' '.hooks.PostToolUse[]? | select(.matcher == "Read") | .hooks[]? | select(.command | test($cmd))' "$HOOKS_JSON" >/dev/null 2>&1; then
+    pass 'hooks.json registers hook-anti-read-poll.sh under matcher Read'
 else
-    fail 'hooks.json must register hook-anti-read-poll.sh under matcher Read|Bash'
+    fail 'hooks.json must register hook-anti-read-poll.sh under matcher Read'
 fi
 
 assert_silent "$(run_hook 0 /tmp/file.md 0 /proj generic)" 'call 1 silent'


### PR DESCRIPTION
## Summary
- Register the anti-read-poll PostToolUse hook for `Read` only.
- Update its regression harness to pin the narrower matcher.

## Matcher audit
Audited the shipped hook registrations. No other matcher/handler scope mismatches found: the PreToolUse hooks align with their Bash and Edit/Write handlers; Stop and SessionStart have no tool matcher.

## Verification
- `python3 -m json.tool hooks/hooks.json`
- `bash scripts/test-hook-anti-read-poll.sh`
- `PYTHONPATH=python pytest -q python/tests/core/test_hook_anti_read_poll.py`
- Scoped `pre-commit` checks (shellcheck, JSON validation, agent-lint, gitleaks)

Fixes #7970